### PR TITLE
Kube Play - allow setting and overriding published host ports

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -151,6 +151,10 @@ func playFlags(cmd *cobra.Command) {
 	replaceFlagName := "replace"
 	flags.BoolVar(&playOptions.Replace, replaceFlagName, false, "Delete and recreate pods defined in the YAML file")
 
+	publishPortsFlagName := "publish"
+	flags.StringSliceVar(&playOptions.PublishPorts, publishPortsFlagName, []string{}, "Publish a container's port, or a range of ports, to the host")
+	_ = cmd.RegisterFlagCompletionFunc(publishPortsFlagName, completion.AutocompleteNone)
+
 	if !registry.IsRemote() {
 		certDirFlagName := "cert-dir"
 		flags.StringVar(&playOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -170,6 +170,13 @@ When no network option is specified and *host* network mode is not configured in
 
 This option conflicts with host added in the Kubernetes YAML.
 
+#### **--publish**=*[[ip:][hostPort]:]containerPort[/protocol]*
+
+Define or override a port definition in the YAML file.
+
+The lists of ports in the YAML file and the command line are merged. Matching is done by using the **containerPort** field.
+If **containerPort** exists in both the YAML file and the option, the latter takes precedence.
+
 #### **--quiet**, **-q**
 
 Suppress output information when pulling images

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -19,15 +19,16 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		Annotations map[string]string `schema:"annotations"`
-		Network     []string          `schema:"network"`
-		TLSVerify   bool              `schema:"tlsVerify"`
-		LogDriver   string            `schema:"logDriver"`
-		LogOptions  []string          `schema:"logOptions"`
-		Start       bool              `schema:"start"`
-		StaticIPs   []string          `schema:"staticIPs"`
-		StaticMACs  []string          `schema:"staticMACs"`
-		NoHosts     bool              `schema:"noHosts"`
+		Annotations  map[string]string `schema:"annotations"`
+		Network      []string          `schema:"network"`
+		TLSVerify    bool              `schema:"tlsVerify"`
+		LogDriver    string            `schema:"logDriver"`
+		LogOptions   []string          `schema:"logOptions"`
+		Start        bool              `schema:"start"`
+		StaticIPs    []string          `schema:"staticIPs"`
+		StaticMACs   []string          `schema:"staticMACs"`
+		NoHosts      bool              `schema:"noHosts"`
+		PublishPorts []string          `schema:"publishPorts"`
 	}{
 		TLSVerify: true,
 		Start:     true,
@@ -82,18 +83,19 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := entities.PlayKubeOptions{
-		Annotations: query.Annotations,
-		Authfile:    authfile,
-		Username:    username,
-		Password:    password,
-		Networks:    query.Network,
-		NoHosts:     query.NoHosts,
-		Quiet:       true,
-		LogDriver:   logDriver,
-		LogOptions:  query.LogOptions,
-		StaticIPs:   staticIPs,
-		StaticMACs:  staticMACs,
-		IsRemote:    true,
+		Annotations:  query.Annotations,
+		Authfile:     authfile,
+		Username:     username,
+		Password:     password,
+		Networks:     query.Network,
+		NoHosts:      query.NoHosts,
+		Quiet:        true,
+		LogDriver:    logDriver,
+		LogOptions:   query.LogOptions,
+		StaticIPs:    staticIPs,
+		StaticMACs:   staticMACs,
+		IsRemote:     true,
+		PublishPorts: query.PublishPorts,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -48,6 +48,8 @@ type PlayOptions struct {
 	Userns *string
 	// Force - remove volumes on --down
 	Force *bool
+	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
+	PublishPorts []string
 }
 
 // ApplyOptions are optional options for applying kube YAML files to a k8s cluster

--- a/pkg/bindings/kube/types_play_options.go
+++ b/pkg/bindings/kube/types_play_options.go
@@ -302,3 +302,18 @@ func (o *PlayOptions) GetForce() bool {
 	}
 	return *o.Force
 }
+
+// WithPublishPorts set field PublishPorts to given value
+func (o *PlayOptions) WithPublishPorts(value []string) *PlayOptions {
+	o.PublishPorts = value
+	return o
+}
+
+// GetPublishPorts returns value of field PublishPorts
+func (o *PlayOptions) GetPublishPorts() []string {
+	if o.PublishPorts == nil {
+		var z []string
+		return z
+	}
+	return o.PublishPorts
+}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -62,6 +62,8 @@ type PlayKubeOptions struct {
 	IsRemote bool
 	// Force - remove volumes on --down
 	Force bool
+	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
+	PublishPorts []string
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -72,6 +72,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts en
 	if start := opts.Start; start != types.OptionalBoolUndefined {
 		options.WithStart(start == types.OptionalBoolTrue)
 	}
+	options.WithPublishPorts(opts.PublishPorts)
 	return play.KubeWithBody(ic.ClientCtx, body, options)
 }
 


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Kube Play - Add --publish flag to set or override port publishing
```