### PR TITLE
Update Mac installer to use gvproxy v0.5.0

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -6,7 +6,7 @@ ifeq ($(ARCH), aarch64)
 else
 	GOARCH:=$(ARCH)
 endif
-GVPROXY_VERSION ?= 0.4.0
+GVPROXY_VERSION ?= 0.5.0
 QEMU_VERSION ?= 7.1.0-1
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
 QEMU_RELEASE_URL ?= https://github.com/containers/podman-machine-qemu/releases/download/v$(QEMU_VERSION)/podman-machine-qemu-$(ARCH)-$(QEMU_VERSION).tar.xz


### PR DESCRIPTION
This PR is the Mac installer portion of #16656
Windows is already handled by #17023 (merged)

Two more pieces remain (external repos)
1. brew package formula
2. rpm specfile for Linux

```release-note
NONE
```

[NO NEW TESTS NEEDED]