### PR TITLE
Build cross-compilation fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -399,9 +399,9 @@ osx_alt_build_task:
         - brew install go-md2man
         - go version
     build_amd64_script:
-        - make podman-remote-release-darwin_amd64.zip GOARCH=amd64
+        - make podman-remote-release-darwin_amd64.zip
     build_arm64_script:
-        - make podman-remote-release-darwin_arm64.zip GOARCH=arm64
+        - make podman-remote-release-darwin_arm64.zip
     build_pkginstaller_script:
         - cd contrib/pkginstaller
         - make ARCH=amd64 NO_CODESIGN=1 pkginstaller

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -10,7 +10,8 @@ SOURCES=${@:3}                      ## directories to find markdown files
 # invoked in a cross-compilation environment, so even if PLATFORM=windows
 # we need an actual executable that we can invoke).
 if [[ -z "$PODMAN" ]]; then
-    case $(env -i HOME=$HOME PATH=$PATH go env GOOS) in
+    DETECTED_OS=$(env -i HOME="$HOME" PATH="$PATH" go env GOOS)
+    case $DETECTED_OS in
         windows)
             PODMAN=bin/windows/podman.exe ;;
         darwin)


### PR DESCRIPTION
Fixes #16702 

Fixes included:
* Build documentation for the same target OS-ARCH as the requested application binaries (needed tools are still built for host)
* Limit msi build to amd64 arch as msitools doesn't support arm64 Windows as of now
* Fixes for HOME and PATH variables having whitespaces inside.

Now these commands work on MacOS M1:
* `make clean podman.msi`
* `make clean podman-remote-release-windows_arm64.zip`
* `make clean podman-remote-release-windows_amd64.zip`

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
