### PR TITLE
[docker compat] Don't overwrite the NetworkMode from "default" to "bridge" if containers.conf specifies a non-default configuration.

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -417,6 +417,24 @@ t GET containers/$cid/json 200 \
 
 t DELETE containers/$cid?v=true 204
 
+# test create with default netns="host"
+stop_service
+CONTAINERS_CONF=$TESTS_DIR/containers.host-netns.conf start_service
+
+# check that the default docker netns "default" is rewritten to "host"
+# when the containers.conf explicitly uses "host"
+t POST containers/create Image=$IMAGE HostConfig='{"NetworkMode":"default"}' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .HostConfig.NetworkMode="host"
+
+t DELETE containers/$cid?v=true 204
+
+# Restart with the default containers.conf for next tests.
+stop_service
+start_service
+
 # Test Compat Create with healthcheck, check default values
 t POST containers/create Image=$IMAGE Cmd='["top"]' Healthcheck='{"Test":["true"]}' 201 \
   .Id~[0-9a-f]\\{64\\}

--- a/test/apiv2/containers.host-netns.conf
+++ b/test/apiv2/containers.host-netns.conf
@@ -1,0 +1,2 @@
+[containers]
+netns="host"


### PR DESCRIPTION
Fixes #16915 (only the part about docker client).

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When creating a container with the Docker API, the `NetworkMode=default` is no longer rewritten to `NetworkMode=bridge` if the `containers.conf` configuration file overwrites `netns`.
```
