### PR TITLE
quadlet: Drop ExecStartPre=rm %t/%N.cid

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -222,11 +222,6 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	// Need the containers filesystem mounted to start podman
 	service.Add(UnitGroup, "RequiresMountsFor", "%t/containers")
 
-	// Remove any leftover cid file before starting, just to be sure.
-	// We remove any actual pre-existing container by name with --replace=true.
-	// But --cidfile will fail if the target exists.
-	service.Add(ServiceGroup, "ExecStartPre", "-rm -f %t/%N.cid")
-
 	// If the conman exited uncleanly it may not have removed the container, so force it,
 	// -i makes it ignore non-existing files.
 	service.Add(ServiceGroup, "ExecStopPost", "-/usr/bin/podman rm -f -i --cidfile=%t/%N.cid")

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -14,7 +14,6 @@
 ## assert-key-is "Service" "Type" "notify"
 ## assert-key-is "Service" "NotifyAccess" "all"
 ## assert-key-is "Service" "SyslogIdentifier" "%N"
-## assert-key-is "Service" "ExecStartPre" "-rm -f %t/%N.cid"
 ## assert-key-is "Service" "ExecStopPost" "-/usr/bin/podman rm -f -i --cidfile=%t/%N.cid" "-rm -f %t/%N.cid"
 ## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
 


### PR DESCRIPTION
Since https://github.com/containers/podman/pull/16394 was merged we now always delete the cid file if --replace=true was specified, so we can avoid this extra command being launched.

Signed-off-by: Alexander Larsson <alexl@redhat.com>

```release-note
None
```
