### PR TITLE
[release-v4.3.1-rhel] compat,build: handle docker's preconfigured `cacheTo`,`cacheFrom`

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -189,6 +189,13 @@ tar --format=posix -C $TMPD -cvf ${CONTAINERFILE_TAR} containerfile &> /dev/null
 t POST "libpod/build?dockerfile=containerfile" $CONTAINERFILE_TAR 200 \
   .stream~"STEP 1/1: FROM $IMAGE"
 
+# Newer Docker client sets empty cacheFrom for every build command even if it is not used,
+# following commit makes sure we test such use-case. See https://github.com/containers/podman/pull/16380
+#TODO: This test should be extended when buildah's cache-from and cache-to functionally supports
+# multiple remote-repos
+t POST "libpod/build?dockerfile=containerfile&cachefrom=[]" $CONTAINERFILE_TAR 200 \
+  .stream~"STEP 1/1: FROM $IMAGE"
+
 # With -q, all we should get is image ID. Test both libpod & compat endpoints.
 t POST "libpod/build?dockerfile=containerfile&q=true" $CONTAINERFILE_TAR 200 \
   .stream~'^[0-9a-f]\{64\}$'

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -129,13 +129,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json list tags", func() {
-		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(search.OutputToString()).To(BeValidJSON())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
-		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
-		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
+		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.2"))
 	})
 
 	// Test for https://github.com/containers/podman/issues/11894


### PR DESCRIPTION
Docker's newer clients popuates `cacheFrom` and `cacheTo` parameter by default as empty array for all commands but buildah's design of distributed cache expects this to be a repo not image hence parse only the first populated repo and igore if empty array.

```release-note
compat,build: make compat build api functional
```

Backport of https://github.com/containers/podman/pull/16380