### PR TITLE
Allow '/' to prefix container names to match Docker

### DIFF
--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
@@ -75,7 +76,7 @@ func attach(cmd *cobra.Command, args []string) error {
 
 	var name string
 	if len(args) > 0 {
-		name = args[0]
+		name = strings.TrimPrefix(args[0], "/")
 	}
 	attachOpts.Stdin = os.Stdin
 	if attachOpts.NoStdin {

--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -87,6 +87,7 @@ func init() {
 
 func checkpoint(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
+	args = utils.RemoveSlash(args)
 	podmanStart := time.Now()
 	if cmd.Flags().Changed("compress") {
 		if checkpointOptions.Export == "" {

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -93,7 +93,7 @@ func init() {
 }
 
 func commit(cmd *cobra.Command, args []string) error {
-	container := args[0]
+	container := strings.TrimPrefix(args[0], "/")
 	if len(args) == 2 {
 		commitOptions.ImageName = args[1]
 	}

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -112,7 +113,7 @@ func exec(_ *cobra.Command, args []string) error {
 	execOpts.Cmd = args
 	if !execOpts.Latest {
 		execOpts.Cmd = args[1:]
-		nameOrID = args[0]
+		nameOrID = strings.TrimPrefix(args[0], "/")
 	}
 	// Validate given environment variables
 	execOpts.Envs = make(map[string]string)

--- a/cmd/podman/containers/exists.go
+++ b/cmd/podman/containers/exists.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
@@ -41,7 +42,7 @@ func exists(cmd *cobra.Command, args []string) error {
 	options := entities.ContainerExistsOptions{
 		External: external,
 	}
-	response, err := registry.ContainerEngine().ContainerExists(context.Background(), args[0], options)
+	response, err := registry.ContainerEngine().ContainerExists(context.Background(), strings.TrimPrefix(args[0], "/"), options)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -87,5 +88,5 @@ func export(cmd *cobra.Command, args []string) error {
 		defer file.Close()
 		exportOpts.Output = file
 	}
-	return registry.ContainerEngine().ContainerExport(context.Background(), args[0], exportOpts)
+	return registry.ContainerEngine().ContainerExport(context.Background(), strings.TrimPrefix(args[0], "/"), exportOpts)
 }

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -69,6 +69,7 @@ func init() {
 
 func initContainer(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
+	args = utils.RemoveSlash(args)
 	report, err := registry.ContainerEngine().ContainerInit(registry.GetContext(), args, initOptions)
 	if err != nil {
 		return err

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -86,6 +86,7 @@ func kill(_ *cobra.Command, args []string) error {
 		err  error
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
 	// Check if the signalString provided by the user is valid
 	// Invalid signals will return err
 	sig, err := signal.ParseSignalNameOrNumber(killOptions.Signal)

--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
@@ -122,6 +123,7 @@ func logsFlags(cmd *cobra.Command) {
 }
 
 func logs(_ *cobra.Command, args []string) error {
+	args = utils.RemoveSlash(args)
 	if logsOptions.SinceRaw != "" {
 		// parse time, error out if something is wrong
 		since, err := util.ParseInputTime(logsOptions.SinceRaw, true)

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -85,6 +85,8 @@ func mount(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && mountOpts.Latest {
 		return errors.New("--latest and containers cannot be used together")
 	}
+	args = utils.RemoveSlash(args)
+
 	reports, err := registry.ContainerEngine().ContainerMount(registry.GetContext(), args, mountOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -90,6 +90,7 @@ func pause(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
 
 	for _, cidFile := range pauseCidFiles {
 		content, err := os.ReadFile(cidFile)

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -80,7 +80,7 @@ func port(_ *cobra.Command, args []string) error {
 		return errors.New("you must supply a running container name or id")
 	}
 	if !portOpts.Latest && len(args) >= 1 {
-		container = args[0]
+		container = strings.TrimPrefix(args[0], "/")
 	}
 	port := ""
 	if len(args) > 2 {

--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -46,7 +46,7 @@ func init() {
 	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePruneFilters)
 }
 
-func prune(cmd *cobra.Command, args []string) error {
+func prune(cmd *cobra.Command, _ []string) error {
 	var (
 		pruneOptions = entities.ContainerPruneOptions{}
 		err          error

--- a/cmd/podman/containers/rename.go
+++ b/cmd/podman/containers/rename.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,7 @@ func rename(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 {
 		return errors.New("must provide at least two arguments to rename")
 	}
+	args = utils.RemoveSlash(args)
 	renameOpts := entities.ContainerRenameOptions{
 		NewName: args[1],
 	}

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -99,6 +99,7 @@ func restart(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
 
 	if cmd.Flag("time").Changed {
 		restartOpts.Timeout = &restartTimeout

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -96,6 +96,8 @@ func restore(cmd *cobra.Command, args []string) error {
 		e    error
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
+
 	podmanStart := time.Now()
 	if rootless.IsRootless() {
 		return fmt.Errorf("restoring a container requires root")

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -132,7 +132,7 @@ func rm(cmd *cobra.Command, args []string) error {
 		rmOptions.Depend = true
 	}
 
-	return removeContainers(args, rmOptions, true)
+	return removeContainers(utils.RemoveSlash(args), rmOptions, true)
 }
 
 // removeContainers will remove the specified containers (names or IDs).

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
@@ -95,5 +96,5 @@ func runlabel(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return registry.ContainerEngine().ContainerRunlabel(context.Background(), args[0], args[1], args[2:], runlabelOptions.ContainerRunlabelOptions)
+	return registry.ContainerEngine().ContainerRunlabel(context.Background(), strings.TrimPrefix(args[0], "/"), args[1], args[2:], runlabelOptions.ContainerRunlabelOptions)
 }

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -124,7 +124,7 @@ func start(cmd *cobra.Command, args []string) error {
 		startOptions.Stdout = os.Stdout
 	}
 
-	containers := args
+	containers := utils.RemoveSlash(args)
 	for _, f := range filters {
 		split := strings.SplitN(f, "=", 2)
 		if len(split) < 2 {

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	putils "github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
@@ -120,6 +121,7 @@ func stats(cmd *cobra.Command, args []string) error {
 		Stream:   !statsOptions.NoStream,
 		Interval: statsOptions.Interval,
 	}
+	args = putils.RemoveSlash(args)
 	statsChan, err := registry.ContainerEngine().ContainerStats(registry.Context(), args, opts)
 	if err != nil {
 		return err

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -101,6 +101,8 @@ func stop(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
+
 	if cmd.Flag("time").Changed {
 		stopOptions.Timeout = &stopTimeout
 	}

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -94,7 +94,7 @@ func top(cmd *cobra.Command, args []string) error {
 	if topOptions.Latest {
 		topOptions.Descriptors = args
 	} else {
-		topOptions.NameOrID = args[0]
+		topOptions.NameOrID = strings.TrimPrefix(args[0], "/")
 		topOptions.Descriptors = args[1:]
 	}
 

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -78,6 +78,7 @@ func init() {
 
 func unmount(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
+	args = utils.RemoveSlash(args)
 	reports, err := registry.ContainerEngine().ContainerUnmount(registry.GetContext(), args, unmountOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -91,6 +91,8 @@ func unpause(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
+
 	if rootless.IsRootless() && !registry.IsRemote() {
 		cgroupv2, _ := cgroups.IsCgroup2UnifiedMode()
 		if !cgroupv2 {

--- a/cmd/podman/containers/update.go
+++ b/cmd/podman/containers/update.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
@@ -71,7 +72,7 @@ func update(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := &entities.ContainerUpdateOptions{
-		NameOrID: args[0],
+		NameOrID: strings.TrimPrefix(args[0], "/"),
 		Specgen:  s,
 	}
 	rep, err := registry.ContainerEngine().ContainerUpdate(context.Background(), opts)

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -80,6 +80,7 @@ func wait(cmd *cobra.Command, args []string) error {
 		err  error
 		errs utils.OutputErrors
 	)
+	args = utils.RemoveSlash(args)
 	if waitOptions.Interval, err = time.ParseDuration(waitInterval); err != nil {
 		var err1 error
 		if waitOptions.Interval, err1 = time.ParseDuration(waitInterval + "ms"); err1 != nil {

--- a/cmd/podman/utils/utils.go
+++ b/cmd/podman/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
@@ -138,4 +139,12 @@ func IsCheckpointImage(ctx context.Context, namesOrIDs []string) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+func RemoveSlash(input []string) []string {
+	output := make([]string, 0, len(input))
+	for _, in := range input {
+		output = append(output, strings.TrimPrefix(in, "/"))
+	}
+	return output
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/containers/buildah/pkg/parse"
@@ -776,6 +777,7 @@ func WithName(name string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 
+		name = strings.TrimPrefix(name, "/")
 		// Check the name against a regex
 		if !define.NameRegex.MatchString(name) {
 			return define.RegexError

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -118,6 +118,7 @@ func (r *Runtime) RenameContainer(ctx context.Context, ctr *Container, newName s
 		return nil, err
 	}
 
+	newName = strings.TrimPrefix(newName, "/")
 	if newName == "" || !define.NameRegex.MatchString(newName) {
 		return nil, define.RegexError
 	}

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -30,7 +30,11 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 	case "name":
 		// we only have to match one name
 		return func(c *libpod.Container) bool {
-			return util.StringMatchRegexSlice(c.Name(), filterValues)
+			var filters []string
+			for _, f := range filterValues {
+				filters = append(filters, strings.ReplaceAll(f, "/", ""))
+			}
+			return util.StringMatchRegexSlice(c.Name(), filters)
 		}, nil
 	case "exited":
 		var exitCodes []int32

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -174,7 +174,7 @@ echo $rand        |   0 | $rand
     run_podman 1 image exists $NONLOCAL_IMAGE
 
     # Run a container, without --rm; this should block subsequent --rmi
-    run_podman run --name keepme $NONLOCAL_IMAGE /bin/true
+    run_podman run --name /keepme $NONLOCAL_IMAGE /bin/true
     run_podman image exists $NONLOCAL_IMAGE
 
     # Now try running with --rmi : it should succeed, but not remove the image
@@ -182,7 +182,7 @@ echo $rand        |   0 | $rand
     run_podman image exists $NONLOCAL_IMAGE
 
     # Remove the stray container, and run one more time with --rmi.
-    run_podman rm keepme
+    run_podman rm /keepme
     run_podman run --rmi --rm $NONLOCAL_IMAGE /bin/true
     run_podman 1 image exists $NONLOCAL_IMAGE
 }
@@ -962,6 +962,16 @@ EOF
     CONTAINERS_CONF="$containersconf" run_podman run --rm --read-only=false $IMAGE touch /testrw
     CONTAINERS_CONF="$containersconf" run_podman run --rm $IMAGE touch /tmp/testrw
     CONTAINERS_CONF="$containersconf" run_podman 1 run --rm --read-only-tmpfs=false $IMAGE touch /tmp/testro
+}
+
+@test "podman run bad --name" {
+    randomname=$(random_string 30)
+    run_podman 125 create --name "$randomname/bad" $IMAGE
+    run_podman create --name "/$randomname" $IMAGE
+    run_podman ps -a --filter name="^/$randomname$" --format '{{ .Names }}'
+    is $output "$randomname" "Should be able to find container by name"
+    run_podman rm "/$randomname"
+    run_podman 125 create --name "$randomname/" $IMAGE
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/16663

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now supports container names beginning with a '/' to match Docker behaviour.
```
