### PR TITLE
linux: add /sys/fs/cgroup if /sys is a bind mount

### DIFF
--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -107,11 +107,19 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		}
 		sysMnt := spec.Mount{
 			Destination: "/sys",
-			Type:        "bind", // should we use a constant for this, like createconfig?
+			Type:        "bind",
 			Source:      "/sys",
 			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r, "rbind"},
 		}
 		g.AddMount(sysMnt)
+		g.RemoveMount("/sys/fs/cgroup")
+		sysFsCgroupMnt := spec.Mount{
+			Destination: "/sys/fs/cgroup",
+			Type:        "bind",
+			Source:      "/sys/fs/cgroup",
+			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r, "rbind"},
+		}
+		g.AddMount(sysFsCgroupMnt)
 		if !s.Privileged && isRootless {
 			g.AddLinuxMaskedPaths("/sys/kernel")
 		}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -974,4 +974,9 @@ EOF
     run_podman 125 create --name "$randomname/" $IMAGE
 }
 
+@test "podman run --net=host --cgroupns=host with read only cgroupfs" {
+    # verify that the last /sys/fs/cgroup mount is read-only
+    run_podman run --net=host --cgroupns=host --rm $IMAGE sh -c "grep ' / /sys/fs/cgroup ' /proc/self/mountinfo | tail -n 1 | grep '/sys/fs/cgroup ro'"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
if /sys is bind mounted from the host then also add an explicit mount for /sys/fs/cgroup so that 'ro' is honored.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
