### PR TITLE
Set runAsNonRoot=true in gen kube

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -686,6 +686,13 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 	if imgData.User == c.User() && hasSecData {
 		kubeSec.RunAsGroup, kubeSec.RunAsUser = nil, nil
 	}
+	// If the image has user set as a positive integer value, then set runAsNonRoot to true
+	// in the kube yaml
+	imgUserID, err := strconv.Atoi(imgData.User)
+	if err == nil && imgUserID > 0 {
+		trueBool := true
+		kubeSec.RunAsNonRoot = &trueBool
+	}
 
 	envVariables, err := libpodEnvVarsToKubeEnvVars(c.config.Spec.Process.Env, imgData.Config.Env)
 	if err != nil {


### PR DESCRIPTION
If the image being used has a user set that is a positive integer greater than 0, then set the securityContext.runAsNonRoot to true for the container in the generated kube yaml.

Fixes https://github.com/containers/podman/issues/15231

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set runAsNonRoot=true in generated kube yaml when image has user set as a positive integer value.
```
