### PR TITLE
Qemu windows machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ endif
 # include this lightweight helper binary.
 #
 GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
-GV_SHA=1382207678c2da7bc6be7d9dcf6806e862e424f8
+GV_SHA=aab0ac9367fc5142f5857c36ac2352bcb3c60ab7
 
 ###
 ### Primary entry-point targets
@@ -764,11 +764,9 @@ gvproxy: test/version/version
          git init; \
          git remote add origin $(GV_GITURL); \
          git fetch --depth 1 origin $(GV_SHA); \
-         git checkout FETCH_HEAD; make gvproxy win-sshproxy)
+         git checkout FETCH_HEAD; make win-gvproxy win-sshproxy)
 	mkdir -p bin/windows/
 	cp tmp-gv/bin/win-sshproxy.exe bin/windows/
-# workaround the build artifact naming
-	cp tmp-gv/bin/gvproxy tmp-gv/bin/gvproxy.exe
 	cp tmp-gv/bin/gvproxy.exe bin/windows/
 	rm -rf tmp-gv
 

--- a/cmd/podman/machine/platform_windows.go
+++ b/cmd/podman/machine/platform_windows.go
@@ -1,10 +1,21 @@
 package machine
 
 import (
+	"os"
+	"strings"
+
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/wsl"
+	"github.com/containers/podman/v4/pkg/machine/qemu"
 )
 
 func GetSystemDefaultProvider() machine.Provider {
-	return wsl.GetWSLProvider()
+	switch strings.ToUpper(os.Getenv("CONTAINERS_MACHINE_PROVIDER")) {
+	case "WSL":
+		return wsl.GetWSLProvider()
+	case "QEMU":
+		return qemu.GetVirtualizationProvider()
+	default:
+		return wsl.GetWSLProvider()
+	}
 }

--- a/contrib/msi/podman.wxs
+++ b/contrib/msi/podman.wxs
@@ -34,6 +34,9 @@
             <Component Id="WinSshProxyExecutable" Guid="0DA730AB-2F97-40E8-A8FC-356E88EAA4D2" Win64="Yes">
               <File Id="4A2AD125-34E7-4BD8-BE28-B2A9A5EDBEB5" Name="win-sshproxy.exe" Source="bin/windows/win-sshproxy.exe" KeyPath="yes"/>
             </Component>
+            <Component Id="GvProxyExecutable" Guid="1A4A2975-AD2D-44AA-974B-9B343C098333" Win64="Yes">
+              <File Id="0C9BDFB8-1DBD-4E51-BE7B-3F55478DACB7" Name="gvproxy.exe" Source="bin/windows/gvproxy.exe" KeyPath="yes"/>
+            </Component>
           </Directory>
         </Directory>
       </Directory>
@@ -47,6 +50,7 @@
       <ComponentRef Id="MainExecutable"/>
       <ComponentRef Id="WinPathExecutable"/>
       <ComponentRef Id="WinSshProxyExecutable"/>
+      <ComponentRef Id="GvProxyExecutable"/>
       <ComponentGroupRef Id="ManFiles"/>
     </Feature>
 

--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -132,6 +132,7 @@ FetchPanel
 
 .\build-hooks.bat; ExitOnError
 SignItem @("artifacts/win-sshproxy.exe",
+          "artifacts/gvproxy.exe",
           "artifacts/podman.exe",
           "artifacts/podman-msihooks.dll",
           "artifacts/podman-wslkerninst.exe")

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -30,6 +30,9 @@
             <Component Id="WinSshProxyExecutable" Guid="0DA730AB-2F97-40E8-A8FC-356E88EAA4D2" Win64="yes">
               <File Id="WinSshProxyExecutableFile" Name="win-sshproxy.exe" Source="artifacts/win-sshproxy.exe" KeyPath="yes"/>
             </Component>
+             <Component Id="GvProxyExecutable" Guid="1A4A2975-AD2D-44AA-974B-9B343C098333" Win64="yes">
+              <File Id="GvProxyExecutableFile" Name="gvproxy.exe" Source="artifacts/gvproxy.exe" KeyPath="yes"/>
+            </Component>
             <Component Id="GuideHTMLComponent" Guid="8B23C76B-F7D4-4030-8C46-1B5729E616B5" Win64="yes">
               <File Id="GuideHTMLFile"  Name="welcome-podman.html" Source="docs/podman-for-windows.html" KeyPath="yes"/>
             </Component>
@@ -60,6 +63,7 @@
       <ComponentRef Id="EnvEntriesComponent"/>
       <ComponentRef Id="MainExecutable"/>
       <ComponentRef Id="WinSshProxyExecutable"/>
+      <ComponentRef Id="GvProxyExecutable"/>
       <ComponentRef Id="GuideHTMLComponent"/>
       <ComponentGroupRef Id="ManFiles"/>
       <ComponentGroupRef Id="WSLFeature"/>

--- a/contrib/win-installer/process-release.ps1
+++ b/contrib/win-installer/process-release.ps1
@@ -123,8 +123,13 @@ try {
         Remove-Item -Recurse -Force -Path expand
     }
 
+    $loc = Get-ChildItem -Recurse -Path . -Name gvproxy.exe
+    if (!$loc) {
+        throw "Could not obtain gvproxy.exe"
+    }
+
     Write-Host "Copying artifacts"
-    Foreach ($fileName in "win-sshproxy.exe", "podman.exe") {
+    Foreach ($fileName in "gvproxy.exe", "win-sshproxy.exe", "podman.exe") {
         Copy-Artifact($fileName)
     }
 

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -10,7 +10,7 @@ SOURCES=${@:3}                      ## directories to find markdown files
 # invoked in a cross-compilation environment, so even if PLATFORM=windows
 # we need an actual executable that we can invoke).
 if [[ -z "$PODMAN" ]]; then
-    DETECTED_OS=$(env -i HOME="$HOME" PATH="$PATH" go env GOOS)
+    DETECTED_OS=$(env -i HOME="$HOME" PATH="$PATH" GOROOT="$GOROOT" go env GOOS)
     case $DETECTED_OS in
         windows)
             PODMAN=bin/windows/podman.exe ;;

--- a/docs/tutorials/qemu-remote-tutorial.md
+++ b/docs/tutorials/qemu-remote-tutorial.md
@@ -1,0 +1,123 @@
+# Podman Remote clients for macOS and Windows with QEMU
+
+***
+**_NOTE:_** For running Podman on Windows, refer to the [Podman for Windows](podman-for-windows.md) guide, which uses the recommended approach of a Podman-managed Linux backend. For Mac, see the [Podman installation instructions](https://podman.io/getting-started/installation). This guide covers the advanced usage of Podman with a custom Linux VM or a remote external Linux system.
+***
+
+## Introduction
+
+There are officially supported podman machines with QEMU on macOS and WSL2 on Windows, but if one wants to use manually configured QEMU VM in a remote mode this could guide them through.
+
+This writing will focus on Windows, because there is no official QEMU support provided, but it should be relatively easy to adapt them for macOS use.
+
+## Prerequisites
+
+* Windows 11 or 10 with unix domain sockets support
+* SSH client feature installed on the machine
+* Hyper-V acceleration should be operational on the machine
+* Direcroty `C:\qemu-remote\` will be used for storing needed assets
+* Port `57561` free to use it for ssh over loopback interface
+
+## Obtaining and installing
+
+### QEMU
+
+Download QEMU (7.2.0 minimal) from https://qemu.weilnetz.de/w64/
+
+Then download the FCOS image for QEMU from https://getfedora.org/coreos/download?tab=metal_virtualized&stream=testing&arch=x86_64
+
+One will need `.xz` format extraction tool like xz itself or 7-zip. Use it to extract the `.qcow2` image to C:\qemu-remote\fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2
+
+With xz the command line (when run from the same directory) will be `xz -d fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2.xz`
+
+### Podman
+
+Download or prepare Podman Windows build with `gvproxy` included and install as default.
+
+### SSH
+
+Generate ssh keys with empty passphrase
+
+ssh-keygen -t ed25519 -f C:\qemu-remote\remote
+
+### Ingition for FCOS
+
+Create ignintion file C:\qemu-remote\remote.ign with content of
+```
+{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.2.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["YOURSSHKEYHERE"],"uid":501},{"name":"root","sshAuthorizedKeys":["YOURSSHKEYHERE"]}]},"storage":{"directories":[{"group":{"name":"core"},"path":"/home/core/.config","user":{"name":"core"},"mode":493},{"group":{"name":"core"},"path":"/home/core/.config/containers","user":{"name":"core"},"mode":493},{"group":{"name":"core"},"path":"/home/core/.config/systemd","user":{"name":"core"},"mode":493},{"group":{"name":"core"},"path":"/home/core/.config/systemd/user","user":{"name":"core"},"mode":493},{"group":{"name":"core"},"path":"/home/core/.config/systemd/user/default.target.wants","user":{"name":"core"},"mode":493},{"group":{"name":"root"},"path":"/etc/containers/registries.conf.d","user":{"name":"root"},"mode":493},{"group":{"name":"root"},"path":"/etc/systemd/system.conf.d","user":{"name":"root"},"mode":493},{"group":{"name":"root"},"path":"/etc/environment.d","user":{"name":"root"},"mode":493}],"files":[{"group":{"name":"core"},"path":"/home/core/.config/systemd/user/linger-example.service","user":{"name":"core"},"contents":{"source":"data:,%5BUnit%5D%0ADescription=A%20systemd%20user%20unit%20demo%0AAfter=network-online.target%0AWants=network-online.target%20podman.socket%0A%5BService%5D%0AExecStart=%2Fusr%2Fbin%2Fsleep%20infinity%0A","verification":{}},"mode":484},{"group":{"name":"core"},"path":"/home/core/.config/containers/containers.conf","user":{"name":"core"},"contents":{"source":"data:,%5Bcontainers%5D%0Anetns=%22bridge%22%0A","verification":{}},"mode":484},{"group":{"name":"root"},"overwrite":true,"path":"/etc/subuid","user":{"name":"root"},"contents":{"source":"data:,core:100000:1000000","verification":{}},"mode":484},{"group":{"name":"root"},"overwrite":true,"path":"/etc/subgid","user":{"name":"root"},"contents":{"source":"data:,core:100000:1000000","verification":{}},"mode":484},{"group":{"name":"root"},"path":"/etc/systemd/system/user@.service.d/delegate.conf","user":{"name":"root"},"contents":{"source":"data:,%5BService%5D%0ADelegate=memory%20pids%20cpu%20io%0A","verification":{}},"mode":420},{"group":{"name":"core"},"path":"/var/lib/systemd/linger/core","user":{"name":"core"},"contents":{"verification":{}},"mode":420},{"group":{"name":"root"},"path":"/etc/containers/containers.conf","user":{"name":"root"},"contents":{"source":"data:,%5Bengine%5D%0Amachine_enabled=true%0A","verification":{}},"mode":420},{"group":{"name":"root"},"path":"/etc/containers/podman-machine","user":{"name":"root"},"contents":{"source":"data:,qemu%0A","verification":{}},"mode":420},{"group":{"name":"root"},"path":"/etc/containers/registries.conf.d/999-podman-machine.conf","user":{"name":"root"},"contents":{"source":"data:,unqualified-search-registries=%5B%22docker.io%22%5D%0A","verification":{}},"mode":420},{"group":{},"path":"/etc/tmpfiles.d/podman-docker.conf","user":{},"contents":{"source":"data:,L+%20%20%2Frun%2Fdocker.sock%20%20%20-%20%20%20%20-%20%20%20%20-%20%20%20%20%20-%20%20%20%2Frun%2Fpodman%2Fpodman.sock%0A","verification":{}},"mode":420},{"group":{"name":"root"},"path":"/etc/profile.d/docker-host.sh","user":{"name":"root"},"contents":{"source":"data:,export%20DOCKER_HOST=%22unix:%2F%2F$%28podman%20info%20-f%20%22%7B%7B.Host.RemoteSocket.Path%7D%7D%22%29%22%0A","verification":{}},"mode":420}],"links":[{"group":{"name":"core"},"path":"/home/core/.config/systemd/user/default.target.wants/linger-example.service","user":{"name":"core"},"hard":false,"target":"/home/core/.config/systemd/user/linger-example.service"},{"group":{"name":"root"},"overwrite":true,"path":"/usr/local/bin/docker","user":{"name":"root"},"hard":false,"target":"/usr/bin/podman"},{"group":{"name":"root"},"overwrite":false,"path":"/etc/localtime","user":{"name":"root"},"hard":false,"target":"\\usr\\share\\zoneinfo"}]},"systemd":{"units":[{"enabled":true,"name":"podman.socket"},{"contents":"[Unit]\nRequires=dev-virtio\\\\x2dports-vport1p1.device\nAfter=remove-moby.service sshd.socket sshd.service\nOnFailure=emergency.target\nOnFailureJobMode=isolate\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/bin/sh -c '/usr/bin/echo Ready \u003e/dev/vport1p1'\n[Install]\nRequiredBy=default.target\n","enabled":true,"name":"ready.service"},{"enabled":false,"mask":true,"name":"docker.service"},{"enabled":false,"mask":true,"name":"docker.socket"},{"contents":"[Unit]\nDescription=Remove moby-engine\n# Run once for the machine\nAfter=systemd-machine-id-commit.service\nBefore=zincati.service\nConditionPathExists=!/var/lib/%N.stamp\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/rpm-ostree override remove moby-engine\nExecStart=/usr/bin/rpm-ostree ex apply-live --allow-replacement\nExecStartPost=/bin/touch /var/lib/%N.stamp\n\n[Install]\nWantedBy=default.target\n","enabled":true,"name":"remove-moby.service"},{"contents":"[Unit]\nDescription=Environment setter from QEMU FW_CFG\n[Service]\nType=oneshot\nRemainAfterExit=yes\nEnvironment=FWCFGRAW=/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/environment/raw\nEnvironment=SYSTEMD_CONF=/etc/systemd/system.conf.d/default-env.conf\nEnvironment=ENVD_CONF=/etc/environment.d/default-env.conf\nEnvironment=PROFILE_CONF=/etc/profile.d/default-env.sh\nExecStart=/usr/bin/bash -c '/usr/bin/test -f ${FWCFGRAW} \u0026\u0026\\\n\techo \"[Manager]\\n#Got from QEMU FW_CFG\\nDefaultEnvironment=$(/usr/bin/base64 -d ${FWCFGRAW} | sed -e \"s+|+ +g\")\\n\" \u003e ${SYSTEMD_CONF} ||\\\n\techo \"[Manager]\\n#Got nothing from QEMU FW_CFG\\n#DefaultEnvironment=\\n\" \u003e ${SYSTEMD_CONF}'\nExecStart=/usr/bin/bash -c '/usr/bin/test -f ${FWCFGRAW} \u0026\u0026 (\\\n\techo \"#Got from QEMU FW_CFG\"\u003e ${ENVD_CONF};\\\n\tIFS=\"|\";\\\n\tfor iprxy in $(/usr/bin/base64 -d ${FWCFGRAW}); do\\\n\t\techo \"$iprxy\" \u003e\u003e ${ENVD_CONF}; done ) || \\\n\techo \"#Got nothing from QEMU FW_CFG\"\u003e ${ENVD_CONF}'\nExecStart=/usr/bin/bash -c '/usr/bin/test -f ${FWCFGRAW} \u0026\u0026 (\\\n\techo \"#Got from QEMU FW_CFG\"\u003e ${PROFILE_CONF};\\\n\tIFS=\"|\";\\\n\tfor iprxy in $(/usr/bin/base64 -d ${FWCFGRAW}); do\\\n\t\techo \"export $iprxy\" \u003e\u003e ${PROFILE_CONF}; done ) || \\\n\techo \"#Got nothing from QEMU FW_CFG\"\u003e ${PROFILE_CONF}'\nExecStartPost=/usr/bin/systemctl daemon-reload\n[Install]\nWantedBy=sysinit.target\n","enabled":true,"name":"envset-fwcfg.service"}]}}
+```
+
+Replace "YOURSSHKEYHERE" with the actual pub keys you generated.
+
+## Laucning
+
+### gvproxy
+
+One needs to run gvproxy first to make it ready for the QEMU VM launched afterwards. Run it  with the command below
+```
+gvproxy.exe -listen-qemu unix://C:/qemu-remote/vlan_remote.sock -pid-file C:\qemu-remote\proxy.pid -ssh-port 57561 -forward-sock C:\qemu-remote\podman.sock -forward-dest /run/user/501/podman/podman.sock -forward-user core -forward-identity C:\qemu-remote\remote
+```
+
+### QEMU
+
+Laucnh QEMU with the following command (it is configure for 4 CPUs and 8 GB RAM, but could be adjusted for less):
+
+```
+qemu-system-x86_64.exe -m 8192 -smp 4 -fw_cfg name=opt/com.coreos/config,file=C:\qemu-remote\remote.ign -netdev stream,id=vlan,server=off,addr.type=unix,addr.path=C:\qemu-remote\vlan_remote.sock -device virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee -device virtio-serial -chardev socket,path=C:\qemu-remote\ready.sock,server=on,wait=off,id=apodman-machine-default_ready -device virtserialport,chardev=apodman-machine-default_ready,name=org.fedoraproject.port.0 -pidfile C:\qemu-remote\vm.pid -machine q35,accel=whpx:tcg -cpu max,vmx=off,monitor=off -drive if=virtio,file=C:\qemu-remote\fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2
+```
+
+### First time launch extras
+
+Observe QEMU loading and wait for the message of SSH keys being provisioned to the machine. Next before making first ssh connection one would need to add it to known hosts.
+We are using `127.0.0.1` instead of `localhost` to force IPv4.
+
+```
+ssh-keyscan -p 57561 127.0.0.1 >> %USERPROFILE%\.ssh\known_hosts
+```
+
+### Add new connection to podman
+
+Create a connection named "qemuremote"
+
+```
+podman system connection add --identity C:\qemu-remote\remote -p 57561 qemuremote ssh://core@127.0.0.1
+```
+
+#### Optional
+
+Make it default for simplicity of operation/testing
+
+```
+podman system connection default qemuremote
+```
+
+## Using podman
+
+Choose the active connection to be "qemuremote" (not needed if one made it default).
+
+Run some basic network enabled workload:
+
+```
+podman run -d --rm -p 8080:80 nginx
+```
+
+Test it with 
+
+```
+curl http -v http://localhost:8080
+```
+
+## Shutting down the machine
+
+Podman machine built in machinery will not work for custom machine. One would need to gracefully shutdown it connecting via SSH.
+
+```
+ssh -i C:\qemu-remote\remote -p 57561 core@127.0.0.1
+```
+
+And then executing
+
+```
+sudo poweroff
+```
+

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -38,7 +38,7 @@ class Preprocessor():
         outfile = os.path.splitext(infile)[0]
         outfile_tmp = outfile + '.tmp.' + str(os.getpid())
 
-        with open(infile, 'r') as fh_in, open(outfile_tmp, 'w') as fh_out:
+        with open(infile, 'r', encoding="utf-8") as fh_in, open(outfile_tmp, 'w', encoding="utf-8", newline='\n') as fh_out:
             for line in fh_in:
                 # '@@option foo' -> include file options/foo.md
                 if line.startswith('@@option '):
@@ -71,7 +71,7 @@ class Preprocessor():
         """
         for optionfile in self.used_by:
             tmpfile = optionfile + '.tmp'
-            with open(optionfile, 'r') as fh_in, open(tmpfile, 'w') as fh_out:
+            with open(optionfile, 'r', encoding="utf-8") as fh_in, open(tmpfile, 'w', encoding="utf-8", newline='\n') as fh_out:
                 fh_out.write("####> This option file is used in:\n")
                 used_by = ', '.join(x for x in self.used_by[optionfile])
                 fh_out.write(f"####>   podman {used_by}\n")
@@ -82,6 +82,7 @@ class Preprocessor():
                         fh_out.write(line)
             # Compare files; only rewrite if the new one differs
             if not filecmp.cmp(optionfile, tmpfile):
+                os.unlink(optionfile)
                 os.rename(tmpfile, optionfile)
             else:
                 os.unlink(tmpfile)
@@ -96,7 +97,7 @@ class Preprocessor():
         # treats them as one line and will unwantedly render the
         # comment in its output.
         fh_out.write("\n[//]: # (BEGIN included file " + path + ")\n")
-        with open(path, 'r') as fh_included:
+        with open(path, 'r', encoding="utf-8") as fh_included:
             for opt_line in fh_included:
                 if opt_line.startswith('####>'):
                     continue

--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -1,7 +1,7 @@
 package qemu
 
 var (
-	QemuCommand = "qemu-system-x86_64"
+	QemuCommand = "qemu-system-x86_64w"
 )
 
 func (v *MachineVM) addArchOptions() []string {

--- a/pkg/machine/qemu/options_windows_arm64.go
+++ b/pkg/machine/qemu/options_windows_arm64.go
@@ -1,0 +1,19 @@
+package qemu
+
+var (
+	QemuCommand = "qemu-system-aarch64w"
+)
+
+func (v *MachineVM) addArchOptions() []string {
+	// stub to fix compilation issues
+	opts := []string{}
+	return opts
+}
+
+func (v *MachineVM) prepare() error {
+	return nil
+}
+
+func (v *MachineVM) archRemovalFiles() []string {
+	return []string{}
+}


### PR DESCRIPTION
Fixes: #13006

Adds QEMU podman machine provider on Windows hosts.

How to test it:

1. Build Windows installer from this branch and install it as normally
2. Install latest QEMU from https://qemu.weilnetz.de/w64/
3. Run commands in console to test it:
3.1. Set environment variable to select provider QEMU
3.2. Set PATH to include qemu binaries (their default installer seems doesn't update path)
3.3. Initialize new machine overriding username and image-path, because defaults are different from WSL and there is no way to have defaults per provider as of now
3.4. Start the machine
3.5. Run some network enabled workload to verify machine and networking

Example for bullet point 3:
```
set CONTAINERS_MACHINE_PROVIDER=QEMU
set PATH=%PROGRAMFILES%\qemu;%PATH%
podman machine init --cpus 4 --memory 8192 --username core --image-path testing
podman machine start
podman run -d -p 8080:80 nginx
curl http://localhost:8080/
```

Alternatively to setting environment variables in console session, one could opt for setting them globally for the host (restart is recommended to make sure that they would be propagated everywhere).

The PR will require rebase later as it includes commit from https://github.com/containers/podman/pull/16807 If needed the former one may be closed and squashed with this one, but for me it looks like #16807 has the value on its own and is pretty complete.

Note worthy technical details:
* stub settings for Windows on Arm were added to allow compilation to pass for this target, but QEMU doesn't exist for it yet (mingw64 doesn't have this build target (at least in stable form);
* usage of Environment Variable to select provider is a hack, because there is no feature to select provider from the CLI
* it is impossible to operate with multiple providers within the same process (like list all QEMU and WSL2 machines)
* ssh keys collision happens for same named WSL2 and QEMU machines - issue created https://github.com/containers/podman/issues/16710
* vlan socket name is derived from qmp socket name, which works, but doesn't feel right - issue registered https://github.com/containers/podman/issues/15852
* named pipe collision with same named WSL2 machine - issue registered https://github.com/containers/podman/issues/16860 

Missing features:
* 9pfs support on Windows hosts is not yet merged into QEMU. So, folder mounts are unsupported.

Known issues:
* ~sending Ctrl-C to the console or closing console session, where the machine was started will terminate QEMU and gvproxy.~ (fixed)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
QEMU podman machine provider on Windows hosts
```
