### PR TITLE
libpod: fix header length in http attach with logs

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -594,6 +594,10 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 					device := logLine.Device
 					var header []byte
 					headerLen := uint32(len(logLine.Msg))
+					if !logLine.Partial() {
+						// we append an extra newline in this case so we need to increment the len as well
+						headerLen++
+					}
 					logSize += len(logLine.Msg)
 					switch strings.ToLower(device) {
 					case "stdin":

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -26,9 +26,10 @@ like "$response_headers" ".*Content-Type: application/json.*" "header does not c
 # Regression test for #12904 (race condition in logging code)
 mytext="hi-there-$(random_string 15)"
 podman run --rm -d --replace --name foo $IMAGE sh -c "echo $mytext;sleep 42"
-# Logs output is prepended by ^A^X
+# Logs output is prepended by ^A^Y (stdout = 1, length = 25 (with newline))
+# Looks like it is missing the required 0 bytes from the message, why?
 t POST "containers/foo/attach?logs=true&stream=false" 200 \
-  $'\001\030'$mytext
+  $'\001\031'$mytext
 t POST "containers/foo/kill" 204
 
 podman run -v /tmp:/tmp $IMAGE true


### PR DESCRIPTION
When we read logs there can be full or partial lines, when it is full we need to append a newline, thus the message length must be incremented by one.

Fixes #16856


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the http attach endpoint where it would return an incorrect length when it was reading logs.
```
