### PR TITLE
[v4.2.0-rhel] Cirrus: Strip only-main CI tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -726,34 +726,6 @@ buildah_bud_test_task:
     always: *int_logs_artifacts
 
 
-rootless_gitlab_test_task:
-    name: *std_name_fmt
-    alias: rootless_gitlab_test
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_tag_branch_build_docs
-    # Community-maintained downstream test may fail unexpectedly.
-    # Ref. repository: https://gitlab.com/gitlab-org/gitlab-runner
-    # If necessary, uncomment the next line and file issue(s) with details.
-    # allow_failures: $CI == $CI
-    depends_on:
-        - build
-        - rootless_integration_test
-    gce_instance: *standardvm
-    env:
-        <<: *ubuntu_envvars
-        TEST_FLAVOR: 'gitlab'
-        PRIV_NAME: rootless
-    clone_script: *get_gosrc
-    setup_script: *setup
-    main_script: *main
-    always:
-        <<: *logs_artifacts
-        junit_artifacts:
-            path: gitlab-runner-podman.xml
-            type: text/xml
-            format: junit
-
-
 upgrade_test_task:
     name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
     alias: upgrade_test
@@ -780,56 +752,6 @@ upgrade_test_task:
     setup_script: *setup
     main_script: *main
     always: *logs_artifacts
-
-
-image_build_task: &image-build
-    name: "Build multi-arch $CTXDIR"
-    alias: image_build
-    # Some of these container images take > 1h to build, limit
-    # this task to a specific Cirrus-Cron entry with this name.
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: $CIRRUS_CRON == 'multiarch'
-    depends_on:
-        - ext_svc_check
-    timeout_in: 120m  # emulation is sssllllooooowwww
-    gce_instance:
-        <<: *standardvm
-        image_name: build-push-${IMAGE_SUFFIX}
-        # More muscle required for parallel multi-arch build
-        type: "n2-standard-4"
-    matrix:
-        - env:
-            CTXDIR: contrib/podmanimage/upstream
-        - env:
-            CTXDIR: contrib/podmanimage/testing
-        - env:
-            CTXDIR: contrib/podmanimage/stable
-        - env:
-            CTXDIR: contrib/hello
-    env:
-        DISTRO_NV: "${FEDORA_NAME}"  # Required for repo cache extraction
-        PODMAN_USERNAME: ENCRYPTED[b9f0f2550029dd2196e086d9dd6c2d1fec7e328630b15990d9bb610f9fcccb5baab8b64a8c3e72b0c1d0f5917cf65aa1]
-        PODMAN_PASSWORD: ENCRYPTED[e3444f6072853f0c8db7f964ead5e2204116af485469fa0de367f26b9316b460fd842a9882f552b9e9a83bbaf650d8b4]
-        CONTAINERS_USERNAME: ENCRYPTED[54a372d5f22f424173c114c6fb25c3214956cad323d5b285c7393a71041884ce96471d0ff733774e5dab9fa5a3c8795c]
-        CONTAINERS_PASSWORD: ENCRYPTED[4ecc3fb534935095a99fb1f2e320ac6bc87f3e7e186746e41cbcc4b5f5379a014b9fc8cc90e1f3d5abdbaf31580a4ab9]
-    main_script:
-        - set -a; source /etc/automation_environment; set +a
-        - main.sh $CIRRUS_REPO_CLONE_URL $CTXDIR
-
-
-test_image_build_task:
-    <<: *image-build
-    alias: test_image_build
-    # Allow this to run inside a PR w/ [CI:BUILD] only.
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: $CIRRUS_PR != '' && $CIRRUS_CHANGE_TITLE =~ '.*CI:BUILD.*'
-    # This takes a LONG time, only run when requested.  N/B: Any task
-    # made to depend on this one will block FOREVER unless triggered.
-    # DO NOT ADD THIS TASK AS DEPENDENCY FOR `success_task`.
-    trigger_type: manual
-    # Overwrite all 'env', don't push anything, just do the build.
-    env:
-        DRYRUN: 1
 
 
 # This task is critical.  It updates the "last-used by" timestamp stored
@@ -893,9 +815,7 @@ success_task:
         - rootless_system_test
         - rootless_remote_system_test
         - buildah_bud_test
-        - rootless_gitlab_test
         - upgrade_test
-        - image_build
         - meta
     container: *smallcontainer
     env:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
