### PR TITLE
make: Use PYTHON var for .install.pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -937,7 +937,7 @@ install.tools: .install.golangci-lint .install.swagger ## Install needed tools
 .PHONY: .install.pre-commit
 .install.pre-commit:
 	if [ -z "$(PRE_COMMIT)" ]; then \
-		python3 -m pip install --user pre-commit; \
+		$(PYTHON) -m pip install --user pre-commit; \
 	fi
 
 .PHONY: uninstall


### PR DESCRIPTION
The PYTHON variable already exists but isn't used for .install.pre-commit PHONY.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
