### PR TITLE
Introduce pkg retry logic in win installer verify task

### DIFF
--- a/contrib/cirrus/win-installer-install.ps1
+++ b/contrib/cirrus/win-installer-install.ps1
@@ -1,6 +1,25 @@
 # Update service is required for dotnet 3.5 (dep of wix)
 Set-Service -Name wuauserv -StartupType "Manual"
-choco install -y wixtoolset mingw golang archiver
-if ($LASTEXITCODE -ne 0) {
-    Exit 1
+function retryInstall {
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $pkgs)
+
+    foreach ($pkg in $pkgs) {
+        for ($retries = 0; ; $retries++) {
+            if ($retries -gt 5) {
+                throw "Could not install package $pkg"
+            }
+
+            if ($pkg -match '(.[^\@]+)@(.+)') {
+                $pkg = @("--version", $Matches.2, $Matches.1)
+            }
+
+            choco install -y $pkg
+            if ($LASTEXITCODE -eq 0) {
+                break
+            }
+            Write-Output "Error installing, waiting before retry..."
+            Start-Sleep -Seconds 6
+        }
+    }
 }
+retryInstall wixtoolset mingw@11.2 golang archiver

--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -1,7 +1,7 @@
  # Powershell doesn't exit after
  function CheckExit {
     if ($LASTEXITCODE -ne 0) {
-        Exit $LASTEXITCODE
+        throw "Exit code = $LASTEXITCODE"
     }
 }
 function DownloadFile {
@@ -50,11 +50,10 @@ $ret = Start-Process -Wait -PassThru ".\podman-${ENV:WIN_INST_VER}-dev-setup.exe
 if ($ret.ExitCode -ne 0) {
     Write-Host "Install failed, dumping log"
     Get-Content inst.log
-    Exit $ret.ExitCode
+    throw "Exit code is $($ret.ExitCode)"
 }
 if (! ((Test-Path -Path "C:\Program Files\RedHat\Podman\podman.exe") -and `
        (Test-Path -Path "C:\Program Files\RedHat\Podman\win-sshproxy.exe"))) {
-    Write-Host "Expected podman.exe and win-sshproxy.exe, one or both not present after install"
-    Exit 1
+    throw "Expected podman.exe and win-sshproxy.exe, one or both not present after install"
 }
 Write-Host "Installer verification successful!"


### PR DESCRIPTION
Recent intermittent connectivity failures to the chocolatey repo caused a number of jobs to fail. This PR improves the robustness of the task in case this happens in the future.

```release-note
NONE
```

[NO NEW TESTS NEEDED]