### PR TITLE
compat API: allow MacAddress on container config

### DIFF
--- a/test/compose/ipam_set_ip/docker-compose.yml
+++ b/test/compose/ipam_set_ip/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.2"
 services:
   test:
     image: alpine
+    mac_address: 32:b5:b2:55:48:72
     networks:
       net1:
         ipv4_address: 10.123.0.253

--- a/test/compose/ipam_set_ip/tests.sh
+++ b/test/compose/ipam_set_ip/tests.sh
@@ -5,4 +5,6 @@ if [ "$TEST_FLAVOR" = "compose_v2" ]; then
     ctr_name="ipam_set_ip-test-1"
 fi
 podman container inspect "$ctr_name" --format '{{ .NetworkSettings.Networks.ipam_set_ip_net1.IPAddress }}'
-like "$output" "10.123.0.253" "$testname : ip address is set"
+is "$output" "10.123.0.253" "$testname : ip address is set"
+podman container inspect "$ctr_name" --format '{{ .NetworkSettings.Networks.ipam_set_ip_net1.MacAddress }}'
+is "$output" "32:b5:b2:55:48:72" "$testname : mac address is set"


### PR DESCRIPTION
docker-compose sets the mac address in the container config and not the network endpoint config. This is ugly when you have more than one network, in this case docker just chooses the first network.

Fixes #16411


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support the mac address field in the container config for the compat API, this ensures that the static mac from the docker-compose.yml is used.
```
