### PR TITLE
container rm: save once for exec removal and state change

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -1072,14 +1072,6 @@ func (c *Container) removeAllExecSessions() error {
 	}
 	c.state.ExecSessions = nil
 	c.state.LegacyExecSessions = nil
-	if err := c.save(); err != nil {
-		if !errors.Is(err, define.ErrCtrRemoved) {
-			if lastErr != nil {
-				logrus.Errorf("Stopping container %s exec sessions: %v", c.ID(), lastErr)
-			}
-			lastErr = err
-		}
-	}
 
 	return lastErr
 }


### PR DESCRIPTION
Do not save the container each for changing the state and for removing running exec sessions.  Saving the container is expensive and avoiding the redundant save makes `container rm` 1.2 times faster on my workstation.

[NO NEW TESTS NEEDED]

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
