### PR TITLE
Add a FreeBSD cross build to the cirrus alt build task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -369,6 +369,8 @@ alt_build_task:
             ALT_NAME: 'Test build podman-next Copr RPM'
       - env:
             ALT_NAME: 'Alt Arch. Cross'
+      - env:
+            ALT_NAME: 'FreeBSD Cross'
     # This task cannot make use of the shared repo.tbz artifact.
     clone_script: *full_clone
     setup_script: *setup

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -283,6 +283,9 @@ function _run_altbuild() {
         *RPM*)
             make package
             ;;
+        FreeBSD*Cross)
+            make bin/podman.cross.freebsd.amd64
+            ;;
         Alt*Cross)
             arches=(\
                 amd64


### PR DESCRIPTION
This just verifies that a non-cgo podman binary can build for FreeBSD.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

```release-note
None
```
