### PR TITLE
[CI:DOCS]  Fix typos in man page regarding transient storage mode.

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -164,9 +164,9 @@ NOTE --tmpdir is not used for the temporary storage of downloaded images.  Use t
 
 #### **--transient-store**
 
-Enables a global transient storaga mode where all container metadata is stored on non-persistant media (i.e. in the location specified by `--runroot`).
+Enables a global transient storage mode where all container metadata is stored on non-persistent media (i.e. in the location specified by `--runroot`).
 This mode allows starting containers faster, as well as guaranteeing a fresh state on boot in case of unclean shutdowns or other problems. However
-it is not compabible with a traditional model where containers persist across reboots.
+it is not compatible with a traditional model where containers persist across reboots.
 
 Default value for this is configured in `containers-storage.conf(5)`.
 


### PR DESCRIPTION
:wave: This PR fixes a few typos I noticed when looking at the documentation for transient storage mode [here](https://docs.podman.io/en/latest/markdown/podman.1.html).


#### Does this PR introduce a user-facing change?

```release-note
Fix typos in documentation relating to transient storage mode.
```
