### PR TITLE
e2e: Avoid hard-coding ImageCacheDir

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -103,7 +103,8 @@ func TestLibpod(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	// make cache dir
-	if err := os.MkdirAll(ImageCacheDir, 0777); err != nil {
+	ImageCacheDir = filepath.Join(os.TempDir(), "imagecachedir")
+	if err := os.MkdirAll(ImageCacheDir, 0700); err != nil {
 		fmt.Printf("%q\n", err)
 		os.Exit(1)
 	}
@@ -192,7 +193,7 @@ var _ = SynchronizedAfterSuite(func() {},
 		}
 		// for localized tests, this removes the image cache dir and for remote tests
 		// this is a no-op
-		podmanTest.removeCache(ImageCacheDir)
+		podmanTest.removeCache(podmanTest.ImageCacheDir)
 
 		// LockTmpDir can already be removed
 		os.RemoveAll(LockTmpDir)
@@ -278,6 +279,9 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		storageFs = os.Getenv("STORAGE_FS")
 		storageOptions = "--storage-driver " + storageFs
 	}
+
+	ImageCacheDir = filepath.Join(os.TempDir(), "imagecachedir")
+
 	p := &PodmanTestIntegration{
 		PodmanTest: PodmanTest{
 			PodmanBinary:       podmanBinary,

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -13,7 +13,6 @@ var (
 	INFRA_IMAGE       = "k8s.gcr.io/pause:3.2" //nolint:revive,stylecheck
 	BB                = "quay.io/libpod/busybox:latest"
 	HEALTHCHECK_IMAGE = "quay.io/libpod/alpine_healthcheck:latest" //nolint:revive,stylecheck
-	ImageCacheDir     = "/tmp/podman/imagecachedir"
 	fedoraToolbox     = "registry.fedoraproject.org/fedora-toolbox:36"
 	volumeTest        = "quay.io/libpod/volume-plugin-test-img:20220623"
 
@@ -25,4 +24,10 @@ var (
 	// This image has a bogus/invalid seccomp profile which should
 	// yield a json error when being read.
 	alpineBogusSeccomp = "quay.io/libpod/alpine-with-bogus-seccomp:label"
+
+	// ImageCacheDir is initialized at runtime.
+	// e.g., filepath.Join(os.TempDir(), "imagecachedir")
+	// This directory should be used by per-user.
+	// Note: "ImageCacheDir" has nothing to do with "PODMAN_TEST_IMAGE_CACHE_DIR".
+	ImageCacheDir = ""
 )


### PR DESCRIPTION
- ImageCacheDir is hard-coded as "/tmp/podman/imagecachedir".
To avoid this hard-coding, I changed it to "os.TempDir()/imagecachedir".

- Change ImageCacheDir permissions from 0777 to 0700.
This directory should be used by per-user.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

---

Related to #17089

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
