### PR TITLE
Refactor windows CI to workaround WSL's recent switch to a Windows Store update stream

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,7 +44,8 @@ env:
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
-    WINDOWS_AMI: "win-server-wsl-${IMAGE_SUFFIX}"
+    # FIXME, replace override with common suffix once everything is in sync
+    WINDOWS_AMI: "win-server-wsl-c6447802205601792"
     ####
     #### Control variables that determine what to run and how to run it.
     #### N/B: Required ALL of these are set for every single task.
@@ -545,7 +546,7 @@ windows_smoke_test_task:
         CIRRUS_SHELL: powershell
         # Fake version, we are only testing the installer functions, so version doesn't matter
         CIRRUS_WORKING_DIR: "${LOCALAPPDATA}\\Temp\\cirrus-ci-build"
-    main_script: 'contrib/cirrus/win-podman-machine-verify.ps1'
+    main_script: 'contrib/cirrus/win-podman-machine-main.ps1'
 
 
 # versions, as root, without involving the podman-remote client.

--- a/contrib/cirrus/win-podman-machine-main.ps1
+++ b/contrib/cirrus/win-podman-machine-main.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = 'Stop'
+
+# Powershell doesn't exit after command failures
+# Note, due to a bug in cirrus that does not correctly evaluate exit
+# code, error conditions should always be thrown
+function CheckExit {
+    if ($LASTEXITCODE -ne 0) {
+        throw "Exit code failure = $LASTEXITCODE"
+    }
+}
+
+# Drop global envs which have unix paths, defaults are fine
+Remove-Item Env:\GOPATH
+Remove-Item Env:\GOSRC
+Remove-Item Env:\GOCACHE
+
+mkdir tmp
+Set-Location tmp
+
+# Download and extract alt_build win release zip
+$url = "${ENV:ART_URL}/Windows%20Cross/repo/repo.tbz"
+Write-Output "URL: $url"
+# Arc requires extension to be "tbz2"
+curl.exe -L -o repo.tbz2 "$url"; CheckExit
+arc unarchive repo.tbz2 .; CheckExit
+Set-Location repo
+Expand-Archive -Path "podman-remote-release-windows_amd64.zip" `
+               -DestinationPath extracted
+Set-Location extracted
+$x = Get-ChildItem -Path bin -Recurse
+Set-Location $x
+
+# Recent versions of WSL are packaged as a Windows store app running in
+# an appX container, which is incompatible with non-interactive
+# session 0 execution (where the cirrus agent runs).
+# Run verification under an interactive session instead.
+powershell.exe -File "$PSScriptRoot\wsl-env-launch.ps1" `
+                     "$PSScriptRoot\win-podman-machine-verify.ps1"
+CheckExit

--- a/contrib/cirrus/wsl-env-launch.ps1
+++ b/contrib/cirrus/wsl-env-launch.ps1
@@ -1,0 +1,70 @@
+# Runs a script and established interactive session (session 1) and
+# tunnels the output such that WSL operations will complete
+$ErrorActionPreference = 'Stop'
+
+if ($Args.Length -lt 1) {
+    Write-Object "Usage: " + $MyInvocation.MyCommand.Name + " <script>"
+    Exit 1;
+}
+
+function RegenPassword {
+    param($username)
+    $syms = [char[]]([char]'a'..[char]'z' `
+               + [char]'A'..[char]'Z'  `
+               + [char]'0'..[char]'9')
+    $rnd = [byte[]]::new(32)
+    [System.Security.Cryptography.RandomNumberGenerator]::create().getBytes($rnd)
+    $password = ($rnd | % { $syms[$_ % $syms.length] }) -join ''
+    $encPass = ConvertTo-SecureString $password -AsPlainText -Force
+    Set-LocalUser -Name $username -Password $encPass
+    return $password
+}
+
+$runScript = $Args[0]
+$nil > tmpout
+$cwd = Get-Location
+Write-Output "Location: $cwd"
+
+# Reset the password to a new random pass since it's needed in the
+# clear to reauth.
+$pass = RegenPassword "Administrator"
+
+$ljob = Start-Job -ArgumentList $cwd -ScriptBlock {
+    param($cwd)
+    Get-Content -Wait "$cwd\tmpout"
+}
+$pjob = Start-Job -ArgumentList $cwd,$runScript,$pass -ScriptBlock {
+    param($cwd, $runScript, $pass)
+    $pwargs = @("-NonInteractive", "-WindowStyle", "hidden")
+    $command = "& { powershell.exe $pwargs -File " +
+               $runScript + " 3>&1 2>&1 > `"$cwd\tmpout`";" +
+               "Exit `$LastExitCode }"
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+    & psexec -accepteula -w $cwd -i 1 -u Administrator -p $pass `
+      powershell.exe $pwargs -EncodedCommand $encoded
+    if ($LASTEXITCODE -ne 0) {
+       throw "failure running psexec"
+    }
+}
+
+while ($pjob.State -eq 'Running') {
+   Start-Sleep -Milliseconds 200
+   Receive-Job $ljob
+}
+
+Start-Sleep  2
+Stop-Job $ljob
+
+while ($ljob.HasMoreData) {
+  Receive-Job $ljob
+  Start-Sleep -Milliseconds 200
+}
+
+if ($pjob.State -eq 'Failed') {
+  Write-Output "Failure occured, see above. Extra info:"
+  Receive-Job $pjob
+  throw "wsl task failed on us!"
+}
+
+Remove-Job $ljob
+Remove-Job $pjob


### PR DESCRIPTION
Builds on containers/automation_images#249

Both PRs can be merged independently, but @cevich and @Luap99 are working on automation changes in parallel, so this should be merged in whatever order works best for them. 

### Background

Recently Microsoft switched from shipping WSL as part of each OS major version delivery stream to a common synchronized, and more current, one provided by the Windows store. Apps in the Windows Store are sandboxed, either as UWP native apps, or as Desktop bridge/centennial apps as is the case with WSL. Calls to launch their respective executables are intercepted and redirected to setup the appropriate silos and run the true app. However these facilities expect usage from an interactive Windows session.

In addition to user/kernel space separation, Windows has the notion of sessions (dates back to historical Windows designs that optimized around the expectation of a single user and were subsequently expanded without breaking compatibility). Since Vista, in order to harden against malware, an isolated restricted non-interactive session 0 was reserved for running system services. Interactive sessions require a user login to start (either GUI console or RDP) and count up from id 1.

Since the Cirrus agent is ran by the EC2 agent which runs as a system service within session 0, all WSL invocations fail due to lack of support for their sandboxing facilities.

### Description

In short the combination prevents podman from executing correctly. To work around this problem, the image and CI process has been redesigned to automatically create an interactive session (# 1), and subsequent script runs proxy execution through it to allow WSL operations to function as expected.

containers/automation_images#249 auto-creates an interactive session through winlogon autologon on boot. Additionally it includes the PsTools psexec command on the system. This change utilizes both aspects to launch the verification portion of the smoke task under the interactive session, away from the session 0 execution environment that the Cirrus agent runs in.

Psexec makes a local RPC call to the service control manager to relaunch itself, and eventually the script as a child process, re-authenticated under the new session. However, doing so results in the loss of program output, so the script in this change stores and monitors results on the filesystem to relay output back to Cirrus. Additionally this re-authentication requires regenerating a crypto random password to replace the ec2 instance boot generated password during task execution. 

An alternative approach to psexec would be to update the image to include a custom developed proxy service, which runs as part of auto logon (e.g. via HKLM/.../Run) and use an AF_UNIX socket or user restricted Windows Pipe to communicate with it. Since such a solution has slightly higher complexity / maintenance cost, and the hope that this whole situation with WSL and session 0 is temporary, I prefer the psexec option for now. 

```release-note
NONE
```

[NO NEW TESTS NEEDED]