### PR TITLE
[v4.4] fix #17244: use /etc/timezone where `timedatectl` is missing on Linux

### DIFF
--- a/pkg/machine/ignition_linux.go
+++ b/pkg/machine/ignition_linux.go
@@ -1,12 +1,17 @@
 package machine
 
 import (
+	"errors"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 func getLocalTimeZone() (string, error) {
 	output, err := exec.Command("timedatectl", "show", "--property=Timezone").Output()
+	if errors.Is(err, exec.ErrNotFound) {
+		output, err = os.ReadFile("/etc/timezone")
+	}
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Signed-off-by: nabbisen <nabbisen@scqr.net>
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
