### PR TITLE
Introduce podman machine os commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,15 @@ bin/rootlessport: $(SOURCES) go.mod go.sum
 .PHONY: rootlessport
 rootlessport: bin/rootlessport
 
+.PHONY: podman-remote-experimental
+podman-remote-experimental: $(SRCBINDIR)/experimental/podman$(BINSFX)
+$(SRCBINDIR)/experimental/podman$(BINSFX): $(SOURCES) go.mod go.sum | $(SRCBINDIR)
+	$(GOCMD) build \
+		$(BUILDFLAGS) \
+		$(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' \
+		-tags "${REMOTETAGS} experimental" \
+		-o $@ ./cmd/podman
+
 ###
 ### Secondary binary-build targets
 ###

--- a/cmd/podman/machine/os.go
+++ b/cmd/podman/machine/os.go
@@ -1,0 +1,28 @@
+//go:build (amd64 || arm64) && experimental
+// +build amd64 arm64
+// +build experimental
+
+package machine
+
+import (
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	OSCmd = &cobra.Command{
+		Use:               "os",
+		Short:             "Manage a virtual machine's os",
+		Long:              "Manage a virtual machine's operating system",
+		PersistentPreRunE: validate.NoOp,
+		RunE:              validate.SubCommandExists,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: OSCmd,
+		Parent:  machineCmd,
+	})
+}

--- a/cmd/podman/machine/os/apply.go
+++ b/cmd/podman/machine/os/apply.go
@@ -1,0 +1,38 @@
+//go:build (amd64 || arm64) && experimental
+// +build amd64 arm64
+// +build experimental
+
+package machineos
+
+import (
+	"fmt"
+
+	"github.com/containers/podman/v4/cmd/podman/machine"
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	applyCmd = &cobra.Command{
+		Use:               "apply",
+		Short:             "Apply OCI image to existing VM",
+		Long:              "Apply custom layers from a containerized Fedora CoreOS image on top of an existing VM",
+		PersistentPreRunE: validate.NoOp,
+		RunE:              apply,
+		Example:           `podman machine os apply myimage`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: applyCmd,
+		Parent:  machine.OSCmd,
+	})
+
+}
+
+func apply(cmd *cobra.Command, args []string) error {
+	fmt.Println("Applying..")
+	return nil
+}

--- a/cmd/podman/main_experimental.go
+++ b/cmd/podman/main_experimental.go
@@ -1,0 +1,8 @@
+//go:build experimental
+// +build experimental
+
+package main
+
+import (
+	_ "github.com/containers/podman/v4/cmd/podman/machine/os"
+)


### PR DESCRIPTION
Introduce machine os and machine os apply. Note that these are both stubs at the current moment, and do not introduce functionality. In order to build them, you must use the `experimental` build tag, or use `make podman-remote-experimental`

[NO NEW TESTS NEEDED]
as there is no actual functionality and this is a WIP.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
