### PR TITLE
infra/abi: refactor ContainerRm

### DIFF
--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -108,7 +108,7 @@ load helpers
 
 @test "podman container rm --force bogus" {
     run_podman 1 container rm bogus
-    is "$output" "Error: no container with name or ID \"bogus\" found: no such container" "Should print error"
+    is "$output" "Error: no container with ID or name \"bogus\" found: no such container" "Should print error"
     run_podman container rm --force bogus
     is "$output" "" "Should print no output"
 }


### PR DESCRIPTION
The function grew into a big hairy ball over time and I personally refrained from touching it as it seemed fragile.  Hence, refactor the function into something more comprehensible and maintainable. There is still potential for improvement but I want to tackle one thing at a time.

[NO NEW TESTS NEEDED] as it shouldn't change behavior.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
