### PR TITLE
Quadlet Kube: Add support for relative path for YAML file

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -2,6 +2,7 @@ package quadlet
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -615,6 +616,18 @@ func ConvertKube(kube *parser.UnitFile) (*parser.UnitFile, error) {
 	yamlPath, ok := kube.Lookup(KubeGroup, KeyYaml)
 	if !ok || len(yamlPath) == 0 {
 		return nil, fmt.Errorf("no Yaml key specified")
+	}
+
+	if !filepath.IsAbs(yamlPath) {
+		if len(kube.Path) > 0 {
+			yamlPath = filepath.Join(filepath.Dir(kube.Path), yamlPath)
+		} else {
+			var err error
+			yamlPath, err = filepath.Abs(yamlPath)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Only allow mixed or control-group, as nothing else works well

--- a/test/e2e/quadlet/absolute.path.kube
+++ b/test/e2e/quadlet/absolute.path.kube
@@ -1,17 +1,17 @@
 ## assert-podman-args "kube"
 ## assert-podman-args "play"
-## assert-podman-final-args-regex /tmp/podman_test.*/quadlet/deployment.yml
+## assert-podman-final-args /opt/k8s/deployment.yml
 ## assert-podman-args "--replace"
 ## assert-podman-args "--service-container=true"
 ## assert-podman-stop-args "kube"
 ## assert-podman-stop-args "down"
-## assert-podman-stop-final-args-regex /tmp/podman_test.*/quadlet/deployment.yml
+## assert-podman-stop-final-args /opt/k8s/deployment.yml
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
 ## assert-key-is "Service" "KillMode" "mixed"
 ## assert-key-is "Service" "Type" "notify"
 ## assert-key-is "Service" "NotifyAccess" "all"
 ## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
-## assert-key-is "Service" "SyslogIdentifier" "%N"
+
 
 [Kube]
-Yaml=deployment.yml
+Yaml=/opt/k8s/deployment.yml

--- a/test/e2e/quadlet/syslog.identifier.kube
+++ b/test/e2e/quadlet/syslog.identifier.kube
@@ -1,16 +1,3 @@
-## assert-podman-args "kube"
-## assert-podman-args "play"
-## assert-podman-final-args deployment.yml
-## assert-podman-args "--replace"
-## assert-podman-args "--service-container=true"
-## assert-podman-stop-args "kube"
-## assert-podman-stop-args "down"
-## assert-podman-stop-final-args deployment.yml
-## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
-## assert-key-is "Service" "KillMode" "mixed"
-## assert-key-is "Service" "Type" "notify"
-## assert-key-is "Service" "NotifyAccess" "all"
-## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
 ## assert-key-is "Service" "SyslogIdentifier" "mytest"
 
 [Service]


### PR DESCRIPTION
If the provided path is relative, turn path to absolute
Add regex verification option in tests

Resolves #16590 

#### Does this PR introduce a user-facing change?
No since Quadlet was not released yet

```release-note
None
```
