### PR TITLE
export: use io.Writer instead of file

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -462,7 +462,7 @@ func (c *Container) Unpause() error {
 
 // Export exports a container's root filesystem as a tar archive
 // The archive will be saved as a file at the given path
-func (c *Container) Export(path string) error {
+func (c *Container) Export(out io.Writer) error {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -477,7 +477,7 @@ func (c *Container) Export(path string) error {
 	}
 
 	defer c.newContainerEvent(events.Mount)
-	return c.export(path)
+	return c.export(out)
 }
 
 // AddArtifact creates and writes to an artifact file for the container

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -745,7 +745,7 @@ func (c *Container) removeConmonFiles() error {
 	return nil
 }
 
-func (c *Container) export(path string) error {
+func (c *Container) export(out io.Writer) error {
 	mountPoint := c.state.Mountpoint
 	if !c.state.Mounted {
 		containerMount, err := c.runtime.store.Mount(c.ID(), c.config.MountLabel)
@@ -765,13 +765,7 @@ func (c *Container) export(path string) error {
 		return fmt.Errorf("reading container directory %q: %w", c.ID(), err)
 	}
 
-	outFile, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("creating file %q: %w", path, err)
-	}
-	defer outFile.Close()
-
-	_, err = io.Copy(outFile, input)
+	_, err = io.Copy(out, input)
 	return err
 }
 

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -181,7 +181,7 @@ type CommitReport struct {
 }
 
 type ContainerExportOptions struct {
-	Output string
+	Output io.Writer
 }
 
 type CheckpointOptions struct {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -355,17 +355,7 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 }
 
 func (ic *ContainerEngine) ContainerExport(ctx context.Context, nameOrID string, options entities.ContainerExportOptions) error {
-	var (
-		err error
-		w   io.Writer
-	)
-	if len(options.Output) > 0 {
-		w, err = os.Create(options.Output)
-		if err != nil {
-			return err
-		}
-	}
-	return containers.Export(ic.ClientCtx, nameOrID, w, nil)
+	return containers.Export(ic.ClientCtx, nameOrID, options.Output, nil)
 }
 
 func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds []string, opts entities.CheckpointOptions) ([]*entities.CheckpointReport, error) {

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -51,6 +51,13 @@ like "$output" ".*merged" "Check container mount"
 # Unmount the container
 t POST libpod/containers/foo/unmount 204
 
+# export the container fs to tarball
+
+t GET libpod/containers/foo/export 200
+like "$(<$WORKDIR/curl.headers.out)" ".*"Content-Type\: application/x-tar".*"
+tar_tf=$(tar tf $WORKDIR/curl.result.out)
+like "$tar_tf" ".*bin/cat.*" "fetched tarball: contains bin/cat path"
+
 t DELETE libpod/containers/foo?force=true 200
 
 # Create 3 stopped containers to test containers prune


### PR DESCRIPTION
This allows use to use STDOUT directly without having to call open again, also this makes the export API endpoint much more performant since it no longer needs to copy to a temp file.
I noticed that there was no export API test so I added one.

And lastly opening /dev/stdout will not work on windows.

Fixes #16870

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a problem with podman export on MacOS and windows where it could not export to STDOUT. 
```
