### PR TITLE
Output Size and Reclaimable in human form for json output

### DIFF
--- a/test/system/320-system-df.bats
+++ b/test/system/320-system-df.bats
@@ -19,6 +19,23 @@ function teardown() {
     is "$output" ".*Local Volumes *0 *0 " "No volumes"
 }
 
+@test "podman system df --format {{ json . }} functionality" {
+    run_podman system df --format '{{json .}}'
+    is "$output" '.*"TotalCount":1'       "Exactly one image"
+    is "$output" '.*"RawSize".*"Size"' "RawSize and Size reported"
+    is "$output" '.*"RawReclaimable".*"Reclaimable"' "RawReclaimable and Reclaimable reported"
+    is "$output" '.*"Containers".*"Total":0' "Total containers reported"
+    is "$output" '.*"Local Volumes".*"Size":"0B"' "Total containers reported"
+    is "$output" '.*"Local Volumes".*"Size":"0B"' "Total containers reported"
+}
+
+@test "podman system df --format json functionality" {
+    run_podman system df --format json
+    is "$output" '.*"TotalCount": 1'       "Exactly one image"
+    is "$output" '.*"RawSize": 0' "RawSize reported"
+    is "$output" '.*"Size": "0B"' "Size reported"
+}
+
 @test "podman system df - with active containers and volumes" {
     run_podman run    -v /myvol1 --name c1 $IMAGE true
     run_podman run -d -v /myvol2 --name c2 $IMAGE \


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Fixes: https://github.com/containers/podman/issues/16902

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve podman system df --format "{{ json . }}"  format to match docker output 
```
