### PR TITLE
Pick a random port on the host for play kube deployments

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -349,6 +349,15 @@ func (ic *ContainerEngine) playKubeDeployment(ctx context.Context, deploymentYAM
 
 	// create "replicas" number of pods
 	var notifyProxies []*notifyproxy.NotifyProxy
+	if numReplicas > 1 {
+		for _, container := range deploymentYAML.Spec.Template.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.HostPort != 0 {
+					return nil, nil, errors.New("deployment has a hostPort defined and multiple replicas are involved")
+				}
+			}
+		}
+	}
 	for i = 0; i < numReplicas; i++ {
 		podName := fmt.Sprintf("%s-pod-%d", deploymentName, i)
 		podReport, proxies, err := ic.playKubePod(ctx, podName, &podSpec, options, ipIndex, deploymentYAML.Annotations, configMaps, serviceContainer)

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -565,3 +565,36 @@ spec:
     run_podman pod rm -a -f
     run_podman rm -a -f
 }
+
+@test "podman kube play - hostport and replicas" {
+    echo "
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test_pod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - name: server
+          image: $IMAGE
+          ports:
+            - name: hostp
+              containerPort: 8080
+              hostPort: 8080
+" > "$PODMAN_TMPDIR/testpod.yaml"
+
+    run_podman 125 kube play "$PODMAN_TMPDIR/testpod.yaml"
+    is "$output" ".*deployment has a hostPort defined and multiple replicas are involved*"
+
+    run_podman pod rm -a -f
+    run_podman rm -a -f
+}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
Pick a random port on the host when exposing `containerPort`s for `podman play kube`
```

`podman play kube` started to expose the port of containers in k8s deployments on the same port on the host with https://github.com/containers/podman/pull/15946. However, that breaks once replicas are involved, as they would then bind to the same port on the host.

With this PR, we change the default behavior so that podman will pick a random port for the container instead of using `containerPort`, but only if no `hostPort` is set.

As this can lead to user-unfriendly error messages, if the user sets `hostPort` and `replicas > 1`, we provide a better error message for that case.