### PR TITLE
podman play kube support container startup probe

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -523,6 +523,7 @@ func probeToHealthConfig(probe *v1.Probe) (*manifest.Schema2HealthConfig, error)
 	// configure healthcheck on the basis of Handler Actions.
 	switch {
 	case probeHandler.Exec != nil:
+		// `makeHealthCheck` function can accept a json array as the command.
 		cmd, err := json.Marshal(probeHandler.Exec.Command)
 		if err != nil {
 			return nil, err
@@ -618,6 +619,8 @@ func makeHealthCheck(inCmd string, interval int32, retries int32, timeout int32,
 			// ...otherwise pass it to "/bin/sh -c" inside the container
 			cmd = []string{define.HealthConfigTestCmdShell}
 			cmd = append(cmd, strings.Split(inCmd, " ")...)
+		} else {
+			cmd = append([]string{define.HealthConfigTestCmd}, cmd...)
 		}
 	}
 	hc := manifest.Schema2HealthConfig{

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -219,6 +219,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure livenessProbe: %w", err)
 	}
+	err = setupStartupProbe(s, opts.Container, opts.RestartPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure startupProbe: %w", err)
+	}
 
 	// Since we prefix the container name with pod name to work-around the uniqueness requirement,
 	// the seccomp profile should reference the actual container name from the YAML
@@ -511,6 +515,40 @@ func parseMountPath(mountPath string, readOnly bool, propagationMode *v1.MountPr
 	return dest, opts, nil
 }
 
+func probeToHealthConfig(probe *v1.Probe) (*manifest.Schema2HealthConfig, error) {
+	var commandString string
+	failureCmd := "exit 1"
+	probeHandler := probe.Handler
+
+	// configure healthcheck on the basis of Handler Actions.
+	switch {
+	case probeHandler.Exec != nil:
+		cmd, err := json.Marshal(probeHandler.Exec.Command)
+		if err != nil {
+			return nil, err
+		}
+		commandString = string(cmd)
+	case probeHandler.HTTPGet != nil:
+		// set defaults as in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes
+		uriScheme := v1.URISchemeHTTP
+		if probeHandler.HTTPGet.Scheme != "" {
+			uriScheme = probeHandler.HTTPGet.Scheme
+		}
+		host := "localhost" // Kubernetes default is host IP, but with Podman there is only one node
+		if probeHandler.HTTPGet.Host != "" {
+			host = probeHandler.HTTPGet.Host
+		}
+		path := "/"
+		if probeHandler.HTTPGet.Path != "" {
+			path = probeHandler.HTTPGet.Path
+		}
+		commandString = fmt.Sprintf("curl -f %s://%s:%d%s || %s", uriScheme, host, probeHandler.HTTPGet.Port.IntValue(), path, failureCmd)
+	case probeHandler.TCPSocket != nil:
+		commandString = fmt.Sprintf("nc -z -v %s %d || %s", probeHandler.TCPSocket.Host, probeHandler.TCPSocket.Port.IntValue(), failureCmd)
+	}
+	return makeHealthCheck(commandString, probe.PeriodSeconds, probe.FailureThreshold, probe.TimeoutSeconds, probe.InitialDelaySeconds)
+}
+
 func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, restartPolicy string) error {
 	var err error
 	if containerYAML.LivenessProbe == nil {
@@ -518,37 +556,41 @@ func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, re
 	}
 	emptyHandler := v1.Handler{}
 	if containerYAML.LivenessProbe.Handler != emptyHandler {
-		var commandString string
-		failureCmd := "exit 1"
-		probe := containerYAML.LivenessProbe
-		probeHandler := probe.Handler
-
-		// configure healthcheck on the basis of Handler Actions.
-		switch {
-		case probeHandler.Exec != nil:
-			execString := strings.Join(probeHandler.Exec.Command, " ")
-			commandString = fmt.Sprintf("%s || %s", execString, failureCmd)
-		case probeHandler.HTTPGet != nil:
-			// set defaults as in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes
-			uriScheme := v1.URISchemeHTTP
-			if probeHandler.HTTPGet.Scheme != "" {
-				uriScheme = probeHandler.HTTPGet.Scheme
-			}
-			host := "localhost" // Kubernetes default is host IP, but with Podman there is only one node
-			if probeHandler.HTTPGet.Host != "" {
-				host = probeHandler.HTTPGet.Host
-			}
-			path := "/"
-			if probeHandler.HTTPGet.Path != "" {
-				path = probeHandler.HTTPGet.Path
-			}
-			commandString = fmt.Sprintf("curl -f %s://%s:%d%s || %s", uriScheme, host, probeHandler.HTTPGet.Port.IntValue(), path, failureCmd)
-		case probeHandler.TCPSocket != nil:
-			commandString = fmt.Sprintf("nc -z -v %s %d || %s", probeHandler.TCPSocket.Host, probeHandler.TCPSocket.Port.IntValue(), failureCmd)
-		}
-		s.HealthConfig, err = makeHealthCheck(commandString, probe.PeriodSeconds, probe.FailureThreshold, probe.TimeoutSeconds, probe.InitialDelaySeconds)
+		s.HealthConfig, err = probeToHealthConfig(containerYAML.LivenessProbe)
 		if err != nil {
 			return err
+		}
+		// if restart policy is in place, ensure the health check enforces it
+		if restartPolicy == "always" || restartPolicy == "onfailure" {
+			s.HealthCheckOnFailureAction = define.HealthCheckOnFailureActionRestart
+		}
+		return nil
+	}
+	return nil
+}
+
+func setupStartupProbe(s *specgen.SpecGenerator, containerYAML v1.Container, restartPolicy string) error {
+	if containerYAML.StartupProbe == nil {
+		return nil
+	}
+	emptyHandler := v1.Handler{}
+	if containerYAML.StartupProbe.Handler != emptyHandler {
+		healthConfig, err := probeToHealthConfig(containerYAML.StartupProbe)
+		if err != nil {
+			return err
+		}
+
+		// currently, StartupProbe still an optional feature, and it requires HealthConfig.
+		if s.HealthConfig == nil {
+			probe := containerYAML.StartupProbe
+			s.HealthConfig, err = makeHealthCheck("exit 0", probe.PeriodSeconds, probe.FailureThreshold, probe.TimeoutSeconds, probe.InitialDelaySeconds)
+			if err != nil {
+				return err
+			}
+		}
+		s.StartupHealthConfig = &define.StartupHealthCheck{
+			Schema2HealthConfig: *healthConfig,
+			Successes:           int(containerYAML.StartupProbe.SuccessThreshold),
 		}
 		// if restart policy is in place, ensure the health check enforces it
 		if restartPolicy == "always" || restartPolicy == "onfailure" {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1754,7 +1754,7 @@ var _ = Describe("Podman play kube", func() {
 		inspect.WaitWithDefaultTimeout()
 		healthcheckcmd := inspect.OutputToString()
 		// check if CMD-SHELL based equivalent health check is added to container
-		Expect(healthcheckcmd).To(ContainSubstring("[echo hello]"))
+		Expect(healthcheckcmd).To(ContainSubstring("[CMD echo hello]"))
 	})
 
 	It("podman play kube liveness probe should fail", func() {


### PR DESCRIPTION
I made two changes in this PR.

First, I add the kube startup probe support. Since the container startup probe has already been merged (#13909), I think we can make `kube play` also support this feature.

Second, I change the implementation of the "command probe".
The current command probe implementation doesn't have the same behavior  with k8s; for example:
```yml
livenessProbe:
  exec:
    command:
      - /bin/sh
      - -c
      - curl -f -s localhost:80
```
You will get the following error:
```
{
     "Start": "2022-12-09T17:19:12.724152979+08:00",
     "End": "2022-12-09T17:19:12.753324336+08:00",
     "ExitCode": 1,
     "Output": "curl: try 'curl --help' or 'curl --manual' for more information"
}
```

You can use the following yml to reproduce this problem.
```yml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
spec:
  replicas: 1
  template:
    spec:
      restartPolicy: Never
      containers:
      - name: nginx
        image: docker.io/library/nginx
        livenessProbe:
          exec:
            command:
            - /bin/sh
            - -c
            - curl -f -s localhost:80
          initialDelaySeconds: 0
          periodSeconds: 1
```

That's because the code concat it simply.

https://github.com/containers/podman/blob/02b7866e6000c8f1b5ddbef78bfc008cdecb6ba1/pkg/specgen/generate/kube/kube.go#L527-L531


Signed-off-by: Liang Chu-Xuan <karta0807913@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman play kube support startup probe
make probe use json string array instead of CMD-SHELL
```
