### PR TITLE
health check: ignore dependencies of transient systemd units/timers

### DIFF
--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -111,7 +111,7 @@ func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool) er
 	// fire after the service is stopped.
 	timerChan := make(chan string)
 	timerFile := fmt.Sprintf("%s.timer", c.hcUnitName(isStartup))
-	if _, err := conn.StopUnitContext(ctx, timerFile, "fail", timerChan); err != nil {
+	if _, err := conn.StopUnitContext(ctx, timerFile, "ignore-dependencies", timerChan); err != nil {
 		if !strings.HasSuffix(err.Error(), ".timer not loaded.") {
 			stopErrors = append(stopErrors, fmt.Errorf("removing health-check timer %q: %w", timerFile, err))
 		}
@@ -126,7 +126,7 @@ func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool) er
 	if err := conn.ResetFailedUnitContext(ctx, serviceFile); err != nil {
 		logrus.Debugf("Failed to reset unit file: %q", err)
 	}
-	if _, err := conn.StopUnitContext(ctx, serviceFile, "fail", serviceChan); err != nil {
+	if _, err := conn.StopUnitContext(ctx, serviceFile, "ignore-dependencies", serviceChan); err != nil {
 		if !strings.HasSuffix(err.Error(), ".service not loaded.") {
 			stopErrors = append(stopErrors, fmt.Errorf("removing health-check service %q: %w", serviceFile, err))
 		}


### PR DESCRIPTION
When stopping the transient systemd timer/unit which powers running health checks, make sure to ignore its dependencies.  It turns out that we're otherwise running into a timeout when running a container in a systemd unit and reboot.

An alternative may be to further tweak some attributes/options when creating the timer/unit via systemd-run but it seems safe to just ignore the dependencies and stop.

[NO NEW TESTS NEEDED] - we don't yet have means to test reboots.

Fixes: #14531
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where system shutdown would be delayed when running health checks on containers running in a systemd unit.
```
