### PR TITLE
e2e: Allow ImageCacheDir to be changed with an environment variable

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -526,7 +526,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
@@ -578,7 +578,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar"
+		fileName := cachePath("/checkpoint-" + cid + ".tar")
 
 		// Checkpoint with the default algorithm
 		result := podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
@@ -687,7 +687,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		// Change the container's root file-system
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /test.output"})
@@ -750,7 +750,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		// Change the container's root file-system
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /test.output"})
@@ -793,7 +793,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		// Change the container's root file-system
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /test.output"})
@@ -837,7 +837,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		// Checkpoint the container
 		result := podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
@@ -887,7 +887,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(result.ErrorToString()).To(ContainSubstring("cannot checkpoint containers that have been started with '--rm'"))
 
 		// Checkpointing with --export should still work
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
@@ -960,7 +960,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 
-		checkpointFileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		checkpointFileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		// Checkpoint the container
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", checkpointFileName})
@@ -1056,8 +1056,8 @@ var _ = Describe("Podman checkpoint", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		cid := session.OutputToString()
-		preCheckpointFileName := "/tmp/pre-checkpoint-" + cid + ".tar.gz"
-		checkpointFileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		preCheckpointFileName := cachePath("/pre-checkpoint-" + cid + ".tar.gz")
+		checkpointFileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "-P", "-e", preCheckpointFileName, cid})
 		result.WaitWithDefaultTimeout()
@@ -1098,7 +1098,7 @@ var _ = Describe("Podman checkpoint", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		if !WaitContainerReady(podmanTest, cid, "Ready to accept connections", 20, 1) {
 			Fail("Container failed to get ready")
@@ -1200,7 +1200,7 @@ var _ = Describe("Podman checkpoint", func() {
 			Expect(session).To(Exit(0))
 			cid := session.OutputToString()
 
-			fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+			fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 			// Checkpoint the container
 			result := podmanTest.Podman([]string{
@@ -1320,7 +1320,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
@@ -1361,7 +1361,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result := podmanTest.Podman([]string{
 			"container",
@@ -1550,7 +1550,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		runtime := session.OutputToString()
 
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result := podmanTest.Podman([]string{
 			"container",
@@ -1653,7 +1653,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Equal("runc"))
 
-		checkpointExportPath := "/tmp/checkpoint-" + cid + ".tar.gz"
+		checkpointExportPath := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		session = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", checkpointExportPath})
 		session.WaitWithDefaultTimeout()
@@ -1723,7 +1723,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		runtime := session.OutputToString()
 
-		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		fileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 
 		result := podmanTest.Podman([]string{
 			"container",
@@ -1808,7 +1808,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(Exit(0))
 		runtime := session.OutputToString()
 
-		checkpointFileName := "/tmp/checkpoint-" + cid + ".tar.gz"
+		checkpointFileName := cachePath("/checkpoint-" + cid + ".tar.gz")
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", checkpointFileName})
 		result.WaitWithDefaultTimeout()
 

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -13,7 +13,6 @@ var (
 	INFRA_IMAGE       = "k8s.gcr.io/pause:3.2" //nolint:revive,stylecheck
 	BB                = "quay.io/libpod/busybox:latest"
 	HEALTHCHECK_IMAGE = "quay.io/libpod/alpine_healthcheck:latest" //nolint:revive,stylecheck
-	ImageCacheDir     = "/tmp/podman/imagecachedir"
 	fedoraToolbox     = "registry.fedoraproject.org/fedora-toolbox:36"
 	volumeTest        = "quay.io/libpod/volume-plugin-test-img:20220623"
 

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -57,11 +57,11 @@ var _ = Describe("Podman mount", func() {
 		opts := podmanTest.PodmanMakeOptions([]string{"mount", cid}, false, false)
 		args = append(args, opts...)
 
-		// container root file system location is /tmp/... because "--root /tmp/..."
+		// container root file system location is cachePath/... because "--root cachePath/..."
 		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("/tmp"))
+		Expect(session.OutputToString()).To(ContainSubstring(cachePath()))
 	})
 
 	It("podman image mount", func() {
@@ -83,10 +83,10 @@ var _ = Describe("Podman mount", func() {
 		opts := podmanTest.PodmanMakeOptions([]string{"image", "mount", ALPINE}, false, false)
 		args = append(args, opts...)
 
-		// image location is /tmp/... because "--root /tmp/..."
+		// image location is cachePath/... because "--root cachePath/..."
 		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("/tmp"))
+		Expect(session.OutputToString()).To(ContainSubstring(cachePath()))
 	})
 })

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -140,9 +140,10 @@ var _ = Describe("Podman push", func() {
 
 		if !IsRemote() { // Remote does not support --digestfile
 			// Test --digestfile option
-			push2 := podmanTest.Podman([]string{"push", "--tls-verify=false", "--digestfile=/tmp/digestfile.txt", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+			digestFile := cachePath("digestfile.txt")
+			push2 := podmanTest.Podman([]string{"push", "--tls-verify=false", "--digestfile=" + digestFile, "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
 			push2.WaitWithDefaultTimeout()
-			fi, err := os.Lstat("/tmp/digestfile.txt")
+			fi, err := os.Lstat(digestFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fi.Name()).To(Equal("digestfile.txt"))
 			Expect(push2).Should(Exit(0))

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -188,6 +188,7 @@ var _ = Describe("Podman save", func() {
 
 		cmd = exec.Command("cp", "sign/key.gpg", "/tmp/key.gpg")
 		Expect(cmd.Run()).To(Succeed())
+		defer os.Remove("/tmp/key.gpg")
 		sigstore := `
 default-docker:
   sigstore: file:///var/lib/containers/sigstore


### PR DESCRIPTION
- We can change the ImageCacheDir with `TMPDIR`.

- Reduce dependency on `/tmp` for e2e tests.

- When a rootless user, the cache directory is failed to
remove due to a permission. Therefore, we use
`podman unshare rm` to remove the cache.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
