### PR TITLE
Quadlet use regular defaults

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -116,8 +116,7 @@ setuid and file capabilities.
 
 #### `DropCapability=` (defaults to `all`)
 
-Drop these capabilities from the default podman capability set, or `all` for all capabilities. The default if no
-`DropCapability` is set is `all`. Set this to empty (i.e. `DropCapability=`) to use the default podman capability set.
+Drop these capabilities from the default podman capability set, or `all` to drop all capabilities.
 
 This is a space separated list of capabilities. This key can be listed multiple times.
 
@@ -140,7 +139,7 @@ AddCapability=CAP_DAC_OVERRIDE CAP_IPC_OWNER
 
 #### `ReadOnly=` (defaults to `no`)
 
-If enabled, makes image read-only, with /var/tmp, /tmp and /run a tmpfs (unless disabled by `VolatileTmp=no`).
+If enabled, makes image read-only, with /var/tmp, /tmp and /run a tmpfs (unless disabled by `VolatileTmp=no`).r
 
 **NOTE:** Podman will automatically copy any content from the image onto the tmpfs
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -190,9 +190,9 @@ of startup on its own.
 
 The timezone to run the container in.
 
-#### `RunInit=` (default to `yes`)
+#### `RunInit=` (default to `no`)
 
-If enabled (and it is by default), the container will have a minimal init process inside the
+If enabled, the container will have a minimal init process inside the
 container that forwards signals and reaps processes.
 
 #### `VolatileTmp=` (default to `yes`)

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -109,7 +109,7 @@ which can be modified with `RemapUsers`, but if that is not specified, this uid 
 The (numeric) gid to run as inside the container. This does not need to match the gid on the host,
 which can be modified with `RemapUsers`, but if that is not specified, this gid is also used on the host.
 
-#### `NoNewPrivileges=` (defaults to `yes`)
+#### `NoNewPrivileges=` (defaults to `no`)
 
 If enabled (which is the default), this disables the container processes from gaining additional privileges via things like
 setuid and file capabilities.

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -138,7 +138,7 @@ For example:
 AddCapability=CAP_DAC_OVERRIDE CAP_IPC_OWNER
 ```
 
-#### `ReadOnly=` (defaults to `yes`)
+#### `ReadOnly=` (defaults to `no`)
 
 If enabled, makes image read-only, with /var/tmp, /tmp and /run a tmpfs (unless disabled by `VolatileTmp=no`).
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -329,7 +329,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 		podman.addf("--cap-add=%s", strings.ToLower(caps))
 	}
 
-	readOnly := container.LookupBoolean(ContainerGroup, KeyReadOnly, true)
+	readOnly := container.LookupBoolean(ContainerGroup, KeyReadOnly, false)
 	if readOnly {
 		podman.add("--read-only")
 	}

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -312,10 +312,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 		podman.add("--security-opt", fmt.Sprintf("seccomp=%s", seccompProfile))
 	}
 
-	dropCaps := []string{"all"} // Default
-	if container.HasKey(ContainerGroup, KeyDropCapability) {
-		dropCaps = container.LookupAllStrv(ContainerGroup, KeyDropCapability)
-	}
+	dropCaps := container.LookupAllStrv(ContainerGroup, KeyDropCapability)
 
 	for _, caps := range dropCaps {
 		podman.addf("--cap-drop=%s", strings.ToLower(caps))

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -253,9 +253,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 
 		// But we still want output to the journal, so use the log driver.
 		"--log-driver", "passthrough",
-
-		// Never try to pull the image during service start
-		"--pull=never")
+	)
 
 	// We use crun as the runtime and delegated groups to it
 	service.Add(ServiceGroup, "Delegate", "yes")

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -276,7 +276,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	}
 
 	// Run with a pid1 init to reap zombies by default (as most apps don't do that)
-	runInit := container.LookupBoolean(ContainerGroup, KeyRunInit, true)
+	runInit := container.LookupBoolean(ContainerGroup, KeyRunInit, false)
 	if runInit {
 		podman.add("--init")
 	}

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -297,7 +297,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	}
 
 	// Default to no higher level privileges or caps
-	noNewPrivileges := container.LookupBoolean(ContainerGroup, KeyNoNewPrivileges, true)
+	noNewPrivileges := container.LookupBoolean(ContainerGroup, KeyNoNewPrivileges, false)
 	if noNewPrivileges {
 		podman.add("--security-opt=no-new-privileges")
 	}

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm -d --log-driver passthrough --pull=never --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon localhost/imagename
+## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm -d --log-driver passthrough --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon localhost/imagename
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -6,7 +6,6 @@
 ## assert-podman-args "-d"
 ## assert-podman-args "--log-driver" "passthrough"
 ## assert-podman-args "--pull=never"
-## assert-podman-args "--init"
 ## assert-podman-args "--runtime" "/usr/bin/crun"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -8,7 +8,6 @@
 ## assert-podman-args "--runtime" "/usr/bin/crun"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"
-## assert-podman-args "--cap-drop=all"
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
 ## assert-key-is "Service" "KillMode" "mixed"
 ## assert-key-is "Service" "Delegate" "yes"

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -10,7 +10,6 @@
 ## assert-podman-args "--runtime" "/usr/bin/crun"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"
-## assert-podman-args "--security-opt=no-new-privileges"
 ## assert-podman-args "--cap-drop=all"
 ## assert-podman-args "--read-only"
 ## !assert-podman-args "--read-only-tmpfs=false"

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -10,8 +10,6 @@
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"
 ## assert-podman-args "--cap-drop=all"
-## assert-podman-args "--read-only"
-## !assert-podman-args "--read-only-tmpfs=false"
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
 ## assert-key-is "Service" "KillMode" "mixed"
 ## assert-key-is "Service" "Delegate" "yes"

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -5,7 +5,6 @@
 ## assert-podman-args "--replace"
 ## assert-podman-args "-d"
 ## assert-podman-args "--log-driver" "passthrough"
-## assert-podman-args "--pull=never"
 ## assert-podman-args "--runtime" "/usr/bin/crun"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"

--- a/test/e2e/quadlet/capabilities.container
+++ b/test/e2e/quadlet/capabilities.container
@@ -5,7 +5,5 @@
 
 [Container]
 Image=localhost/imagename
-# Verify that we can reset to the default cap set
-DropCapability=
 AddCapability=CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
 AddCapability=CAP_IPC_OWNER

--- a/test/e2e/quadlet/readonly-notmpfs.container
+++ b/test/e2e/quadlet/readonly-notmpfs.container
@@ -3,4 +3,5 @@
 
 [Container]
 Image=localhost/imagename
+ReadOnly=yes
 VolatileTmp=no


### PR DESCRIPTION
Revert all quadlet custom defaults to whatever `podman run` does. 

No release notes should be needed, as we have the initial quadlet release note covering this.
```release-note
None
```
