### PR TITLE
ps: query health check in batch mode

### DIFF
--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -407,10 +407,13 @@ func (c *Container) getHealthCheckLog() (define.HealthCheckResults, error) {
 	return healthCheck, nil
 }
 
-// HealthCheckStatus returns the current state of a container with a healthcheck
+// HealthCheckStatus returns the current state of a container with a healthcheck.
+// Returns an empty string if no health check is defined for the container.
 func (c *Container) HealthCheckStatus() (string, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	if !c.batched {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+	}
 	return c.healthCheckStatus()
 }
 
@@ -418,7 +421,7 @@ func (c *Container) HealthCheckStatus() (string, error) {
 // This function does not lock the container.
 func (c *Container) healthCheckStatus() (string, error) {
 	if !c.HasHealthCheck() {
-		return "", fmt.Errorf("container %s has no defined healthcheck", c.ID())
+		return "", nil
 	}
 
 	if err := c.syncContainer(); err != nil {


### PR DESCRIPTION
Also do not return (and immediately suppress) an error if no health check is defined for a given container.

Makes listing 100 containers around 10 percent faster.

[NO NEW TESTS NEEDED]

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@containers/podman-maintainers PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
