### PR TITLE
e2e: keeps the http_proxy value

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -300,6 +300,11 @@ var _ = Describe("Podman build", func() {
 	})
 
 	It("podman build --http_proxy flag", func() {
+		if env, found := os.LookupEnv("http_proxy"); found {
+			defer os.Setenv("http_proxy", env)
+		} else {
+			defer os.Unsetenv("http_proxy")
+		}
 		os.Setenv("http_proxy", "1.2.3.4")
 		if IsRemote() {
 			podmanTest.StopRemoteService()
@@ -316,7 +321,6 @@ RUN printenv http_proxy`, ALPINE)
 		session.Wait(120)
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("1.2.3.4"))
-		os.Unsetenv("http_proxy")
 	})
 
 	It("podman build relay exit code to process", func() {

--- a/test/e2e/run_env_test.go
+++ b/test/e2e/run_env_test.go
@@ -121,6 +121,11 @@ ENV hello=world
 	})
 
 	It("podman run --http-proxy test", func() {
+		if env, found := os.LookupEnv("http_proxy"); found {
+			defer os.Setenv("http_proxy", env)
+		} else {
+			defer os.Unsetenv("http_proxy")
+		}
 		os.Setenv("http_proxy", "1.2.3.4")
 		if IsRemote() {
 			podmanTest.StopRemoteService()
@@ -140,12 +145,10 @@ ENV hello=world
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("5.6.7.8"))
-		os.Unsetenv("http_proxy")
 
 		session = podmanTest.Podman([]string{"run", "--http-proxy=false", "--env", "http_proxy=5.6.7.8", ALPINE, "printenv", "http_proxy"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("5.6.7.8"))
-		os.Unsetenv("http_proxy")
 	})
 })


### PR DESCRIPTION
In a proxy environment, `http_proxy` needs to keep
the value to use a proxy.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
