### PR TITLE
e2e: fix e2e tests in proxy environment

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -434,7 +434,8 @@ func (p *PodmanTestIntegration) RunTopContainer(name string) *PodmanSessionInteg
 // RunTopContainerWithArgs runs a simple container in the background that
 // runs top.  If the name passed != "", it will have a name, command args can also be passed in
 func (p *PodmanTestIntegration) RunTopContainerWithArgs(name string, args []string) *PodmanSessionIntegration {
-	var podmanArgs = []string{"run"}
+	// In proxy environment, some tests need to the --http-proxy=false option (#16684)
+	var podmanArgs = []string{"run", "--http-proxy=false"}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
 	}
@@ -474,6 +475,17 @@ func (p *PodmanTestIntegration) RunNginxWithHealthCheck(name string) (*PodmanSes
 	session := p.Podman(podmanArgs)
 	session.WaitWithDefaultTimeout()
 	return session, session.OutputToString()
+}
+
+// RunContainerWithNetworkTest runs the fedoraMinimal curl with the specified network mode.
+func (p *PodmanTestIntegration) RunContainerWithNetworkTest(mode string) *PodmanSessionIntegration {
+	var podmanArgs = []string{"run"}
+	if mode != "" {
+		podmanArgs = append(podmanArgs, "--network", mode)
+	}
+	podmanArgs = append(podmanArgs, fedoraMinimal, "curl", "-k", "-o", "/dev/null", "http://www.podman.io:80")
+	session := p.Podman(podmanArgs)
+	return session
 }
 
 func (p *PodmanTestIntegration) RunLsContainerInPod(name, pod string) (*PodmanSessionIntegration, int, string) {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -1259,7 +1259,8 @@ USER test1`
 
 		ctrName := "gen-kube-env-ctr"
 		podName := "gen-kube-env"
-		session1 := podmanTest.Podman([]string{"run", "-d", "--pod", "new:" + podName, "--name", ctrName,
+		// In proxy environment, this test needs to the --http-proxy=false option (#16684)
+		session1 := podmanTest.Podman([]string{"run", "-d", "--http-proxy=false", "--pod", "new:" + podName, "--name", ctrName,
 			"-e", "FOO=bar",
 			"-e", "HELLO=WORLD",
 			"alpine", "top"})

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -42,38 +42,37 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run network connection with default bridge", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", ALPINE, "wget", "www.podman.io"})
-		session.Wait(90)
+		session := podmanTest.RunContainerWithNetworkTest("")
+		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
 
 	It("podman run network connection with host", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--network", "host", ALPINE, "wget", "www.podman.io"})
-		session.Wait(90)
+		session := podmanTest.RunContainerWithNetworkTest("host")
+		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
 
 	It("podman run network connection with default", func() {
-		session := podmanTest.Podman([]string{"run", "--network", "default", ALPINE, "wget", "www.podman.io"})
+		session := podmanTest.RunContainerWithNetworkTest("default")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
 
 	It("podman run network connection with none", func() {
-		session := podmanTest.Podman([]string{"run", "--network", "none", ALPINE, "wget", "www.podman.io"})
+		session := podmanTest.RunContainerWithNetworkTest("none")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
-		Expect(session.ErrorToString()).To(ContainSubstring("wget: bad address 'www.podman.io'"))
+		if _, found := os.LookupEnv("http_proxy"); found {
+			Expect(session).Should(Exit(5))
+			Expect(session.ErrorToString()).To(ContainSubstring("Could not resolve proxy:"))
+		} else {
+			Expect(session).Should(Exit(6))
+			Expect(session.ErrorToString()).To(ContainSubstring("Could not resolve host: www.podman.io"))
+		}
 	})
 
 	It("podman run network connection with private", func() {
-		session := podmanTest.Podman([]string{"run", "--network", "private", ALPINE, "wget", "www.podman.io"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-	})
-
-	It("podman run network connection with loopback", func() {
-		session := podmanTest.Podman([]string{"run", "--network", "host", ALPINE, "wget", "www.podman.io"})
+		session := podmanTest.RunContainerWithNetworkTest("private")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})

--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -65,6 +65,8 @@ var _ = Describe("Systemd activate", func() {
 		addr := net.JoinHostPort(host, strconv.Itoa(port))
 
 		activateSession := testUtils.StartSystemExec(activate, []string{
+			"-E", "http_proxy", "-E", "https_proxy", "-E", "no_proxy",
+			"-E", "HTTP_PROXY", "-E", "HTTPS_PROXY", "-E", "NO_PROXY",
 			"--listen", addr,
 			podmanTest.PodmanBinary,
 			"--root=" + filepath.Join(tempDir, "server_root"),


### PR DESCRIPTION
- podman generate kube inheritents the proxy environment valiable by default.
  Therefore, Env field is not empty if it is set.

- systemd-socket-acrivate needs to pass an proxy environment variable.

- busybox wget with an proxy doesn't work.
  Network tests should use not wget but curl.
  https://gitlab.alpinelinux.org/alpine/aports/-/issues/10446

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
