### PR TITLE
Support sig-proxy for podman-remote attach and start

### DIFF
--- a/test/system/032-sig-proxy.bats
+++ b/test/system/032-sig-proxy.bats
@@ -2,32 +2,38 @@
 
 load helpers
 
-@test "podman sigkill" {
-    $PODMAN run -i --name foo $IMAGE sh -c 'trap "echo BYE;exit 0" INT;echo READY;while :;do sleep 0.1;done' &
-    local kidpid=$!
+# Command to run in each of the tests.
+SLEEPLOOP='trap "echo BYE;exit 0" INT;echo READY;while :;do sleep 0.1;done'
+
+# Main test code: wait for container to exist and be ready, send it a
+# signal, wait for container to acknowledge and exit.
+function _test_sigproxy() {
+    local cname=$1
+    local kidpid=$2
 
     # Wait for container to appear
     local timeout=5
     while :;do
           sleep 0.5
-          run_podman '?' container exists foo
+          run_podman '?' container exists $cname
           if [[ $status -eq 0 ]]; then
               break
           fi
           timeout=$((timeout - 1))
           if [[ $timeout -eq 0 ]]; then
-              die "Timed out waiting for container to start"
+              die "Timed out waiting for container $cname to start"
           fi
     done
 
-    wait_for_ready foo
+    # Now that container exists, wait for it to declare itself READY
+    wait_for_ready $cname
 
     # Signal, and wait for container to exit
     kill -INT $kidpid
     local timeout=10
     while :;do
           sleep 0.5
-          run_podman logs foo
+          run_podman logs $cname
           if [[ "$output" =~ BYE ]]; then
               break
           fi
@@ -37,7 +43,37 @@ load helpers
           fi
     done
 
-    run_podman rm -f -t0 foo
+    run_podman rm -f -t0 $cname
+}
+
+# Each of the tests below does some setup, then invokes the above helper.
+
+@test "podman sigproxy test: run" {
+    # We're forced to use $PODMAN because run_podman cannot be backgrounded
+    $PODMAN run -i --name c_run $IMAGE sh -c "$SLEEPLOOP" &
+    local kidpid=$!
+
+    _test_sigproxy c_run $kidpid
+}
+
+@test "podman sigproxy test: start" {
+    run_podman create --name c_start $IMAGE sh -c "$SLEEPLOOP"
+
+    # See above comments regarding $PODMAN and backgrounding
+    $PODMAN start --attach c_start &
+    local kidpid=$!
+
+    _test_sigproxy c_start $kidpid
+}
+
+@test "podman sigproxy test: attach" {
+    run_podman run -d --name c_attach $IMAGE sh -c "$SLEEPLOOP"
+
+    # See above comments regarding $PODMAN and backgrounding
+    $PODMAN attach c_attach &
+    local kidpid=$!
+
+    _test_sigproxy c_attach $kidpid
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
Signals were not proxied for attach and start for podman-remote. Now they are.

Signed-off-by: Ashley Cui <acui@redhat.com>

Fixes: #16662

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Sig-proxy is now supported for podman-remote attach and start
```
