### PR TITLE
[v4.2.0] libpod: fix race condition rm'ing stopping containers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2200,7 +2200,7 @@ func (c *Container) checkReadyForRemoval() error {
 		return fmt.Errorf("container %s is in invalid state: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
-	if c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused) && !c.IsInfra() {
+	if c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopping) && !c.IsInfra() {
 		return fmt.Errorf("cannot remove container %s as it is %s - running or paused containers cannot be removed without force: %w", c.ID(), c.state.State.String(), define.ErrCtrStateInvalid)
 	}
 


### PR DESCRIPTION
do not allow removing containers that are in the stopping state, otherwise it can lead to a race condition where a "podman rm" removes the container from the storage while another process is stopping the same container.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2155828

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 6886e80b45caae27dda81a9b44d8dd179c414580)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a race condition where a container being stopped could be removed from a separate process
```
