### PR TITLE
Network tests: ping redhat.com, not podman.io

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -483,7 +483,7 @@ func (p *PodmanTestIntegration) RunContainerWithNetworkTest(mode string) *Podman
 	if mode != "" {
 		podmanArgs = append(podmanArgs, "--network", mode)
 	}
-	podmanArgs = append(podmanArgs, fedoraMinimal, "curl", "-k", "-o", "/dev/null", "http://www.podman.io:80")
+	podmanArgs = append(podmanArgs, fedoraMinimal, "curl", "-k", "-o", "/dev/null", "http://www.redhat.com:80")
 	session := p.Podman(podmanArgs)
 	return session
 }

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Podman run networking", func() {
 			Expect(session.ErrorToString()).To(ContainSubstring("Could not resolve proxy:"))
 		} else {
 			Expect(session).Should(Exit(6))
-			Expect(session.ErrorToString()).To(ContainSubstring("Could not resolve host: www.podman.io"))
+			Expect(session.ErrorToString()).To(ContainSubstring("Could not resolve host: www.redhat.com"))
 		}
 	})
 
@@ -678,7 +678,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 			Expect(delXXX).Should(Exit(0))
 		}()
 
-		session := podmanTest.Podman([]string{"run", "-dt", "--net", "ns:/run/netns/xxx", ALPINE, "wget", "www.podman.io"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--net", "ns:/run/netns/xxx", ALPINE, "wget", "www.redhat.com"})
 		session.Wait(90)
 		Expect(session).Should(Exit(0))
 	})
@@ -861,7 +861,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run network in bogus user created network namespace", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--net", "ns:/run/netns/xxy", ALPINE, "wget", "www.podman.io"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--net", "ns:/run/netns/xxy", ALPINE, "wget", "www.redhat.com"})
 		session.Wait(90)
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("stat /run/netns/xxy: no such file or directory"))


### PR DESCRIPTION
Much as we'd love to eat our dogfood, podman.io is not hosted
on reliable infrastructure; redhat.com is. Let's see if this
gets rid of CI flakes.

Closes: #17044

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```