### PR TITLE
golangci-lint: remove three deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,9 @@ linters:
     - golint # replaced by revive
     - scopelint # replaced by exportloopref
     - interfacer
+    - deadcode    # deprecated since v1.49.0, replaced by unused
+    - structcheck # deprecated since v1.49.0, replaced by unused
+    - varcheck    # deprecated since v1.49.0, replaced by unused
 linters-settings:
   errcheck:
     check-blank: false

--- a/pkg/api/handlers/swagger/errors.go
+++ b/pkg/api/handlers/swagger/errors.go
@@ -1,4 +1,4 @@
-//nolint:deadcode,unused // these types are used to wire generated swagger to API code
+//nolint:unused // these types are used to wire generated swagger to API code
 package swagger
 
 import (

--- a/pkg/api/handlers/swagger/models.go
+++ b/pkg/api/handlers/swagger/models.go
@@ -1,4 +1,4 @@
-//nolint:deadcode,unused // these types are used to wire generated swagger to API code
+//nolint:unused // these types are used to wire generated swagger to API code
 package swagger
 
 import (

--- a/pkg/api/handlers/swagger/responses.go
+++ b/pkg/api/handlers/swagger/responses.go
@@ -1,4 +1,4 @@
-//nolint:deadcode,unused // these types are used to wire generated swagger to API code
+//nolint:unused // these types are used to wire generated swagger to API code
 package swagger
 
 import (

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -27,7 +27,7 @@ type initMachine struct {
 	memory       *uint
 	now          bool
 	timezone     string
-	rootful      bool //nolint:unused,structcheck
+	rootful      bool //nolint:unused
 	volumes      []string
 
 	cmd []string


### PR DESCRIPTION
golangci-lint is throwing warnings on each run:

   WARN [runner] The linter 'xxxxx' is deprecated (since v1.49.0)
      due to: The owner seems to have abandoned the linter.
      Replaced by unused.

...for xxxxx in deadcode, structcheck, varcheck. Add those three
to the deprecated-linter list, and remove any exceptions from
the code base.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```