### PR TITLE
[skip-ci] GHA/Cirrus-cron: Fix execution order

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -11,7 +11,7 @@ on:
         # N/B: This should correspond to a period slightly after
         # the last job finishes running.  See job defs. at:
         # https://cirrus-ci.com/settings/repository/6707778565701632
-        - cron:  '59 23 * * 1-5'
+        - cron:  '03 03 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
     # Allow re-use of this workflow by other repositories

--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -10,7 +10,7 @@ on:
     schedule:
         # N/B: This should fire about an hour prior to check_cirrus_cron
         # so the re-runs have a chance to complete.
-        - cron:  '05 22 * * 1-5'
+        - cron:  '01 01 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
     # Allow re-use of this workflow by other repositories


### PR DESCRIPTION
Fairly universally, the last Cirrus-Cron job is set to fire off at 22:22 UTC.  However, the re-run of failed jobs GHA workflow was scheduled for 22:05, meaning it will never re-run the last cirrus-cron job should it fail.

Re-arrange the execution order so as to give plenty of time between the last cirrus-cron job starting, the auto-re-run attempt, and the final failure-check e-mail.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
