### PR TITLE
[CI:BUILD] Makefile: Use CGO when building natively on MacOS.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -399,15 +399,15 @@ osx_alt_build_task:
         TEST_FLAVOR: "altbuild"
         ALT_NAME: 'OSX Cross'
     osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
+        image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
     setup_script:
         - brew install go
         - brew install go-md2man
         - go version
-    build_amd64_script:
-        - make podman-remote-release-darwin_amd64.zip
     build_arm64_script:
         - make podman-remote-release-darwin_arm64.zip
+    build_amd64_script:
+        - make podman-remote-release-darwin_amd64.zip
     build_pkginstaller_script:
         - cd contrib/pkginstaller
         - make ARCH=amd64 NO_CODESIGN=1 pkginstaller

--- a/Makefile
+++ b/Makefile
@@ -179,17 +179,15 @@ else
 BINSFX := -remote
 SRCBINDIR := bin
 endif
-# Necessary for nested-$(MAKE) calls and docs/remote-docs.sh
-export GOOS GOARCH CGO_ENABLED BINSFX SRCBINDIR
-
 # Need to use CGO for mDNS resolution, but cross builds need CGO disabled
 # See https://github.com/golang/go/issues/12524 for details
-DARWIN_GCO := 0
 ifeq ($(call err_if_empty,NATIVE_GOOS),darwin)
 ifdef HOMEBREW_PREFIX
-	DARWIN_GCO := 1
+	CGO_ENABLED := 1
 endif
 endif
+# Necessary for nested-$(MAKE) calls and docs/remote-docs.sh
+export GOOS GOARCH CGO_ENABLED BINSFX SRCBINDIR
 
 # win-sshproxy is checked out manually to keep from pulling in gvisor and it's transitive
 # dependencies. This is only used for the Windows installer task (podman.msi), which must
@@ -718,7 +716,7 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 	$(eval GOARCH := $(lastword $(subst _, ,$*)))
 	$(eval _GOPLAT := GOOS=$(call err_if_empty,GOOS) GOARCH=$(call err_if_empty,GOARCH))
 	mkdir -p "$(call err_if_empty,TMPDIR)/$(SUBDIR)"
-	$(MAKE) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+	$(MAKE) GOOS=$(GOOS) GOARCH=$(NATIVE_GOARCH) \
 		clean-binaries podman-remote-$(GOOS)-docs
 	if [[ "$(GOARCH)" != "$(NATIVE_GOARCH)" ]]; then \
 		$(MAKE) CGO_ENABLED=0 $(GOPLAT) BUILDTAGS="$(BUILDTAGS_CROSS)" \


### PR DESCRIPTION
Fix a regression (DNS not resolvable) caused by not setting CGO correctly in the Makefile while building podman-remote on OSX. See https://github.com/golang/go/issues/12524 for details.

Signed-off-by: Ashley Cui <acui@redhat.com>

Fixes: https://github.com/containers/podman/issues/16230
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
