### PR TITLE
e2e: fix play_kube_test

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -3157,11 +3157,17 @@ spec:
 		hostPathDir := filepath.Join(tempdir, testdir)
 		err := os.Mkdir(hostPathDir, 0755)
 		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(hostPathDir)
 
 		hostPathDirFile := filepath.Join(hostPathDir, testfile)
 		f, err := os.Create(hostPathDirFile)
 		Expect(err).ToNot(HaveOccurred())
 		f.Close()
+
+		if selinux.GetEnabled() {
+			label := SystemExec("chcon", []string{"-t", "container_file_t", hostPathDirFile})
+			Expect(label).Should(Exit(0))
+		}
 
 		// Create container image with named volume
 		containerfile := fmt.Sprintf(`


### PR DESCRIPTION
When SELinux is enabled, e2e test could be failed
due to run a ls command in a running container.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
