### PR TITLE
add support for limiting tmpfs size for systemd-specific mnts

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -638,6 +638,13 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(shmSizeFlagName, completion.AutocompleteNone)
 
+		shmSizeSystemdFlagName := "shm-size-systemd"
+		createFlags.String(
+			shmSizeSystemdFlagName, "",
+			"Size of systemd specific tmpfs mounts (/run, /run/lock) "+sizeWithUnitFormat,
+		)
+		_ = cmd.RegisterFlagCompletionFunc(shmSizeSystemdFlagName, completion.AutocompleteNone)
+
 		sysctlFlagName := "sysctl"
 		createFlags.StringSliceVar(
 			&cf.Sysctl,

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -295,6 +295,9 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 	if c.Flag("shm-size").Changed {
 		vals.ShmSize = c.Flag("shm-size").Value.String()
 	}
+	if c.Flag("shm-size-systemd").Changed {
+		vals.ShmSizeSystemd = c.Flag("shm-size-systemd").Value.String()
+	}
 	if (c.Flag("dns").Changed || c.Flag("dns-option").Changed || c.Flag("dns-search").Changed) && vals.Net != nil && (vals.Net.Network.NSMode == specgen.NoNetwork || vals.Net.Network.IsContainer()) {
 		return vals, fmt.Errorf("conflicting options: dns and the network mode: " + string(vals.Net.Network.NSMode))
 	}

--- a/docs/source/markdown/options/shm-size-systemd.md
+++ b/docs/source/markdown/options/shm-size-systemd.md
@@ -1,0 +1,10 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--shm-size-systemd**=*number[unit]*
+
+Size of systemd-specific tmpfs mounts such as /run, /run/lock, /var/log/journal and /tmp.
+A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).
+If the unit is omitted, the system uses bytes. If the size is omitted, the default is **64m**.
+When _size_ is **0**, the usage is limited to 50% of the host's available memory.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -328,6 +328,8 @@ Automatically remove the container when it exits. The default is *false*.
 
 @@option shm-size
 
+@@option shm-size-systemd
+
 @@option stop-signal
 
 @@option stop-timeout

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -71,6 +71,8 @@ Set a custom name for the cloned pod. The default if not specified is of the syn
 
 @@option shm-size
 
+@@option shm-size-systemd
+
 #### **--start**
 
 When set to true, this flag starts the newly created pod after the

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -157,6 +157,8 @@ Note: This options conflict with **--share=cgroup** since that would set the pod
 
 @@option shm-size
 
+@@option shm-size-systemd
+
 @@option subgidname
 
 @@option subuidname

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -358,6 +358,8 @@ container is using it. The default is *false*.
 
 @@option shm-size
 
+@@option shm-size-systemd
+
 @@option sig-proxy
 
 The default is **true**.

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -130,6 +130,8 @@ type ContainerRootFSConfig struct {
 	// ShmSize is the size of the container's SHM. Only used if ShmDir was
 	// not set manually at time of creation.
 	ShmSize int64 `json:"shmSize"`
+	// ShmSizeSystemd is the size of systemd-specific tmpfs mounts
+	ShmSizeSystemd int64 `json:"shmSizeSystemd"`
 	// Static directory for container content that will persist across
 	// reboot.
 	// StaticDir is a persistent directory for Libpod files that will
@@ -443,6 +445,7 @@ type InfraInherit struct {
 	SelinuxOpts        []string                 `json:"selinux_opts,omitempty"`
 	Volumes            []*specgen.NamedVolume   `json:"volumes,omitempty"`
 	ShmSize            *int64                   `json:"shm_size"`
+	ShmSizeSystemd     *int64                   `json:"shm_size_systemd"`
 }
 
 // IsDefaultShmSize determines if the user actually set the shm in the parent ctr or if it has been set to the default size

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -671,6 +671,23 @@ func WithShmSize(size int64) CtrCreateOption {
 	}
 }
 
+// WithShmSizeSystemd sets the size of systemd-specific mounts:
+//
+//	/run
+//	/run/lock
+//	/var/log/journal
+//	/tmp
+func WithShmSizeSystemd(size int64) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.ShmSizeSystemd = size
+		return nil
+	}
+}
+
 // WithPrivileged sets the privileged flag in the container runtime.
 func WithPrivileged(privileged bool) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -260,6 +260,7 @@ type ContainerCreateOptions struct {
 	SecurityOpt        []string `json:"security_opt,omitempty"`
 	SdNotifyMode       string
 	ShmSize            string
+	ShmSizeSystemd     string
 	SignaturePolicy    string
 	StartupHCCmd       string
 	StartupHCInterval  string
@@ -269,8 +270,8 @@ type ContainerCreateOptions struct {
 	StopSignal         string
 	StopTimeout        uint
 	StorageOpts        []string
-	SubUIDName         string
 	SubGIDName         string
+	SubUIDName         string
 	Sysctl             []string `json:"sysctl,omitempty"`
 	Systemd            string
 	Timeout            uint

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -478,6 +478,7 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 	specg.HostDeviceList = conf.DeviceHostSrc
 	specg.Networks = conf.Networks
 	specg.ShmSize = &conf.ShmSize
+	specg.ShmSizeSystemd = &conf.ShmSizeSystemd
 
 	mapSecurityConfig(conf, specg)
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -512,6 +512,9 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 	if s.ShmSize != nil {
 		options = append(options, libpod.WithShmSize(*s.ShmSize))
 	}
+	if s.ShmSizeSystemd != nil {
+		options = append(options, libpod.WithShmSizeSystemd(*s.ShmSizeSystemd))
+	}
 	if s.Rootfs != "" {
 		options = append(options, libpod.WithRootFS(s.Rootfs, s.RootfsOverlay, s.RootfsMapping))
 	}

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -192,6 +192,10 @@ type PodStorageConfig struct {
 	// Conflicts with ShmSize if IpcNS is not private.
 	// Optional.
 	ShmSize *int64 `json:"shm_size,omitempty"`
+	// ShmSizeSystemd is the size of systemd-specific tmpfs mounts
+	// specifically /run, /run/lock, /var/log/journal and /tmp.
+	// Optional
+	ShmSizeSystemd *int64 `json:"shm_size_systemd,omitempty"`
 }
 
 // PodCgroupConfig contains configuration options about a pod's cgroups.

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -295,6 +295,10 @@ type ContainerStorageConfig struct {
 	// Conflicts with ShmSize if IpcNS is not private.
 	// Optional.
 	ShmSize *int64 `json:"shm_size,omitempty"`
+	// ShmSizeSystemd is the size of systemd-specific tmpfs mounts
+	// specifically /run, /run/lock, /var/log/journal and /tmp.
+	// Optional
+	ShmSizeSystemd *int64 `json:"shm_size_systemd,omitempty"`
 	// WorkDir is the container's working directory.
 	// If unset, the default, /, will be used.
 	// Optional.

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -488,6 +488,16 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.ShmSize = &val
 	}
 
+	// SHM Size Systemd
+	if c.ShmSizeSystemd != "" {
+		val, err := units.RAMInBytes(c.ShmSizeSystemd)
+		if err != nil {
+			return fmt.Errorf("unable to translate --shm-size-systemd: %w", err)
+		}
+
+		s.ShmSizeSystemd = &val
+	}
+
 	if c.Net != nil {
 		s.Networks = c.Net.Networks
 	}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2053,4 +2053,22 @@ WORKDIR /madethis`, BB)
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull"))
 	})
+
+	It("podman run --shm-size-systemd", func() {
+		ctrName := "testShmSizeSystemd"
+		run := podmanTest.Podman([]string{"run", "--name", ctrName, "--shm-size-systemd", "10mb", "-d", SYSTEMD_IMAGE, "/sbin/init"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+
+		logs := podmanTest.Podman([]string{"logs", ctrName})
+		logs.WaitWithDefaultTimeout()
+		Expect(logs).Should(Exit(0))
+
+		mount := podmanTest.Podman([]string{"exec", ctrName, "mount"})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount).Should(Exit(0))
+		t, strings := mount.GrepString("tmpfs on /run/lock")
+		Expect(t).To(BeTrue())
+		Expect(strings[0]).Should(ContainSubstring("size=10240k"))
+	})
 })


### PR DESCRIPTION
Add support for limiting tmpfs size for systemd-specific mounts via `--shm-size-systemd`

Closes #17037 

Signed-off-by: danishprakash <danish.prakash@suse.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add support for limiting tmpfs size for systemd-specific mounts via `--shm-size-systemd`
```
