### PR TITLE
Allow manual override of install location in Windows installer

### DIFF
--- a/contrib/win-installer/burn.wxs
+++ b/contrib/win-installer/burn.wxs
@@ -15,7 +15,7 @@
                                               SuppressOptionsUI="yes"
                                               ShowVersion="yes"/>
     </BootstrapperApplicationRef>
-    <Variable Name='InstallFolder' Type='string' Value='[ProgramFiles64Folder]RedHat\Podman'/>
+    <Variable Name='InstallFolder' Type='string' Value='[ProgramFiles64Folder]RedHat\Podman' bal:Overridable="yes"/>
     <Variable Name="VERSION" Value="$(var.VERSION)"/>
     <Variable Name="WSLCheckbox" Type="numeric" Value="1" bal:Overridable="yes"/>
     <Variable Name="AllowOldWin" Type="numeric" Value="0" bal:Overridable="yes"/>
@@ -23,7 +23,8 @@
     <Variable Name="LaunchArguments" Value="&quot;[InstallFolder]\podman-for-windows.html&quot;"/>
 
     <util:RegistrySearch Id="PreviousVersionSearch" Variable="PreviousVersion"  Result="value" Root="HKLM"  Key="SOFTWARE\[WixBundleManufacturer]\Updates\[WixBundleName]" Value="PackageVersion"/>
-    <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="SOFTWARE\[WixBundleManufacturer]\[WixBundleName]" Value="InstallDir" Variable="PreviousInstallFolder"/>
+    <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="SOFTWARE\[WixBundleManufacturer]\[WixBundleName]" Value="InstallDir" Variable="PreviousInstallFolder" Win64="yes"/>
+    <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="InstallFolder" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />
     <util:RegistrySearch Id="CurrentBuild" Variable="CBNumber" Result="value" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Value="CurrentBuildNumber"/>
     <bal:Condition Message="Windows 10 (19041) or later is required to run this application.">
       <![CDATA[VersionNT >= v10.0 AND (CBNumber >= 19041 OR AllowOldWin = 1)]]>

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -20,6 +20,9 @@
           <Directory Id="INSTALLDIR" Name="Podman">
             <Component Id="INSTALLDIR_Component" Guid="14B310C4-9B5D-4DA5-ADF9-B9D008E4CD82" Win64="yes">
               <CreateFolder/>
+              <RegistryKey Root="HKLM" Key="SOFTWARE\Red Hat\Podman">
+                <RegistryValue Name="InstallDir" Value="[INSTALLDIR]" Type="string" />
+              </RegistryKey>
             </Component>
             <Component Id="MainExecutable" Guid="73752F94-6589-4C7B-ABED-39D655A19714" Win64="yes">
               <File Id="MainExecutableFile" Name="podman.exe" Source="artifacts/podman.exe" KeyPath="yes"/>


### PR DESCRIPTION
Fixes #16265

Allow manual override of install location

Also reuse install location for previous installs if present

Example Usage: .\podman-4.3.2-setup.exe InstallFolder=C:\Other\Loc

Signed-off-by: Jason T. Greene <jason.greene@redhat.com>

```release-note
Allow manual override of install location in windows installer
```

[NO NEW TESTS NEEDED]