### PR TITLE
[CI:DOCS] Change example target to default in doc

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -47,7 +47,7 @@ For example, to start a container on boot, add something like this to the file:
 
 ```
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 
 Currently, only the `Alias`, `WantedBy` and `RequiredBy` keys are supported.


### PR DESCRIPTION

#### Does this PR introduce a user-facing change?


```release-note None
None
```
