### PR TITLE
[release-v4.2.0-rhel] compat,build: handle docker's preconfigured cacheTo,cacheFrom

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -391,20 +391,47 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Docker clients, as of v19.03.0, populates `cacheFrom` and `cacheTo`
+	// parameter by default as empty array for all commands but buildah's
+	// design of distributed cache expects this to be a repo not image hence
+	// parse only the first populated repo and igore if empty array.
+	// Read more here: https://github.com/containers/podman/issues/15928
+	// TODO: Remove this when buildah's API is extended.
+	compatIgnoreForcedCacheOptions := func(queryStr string) string {
+		query := queryStr
+		if strings.HasPrefix(query, "[") {
+			query = ""
+			var arr []string
+			parseErr := json.Unmarshal([]byte(query), &arr)
+			if parseErr != nil {
+				if len(arr) > 0 {
+					query = arr[0]
+				}
+			}
+		}
+		return query
+	}
+
 	var cacheFrom reference.Named
 	if _, found := r.URL.Query()["cachefrom"]; found {
-		cacheFrom, err = parse.RepoNameToNamedReference(query.CacheFrom)
-		if err != nil {
-			utils.BadRequest(w, "cacheFrom", query.CacheFrom, err)
-			return
+		cacheFromQuery := compatIgnoreForcedCacheOptions(query.CacheFrom)
+		if cacheFromQuery != "" {
+			cacheFrom, err = parse.RepoNameToNamedReference(cacheFromQuery)
+			if err != nil {
+				utils.BadRequest(w, "cacheFrom", cacheFromQuery, err)
+				return
+			}
 		}
 	}
 	var cacheTo reference.Named
 	if _, found := r.URL.Query()["cacheto"]; found {
-		cacheTo, err = parse.RepoNameToNamedReference(query.CacheTo)
-		if err != nil {
-			utils.BadRequest(w, "cacheto", query.CacheTo, err)
-			return
+		cacheToQuery := compatIgnoreForcedCacheOptions(query.CacheTo)
+		if cacheToQuery != "" {
+			cacheTo, err = parse.RepoNameToNamedReference(cacheToQuery)
+			if err != nil {
+				utils.BadRequest(w, "cacheto", cacheToQuery, err)
+				return
+			}
 		}
 	}
 	var cacheTTL time.Duration

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -189,6 +189,13 @@ tar --format=posix -C $TMPD -cvf ${CONTAINERFILE_TAR} containerfile &> /dev/null
 t POST "libpod/build?dockerfile=containerfile" $CONTAINERFILE_TAR 200 \
   .stream~"STEP 1/1: FROM $IMAGE"
 
+# Docker client as of v19.03.0 sets empty cacheFrom for every build command even if it is not used,
+# following commit makes sure we test such use-case. See https://github.com/containers/podman/pull/16380
+#TODO: This test should be extended when buildah's cache-from and cache-to functionally supports
+# multiple remote-repos
+t POST "libpod/build?dockerfile=containerfile&cachefrom=[]" $CONTAINERFILE_TAR 200 \
+  .stream~"STEP 1/1: FROM $IMAGE"
+
 # With -q, all we should get is image ID. Test both libpod & compat endpoints.
 t POST "libpod/build?dockerfile=containerfile&q=true" $CONTAINERFILE_TAR 200 \
   .stream~'^[0-9a-f]\{64\}$'


### PR DESCRIPTION
This is a backport of #16380 which also impacts podman 4.2, while I initially wrongly assumed the problem was only in podman >= 4.3. It seems we in Amadeus have upgraded our build machine during the holiday season and first day of 2023 many of our builds were broken. I have already internally patched podman, repackaged it, and pushed our own Amadeus podman to all our machine, but I wish to make this fix more official and shipped by Red Hat directly.

I have effectively cherry-picked the commit taken from the 4.3 backport done by @flouthoc in #16822.

Note, for the tracking side, I had opened a Red Hat case for the backport to branch 4.3. It was Red Hat customer case 03387104. This lead to the creation of this bugzilla ticket: https://bugzilla.redhat.com/show_bug.cgi?id=2152516

#### Does this PR introduce a user-facing change?

No

```release-note
None
```
