### PR TITLE
New system tests for conflicting options

### DIFF
--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -65,11 +65,11 @@ func cleanup(cmd *cobra.Command, args []string) error {
 	if cleanupOptions.Exec != "" {
 		switch {
 		case cleanupOptions.All:
-			return errors.New("exec and all options conflict")
+			return errors.New("--all and --exec cannot be set together")
 		case len(args) > 1:
 			return errors.New("cannot use exec option when more than one container is given")
 		case cleanupOptions.RemoveImage:
-			return errors.New("exec and rmi options conflict")
+			return errors.New("--exec and --rmi cannot be set together")
 		}
 	}
 

--- a/test/system/620-option-conflicts.bats
+++ b/test/system/620-option-conflicts.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# options that cannot be set together
+#
+
+load helpers
+
+
+@test "options that cannot be set together" {
+    skip_if_remote "not much point testing remote, and container-cleanup fails anyway"
+
+    tests="
+create,run        | --cpu-period=1 | --cpus=2               | $IMAGE
+create,run        | --cpu-quota=1  | --cpus=2               | $IMAGE
+create,run        | --no-hosts     | --add-host=foo:1.1.1.1 | $IMAGE
+create,run        | --userns=bar   | --pod=foo              | $IMAGE
+container cleanup | --all          | --exec=foo
+container cleanup | --exec=foo     | --rmi                  | foo
+"
+
+    # FIXME: parse_table is what does all the work, giving us test cases.
+    while read subcommands opt1 opt2 args; do
+        opt1_name=${opt1%=*}
+        opt2_name=${opt2%=*}
+
+        readarray -d, -t subcommand_list <<<$subcommands
+        for subcommand in "${subcommand_list[@]}"; do
+            run_podman 125 $subcommand $opt1 $opt2 $args
+            is "$output" "Error: $opt1_name and $opt2_name cannot be set together" \
+               "podman $subcommand $opt1 $opt2"
+
+            # Reverse order
+            run_podman 125 $subcommand $opt2 $opt1 $args
+            is "$output" "Error: $opt1_name and $opt2_name cannot be set together" \
+               "podman $subcommand $opt2 $opt1"
+        done
+    done < <(parse_table "$tests")
+
+    # Different error message; cannot be tested with the other ones above
+    for opt in arch os; do
+        for cmd in create pull; do
+            run_podman 125 $cmd --platform=foo --$opt=bar sdfsdf
+            is "$output" "Error: --platform option can not be specified with --arch or --os" \
+               "podman $cmd --platform + --$opt"
+        done
+    done
+}
+
+
+# vim: filetype=sh


### PR DESCRIPTION
...make sure podman rejects being called with incompatible options

Replaces: https://github.com/containers/podman/pull/16813

Which is stuck in CI and Ed is on break.

Signed-off-by: Ed Santiago <santiago@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
