### PR TITLE
fix: running check error when podman is default in wsl

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1175,7 +1175,7 @@ func IsWSLFeatureEnabled() bool {
 }
 
 func isWSLRunning(dist string) (bool, error) {
-	cmd := exec.Command("wsl", "-l", "--running")
+	cmd := exec.Command("wsl", "-l", "--running", "--quiet")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
If podman is set to the wsl default distribution, the (default) value is appended like podman-machine-default **(default)**.  

``` bat
> wsl --list --running
Linux용 Windows 하위 시스템 배포:
podman-machine-default(default)
```
Because of **(default)**, it determines that podman wsl deployment has not been executed.  
It can be solved simply by outputting only the wsl distribution name with the --quiet option.
``` bat
> wsl --list --running --quiet
podman-machine-default
```

Related to #17227, #17158  

Signed-off-by: shblue21 <jihunkimkw@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a startup issue with podman machine when running under some locales of Windows. 
```

[NO NEW TESTS NEEDED]