### PR TITLE
wait: add --ignore option

### DIFF
--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -53,6 +53,8 @@ func waitFlags(cmd *cobra.Command) {
 	flags.StringVarP(&waitInterval, intervalFlagName, "i", "250ms", "Time Interval to wait before polling for completion")
 	_ = cmd.RegisterFlagCompletionFunc(intervalFlagName, completion.AutocompleteNone)
 
+	flags.BoolVarP(&waitOptions.Ignore, "ignore", "", false, "Ignore if a container does not exist")
+
 	conditionFlagName := "condition"
 	flags.StringSliceVar(&waitConditions, conditionFlagName, []string{}, "Condition to wait on")
 	_ = cmd.RegisterFlagCompletionFunc(conditionFlagName, common.AutocompleteWaitCondition)

--- a/docs/source/markdown/podman-wait.1.md.in
+++ b/docs/source/markdown/podman-wait.1.md.in
@@ -23,6 +23,10 @@ Condition to wait on (default "stopped")
 
  Print usage statement
 
+
+#### **--ignore**
+Ignore errors when a specified container is missing and mark its return code as -1.
+
 #### **--interval**, **-i**=*duration*
   Time interval to wait before polling for completion. A duration string is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Time unit defaults to "ms".
 
@@ -46,6 +50,9 @@ $ podman wait 860a4b23
 $ podman wait mywebserver myftpserver
 0
 125
+
+$ podman wait --ignore does-not-exist
+-1
 ```
 
 ## SEE ALSO

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -52,11 +52,11 @@ type ContainerRunlabelReport struct{}
 type WaitOptions struct {
 	Condition []define.ContainerStatus
 	Interval  time.Duration
+	Ignore    bool
 	Latest    bool
 }
 
 type WaitReport struct {
-	Id       string //nolint:revive,stylecheck
 	Error    error
 	ExitCode int32
 }

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -20,6 +20,15 @@ load helpers
     run_podman rm $rand
     is "$output" "$rand" "display raw input"
     run_podman 125 inspect $rand
+    run_podman 125 wait $rand
+    run_podman wait --ignore $rand
+    is "$output" "-1" "wait --ignore will mark missing containers with -1"
+
+    if !is_remote; then
+        # remote does not support the --latest flag
+        run_podman wait --ignore --latest
+        is "$output" "-1" "wait --ignore will mark missing containers with -1"
+    fi
 }
 
 @test "podman rm - running container, w/o and w/ force" {


### PR DESCRIPTION
In the recent past, I met the frequent need to wait for a container to exit that, at the same time, may get removed (e.g., system tests in [1]).

Add an `--ignore` option to podman-wait which will ignore errors when a specified container is missing and mark its exit code as -1.  Also remove ID fields from the WaitReport.  It is actually not used by callers and removing it makes the code simpler and faster.

Once merged, we can go over the tests and simplify them.

[1] github.com/containers/podman/pull/16852

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new --ignore option to podman-wait.
```
@containers/podman-maintainers PTAL