### PR TITLE
libpod: fix race condition rm'ing stopping containers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2210,7 +2210,7 @@ func (c *Container) checkReadyForRemoval() error {
 		return fmt.Errorf("container %s is in invalid state: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
-	if c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused) && !c.IsInfra() {
+	if c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopping) && !c.IsInfra() {
 		return fmt.Errorf("cannot remove container %s as it is %s - running or paused containers cannot be removed without force: %w", c.ID(), c.state.State.String(), define.ErrCtrStateInvalid)
 	}
 

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -113,4 +113,50 @@ load helpers
     is "$output" "" "Should print no output"
 }
 
+@test "podman container rm doesn't affect stopping containers" {
+    local cname=c$(random_string 30)
+    run_podman run -d --name $cname \
+               --health-cmd /bin/false \
+               --health-interval 1s \
+               --health-retries 2 \
+               --health-timeout 1s \
+               --health-on-failure=stop \
+               --stop-timeout=2 \
+               --health-start-period 0 \
+               --stop-signal SIGTERM \
+               $IMAGE sleep infinity
+    local cid=$output
+
+    # We'll use the PID later to confirm that container is not running
+    run_podman inspect --format '{{.State.Pid}}' $cname
+    local pid=$output
+
+    # rm without -f should fail, because container is running/stopping.
+    # We have no way to guarantee that we see 'stopping', but at a very
+    # minimum we need to check at least one rm failure
+    local rm_failures=0
+    for i in {1..10}; do
+        run_podman '?' rm $cname
+        if [[ $status -eq 0 ]]; then
+            break
+        fi
+
+        # rm failed. Confirm that it's for the right reason.
+        assert "$output" =~ "Error: cannot remove container $cid as it is .* - running or paused containers cannot be removed without force: container state improper" \
+               "Expected error message from podman rm"
+        rm_failures=$((rm_failures + 1))
+        sleep 1
+    done
+
+    # At this point, container should be gone
+    run_podman 1 container exists $cname
+    run_podman 1 container exists $cid
+
+    assert "$rm_failures" -gt 0 "we want at least one failure from podman-rm"
+
+    if kill -0 $pid; then
+        die "Container $cname process is still running (pid $pid)"
+    fi
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
do not allow removing containers that are in the stopping state, otherwise it can lead to a race condition where a "podman rm" removes the container from the storage while another process is stopping the same container.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2155828

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a race condition where a container being stopped could be removed from a separate process
```
