### PR TITLE
Unify --noheading and -n to be consistent on all commands

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -55,7 +55,7 @@ func init() {
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, "{{range .}}{{.Name}}\t{{.VMType}}\t{{.Created}}\t{{.LastUp}}\t{{.CPUs}}\t{{.Memory}}\t{{.DiskSize}}\n{{end -}}", "Format volume output using JSON or a Go template")
 	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.ListReporter{}))
-	flags.BoolVar(&listFlag.noHeading, "noheading", false, "Do not print headers")
+	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print headers")
 	flags.BoolVarP(&listFlag.quiet, "quiet", "q", false, "Show only machine names")
 }
 

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -47,7 +47,7 @@ func networkListFlags(flags *pflag.FlagSet) {
 
 	filterFlagName := "filter"
 	flags.StringArrayVarP(&filters, filterFlagName, "f", nil, "Provide filter values (e.g. 'name=podman')")
-	flags.Bool("noheading", false, "Do not print headers")
+	flags.BoolP("noheading", "n", false, "Do not print headers")
 	_ = networklistCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteNetworkFilters)
 }
 

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -59,7 +59,7 @@ func init() {
 	flags.StringVar(&psInput.Format, formatFlagName, "", "Pretty-print pods to JSON or using a Go template")
 	_ = psCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&ListPodReporter{}))
 
-	flags.Bool("noheading", false, "Do not print headers")
+	flags.BoolP("noheading", "n", false, "Do not print headers")
 	flags.BoolVar(&psInput.Namespace, "ns", false, "Display namespace information of the pod")
 	flags.BoolVar(&noTrunc, "no-trunc", false, "Do not truncate pod and container IDs")
 	flags.BoolVarP(&psInput.Quiet, "quiet", "q", false, "Print the numeric IDs of the pods only")

--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -54,7 +54,7 @@ func init() {
 	_ = lsCmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteSecretFilters)
 
 	noHeadingFlagName := "noheading"
-	flags.BoolVar(&listFlag.noHeading, noHeadingFlagName, false, "Do not print headers")
+	flags.BoolVarP(&listFlag.noHeading, noHeadingFlagName, "n", false, "Do not print headers")
 
 	quietFlagName := "quiet"
 	flags.BoolVarP(&listFlag.quiet, quietFlagName, "q", false, "Print secret IDs only")

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -58,7 +58,7 @@ func init() {
 	flags.StringVar(&cliOpts.Format, formatFlagName, "{{range .}}{{.Driver}}\t{{.Name}}\n{{end -}}", "Format volume output using Go template")
 	_ = lsCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.VolumeListReport{}))
 
-	flags.Bool("noheading", false, "Do not print headers")
+	flags.BoolP("noheading", "n", false, "Do not print headers")
 	flags.BoolVarP(&cliOpts.Quiet, "quiet", "q", false, "Print volume output in quiet mode")
 }
 

--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -3,12 +3,14 @@ podman-auto-update.1.md
 podman-build.1.md
 podman-container-clone.1.md
 podman-container-diff.1.md
-podman-container-runlabel.1.md
 podman-container-inspect.1.md
+podman-container-runlabel.1.md
 podman-create.1.md
 podman-diff.1.md
 podman-exec.1.md
 podman-image-sign.1.md
+podman-image-trust.1.md
+podman-images.1.md
 podman-init.1.md
 podman-init.1.md
 podman-inspect.1.md
@@ -17,12 +19,14 @@ podman-kube-play.1.md
 podman-login.1.md
 podman-logout.1.md
 podman-logs.1.md
+podman-machine-list.1.md
 podman-manifest-add.1.md
 podman-manifest-annotate.1.md
 podman-manifest-create.1.md
 podman-manifest-inspect.1.md
 podman-manifest-push.1.md
 podman-mount.1.md
+podman-network-ls.1.md
 podman-network-reload.1.md
 podman-pause.1.md
 podman-pod-clone.1.md
@@ -31,6 +35,7 @@ podman-pod-inspect.1.md
 podman-pod-inspect.1.md
 podman-pod-kill.1.md
 podman-pod-logs.1.md
+podman-pod-ps.1.md
 podman-pod-rm.1.md
 podman-pod-start.1.md
 podman-pod-stats.1.md
@@ -43,6 +48,7 @@ podman-restart.1.md
 podman-rm.1.md
 podman-run.1.md
 podman-search.1.md
+podman-secret-ls.1.md
 podman-start.1.md
 podman-stats.1.md
 podman-stop.1.md
@@ -50,4 +56,5 @@ podman-top.1.md
 podman-unmount.1.md
 podman-unpause.1.md
 podman-update.1.md
+podman-volume-ls.1.md
 podman-wait.1.md

--- a/docs/source/markdown/options/noheading.md
+++ b/docs/source/markdown/options/noheading.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman image trust, images, machine list, network ls, pod ps, secret ls, volume ls
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--noheading**, **-n**
+
+Omit the table headings from the listing.

--- a/docs/source/markdown/podman-image-trust.1.md.in
+++ b/docs/source/markdown/podman-image-trust.1.md.in
@@ -64,8 +64,7 @@ Trust may be updated using the command **podman image trust set** for an existin
 #### **--json**, **-j**
   Output trust as JSON for machine parsing
 
-#### **--noheading**, **-n**
-  Omit the table headings from the trust listings
+@@option noheading
 
 #### **--raw**
   Output trust policy file as raw JSON

--- a/docs/source/markdown/podman-images.1.md.in
+++ b/docs/source/markdown/podman-images.1.md.in
@@ -108,9 +108,7 @@ Display the history of image names.  If an image gets re-tagged or untagged, the
 
 Do not truncate the output (default *false*).
 
-#### **--noheading**, **-n**
-
-Omit the table headings from the listing of images.
+@@option noheading
 
 #### **--quiet**, **-q**
 

--- a/docs/source/markdown/podman-machine-list.1.md.in
+++ b/docs/source/markdown/podman-machine-list.1.md.in
@@ -53,9 +53,7 @@ Valid placeholders for the Go template are listed below:
 
 Print usage statement.
 
-#### **--noheading**
-
-Omit the table headings from the listing of machines
+@@option noheading
 
 #### **--quiet**, **-q**
 

--- a/docs/source/markdown/podman-network-ls.1.md.in
+++ b/docs/source/markdown/podman-network-ls.1.md.in
@@ -61,9 +61,7 @@ Valid placeholders for the Go template are listed below:
 
 Do not truncate the network ID.
 
-#### **--noheading**
-
-Omit the table headings from the listing of networks.
+@@option noheading
 
 #### **--quiet**, **-q**
 

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -105,9 +105,7 @@ Display namespace information of the pod
 
 Do not truncate the output (default *false*).
 
-#### **--noheading**
-
-Omit the table headings from the listing of pods.
+@@option noheading
 
 #### **--quiet**, **-q**
 

--- a/docs/source/markdown/podman-secret-ls.1.md.in
+++ b/docs/source/markdown/podman-secret-ls.1.md.in
@@ -28,9 +28,7 @@ Valid filters are listed below:
 
 Format secret output using Go template.
 
-#### **--noheading**
-
-Omit the table headings from the listing of secrets.
+@@option noheading
 
 #### **--quiet**, **-q**
 

--- a/docs/source/markdown/podman-volume-ls.1.md.in
+++ b/docs/source/markdown/podman-volume-ls.1.md.in
@@ -36,9 +36,7 @@ Format volume output using Go template.
 
 Print usage statement.
 
-#### **--noheading**
-
-Omit the table headings from the listing of volumes.
+@@option noheading
 
 #### **--quiet**, **-q**
 

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -198,7 +198,17 @@ var _ = Describe("Podman secret", func() {
 		secret1 := "Secret1"
 		secret2 := "Secret2"
 
-		session := podmanTest.Podman([]string{"secret", "create", secret1, secretFilePath})
+		session := podmanTest.Podman([]string{"secret", "ls", "-n"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(""))
+
+		session = podmanTest.Podman([]string{"secret", "ls", "--noheading"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(""))
+
+		session = podmanTest.Podman([]string{"secret", "create", secret1, secretFilePath})
 		session.WaitWithDefaultTimeout()
 		secrID1 := session.OutputToString()
 		Expect(session).Should(Exit(0))

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -23,6 +23,8 @@ function teardown() {
 @test "podman run --volumes : basic" {
     run_podman volume list --noheading
     is "$output" "" "baseline: empty results from list --noheading"
+    run_podman volume list -n
+    is "$output" "" "baseline: empty results from list -n"
 
     # Create three temporary directories
     vol1=${PODMAN_TMPDIR}/v1_$(random_string)

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -21,8 +21,8 @@ function teardown() {
     run_podman pod list --noheading
     is "$output" "" "baseline: empty results from list --noheading"
 
-    run_podman pod ls --noheading
-    is "$output" "" "baseline: empty results from ls --noheading"
+    run_podman pod ls -n
+    is "$output" "" "baseline: empty results from ls -n"
 
     run_podman pod ps --noheading
     is "$output" "" "baseline: empty results from ps --noheading"

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -14,6 +14,9 @@ load helpers.network
     run_podman network ls --noheading
     assert "$output" !~ "$heading" "network ls --noheading shows header anyway"
 
+    run_podman network ls -n
+    assert "$output" !~ "$heading" "network ls -n shows header anyway"
+
     # check deterministic list order
     local net1=a-$(random_string 10)
     local net2=b-$(random_string 10)


### PR DESCRIPTION
Helps with https://github.com/containers/podman/issues/16536

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support for -n on all listing commands with --noheading option
```
