### PR TITLE
fix: event read from syslog when syslog entry too long

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -101,6 +101,10 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 			logrus.Errorf("Unable to close journal :%v", err)
 		}
 	}()
+	err = j.SetDataThreshold(0)
+	if err != nil {
+		logrus.Warnf("cannot set data threshold: %v", err)
+	}
 	// match only podman journal entries
 	podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"}
 	if err := j.AddMatch(podmanJournal.String()); err != nil {


### PR DESCRIPTION
When labels map is too big we may get syslog entry truncated.
This breaks JSON parsing making event loading impossible.

```
ERRO[0016] Unable to decode event: unexpected end of JSON input
```

By default the limit is 64KiB, this PR set it to 0 == unlimited.


```release-note
fix: increased event syslog deserialization buffer 
```

related to:
* https://github.com/containers/podman/issues/16834
* https://github.com/containers/container-selinux/pull/196