### PR TITLE
ps: do not create copy of container config

### DIFF
--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -143,7 +143,7 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 			}
 		}
 
-		conConfig = c.Config()
+		conConfig = c.ConfigNoCopy()
 		conState, err = c.State()
 		if err != nil {
 			return fmt.Errorf("unable to obtain container state: %w", err)


### PR DESCRIPTION
The user is only reading the config, so creating a copy turns out to be extremely expensive.  With this change, listing containers is 1.39 times faster than before.

[NO NEW TESTS NEEDED] as it is not a functional change.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve the performance of `podman ps`.
```
