### PR TITLE
Add openssh-clients to podmanimage

### DIFF
--- a/contrib/podmanimage/stable/Containerfile
+++ b/contrib/podmanimage/stable/Containerfile
@@ -16,7 +16,7 @@ FROM registry.fedoraproject.org/fedora:latest
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
 RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
-    dnf -y install podman fuse-overlayfs \
+    dnf -y install podman fuse-overlayfs openssh-clients \
         --exclude container-selinux && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*

--- a/contrib/podmanimage/testing/Containerfile
+++ b/contrib/podmanimage/testing/Containerfile
@@ -16,7 +16,7 @@ FROM registry.fedoraproject.org/fedora:latest
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
 RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
-    dnf -y install podman fuse-overlayfs \
+    dnf -y install podman fuse-overlayfs openssh-clients \
         --exclude container-selinux --enablerepo updates-testing && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*

--- a/contrib/podmanimage/upstream/Containerfile
+++ b/contrib/podmanimage/upstream/Containerfile
@@ -21,7 +21,7 @@ RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
     dnf -y copr enable rhcontainerbot/podman-next && \
-    dnf -y install podman fuse-overlayfs \
+    dnf -y install podman fuse-overlayfs openssh-clients \
         --exclude container-selinux \
         --enablerepo=updates-testing && \
     dnf clean all && \


### PR DESCRIPTION
The main goal is to provide ssh-agent, which is required by podman build --ssh.

closes #17117


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`ssh-agent` is now pre-installed in the podman official image, allowing the use of `podman build --ssh`.
```