### PR TITLE
Add podman-clean-transient.service service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,7 +871,8 @@ ifneq (,$(findstring systemd,$(BUILDTAGS)))
 PODMAN_UNIT_FILES = contrib/systemd/auto-update/podman-auto-update.service \
 		    contrib/systemd/system/podman.service \
 		    contrib/systemd/system/podman-restart.service \
-		    contrib/systemd/system/podman-kube@.service
+		    contrib/systemd/system/podman-kube@.service \
+		    contrib/systemd/system/podman-clean-transient.service
 
 %.service: %.service.in
 	sed -e 's;@@PODMAN@@;$(BINDIR)/podman;g' $< >$@.tmp.$$ \
@@ -893,6 +894,7 @@ install.systemd: $(PODMAN_UNIT_FILES)
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman.service ${DESTDIR}${SYSTEMDDIR}/podman.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-restart.service ${DESTDIR}${SYSTEMDDIR}/podman-restart.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-kube@.service ${DESTDIR}${SYSTEMDDIR}/podman-kube@.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-clean-transient.service ${DESTDIR}${SYSTEMDDIR}/podman-clean-transient.service
 	rm -f $(PODMAN_UNIT_FILES)
 else
 install.systemd:

--- a/contrib/systemd/system/podman-clean-transient.service.in
+++ b/contrib/systemd/system/podman-clean-transient.service.in
@@ -1,0 +1,21 @@
+# This service runs once each boot to remove potential leftover
+# container state from previous boots.
+
+# This is needed when using transient storage mode in podman where the
+# database and other configs are stored in tmpfs, but some other files
+# are not. If we don't run this after an unclean boot then there may
+# be some leftover files that grow over time.
+
+[Unit]
+Description=Clean up podman transient data
+RequiresMountsFor=%t/containers
+Documentation=man:podman-system-prune(1)
+Requires=boot-complete.target
+After=local-fs.target boot-complete.target
+
+[Service]
+Type=oneshot
+ExecStart=@@PODMAN@@ system prune --external
+
+[Install]
+WantedBy=default.target

--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -252,6 +252,7 @@ fi
 %{_unitdir}/%{name}.socket
 %{_unitdir}/%{name}-restart.service
 %{_unitdir}/%{name}-kube@.service
+%{_unitdir}/%{name}-clean-transient.service
 %{_userunitdir}/%{name}-auto-update.service
 %{_userunitdir}/%{name}-auto-update.timer
 %{_userunitdir}/%{name}.service


### PR DESCRIPTION
This is a unit that can be enabled when using transient store mode to clean up potential leftovers from previous boots. All it does is run "podman system prune --external" once each boot.

Signed-off-by: Alexander Larsson <alexl@redhat.com>

```release-note
Added a systemd unit file that is useful for transient storage mode cleanup
```
