### PR TITLE
[CI:DOCS] Example in volume import usage is backwards

### DIFF
--- a/cmd/podman/volumes/import.go
+++ b/cmd/podman/volumes/import.go
@@ -25,7 +25,7 @@ var (
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: common.AutocompleteVolumes,
 		Example: `podman volume import my_vol /home/user/import.tar
-  cat ctr.tar | podman import volume my_vol -`,
+  cat ctr.tar | podman volume import my_vol -`,
 	}
 )
 


### PR DESCRIPTION
Fixes #17205

Changes --help **Example:** from `podman import volume` to `podman volume import`.

Signed-off-by: Trevor Benson <trevor.benson@scality.com>

```release-note
None
```
