### PR TITLE
Makefile: Add podman-mac-helper to darwin client zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -728,11 +728,14 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 	if [[ "$(GOOS)" == "windows" ]]; then \
 		$(MAKE) $(GOPLAT) TMPDIR="" win-sshproxy; \
 	fi
+	if [[ "$(GOOS)" == "darwin" ]]; then \
+		$(MAKE) $(GOPLAT) podman-mac-helper;\
+	fi
 	cp -r ./docs/build/remote/$(GOOS) "$(TMPDIR)/$(SUBDIR)/docs/"
 	cp ./contrib/remote/containers.conf "$(TMPDIR)/$(SUBDIR)/"
 	$(MAKE) $(GOPLAT) $(_DSTARGS) SELINUXOPT="" install.remote
 	cd "$(TMPDIR)" && \
-		zip --recurse-paths "$(CURDIR)/$@" "./"
+		zip --recurse-paths "$(CURDIR)/$@" "./$(SUBDIR)"
 	if [[ "$(GOARCH)" != "$(NATIVE_GOARCH)" ]]; then $(MAKE) clean-binaries; fi
 	-rm -rf "$(TMPDIR)"
 
@@ -795,6 +798,8 @@ install.remote:
 		$(DESTDIR)$(BINDIR)/podman$(BINSFX)
 	test "${GOOS}" != "windows" || \
 		install -m 755 $(SRCBINDIR)/win-sshproxy.exe $(DESTDIR)$(BINDIR)
+	test "${GOOS}" != "darwin" || \
+		install -m 755 $(SRCBINDIR)/podman-mac-helper $(DESTDIR)$(BINDIR)
 	test -z "${SELINUXOPT}" || \
 		chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman-remote \
 		bin/podman-remote


### PR DESCRIPTION
As well as as small fix for zipping the correct folder when building on Mac

Signed-off-by: Ashley Cui <acui@redhat.com>

Closes: #16746

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
