### PR TITLE
quadlet: Default VolatileTmp to off

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -194,9 +194,9 @@ The timezone to run the container in.
 If enabled, the container will have a minimal init process inside the
 container that forwards signals and reaps processes.
 
-#### `VolatileTmp=` (default to `yes`)
+#### `VolatileTmp=` (default to `no`, or `yes` if `ReadOnly` enabled)
 
-If enabled (and it is by default), the container will have a fresh tmpfs mounted on `/tmp`.
+If enabled, the container will have a fresh tmpfs mounted on `/tmp`.
 
 **NOTE:** Podman will automatically copy any content from the image onto the tmpfs
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -329,8 +329,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 		podman.add("--read-only")
 	}
 
-	// We want /tmp to be a tmpfs, like on rhel host
-	volatileTmp := container.LookupBoolean(ContainerGroup, KeyVolatileTmp, true)
+	volatileTmp := container.LookupBoolean(ContainerGroup, KeyVolatileTmp, false)
 	if volatileTmp {
 		/* Read only mode already has a tmpfs by default */
 		if !readOnly {

--- a/test/e2e/quadlet/readwrite.container
+++ b/test/e2e/quadlet/readwrite.container
@@ -3,4 +3,5 @@
 
 [Container]
 Image=localhost/imagename
+VolatileTmp=yes
 ReadOnly=no


### PR DESCRIPTION
This is another case where we're diverging from the defaults in podman.

Signed-off-by: Alexander Larsson <alexl@redhat.com>

```release-note
None
```
