### PR TITLE
[CI:DOCS] Preprocess files in UTF-8 mode

### DIFF
--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -38,7 +38,7 @@ class Preprocessor():
         outfile = os.path.splitext(infile)[0]
         outfile_tmp = outfile + '.tmp.' + str(os.getpid())
 
-        with open(infile, 'r') as fh_in, open(outfile_tmp, 'w') as fh_out:
+        with open(infile, 'r', encoding='utf-8') as fh_in, open(outfile_tmp, 'w', encoding='utf-8') as fh_out:
             for line in fh_in:
                 # '@@option foo' -> include file options/foo.md
                 if line.startswith('@@option '):
@@ -71,7 +71,7 @@ class Preprocessor():
         """
         for optionfile in self.used_by:
             tmpfile = optionfile + '.tmp'
-            with open(optionfile, 'r') as fh_in, open(tmpfile, 'w') as fh_out:
+            with open(optionfile, 'r', encoding='utf-8') as fh_in, open(tmpfile, 'w', encoding='utf-8') as fh_out:
                 fh_out.write("####> This option file is used in:\n")
                 used_by = ', '.join(x for x in self.used_by[optionfile])
                 fh_out.write(f"####>   podman {used_by}\n")
@@ -96,7 +96,7 @@ class Preprocessor():
         # treats them as one line and will unwantedly render the
         # comment in its output.
         fh_out.write("\n[//]: # (BEGIN included file " + path + ")\n")
-        with open(path, 'r') as fh_included:
+        with open(path, 'r', encoding='utf-8') as fh_included:
             for opt_line in fh_included:
                 if opt_line.startswith('####>'):
                     continue


### PR DESCRIPTION
Some (?) Python versions assume that text files are encoded as 7-bit ASCII and abort when encountering other encoding. Some of podman's markdown documentation files are encoded as UTF-8, and this needs to be specified explicitly when opening files.

Closes https://github.com/containers/podman/issues/16996.

[NO NEW TESTS NEEDED]

Signed-off-by: Erik Schnetter <schnetter@gmail.com>

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional comments

In principle one could add a CI test for this (by investigating which Python versions or setups fail or succeed, and by running a test with one of these versions). This seems quite tedious and likely not worth the effort.