### PR TITLE
[CI:DOCS] stale workflow: don't apply issue label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'
         stale-pr-message: 'A friendly reminder that this PR had no activity for 30 days.'
-        stale-issue-label: 'stale-issue'
         stale-pr-label: 'stale-pr'
         days-before-stale: 30
         days-before-close: 365


### PR DESCRIPTION
Let's stop adding a label to "stale" issues.  I am under the impression that it's discouraging to users and contributors to see their issues marked as such.  However, let's continue to drop a comment when an issue didn't receive attention for more than 30 days to help things move back onto our radar.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
