### PR TITLE
disable healthchecks automatically on non systemd systems

### DIFF
--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -432,27 +432,3 @@ func (c *Container) healthCheckStatus() (string, error) {
 
 	return results.Status, nil
 }
-
-func (c *Container) disableHealthCheckSystemd(isStartup bool) bool {
-	if os.Getenv("DISABLE_HC_SYSTEMD") == "true" {
-		return true
-	}
-	if isStartup {
-		if c.config.StartupHealthCheckConfig.Interval == 0 {
-			return true
-		}
-	}
-	if c.config.HealthCheckConfig.Interval == 0 {
-		return true
-	}
-	return false
-}
-
-// Systemd unit name for the healthcheck systemd unit
-func (c *Container) hcUnitName(isStartup bool) string {
-	unitName := c.ID()
-	if isStartup {
-		unitName += "-startup"
-	}
-	return unitName
-}

--- a/libpod/healthcheck_nosystemd_linux.go
+++ b/libpod/healthcheck_nosystemd_linux.go
@@ -1,0 +1,24 @@
+//go:build !systemd
+// +build !systemd
+
+package libpod
+
+import (
+	"context"
+)
+
+// createTimer systemd timers for healthchecks of a container
+func (c *Container) createTimer(interval string, isStartup bool) error {
+	return nil
+}
+
+// startTimer starts a systemd timer for the healthchecks
+func (c *Container) startTimer(isStartup bool) error {
+	return nil
+}
+
+// removeTransientFiles removes the systemd timer and unit files
+// for the container
+func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool) error {
+	return nil
+}


### PR DESCRIPTION
The podman healthchecks are implemented using systemd timers, this works great but it will never work on non system distros. Currently the logic always assumes systemd is available and will fail with an error, so users are forced to always run with `--no-healthcheck` to disable healthchecks that are defined in an image for example. This is annoying and IMO unessesary, we should just default to no healthcheck on these systems.

First, use the systemd build tag to disable it at build time if this tag is not used.
Second, use make sure systemd is used as init before trying to use healthchecks. This could be the case when we are run in a container.

[NO NEW TESTS NEEDED] We do not have any non systemd VMs in CI AFAIK.

Fixes #16644

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Healthchecks are automatically disabled if your system does not run systemd. If podman is compiled without systemd build tag, healthcheck will be disabled at build time.
```
