### PR TITLE
Add podman buildx version support

### DIFF
--- a/cmd/podman/images/version.go
+++ b/cmd/podman/images/version.go
@@ -1,0 +1,35 @@
+package images
+
+import (
+	"fmt"
+
+	"github.com/containers/buildah/define"
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	versionDescription = `Print build version`
+	versionCmd         = &cobra.Command{
+		Use:               "version",
+		Args:              validate.NoArgs,
+		Short:             "Print build version",
+		Long:              versionDescription,
+		RunE:              version,
+		ValidArgsFunction: completion.AutocompleteNone,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: versionCmd,
+		Parent:  buildxCmd,
+	})
+}
+
+func version(cmd *cobra.Command, args []string) error {
+	fmt.Printf("%s %s\n", define.Package, define.Version)
+	return nil
+}

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -43,6 +43,12 @@ VOLUME /a/b/c
 VOLUME ['/etc/foo', '/etc/bar']
 EOF
 
+    run_podman info --format '{{ .Host.BuildahVersion}}'
+    BUILDAH_VERSION=$output
+
+    run_podman buildx version
+    is "$output" "buildah ${BUILDAH_VERSION}" "buildx version contains Buildah version"
+
     run_podman buildx build --load -t build_test --format=docker $tmpdir
     is "$output" ".*COMMIT" "COMMIT seen in log"
 


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/16793

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman buildx --version now shows buildah version.
```
