### PR TITLE
[v4.1.1-rhel] [CI:BUILD] Cirrus: Stop building for OSX

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -329,31 +329,6 @@ alt_build_task:
     always: *binary_artifacts
 
 
-# Confirm building the remote client, natively on a Mac OS-X VM.
-osx_alt_build_task:
-    name: "OSX Cross"
-    alias: osx_alt_build
-    only_if: *not_docs
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        # OSX platform variation prevents this being included in alt_build_task
-        TEST_FLAVOR: "altbuild"
-        ALT_NAME: 'OSX Cross'
-    osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
-    setup_script:
-        - brew install go
-        - brew install go-md2man
-        - go version
-    build_amd64_script:
-        - make podman-remote-release-darwin_amd64.zip
-    build_arm64_script:
-        - make podman-remote-release-darwin_arm64.zip GOARCH=arm64
-    always: *binary_artifacts
-
-
 # Verify podman is compatible with the docker python-module.
 docker-py_test_task:
     name: Docker-py Compat.
@@ -714,7 +689,6 @@ success_task:
         - swagger
         - consistency
         - alt_build
-        - osx_alt_build
         - docker-py_test
         - unit_test
         - apiv2_test


### PR DESCRIPTION
There's no reason to maintain this task on a release-branch.  The environment is managed by Cirrus, no us.  Nobody will ever need/want/try to cross-compile an old podman version with the latest environment. Just remove the test.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
