### PR TITLE
logformatter: nicer formatting for bats failures

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -251,6 +251,19 @@ END_HTML
             $previous_timestamp = $timestamp;
         }
 
+        # Helper function for printing a formatted line. This should always
+        # be followed by 'next LINE'.
+        my $print_line = sub {
+            my $css = shift;
+
+            print { $out_fh } "<span class=\"timestamp\">$timestamp</span>"
+                if $timestamp;
+            print { $out_fh } "<span class='$css'>"     if $css;
+            print { $out_fh } $line;
+            print { $out_fh } "</span>"                 if $css;
+            print { $out_fh } "\n";
+        };
+
         # Try to identify the git commit we're working with...
         if ($line =~ m!/define.gitCommit=([0-9a-f]+)!) {
             $git_commit = $1;
@@ -305,9 +318,7 @@ END_HTML
             if ($line =~ /^\s*(OK|FAILED)\s+\(/) {
                 undef $looks_like_python;
                 my $css = ($1 eq 'OK' ? 'passed' : 'failed');
-                print { $out_fh } "<span class=\"timestamp\">$timestamp</span>"
-                    if $timestamp;
-                print { $out_fh } "<span class='bats-$css'>", $line, "</span>\n";
+                $print_line->("bats-$css");
                 next LINE;
             }
         }
@@ -339,14 +350,11 @@ END_HTML
 
                     push @{$bats_count{__fail_list}}, [ $2, $3 ] if $1;
                 }
-                $line = "<span class='bats-$css'>$line</span>";
-
                 $bats_count{$css}++;
+                $css = "bats-$css";
             }
 
-            print { $out_fh } "<span class=\"timestamp\">$timestamp</span>"
-                if $timestamp;
-            print { $out_fh } $line, "\n";
+            $print_line->($css);
             next LINE;
         }
         elsif ($looks_like_python) {
@@ -362,13 +370,10 @@ END_HTML
             }
 
             if ($css) {
-                $line = "<span class='bats-$css'>$line</span>";
-
                 $bats_count{$css}++;
+                $css = "bats-$css";
             }
-            print { $out_fh } "<span class=\"timestamp\">$timestamp</span>"
-                if $timestamp;
-            print { $out_fh } $line, "\n";
+            $print_line->($css);
             next LINE;
         }
 

--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -18,7 +18,7 @@ use warnings;
 
 (our $ME = $0) =~ s|.*/||;
 
-our $VERSION = '0.1';
+our $VERSION = '0.2';
 
 # Autoflush stdout
 $| = 1;
@@ -40,20 +40,20 @@ table.synopsis { border: none; border-collapse: collapse; margin-left: 2em; marg
 .synopsis td   { font-weight: bold;   font-size: 120%; font-family: monospace; }
 
 /* test results */
-.testname  { font-size: 125%; color: #444; }
-.boring    { color: #999; }
-.timestamp { color: #999; }
-.log-debug { color: #999; }
-.log-info  { color: #333; }
-.log-warn  { color: #f60; }
-.log-error { color: #900; font-weight: bold; }
-.log-skip  { color: #F90; }
-.log-slow  { background: #FF0; color: #000; font-weight: bold; }
-.subtest   { background: #eee; }
-.subsubtest { color: #F39; font-weight: bold; }
-.string    { color: #00c; }
-.command   { font-weight: bold; color: #000; }
-.changed   { color: #000; font-weight: bold; }
+.testname     { font-size: 125%; color: #444; }
+.boring       { color: #999; }
+.timestamp    { color: #999; }
+.log-debug    { color: #999; }
+.log-info     { color: #333; }
+.log-warning  { color: #f60; }
+.log-error    { color: #900; font-weight: bold; }
+.log-skip     { color: #F90; }
+.log-slow     { background: #FF0; color: #000; font-weight: bold; }
+.subtest      { background: #eee; }
+.subsubtest   { color: #F39; font-weight: bold; }
+.string       { color: #00c; }
+.command      { font-weight: bold; color: #000; }
+.changed      { color: #000; font-weight: bold; }
 
 /* links to source files: not as prominent as links to errors */
 a.codelink:link    { color: #000; }
@@ -68,8 +68,8 @@ a.timing           { text-decoration: none; }
 .bats-passed    { color: #393; }
 .bats-failed    { color: #F00; font-weight: bold; }
 .bats-skipped   { color: #F90; }
-.bats-log       { color: #900; }
-.bats-log-esm   { color: #b00; font-weight: bold; }
+.bats-log       { color: #933; }
+.bats-log-failblock { color: #b00; background-color: #fee; display: inline-flex; margin: 0 -500%; padding: 0 500% !important; }
 
 .bats-summary   { font-size: 150%; }
 
@@ -285,6 +285,13 @@ END_HTML
             $cirrus_task = $1;
         }
 
+        # logrus messages, always highlighted
+        #              1   2   2 13     34  4 5      56   6 7    78  8
+        if ($line =~ /^(\s*(#\s)?)(time=)(.*) (level=)(\S+) (msg=)(.*)/) {
+            my $span = "<span class='log-$6'>";
+            $line = "$1$3$span$4</span> $5$span$6</span> $7$span$8</span>";
+        }
+
         # BATS handling. This will recognize num_tests both at start and end
         if ($line =~ /^1\.\.(\d+)$/) {
             $looks_like_bats = 1;
@@ -331,11 +338,11 @@ END_HTML
             $line =~ s{^(#\s+(#|\$)\s+)(\S+/)(podman\S*)(\s.*)}
                       {$1<b><span title="$3$4">$4</span>$5</b>};
 
-            if    ($line =~ /^ok\s.*\s# skip/) { $css = 'skipped' }
-            elsif ($line =~ /^ok\s/)           { $css = 'passed'  }
-            elsif ($line =~ /^not\s+ok\s/)     { $css = 'failed'  }
-            elsif ($line =~ /^#\s#\|\s/)       { $css = 'log-esm' }
-            elsif ($line =~ /^#\s/)            { $css = 'log'     }
+            if    ($line =~ /^ok\s.*\s# skip/)    { $css = 'skipped'       }
+            elsif ($line =~ /^ok\s/)              { $css = 'passed'        }
+            elsif ($line =~ /^not\s+ok\s/)        { $css = 'failed'        }
+            elsif ($line =~ /^# #(\/v|\| |\\\^)/) { $css = 'log-failblock' }
+            elsif ($line =~ /^#\s/)               { $css = 'log'           }
 
             # Link to source file. This is ugly: we have to hardcode 'podman'
             # and 'test/system' because there's no way to get them from log.
@@ -444,7 +451,7 @@ END_HTML
             }
         }
         elsif ($line =~ /^Error:/ || $line =~ / level=(warning|error) /) {
-            $line = "<span class='log-warn'>" . $line . "</span>";
+            $line = "<span class='log-warning'>" . $line . "</span>";
         }
         elsif ($line =~ /^panic:/) {
             $line = "<span class='log-error'>" . $line . "</span>";

--- a/contrib/cirrus/logformatter.t
+++ b/contrib/cirrus/logformatter.t
@@ -95,6 +95,8 @@ not ok 3 fail
 #  from function `expect_output' in file ./helpers.bash, line 370,
 #  in test file ./run.bats, line 786)
 # $ /path/to/podman foo -bar
+# time="2023-01-05T15:15:20Z" level=debug msg="this is debug"
+# time="2023-01-05T15:15:20Z" level=warning msg="this is warning"
 # #| FAIL: exit code is 123; expected 321
 ok 4 blah
 >>>
@@ -106,7 +108,9 @@ ok 4 blah
 <span class='bats-log'>#  from function `expect_output&#39; in file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L370">helpers.bash, line 370</a>,</span>
 <span class='bats-log'>#  in test file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/run.bats#L786">run.bats, line 786</a>)</span>
 <span class='bats-log'># $ <b><span title="/path/to/podman">podman</span> foo -bar</b></span>
-<span class='bats-log-esm'># #| FAIL: exit code is 123; expected 321</span>
+<span class='bats-log'># time=<span class='log-debug'>&quot;2023-01-05T15:15:20Z&quot;</span> level=<span class='log-debug'>debug</span> msg=<span class='log-debug'>&quot;this is debug&quot;</span></span>
+<span class='bats-log'># time=<span class='log-warning'>&quot;2023-01-05T15:15:20Z&quot;</span> level=<span class='log-warning'>warning</span> msg=<span class='log-warning'>&quot;this is warning&quot;</span></span>
+<span class='bats-log-failblock'># #| FAIL: exit code is 123; expected 321</span>
 <span class='bats-passed'><a name='t--00004'>ok 4 blah</a></span>
 <hr/><span class='bats-summary'>Summary: <span class='bats-passed'>2 Passed</span>, <span class='bats-failed'>1 Failed</span>, <span class='bats-skipped'>1 Skipped</span>. Total tests: 4</span>
 
@@ -209,7 +213,7 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 --tmpdir /tmp/podman_test553496330
 --events-backend file
 --storage-driver vfs">[options]</span><b> pod restart 4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89</b>
-<span class="timestamp">         </span><span class='log-warn'>Error: no containers in pod 4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89 have no dependencies, cannot start pod: no such container</span>
+<span class="timestamp">         </span><span class='log-warning'>Error: no containers in pod 4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89 have no dependencies, cannot start pod: no such container</span>
 <span class="timestamp">         </span>output:
 <span class="timestamp">         </span>[AfterEach] Podman pod restart
 <span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L28'>/containers/podman/test/e2e/pod_restart_test.go:28</a>


### PR DESCRIPTION
add a new failblock style, with light red background all across
the entire page, and use it for bats "FAIL" blocks.
    
Also highlight logrus level=(debug|info|warning|error|fatal)
messages in increasingly prominent styles

Also refactored a cluttery `print` sequence, because I thought I'd
be using it for this prettification. Turns out I didn't, but the
refactoring (first commit) still seems worth keeping.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```