### PR TITLE
Support for Windows paths in the source position of the volume mounts

### DIFF
--- a/pkg/machine/qemu/machine_unix.go
+++ b/pkg/machine/qemu/machine_unix.go
@@ -6,6 +6,7 @@ package qemu
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -30,4 +31,15 @@ func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) er
 		return fmt.Errorf("%s exited unexpectedly with exit code %d, stderr: %s", processHint, status.ExitStatus(), stderrBuf.String())
 	}
 	return nil
+}
+
+func pathsFromVolume(volume string) []string {
+	return strings.SplitN(volume, ":", 3)
+}
+
+func extractTargetPath(paths []string) string {
+	if len(paths) > 1 {
+		return paths[1]
+	}
+	return paths[0]
 }

--- a/pkg/machine/qemu/machine_windows.go
+++ b/pkg/machine/qemu/machine_windows.go
@@ -3,6 +3,8 @@ package qemu
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/containers/podman/v4/pkg/machine"
 )
@@ -24,4 +26,27 @@ func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) er
 		}
 	}
 	return nil
+}
+
+func pathsFromVolume(volume string) []string {
+	paths := strings.SplitN(volume, ":", 3)
+	driveLetterMatcher := regexp.MustCompile(`^(?:\\\\[.?]\\)?[a-zA-Z]$`)
+	if len(paths) > 1 && driveLetterMatcher.MatchString(paths[0]) {
+		paths = strings.SplitN(volume, ":", 4)
+		paths = append([]string{paths[0] + ":" + paths[1]}, paths[2:]...)
+	}
+	return paths
+}
+
+func extractTargetPath(paths []string) string {
+	if len(paths) > 1 {
+		return paths[1]
+	}
+	target := strings.ReplaceAll(paths[0], "\\", "/")
+	target = strings.ReplaceAll(target, ":", "/")
+	if strings.HasPrefix(target, "//./") || strings.HasPrefix(target, "//?/") {
+		target = target[4:]
+	}
+	dedup := regexp.MustCompile(`//+`)
+	return dedup.ReplaceAllLiteralString("/"+target, "/")
 }


### PR DESCRIPTION
Fixes #17098 

Was tested as part of https://github.com/containers/podman/issues/13006#issuecomment-1381000284 

Implementation demo isolated https://go.dev/play/p/Do-tBPHESLE (~[Original outdated version](https://go.dev/play/p/xUTMgZgD5fj)~)

There are 2 things added. First there is added support for handling drive letters while doing value split. If drive letter is detected, then max number of elements will be increased by one, but then first two will be concatenated to reconstruct the path. Second part is basic, but working conversion of Windows path to Unix to be used, when target path is not explicitly specified.

Used regex for drive letter detection, because init would be never used in the hotpath, so, performance wise it affordable.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
