### PR TITLE
Stop recording annotations set to false

### DIFF
--- a/docs/source/markdown/podman-container-inspect.1.md.in
+++ b/docs/source/markdown/podman-container-inspect.1.md.in
@@ -202,11 +202,6 @@ $ podman container inspect foobar
             "Annotations": {
                 "io.container.manager": "libpod",
                 "io.kubernetes.cri-o.Created": "2021-09-16T06:09:08.936623325-04:00",
-                "io.kubernetes.cri-o.TTY": "false",
-                "io.podman.annotations.autoremove": "FALSE",
-                "io.podman.annotations.init": "FALSE",
-                "io.podman.annotations.privileged": "FALSE",
-                "io.podman.annotations.publish-all": "FALSE",
                 "org.opencontainers.image.stopSignal": "15"
             },
             "StopSignal": 15,

--- a/pkg/specgen/generate/namespaces_linux.go
+++ b/pkg/specgen/generate/namespaces_linux.go
@@ -152,8 +152,6 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	}
 	if s.PublishExposedPorts {
 		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseTrue
-	} else {
-		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseFalse
 	}
 
 	return nil

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -63,8 +63,6 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	if s.Remove {
 		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseTrue
-	} else {
-		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseFalse
 	}
 
 	if len(s.VolumesFrom) > 0 {
@@ -73,14 +71,10 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	if s.Privileged {
 		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseTrue
-	} else {
-		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseFalse
 	}
 
 	if s.Init {
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
-	} else {
-		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseFalse
 	}
 
 	if s.OOMScoreAdj != nil {

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -286,8 +286,6 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	if s.Remove {
 		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseTrue
-	} else {
-		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseFalse
 	}
 
 	if len(s.VolumesFrom) > 0 {
@@ -296,14 +294,10 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	if s.Privileged {
 		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseTrue
-	} else {
-		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseFalse
 	}
 
 	if s.Init {
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
-	} else {
-		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseFalse
 	}
 
 	if s.OOMScoreAdj != nil {

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -434,7 +434,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	annotations := make(map[string]string)
 
 	// First, add our default annotations
-	annotations[ann.TTY] = "false"
 	if c.TTY {
 		annotations[ann.TTY] = "true"
 	}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -335,7 +335,7 @@ var _ = Describe("Podman run", func() {
 		Expect(result).Should(Exit(0))
 		conData := result.InspectContainerToJSON()
 		Expect(conData[0]).To(HaveField("Path", "ls"))
-		Expect(conData[0].Config.Annotations).To(HaveKeyWithValue("io.podman.annotations.init", "FALSE"))
+		Expect(conData[0].Config.Annotations).To(Not(HaveKey("io.podman.annotations.init")))
 	})
 
 	forbidGetCWDSeccompProfile := func() string {

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -53,12 +53,6 @@ json.dump(yaml.safe_load(sys.stdin), sys.stdout)'
 apiVersion | =  | v1
 kind       | =  | Pod
 
-metadata.annotations.\"io.kubernetes.cri-o.TTY/$cname\"           | =  | false
-metadata.annotations.\"io.podman.annotations.autoremove/$cname\"  | =  | FALSE
-metadata.annotations.\"io.podman.annotations.init/$cname\"        | =  | FALSE
-metadata.annotations.\"io.podman.annotations.privileged/$cname\"  | =  | FALSE
-metadata.annotations.\"io.podman.annotations.publish-all/$cname\" | =  | FALSE
-
 metadata.creationTimestamp | =~ | [0-9T:-]\\+Z
 metadata.labels.app        | =  | ${cname}-pod
 metadata.name              | =  | ${cname}-pod
@@ -111,16 +105,6 @@ metadata.annotations.\"io.kubernetes.cri-o.ContainerType/$cname1\" | =  | contai
 metadata.annotations.\"io.kubernetes.cri-o.ContainerType/$cname2\" | =  | container
 metadata.annotations.\"io.kubernetes.cri-o.SandboxID/$cname1\"     | =~ | [0-9a-f]\\{56\\}
 metadata.annotations.\"io.kubernetes.cri-o.SandboxID/$cname2\"     | =~ | [0-9a-f]\\{56\\}
-metadata.annotations.\"io.kubernetes.cri-o.TTY/$cname1\"           | =  | false
-metadata.annotations.\"io.kubernetes.cri-o.TTY/$cname2\"           | =  | false
-metadata.annotations.\"io.podman.annotations.autoremove/$cname1\"  | =  | FALSE
-metadata.annotations.\"io.podman.annotations.autoremove/$cname2\"  | =  | FALSE
-metadata.annotations.\"io.podman.annotations.init/$cname1\"        | =  | FALSE
-metadata.annotations.\"io.podman.annotations.init/$cname2\"        | =  | FALSE
-metadata.annotations.\"io.podman.annotations.privileged/$cname1\"  | =  | FALSE
-metadata.annotations.\"io.podman.annotations.privileged/$cname2\"  | =  | FALSE
-metadata.annotations.\"io.podman.annotations.publish-all/$cname1\" | =  | FALSE
-metadata.annotations.\"io.podman.annotations.publish-all/$cname2\" | =  | FALSE
 
 metadata.creationTimestamp | =~ | [0-9T:-]\\+Z
 metadata.labels.app        | =  | ${pname}


### PR DESCRIPTION
False is the assumed value, and inspect and podman generate kube are being cluttered with a ton of annotations that indicate nothing.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman container inspect and podman kube generate will no longer list default annotations set to false.
```
