### PR TITLE
Get correct username in pod when using --userns=keep-id

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2465,6 +2465,10 @@ func (c *Container) generateUserPasswdEntry(addedUID int) (string, error) {
 		return entry, nil
 	}
 
+	u, err := user.LookupId(fmt.Sprintf("%d", uid))
+	if err == nil {
+		return fmt.Sprintf("%s:*:%d:%d:%s:%s:/bin/sh\n", u.Username, uid, gid, u.Name, c.WorkingDir()), nil
+	}
 	return fmt.Sprintf("%d:*:%d:%d:container user:%s:/bin/sh\n", uid, uid, gid, c.WorkingDir()), nil
 }
 

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -711,12 +711,14 @@ ENTRYPOINT ["sleep","99999"]
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		// container inside pod inherits user form infra container if --user is not set
-		// etc/passwd entry will look like 1000:*:1000:1000:container user:/:/bin/sh
+		u, err := user.Current()
+		Expect(err).ToNot(HaveOccurred())
+		// container inside pod inherits user from infra container if --user is not set
+		// etc/passwd entry will look like USERNAME:*:1000:1000:Full User Name:/:/bin/sh
 		exec1 := podmanTest.Podman([]string{"exec", ctrName, "cat", "/etc/passwd"})
 		exec1.WaitWithDefaultTimeout()
 		Expect(exec1).Should(Exit(0))
-		Expect(exec1.OutputToString()).To(ContainSubstring("container"))
+		Expect(exec1.OutputToString()).To(ContainSubstring(u.Name))
 
 		exec2 := podmanTest.Podman([]string{"exec", ctrName, "useradd", "testuser"})
 		exec2.WaitWithDefaultTimeout()

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -140,3 +140,16 @@ EOF
         is "${output}" "Error: keep-id is only supported in rootless mode" "Container should fail to start since keep-id is not supported in rootful mode"
     fi
 }
+
+@test "podman userns=keep-id in a pod" {
+    if is_rootless; then
+        user=$(id -u)
+	run_podman pod create --userns keep-id
+	pid=$output
+        run_podman run --rm --pod $pid $IMAGE id -u
+        is "${output}" "$user" "Container should run as the current user"
+    else
+	run_podman 125 pod create --userns keep-id
+        is "${output}" 'Error:.*keep-id is only supported in rootless mode' "pod should fail to be created since keep-id is not supported in rootful mode"
+    fi
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/17148

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Pods with --userns=keep-id will add entry including username to /etc/passwd within container.
```
