### PR TITLE
kube play: fix the error logic with --quiet

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -344,10 +344,12 @@ func teardown(body io.Reader, options entities.PlayKubeDownOptions, quiet bool) 
 		fmt.Println("Pods stopped:")
 	}
 	for _, stopped := range reports.StopReport {
-		if len(stopped.Errs) == 0 && !quiet {
-			fmt.Println(stopped.Id)
-		} else {
+		switch {
+		case len(stopped.Errs) > 0:
 			podStopErrors = append(podStopErrors, stopped.Errs...)
+		case quiet:
+		default:
+			fmt.Println(stopped.Id)
 		}
 	}
 	// Dump any stop errors
@@ -361,10 +363,12 @@ func teardown(body io.Reader, options entities.PlayKubeDownOptions, quiet bool) 
 		fmt.Println("Pods removed:")
 	}
 	for _, removed := range reports.RmReport {
-		if removed.Err == nil && !quiet {
-			fmt.Println(removed.Id)
-		} else {
+		switch {
+		case removed.Err != nil:
 			podRmErrors = append(podRmErrors, removed.Err)
+		case quiet:
+		default:
+			fmt.Println(removed.Id)
 		}
 	}
 
@@ -378,10 +382,12 @@ func teardown(body io.Reader, options entities.PlayKubeDownOptions, quiet bool) 
 		fmt.Println("Volumes removed:")
 	}
 	for _, removed := range reports.VolumeRmReport {
-		if removed.Err == nil && !quiet {
-			fmt.Println(removed.Id)
-		} else {
+		switch {
+		case removed.Err != nil:
 			volRmErrors = append(volRmErrors, removed.Err)
+		case quiet:
+		default:
+			fmt.Println(removed.Id)
 		}
 	}
 


### PR DESCRIPTION
Fix a bug where kube play would print format errors such as `Error: %!s(<nil>)`.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
