### PR TITLE
Add support for Windows on ARM64

### DIFF
--- a/pkg/machine/fedora_unix.go
+++ b/pkg/machine/fedora_unix.go
@@ -1,0 +1,12 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package machine
+
+import (
+	"runtime"
+)
+
+func determineFedoraArch() string {
+	return runtime.GOARCH
+}

--- a/pkg/machine/fedora_windows.go
+++ b/pkg/machine/fedora_windows.go
@@ -1,0 +1,32 @@
+package machine
+
+import (
+	"runtime"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+func determineFedoraArch() string {
+	const fallbackMsg = "this may result in the wrong Linux arch under emulation"
+	var machine, native uint16
+	current, _ := syscall.GetCurrentProcess()
+
+	if err := windows.IsWow64Process2(windows.Handle(current), &machine, &native); err != nil {
+		logrus.Warnf("Failure detecting native system architecture, %s: %w", fallbackMsg, err)
+		// Fall-back to binary arch
+		return runtime.GOARCH
+	}
+
+	switch native {
+	// Only care about archs in use with WSL
+	case 0xAA64:
+		return "arm64"
+	case 0x8664:
+		return "amd64"
+	default:
+		logrus.Warnf("Unknown or unsupported native system architecture [%d], %s", fallbackMsg)
+		return runtime.GOARCH
+	}
+}


### PR DESCRIPTION
Works with both emulated x86_64  and native arm64 binaries (Windows includes a userspace emulation facility for x86 compatibility).

The underlying distro is hosted and generated by:
https://github.com/containers/podman-wsl-fedora-arm

Subsequent PRs will introduce native arm artifacts, including through the installer. However, these are not required since the existing x86 binaries will run after this PR.

Also note there is a minor installer issue, where it will direct the user to install WSL manually. A follow-up PR will address this.

```release-note
Add initial support for Windows on ARM64
```
[NO NEW TESTS NEEDED]