### PR TITLE
[minor] System tests: add missing cleanup

### DIFF
--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -102,6 +102,7 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
     is "$output" "0" "Failing streak of restarted container should be 0 again"
 
     run_podman rm -f -t0 $ctr
+    run_podman rmi $img
 }
 
 @test "podman healthcheck --health-on-failure" {

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -319,6 +319,7 @@ EOF
     is "$output" "running" "container should be started by systemd and hence be running"
 
     service_cleanup $QUADLET_SERVICE_NAME inactive
+    run_podman rmi $(pause_image)
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
New tests got added since I've been on PTO. Some of those tests
weren't doing cleanup, resulting in nasty red logs. Fix.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```