### PR TITLE
StopContainer: return if cleanup process changed state

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -965,7 +965,7 @@ func waitPidStop(pid int, timeout time.Duration) error {
 				}
 				logrus.Errorf("Pinging PID %d with signal 0: %v", pid, err)
 			}
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 }

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -427,6 +427,8 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 		}
 	}
 
+	// If the timeout was set to 0 or if stopping the container with the
+	// specified signal did not work, use the big hammer with SIGKILL.
 	if err := r.KillContainer(ctr, uint(unix.SIGKILL), all); err != nil {
 		// Ignore the error if KillContainer complains about it already
 		// being stopped or exited.  There's an inherent race with the

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -400,12 +400,11 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 		return nil
 	}
 
-	stopSignal := ctr.config.StopSignal
-	if stopSignal == 0 {
-		stopSignal = uint(syscall.SIGTERM)
-	}
-
 	if timeout > 0 {
+		stopSignal := ctr.config.StopSignal
+		if stopSignal == 0 {
+			stopSignal = uint(syscall.SIGTERM)
+		}
 		if err := r.KillContainer(ctr, stopSignal, all); err != nil {
 			// Is the container gone?
 			// If so, it probably died between the first check and


### PR DESCRIPTION
Commit 067442b5701f improved stopping/killing a container by detecting
whether the cleanup process has already fired and changed the state of
the container.  Further improve on that by returning early instead of
trying to wait for the PID to finish.  At that point we know that the
container has exited but the previous PID may have been recycled
already by the kernel.

[NO NEW TESTS NEEDED] - the absence of the two flaking tests recorded
in #17142 will tell.

Fixes: #17142
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@edsantiago PTAL
@containers/podman-maintainers 

Also did some minor refactoring in the function(s).

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
