### PR TITLE
Fixed `podman update --pids-limit`

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -329,13 +329,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
-		pidsLimitFlagName := "pids-limit"
-		createFlags.Int64(
-			pidsLimitFlagName, pidsLimit(),
-			"Tune container pids limit (set -1 for unlimited)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(pidsLimitFlagName, completion.AutocompleteNone)
-
 		platformFlagName := "platform"
 		createFlags.StringVar(
 			&cf.Platform,
@@ -898,6 +891,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(deviceWriteIopsFlagName, completion.AutocompleteDefault)
+
+		pidsLimitFlagName := "pids-limit"
+		createFlags.Int64Var(
+			cf.PIDsLimit,
+			pidsLimitFlagName, pidsLimit(),
+			"Tune container pids limit (set -1 for unlimited)",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(pidsLimitFlagName, completion.AutocompleteNone)
 	}
 	// anyone can use these
 	cpusFlagName := "cpus"

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -92,4 +92,5 @@ func DefineCreateDefaults(opts *entities.ContainerCreateOptions) {
 	opts.Ulimit = ulimits()
 	opts.SeccompPolicy = "default"
 	opts.Volume = volumes()
+	opts.PIDsLimit = &podmanConfig.ContainersConf.Containers.PidsLimit
 }

--- a/docs/source/markdown/options/pids-limit.md
+++ b/docs/source/markdown/options/pids-limit.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman create, run
+####>   podman create, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--pids-limit**=*limit*

--- a/docs/source/markdown/podman-update.1.md.in
+++ b/docs/source/markdown/podman-update.1.md.in
@@ -53,6 +53,8 @@ This command takes one argument, a container name or ID, alongside the resource 
 
 @@option memory-swappiness
 
+@@option pids-limit
+
 
 ## EXAMPLEs
 
@@ -63,12 +65,12 @@ podman update --cpus=5 myCtr
 
 update a container with all available options for cgroups v2
 ```
-podman update --cpus 5 --cpuset-cpus 0 --cpu-shares 123 --cpuset-mems 0 --memory 1G --memory-swap 2G --memory-reservation 2G --blkio-weight-device /dev/zero:123 --blkio-weight 123 --device-read-bps /dev/zero:10mb --device-write-bps /dev/zero:10mb --device-read-iops /dev/zero:1000 --device-write-iops /dev/zero:1000 ctrID
+podman update --cpus 5 --cpuset-cpus 0 --cpu-shares 123 --cpuset-mems 0 --memory 1G --memory-swap 2G --memory-reservation 2G --blkio-weight-device /dev/zero:123 --blkio-weight 123 --device-read-bps /dev/zero:10mb --device-write-bps /dev/zero:10mb --device-read-iops /dev/zero:1000 --device-write-iops /dev/zero:1000 --pids-limit 123 ctrID
 ```
 
 update a container with all available options for cgroups v1
 ```
-podman update --cpus 5 --cpuset-cpus 0 --cpu-shares 123 --cpuset-mems 0 --memory 1G --memory-swap 2G --memory-reservation 2G --memory-swappiness 50 ctrID
+podman update --cpus 5 --cpuset-cpus 0 --cpu-shares 123 --cpuset-mems 0 --memory 1G --memory-swap 2G --memory-reservation 2G --memory-swappiness 50 --pids-limit 123 ctrID
 ```
 
 ## SEE ALSO

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -47,7 +47,8 @@ var _ = Describe("Podman update", func() {
 			"--memory", "1G",
 			"--memory-swap", "2G",
 			"--memory-reservation", "2G",
-			"--memory-swappiness", "50", ctrID}
+			"--memory-swappiness", "50",
+			"--pids-limit", "123", ctrID}
 
 		session = podmanTest.Podman(commonArgs)
 		session.WaitWithDefaultTimeout()
@@ -89,6 +90,12 @@ var _ = Describe("Podman update", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 
+		// checking pids-limit
+		session = podmanTest.Podman([]string{"exec", "-it", ctrID, "cat", "/sys/fs/cgroup/pids/pids.max"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(ContainSubstring("123"))
+
 	})
 
 	It("podman update container all options v2", func() {
@@ -114,6 +121,7 @@ var _ = Describe("Podman update", func() {
 			"--device-write-bps", "/dev/zero:10mb",
 			"--device-read-iops", "/dev/zero:1000",
 			"--device-write-iops", "/dev/zero:1000",
+			"--pids-limit", "123",
 			ctrID}
 
 		session = podmanTest.Podman(commonArgs)
@@ -169,6 +177,12 @@ var _ = Describe("Podman update", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).Should(ContainSubstring("5"))
+
+		// checking pids-limit
+		session = podmanTest.Podman([]string{"exec", "-it", ctrID, "cat", "/sys/fs/cgroup/pids.max"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 	})
 
 	It("podman update keep original resources if not overridden", func() {


### PR DESCRIPTION
Adds the functionality for a user to update the PIDs limit for a container. This is one of the tasks listed in #16543. 

Signed-off-by: Jake Correnti <jakecorrenti+github@proton.me>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds the functionality to update the PIDs limit for a container.
```
