### PR TITLE
[v4.0-rhel] runtime: unpause the container before killing it

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -624,9 +624,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	}
 
 	if c.state.State == define.ContainerStatePaused {
-		if err := c.ociRuntime.KillContainer(c, 9, false); err != nil {
-			return err
-		}
 		isV2, err := cgroups.IsCgroup2UnifiedMode()
 		if err != nil {
 			return err
@@ -636,6 +633,9 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 			if err := c.unpause(); err != nil {
 				return err
 			}
+		}
+		if err := c.ociRuntime.KillContainer(c, 9, false); err != nil {
+			return err
 		}
 		// Need to update container state to make sure we know it's stopped
 		if err := c.waitForExitFileAndSync(); err != nil {

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -132,13 +132,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json list tags", func() {
-		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(search.OutputToString()).To(BeValidJSON())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
-		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
-		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
+		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.2"))
 	})
 
 	// Test for https://github.com/containers/podman/issues/11894


### PR DESCRIPTION
[EDIT: backport of #14765, requested by @jnovy]
[EDIT: and one small part ( ae9a2d26d ) of #16464 to get e2e tests passing ]

the new version of runc has the same check in place and it automatically resume the container if it is paused.  So when Podman tries to resume it again, it fails since the container is not in the paused state.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2100740

[NO NEW TESTS NEEDED] the CI doesn't use a new runc on cgroup v1 systems.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
```release-note
It solves a problem with new runc versions where it is not possible to remove a paused container.
```