### PR TITLE
libpod: use OCI idmappings for mounts

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -37,6 +37,11 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
 	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+          The idmap option supports a custom mapping that can be different than the user namespace used by the container.
+          The mapping can be specified after the idmap option like: idmap=uids=0-1-10#10-11-10;gids=0-100-10.  For each triplet, the first value is the
+          start of the backing file system IDs that are mapped to the second value on the host.  The length of this mapping is given in the third value.
+
+       Multiple ranges are separated with #.
 
        Options specific to image:
 

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -8,12 +8,108 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/containers/storage/pkg/idtools"
+	stypes "github.com/containers/storage/types"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
 
 // hookPath is the path to an example hook executable.
 var hookPath string
+
+func TestParseOptionIDs(t *testing.T) {
+	_, err := parseOptionIDs("uids=100-200-2")
+	assert.NotNil(t, err)
+
+	mappings, err := parseOptionIDs("100-200-2")
+	assert.Nil(t, err)
+	assert.NotNil(t, mappings)
+
+	assert.Equal(t, len(mappings), 1)
+
+	assert.Equal(t, mappings[0].ContainerID, 100)
+	assert.Equal(t, mappings[0].HostID, 200)
+	assert.Equal(t, mappings[0].Size, 2)
+
+	mappings, err = parseOptionIDs("100-200-2#300-400-5")
+	assert.Nil(t, err)
+	assert.NotNil(t, mappings)
+
+	assert.Equal(t, len(mappings), 2)
+
+	assert.Equal(t, mappings[0].ContainerID, 100)
+	assert.Equal(t, mappings[0].HostID, 200)
+	assert.Equal(t, mappings[0].Size, 2)
+
+	assert.Equal(t, mappings[1].ContainerID, 300)
+	assert.Equal(t, mappings[1].HostID, 400)
+	assert.Equal(t, mappings[1].Size, 5)
+}
+
+func TestParseIDMapMountOption(t *testing.T) {
+	uidMap := []idtools.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      1000,
+			Size:        10000,
+		},
+	}
+	gidMap := []idtools.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      2000,
+			Size:        10000,
+		},
+	}
+	options := stypes.IDMappingOptions{
+		UIDMap: uidMap,
+		GIDMap: gidMap,
+	}
+	uids, gids, err := parseIDMapMountOption(options, "idmap")
+	assert.Nil(t, err)
+	assert.Equal(t, len(uids), 1)
+	assert.Equal(t, len(gids), 1)
+
+	assert.Equal(t, uids[0].ContainerID, uint32(1000))
+	assert.Equal(t, uids[0].HostID, uint32(0))
+	assert.Equal(t, uids[0].Size, uint32(10000))
+
+	assert.Equal(t, gids[0].ContainerID, uint32(2000))
+	assert.Equal(t, gids[0].HostID, uint32(0))
+	assert.Equal(t, gids[0].Size, uint32(10000))
+
+	uids, gids, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10")
+	assert.Nil(t, err)
+	assert.Equal(t, len(uids), 2)
+	assert.Equal(t, len(gids), 1)
+
+	assert.Equal(t, uids[0].ContainerID, uint32(1))
+	assert.Equal(t, uids[0].HostID, uint32(0))
+	assert.Equal(t, uids[0].Size, uint32(10))
+
+	assert.Equal(t, uids[1].ContainerID, uint32(11))
+	assert.Equal(t, uids[1].HostID, uint32(10))
+	assert.Equal(t, uids[1].Size, uint32(10))
+
+	assert.Equal(t, gids[0].ContainerID, uint32(3))
+	assert.Equal(t, gids[0].HostID, uint32(0))
+	assert.Equal(t, gids[0].Size, uint32(10))
+
+	_, _, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10;foobar=bar")
+	assert.NotNil(t, err)
+
+	_, _, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10#0-12")
+	assert.NotNil(t, err)
+
+	_, _, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10#0-12--12")
+	assert.NotNil(t, err)
+
+	_, _, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10#-1-12-12")
+	assert.NotNil(t, err)
+
+	_, _, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10#0--12-0")
+	assert.NotNil(t, err)
+}
 
 func TestPostDeleteHooks(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Now that the OCI runtime specs have support for idmapped mounts, let's use them instead of relying on the custom annotation in crun.

Also add the mechanism to specify the mapping to use.  Pick the same format used by crun so it won't be a breaking change for users that are already using it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
