### PR TITLE
[v4.2.0-rhel] podman: podman rm -f doesn't leave processes

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -444,6 +444,10 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 	}
 
 	if err := r.KillContainer(ctr, 9, all); err != nil {
+		// If the PID is 0, then the container is already stopped.
+		if ctr.state.PID == 0 {
+			return nil
+		}
 		// Again, check if the container is gone. If it is, exit cleanly.
 		err := unix.Kill(ctr.state.PID, 0)
 		if err == unix.ESRCH {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -698,7 +698,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	}
 
 	// Check that the container's in a good state to be removed.
-	if c.state.State == define.ContainerStateRunning {
+	if c.ensureState(define.ContainerStateRunning, define.ContainerStateStopping) {
 		time := c.StopTimeout()
 		if timeout != nil {
 			time = *timeout

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -103,9 +103,8 @@ load helpers
     is "$output" "" "Should print no output"
 }
 
-@test "podman container rm doesn't affect stopping containers" {
-    local cname=c$(random_string 30)
-    run_podman run -d --name $cname \
+function __run_healthcheck_container() {
+    run_podman run -d --name $1 \
                --health-cmd /bin/false \
                --health-interval 1s \
                --health-retries 2 \
@@ -115,6 +114,11 @@ load helpers
                --health-start-period 0 \
                --stop-signal SIGTERM \
                $IMAGE sleep infinity
+}
+
+@test "podman container rm doesn't affect stopping containers" {
+    local cname=c$(random_string 30)
+    __run_healthcheck_container $cname
     local cid=$output
 
     # We'll use the PID later to confirm that container is not running
@@ -143,6 +147,31 @@ load helpers
     run_podman 1 container exists $cid
 
     assert "$rm_failures" -gt 0 "we want at least one failure from podman-rm"
+
+    if kill -0 $pid; then
+        die "Container $cname process is still running (pid $pid)"
+    fi
+}
+
+@test "podman container rm --force doesn't leave running processes" {
+    local cname=c$(random_string 30)
+    __run_healthcheck_container $cname
+    local cid=$output
+
+    # We'll use the PID later to confirm that container is not running
+    run_podman inspect --format '{{.State.Pid}}' $cname
+    local pid=$output
+
+    for i in {1..10}; do
+        run_podman inspect $cname --format '{{.State.Status}}'
+        if [ "$output" = "stopping" ]; then
+            break
+        fi
+
+	sleep 0.5
+    done
+
+    run_podman rm -f $cname
 
     if kill -0 $pid; then
         die "Container $cname process is still running (pid $pid)"


### PR DESCRIPTION
follow-up to 6886e80b45caae27dda81a9b44d8dd179c414580
    
when "podman -rm -f" is used on a container in "stopping" state, also
make sure it is terminated before removing it from the local storage.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2155828

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 4cf06fe7e074cb9a09670f8308ade12f30bb958d)


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
now podman rm -f also terminates containers in "stopping" state
```
