### PR TITLE
service container: less verbose error logs

### DIFF
--- a/libpod/service.go
+++ b/libpod/service.go
@@ -135,7 +135,9 @@ func (p *Pod) maybeStopServiceContainer() error {
 		}
 		logrus.Debugf("Stopping service container %s", serviceCtr.ID())
 		if err := serviceCtr.Stop(); err != nil {
-			logrus.Errorf("Stopping service container %s: %v", serviceCtr.ID(), err)
+			if !errors.Is(err, define.ErrCtrStopped) {
+				logrus.Errorf("Stopping service container %s: %v", serviceCtr.ID(), err)
+			}
 		}
 	})
 	return nil
@@ -239,7 +241,9 @@ func (p *Pod) maybeRemoveServiceContainer() error {
 		timeout := uint(0)
 		logrus.Debugf("Removing service container %s", serviceCtr.ID())
 		if err := p.runtime.RemoveContainer(context.Background(), serviceCtr, true, false, &timeout); err != nil {
-			logrus.Errorf("Removing service container %s: %v", serviceCtr.ID(), err)
+			if !errors.Is(err, define.ErrNoSuchCtr) {
+				logrus.Errorf("Removing service container %s: %v", serviceCtr.ID(), err)
+			}
 		}
 	})
 	return nil


### PR DESCRIPTION
While manually playing with --service-container, I encountered a number of too verbose logs.  For instance, there's no need to error-log when the service-container has already been stopped.

For testing, add a new kube test with a multi-pod YAML which will implicitly show that #17024 is now working.

Fixes: #17024
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
