### PR TITLE
When in transient store mode, use rundir for bundlepath

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -128,6 +128,9 @@ func (c *Container) rwSize() (int64, error) {
 // bundlePath returns the path to the container's root filesystem - where the OCI spec will be
 // placed, amongst other things
 func (c *Container) bundlePath() string {
+	if c.runtime.storageConfig.TransientStore {
+		return c.state.RunDir
+	}
 	return c.config.StaticDir
 }
 

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -118,6 +118,7 @@ func TestPostDeleteHooks(t *testing.T) {
 	statePath := filepath.Join(dir, "state")
 	copyPath := filepath.Join(dir, "copy")
 	c := Container{
+		runtime: &Runtime{},
 		config: &ContainerConfig{
 			ID: "123abc",
 			Spec: &rspec.Spec{


### PR DESCRIPTION
This means we store things like config.json and the secret files also on tmpfs, lowering wear on disk and leaving less stuff on disk on an unclean shutdown.

This was originally in the initial transient store PR, but I removed because it triggered some test failures. Lemme see now if we can figure those out in isolation.

```release-note
None
```
