### PR TITLE
stop reporting errors removing containers that don't exist

### DIFF
--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -44,10 +44,6 @@ func (p *Pod) startInitContainers(ctx context.Context) error {
 				icLock.Unlock()
 				return fmt.Errorf("failed to remove once init container %s: %w", initCon.ID(), err)
 			}
-			// Removing a container this way requires an explicit call to clean up the db
-			if err := p.runtime.state.RemoveContainerFromPod(p, initCon); err != nil {
-				logrus.Errorf("Removing container %s from database: %v", initCon.ID(), err)
-			}
 			icLock.Unlock()
 		}
 	}


### PR DESCRIPTION
Init containers are removed once they exit, but podman reports and error that the container does not exist, when it was previously removed.  Stop reporting missing containers when removing.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman will stop reporting errors on short lived init containers in pods.
```
