### PR TITLE
libpod: remove CNI word were no longer applicable

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1251,12 +1251,7 @@ func (c *Container) Secrets() []*ContainerSecret {
 // Networks gets all the networks this container is connected to.
 // Please do NOT use ctr.config.Networks, as this can be changed from those
 // values at runtime via network connect and disconnect.
-// If the container is configured to use CNI and this function returns an empty
-// array, the container will still be connected to the default network.
-// The second return parameter, a bool, indicates that the container
-// is joining the default CNI network - the network name will be included in the
-// returned array of network names, but the container did not explicitly join
-// this network.
+// Returned array of network names or error.
 func (c *Container) Networks() ([]string, error) {
 	if !c.batched {
 		c.lock.Lock()

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -24,7 +24,7 @@ type ContainerConfig struct {
 	// in when the container is created, but it is not the final spec used
 	// to run the container - it will be modified by Libpod to add things we
 	// manage (e.g. bind mounts for /etc/resolv.conf, named volumes, a
-	// network namespace prepared by CNI or slirp4netns) in the
+	// network namespace prepared by the network backend) in the
 	// generateSpec() function.
 	Spec *spec.Spec `json:"spec"`
 

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -552,7 +552,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	hostConfig.NetworkMode = networkMode
 
 	// Port bindings.
-	// Only populate if we're using CNI to configure the network.
+	// Only populate if we are creating the network namespace to configure the network.
 	if c.config.CreateNetNS {
 		hostConfig.PortBindings = makeInspectPortBindings(c.config.PortMappings)
 	} else {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -984,7 +984,7 @@ func (c *Container) completeNetworkSetup() error {
 		return err
 	}
 	state := c.state
-	// collect any dns servers that cni tells us to use (dnsname)
+	// collect any dns servers that the network backend tells us to use
 	for _, status := range c.getNetworkStatus() {
 		for _, server := range status.DNSServerIPs {
 			nameservers = append(nameservers, server.String())

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -82,7 +82,7 @@ func (c *Container) validate() error {
 		return fmt.Errorf("cannot set static IP or MAC address if not creating a network namespace: %w", define.ErrInvalidArg)
 	}
 
-	// Cannot set static IP or MAC if joining >1 CNI network.
+	// Cannot set static IP or MAC if joining >1 network.
 	if len(c.config.Networks) > 1 && (c.config.StaticIP != nil || c.config.StaticMAC != nil) {
 		return fmt.Errorf("cannot set static IP or MAC address if joining more than one network: %w", define.ErrInvalidArg)
 	}

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -606,7 +606,7 @@ type InspectBasicNetworkConfig struct {
 	AdditionalMacAddresses []string `json:"AdditionalMACAddresses,omitempty"`
 }
 
-// InspectAdditionalNetwork holds information about non-default CNI networks the
+// InspectAdditionalNetwork holds information about non-default networks the
 // container has been connected to.
 // As with InspectNetworkSettings, many fields are unused and maintained only
 // for compatibility with Docker.
@@ -642,7 +642,7 @@ type InspectNetworkSettings struct {
 	LinkLocalIPv6PrefixLen int                          `json:"LinkLocalIPv6PrefixLen"`
 	Ports                  map[string][]InspectHostPort `json:"Ports"`
 	SandboxKey             string                       `json:"SandboxKey"`
-	// Networks contains information on non-default CNI networks this
+	// Networks contains information on non-default networks this
 	// container has joined.
 	// It is a map of network name to network information.
 	Networks map[string]*InspectAdditionalNetwork `json:"Networks,omitempty"`

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -120,7 +120,7 @@ type InspectPodInfraConfig struct {
 	// HostAdd adds a number of hosts to the infra container's resolv.conf
 	// which will be shared with the rest of the pod.
 	HostAdd []string
-	// Networks is a list of CNI networks the pod will join.
+	// Networks is a list of networks the pod will join.
 	Networks []string
 	// NetworkOptions are additional options for each network
 	NetworkOptions map[string][]string

--- a/libpod/networking_freebsd.go
+++ b/libpod/networking_freebsd.go
@@ -85,7 +85,7 @@ func (r *RootlessNetNS) getPath(path string) string {
 
 // Do - run the given function in the rootless netns.
 // It does not lock the rootlessCNI lock, the caller
-// should only lock when needed, e.g. for cni operations.
+// should only lock when needed, e.g. for network operations.
 func (r *RootlessNetNS) Do(toRun func() error) error {
 	return errors.New("not supported on freebsd")
 }
@@ -192,7 +192,7 @@ func (r *Runtime) teardownNetNS(ctr *Container) error {
 		// do not return an error otherwise we would prevent network cleanup
 		logrus.Errorf("failed to free gvproxy machine ports: %v", err)
 	}
-	if err := r.teardownCNI(ctr); err != nil {
+	if err := r.teardownNetwork(ctr); err != nil {
 		return err
 	}
 

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -63,7 +63,7 @@ func (r *RootlessNetNS) getPath(path string) string {
 
 // Do - run the given function in the rootless netns.
 // It does not lock the rootlessCNI lock, the caller
-// should only lock when needed, e.g. for cni operations.
+// should only lock when needed, e.g. for network operations.
 func (r *RootlessNetNS) Do(toRun func() error) error {
 	err := r.ns.Do(func(_ ns.NetNS) error {
 		// Before we can run the given function,
@@ -269,7 +269,7 @@ func (r *RootlessNetNS) Cleanup(runtime *Runtime) error {
 		// at this stage the container is already locked.
 		// also do not try to lock only containers which are not currently in net
 		// teardown because this will result in an ABBA deadlock between the rootless
-		// cni lock and the container lock
+		// rootless netns lock and the container lock
 		// because we need to get the state we have to sync otherwise this will not
 		// work because the state is empty by default
 		// I do not like this but I do not see a better way at moment
@@ -702,7 +702,7 @@ func (r *Runtime) teardownNetNS(ctr *Container) error {
 	// Do not check the error here, we want to always umount the netns
 	// This will ensure that the container interface will be deleted
 	// even when there is a CNI or netavark bug.
-	prevErr := r.teardownCNI(ctr)
+	prevErr := r.teardownNetwork(ctr)
 
 	// First unmount the namespace
 	if err := netns.UnmountNS(ctr.state.NetNS.Path()); err != nil {

--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -42,12 +42,12 @@ func (r *Runtime) normalizeNetworkName(nameOrID string) (string, error) {
 	return "", errors.New("not implemented (*Runtime) normalizeNetworkName")
 }
 
-// DisconnectContainerFromNetwork removes a container from its CNI network
+// DisconnectContainerFromNetwork removes a container from its network
 func (r *Runtime) DisconnectContainerFromNetwork(nameOrID, netName string, force bool) error {
 	return errors.New("not implemented (*Runtime) DisconnectContainerFromNetwork")
 }
 
-// ConnectContainerToNetwork connects a container to a CNI network
+// ConnectContainerToNetwork connects a container to a network
 func (r *Runtime) ConnectContainerToNetwork(nameOrID, netName string, netOpts types.PerNetworkOptions) error {
 	return errors.New("not implemented (*Runtime) ConnectContainerToNetwork")
 }
@@ -59,7 +59,7 @@ func (r *RootlessNetNS) getPath(path string) string {
 
 // Do - run the given function in the rootless netns.
 // It does not lock the rootlessCNI lock, the caller
-// should only lock when needed, e.g. for cni operations.
+// should only lock when needed, e.g. for network operations.
 func (r *RootlessNetNS) Do(toRun func() error) error {
 	return errors.New("not implemented (*RootlessNetNS) Do")
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -374,8 +374,8 @@ func WithNoPivotRoot() RuntimeOption {
 	}
 }
 
-// WithCNIConfigDir sets the CNI configuration directory.
-func WithCNIConfigDir(dir string) RuntimeOption {
+// WithNetworkConfigDir sets the network configuration directory.
+func WithNetworkConfigDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
 			return define.ErrRuntimeFinalized

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -181,7 +181,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Delete unused networks
-	// description: Remove CNI networks that do not have containers
+	// description: Remove networks that do not have containers
 	// produces:
 	// - application/json
 	// parameters:
@@ -213,7 +213,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks
 	// summary: Remove a network
-	// description: Remove a CNI configured network
+	// description: Remove a configured network
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -289,8 +289,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//  - networks
 	// summary: Inspect a network
 	// description: |
-	//   Display low level configuration for a CNI network.
-	//     - In a 200 response, all of the fields named Bytes are returned as a Base64 encoded string.
+	//   Display configuration for a network.
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -391,7 +390,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks
 	// summary: Delete unused networks
-	// description: Remove CNI networks that do not have containers
+	// description: Remove networks that do not have containers
 	// produces:
 	// - application/json
 	// parameters:

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -12,7 +12,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-// Create makes a new CNI network configuration
+// Create makes a new network configuration
 func Create(ctx context.Context, network *types.Network) (types.Network, error) {
 	return CreateWithOptions(ctx, network, nil)
 }
@@ -50,7 +50,7 @@ func CreateWithOptions(ctx context.Context, network *types.Network, extraCreateO
 	return report, response.Process(&report)
 }
 
-// Inspect returns low level information about a CNI network configuration
+// Inspect returns information about a network configuration
 func Inspect(ctx context.Context, nameOrID string, _ *InspectOptions) (types.Network, error) {
 	var net types.Network
 	conn, err := bindings.GetClient(ctx)
@@ -66,7 +66,7 @@ func Inspect(ctx context.Context, nameOrID string, _ *InspectOptions) (types.Net
 	return net, response.Process(&net)
 }
 
-// Remove deletes a defined CNI network configuration by name.  The optional force boolean
+// Remove deletes a defined network configuration by name.  The optional force boolean
 // will remove all containers associated with the network when set to true.  A slice
 // of NetworkRemoveReports are returned.
 func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) ([]*entities.NetworkRmReport, error) {
@@ -91,7 +91,7 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) ([]*en
 	return reports, response.Process(&reports)
 }
 
-// List returns a summary of all CNI network configurations
+// List returns a summary of all network configurations
 func List(ctx context.Context, options *ListOptions) ([]types.Network, error) {
 	var netList []types.Network
 	if options == nil {
@@ -192,7 +192,7 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 	return response.IsSuccess(), nil
 }
 
-// Prune removes unused CNI networks
+// Prune removes unused networks
 func Prune(ctx context.Context, options *PruneOptions) ([]*entities.NetworkPruneReport, error) {
 	if options == nil {
 		options = new(PruneOptions)

--- a/pkg/bindings/network/types.go
+++ b/pkg/bindings/network/types.go
@@ -76,7 +76,7 @@ type ExistsOptions struct {
 }
 
 // PruneOptions are optional options for removing unused
-// CNI networks
+// networks
 //
 //go:generate go run ../generator/generator.go PruneOptions
 type PruneOptions struct {

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -253,7 +253,7 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 	// TODO flag to set libpod tmp dir?
 
 	if fs.Changed("network-config-dir") {
-		options = append(options, libpod.WithCNIConfigDir(cfg.ContainersConf.Network.NetworkConfigDir))
+		options = append(options, libpod.WithNetworkConfigDir(cfg.ContainersConf.Network.NetworkConfigDir))
 	}
 	if fs.Changed("default-mounts-file") {
 		options = append(options, libpod.WithDefaultMountsFile(cfg.ContainersConf.Containers.DefaultMountsFile))

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -334,7 +334,7 @@ Delegate=memory pids cpu io
 		},
 	})
 
-	// Set containers.conf up for core user to use cni networks
+	// Set containers.conf up for core user to use networks
 	// by default
 	files = append(files, File{
 		Node: Node{

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -44,7 +44,7 @@ const (
 	// be joined.  loopback should still exist.
 	// Only used with the network namespace, invalid otherwise.
 	NoNetwork NamespaceMode = "none"
-	// Bridge indicates that a CNI network stack
+	// Bridge indicates that the network backend (CNI/netavark)
 	// should be used.
 	// Only used with the network namespace, invalid otherwise.
 	Bridge NamespaceMode = "bridge"


### PR DESCRIPTION
We should have done this much earlier, most of the times CNI networks just mean networks so I changed this and also fixed some function names. This should make it more clear what actually refers to CNI and what is just general network backend stuff.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
