### PR TITLE
Quadlet Kube: Add support for userns flag

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -336,7 +336,7 @@ func main() {
 		case strings.HasSuffix(name, ".volume"):
 			service, err = quadlet.ConvertVolume(unit, name)
 		case strings.HasSuffix(name, ".kube"):
-			service, err = quadlet.ConvertKube(unit)
+			service, err = quadlet.ConvertKube(unit, isUser)
 		default:
 			Logf("Unsupported file type '%s'", name)
 			continue

--- a/test/e2e/quadlet/remap-auto.kube
+++ b/test/e2e/quadlet/remap-auto.kube
@@ -1,0 +1,5 @@
+## assert-podman-args --userns=auto
+
+[Kube]
+Yaml=/opt/k8s/deployment.yml
+RemapUsers=auto

--- a/test/e2e/quadlet/remap-auto2.kube
+++ b/test/e2e/quadlet/remap-auto2.kube
@@ -1,0 +1,10 @@
+## assert-podman-args "--userns=auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
+
+[Kube]
+Yaml=/opt/k8s/deployment.yml
+RemapUsers=auto
+RemapUid=0:10000:10
+RemapUid=10:20000:10
+RemapGid=0:10000:10
+RemapGid=10:20000:10
+RemapUidSize=20

--- a/test/e2e/quadlet/remap-manual.kube
+++ b/test/e2e/quadlet/remap-manual.kube
@@ -1,0 +1,10 @@
+## assert-failed
+## assert-stderr-contains "RemapUsers=manual is not supported"
+
+[Kube]
+Yaml=/opt/k8s/deployment.yml
+RemapUsers=manual
+RemapUid=0:10000:10
+RemapUid=10:20000:10
+RemapGid=0:10000:10
+RemapGid=10:20000:10

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -359,6 +359,9 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("Basic kube", "basic.kube"),
 		Entry("Syslog Identifier", "syslog.identifier.kube"),
 		Entry("Absolute Path", "absolute.path.kube"),
+		Entry("Kube - User Remap Manual", "remap-manual.kube"),
+		Entry("Kube - User Remap Auto", "remap-auto.kube"),
+		Entry("Kube - User Remap Auto with IDs", "remap-auto2.kube"),
 	)
 
 })


### PR DESCRIPTION
Move the handling of userns keys from ConvertContainer to a separate method
Adjust the method according to the different supported values
Use the new method in both ConvertContainer and ConvertKube 
Pass isUser to ConvertKube as well
Add tests

Signed-off-by: Ygal Blum <ygal.blum@gmail.com>

#### Does this PR introduce a user-facing change?
No

```release-note
None
```
Resolves #16594 
