### PR TITLE
cobra: move engine shutdown to Execute

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -238,4 +238,11 @@ run_podman --noout system connection ls
     is "$output" "" "output should be empty"
 }
 
+@test "podman - shutdown engines" {
+    run_podman --log-level=debug run --rm $IMAGE true
+    is "$output" ".*Shutting down engines.*"
+    run_podman 125 --log-level=debug run dockah://rien.de/rien:latest
+    is "${lines[-1]}" ".*Shutting down engines"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
If the run errors, cobra does not execute post runs.  It is a somehow
known issue (https://github.com/spf13/cobra/issues/914) but problematic
for Podmand as the runtime is shutdown during post run.

Since some commands overwrite the post run and a general lack in cobra
of post runs on errors, move the shutting down the engines directly into
Execute.  Fixing the issue may fix a number of flakes.

Note that the shutdowns are NOPs for the remote client.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where the runtime was not shutdown correctly on error.
```
