### PR TITLE
network create: do not allow `default` as name

### DIFF
--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -151,7 +151,7 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 
 func (ic *ContainerEngine) NetworkCreate(ctx context.Context, network types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error) {
 	// TODO (5.0): Stop accepting "pasta" as value here
-	if util.StringInSlice(network.Name, []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns"}) {
+	if util.StringInSlice(network.Name, []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns", "default"}) {
 		return nil, fmt.Errorf("cannot create network with name %q because it conflicts with a valid network mode", network.Name)
 	}
 	network, err := ic.Libpod.Network().NetworkCreate(network, createOptions)

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -366,7 +366,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid name", func() {
-		for _, name := range []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns"} {
+		for _, name := range []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns", "default"} {
 			nc := podmanTest.Podman([]string{"network", "create", name})
 			nc.WaitWithDefaultTimeout()
 			Expect(nc).To(Exit(125))


### PR DESCRIPTION
`default` is already used as network mode, i.e. podman run --network default will choose the default mode not a network named `default`.

We already block names from other network modes, default was forgotten.

Fixes #17169

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman network create` no longer accepts `default` as valid name, it is impossible to use this network name in the `podman run/create` command because it was parsed as network mode instead.
```
