### PR TITLE
Kube Play: use passthrough as the default log-driver if service-container is set

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -414,6 +414,12 @@ EOF
     run_podman 125 container rm $service_container
     is "$output" "Error: container .* is the service container of pod(s) .* and cannot be removed without removing the pod(s)"
 
+    # Verify that the log-driver for the Pod's containers is passthrough
+    for name in "a" "b"; do
+        run_podman container inspect test_pod-${name} --format "{{.HostConfig.LogConfig.Type}}"
+        is $output "passthrough"
+    done
+
     # Add a simple `auto-update --dry-run` test here to avoid too much redundancy
     # with 255-auto-update.bats
     run_podman auto-update --dry-run --format "{{.Unit}},{{.Container}},{{.Image}},{{.Updated}},{{.Policy}}"

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -225,7 +225,7 @@ EOF
     wait_for_file $_SOCAT_LOG
 
     # Will run until all containers have stopped.
-    run_podman play kube --service-container=true $yaml_source
+    run_podman play kube --service-container=true --log-driver journald $yaml_source
     run_podman container wait $service_container test_pod-test
 
     # Make sure the containers have the correct policy.
@@ -302,7 +302,7 @@ EOF
     # Run `play kube` in the background as it will wait for all containers to
     # send the READY=1 message.
     timeout --foreground -v --kill=10 60 \
-        $PODMAN play kube --service-container=true $yaml_source &>/dev/null &
+        $PODMAN play kube --service-container=true --log-driver journald $yaml_source &>/dev/null &
 
     # Wait for both containers to be running
     for i in $(seq 1 20); do

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -126,7 +126,7 @@ EOF
     # Run `play kube` in the background as it will wait for the service
     # container to exit.
     timeout --foreground -v --kill=10 60 \
-        $PODMAN play kube --service-container=true $yaml_source &>/dev/null &
+        $PODMAN play kube --service-container=true --log-driver journald $yaml_source &>/dev/null &
 
     # Wait for the container to be running
     container_a=test_pod-test


### PR DESCRIPTION
If log-driver is not set, set to passthough is service-container is set otherwise use the global default

Update the system tests
- explicitly set logdriver in sdnotify and play tests
- podman-kube template test:  Verify the default log driver for service-container

#### Does this PR introduce a user-facing change?
Yes

```release-note
When using --service-container the default log-driver is now passthrough
```

Resolves: #16592