### PR TITLE
[CI:DOCS] Add warning about --opts,o with mount's -o

### DIFF
--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -46,12 +46,15 @@ The `type` option sets the type of the filesystem to be mounted, and is equivale
 The `device` option sets the device to be mounted, and is equivalent to the `device` argument to **mount(8)**.
 The `copy` option enables copying files from the container image path where the mount is created to the newly created volume on the first run.  `copy` is the default.
 
-The `o` option sets options for the mount, and is equivalent to the `-o` flag to **mount(8)** with these exceptions:
+The `o` option sets options for the mount, and is equivalent to the filesystem
+options (also `-o`) passed to **mount(8)** with the following exceptions:
 
   - The `o` option supports `uid` and `gid` options to set the UID and GID of the created volume that are not normally supported by **mount(8)**.
   - The `o` option supports the `size` option to set the maximum size of the created volume, the `inodes` option to set the maximum number of inodes for the volume and `noquota` to completely disable quota support even for tracking of disk usage. Currently these flags are only supported on "xfs" file system mounted with the `prjquota` flag described in the **xfs_quota(8)** man page.
   - The `o` option supports using volume options other than the UID/GID options with the **local** driver and requires root privileges.
   - The `o` options supports the `timeout` option which allows users to set a driver specific timeout in seconds before volume creation fails. For example, **--opts=o=timeout=10** sets a driver timeout of 10 seconds.
+
+***Note*** Do not confuse the `--opts,-o` create option with the `-o` mount option.  For example, with `podman volume create`, use `-o=o=uid=1000` *not* `-o=uid=1000`.
 
 For the **image** driver, the only supported option is `image`, which specifies the image the volume is based on.
 This option is mandatory when using the **image** driver.


### PR DESCRIPTION
Ref: https://github.com/containers/podman/issues/16576

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
