### PR TITLE
several podman logs fixes

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -72,6 +72,14 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			}
 		}
 	}
+	go func() {
+		if options.Until.After(time.Now()) {
+			time.Sleep(time.Until(options.Until))
+			if err := t.Stop(); err != nil {
+				logrus.Errorf("Stopping logger: %v", err)
+			}
+		}
+	}()
 
 	go func() {
 		defer options.WaitGroup.Done()

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -133,7 +133,7 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 	}
 
 	for {
-		entry, err := getNextEntry(ctx, j, options.Stream, untilTime)
+		entry, err := GetNextEntry(ctx, j, options.Stream, untilTime)
 		if err != nil {
 			return err
 		}
@@ -219,10 +219,10 @@ func (e EventJournalD) String() string {
 	return Journald.String()
 }
 
-// getNextEntry returns the next entry in the journal. If the end  of the
+// GetNextEntry returns the next entry in the journal. If the end  of the
 // journal is reached and stream is not set or the current time is after
 // the until time this function return nil,nil.
-func getNextEntry(ctx context.Context, j *sdjournal.Journal, stream bool, untilTime time.Time) (*sdjournal.JournalEntry, error) {
+func GetNextEntry(ctx context.Context, j *sdjournal.Journal, stream bool, untilTime time.Time) (*sdjournal.JournalEntry, error) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -121,6 +121,15 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 		if _, err := j.Previous(); err != nil {
 			return fmt.Errorf("failed to move journal cursor to previous entry: %w", err)
 		}
+	} else if len(options.Since) > 0 {
+		since, err := util.ParseInputTime(options.Since, true)
+		if err != nil {
+			return err
+		}
+		// seek based on time which helps to reduce unnecessary event reads
+		if err := j.SeekRealtimeUsec(uint64(since.UnixMicro())); err != nil {
+			return err
+		}
 	}
 
 	for {

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -344,4 +344,39 @@ timeout: sending signal TERM to command.*" "logs --since -f on running container
     _log_test_follow_since journald
 }
 
+function _log_test_follow_until() {
+    local driver=$1
+    cname=$(random_string)
+    content=$(random_string)
+    local events_backend=$(_additional_events_backend $driver)
+
+    if [[ -n "${events_backend}" ]]; then
+        skip_if_remote "remote does not support --events-backend"
+    fi
+
+    run_podman ${events_backend} run --log-driver=$driver --name $cname -d $IMAGE \
+        sh -c "while :; do echo $content && sleep 2; done"
+
+    t0=$SECONDS
+    # The logs command should exit after the until time even when follow is set
+    PODMAN_TIMEOUT=10 run_podman ${events_backend} logs --until 3s -f $cname
+    t1=$SECONDS
+
+    # The delta should be 3 but because it could be a bit longer on a slow system such as CI we also accept 4.
+    delta_t=$(( $t1 - $t0 ))
+    assert $delta_t -gt 2 "podman logs --until: exited too early!"
+    assert $delta_t -lt 5 "podman logs --until: exited too late!"
+
+    assert "$output" == "$content
+$content" "logs --until -f on running container works"
+
+    run_podman ${events_backend} rm -t 0 -f $cname
+}
+
+@test "podman logs - --until --follow journald" {
+    # We can't use journald on RHEL as rootless: rhbz#1895105
+    skip_if_journald_unavailable
+
+    _log_test_follow_until journald
+}
 # vim: filetype=sh

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -373,6 +373,10 @@ $content" "logs --until -f on running container works"
     run_podman ${events_backend} rm -t 0 -f $cname
 }
 
+@test "podman logs - --until --follow k8s-file" {
+    _log_test_follow_until k8s-file
+}
+
 @test "podman logs - --until --follow journald" {
     # We can't use journald on RHEL as rootless: rhbz#1895105
     skip_if_journald_unavailable

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -298,4 +298,50 @@ $contentC" "logs -f on exitted container works"
 
     _log_test_follow journald
 }
+
+function _log_test_follow_since() {
+    local driver=$1
+    cname=$(random_string)
+    content=$(random_string)
+    local events_backend=$(_additional_events_backend $driver)
+
+    if [[ -n "${events_backend}" ]]; then
+        skip_if_remote "remote does not support --events-backend"
+    fi
+
+    run_podman ${events_backend} run --log-driver=$driver --name $cname $IMAGE echo "$content"
+    # Using --since 0s can flake because the log might written in the second as the logs call is made.
+    # The -1s makes sure we only read logs that would be created 1s in the future which cannot happen.
+    run_podman ${events_backend} logs --since -1s -f $cname
+    assert "$output" == "" "logs --since -f on exited container works"
+
+    run_podman ${events_backend} rm -t 0 -f $cname
+
+    # Now do the same with a running container to check #16950.
+    run_podman ${events_backend} run --log-driver=$driver --name $cname -d $IMAGE \
+        sh -c "sleep 0.5; while :; do echo $content && sleep 3; done"
+
+    # sleep is required to make sure the podman event backend no longer sees the start event in the log
+    # This value must be greater or equal than the the value given in --since below
+    sleep 0.2
+
+    # Make sure podman logs actually follows by giving a low timeout and check that the command times out
+    PODMAN_TIMEOUT=2 run_podman 124 ${events_backend} logs --since 0.1s -f $cname
+    assert "$output" =~ "^$content
+timeout: sending signal TERM to command.*" "logs --since -f on running container works"
+
+    run_podman ${events_backend} rm -t 0 -f $cname
+}
+
+@test "podman logs - --since --follow k8s-file" {
+    _log_test_follow_since k8s-file
+}
+
+@test "podman logs - --since --follow journald" {
+    # We can't use journald on RHEL as rootless: rhbz#1895105
+    skip_if_journald_unavailable
+
+    _log_test_follow_since journald
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
see individual commits for details, I recommend you review this commit by commit and not the full diff at once.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman logs --since --follow would not follow and just exit with the journald driver.
Fixed a bug where podman logs --until --follow would not exit after the given until time.
The journald driver for both events and logs is now more efficient when --since is used, it will now seek directly to the correct time instead of reading all entries from he journal.
```
