### PR TITLE
network create: support "-o parent=XXX" for ipvlan

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -125,7 +125,7 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 		logrus.Warn("The --macvlan option is deprecated, use `--driver macvlan --opt parent=<device>` instead")
 		network.Driver = types.MacVLANNetworkDriver
 		network.NetworkInterface = networkCreateOptions.MacVLAN
-	} else if networkCreateOptions.Driver == types.MacVLANNetworkDriver {
+	} else if networkCreateOptions.Driver == types.MacVLANNetworkDriver || networkCreateOptions.Driver == types.IPVLANNetworkDriver {
 		// new -d macvlan --opt parent=... syntax
 		if parent, ok := network.Options["parent"]; ok {
 			network.NetworkInterface = parent

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -658,6 +658,35 @@ var _ = Describe("Podman network", func() {
 		Expect(nc).Should(Exit(0))
 	})
 
+	It("podman network create/remove ipvlan as driver (-d) with device name", func() {
+		// Netavark currently does not support ipvlan
+		SkipIfNetavark(podmanTest)
+		net := "ipvlan" + stringid.GenerateRandomID()
+		nc := podmanTest.Podman([]string{"network", "create", "-d", "ipvlan", "-o", "parent=lo", net})
+		nc.WaitWithDefaultTimeout()
+		defer podmanTest.removeNetwork(net)
+		Expect(nc).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"network", "inspect", net})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+
+		var results []types.Network
+		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		result := results[0]
+
+		Expect(result).To(HaveField("Driver", "ipvlan"))
+		Expect(result).To(HaveField("NetworkInterface", "lo"))
+		Expect(result.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
+		Expect(result.Subnets).To(HaveLen(0))
+
+		nc = podmanTest.Podman([]string{"network", "rm", net})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc).Should(Exit(0))
+	})
+
 	It("podman network exists", func() {
 		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})


### PR DESCRIPTION
Just like macvlan the ipvlan driver accepts a specific parent interface.

Fixes #16621


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Accept the `--opt parent=...` option  in podman network create with the ipvlan network driver.
```
