### PR TITLE
quadlet: Support Type=oneshot container files

### DIFF
--- a/hack/bats
+++ b/hack/bats
@@ -109,6 +109,7 @@ export PODMAN_ROOTLESS_USER=$(id -un)
 if [ -z "$ROOTLESS_ONLY" ]; then
     echo "# bats ${bats_filter[*]} $TESTS"
     sudo    --preserve-env=PODMAN \
+            --preserve-env=QUADLET \
             --preserve-env=PODMAN_TEST_DEBUG \
             --preserve-env=OCI_RUNTIME \
             --preserve-env=CONTAINERS_HELPER_BINARY_DIR \

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm -d --log-driver passthrough --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon localhost/imagename
+## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --log-driver passthrough --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon  -d localhost/imagename
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/oneshot.container
+++ b/test/e2e/quadlet/oneshot.container
@@ -1,0 +1,9 @@
+## !assert-podman-args "--sdnotify=conmon"
+## !assert-podman-args "--sdnotify=container"
+## assert-key-is Service Type oneshot
+
+[Container]
+Image=localhost/imagename
+
+[Service]
+Type=oneshot

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -366,6 +366,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("network.quadlet.container", "network.quadlet.container"),
 		Entry("noimage.container", "noimage.container"),
 		Entry("notify.container", "notify.container"),
+		Entry("oneshot.container", "oneshot.container"),
 		Entry("other-sections.container", "other-sections.container"),
 		Entry("podmanargs.container", "podmanargs.container"),
 		Entry("ports.container", "ports.container"),

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -198,6 +198,29 @@ EOF
     service_cleanup $QUADLET_SERVICE_NAME failed
 }
 
+@test "quadlet - oneshot" {
+    local quadlet_file=$PODMAN_TMPDIR/oneshot_$(random_string).container
+    cat > $quadlet_file <<EOF
+[Container]
+Image=$IMAGE
+Exec=echo INITIALIZED
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EOF
+
+    run_quadlet "$quadlet_file"
+
+    service_setup $QUADLET_SERVICE_NAME
+
+    # Ensure we have output. Output is synced by oneshot command exit
+    run journalctl "--since=$STARTED_TIME"  SYSLOG_IDENTIFIER="$QUADLET_SYSLOG_ID"
+    is "$output" '.*INITIALIZED.*'
+
+    service_cleanup $QUADLET_SERVICE_NAME inactive
+}
+
 @test "quadlet - volume" {
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).volume
     cat > $quadlet_file <<EOF


### PR DESCRIPTION
These just run once and are considered successful at exist. Not much is needed to support it, but we have to avoid overwriting the type with Type=notify.

Signed-off-by: Alexander Larsson <alexl@redhat.com>


```release-note
None
```
