### PR TITLE
[CI:DOCS] Improve basic tutorial

### DIFF
--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -9,7 +9,7 @@ If you are running on a Mac or Windows PC, you should instead follow the [Mac an
 to set up the remote Podman client.
 
 **NOTE**: the code samples are intended to be run as a non-root user, and use `sudo` where
-root escalation is required.
+root escalation is required. 
 
 ## Installing Podman
 
@@ -46,8 +46,8 @@ podman inspect -l | grep IPAddress\":
             "IPAddress": "",
 ```
 
-Note: The -l is a convenience argument for **latest container**.  You can also use the container's ID instead
-of -l.
+Note: The -l is a convenience argument for **latest container**. When using the remote Podman client you have to use the container's ID instead
+of -l. 
 
 ### Testing the httpd server
 As we do not have the IP address of the container, we can test the network communication between the host
@@ -60,7 +60,7 @@ curl http://localhost:8080
 ### Viewing the container's logs
 You can view the container's logs with Podman as well:
 ```console
-podman logs --latest
+podman logs -l
 10.88.0.1 - - [07/Feb/2018:15:22:11 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
@@ -71,7 +71,7 @@ podman logs --latest
 ### Viewing the container's pids
 And you can observe the httpd pid in the container with *top*.
 ```console
-podman top <container_id>
+podman top -l
   UID   PID  PPID  C STIME TTY          TIME CMD
     0 31873 31863  0 09:21 ?        00:00:00 nginx: master process nginx -g daemon off;
   101 31889 31873  0 09:21 ?        00:00:00 nginx: worker process
@@ -85,7 +85,7 @@ This feature is not supported as rootless; as such, if you wish to try it, you'l
 
 To checkpoint the container use:
 ```console
-sudo podman container checkpoint <container_id>
+sudo podman container checkpoint -l
 ```
 
 ### Restoring the container
@@ -93,7 +93,7 @@ Restoring a container is only possible for a previously checkpointed container. 
 continue to run at exactly the same point in time it was checkpointed.
 To restore the container use:
 ```console
-sudo podman container restore <container_id>
+sudo podman container restore -l
 ```
 
 After being restored, the container will answer requests again as it did before checkpointing.
@@ -108,7 +108,7 @@ system. When transferring the checkpoint, it is possible to specify an output-fi
 
 On the source system:
 ```console
-sudo podman container checkpoint <container_id> -e /tmp/checkpoint.tar.gz
+sudo podman container checkpoint -l -e /tmp/checkpoint.tar.gz
 scp /tmp/checkpoint.tar.gz <destination_system>:/tmp
 ```
 
@@ -126,7 +126,7 @@ curl http://<IP_address>:8080
 ### Stopping the container
 To stop the httpd container:
 ```console
-podman stop --latest
+podman stop -l
 ```
 You can also check the status of one or more containers using the *ps* subcommand. In this case, we should
 use the *-a* argument to list all containers.
@@ -137,7 +137,7 @@ podman ps -a
 ### Removing the container
 To remove the httpd container:
 ```console
-podman rm --latest
+podman rm -l
 ```
 You can verify the deletion of the container by running *podman ps -a*.
 


### PR DESCRIPTION
Closes #17019
- Use `-l` consistently instead of mixing `<container_id>` , `--latest` and `-l`.
- Guide the reader to use the container id instead of `-l` when using the remote Podman client.

Signed-off-by: biergit <l4143-github@yahoo.de>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
