### PR TITLE
Build and use a newer systemd image

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -31,8 +31,7 @@ function teardown() {
             quay.io/libpod/busybox:latest          \
             quay.io/libpod/localtest:latest        \
             quay.io/libpod/autoupdatebroken:latest \
-            quay.io/libpod/test:latest             \
-            quay.io/libpod/fedora:31
+            quay.io/libpod/test:latest
 
     # The rollback tests may leave some dangling images behind, so let's prune
     # them to leave a clean state.
@@ -267,7 +266,7 @@ function _confirm_update() {
 
     dockerfile1=$PODMAN_TMPDIR/Dockerfile.1
     cat >$dockerfile1 <<EOF
-FROM quay.io/libpod/fedora:31
+FROM $SYSTEMD_IMAGE
 RUN echo -e "#!/bin/sh\n\
 printenv NOTIFY_SOCKET; echo READY; systemd-notify --ready;\n\
 trap 'echo Received SIGTERM, finishing; exit' SIGTERM; echo WAITING; while :; do sleep 0.1; done" \
@@ -277,7 +276,7 @@ EOF
 
     dockerfile2=$PODMAN_TMPDIR/Dockerfile.2
     cat >$dockerfile2 <<EOF
-FROM quay.io/libpod/fedora:31
+FROM $SYSTEMD_IMAGE
 RUN echo -e "#!/bin/sh\n\
 exit 1" >> /runme
 RUN chmod +x /runme
@@ -446,7 +445,7 @@ EOF
 
     dockerfile1=$PODMAN_TMPDIR/Dockerfile.1
     cat >$dockerfile1 <<EOF
-FROM quay.io/libpod/fedora:31
+FROM $SYSTEMD_IMAGE
 RUN echo -e "#!/bin/sh\n\
 printenv NOTIFY_SOCKET; echo READY; systemd-notify --ready;\n\
 trap 'echo Received SIGTERM, finishing; exit' SIGTERM; echo WAITING; while :; do sleep 0.1; done" \
@@ -456,7 +455,7 @@ EOF
 
     dockerfile2=$PODMAN_TMPDIR/Dockerfile.2
     cat >$dockerfile2 <<EOF
-FROM quay.io/libpod/fedora:31
+FROM $SYSTEMD_IMAGE
 RUN echo -e "#!/bin/sh\n\
 exit 1" >> /runme
 RUN chmod +x /runme

--- a/test/system/build-systemd-image
+++ b/test/system/build-systemd-image
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# build-systemd-image - script for producing a test image with systemd
+#
+# Based on the build-testimage script. This script builds a fedora-based
+# image with systemd in it, for use in systemd-based tests.
+#
+
+# Podman binary to use
+PODMAN=${PODMAN:-$(pwd)/bin/podman}
+
+# Tag for this new image
+YMD=$(date +%Y%m%d)
+
+# git-relative path to this script
+create_script=$(cd $(dirname $0) && git ls-files --full-name $(basename $0))
+if [ -z "$create_script" ]; then
+    create_script=$0
+fi
+
+# Creation timestamp, Zulu time
+create_time_t=$(date +%s)
+create_time_z=$(env TZ=UTC date --date=@$create_time_t +'%Y-%m-%dT%H:%M:%SZ')
+
+set -ex
+
+# We'll need to create a Containerfile plus various other files to add in
+tmpdir=$(mktemp -t -d $(basename $0).tmp.XXXXXXX)
+cd $tmpdir
+echo $YMD >testimage-id
+
+cat >Containerfile <<EOF
+FROM registry.fedoraproject.org/fedora-minimal:37
+LABEL created_by=$create_script
+LABEL created_at=$create_time_z
+RUN microdnf install -y systemd && microdnf clean all
+ADD testimage-id /home/podman/
+WORKDIR /home/podman
+CMD ["/bin/echo", "This image is intended for podman CI testing"]
+EOF
+
+# Start from scratch
+testimg_base=quay.io/libpod/systemd-image
+testimg=${testimg_base}:$YMD
+$PODMAN rmi -f $testimg &> /dev/null || true
+
+# Arch emulation on Fedora requires the qemu-user-static package.
+for arch in amd64 arm64 ppc64le s390x;do
+    $PODMAN build \
+            --arch=$arch \
+            --squash-all \
+            --timestamp=$create_time_t \
+            --manifest=$testimg \
+            .
+done
+
+# Clean up
+cd /tmp
+rm -rf $tmpdir
+
+# Tag image and push (all arches) to quay.
+cat <<EOF
+
+If you're happy with this image, run:
+
+   podman manifest push --all  ${testimg} docker://${testimg}
+EOF


### PR DESCRIPTION
...based on f37, not f31. And make it fedora-minimal so it's
smaller. And clean up dnf so it's even smaller. And tag it
with our proper YMD tag, and commit the script that builds it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```