### PR TITLE
pkg/rootless: Change error text ...

### DIFF
--- a/pkg/rootless/rootless_freebsd.go
+++ b/pkg/rootless/rootless_freebsd.go
@@ -22,7 +22,7 @@ func IsRootless() bool {
 // If podman was re-executed the caller needs to propagate the error code returned by the child
 // process.  It is a convenience function for BecomeRootInUserNSWithOpts with a default configuration.
 func BecomeRootInUserNS(pausePid string) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
+	return false, -1, errors.New("Rootless mode is not supported on FreeBSD - run podman as root")
 }
 
 // GetRootlessUID returns the UID of the user in the parent userNS


### PR DESCRIPTION
... redirect the user to run with superuser privileges instead of printing 'this function is not supported'.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

User sees an informative error message if they attempt to run podman without superuser privileges on FreeBSD.

```release-note
None
```
