### PR TITLE
[CI:DOCS] Clarify secret target behavior

### DIFF
--- a/docs/source/markdown/options/secret.md
+++ b/docs/source/markdown/options/secret.md
@@ -19,8 +19,28 @@ Secrets and its storage are managed using the `podman secret` command.
 
 Secret Options
 
-- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
-- `target=target`     : Target of secret. Defaults to secret name.
+- `type=mount|env`    : How the secret will be exposed to the container.
+                        `mount` mounts the secret into the container as a file.
+                        `env` exposes the secret as a environment variable.
+                        Defaults to `mount`.
+- `target=target`     : Target of secret.
+                        For mounted secrets, this is the path to the secret inside the container.
+                        If a fully qualified path is provided, the secret will be mounted at that location.
+                        Otherwise, the secret will be mounted to `/run/secrets/target`.
+                        If target is not set, by default the secret will be mounted to `/run/secrets/secretname`.
+                        For env secrets, this is the environment variable key. Defaults to `secretname`.
 - `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
 - `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
 - `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.
+
+
+Examples
+
+Mount at `/my/location/mysecret` with UID 1.
+```--secret mysecret,target=/my/location/mysecret,uid=1```
+
+Mount at `/run/secrets/customtarget` with mode 0777.
+```--secret mysecret,target=customtarget,mode=0777```
+
+Create a secret environment variable called `ENVSEC`.
+```--secret mysecret,type=env,target=ENVSEC```


### PR DESCRIPTION
Add documentation on how the the target option works when adding a secret to a container

Signed-off-by: Ashley Cui <acui@redhat.com>

Closes: https://github.com/containers/podman/issues/16649

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
