### PR TITLE
Do not chown newly created volume sources

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1700,7 +1700,7 @@ func WithVolumeUID(uid int) VolumeCreateOption {
 			return define.ErrVolumeFinalized
 		}
 
-		volume.config.UID = uid
+		volume.config.UID = &uid
 
 		return nil
 	}
@@ -1739,7 +1739,7 @@ func WithVolumeGID(gid int) VolumeCreateOption {
 			return define.ErrVolumeFinalized
 		}
 
-		volume.config.GID = gid
+		volume.config.GID = &gid
 
 		return nil
 	}

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -46,9 +46,9 @@ type VolumeConfig struct {
 	// Whether this volume is anonymous (will be removed on container exit)
 	IsAnon bool `json:"isAnon"`
 	// UID the volume will be created as.
-	UID int `json:"uid"`
+	UID *int `json:"uid"`
 	// GID the volume will be created as.
-	GID int `json:"gid"`
+	GID *int `json:"gid"`
 	// Size maximum of the volume.
 	Size uint64 `json:"size"`
 	// Inodes maximum of the volume.
@@ -200,7 +200,10 @@ func (v *Volume) uid() int {
 	if v.state.UIDChowned > 0 {
 		return v.state.UIDChowned
 	}
-	return v.config.UID
+	if v.config.UID == nil {
+		return -1
+	}
+	return *v.config.UID
 }
 
 // GID returns the GID the volume will be created as.
@@ -220,7 +223,10 @@ func (v *Volume) gid() int {
 	if v.state.GIDChowned > 0 {
 		return v.state.GIDChowned
 	}
-	return v.config.GID
+	if v.config.GID == nil {
+		return -1
+	}
+	return *v.config.GID
 }
 
 // CreatedTime returns the time the volume was created at. It was not tracked


### PR DESCRIPTION
When running containers with

podman run --userns=keep-id --userns $UID:$GID -v test:/tmp/test ...

The volumes directory ends up being owned by root within the user namespace, which is not root of the general namespace nor the users uid.

If we just allow podman to create these directories with the same UID that is running podman, IE don't chown, they end up with the correct UID in all cases.

The actual volume will be chowned to the UID of the container.

Fixes: https://github.com/containers/podman/issues/16741

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Builtin volumes with --userns=keep-id will get proper permissions.
```
