### PR TITLE
[CI:BUILD] copr: enable podman-restart.service on rpm installation

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -75,6 +75,7 @@ BuildRequires: shadow-utils-subid-devel
 BuildRequires: pkgconfig
 BuildRequires: make
 BuildRequires: ostree-devel
+%{?systemd_requires}
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: conmon >= 2:2.0.30-2
@@ -220,6 +221,17 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 for file in `find %{buildroot}%{_mandir}/man[15] -type f | sed "s,%{buildroot},," | grep -v -e remote -e docker`; do
     echo "$file*" >> podman.file-list
 done
+
+%post
+if [ $1 -eq 1 ]; then
+    %{_bindir}/systemctl enable --now %{name}-restart.service
+fi
+
+%preun
+%systemd_preun %{name}-restart.service
+
+%postun
+%systemd_postun %{name}-restart.service
 
 # This lists all the files that are included in the rpm package and that
 # are going to be installed into target system where the rpm is installed.


### PR DESCRIPTION
Resolves: #16669

@rhatdan PTAL

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
