### PR TITLE
Make released binary names more consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,10 +335,10 @@ $(SRCBINDIR)/podman$(BINSFX): $(SOURCES) go.mod go.sum | $(SRCBINDIR)
 		-tags "${REMOTETAGS}" \
 		-o $@ ./cmd/podman
 
-$(SRCBINDIR)/podman-remote-static: $(SRCBINDIR) $(SOURCES) go.mod go.sum
+$(SRCBINDIR)/podman-remote-static_amd64 $(SRCBINDIR)/podman-remote-static_arm64: $(SRCBINDIR)/podman-remote-static_%: $(SRCBINDIR) $(SOURCES) go.mod go.sum
 	CGO_ENABLED=0 \
 	GOOS=linux \
-	GOARCH=$(GOARCH) \
+	GOARCH=$* \
 	$(GO) build \
 		$(BUILDFLAGS) \
 		$(GO_LDFLAGS) '$(LDFLAGS_PODMAN_STATIC)' \
@@ -362,8 +362,9 @@ $(SRCBINDIR)/quadlet: $(SOURCES) go.mod go.sum
 .PHONY: quadlet
 quadlet: bin/quadlet
 
-PHONY: podman-remote-static
-podman-remote-static: $(SRCBINDIR)/podman-remote-static
+PHONY: podman-remote-static_amd64 podman-remote-static_arm64
+podman-remote-static_amd64: $(SRCBINDIR)/podman-remote-static_amd64
+podman-remote-static_arm64: $(SRCBINDIR)/podman-remote-static_arm64
 
 .PHONY: podman-winpath
 podman-winpath: $(SOURCES) go.mod go.sum

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ $(SRCBINDIR)/podman$(BINSFX): $(SOURCES) go.mod go.sum | $(SRCBINDIR)
 		-tags "${REMOTETAGS}" \
 		-o $@ ./cmd/podman
 
-$(SRCBINDIR)/podman-remote-static_amd64 $(SRCBINDIR)/podman-remote-static_arm64: $(SRCBINDIR)/podman-remote-static_%: $(SRCBINDIR) $(SOURCES) go.mod go.sum
+$(SRCBINDIR)/podman-remote-static-linux_amd64 $(SRCBINDIR)/podman-remote-static-linux_arm64: $(SRCBINDIR)/podman-remote-static-linux_%: $(SRCBINDIR) $(SOURCES) go.mod go.sum
 	CGO_ENABLED=0 \
 	GOOS=linux \
 	GOARCH=$* \
@@ -362,9 +362,9 @@ $(SRCBINDIR)/quadlet: $(SOURCES) go.mod go.sum
 .PHONY: quadlet
 quadlet: bin/quadlet
 
-PHONY: podman-remote-static_amd64 podman-remote-static_arm64
-podman-remote-static_amd64: $(SRCBINDIR)/podman-remote-static_amd64
-podman-remote-static_arm64: $(SRCBINDIR)/podman-remote-static_arm64
+PHONY: podman-remote-static-linux_amd64 podman-remote-static-linux_arm64
+podman-remote-static-linux_amd64: $(SRCBINDIR)/podman-remote-static-linux_amd64
+podman-remote-static-linux_arm64: $(SRCBINDIR)/podman-remote-static-linux_arm64
 
 .PHONY: podman-winpath
 podman-winpath: $(SOURCES) go.mod go.sum

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -244,10 +244,12 @@ spelled with complete minutiae.
       $ make podman-remote-release-darwin_amd64.zip \
           podman-remote-release-darwin_arm64.zip \
           podman-remote-release-windows_amd64.zip \
-          podman-remote-static
+          podman-remote-static_amd64 \
+          podman-remote-static_arm64
       $ mv podman-* bin/
       $ cd bin/
-      $ tar -cvzf podman-remote-static.tar.gz podman-remote-static
+      $ tar -cvzf podman-remote-static_amd64.tar.gz podman-remote-static_amd64
+      $ tar -cvzf podman-remote-static_arm64.tar.gz podman-remote-static_arm64
       $ sha256sum *.zip *.tar.gz > shasums
       ```
 
@@ -270,7 +272,8 @@ spelled with complete minutiae.
       * podman-remote-release-darwin_arm64.zip
       * podman-remote-release-windows_amd64.zip
       * podman-vX.Y.Z.msi
-      * podman-remote-static.tar.gz
+      * podman-remote-static_amd64.tar.gz
+      * podman-remote-static_arm64.tar.gz
       * shasums
    1. Click the Publish button to make the release (or pre-release)
       available.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -244,12 +244,12 @@ spelled with complete minutiae.
       $ make podman-remote-release-darwin_amd64.zip \
           podman-remote-release-darwin_arm64.zip \
           podman-remote-release-windows_amd64.zip \
-          podman-remote-static_amd64 \
-          podman-remote-static_arm64
+          podman-remote-static-linux_amd64 \
+          podman-remote-static-linux_arm64
       $ mv podman-* bin/
       $ cd bin/
-      $ tar -cvzf podman-remote-static_amd64.tar.gz podman-remote-static_amd64
-      $ tar -cvzf podman-remote-static_arm64.tar.gz podman-remote-static_arm64
+      $ tar -cvzf podman-remote-static-linux_amd64.tar.gz podman-remote-static-linux_amd64
+      $ tar -cvzf podman-remote-static-linux_arm64.tar.gz podman-remote-static-linux_arm64
       $ sha256sum *.zip *.tar.gz > shasums
       ```
 
@@ -272,8 +272,8 @@ spelled with complete minutiae.
       * podman-remote-release-darwin_arm64.zip
       * podman-remote-release-windows_amd64.zip
       * podman-vX.Y.Z.msi
-      * podman-remote-static_amd64.tar.gz
-      * podman-remote-static_arm64.tar.gz
+      * podman-remote-static-linux_amd64.tar.gz
+      * podman-remote-static-linux_arm64.tar.gz
       * shasums
    1. Click the Publish button to make the release (or pre-release)
       available.

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -1,6 +1,11 @@
 SHELL := bash
 
 ARCH ?= aarch64
+ifeq ($(ARCH), aarch64)
+	GOARCH:=arm64
+else
+	GOARCH:=$(ARCH)
+endif
 GVPROXY_VERSION ?= 0.4.0
 QEMU_VERSION ?= 7.1.0-1
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
@@ -8,7 +13,7 @@ QEMU_RELEASE_URL ?= https://github.com/containers/podman-machine-qemu/releases/d
 PACKAGE_DIR ?= out/packaging
 TMP_DOWNLOAD ?= tmp-download
 PACKAGE_ROOT ?= root
-PKG_NAME := podman-installer-macos-$(ARCH).pkg
+PKG_NAME := podman-installer-macos-$(GOARCH).pkg
 
 default: pkginstaller
 

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -17,10 +17,6 @@ arch=$(cat "${BASEDIR}/ARCH")
 
 function build_podman() {
   pushd "$1"
-    local goArch="${arch}"
-    if [ "${goArch}" = aarch64 ]; then
-        goArch=arm64
-    fi
     make GOARCH="${goArch}" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}"
     make GOARCH="${goArch}" podman-mac-helper
     cp bin/darwin/podman "contrib/pkginstaller/out/packaging/${binDir}/podman"
@@ -66,6 +62,11 @@ function signQemu() {
     --entitlements "${BASEDIR}/hvf.entitlements" "${qemuBinDir}/qemu-system-${qemuArch}"
 }
 
+goArch="${arch}"
+if [ "${goArch}" = aarch64 ]; then
+  goArch=arm64
+fi
+
 build_podman "../../../../"
 sign "${binDir}/podman"
 sign "${binDir}/gvproxy"
@@ -86,7 +87,7 @@ productbuild --distribution "${BASEDIR}/Distribution" \
 rm "${OUTPUT}/podman.pkg"
 
 if [ ! "${NO_CODESIGN}" -eq "1" ]; then
-  productsign --timestamp --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/podman-unsigned.pkg" "${OUTPUT}/podman-installer-macos-${arch}.pkg"
+  productsign --timestamp --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/podman-unsigned.pkg" "${OUTPUT}/podman-installer-macos-${goArch}.pkg"
 else
-  mv "${OUTPUT}/podman-unsigned.pkg" "${OUTPUT}/podman-installer-macos-${arch}.pkg"
+  mv "${OUTPUT}/podman-unsigned.pkg" "${OUTPUT}/podman-installer-macos-${goArch}.pkg"
 fi

--- a/contrib/podmanremoteimage/Containerfile
+++ b/contrib/podmanremoteimage/Containerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
 WORKDIR /opt/app-root/src
 COPY . .
-RUN make podman-remote-static_amd64
+RUN make podman-remote-static-linux_amd64
 RUN GOOS=windows make podman-remote
 RUN GOOS=darwin make podman-remote
 
 FROM scratch
 COPY --from=builder /opt/app-root/src/bin .
-ENTRYPOINT ["/podman-remote-static_amd64"]
+ENTRYPOINT ["/podman-remote-static-linux_amd64"]

--- a/contrib/podmanremoteimage/Containerfile
+++ b/contrib/podmanremoteimage/Containerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
 WORKDIR /opt/app-root/src
 COPY . .
-RUN make podman-remote-static
+RUN make podman-remote-static_amd64
 RUN GOOS=windows make podman-remote
 RUN GOOS=darwin make podman-remote
 
 FROM scratch
 COPY --from=builder /opt/app-root/src/bin .
-ENTRYPOINT ["/podman-remote-static"]
+ENTRYPOINT ["/podman-remote-static_amd64"]

--- a/contrib/podmanremoteimage/README.md
+++ b/contrib/podmanremoteimage/README.md
@@ -16,7 +16,7 @@ $ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-
 
 - For Linux binary
 ```bash
-$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/podman-remote-static . && podman rm remote-temp
+$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/podman-remote-static_amd64 . && podman rm remote-temp
 ```
 
 - For Mac binary

--- a/contrib/podmanremoteimage/README.md
+++ b/contrib/podmanremoteimage/README.md
@@ -16,7 +16,7 @@ $ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-
 
 - For Linux binary
 ```bash
-$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/podman-remote-static_amd64 . && podman rm remote-temp
+$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/podman-remote-static-linux_amd64 . && podman rm remote-temp
 ```
 
 - For Mac binary


### PR DESCRIPTION
This PR changes the name of some of the binaries which go to 
https://github.com/containers/podman/releases/

It renames `podman-release-static` to `podman-release-static-linux_{amd64,arm64}`,
and renames `podman-installer-macos-aarch64.pkg` to `podman-installer-macos-arm64.pkg` 

automation/scripts relying on these file names which are not stored in
github.com/containers/podman will need to be adjusted for these changes.

This fixes https://github.com/containers/podman/issues/16612

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman-release-static.tar.gz` has been renamed to `podman-release-static-linux_{amd64,arm64}.tar.gz`.
`podman-installer-macos-aarch64.pkg` has been renamed to `podman-installer-macos-arm64.pkg`.
```