### PR TITLE
[CI:DOCS] Skip windows-smoke when not useful

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -524,8 +524,13 @@ compose_test_task:
 windows_smoke_test_task:
     name: "Windows Smoke Test"
     alias: windows_smoke_test
-    # Don't run for multiarch/container image cirrus-cron job.
-    only_if: $CIRRUS_CRON != 'multiarch'
+    # Only run for non-docs/copr PRs and non-multiarch branch builds
+    # and never for tags.  Docs: ./contrib/cirrus/CIModes.md
+    only_if: >-
+        $CIRRUS_TAG == '' &&
+        $CIRRUS_CRON != 'multiarch' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*'
     depends_on:
       - alt_build
     ec2_instance:


### PR DESCRIPTION
It's important to actually perform a windows build for a `[CI:DOCS]` PR since it verifies and includes a copy of the docs.  However, it's not necessary to actually test if the installer functions or not. That task should happen in other contexts.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
