### PR TITLE
e2e: use isRootless() instead of rootless.IsRootless()

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -63,7 +63,7 @@ output with given format JSON by using *structs* defined in inspect package.
 You can run the entire suite of integration tests with the following command:
 
 ```
-GOPATH=~/go ginkgo -v test/e2e/.
+GOPATH=~/go ginkgo -tags "remote" -v test/e2e/.
 ```
 
 Note the trailing period on the command above. Also, **-v** invokes verbose mode.  That

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -58,7 +57,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		// Rootless static ip assignment without network should error
-		if rootless.IsRootless() {
+		if isRootless() {
 			Expect(result).Should(Exit(125))
 		} else {
 			Expect(result).Should(Exit(0))

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"os"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
@@ -39,7 +38,7 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 	It("Podman run --mac-address", func() {
 		result := podmanTest.Podman([]string{"run", "--mac-address", "92:d0:c6:0a:29:34", ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		if rootless.IsRootless() {
+		if isRootless() {
 			Expect(result).Should(Exit(125))
 		} else {
 			Expect(result).Should(Exit(0))

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/onsi/gomega"
 )
 
@@ -34,7 +33,7 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 	args = p.makeOptions(args, false, false)
 
 	wrapper := []string{"systemd-run", "--scope"}
-	if rootless.IsRootless() {
+	if isRootless() {
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
 
@@ -71,7 +70,7 @@ func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
 }
 
 func (p *PodmanTestIntegration) StartRemoteService() {
-	if os.Geteuid() == 0 {
+	if !isRootless() {
 		err := os.MkdirAll("/run/podman", 0755)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -99,7 +98,7 @@ func (p *PodmanTestIntegration) StartRemoteService() {
 }
 
 func (p *PodmanTestIntegration) StopRemoteService() {
-	if !rootless.IsRootless() {
+	if !isRootless() {
 		if err := p.RemoteSession.Kill(); err != nil {
 			fmt.Fprintf(os.Stderr, "error on remote stop-kill %q", err)
 		}

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/onsi/gomega"
 )
 
@@ -25,7 +24,7 @@ func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration 
 // PodmanSystemdScope runs the podman command in a new systemd scope
 func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSessionIntegration {
 	wrapper := []string{"systemd-run", "--scope"}
-	if rootless.IsRootless() {
+	if isRootless() {
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
 	podmanSession := p.PodmanAsUserBase(args, 0, 0, "", nil, false, false, wrapper, nil)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/containers/common/libnetwork/types"
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
@@ -265,7 +264,7 @@ var _ = Describe("Podman network", func() {
 		defer removeConf(path)
 
 		expectedNetworks := []string{name}
-		if !rootless.IsRootless() {
+		if !isRootless() {
 			// rootful image contains "podman/cni/87-podman-bridge.conflist" for "podman" network
 			expectedNetworks = append(expectedNetworks, "podman")
 		}

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4368,7 +4368,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 		initialUsernsConfig, err := os.ReadFile("/proc/self/uid_map")
 		Expect(err).ToNot(HaveOccurred())
-		if os.Geteuid() != 0 {
+		if isRootless() {
 			unshare := podmanTest.Podman([]string{"unshare", "cat", "/proc/self/uid_map"})
 			unshare.WaitWithDefaultTimeout()
 			Expect(unshare).Should(Exit(0))

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/seccomp"
 	"github.com/containers/common/pkg/sysinfo"
-	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -252,7 +251,7 @@ var _ = Describe("Podman pod create", func() {
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", name})
 		podCreate.WaitWithDefaultTimeout()
 		// Rootless should error without network
-		if rootless.IsRootless() {
+		if isRootless() {
 			Expect(podCreate).Should(Exit(125))
 		} else {
 			Expect(podCreate).Should(Exit(0))
@@ -295,7 +294,7 @@ var _ = Describe("Podman pod create", func() {
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--mac-address", mac, "--name", name})
 		podCreate.WaitWithDefaultTimeout()
 		// Rootless should error
-		if rootless.IsRootless() {
+		if isRootless() {
 			Expect(podCreate).Should(Exit(125))
 		} else {
 			Expect(podCreate).Should(Exit(0))
@@ -662,7 +661,7 @@ ENTRYPOINT ["sleep","99999"]
 	})
 
 	It("podman pod create with --userns=keep-id", func() {
-		if os.Geteuid() == 0 {
+		if !isRootless() {
 			Skip("Test only runs without root")
 		}
 
@@ -698,7 +697,7 @@ ENTRYPOINT ["sleep","99999"]
 	})
 
 	It("podman pod create with --userns=keep-id can add users", func() {
-		if os.Geteuid() == 0 {
+		if !isRootless() {
 			Skip("Test only runs without root")
 		}
 
@@ -1097,7 +1096,7 @@ ENTRYPOINT ["sleep","99999"]
 
 		inspect := podmanTest.InspectContainer(ctrCreate.OutputToString())
 		Expect(data.CgroupPath).To(HaveLen(0))
-		if podmanTest.CgroupManager == "cgroupfs" || !rootless.IsRootless() {
+		if podmanTest.CgroupManager == "cgroupfs" || !isRootless() {
 			Expect(inspect[0].HostConfig.CgroupParent).To(HaveLen(0))
 		} else if podmanTest.CgroupManager == "systemd" {
 			Expect(inspect[0].HostConfig).To(HaveField("CgroupParent", "user.slice"))

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -623,7 +622,7 @@ var _ = Describe("Podman pull", func() {
 
 			podmanTest.AddImageToRWStore(ALPINE)
 
-			if rootless.IsRootless() {
+			if isRootless() {
 				err := podmanTest.RestoreArtifact(REGISTRY_IMAGE)
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/archive"
 	. "github.com/onsi/ginkgo"
@@ -99,7 +98,7 @@ var _ = Describe("Podman push", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			err := podmanTest.RestoreArtifact(REGISTRY_IMAGE)
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,7 +54,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		udsPath := filepath.Join(udsDir, "fifo")
 		err = syscall.Mkfifo(udsPath, 0600)
 		Expect(err).ToNot(HaveOccurred())
-		if rootless.IsRootless() {
+		if isRootless() {
 			err = podmanTest.RestoreArtifact(fedoraMinimal)
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -113,7 +112,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 
 	Specify("signals are not forwarded to container with sig-proxy false", func() {
 		signal := syscall.SIGFPE
-		if rootless.IsRootless() {
+		if isRootless() {
 			err = podmanTest.RestoreArtifact(fedoraMinimal)
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
@@ -261,7 +260,7 @@ var _ = Describe("Podman run", func() {
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}
@@ -562,7 +561,7 @@ var _ = Describe("Podman run", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
 
-		if os.Geteuid() > 0 {
+		if isRootless() {
 			if os.Getenv("SKIP_USERNS") != "" {
 				Skip("Skip userns tests.")
 			}
@@ -2022,7 +2021,7 @@ WORKDIR /madethis`, BB)
 
 		podmanTest.AddImageToRWStore(ALPINE)
 
-		if rootless.IsRootless() {
+		if isRootless() {
 			err := podmanTest.RestoreArtifact(REGISTRY_IMAGE)
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -128,8 +128,9 @@ var _ = Describe("Podman UserNS support", func() {
 	It("podman --userns=keep-id", func() {
 		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "alpine", "id", "-u"})
 		session.WaitWithDefaultTimeout()
-		if os.Geteuid() == 0 {
+		if !isRootless() {
 			Expect(session).Should(Exit(125))
+			Expect(session.ErrorToString()).To(ContainSubstring("keep-id is only supported in rootless mode"))
 			return
 		}
 
@@ -139,8 +140,9 @@ var _ = Describe("Podman UserNS support", func() {
 
 		session = podmanTest.Podman([]string{"run", "--userns=keep-id:uid=10,gid=12", "alpine", "sh", "-c", "echo $(id -u):$(id -g)"})
 		session.WaitWithDefaultTimeout()
-		if os.Geteuid() == 0 {
+		if !isRootless() {
 			Expect(session).Should(Exit(125))
+			Expect(session.ErrorToString()).To(ContainSubstring("keep-id is only supported in rootless mode"))
 			return
 		}
 

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -222,7 +221,7 @@ var _ = Describe("Podman run with volumes", func() {
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}
@@ -242,7 +241,7 @@ var _ = Describe("Podman run with volumes", func() {
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}
@@ -275,7 +274,7 @@ var _ = Describe("Podman run with volumes", func() {
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}
@@ -329,7 +328,7 @@ var _ = Describe("Podman run with volumes", func() {
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}
@@ -655,7 +654,7 @@ VOLUME /test/`, ALPINE)
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}
@@ -778,7 +777,7 @@ VOLUME /test/`, ALPINE)
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if rootless.IsRootless() {
+		if isRootless() {
 			if _, err := exec.LookPath("fuse_overlay"); err != nil {
 				Skip("Fuse-Overlayfs required for rootless overlay mount test")
 			}

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -88,7 +87,7 @@ var _ = Describe("Podman save", func() {
 	})
 
 	It("podman save to directory with oci format", func() {
-		if rootless.IsRootless() {
+		if isRootless() {
 			Skip("Requires a fix in containers image for chown/lchown")
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
@@ -99,7 +98,7 @@ var _ = Describe("Podman save", func() {
 	})
 
 	It("podman save to directory with v2s2 docker format", func() {
-		if rootless.IsRootless() {
+		if isRootless() {
 			Skip("Requires a fix in containers image for chown/lchown")
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
@@ -110,7 +109,7 @@ var _ = Describe("Podman save", func() {
 	})
 
 	It("podman save to directory with docker format and compression", func() {
-		if rootless.IsRootless() && podmanTest.RemoteTest {
+		if isRootless() && podmanTest.RemoteTest {
 			Skip("Requires a fix in containers image for chown/lchown")
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
@@ -121,7 +120,7 @@ var _ = Describe("Podman save", func() {
 	})
 
 	It("podman save to directory with --compress but not use docker-dir and oci-dir", func() {
-		if rootless.IsRootless() && podmanTest.RemoteTest {
+		if isRootless() && podmanTest.RemoteTest {
 			Skip("Requires a fix in containers image for chown/lchown")
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -95,7 +94,7 @@ var _ = Describe("podman system reset", func() {
 		// TODO: machine tests currently don't run outside of the machine test pkg
 		// no machines are created here to cleanup
 		// machine commands are rootless only
-		if rootless.IsRootless() {
+		if isRootless() {
 			session = podmanTest.Podman([]string{"machine", "list", "-q"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))

--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	testUtils "github.com/containers/podman/v4/test/utils"
 	podmanUtils "github.com/containers/podman/v4/utils"
 	. "github.com/onsi/ginkgo"
@@ -77,7 +76,7 @@ var _ = Describe("Systemd activate", func() {
 		if selinux.GetEnabled() {
 			rootDir := "/var/lib/containers"
 			label := "container_var_lib_t"
-			if rootless.IsRootless() {
+			if isRootless() {
 				rootDir = filepath.Join(os.Getenv("HOME"), ".local/share/containers")
 				label = "data_home_t"
 			}

--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -35,7 +35,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -381,7 +380,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring(currentUser.HomeDir))
 
-		if rootless.IsRootless() {
+		if isRootless() {
 			location := path.Dir(currentUser.HomeDir)
 			volumeArg := fmt.Sprintf("%s:%s", location, location)
 			session = podmanTest.Podman([]string{"run",

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Podman unshare", func() {
 			Skip("User namespaces not supported.")
 		}
 
-		if os.Geteuid() == 0 {
+		if !isRootless() {
 			Skip("Use unshare in rootless only")
 		}
 


### PR DESCRIPTION
Unify the functions used to detect rootless to "isRootless()".
This function can detect to join the user namespace by mistake.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
