### PR TITLE
kube sdnotify: run proxies for the lifespan of the service

### DIFF
--- a/pkg/systemd/notifyproxy/notifyproxy_test.go
+++ b/pkg/systemd/notifyproxy/notifyproxy_test.go
@@ -18,7 +18,7 @@ func TestNotifyProxy(t *testing.T) {
 	proxy, err := New("")
 	require.NoError(t, err)
 	require.FileExists(t, proxy.SocketPath())
-	require.NoError(t, proxy.close())
+	require.NoError(t, proxy.Close())
 	require.NoFileExists(t, proxy.SocketPath())
 }
 
@@ -28,9 +28,12 @@ func TestWaitAndClose(t *testing.T) {
 	require.FileExists(t, proxy.SocketPath())
 
 	ch := make(chan error)
-
+	defer func() {
+		err := proxy.Close()
+		require.NoError(t, err, "proxy should close successfully")
+	}()
 	go func() {
-		ch <- proxy.WaitAndClose()
+		ch <- proxy.Wait()
 	}()
 
 	sendMessage(t, proxy, "foo\n")


### PR DESCRIPTION
As outlined in #16076, a subsequent BARRIER *may* follow the READY
message sent by a container.  To correctly imitate the behavior of
systemd's NOTIFY_SOCKET, the notify proxies span up by `kube play` must
hence process messages for the entirety of the workload.

We know that the workload is done and that all containers and pods have
exited when the service container exits.  Hence, all proxies are closed
at that time.

The above changes imply that Podman runs for the entirety of the
workload and will henceforth act as the MAINPID when running inside of
systemd.  Prior to this change, the service container acted as the
MAINPID which is now not possible anymore; Podman would be killed
immediately on exit of the service container and could not clean up.

The kube template now correctly transitions to in-active instead of
failed in systemd.

Fixes: #16076
Fixes: #16515
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where barrier sd-notify messages were ignored when using notify policies in kube-play.
```
