### PR TITLE
Tests: remove/update obsolete skips

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -572,8 +572,6 @@ subdir**`
 	// See https://github.com/containers/podman/issues/13535
 	It("Remote build .containerignore filtering embedded directory (#13535)", func() {
 		SkipIfNotRemote("Testing remote .containerignore file filtering")
-		Skip("FIXME: #15014: test times out in 'dd' on f36.")
-
 		podmanTest.RestartRemoteService()
 
 		// Switch to temp dir and restore it afterwards
@@ -605,7 +603,7 @@ subdir**`
 		dd := exec.Command("dd", "if=/dev/urandom", "of="+randomFile, "bs=1G", "count=1")
 		ddSession, err := Start(dd, GinkgoWriter, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred())
-		Eventually(ddSession, "10s", "1s").Should(Exit(0))
+		Eventually(ddSession, "30s", "1s").Should(Exit(0))
 
 		// make cwd as context root path
 		Expect(os.Chdir(contextDir)).ToNot(HaveOccurred())

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1081,7 +1081,6 @@ ENTRYPOINT ["sleep","99999"]
 
 	It("podman pod create --share-parent test", func() {
 		SkipIfRootlessCgroupsV1("rootless cannot use cgroups with cgroupsv1")
-		SkipIfCgroupV1("FIXME: #15013: CgroupMode shows 'host' instead of CID under Cgroups V1.")
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--share-parent=false"})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(Exit(0))

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -76,7 +76,7 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run - uidmapping has no /sys/kernel mounts" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     skip_if_rootless "cannot umount as rootless"
     skip_if_remote "TODO Fix this for remote case"
 
@@ -830,7 +830,7 @@ EOF
 
 # rhbz#1902979 : podman run fails to update /etc/hosts when --uidmap is provided
 @test "podman run update /etc/hosts" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     HOST=$(random_string 25)
     run_podman run --uidmap 0:10001:10002 --rm --hostname ${HOST} $IMAGE grep ${HOST} /etc/hosts
     is "${lines[0]}" ".*${HOST}.*"

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -30,7 +30,7 @@ function _require_crun() {
 }
 
 @test "podman --group-add without keep-groups while in a userns" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
     run chroot --groups 1234,5678 / ${PODMAN} run --rm --uidmap 0:200000:5000 --group-add 457 $IMAGE id
@@ -38,7 +38,7 @@ function _require_crun() {
 }
 
 @test "rootful pod with custom ID mapping" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     skip_if_rootless "does not work rootless - rootful feature"
     random_pod_name=$(random_string 30)
     run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -76,11 +76,6 @@ function service_cleanup() {
 # These tests can fail in dev. environment because of SELinux.
 # quick fix: chcon -t container_runtime_exec_t ./bin/podman
 @test "podman generate - systemd - basic" {
-    # Flakes with "ActiveState=failed (expected =inactive)"
-    if is_ubuntu; then
-        skip "FIXME: 2022-09-01: requires conmon-2.1.4, ubuntu has 2.1.3"
-    fi
-
     # Warn when a custom restart policy is used without --new (see #15284)
     run_podman create --restart=always $IMAGE
     cid="$output"

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -7,7 +7,7 @@
 load helpers
 
 @test "podman container storage is not accessible by unprivileged users" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     skip_if_rootless "test meaningless without suid"
     skip_if_remote
 

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -118,7 +118,7 @@ function check_label() {
     skip_if_rootless_cgroupsv1
 
     if [[ $(podman_runtime) == "runc" ]]; then
-	skip "some sort of runc bug, not worth fixing (#11784)"
+	skip "some sort of runc bug, not worth fixing (issue 11784, ewontfix)"
     fi
 
     run_podman run -d --name myctr $IMAGE top

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -88,7 +88,7 @@ load helpers.network
 
 # Issue #5466 - port-forwarding doesn't work with this option and -d
 @test "podman networking: port with --userns=keep-id for rootless or --uidmap=* for rootful" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     for cidr in "" "$(random_rfc1918_subnet).0/24"; do
         myport=$(random_free_port 52000-52999)
         if [[ -z $cidr ]]; then
@@ -748,7 +748,7 @@ EOF
 }
 
 @test "podman run /etc/* permissions" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1"
     userns="--userns=keep-id"
     if ! is_rootless; then
         userns="--uidmap=0:1111111:65536 --gidmap=0:1111111:65536"


### PR DESCRIPTION
To silence my find-obsolete-skips script:
 - #11784 : issue closed wont-fix
 - #15013 : issue closed, we no longer test with runc
 - #15014 : issue closed wontfix
 - #15025 : issue closed, we no longer test with runc

...and one FIXME not associated with an issue, ubuntu-related,
and we no longer test ubuntu.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```