### PR TITLE
Always allow pushing from containers-storage

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -304,6 +304,8 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	pushOptions.Password = options.Password
 	pushOptions.ManifestMIMEType = manifestType
 	pushOptions.RemoveSignatures = options.RemoveSignatures
+	pushOptions.PolicyAllowStorage = true
+	pushOptions.SignaturePolicyPath = options.SignaturePolicy
 	pushOptions.SignBy = options.SignBy
 	pushOptions.SignPassphrase = options.SignPassphrase
 	pushOptions.SignBySigstorePrivateKeyFile = options.SignBySigstorePrivateKeyFile
@@ -357,6 +359,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	}
 	return pushError
 }
+
 func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, options entities.ImageTagOptions) error {
 	// Allow tagging manifest list instead of resolving instances from manifest
 	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}

--- a/test/deny.json
+++ b/test/deny.json
@@ -1,0 +1,7 @@
+{
+  "default": [
+    {
+      "type": "reject"
+    }
+  ]
+}

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -188,6 +188,21 @@ var _ = Describe("Podman push", func() {
 		}
 	})
 
+	It("podman push from local storage with nothing-allowed signature policy", func() {
+		SkipIfRemote("Remote push does not support dir transport")
+		denyAllPolicy := filepath.Join(INTEGRATION_ROOT, "test/deny.json")
+
+		inspect := podmanTest.Podman([]string{"inspect", "--format={{.ID}}", ALPINE})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		imageID := inspect.OutputToString()
+
+		push := podmanTest.Podman([]string{"push", "--signature-policy", denyAllPolicy, "-q", imageID, "dir:" + filepath.Join(podmanTest.TempDir, imageID)})
+		push.WaitWithDefaultTimeout()
+		Expect(push).Should(Exit(0))
+		Expect(push.ErrorToString()).To(BeEmpty())
+	})
+
 	It("podman push to local registry with authorization", func() {
 		SkipIfRootless("volume-mounting a certs.d file N/A over remote")
 		if podmanTest.Host.Arch == "ppc64le" {


### PR DESCRIPTION
Override the signature policy to always allow pushing images from local storage, even if the default policy is set up to always disallow reading images from any location.  Fixes OCPBUGS-2383.

Pay attention to the --signature-policy option in `podman push`, so that we can test this properly.

#### Does this PR introduce a user-facing change?

```release-note
`podman push` no longer ignores the hidden `--signature-policy` flag.
```
