### PR TITLE
Quadlet: Add support for ConfigMap key in Kube section

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -357,6 +357,14 @@ created by using a `$name.network` quadlet file.
 
 This key can be listed multiple times.
 
+#### `ConfigMap=`
+
+Pass the Kubernetes ConfigMap YAML at path to `podman kube play` via the `--configmap` argument.
+Unlike the `configmap` argument, the value may contain only one path but
+it may be absolute or relative to the location of the unit file.
+
+This key may be used multiple times
+
 ### Volume units
 
 Volume files are named with a `.volume` extension and contain a section `[Volume]` describing the

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -72,6 +72,7 @@ const (
 	KeyNetworkIPv6       = "IPv6"
 	KeyNetworkOptions    = "Options"
 	KeyNetworkSubnet     = "Subnet"
+	KeyConfigMap         = "ConfigMap"
 )
 
 // Supported keys in "Container" group
@@ -136,6 +137,7 @@ var supportedKubeKeys = map[string]bool{
 	KeyRemapUsers:   true,
 	KeyRemapUIDSize: true,
 	KeyNetwork:      true,
+	KeyConfigMap:    true,
 }
 
 func replaceExtension(name string, extension string, extraPrefix string, extraSuffix string) string {
@@ -756,6 +758,15 @@ func ConvertKube(kube *parser.UnitFile, isUser bool) (*parser.UnitFile, error) {
 	}
 
 	addNetworks(kube, KubeGroup, service, execStart)
+
+	configMaps := kube.LookupAllStrv(KubeGroup, KeyConfigMap)
+	for _, configMap := range configMaps {
+		configMapPath, err := getAbsolutePath(kube, configMap)
+		if err != nil {
+			return nil, err
+		}
+		execStart.add("--configmap", configMapPath)
+	}
 
 	execStart.add(yamlPath)
 

--- a/test/e2e/quadlet/configmap.kube
+++ b/test/e2e/quadlet/configmap.kube
@@ -1,0 +1,7 @@
+## assert-podman-args "--configmap" "/opt/k8s/abs.yml"
+## assert-podman-args-regex "--configmap" ".*/podman_test.*/quadlet/rel.yml"
+
+[Kube]
+Yaml=deployment.yml
+ConfigMap=rel.yml
+ConfigMap=/opt/k8s/abs.yml

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -491,6 +491,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("Kube - User Remap Auto with IDs", "remap-auto2.kube"),
 		Entry("Kube - Network", "network.kube"),
 		Entry("Kube - Quadlet Network", "network.quadlet.kube"),
+		Entry("Kube - ConfigMap", "configmap.kube"),
 
 		Entry("Network - Basic", "basic.network"),
 		Entry("Network - Label", "label.network"),


### PR DESCRIPTION
For each instance of ConfigMap pass the path via --configmap Add tests
Add to doc

Signed-off-by: Ygal Blum <ygal.blum@gmail.com>

#### Does this PR introduce a user-facing change?
No

```release-note
None
```
