### PR TITLE
[CI:DOCS] Man page checker: require canonical name in SEE ALSO

### DIFF
--- a/docs/source/markdown/podman-image-mount.1.md
+++ b/docs/source/markdown/podman-image-mount.1.md
@@ -73,4 +73,4 @@ podman image mount --format json
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-image(1)](podman-image.1.md)**, **[podman-image-umount(1)](podman-image-umount.1.md)**, **[podman-unshare(1)](podman-unshare.1.md)**, **mount(8)**
+**[podman(1)](podman.1.md)**, **[podman-image(1)](podman-image.1.md)**, **[podman-image-unmount(1)](podman-image-unmount.1.md)**, **[podman-unshare(1)](podman-unshare.1.md)**, **mount(8)**

--- a/docs/source/markdown/podman-image-unmount.1.md
+++ b/docs/source/markdown/podman-image-unmount.1.md
@@ -48,4 +48,4 @@ Unmount all images
 podman image unmount --all
 ```
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-image-mount(1)](podman-image-mount.1.md)**, **[podman-container-mount(1)](podman-container-mount.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-image-mount(1)](podman-image-mount.1.md)**, **[podman-mount(1)](podman-mount.1.md)**

--- a/docs/source/markdown/podman-logs.1.md.in
+++ b/docs/source/markdown/podman-logs.1.md.in
@@ -98,7 +98,7 @@ AH00558: httpd: Could not reliably determine the server's fully qualified domain
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-run(1)](podman-run.1.md)**, **[podman-container-rm(1)](podman-container-rm.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-run(1)](podman-run.1.md)**, **[podman-rm(1)](podman-rm.1.md)**
 
 ## HISTORY
 February 2018, Updated by Brent Baude <bbaude@redhat.com>

--- a/docs/source/markdown/podman-unmount.1.md.in
+++ b/docs/source/markdown/podman-unmount.1.md.in
@@ -59,4 +59,4 @@ podman unmount --all
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-container-mount(1)](podman-container-mount.1.md)**, **[podman-image-mount(1)](podman-image-mount.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-mount(1)](podman-mount.1.md)**, **[podman-image-mount(1)](podman-image-mount.1.md)**

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -554,7 +554,7 @@ sub _check_seealso_links {
             my ($name, $link) = ($1, $2);
             if ($name =~ /^(.*)\((\d)\)$/) {
                 my ($base, $section) = ($1, $2);
-                if (-e "$Markdown_Path/$base.$section.md" || -e "$Markdown_Path/links/$base.$section") {
+                if (-e "$Markdown_Path/$base.$section.md") {
                     if ($link ne "$base.$section.md") {
                         warn "$ME: $path: inconsistent link $name -> $link, expected $base.$section.md\n";
                         ++$Errs;
@@ -578,8 +578,14 @@ sub _check_seealso_links {
             my ($base, $section) = ($1, $2);
 
             # Unadorned 'podman-foo(1)' must be a link.
-            if (-e "$Markdown_Path/$base.$section.md" || -e "$Markdown_Path/links/$base.$section") {
+            if (-e "$Markdown_Path/$base.$section.md") {
                 warn "$ME: $path: '$token' should be '[$token]($base.$section.md)'\n";
+                ++$Errs;
+            }
+
+            # Aliases (non-canonical command names): never link to these
+            if (-e "$Markdown_Path/links/$base.$section") {
+                warn "$ME: $path: '$token' refers to a command alias; please use the canonical command name instead\n";
                 ++$Errs;
             }
 


### PR DESCRIPTION
The man-page cross-reference script checks the SEE ALSO section
to confirm that all references are to existing man pages (#12258).
However, it's a little too forgiving: it allows aliases, the
short '.so' files under the 'links/' subdirectory. That means
we could link to non-default command names, and were doing so.

As of this PR, we no longer allow that. Any podman command
referenced in SEE ALSO must be the canonical command name
(and man page). Fix existing non-canonical names, and
remove the exception so we don't allow this again.

See #16848 for discussion of context.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```