### PR TITLE
rootless: always create userns with euid != 0

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -420,13 +420,14 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 	}
 	logrus.Debugf("Set libpod namespace to %q", runtime.config.Engine.Namespace)
 
-	hasCapSysAdmin, err := unshare.HasCapSysAdmin()
-	if err != nil {
-		return err
+	needsUserns := os.Geteuid() != 0
+	if !needsUserns {
+		hasCapSysAdmin, err := unshare.HasCapSysAdmin()
+		if err != nil {
+			return err
+		}
+		needsUserns = !hasCapSysAdmin
 	}
-
-	needsUserns := !hasCapSysAdmin
-
 	// Set up containers/storage
 	var store storage.Store
 	if needsUserns {

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -172,7 +172,7 @@ func joinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
 	if err != nil {
 		return false, 0, err
 	}
-	if hasCapSysAdmin || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
+	if (os.Geteuid() == 0 && hasCapSysAdmin) || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
 		return false, 0, nil
 	}
 
@@ -248,7 +248,7 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 		return false, 0, err
 	}
 
-	if hasCapSysAdmin || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
+	if (os.Geteuid() == 0 && hasCapSysAdmin) || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
 		if os.Getenv("_CONTAINERS_USERNS_CONFIGURED") == "init" {
 			return false, 0, runInUser()
 		}

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -223,6 +223,11 @@ func GetConfiguredMappings(quiet bool) ([]idtools.IDMap, []idtools.IDMap, error)
 }
 
 func copyMappings(from, to string) error {
+	// when running as non-root always go through the newuidmap/newgidmap
+	// configuration since this is the expectation when running on Kubernetes
+	if os.Geteuid() != 0 {
+		return errors.New("copying mappings is allowed only for root")
+	}
 	content, err := os.ReadFile(from)
 	if err != nil {
 		return err


### PR DESCRIPTION
always create a user namespace when running with euid != 0 since the
user is not owning the current mount namespace.
    
This issue happened on a Kubernetes cluster, where the pod was running
privileged but the UID was not 0, as it was configured in the image
itself.

[NO NEW TESTS NEEDED] this is useful only on Kubernetes

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A user namespace is always created when running with EUID != 0.  This is necessary to work in a Kubernetes environment where the POD is "privileged" but it is still running with a non-root user.
```
