### PR TITLE
Quadlet -dryrun arg

### DIFF
--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -328,6 +328,73 @@ var _ = Describe("quadlet system generator", func() {
 
 	})
 
+	Describe("Running quadlet dryrun tests", func() {
+		It("Should exit with an error because of no files are found to parse", func() {
+			fileName := "basic.kube"
+			testcase := loadQuadletTestcase(filepath.Join("quadlet", fileName))
+
+			// Write the tested file to the quadlet dir
+			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			session := podmanTest.Quadlet([]string{"-dryrun"}, "/something")
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(1))
+
+			current := session.ErrorToStringArray()
+			expected := "No files to parse from [/something]"
+
+			Expect(strings.Contains(current[0], expected)).To(BeTrue())
+		})
+
+		It("Should parse a kube file and print it to stdout", func() {
+			fileName := "basic.kube"
+			testcase := loadQuadletTestcase(filepath.Join("quadlet", fileName))
+
+			// Write the tested file to the quadlet dir
+			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			session := podmanTest.Quadlet([]string{"-dryrun"}, quadletDir)
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+
+			current := session.OutputToStringArray()
+			expected := []string{
+				"---basic.service---",
+				"## assert-podman-args \"kube\"",
+				"## assert-podman-args \"play\"",
+				"## assert-podman-final-args-regex /tmp/podman_test.*/quadlet/deployment.yml",
+				"## assert-podman-args \"--replace\"",
+				"## assert-podman-args \"--service-container=true\"",
+				"## assert-podman-stop-args \"kube\"",
+				"## assert-podman-stop-args \"down\"",
+				"## assert-podman-stop-final-args-regex /tmp/podman_test.*/quadlet/deployment.yml",
+				"## assert-key-is \"Unit\" \"RequiresMountsFor\" \"%t/containers\"",
+				"## assert-key-is \"Service\" \"KillMode\" \"mixed\"",
+				"## assert-key-is \"Service\" \"Type\" \"notify\"",
+				"## assert-key-is \"Service\" \"NotifyAccess\" \"all\"",
+				"## assert-key-is \"Service\" \"Environment\" \"PODMAN_SYSTEMD_UNIT=%n\"",
+				"## assert-key-is \"Service\" \"SyslogIdentifier\" \"%N\"",
+				"[X-Kube]",
+				"Yaml=deployment.yml",
+				"[Unit]",
+				fmt.Sprintf("SourcePath=%s/basic.kube", quadletDir),
+				"RequiresMountsFor=%t/containers",
+				"[Service]",
+				"KillMode=mixed",
+				"Environment=PODMAN_SYSTEMD_UNIT=%n",
+				"Type=notify",
+				"NotifyAccess=all",
+				"SyslogIdentifier=%N",
+				fmt.Sprintf("ExecStart=/usr/local/bin/podman kube play --replace --service-container=true %s/deployment.yml", quadletDir),
+				fmt.Sprintf("ExecStop=/usr/local/bin/podman kube down %s/deployment.yml", quadletDir),
+			}
+
+			Expect(expected).To(Equal(current))
+		})
+	})
+
 	DescribeTable("Running quadlet test case",
 		func(fileName string) {
 			testcase := loadQuadletTestcase(filepath.Join("quadlet", fileName))


### PR DESCRIPTION
Signed-off-by: Leonardo Rossetti <lrossett@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

I've added a `-dyrun` argument to the Quadlet CLI so generated unit files are printed to stdout instead of creating a file - I found this useful when I needed to check how the end result of the generated unit file.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a -dryrun cli argument to quadlet, making parsed unit files to be printed out to stdout instead of creating files.
```
