### PR TITLE
Make qemu security model none 

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -97,8 +97,12 @@ options are:
 
 The 9p security model [determines] https://wiki.qemu.org/Documentation/9psetup#Starting_the_Guest_directly
 if and how the 9p filesystem translates some filesystem operations before
-actual storage on the host. The
-default value of *mapped-xattr* specifies that 9p store symlinks and some file
+actual storage on the host.
+
+In order to allow symlinks to work, on MacOS the default security model is
+ *none*.
+
+The value of *mapped-xattr* specifies that 9p store symlinks and some file
 attributes as extended attributes on the host. This is suitable when the host
 and the guest do not need to interoperate on the shared filesystem, but has
 caveats for actual shared access; notably, symlinks on the host are not usable

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -305,7 +305,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		source := paths[0]
 		target := source
 		readonly := false
-		securityModel := "mapped-xattr"
+		securityModel := "none"
 		if len(paths) > 1 {
 			target = paths[1]
 		}


### PR DESCRIPTION
On Mac machines security model none works, while "mapped-xattr"
causes symlinks to not work.

Update docs/source/markdown/podman-machine-init.1.md

[NO NEW TESTS NEEDED]

Related: https://github.com/containers/podman/discussions/16102

Co-authored-by: Tom Sweeney <tsweeney@redhat.com>
Signed-off-by: Sorin Sbarnea <sorin.sbarnea@gmail.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Security model on MacOS changed to "none"
```
Replaces: https://github.com/containers/podman/pull/16261
