### PR TITLE
Correct output when inspecting containers created with --ipc

### DIFF
--- a/test/system/190-run-ipcns.bats
+++ b/test/system/190-run-ipcns.bats
@@ -8,14 +8,20 @@ load helpers
 
 @test "podman --ipc=host" {
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run --rm --ipc=host $IMAGE readlink /proc/self/ns/ipc
+    run_podman run --name IPC --ipc=host $IMAGE readlink /proc/self/ns/ipc
     is "$output" "$hostipc" "HostIPC and container IPC should be same"
+    run_podman inspect IPC --format '{{ .HostConfig.IpcMode }}'
+    is "$output" "host" "host mode should be selected"
+    run_podman rm IPC
 }
 
 @test "podman --ipc=none" {
     hostipc="$(readlink /proc/self/ns/ipc)"
-    run_podman run --rm --ipc=none $IMAGE readlink /proc/self/ns/ipc
+    run_podman run --ipc=none --name IPC $IMAGE readlink /proc/self/ns/ipc
     assert "$output" != "$hostipc" "containeripc should != hostipc"
+    run_podman inspect IPC --format '{{ .HostConfig.IpcMode }}'
+    is "$output" "none" "none mode should be selected"
+    run_podman rm IPC
 
     run_podman 1 run --rm --ipc=none $IMAGE ls /dev/shm
     is "$output" "ls: /dev/shm: No such file or directory" "Should fail with missing /dev/shm"
@@ -25,6 +31,8 @@ load helpers
     hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run -d --ipc=private --name test $IMAGE sleep 100
     assert "$output" != "$hostipc" "containeripc should != hostipc"
+    run_podman inspect test --format '{{ .HostConfig.IpcMode }}'
+    is "$output" "private" "private mode should be selected"
 
     run_podman 125 run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
     is "$output" ".*is not allowed: non-shareable IPC (hint: use IpcMode:shareable for the donor container)" "Containers should not share private ipc namespace"
@@ -36,6 +44,8 @@ load helpers
     hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run -d --ipc=shareable --name test $IMAGE sleep 100
     assert "$output" != "$hostipc" "containeripc(shareable) should != hostipc"
+    run_podman inspect test --format '{{ .HostConfig.IpcMode }}'
+    is "$output" "shareable" "shareable mode should be selected"
 
     run_podman run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
     assert "$output" != "$hostipc" "containeripc(:test) should != hostipc"
@@ -47,12 +57,19 @@ load helpers
 @test "podman --ipc=container@test" {
     hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run -d --name test $IMAGE sleep 100
+    containerid=$output
+    run_podman inspect test --format '{{ .HostConfig.IpcMode }}'
+    is "$output" "shareable" "shareable mode should be selected"
     run_podman exec test readlink /proc/self/ns/ipc
     assert "$output" != "$hostipc" "containeripc(exec) should != hostipc"
 
     testipc=$output
-    run_podman run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
+    run_podman run --name IPC --ipc=container:test $IMAGE readlink /proc/self/ns/ipc
     assert "$output" = "$testipc" "Containers should share ipc namespace"
+    run_podman inspect IPC --format '{{ .HostConfig.IpcMode }}'
+    is "$output" "container:$containerid" "ipc mode should be selected"
+    run_podman rm IPC
+
     run_podman stop -t 0 test
     run_podman rm test
 }


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/17189

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix output of podman inspect to correctly report the IPCMode of containers.
```
