### PR TITLE
Add completion for --init-ctr

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -906,6 +906,13 @@ func AutocompleteImageFormat(cmd *cobra.Command, args []string, toComplete strin
 	return ImageFormat, cobra.ShellCompDirectiveNoFileComp
 }
 
+// AutocompleteInitCtr - Autocomplete init container type
+// -> "once", "always"
+func AutocompleteInitCtr(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	InitCtrType := []string{define.AlwaysInitContainer, define.OneShotInitContainer}
+	return InitCtrType, cobra.ShellCompDirectiveNoFileComp
+}
+
 // AutocompleteCreateAttach - Autocomplete create --attach options.
 // -> "stdin", "stdout", "stderr"
 func AutocompleteCreateAttach(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
 	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -69,6 +68,7 @@ func createFlags(cmd *cobra.Command) {
 		initContainerFlagName, "",
 		"Make this a pod init container.",
 	)
+	_ = cmd.RegisterFlagCompletionFunc(initContainerFlagName, common.AutocompleteInitCtr)
 
 	flags.SetInterspersed(false)
 	common.DefineCreateDefaults(&cliVals)
@@ -86,8 +86,6 @@ func createFlags(cmd *cobra.Command) {
 
 		_ = flags.MarkHidden("pidfile")
 	}
-
-	_ = cmd.RegisterFlagCompletionFunc(initContainerFlagName, completion.AutocompleteDefault)
 }
 
 func init() {


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
--init-ctr completions now work.
```
[NO NEW TESTS NEEDED] Since I don't know how to test completions.