### PR TITLE
Subpath flag

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -370,6 +371,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		}
 
 		volume.MountPath = dest
+		path := volumeSource.Source
+		if len(volume.SubPath) > 0 {
+			path = filepath.Join(path, volume.SubPath)
+		}
 		switch volumeSource.Type {
 		case KubeVolumeTypeBindMount:
 			// If the container has bind mounts, we need to check if
@@ -378,14 +383,14 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				// Make sure the z/Z option is not already there (from editing the YAML)
 				if k == define.BindMountPrefix {
 					lastIndex := strings.LastIndex(v, ":")
-					if v[:lastIndex] == volumeSource.Source && !cutil.StringInSlice("z", options) && !cutil.StringInSlice("Z", options) {
+					if v[:lastIndex] == path && !cutil.StringInSlice("z", options) && !cutil.StringInSlice("Z", options) {
 						options = append(options, v[lastIndex+1:])
 					}
 				}
 			}
 			mount := spec.Mount{
 				Destination: volume.MountPath,
-				Source:      volumeSource.Source,
+				Source:      path,
 				Type:        "bind",
 				Options:     options,
 			}
@@ -403,13 +408,14 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				Dest:    volume.MountPath,
 				Name:    volumeSource.Source,
 				Options: options,
+				SubPath: volume.SubPath,
 			}
 			s.Volumes = append(s.Volumes, &cmVolume)
 		case KubeVolumeTypeCharDevice:
 			// We are setting the path as hostPath:mountPath to comply with pkg/specgen/generate.DeviceFromPath.
 			// The type is here just to improve readability as it is not taken into account when the actual device is created.
 			device := spec.LinuxDevice{
-				Path: fmt.Sprintf("%s:%s", volumeSource.Source, volume.MountPath),
+				Path: fmt.Sprintf("%s:%s", path, volume.MountPath),
 				Type: "c",
 			}
 			s.Devices = append(s.Devices, device)
@@ -417,7 +423,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			// We are setting the path as hostPath:mountPath to comply with pkg/specgen/generate.DeviceFromPath.
 			// The type is here just to improve readability as it is not taken into account when the actual device is created.
 			device := spec.LinuxDevice{
-				Path: fmt.Sprintf("%s:%s", volumeSource.Source, volume.MountPath),
+				Path: fmt.Sprintf("%s:%s", path, volume.MountPath),
 				Type: "b",
 			}
 			s.Devices = append(s.Devices, device)
@@ -428,6 +434,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				Dest:    volume.MountPath,
 				Name:    volumeSource.Source,
 				Options: options,
+				SubPath: volume.SubPath,
 			}
 			s.Volumes = append(s.Volumes, &secretVolume)
 		case KubeVolumeTypeEmptyDir:
@@ -436,6 +443,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				Name:        volumeSource.Source,
 				Options:     options,
 				IsAnonymous: true,
+				SubPath:     volume.SubPath,
 			}
 			s.Volumes = append(s.Volumes, &emptyDirVolume)
 		default:

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -180,10 +180,20 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 			}
 		} else {
 			// This is a named volume
+			// however, we might still have a subpath
+			// the syntax is NAMED_VOL/sub/path:dest
+
+			subpath := ""
+			srcAndSubPath := strings.SplitN(src, "/", 2)
+			if len(srcAndSubPath) > 1 {
+				src = srcAndSubPath[0]
+				subpath = "/" + srcAndSubPath[1]
+			}
 			newNamedVol := new(NamedVolume)
 			newNamedVol.Name = src
 			newNamedVol.Dest = dest
 			newNamedVol.Options = options
+			newNamedVol.SubPath = subpath
 
 			if vol, ok := volumes[newNamedVol.Dest]; ok {
 				if vol.Name == newNamedVol.Name {


### PR DESCRIPTION
support subpaths for named volumes when using the -v flag in podman create/run

the syntax is as follows `-v NAMED_VOL/sub/path/to/mount`

resolves #16903

(needs the other subpath PR to merge first)


Signed-off-by: Charlie Doern <cbddoern@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
support /subpath notation with named volumes when using the -v flag in podman container create/run
```
