### PR TITLE
Log data that we failed to unmarshal

### DIFF
--- a/pkg/bindings/errors.go
+++ b/pkg/bindings/errors.go
@@ -15,7 +15,7 @@ var (
 
 func handleError(data []byte, unmarshalErrorInto interface{}) error {
 	if err := json.Unmarshal(data, unmarshalErrorInto); err != nil {
-		return err
+		return fmt.Errorf("unmarshaling error into %#v, data %q: %w", unmarshalErrorInto, string(data), err)
 	}
 	return unmarshalErrorInto.(error)
 }
@@ -35,7 +35,10 @@ func (h APIResponse) ProcessWithError(unmarshalInto interface{}, unmarshalErrorI
 	}
 	if h.IsSuccess() || h.IsRedirection() {
 		if unmarshalInto != nil {
-			return json.Unmarshal(data, unmarshalInto)
+			if err := json.Unmarshal(data, unmarshalInto); err != nil {
+				return fmt.Errorf("unmarshaling into %#v, data %q: %w", unmarshalInto, string(data), err)
+			}
+			return nil
 		}
 		return nil
 	}


### PR DESCRIPTION
This should never happen with a consistent client/server, and we are seeing this show up with some hard-to-diagnose flakes: #16154 .

So, log details about failures. After we find the cause, we might remove this extra logging again.

#### Does this PR introduce a user-facing change?

```release-note
Added more (noisy) logging on unexpected remote client data parsing failures, to help debug them.
```
