### PR TITLE
fix #17244: use /etc/timezone where `timedatectl` is missing on Linux

### DIFF
--- a/pkg/machine/ignition_linux.go
+++ b/pkg/machine/ignition_linux.go
@@ -1,12 +1,17 @@
 package machine
 
 import (
+	"errors"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 func getLocalTimeZone() (string, error) {
 	output, err := exec.Command("timedatectl", "show", "--property=Timezone").Output()
+	if errors.Is(err, exec.ErrNotFound) {
+		output, err = os.ReadFile("/etc/timezone")
+	}
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
None
```
[NO NEW TESTS NEEDED]