### PR TITLE
fix: don't output "ago" when container is currently up and running

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -357,7 +357,7 @@ func (l psReporter) State() string {
 	switch l.ListContainer.State {
 	case "running":
 		t := units.HumanDuration(time.Since(time.Unix(l.StartedAt, 0)))
-		state = "Up " + t + " ago"
+		state = "Up " + t
 	case "exited", "stopped":
 		t := units.HumanDuration(time.Since(time.Unix(l.ExitedAt, 0)))
 		state = fmt.Sprintf("Exited (%d) %s ago", l.ExitCode, t)

--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -136,8 +136,8 @@ $ systemctl --user start container-be0889fd06f252a2e5141b37072c6bada68563026cb2b
 
 ### Get the name of the container
 $ podman ps
-CONTAINER ID  IMAGE                             COMMAND  CREATED        STATUS            PORTS   NAMES
-01f5c8113e84  docker.io/library/busybox:latest  top      2 seconds ago  Up 3 seconds ago          inspiring_galileo
+CONTAINER ID  IMAGE                             COMMAND  CREATED        STATUS        PORTS   NAMES
+01f5c8113e84  docker.io/library/busybox:latest  top      2 seconds ago  Up 3 seconds          inspiring_galileo
 
 ### Modify the image
 $ podman commit --change CMD=/bin/bash inspiring_galileo busybox:latest

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -301,9 +301,9 @@ CONTAINER ID  IMAGE                            COMMAND  CREATED        STATUS   
 bb310a0780ae  docker.io/library/alpine:latest  /bin/sh  2 minutes ago  Created           busy_moser
 $ sudo systemctl start container-busy_moser.service
 $ sudo podman ps -a
-CONTAINER ID  IMAGE                            COMMAND  CREATED        STATUS            PORTS      NAMES
-772df2f8cf3b  docker.io/library/alpine:latest  /bin/sh  1 second ago   Up 1 second ago              distracted_albattani
-bb310a0780ae  docker.io/library/alpine:latest  /bin/sh  3 minutes ago  Created                      busy_moser
+CONTAINER ID  IMAGE                            COMMAND  CREATED        STATUS        PORTS      NAMES
+772df2f8cf3b  docker.io/library/alpine:latest  /bin/sh  1 second ago   Up 1 second              distracted_albattani
+bb310a0780ae  docker.io/library/alpine:latest  /bin/sh  3 minutes ago  Created                  busy_moser
 ```
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**, **systemctl(1)**, **systemd.unit(5)**, **systemd.service(5)**, **[conmon(8)](https://github.com/containers/conmon/blob/main/docs/conmon.8.md)**

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -175,9 +175,9 @@ CONTAINER ID   IMAGE         COMMAND         CREATED       STATUS               
 
 ```
 $ podman ps
-CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS            PORTS                                                   NAMES
-4089df24d4f3  docker.io/library/centos:latest  /bin/bash  2 minutes ago  Up 2 minutes ago  0.0.0.0:80->8080/tcp, 0.0.0.0:2000-2006->2000-2006/tcp  manyports
-92f58933c28c  docker.io/library/centos:latest  /bin/bash  3 minutes ago  Up 3 minutes ago  192.168.99.100:1000-1006->1000-1006/tcp                 zen_sanderson
+CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS        PORTS                                                   NAMES
+4089df24d4f3  docker.io/library/centos:latest  /bin/bash  2 minutes ago  Up 2 minutes  0.0.0.0:80->8080/tcp, 0.0.0.0:2000-2006->2000-2006/tcp  manyports
+92f58933c28c  docker.io/library/centos:latest  /bin/bash  3 minutes ago  Up 3 minutes  192.168.99.100:1000-1006->1000-1006/tcp                 zen_sanderson
 
 ```
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -280,8 +280,8 @@ var _ = Describe("Podman ps", func() {
 		// must contain "Status"
 		match, StatusLine := result.GrepString(`Status`)
 		Expect(match).To(BeTrue())
-		// container is running or exit, so it must contain `ago`
-		Expect(StatusLine[0]).To(ContainSubstring("ago"))
+		// we waited for container to exit, so this must contain `Exited`
+		Expect(StatusLine[0]).To(ContainSubstring("Exited"))
 	})
 
 	It("podman ps namespace flag with go template format", func() {


### PR DESCRIPTION
Closes #17250

#### Does this PR introduce a user-facing change?

```release-note
Fix `podman ps` STATUS output to say "Up 3 seconds", if the container has been up and running for 3 seconds (removing the word "ago".
```
