### PR TITLE
Compile regex on demand not in init

### DIFF
--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 const (
@@ -22,8 +23,9 @@ const (
 
 var (
 	whiteSpaces  = " \t"
-	alphaRegexp  = regexp.MustCompile(`[a-zA-Z]`)
-	domainRegexp = regexp.MustCompile(`^(:?(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))(:?\.(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])))*)\.?\s*$`)
+	alphaRegexp  *regexp.Regexp
+	domainRegexp *regexp.Regexp
+	onceRegex    sync.Once
 )
 
 // validateExtraHost validates that the specified string is a valid extrahost and returns it.
@@ -52,6 +54,10 @@ func validateIPAddress(val string) (string, error) {
 }
 
 func ValidateDomain(val string) (string, error) {
+	onceRegex.Do(func() {
+		alphaRegexp = regexp.MustCompile(`[a-zA-Z]`)
+		domainRegexp = regexp.MustCompile(`^(:?(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))(:?\.(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])))*)\.?\s*$`)
+	})
 	if alphaRegexp.FindString(val) == "" {
 		return "", fmt.Errorf("%s is not a valid domain", val)
 	}

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -3,7 +3,6 @@ package define
 import (
 	"bufio"
 	"io"
-	"regexp"
 
 	"github.com/containers/common/libnetwork/types"
 )
@@ -20,8 +19,6 @@ var (
 	NameRegex = types.NameRegex
 	// RegexError is thrown in presence of an invalid container/pod name.
 	RegexError = types.RegexError
-	// UmaskRegex is a regular expression to validate Umask.
-	UmaskRegex = regexp.MustCompile(`^[0-7]{1,4}$`)
 )
 
 const (

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/containers/buildah/define"
 	"github.com/containers/image/v5/types"
@@ -37,11 +38,16 @@ type devino struct {
 }
 
 var (
-	iidRegex = regexp.MustCompile(`^[0-9a-f]{12}`)
+	iidRegex  *regexp.Regexp
+	onceRegex sync.Once
 )
 
 // Build creates an image using a containerfile reference
 func Build(ctx context.Context, containerFiles []string, options entities.BuildOptions) (*entities.BuildReport, error) {
+	onceRegex.Do(func() {
+		iidRegex = regexp.MustCompile(`^[0-9a-f]{12}`)
+	})
+
 	if options.CommonBuildOpts == nil {
 		options.CommonBuildOpts = new(define.CommonBuildOptions)
 	}


### PR DESCRIPTION
Every podman command is paying the price for this compile even when they don't use the Regex, this will speed up start of podman by a little.

[NO NEW TESTS NEEDED]

 Existing tests should catch issues.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
