### PR TITLE
Updated options for QEMU on Windows hosts

### DIFF
--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -1,7 +1,7 @@
 package qemu
 
 var (
-	QemuCommand = "qemu-system-x86_64"
+	QemuCommand = "qemu-system-x86_64w"
 )
 
 func (v *MachineVM) addArchOptions() []string {

--- a/pkg/machine/qemu/options_windows_arm64.go
+++ b/pkg/machine/qemu/options_windows_arm64.go
@@ -1,0 +1,19 @@
+package qemu
+
+var (
+	QemuCommand = "qemu-system-aarch64w"
+)
+
+func (v *MachineVM) addArchOptions() []string {
+	// stub to fix compilation issues
+	opts := []string{}
+	return opts
+}
+
+func (v *MachineVM) prepare() error {
+	return nil
+}
+
+func (v *MachineVM) archRemovalFiles() []string {
+	return []string{}
+}


### PR DESCRIPTION
These changes are extracted from #16872 draft. arm64 will not be supported as QEMU machine host, because there is no QEMU for that arch on Windows, but it will be needed to compile remote client on that arch (alternative is to introduce a bigger refactoring around machine related code).

Using "w" suffixed versions of QEMU binaries for correct background process handling and not bind it to lifecycle of command prompt window. Stub for arm64 version added to fix compilation issues of this target, when QEMU machine will be finally enabled.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
