### PR TITLE
fix flake in kube system test

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -431,7 +431,7 @@ EOF
     # design yet for propagating exit codes up to the service
     # container.
     run_podman pod kill test_pod
-    for i in {0..5}; do
+    for i in {0..20}; do
         run systemctl is-active $service_name
         if [[ $output == "inactive" ]]; then
             break


### PR DESCRIPTION
Increase the loop range from 5 to 20 to make sure we give the service enough time to transition to inactive.  Other tests have the same range with 0.5 seconds sleeps, so I expect the new value to be sufficient and consistent.

Fixes: #17093
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@containers/podman-maintainers PTAL