### PR TITLE
Make rootless privileged containers share the same tty devices as rootfull ones

### DIFF
--- a/docs/source/markdown/options/privileged.md
+++ b/docs/source/markdown/options/privileged.md
@@ -9,7 +9,9 @@ Give extended privileges to this container. The default is **false**.
 By default, Podman containers are unprivileged (**=false**) and cannot, for
 example, modify parts of the operating system. This is because by default a
 container is only allowed limited access to devices. A "privileged" container
-is given the same access to devices as the user launching the container.
+is given the same access to devices as the user launching the container, with
+the exception of virtual consoles (_/dev/tty\d+_) when running in systemd
+mode (**--systemd=always**).
 
 A privileged container turns off the security features that isolate the
 container from the host. Dropped Capabilities, limited devices, read-only mount

--- a/docs/source/markdown/options/systemd.md
+++ b/docs/source/markdown/options/systemd.md
@@ -24,6 +24,7 @@ Running the container in systemd mode causes the following changes:
 * Podman sets the default stop signal to **SIGRTMIN+3**.
 * Podman sets **container_uuid** environment variable in the container to the
 first 32 characters of the container id.
+* Podman will not mount virtual consoles (_/dev/tty\d+_) when running with **--privileged**.
 
 This allows systemd to run in a confined container without any modifications.
 


### PR DESCRIPTION
    Until Podman v4.3, privileged rootfull containers would expose all the
    host devices to the container while rootless ones would exclude
    `/dev/ptmx` and `/dev/tty*`.
    
    When 5a2405ae1b3a ("Don't mount /dev/tty* inside privileged containers
    running systemd") landed, rootfull containers started excluding all the
    `/dev/tty*` devices when the container would be running in systemd
    mode, reducing the disparity between rootless and rootfull containers
    when running in this mode.
    
    However, this commit regressed some legitimate use cases: exposing
    non-virtual-terminal tty devices (modems, arduinos, serial
    consoles, ...) to the container, and the regression was addressed in
    f4c81b0aa5fd ("Only prevent VTs to be mounted inside privileged
    systemd containers").
    
    This now calls into question why all tty devices were historically
    prevented from being shared to the rootless non-privileged containers.
    A look at the podman git history reveals that the code was introduced
    as part of ba430bfe5ef6 ("podman v2 remove bloat v2"), and obviously
    was copy-pasted from some other code I couldn't find.
    
    In any case, we can easily guess that this check was put for the same
    reason 5a2405ae1b3a was introduced: to prevent breaking the host
    environment's consoles. This also means that excluding *all* tty
    devices is overbearing, and should instead be limited to just virtual
    terminals like we do on the rootfull path.
    
    This is what this commit does, thus making the rootless codepath behave
    like the rootfull one when in systemd mode.
    
    This leaves `/dev/ptmx` as the main difference between the two
    codepath. Based on the blog post from the then-runC maintainer[1] and
    this Red Hat bug[2], I believe that this is intentional and a needed
    difference for the rootless path.
    
    Closes: #16925
    Suggested-by: Fabian Holler <mail@fholler.de>
    Signed-off-by: Martin Roukala (né Peres) <martin.roukala@mupuf.org>
    
    [1]: https://www.cyphar.com/blog/post/20160627-rootless-containers-with-runc
    [2]: https://bugzilla.redhat.com/show_bug.cgi?id=501718

#### Does this PR introduce a user-facing change?

```release-note
Rootless privileged containers will now mount all tty devices, except for the virtual-console ones (/dev/tty[0-9]+)
```
