### PR TITLE
fix `podman system connection - tcp` flake

### DIFF
--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -112,9 +112,17 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true" \
                         --runroot ${PODMAN_TMPDIR}/runroot \
                         system service -t 99 tcp://localhost:$_SERVICE_PORT &
     _SERVICE_PID=$!
+    # Wait for the port and the podman-service to be ready.
     wait_for_port localhost $_SERVICE_PORT
-
-    _run_podman_remote info --format '{{.Host.RemoteSocket.Path}}'
+    local timeout=10
+    while [[ $timeout -gt 1 ]]; do
+        _run_podman_remote ? info --format '{{.Host.RemoteSocket.Path}}'
+        if [[ $status == 0 ]]; then
+            break
+        fi
+        sleep 1
+        let timeout=$timeout-1
+    done
     is "$output" "tcp://localhost:$_SERVICE_PORT" \
        "podman info works, and talks to the correct server"
 


### PR DESCRIPTION
The test was only waiting for the port to be ready but that doesn't imply the server being ready to serve requests.  Hence, add a loop waiting for the `info` call to succeed.

Fixes: #16916
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@containers/podman-maintainers PTAL
