### PR TITLE
kube-play: add support for HostPID

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -47,7 +47,7 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | dnsConfig.searches                                | ✅      |
 | dnsPolicy                                         |         |
 | hostNetwork                                       | ✅      |
-| hostPID                                           |         |
+| hostPID                                           | ✅      |
 | hostIPC                                           |         |
 | shareProcessNamespace                             | ✅      |
 | serviceAccountName                                |         |

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -722,6 +722,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			RestartPolicy:      ctrRestartPolicy,
 			SeccompPaths:       seccompPaths,
 			SecretsManager:     secretsManager,
+			PidNSIsHost:        p.Pid.IsHost(),
 			UserNSIsHost:       p.Userns.IsHost(),
 			Volumes:            volumes,
 		}

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -53,6 +53,9 @@ func ToPodOpt(ctx context.Context, podName string, p entities.PodCreateOptions, 
 	if podYAML.Spec.ShareProcessNamespace != nil && *podYAML.Spec.ShareProcessNamespace {
 		p.Share = append(p.Share, "pid")
 	}
+	if podYAML.Spec.HostPID {
+		p.Pid = "host"
+	}
 	p.Hostname = podYAML.Spec.Hostname
 	if p.Hostname == "" {
 		p.Hostname = podName
@@ -131,6 +134,8 @@ type CtrSpecGenOptions struct {
 	NetNSIsHost bool
 	// UserNSIsHost tells the container to use the host userns
 	UserNSIsHost bool
+	// PidNSIsHost tells the container to use the host pidns
+	PidNSIsHost bool
 	// SecretManager to access the secrets
 	SecretsManager *secrets.SecretsManager
 	// LogDriver which should be used for the container
@@ -461,6 +466,9 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	}
 	if opts.UserNSIsHost {
 		s.UserNS.NSMode = specgen.Host
+	}
+	if opts.PidNSIsHost {
+		s.PidNS.NSMode = specgen.Host
 	}
 
 	// Add labels that come from kube


### PR DESCRIPTION
Adds support for hostPID in Pod manifest for podman kube play

Closes #17157 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- play-kube: add support for hostPID in pod.spec
```
Signed-off-by: danishprakash <danish.prakash@suse.com>


Having some issues running the tests locally, hence the draft for now.