### PR TITLE
Must use mountlabel when creating builtin volumes

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1665,6 +1665,18 @@ func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 	}
 }
 
+// WithVolumeMountLabel sets the MountLabel of the volume.
+func WithVolumeMountLabel(mountLabel string) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return define.ErrVolumeFinalized
+		}
+
+		volume.config.MountLabel = mountLabel
+		return nil
+	}
+}
+
 // WithVolumeOptions sets the options of the volume.
 func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 	return func(volume *Volume) error {

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -107,6 +107,18 @@ func (p *Pod) Name() string {
 	return p.config.Name
 }
 
+// MountLabel returns the SELinux label associated with the pod
+func (p *Pod) MountLabel() (string, error) {
+	if !p.HasInfraContainer() {
+		return "", nil
+	}
+	ctr, err := p.infraContainer()
+	if err != nil {
+		return "", err
+	}
+	return ctr.MountLabel(), nil
+}
+
 // Namespace returns the pod's libpod namespace.
 // Namespaces are used to logically separate containers and pods in the state.
 func (p *Pod) Namespace() string {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -495,7 +495,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		logrus.Debugf("Creating new volume %s for container", vol.Name)
 
 		// The volume does not exist, so we need to create it.
-		volOptions := []VolumeCreateOption{WithVolumeName(vol.Name)}
+		volOptions := []VolumeCreateOption{
+			WithVolumeName(vol.Name),
+			WithVolumeMountLabel(ctr.MountLabel()),
+		}
 		if isAnonymous {
 			volOptions = append(volOptions, withSetAnon())
 		}

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/stringid"
 	pluginapi "github.com/docker/go-plugins-helpers/volume"
+	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 )
 
@@ -122,6 +123,13 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 		storageConfig := storage.ContainerOptions{
 			LabelOpts: []string{"filetype:container_file_t:s0"},
 		}
+		if len(volume.config.MountLabel) > 0 {
+			context, err := selinux.NewContext(volume.config.MountLabel)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get SELinux context from %s: %w", volume.config.MountLabel, err)
+			}
+			storageConfig.LabelOpts = []string{fmt.Sprintf("filetype:%s:s0", context["type"])}
+		}
 		if _, err := r.storageService.CreateContainerStorage(ctx, r.imageContext, imgString, image.ID(), volume.config.StorageName, volume.config.StorageID, storageConfig); err != nil {
 			return nil, fmt.Errorf("creating backing storage for image driver: %w", err)
 		}
@@ -161,7 +169,7 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 		if err := idtools.SafeChown(fullVolPath, volume.config.UID, volume.config.GID); err != nil {
 			return nil, fmt.Errorf("chowning volume directory %q to %d:%d: %w", fullVolPath, volume.config.UID, volume.config.GID, err)
 		}
-		if err := LabelVolumePath(fullVolPath); err != nil {
+		if err := LabelVolumePath(fullVolPath, volume.config.MountLabel); err != nil {
 			return nil, err
 		}
 		if volume.config.DisableQuota {

--- a/libpod/util_freebsd.go
+++ b/libpod/util_freebsd.go
@@ -25,7 +25,7 @@ func deleteSystemdCgroup(path string, resources *spec.LinuxResources) error {
 }
 
 // No equivalent on FreeBSD?
-func LabelVolumePath(path string) error {
+func LabelVolumePath(path, mountLabel string) error {
 	return nil
 }
 

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -109,13 +109,16 @@ var lvpReleaseLabel = label.ReleaseLabel
 
 // LabelVolumePath takes a mount path for a volume and gives it an
 // selinux label of either shared or not
-func LabelVolumePath(path string) error {
-	_, mountLabel, err := lvpInitLabels([]string{})
-	if err != nil {
-		return fmt.Errorf("getting default mountlabels: %w", err)
-	}
-	if err := lvpReleaseLabel(mountLabel); err != nil {
-		return fmt.Errorf("releasing label %q: %w", mountLabel, err)
+func LabelVolumePath(path, mountLabel string) error {
+	if mountLabel == "" {
+		var err error
+		_, mountLabel, err = lvpInitLabels([]string{})
+		if err != nil {
+			return fmt.Errorf("getting default mountlabels: %w", err)
+		}
+		if err := lvpReleaseLabel(mountLabel); err != nil {
+			return fmt.Errorf("releasing label %q: %w", mountLabel, err)
+		}
 	}
 
 	if err := lvpRelabel(path, mountLabel, true); err != nil {

--- a/libpod/util_linux_test.go
+++ b/libpod/util_linux_test.go
@@ -34,6 +34,6 @@ func TestLabelVolumePath(t *testing.T) {
 	}
 
 	// LabelVolumePath should not return an error if the operation is unsupported.
-	err := LabelVolumePath("/foo/bar")
+	err := LabelVolumePath("/foo/bar", "")
 	assert.NoError(t, err)
 }

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -22,6 +22,6 @@ func Unmount(mount string) {
 
 // LabelVolumePath takes a mount path for a volume and gives it an
 // selinux label of either shared or not
-func LabelVolumePath(path string) error {
+func LabelVolumePath(path, mountLabel string) error {
 	return errors.New("not implemented LabelVolumePath")
 }

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -67,6 +67,8 @@ type VolumeConfig struct {
 	// StorageImageID is the ID of the image the volume was based off of.
 	// Only used for image volumes.
 	StorageImageID string `json:"storageImageID,omitempty"`
+	// MountLabel is the SELinux label to assign to mount points
+	MountLabel string `json:"mountlabel,omitempty"`
 }
 
 // VolumeState holds the volume's mutable state.

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -519,5 +519,15 @@ EOF
     run_podman rm -f -t 0 -a
 }
 
+@test "podman run with building volume and selinux file label" {
+    skip_if_no_selinux
+    run_podman create --security-opt label=filetype:usr_t --volume myvol:/myvol $IMAGE top
+    run_podman volume inspect myvol --format '{{ .Mountpoint }}'
+    path=${output}
+    run ls -Zd $path
+    is "$output" "system_u:object_r:usr_t:s0 $path" "volume should be labeled with usr_t type"
+    run_podman volume rm myvol --force
+}
+
 
 # vim: filetype=sh


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If user modifies the filelabel security-opt, builtin volumes will now use the specified label.
```
