### PR TITLE
podman-kube@ template: use `podman kube`

### DIFF
--- a/contrib/systemd/system/podman-kube@.service.in
+++ b/contrib/systemd/system/podman-kube@.service.in
@@ -1,6 +1,6 @@
 [Unit]
-Description=A template for running K8s workloads via podman-play-kube
-Documentation=man:podman-play-kube(1)
+Description=A template for running K8s workloads via podman-kube-play
+Documentation=man:podman-kube-play(1)
 Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=%t/containers
@@ -8,8 +8,8 @@ RequiresMountsFor=%t/containers
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 TimeoutStopSec=70
-ExecStart=@@PODMAN@@ play kube --replace --service-container=true %I
-ExecStop=@@PODMAN@@ play kube --down %I
+ExecStart=@@PODMAN@@ kube play --replace --service-container=true %I
+ExecStop=@@PODMAN@@ kube down %I
 Type=notify
 NotifyAccess=all
 


### PR DESCRIPTION
Use the new `podman kube {down,play}` commands.

[NO NEW TESTS NEEDED] as this is a purely cosmetic change.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
