### PR TITLE
test/system/250-systemd.bats: fix flake

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -443,7 +443,14 @@ EOF
 
     # Clean up
     systemctl stop $service_name
-    run_podman 1 container exists $service_container
+    for i in {0..5}; do
+        run_podman ? container exists $service_container
+        if [[ $status == 1 ]]; then
+            break
+        fi
+        sleep 0.5
+    done
+    is "$status" "1" "service container should have been removed"
     run_podman 1 pod exists test_pod
     run_podman rmi $(pause_image)
     rm -f $UNIT_DIR/$unit_name


### PR DESCRIPTION
Fix a flake in the kube-template test.  After stopping the service, we want to make sure that the service container gets removed.  However, ther is a small race window. `systemctl stop` will return when the service container _exits_.  In between that and the `container exists` check, the service container may have not yet been removed.  Hence, add a loop to account for that race.

Fixes: #16047
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
