### PR TITLE
Set StoppedByUser earlier in the process of stopping

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1296,6 +1296,7 @@ func (c *Container) stop(timeout uint) error {
 	// demonstrates nicely that a high stop timeout will block even simple
 	// commands such as `podman ps` from progressing if the container lock
 	// is held when busy-waiting for the container to be stopped.
+	c.state.StoppedByUser = true
 	c.state.State = define.ContainerStateStopping
 	if err := c.save(); err != nil {
 		return fmt.Errorf("saving container %s state before stopping: %w", c.ID(), err)
@@ -1343,7 +1344,6 @@ func (c *Container) stop(timeout uint) error {
 	}
 
 	c.newContainerEvent(events.Stop)
-	c.state.StoppedByUser = true
 	return c.waitForConmonToExitAndSave()
 }
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1407,6 +1407,22 @@ USER mail`, BB)
 		Expect(found).To(BeTrue())
 	})
 
+	It("podman run with restart policy does not restart on manual stop", func() {
+		ctrName := "testCtr"
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--restart=always", "--name", ctrName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(Exit(0))
+
+		stop := podmanTest.Podman([]string{"stop", ctrName})
+		stop.WaitWithDefaultTimeout()
+		Expect(stop).Should(Exit(0))
+
+		// This is ugly, but I don't see a better way
+		time.Sleep(10 * time.Second)
+
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
+
 	It("podman run with cgroups=split", func() {
 		SkipIfNotSystemd(podmanTest.CgroupManager, "do not test --cgroups=split if not running on systemd")
 		SkipIfRootlessCgroupsV1("Disable cgroups not supported on cgroupv1 for rootless users")


### PR DESCRIPTION
The StoppedByUser variable indicates that the container was requested to stop by a user. It's used to prevent restart policy from firing (so that a restart=always container won't restart if the user does a `podman stop`. The problem is we were setting it *very* late in the stop() function. Originally, this was fine, but after the changes to add the new Stopping state, the logic that triggered restart policy was firing before StoppedByUser was even set - so the container would still restart.

Setting it earlier shouldn't hurt anything and guarantees that checks will see that the container was stopped manually.

Fixes #17069

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where containers with a restart policy set could still restart even after a manual `podman stop`.
```
