### PR TITLE
[CI:DOCS] Cirrus: Support using updated/latest NV/AV in PRs

### DIFF
--- a/contrib/cirrus/CIModes.md
+++ b/contrib/cirrus/CIModes.md
@@ -86,7 +86,7 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + meta
 + success
 
-### Intend `[CI:BUILD]` PR Tasks:
+### Intended `[CI:BUILD]` PR Tasks:
 + *build*
 + validate
 + *alt_build*
@@ -95,6 +95,23 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + meta
 + success
 + artifacts
+
+### Intended `[CI:NVAV=update]` or `[CI:NVAV=main]` behavior:
+
+If and only if the PR is in **draft-mode**, either update Fedora CI VMs to the
+latest Netavark/Aardvark-dns RPMs ("update" keyword), or install the most
+recent package builds from their `main` branch ("main" keyword).  These are
+**runtime changes** only, and will not persist or impact other PRs
+in any way.
+
+The intent is to temporarily support testing of updates with the latest podman
+code & tests.  To help prevent accidents, when the PR is not in draft-mode, the
+presence of the magic string will cause VM-setup script to fail, until the magic
+is removed.
+
+**Note:** When changing the draft-status of PR, you will need to re-push a
+commit-change before Cirrus-CI will notice the draft-status update (i.e.
+pressing the re-run button **is not** good enough).
 
 ### Intended Branch tasks (and Cirrus-cron jobs, except "multiarch"):
 + *build*


### PR DESCRIPTION
On occasion, developers need to run the latest or bleeding-edge netavark/aardvark-dns in the podman CI environment.  Enable this through use of magic strings in the PR title, but only if the PR is marked as a draft.  The intent being, when the PR is ready for review, the current CI VM package versions will be used.  Hopefully also reminding the PR author to remove the magic strings from the title.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
