### PR TITLE
Remove references to qcow2

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -89,11 +89,11 @@ func init() {
 	_ = flags.MarkHidden("reexec")
 
 	UsernameFlagName := "username"
-	flags.StringVar(&initOpts.Username, UsernameFlagName, cfg.ContainersConfDefaultsRO.Machine.User, "Username used in qcow image")
+	flags.StringVar(&initOpts.Username, UsernameFlagName, cfg.ContainersConfDefaultsRO.Machine.User, "Username used in image")
 	_ = initCmd.RegisterFlagCompletionFunc(UsernameFlagName, completion.AutocompleteDefault)
 
 	ImagePathFlagName := "image-path"
-	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.ContainersConfDefaultsRO.Machine.Image, "Path to qcow image")
+	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.ContainersConfDefaultsRO.Machine.Image, "Path to bootable image")
 	_ = initCmd.RegisterFlagCompletionFunc(ImagePathFlagName, completion.AutocompleteDefault)
 
 	VolumeFlagName := "volume"

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -10,7 +10,7 @@ type initMachine struct {
 	      --disk-size uint         Disk size in GB (default 100)
 	      --ignition-path string   Path to ignition file
 	      --username string        Username of the remote user (default "core" for FCOS, "user" for Fedora)
-	      --image-path string      Path to qcow image (default "testing")
+	      --image-path string      Path to bootable image (default "testing")
 	  -m, --memory uint            Memory in MB (default 2048)
 	      --now                    Start machine now
 	      --rootful                Whether this machine should prefer rootful container execution


### PR DESCRIPTION
Issue #16928 rightly points out that qcow2 images are not used on all podman architectures.

Fixes: #16928

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
