### PR TITLE
play kube: Add --wait option

### DIFF
--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -52,5 +52,5 @@ func down(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return teardown(reader, entities.PlayKubeDownOptions{Force: downOptions.Force}, false)
+	return teardown(reader, entities.PlayKubeDownOptions{Force: downOptions.Force})
 }

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -205,6 +205,18 @@ Start the pod after creating it, set to false to only create it.
 
 @@option userns.container
 
+#### **--wait**, **-w**
+
+Run pods and containers in the foreground. Default is false.
+
+At  any time you can run `podman pod ps` in the other shell to view a list of
+the running pods and containers.
+
+When  attached  in the tty mode, you can kill the pods and containers by pressing
+Ctrl-C or receiving any other interrupt signals.
+
+Volumes created with `podman kube play` will be removed when `--wait=true`.
+
 ## EXAMPLES
 
 Recreate the pod and containers as described in a file called `demo.yml`

--- a/libpod/service.go
+++ b/libpod/service.go
@@ -134,10 +134,12 @@ func (p *Pod) maybeStopServiceContainer() error {
 			return
 		}
 		logrus.Debugf("Stopping service container %s", serviceCtr.ID())
-		if err := serviceCtr.Stop(); err != nil {
-			if !errors.Is(err, define.ErrCtrStopped) {
-				logrus.Errorf("Stopping service container %s: %v", serviceCtr.ID(), err)
-			}
+		if err := serviceCtr.Stop(); err != nil && !errors.Is(err, define.ErrCtrStopped) {
+			// Log this in debug mode so that we don't print out an error and confuse the user
+			// when the service container can't be stopped because it is in created state
+			// This can happen when an error happens during kube play and we are trying to
+			// clean up after the error.
+			logrus.Debugf("Error stopping service container %s: %v", serviceCtr.ID(), err)
 		}
 	})
 	return nil

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -27,6 +27,7 @@ var (
 	handlerOrder    []string
 	shutdownInhibit sync.RWMutex
 	logrus          = logrusImport.WithField("PID", os.Getpid())
+	ErrNotStarted   = errors.New("shutdown signal handler has not yet been started")
 )
 
 // Start begins handling SIGTERM and SIGINT and will run the given on-signal
@@ -84,7 +85,7 @@ func Start() error {
 // Stop the shutdown signal handler.
 func Stop() error {
 	if cancelChan == nil {
-		return errors.New("shutdown signal handler has not yet been started")
+		return ErrNotStarted
 	}
 	if stopped {
 		return nil

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -19,16 +19,18 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		Annotations  map[string]string `schema:"annotations"`
-		Network      []string          `schema:"network"`
-		TLSVerify    bool              `schema:"tlsVerify"`
-		LogDriver    string            `schema:"logDriver"`
-		LogOptions   []string          `schema:"logOptions"`
-		Start        bool              `schema:"start"`
-		StaticIPs    []string          `schema:"staticIPs"`
-		StaticMACs   []string          `schema:"staticMACs"`
-		NoHosts      bool              `schema:"noHosts"`
-		PublishPorts []string          `schema:"publishPorts"`
+		Annotations      map[string]string `schema:"annotations"`
+		Network          []string          `schema:"network"`
+		TLSVerify        bool              `schema:"tlsVerify"`
+		LogDriver        string            `schema:"logDriver"`
+		LogOptions       []string          `schema:"logOptions"`
+		Start            bool              `schema:"start"`
+		StaticIPs        []string          `schema:"staticIPs"`
+		StaticMACs       []string          `schema:"staticMACs"`
+		NoHosts          bool              `schema:"noHosts"`
+		PublishPorts     []string          `schema:"publishPorts"`
+		Wait             bool              `schema:"wait"`
+		ServiceContainer bool              `schema:"serviceContainer"`
 	}{
 		TLSVerify: true,
 		Start:     true,
@@ -83,19 +85,21 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := entities.PlayKubeOptions{
-		Annotations:  query.Annotations,
-		Authfile:     authfile,
-		Username:     username,
-		Password:     password,
-		Networks:     query.Network,
-		NoHosts:      query.NoHosts,
-		Quiet:        true,
-		LogDriver:    logDriver,
-		LogOptions:   query.LogOptions,
-		StaticIPs:    staticIPs,
-		StaticMACs:   staticMACs,
-		IsRemote:     true,
-		PublishPorts: query.PublishPorts,
+		Annotations:      query.Annotations,
+		Authfile:         authfile,
+		Username:         username,
+		Password:         password,
+		Networks:         query.Network,
+		NoHosts:          query.NoHosts,
+		Quiet:            true,
+		LogDriver:        logDriver,
+		LogOptions:       query.LogOptions,
+		StaticIPs:        staticIPs,
+		StaticMACs:       staticMACs,
+		IsRemote:         true,
+		PublishPorts:     query.PublishPorts,
+		Wait:             query.Wait,
+		ServiceContainer: query.ServiceContainer,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -37,6 +37,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    default: true
 	//    description: Start the pod after creating it.
 	//  - in: query
+	//    name: serviceContainer
+	//    type: boolean
+	//    default: false
+	//    description: Starts a service container before all pods.
+	//  - in: query
 	//    name: staticIPs
 	//    type: array
 	//    description: Static IPs used for the pods.
@@ -48,6 +53,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    description: Static MACs used for the pods.
 	//    items:
 	//      type: string
+	//  - in: query
+	//    name: wait
+	//    type: boolean
+	//    default: false
+	//    description: Clean up all objects created when a SIGTERM is received or pods exit.
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -50,6 +50,9 @@ type PlayOptions struct {
 	Force *bool
 	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
 	PublishPorts []string
+	// // Wait - indicates whether to return after having created the pods
+	Wait             *bool
+	ServiceContainer *bool
 }
 
 // ApplyOptions are optional options for applying kube YAML files to a k8s cluster

--- a/pkg/bindings/kube/types_play_options.go
+++ b/pkg/bindings/kube/types_play_options.go
@@ -317,3 +317,33 @@ func (o *PlayOptions) GetPublishPorts() []string {
 	}
 	return o.PublishPorts
 }
+
+// WithWait set field Wait to given value
+func (o *PlayOptions) WithWait(value bool) *PlayOptions {
+	o.Wait = &value
+	return o
+}
+
+// GetWait returns value of field Wait
+func (o *PlayOptions) GetWait() bool {
+	if o.Wait == nil {
+		var z bool
+		return z
+	}
+	return *o.Wait
+}
+
+// WithServiceContainer set field ServiceContainer to given value
+func (o *PlayOptions) WithServiceContainer(value bool) *PlayOptions {
+	o.ServiceContainer = &value
+	return o
+}
+
+// GetServiceContainer returns value of field ServiceContainer
+func (o *PlayOptions) GetServiceContainer() bool {
+	if o.ServiceContainer == nil {
+		var z bool
+		return z
+	}
+	return *o.ServiceContainer
+}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -64,6 +64,8 @@ type PlayKubeOptions struct {
 	Force bool
 	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
 	PublishPorts []string
+	// Wait - indicates whether to return after having created the pods
+	Wait bool
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube
@@ -94,7 +96,10 @@ type PlayKubeReport struct {
 	// Volumes - volumes created by play kube.
 	Volumes []PlayKubeVolume
 	PlayKubeTeardown
+	// Secrets - secrets created by play kube
 	Secrets []PlaySecret
+	// ServiceContainerID - ID of the service container if one is created
+	ServiceContainerID string
 }
 
 type KubePlayReport = PlayKubeReport

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -58,7 +58,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts en
 	options := new(kube.PlayOptions).WithAuthfile(opts.Authfile).WithUsername(opts.Username).WithPassword(opts.Password)
 	options.WithCertDir(opts.CertDir).WithQuiet(opts.Quiet).WithSignaturePolicy(opts.SignaturePolicy).WithConfigMaps(opts.ConfigMaps)
 	options.WithLogDriver(opts.LogDriver).WithNetwork(opts.Networks).WithSeccompProfileRoot(opts.SeccompProfileRoot)
-	options.WithStaticIPs(opts.StaticIPs).WithStaticMACs(opts.StaticMACs)
+	options.WithStaticIPs(opts.StaticIPs).WithStaticMACs(opts.StaticMACs).WithWait(opts.Wait).WithServiceContainer(opts.ServiceContainer)
 	if len(opts.LogOptions) > 0 {
 		options.WithLogOptions(opts.LogOptions)
 	}


### PR DESCRIPTION
Add a way to keep play kube running in the foreground and terminating all pods
after receiving a a SIGINT or SIGTERM signal. The pods will also be
cleaned up after the containers in it have exited.
If an error occurrs during kube play, any resources created till the
error point will be cleane up also.

Add tests for the various scenarios.

Fixes https://github.com/containers/podman/issues/14522

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Add new --wait flag to podman kube play command

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add new --wait flag to podman kube play command that keeps workload running in foreground until killed with a sigkill or sigterm. The workloads are cleaned up and removed when killed.
```
