### PR TITLE
events: support "die" filter

### DIFF
--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -26,6 +26,7 @@ The *container* event type will report the follow statuses:
  * commit
  * connect
  * create
+ * died
  * disconnect
  * exec
  * exec_died
@@ -91,7 +92,7 @@ filters are supported:
  * volume=name_or_id
  * type=event_type (described above)
 
-In the case where an ID is used, the ID may be in its full or shortened form.
+In the case where an ID is used, the ID may be in its full or shortened form.  The "die" event is mapped to "died" for Docker compatibility.
 
 #### **--format**
 

--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -21,6 +21,9 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 			return strings.HasPrefix(e.ID, filterValue)
 		}, nil
 	case "EVENT", "STATUS":
+		if filterValue == "die" { // Docker compat
+			filterValue = "died"
+		}
 		return func(e *Event) bool {
 			return string(e.Status) == filterValue
 		}, nil

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -291,3 +291,15 @@ EOF
     _events_container_create_inspect_data journald
     _events_container_create_inspect_data file
 }
+
+@test "events - docker compat" {
+    local cname=c$(random_string 15)
+    t0=$(date --iso-8601=seconds)
+    run_podman run --name=$cname --rm $IMAGE true
+    run_podman events \
+        --since="$t0"           \
+        --filter=status=$cname  \
+        --filter=status=die     \
+        --stream=false
+    is "${lines[0]}" ".* container died .* (image=$IMAGE, name=$cname, .*)"
+}


### PR DESCRIPTION
Map "die" to the "died" status for Docker compat.

Fixes: #16857 
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now supports "die" as a filter value for events for Docker compatibility (mapping to "died") .
```
