### PR TITLE
Quadlet handle podman binary name better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ LDFLAGS_PODMAN ?= \
 	$(if $(BUILD_INFO),-X $(LIBPOD)/define.buildInfo=$(BUILD_INFO),) \
 	-X $(LIBPOD)/config._installPrefix=$(PREFIX) \
 	-X $(LIBPOD)/config._etcDir=$(ETCDIR) \
+	-X $(PROJECT)/v4/pkg/systemd/quadlet._binDir=$(BINDIR) \
 	-X github.com/containers/common/pkg/config.additionalHelperBinariesDir=$(HELPER_BINARIES_DIR)\
 	$(EXTRA_LDFLAGS)
 LDFLAGS_PODMAN_STATIC ?= \

--- a/pkg/systemd/quadlet/podmancmdline.go
+++ b/pkg/systemd/quadlet/podmancmdline.go
@@ -2,8 +2,23 @@ package quadlet
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"sort"
 )
+
+// Overwritten at build time
+var (
+	_binDir string
+)
+
+func podmanBinary() string {
+	podman := os.Getenv("PODMAN")
+	if len(podman) > 0 {
+		return podman
+	}
+	return path.Join(_binDir, "podman")
+}
 
 /* This is a helper for constructing podman commandlines */
 type PodmanCmdline struct {
@@ -47,7 +62,7 @@ func NewPodmanCmdline(args ...string) *PodmanCmdline {
 		Args: make([]string, 0),
 	}
 
-	c.add("/usr/bin/podman")
+	c.add(podmanBinary())
 	c.add(args...)
 	return c
 }

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -229,7 +229,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 
 	// If the conman exited uncleanly it may not have removed the container, so force it,
 	// -i makes it ignore non-existing files.
-	service.Add(ServiceGroup, "ExecStopPost", "-/usr/bin/podman rm -f -i --cidfile=%t/%N.cid")
+	service.Add(ServiceGroup, "ExecStopPost", "-"+podmanBinary()+" rm -f -i --cidfile=%t/%N.cid")
 
 	// Remove the cid file, to avoid confusion as the container is no longer running.
 	service.Add(ServiceGroup, "ExecStopPost", "-rm -f %t/%N.cid")

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -14,7 +14,7 @@
 ## assert-key-is "Service" "Type" "notify"
 ## assert-key-is "Service" "NotifyAccess" "all"
 ## assert-key-is "Service" "SyslogIdentifier" "%N"
-## assert-key-is "Service" "ExecStopPost" "-/usr/bin/podman rm -f -i --cidfile=%t/%N.cid" "-rm -f %t/%N.cid"
+## assert-key-is-regex "Service" "ExecStopPost" "-.*/podman rm -f -i --cidfile=%t/%N.cid" "-rm -f %t/%N.cid"
 ## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
 
 [Container]

--- a/test/e2e/quadlet/basic.volume
+++ b/test/e2e/quadlet/basic.volume
@@ -1,7 +1,7 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type oneshot
 ## assert-key-is Service RemainAfterExit yes
-## assert-key-is Service ExecStart "/usr/bin/podman volume create --ignore systemd-basic"
+## assert-key-is-regex Service ExecStart ".*/podman volume create --ignore systemd-basic"
 ## assert-key-is Service SyslogIdentifier "%N"
 
 [Volume]

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -117,6 +117,26 @@ func (t *quadletTestcase) assertKeyIs(args []string, unit *parser.UnitFile) bool
 	return true
 }
 
+func (t *quadletTestcase) assertKeyIsRegex(args []string, unit *parser.UnitFile) bool {
+	Expect(len(args)).To(BeNumerically(">=", 3))
+	group := args[0]
+	key := args[1]
+	values := args[2:]
+
+	realValues := unit.LookupAll(group, key)
+	if len(realValues) != len(values) {
+		return false
+	}
+
+	for i := range realValues {
+		matched, _ := regexp.MatchString(values[i], realValues[i])
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
 func (t *quadletTestcase) assertKeyContains(args []string, unit *parser.UnitFile) bool {
 	Expect(args).To(HaveLen(3))
 	group := args[0]
@@ -209,6 +229,8 @@ func (t *quadletTestcase) doAssert(check []string, unit *parser.UnitFile, sessio
 		ok = t.assertStdErrContains(args, session)
 	case "assert-key-is":
 		ok = t.assertKeyIs(args, unit)
+	case "assert-key-is-regex":
+		ok = t.assertKeyIsRegex(args, unit)
 	case "assert-key-contains":
 		ok = t.assertKeyContains(args, unit)
 	case "assert-podman-args":

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -99,6 +99,7 @@ func (t *quadletTestcase) assertStdErrContains(args []string, session *PodmanSes
 }
 
 func (t *quadletTestcase) assertKeyIs(args []string, unit *parser.UnitFile) bool {
+	Expect(len(args)).To(BeNumerically(">=", 3))
 	group := args[0]
 	key := args[1]
 	values := args[2:]
@@ -117,6 +118,7 @@ func (t *quadletTestcase) assertKeyIs(args []string, unit *parser.UnitFile) bool
 }
 
 func (t *quadletTestcase) assertKeyContains(args []string, unit *parser.UnitFile) bool {
+	Expect(args).To(HaveLen(3))
 	group := args[0]
 	key := args[1]
 	value := args[2]
@@ -171,6 +173,7 @@ func (t *quadletTestcase) assertStopPodmanFinalArgsRegex(args []string, unit *pa
 }
 
 func (t *quadletTestcase) assertSymlink(args []string, unit *parser.UnitFile) bool {
+	Expect(args).To(HaveLen(2))
 	symlink := args[0]
 	expectedTarget := args[1]
 
@@ -183,6 +186,7 @@ func (t *quadletTestcase) assertSymlink(args []string, unit *parser.UnitFile) bo
 }
 
 func (t *quadletTestcase) doAssert(check []string, unit *parser.UnitFile, session *PodmanSessionIntegration) error {
+	Expect(len(check)).To(BeNumerically(">=", 1))
 	op := check[0]
 	args := make([]string, 0)
 	for _, a := range check[1:] {


### PR DESCRIPTION
This makes quadlet respect the PODMAN env var (useful for tests) as well as using the proper podman binary installed by the build in $BINDIR. Some of the changes also had to be changed to support the changed podman binary name in the generated files.

This is a preparation for the changes in https://github.com/containers/podman/pull/16825 which has to wait for Ed to get back, but we would like to get the preparatory changes in now as they conflict with other outstanding things.

```release-note
None
```
