### PR TITLE
[v4.3.1-rhel] Cirrus: tmp disable osx_alt_build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -362,37 +362,37 @@ alt_build_task:
 
 
 # Confirm building the remote client, natively on a Mac OS-X VM.
-osx_alt_build_task:
-    name: "OSX Cross"
-    alias: osx_alt_build
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: $CIRRUS_CRON != 'multiarch'
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        # OSX platform variation prevents this being included in alt_build_task
-        TEST_FLAVOR: "altbuild"
-        ALT_NAME: 'OSX Cross'
-    osx_instance:
-        image: 'big-sur-base'
-    setup_script:
-        - brew install go
-        - brew install go-md2man
-        - go version
-    build_amd64_script:
-        - make podman-remote-release-darwin_amd64.zip GOARCH=amd64
-    build_arm64_script:
-        - make podman-remote-release-darwin_arm64.zip GOARCH=arm64
-    build_pkginstaller_script:
-        - cd contrib/pkginstaller
-        - make ARCH=amd64 NO_CODESIGN=1 pkginstaller
-        - make ARCH=aarch64 NO_CODESIGN=1 pkginstaller
-    # This task cannot make use of the shared repo.tbz artifact and must
-    # produce a new repo.tbz artifact for consumption by 'artifacts' task.
-    repo_prep_script: *repo_prep
-    repo_artifacts: *repo_artifacts
-    always: *runner_stats
+#osx_alt_build_task:
+#    name: "OSX Cross"
+#    alias: osx_alt_build
+#    # Docs: ./contrib/cirrus/CIModes.md
+#    only_if: $CIRRUS_CRON != 'multiarch'
+#    depends_on:
+#        - build
+#    env:
+#        <<: *stdenvars
+#        # OSX platform variation prevents this being included in alt_build_task
+#        TEST_FLAVOR: "altbuild"
+#        ALT_NAME: 'OSX Cross'
+#    osx_instance:
+#        image: 'big-sur-base'
+#    setup_script:
+#        - brew install go
+#        - brew install go-md2man
+#        - go version
+#    build_amd64_script:
+#        - make podman-remote-release-darwin_amd64.zip GOARCH=amd64
+#    build_arm64_script:
+#        - make podman-remote-release-darwin_arm64.zip GOARCH=arm64
+#    build_pkginstaller_script:
+#        - cd contrib/pkginstaller
+#        - make ARCH=amd64 NO_CODESIGN=1 pkginstaller
+#        - make ARCH=aarch64 NO_CODESIGN=1 pkginstaller
+#    # This task cannot make use of the shared repo.tbz artifact and must
+#    # produce a new repo.tbz artifact for consumption by 'artifacts' task.
+#    repo_prep_script: *repo_prep
+#    repo_artifacts: *repo_artifacts
+#    always: *runner_stats
 
 
 # Verify podman is compatible with the docker python-module.
@@ -929,7 +929,7 @@ success_task:
         - bindings
         - swagger
         - alt_build
-        - osx_alt_build
+        # - osx_alt_build
         - win_installer
         - docker-py_test
         - unit_test

--- a/contrib/cirrus/cirrus_yaml_test.py
+++ b/contrib/cirrus/cirrus_yaml_test.py
@@ -27,6 +27,7 @@ class TestDependsOn(TestCaseBase):
 
     ALL_TASK_NAMES = None
     SUCCESS_DEPS_EXCLUDE = set(['success', 'artifacts',
+        'osx_alt_build',
         'test_image_build', 'release', 'release_test'])
 
     def setUp(self):


### PR DESCRIPTION
Cirrus: tmp disable osx_alt_build

Cron jobs for the release branches are failing with complaints about
intel macos not being supported anymore. This commit disables osx tasks
until we find out the best way to resolve these.

Ref: https://cirrus-ci.com/task/5984481031487488

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
