### PR TITLE
Quadlet Network - Fix the name of the required network service

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -811,13 +811,13 @@ func addNetworks(quadletUnitFile *parser.UnitFile, groupName string, serviceUnit
 	networks := quadletUnitFile.LookupAll(groupName, KeyNetwork)
 	for _, network := range networks {
 		if len(network) > 0 {
-			networkName, options, found := strings.Cut(network, ":")
-			if strings.HasSuffix(networkName, ".network") {
+			quadletNetworkName, options, found := strings.Cut(network, ":")
+			if strings.HasSuffix(quadletNetworkName, ".network") {
 				// the podman network name is systemd-$name
-				networkName = replaceExtension(networkName, "", "systemd-", "")
+				networkName := replaceExtension(quadletNetworkName, "", "systemd-", "")
 
 				// the systemd unit name is $name-network.service
-				networkServiceName := replaceExtension(networkName, ".service", "", "-network")
+				networkServiceName := replaceExtension(quadletNetworkName, ".service", "", "-network")
 
 				serviceUnitFile.Add(UnitGroup, "Requires", networkServiceName)
 				serviceUnitFile.Add(UnitGroup, "After", networkServiceName)

--- a/test/e2e/quadlet/network.quadlet.container
+++ b/test/e2e/quadlet/network.quadlet.container
@@ -1,6 +1,6 @@
 ## assert-podman-args "--network=systemd-basic"
-## assert-key-is "Unit" "Requires" "systemd-basic-network.service"
-## assert-key-is "Unit" "After" "systemd-basic-network.service"
+## assert-key-is "Unit" "Requires" "basic-network.service"
+## assert-key-is "Unit" "After" "basic-network.service"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/network.quadlet.kube
+++ b/test/e2e/quadlet/network.quadlet.kube
@@ -1,6 +1,6 @@
 ## assert-podman-args "--network=systemd-basic"
-## assert-key-is "Unit" "Requires" "systemd-basic-network.service"
-## assert-key-is "Unit" "After" "systemd-basic-network.service"
+## assert-key-is "Unit" "Requires" "basic-network.service"
+## assert-key-is "Unit" "After" "basic-network.service"
 
 
 [Kube]


### PR DESCRIPTION
The name of the network service does not start with systemd only the podman network name

Signed-off-by: Ygal Blum <ygal.blum@gmail.com>

#### Does this PR introduce a user-facing change?
No

```release-note
None
```
