### PR TITLE
System tests: fix unquoted question marks

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -26,7 +26,7 @@ function teardown() {
     done < $SNAME_FILE
 
     rm -f $SNAME_FILE
-    run_podman ? rmi -f                            \
+    run_podman '?' rmi -f                            \
             quay.io/libpod/alpine:latest           \
             quay.io/libpod/busybox:latest          \
             quay.io/libpod/localtest:latest        \
@@ -36,7 +36,7 @@ function teardown() {
 
     # The rollback tests may leave some dangling images behind, so let's prune
     # them to leave a clean state.
-    run_podman ? image prune -f
+    run_podman '?' image prune -f
     basic_teardown
 }
 

--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -116,7 +116,7 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true" \
     wait_for_port localhost $_SERVICE_PORT
     local timeout=10
     while [[ $timeout -gt 1 ]]; do
-        _run_podman_remote ? info --format '{{.Host.RemoteSocket.Path}}'
+        _run_podman_remote '?' info --format '{{.Host.RemoteSocket.Path}}'
         if [[ $status == 0 ]]; then
             break
         fi


### PR DESCRIPTION
In 'run_podman ? ...', the question mark will _usually_ be
interpreted as a literal question mark, meaning "ignore
exit status". But if there are one or more single-character
filenames in the working directory, such as droppings from
a command such as 'my-test-command > a', Very Bad Things
will happen: the test will fail with an incomprehensible
error message. Prevent that.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```