### PR TITLE
[v4.1.1-rhel] [CI:BUILD] remove osx task from artifacts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -750,9 +750,6 @@ artifacts_task:
         - unzip gosrc.zip
         - cd $CIRRUS_WORKING_DIR
         - mv /tmp/win/podman-remote*.zip /tmp/win/*.msi ./
-        # OSX
-        - $CURL/OSX%20Cross/gosrc/podman-remote-release-darwin_amd64.zip
-        - $CURL/OSX%20Cross/gosrc/podman-remote-release-darwin_arm64.zip
     # Always show contents to assist in debugging
     always:
         contents_script: ls -1 $CIRRUS_WORKING_DIR


### PR DESCRIPTION
OSX builds are no longer done on this branch. Remove them from the artifacts task as well.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

DO NOT MERGE until lgtm'd by @cevich 