### PR TITLE
e2e: Remove some directories at SynchronizedAfterSuite

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -180,6 +180,7 @@ var _ = SynchronizedAfterSuite(func() {},
 			os.Exit(1)
 		}
 		podmanTest := PodmanTestCreate(tempdir)
+		defer os.RemoveAll(tempdir)
 
 		if err := os.RemoveAll(podmanTest.Root); err != nil {
 			fmt.Printf("%q\n", err)
@@ -192,6 +193,9 @@ var _ = SynchronizedAfterSuite(func() {},
 		// for localized tests, this removes the image cache dir and for remote tests
 		// this is a no-op
 		removeCache()
+
+		// LockTmpDir can already be removed
+		os.RemoveAll(LockTmpDir)
 	})
 
 // PodmanTestCreate creates a PodmanTestIntegration instance for the tests


### PR DESCRIPTION
"tempdir" in SynchronizedAftersuite and "LockTmpDir" can be removed.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
