### PR TITLE
Cleanup kube play workloads if error happens

### DIFF
--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -52,5 +52,5 @@ func down(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return teardown(reader, entities.PlayKubeDownOptions{Force: downOptions.Force})
+	return teardown(reader, entities.PlayKubeDownOptions{Force: downOptions.Force}, false)
 }


### PR DESCRIPTION
If an error happening while playing a kube yaml,
clean up any pods, containers, and volumes that might have been created before the error was hit.
This improves the user experience for when they go to re-run the same yaml with their fixes and podman doesn't complain about any existing workloads from the previously failed run.

Suppress the clean up output when clean up happens after an error as the user doesn't need to see or know about that.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Clean up containers, pods, and volumes if an error happens while playing a kube yaml file.
```
