### PR TITLE
[CI:DOCS] Fix instructions about setting storage driver on command-line

### DIFF
--- a/docs/tutorials/performance.md
+++ b/docs/tutorials/performance.md
@@ -90,8 +90,8 @@ See the example above "_Using a separate user account for benchmarking_" for how
 
 Storage driver   | Podman command
 ----             | ------
-native overlayfs | `podman --storage-driver=overlayfs run ...`
-fuse-overlayfs   | `podman --storage-driver=overlayfs --storage-opt overlay.mount_program=/usr/bin/fuse-overlayfs run ...`
+native overlayfs | `podman --storage-driver=overlay run ...`
+fuse-overlayfs   | `podman --storage-driver=overlay --storage-opt overlay.mount_program=/usr/bin/fuse-overlayfs run ...`
 VFS              | `podman --storage-driver=vfs run ...`
 
 #### Configuring the default storage driver


### PR DESCRIPTION
The OverlayFS storage driver is called `overlay`, not `overlayfs`.

Signed-off-by: Patrick Reader <_@pxeger.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

(I'm assuming that a change this minor doesn't need to be in the release notes)