### PR TITLE
Quadlet Container: Add support for EnvironmentFile and EnvironmentHost

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -93,6 +93,16 @@ Set an environment variable in the container. This uses the same format as
 [services in systemd](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment=)
 and can be listed multiple times.
 
+#### `EnvironmentFile=`
+
+Use a line-delimited file to set environment variables in the container.
+The path may be absolute or relative to the location of the unit file.
+This key may be used multiple times, and the order persists when passed to `podman run`.
+
+#### `EnvironmentHost=` (defaults to `no`)
+
+Use the host environment inside of the container.
+
 #### `Exec=`
 
 If this is set then it defines what command line to run in the container. If it is not set the

--- a/test/e2e/quadlet/env-file.container
+++ b/test/e2e/quadlet/env-file.container
@@ -1,0 +1,9 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --env-file /opt/env/abs-1 --env-file /opt/env/abs-2
+## assert-podman-args-regex --env-file /.*/podman_test.*/quadlet/rel-1
+
+[Container]
+Image=localhost/imagename
+EnvironmentFile=/opt/env/abs-1
+EnvironmentFile=/opt/env/abs-2
+EnvironmentFile=rel-1

--- a/test/e2e/quadlet/env-host-false.container
+++ b/test/e2e/quadlet/env-host-false.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --env-host=false
+
+[Container]
+Image=localhost/imagename
+EnvironmentHost=no

--- a/test/e2e/quadlet/env-host.container
+++ b/test/e2e/quadlet/env-host.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --env-host
+
+[Container]
+Image=localhost/imagename
+EnvironmentHost=yes

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -97,6 +97,21 @@ func findSublist(full []string, sublist []string) int {
 	return -1
 }
 
+func findSublistRegex(full []string, sublist []string) int {
+	if len(sublist) > len(full) {
+		return -1
+	}
+	if len(sublist) == 0 {
+		return -1
+	}
+	for i := 0; i < len(full)-len(sublist)+1; i++ {
+		if matchSublistRegexAt(full, i, sublist) {
+			return i
+		}
+	}
+	return -1
+}
+
 func (t *quadletTestcase) assertStdErrContains(args []string, session *PodmanSessionIntegration) bool {
 	return strings.Contains(session.ErrorToString(), args[0])
 }
@@ -155,6 +170,11 @@ func (t *quadletTestcase) assertPodmanArgs(args []string, unit *parser.UnitFile,
 	return findSublist(podmanArgs, args) != -1
 }
 
+func (t *quadletTestcase) assertPodmanArgsRegex(args []string, unit *parser.UnitFile, key string) bool {
+	podmanArgs, _ := unit.LookupLastArgs("Service", key)
+	return findSublistRegex(podmanArgs, args) != -1
+}
+
 func (t *quadletTestcase) assertPodmanFinalArgs(args []string, unit *parser.UnitFile, key string) bool {
 	podmanArgs, _ := unit.LookupLastArgs("Service", key)
 	if len(podmanArgs) < len(args) {
@@ -173,6 +193,10 @@ func (t *quadletTestcase) assertPodmanFinalArgsRegex(args []string, unit *parser
 
 func (t *quadletTestcase) assertStartPodmanArgs(args []string, unit *parser.UnitFile) bool {
 	return t.assertPodmanArgs(args, unit, "ExecStart")
+}
+
+func (t *quadletTestcase) assertStartPodmanArgsRegex(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgsRegex(args, unit, "ExecStart")
 }
 
 func (t *quadletTestcase) assertStartPodmanFinalArgs(args []string, unit *parser.UnitFile) bool {
@@ -238,6 +262,8 @@ func (t *quadletTestcase) doAssert(check []string, unit *parser.UnitFile, sessio
 		ok = t.assertKeyContains(args, unit)
 	case "assert-podman-args":
 		ok = t.assertStartPodmanArgs(args, unit)
+	case "assert-podman-args-regex":
+		ok = t.assertStartPodmanArgsRegex(args, unit)
 	case "assert-podman-final-args":
 		ok = t.assertStartPodmanFinalArgs(args, unit)
 	case "assert-podman-final-args-regex":
@@ -382,6 +408,9 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("remap-auto.container", "remap-auto.container"),
 		Entry("remap-auto2.container", "remap-auto2.container"),
 		Entry("volume.container", "volume.container"),
+		Entry("env-file.container", "env-file.container"),
+		Entry("env-host.container", "env-host.container"),
+		Entry("env-host-false.container", "env-host-false.container"),
 
 		Entry("basic.volume", "basic.volume"),
 		Entry("label.volume", "label.volume"),


### PR DESCRIPTION
Add the new keys to the supported keys list for the Container group Pass the list of EnvironmentFile values while maintaining the order Quadlet e2e test framework: Add support for checking regex in Podman args Add relevant tests
Update man

Signed-off-by: Ygal Blum <ygal.blum@gmail.com>

#### Does this PR introduce a user-facing change?
No since Quadlet was not yet released

```release-note
None
```

Resolves: #16730 