### PR TITLE
api: remove unmapped ports from PortBindings

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -554,7 +554,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	// Port bindings.
 	// Only populate if we're using CNI to configure the network.
 	if c.config.CreateNetNS {
-		hostConfig.PortBindings = makeInspectPortBindings(c.config.PortMappings, c.config.ExposedPorts)
+		hostConfig.PortBindings = makeInspectPortBindings(c.config.PortMappings)
 	} else {
 		hostConfig.PortBindings = make(map[string][]define.InspectHostPort)
 	}

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -229,7 +229,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	}
 
 	settings := new(define.InspectNetworkSettings)
-	settings.Ports = makeInspectPortBindings(c.config.PortMappings, c.config.ExposedPorts)
+	settings.Ports = makeInspectPorts(c.config.PortMappings, c.config.ExposedPorts)
 
 	networks, err := c.networks()
 	if err != nil {

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -709,7 +709,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			infraConfig.Networks = netNames
 		}
 		infraConfig.NetworkOptions = infra.config.ContainerNetworkConfig.NetworkOptions
-		infraConfig.PortBindings = makeInspectPortBindings(infra.config.ContainerNetworkConfig.PortMappings, nil)
+		infraConfig.PortBindings = makeInspectPortBindings(infra.config.ContainerNetworkConfig.PortMappings)
 	}
 
 	inspectData := define.InspectPodData{

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -312,7 +312,12 @@ func writeHijackHeader(r *http.Request, conn io.Writer) {
 }
 
 // Convert OCICNI port bindings into Inspect-formatted port bindings.
-func makeInspectPortBindings(bindings []types.PortMapping, expose map[uint16][]string) map[string][]define.InspectHostPort {
+func makeInspectPortBindings(bindings []types.PortMapping) map[string][]define.InspectHostPort {
+	return makeInspectPorts(bindings, nil)
+}
+
+// Convert OCICNI port bindings into Inspect-formatted port bindings with exposed, but not bound ports set to nil.
+func makeInspectPorts(bindings []types.PortMapping, expose map[uint16][]string) map[string][]define.InspectHostPort {
 	portBindings := make(map[string][]define.InspectHostPort)
 	for _, port := range bindings {
 		protocols := strings.Split(port.Protocol, ",")

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -519,7 +519,7 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	stopTimeout := int(l.StopTimeout())
 
 	exposedPorts := make(nat.PortSet)
-	for ep := range inspect.HostConfig.PortBindings {
+	for ep := range inspect.NetworkSettings.Ports {
 		splitp := strings.SplitN(ep, "/", 2)
 		if len(splitp) != 2 {
 			return nil, fmt.Errorf("PORT/PROTOCOL Format required for %q", ep)


### PR DESCRIPTION
The docker API doesn't list exposed, but unmapped ports in `HostConfig.PortBindings`. Podman lists them with a value of `null`. This PR changes this behaviour to also omit them completely.

This is required for https://github.com/testcontainers/testcontainers-java/pull/6158

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
