### PR TITLE
fix ipc namespace inspect logic

### DIFF
--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -188,17 +188,22 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 				if ns.Path != "" {
 					hostConfig.IpcMode = fmt.Sprintf("ns:%s", ns.Path)
 				} else {
-					break
+					if c.config.NoShm {
+						hostConfig.IpcMode = "none"
+						break
+					}
+					if c.config.NoShmShare {
+						hostConfig.IpcMode = "private"
+					} else {
+						hostConfig.IpcMode = "shareable"
+					}
 				}
+				break
 			}
 		}
-	case c.config.NoShm:
-		hostConfig.IpcMode = "none"
-	case c.config.NoShmShare:
-		hostConfig.IpcMode = "private"
 	}
 	if hostConfig.IpcMode == "" {
-		hostConfig.IpcMode = "shareable"
+		hostConfig.IpcMode = "host"
 	}
 
 	// Cgroup namespace mode

--- a/test/system/190-run-ipcns.bats
+++ b/test/system/190-run-ipcns.bats
@@ -7,54 +7,84 @@
 load helpers
 
 @test "podman --ipc=host" {
+    cname=c-$(random_string 10)
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run --rm --ipc=host $IMAGE readlink /proc/self/ns/ipc
+    run_podman run --name=$cname --ipc=host $IMAGE readlink /proc/self/ns/ipc
     is "$output" "$hostipc" "HostIPC and container IPC should be same"
+
+    run_podman container inspect --format "{{.HostConfig.IpcMode}}" $cname
+    assert "host" "inspect should show host ipc"
+
+    run_podman rm -f -t0 $cname
 }
 
 @test "podman --ipc=none" {
+    cname=c-$(random_string 10)
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run --rm --ipc=none $IMAGE readlink /proc/self/ns/ipc
+    run_podman run --name=$cname --ipc=none $IMAGE readlink /proc/self/ns/ipc
     assert "$output" != "$hostipc" "containeripc should != hostipc"
+
+    run_podman container inspect --format "{{.HostConfig.IpcMode}}" $cname
+    assert "none" "inspect should show none ipc"
 
     run_podman 1 run --rm --ipc=none $IMAGE ls /dev/shm
     is "$output" "ls: /dev/shm: No such file or directory" "Should fail with missing /dev/shm"
+
+    run_podman rm -f -t0 $cname
 }
 
 @test "podman --ipc=private" {
+    cname=c-$(random_string 10)
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run -d --ipc=private --name test $IMAGE sleep 100
+    run_podman run -d --ipc=private --name=$cname $IMAGE sleep 100
     assert "$output" != "$hostipc" "containeripc should != hostipc"
 
-    run_podman 125 run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
+    run_podman container inspect --format "{{.HostConfig.IpcMode}}" $cname
+    assert "private" "inspect should show private ipc"
+
+    run_podman 125 run --ipc=container:$cname --rm $IMAGE readlink /proc/self/ns/ipc
     is "$output" ".*is not allowed: non-shareable IPC (hint: use IpcMode:shareable for the donor container)" "Containers should not share private ipc namespace"
-    run_podman stop -t 0 test
-    run_podman rm test
+
+    run_podman rm -f -t0 $cname
 }
 
 @test "podman --ipc=shareable" {
+    cname=c-$(random_string 10)
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run -d --ipc=shareable --name test $IMAGE sleep 100
+    run_podman run -d --ipc=shareable --name=$cname $IMAGE sleep 100
     assert "$output" != "$hostipc" "containeripc(shareable) should != hostipc"
 
-    run_podman run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
-    assert "$output" != "$hostipc" "containeripc(:test) should != hostipc"
+    run_podman container inspect --format "{{.HostConfig.IpcMode}}" $cname
+    assert "shareable" "inspect should show shareable ipc"
 
-    run_podman stop -t 0 test
-    run_podman rm test
+    run_podman run --ipc=container:$cname --rm $IMAGE readlink /proc/self/ns/ipc
+    assert "$output" != "$hostipc" "containeripc(:XXX) should != hostipc"
+
+    run_podman rm -f -t0 $cname
 }
 
 @test "podman --ipc=container@test" {
+    cname1=c1-$(random_string 10)
+    cname2=c2-$(random_string 10)
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run -d --name test $IMAGE sleep 100
-    run_podman exec test readlink /proc/self/ns/ipc
+    run_podman run -d --name=$cname1 $IMAGE sleep 100
+    run_podman exec $cname1 readlink /proc/self/ns/ipc
     assert "$output" != "$hostipc" "containeripc(exec) should != hostipc"
-
     testipc=$output
-    run_podman run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
+
+    run_podman container inspect --format "{{.HostConfig.IpcMode}}" $cname1
+    assert "shareable" "inspect should show shareable ipc"
+
+    run_podman run --ipc=container:$cname1 --name=$cname2 $IMAGE readlink /proc/self/ns/ipc
     assert "$output" = "$testipc" "Containers should share ipc namespace"
-    run_podman stop -t 0 test
-    run_podman rm test
+
+    run_podman container inspect --format "{{.HostConfig.IpcMode}}" $cname2
+    assert "$output" =~ "container:[0-9a-f]{64}" "inspect should show container:<FULL_ID> ipc"
+
+    # We cannot remove both at once due "container XXXX has dependent containers
+    # which must be removed before it" error.
+    run_podman rm -f -t0 $cname2
+    run_podman rm -f -t0 $cname1
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
The ipc ns inspect logic did not work, the switch case was just broken because it will only execute the first branch. Therefore it always showed `shareable` or `container:...` as mode.

This fixes the logic and adds tests for all modes.

Fixes #17189


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in the the container inspect output where it showed the incorrect ipc namespace mode.
```
