### PR TITLE
quadlet: Add device support for .volume files

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -310,6 +310,23 @@ Set one or more OCI labels on the volume. The format is a list of
 
 This key can be listed multiple times.
 
+#### `Device=`
+
+The path of a device which should be mounted for the volume.
+
+#### `Type=`
+
+The filesystem type of `Device` as used by the **mount(8)** commands `-t` flag.
+
+#### `Options=`
+
+The mount options to use for a filesystem as used by the **mount(8)** command `-o` flag.
+
+#### `Copy=` (default to `yes`)
+
+If enabled the content of the image located at the mountpoint of the volume is copied into the
+volume on the first run.
+
 ### Network units
 
 Network files are named with a `.network` extension and contain a section `[Network]` describing the

--- a/test/e2e/quadlet/device.volume
+++ b/test/e2e/quadlet/device.volume
@@ -1,0 +1,13 @@
+## assert-key-contains Service ExecStart " --opt o=uid=0,gid=11,rw,compress=zstd "
+## assert-key-contains Service ExecStart " --opt type=btrfs "
+## assert-key-contains Service ExecStart " --opt device=/dev/vda1 "
+## assert-key-contains Service ExecStart " --opt nocopy "
+
+[Volume]
+# Test usernames too
+User=root
+Group=11
+Device=/dev/vda1
+Type=btrfs
+Options=rw,compress=zstd
+Copy=no


### PR DESCRIPTION
The Device, Type, Copy and Options keys are now supported in quadlet .volume files. This allows users to create filesystem based volumes with quadlets .volume files.

Closes #16896

Signed-off-by: Ingo Becker <ingo@orgizm.net>

#### Does this PR introduce a user-facing change?

```release-note
The `Device`, `Type`, `Copy` and `Options` keys are now supported in quadlet .volume files.
```