### PR TITLE
checkpoint restore: fix --ignore-static-ip/mac

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1232,6 +1232,16 @@ func (s *BoltState) GetNetworks(ctr *Container) (map[string]types.PerNetworkOpti
 // NetworkConnect adds the given container to the given network. If aliases are
 // specified, those will be added to the given network.
 func (s *BoltState) NetworkConnect(ctr *Container, network string, opts types.PerNetworkOptions) error {
+	return s.networkModify(ctr, network, opts, true)
+}
+
+// NetworkModify will allow you to set new options on an existing connected network
+func (s *BoltState) NetworkModify(ctr *Container, network string, opts types.PerNetworkOptions) error {
+	return s.networkModify(ctr, network, opts, false)
+}
+
+// networkModify allows you to modify or add a new network, to add a new network use the new bool
+func (s *BoltState) networkModify(ctr *Container, network string, opts types.PerNetworkOptions, new bool) error {
 	if !s.valid {
 		return define.ErrDBClosed
 	}
@@ -1278,11 +1288,14 @@ func (s *BoltState) NetworkConnect(ctr *Container, network string, opts types.Pe
 			return fmt.Errorf("container %s does not have a network bucket: %w", ctr.ID(), define.ErrNoSuchNetwork)
 		}
 		netConnected := ctrNetworksBkt.Get([]byte(network))
-		if netConnected != nil {
+
+		if new && netConnected != nil {
 			return fmt.Errorf("container %s is already connected to network %q: %w", ctr.ID(), network, define.ErrNetworkConnected)
+		} else if !new && netConnected == nil {
+			return fmt.Errorf("container %s is not connected to network %q: %w", ctr.ID(), network, define.ErrNoSuchNetwork)
 		}
 
-		// Add the network
+		// Modify/Add the network
 		if err := ctrNetworksBkt.Put([]byte(network), optBytes); err != nil {
 			return fmt.Errorf("adding container %s to network %s in DB: %w", ctr.ID(), network, err)
 		}

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1255,6 +1255,25 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	c.state.RestoreLog = path.Join(c.bundlePath(), "restore.log")
 	c.state.CheckpointPath = c.CheckpointPath()
 
+	if options.IgnoreStaticIP || options.IgnoreStaticMAC {
+		networks, err := c.networks()
+		if err != nil {
+			return nil, 0, err
+		}
+
+		for net, opts := range networks {
+			if options.IgnoreStaticIP {
+				opts.StaticIPs = nil
+			}
+			if options.IgnoreStaticMAC {
+				opts.StaticMAC = nil
+			}
+			if err := c.runtime.state.NetworkModify(c, net, opts); err != nil {
+				return nil, 0, fmt.Errorf("failed to rewrite network config: %w", err)
+			}
+		}
+	}
+
 	// Read network configuration from checkpoint
 	var netStatus map[string]types.StatusBlock
 	_, err := metadata.ReadJSONFile(&netStatus, c.bundlePath(), metadata.NetworkStatusFile)
@@ -1282,7 +1301,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 			perNetOpts.StaticIPs = nil
 			for name, netInt := range netStatus[network].Interfaces {
 				perNetOpts.InterfaceName = name
-				if !options.IgnoreStaticIP {
+				if !options.IgnoreStaticMAC {
 					perNetOpts.StaticMAC = netInt.MacAddress
 				}
 				if !options.IgnoreStaticIP {

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -104,6 +104,8 @@ type State interface { //nolint:interfacebloat
 	GetNetworks(ctr *Container) (map[string]types.PerNetworkOptions, error)
 	// Add the container to the given network with the given options
 	NetworkConnect(ctr *Container, network string, opts types.PerNetworkOptions) error
+	// Modify the container network with the given options.
+	NetworkModify(ctr *Container, network string, opts types.PerNetworkOptions) error
 	// Remove the container from the given network, removing all aliases for
 	// the container in that network in the process.
 	NetworkDisconnect(ctr *Container, network string) error

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -81,18 +81,6 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		}
 	}
 
-	if restoreOptions.IgnoreStaticIP || restoreOptions.IgnoreStaticMAC {
-		for net, opts := range ctrConfig.Networks {
-			if restoreOptions.IgnoreStaticIP {
-				opts.StaticIPs = nil
-			}
-			if restoreOptions.IgnoreStaticMAC {
-				opts.StaticMAC = nil
-			}
-			ctrConfig.Networks[net] = opts
-		}
-	}
-
 	ctrID := ctrConfig.ID
 	newName := false
 


### PR DESCRIPTION
With the 4.0 network rewrite I introduced a regression in 094e1d70dee1. It only covered the case where a checkpoint is restored via --import. The normal restore path was not covered since the static ip/mac are now part in an extra db bucket. This commit fixes that by changing the config in the db.

Note that there were no test for --ignore-static-ip/mac so I added a big system test which should cover all cases (even the ones that already work). This is not exactly pretty but I don't have to enough time to come up with something better at the moment.

Fixes #16666


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix `podman container restore --ignore-static-ip` and `--ignore-static-mac` options when restoring a normal container, i.e without `--import`. 
```
