### PR TITLE
Create netavark.lock in the run directory

### DIFF
--- a/vendor/github.com/containers/common/libnetwork/netavark/network.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/network.go
@@ -95,7 +95,7 @@ type InitConfig struct {
 // Note: The networks are not loaded from disk until a method is called.
 func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	// TODO: consider using a shared memory lock
-	lock, err := lockfile.GetLockFile(filepath.Join(conf.NetworkConfigDir, "netavark.lock"))
+	lock, err := lockfile.GetLockFile(filepath.Join(conf.NetworkRunDir, "netavark.lock"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It tried to create the file in /etc but SELinux blocked it. One observed consequence is the API service failing to start.

I checked it builds fine on the main branch but did not run the binary.
I backported it to 3.4.1 (the version in CentOS 9 Stream I'm using) and the API service was able to start properly.

```release-note
Fix netavark creating its lock file in the configuration directory instead of the runtime directory. SELinux would not allow that and starting the API service would fail.
```
