### PR TITLE
podman-restart: Drop `network-online.target` dependency

### DIFF
--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -2,8 +2,6 @@
 Description=Podman Start All Containers With Restart Policy Set To Always
 Documentation=man:podman-start(1)
 StartLimitIntervalSec=0
-Wants=network-online.target
-After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This service recently got enabled by default, which forces a `network-online.target` dependency for *everyone* even if they're not using autostarted containers.  That's a bad bug.

See discussion in https://bugzilla.redhat.com/show_bug.cgi?id=2149642

For this service itself, we shouldn't be trying to pull the container, so networking shouldn't be required.

If we want the *autostarted containers* to have networking...I don't think this is the right way to go about it.  Really each container should probably either:

- Handle network availability dynamically
- Run as an individual systemd unit with its own ordering

Signed-off-by: Colin Walters <walters@verbum.org>
