### PR TITLE
Fix default handling of pids-limit

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -893,8 +893,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		_ = cmd.RegisterFlagCompletionFunc(deviceWriteIopsFlagName, completion.AutocompleteDefault)
 
 		pidsLimitFlagName := "pids-limit"
-		createFlags.Int64Var(
-			cf.PIDsLimit,
+		createFlags.Int64(
 			pidsLimitFlagName, pidsLimit(),
 			"Tune container pids limit (set -1 for unlimited)",
 		)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -92,5 +92,4 @@ func DefineCreateDefaults(opts *entities.ContainerCreateOptions) {
 	opts.Ulimit = ulimits()
 	opts.SeccompPolicy = "default"
 	opts.Volume = volumes()
-	opts.PIDsLimit = &podmanConfig.ContainersConf.Containers.PidsLimit
 }

--- a/cmd/podman/containers/update.go
+++ b/cmd/podman/containers/update.go
@@ -65,6 +65,11 @@ func update(cmd *cobra.Command, args []string) error {
 	s := &specgen.SpecGenerator{}
 	s.ResourceLimits = &specs.LinuxResources{}
 
+	err = createOrUpdateFlags(cmd, &updateOpts)
+	if err != nil {
+		return err
+	}
+
 	// we need to pass the whole specgen since throttle devices are parsed later due to cross compat.
 	s.ResourceLimits, err = specgenutil.GetResources(s, &updateOpts)
 	if err != nil {


### PR DESCRIPTION
I noticed container creation/run commands on podman remote were printing:

"Resource limits are not supported and ignored on cgroups V1 rootless systems"

The underlying cause was a problem with default handling introduced in the enhancement that added pids-limit for container update operations (479052af)

This also meant that updates for other values would unintentionally change the pids-limit back to the default value. This PR adds a test for that condition as well.

Signed-off-by: Jason T. Greene <jason.greene@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
