### PR TITLE
add support for subpath in play kube for named volumes

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -254,6 +254,8 @@ type ContainerNamedVolume struct {
 	// IsAnonymous sets the named volume as anonymous even if it has a name
 	// This is used for emptyDir volumes from a kube yaml
 	IsAnonymous bool `json:"setAnonymous,omitempty"`
+	// SubPath determines which part of the Source will be mounted in the container
+	SubPath string
 }
 
 // ContainerOverlayVolume is an overlay volume that will be mounted into the
@@ -440,6 +442,7 @@ func (c *Container) NamedVolumes() []*ContainerNamedVolume {
 		newVol.Name = vol.Name
 		newVol.Dest = vol.Dest
 		newVol.Options = vol.Options
+		newVol.SubPath = vol.SubPath
 		volumes = append(volumes, newVol)
 	}
 

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -157,6 +157,10 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			return nil, err
 		}
 
+		if len(namedVol.SubPath) > 0 {
+			mountPoint = filepath.Join(mountPoint, namedVol.SubPath)
+		}
+
 		overlayFlag := false
 		upperDir := ""
 		workDir := ""

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1440,6 +1440,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 				Dest:        vol.Dest,
 				Options:     mountOpts,
 				IsAnonymous: vol.IsAnonymous,
+				SubPath:     vol.SubPath,
 			})
 		}
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -404,6 +404,7 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 				Dest:        v.Dest,
 				Options:     v.Options,
 				IsAnonymous: v.IsAnonymous,
+				SubPath:     v.SubPath,
 			})
 		}
 		options = append(options, libpod.WithNamedVolumes(vols))

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -395,6 +395,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				Dest:    volume.MountPath,
 				Name:    volumeSource.Source,
 				Options: options,
+				SubPath: volume.SubPath,
 			}
 			s.Volumes = append(s.Volumes, &namedVolume)
 		case KubeVolumeTypeConfigMap:

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -27,6 +27,8 @@ type NamedVolume struct {
 	// IsAnonymous sets the named volume as anonymous even if it has a name
 	// This is used for emptyDir volumes from a kube yaml
 	IsAnonymous bool
+	// SubPath stores the sub directory of the named volume to be mounted in the container
+	SubPath string
 }
 
 // OverlayVolume holds information about an overlay volume that will be mounted into


### PR DESCRIPTION
subpath allows for only a subdirecty of a volumes data to be mounted in the container add support for the named volume type sub path with others to follow.

resolves #12929

Signed-off-by: Charlie Doern <cbddoern@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add the ability to specify a volume subpath when using named volumes in podman play kube
```
