### PR TITLE
e2e tests: fix incorrect os.User.Name

### DIFF
--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on pod with user namespace", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -682,7 +682,7 @@ ENTRYPOINT ["sleep","99999"]
 		Expect(session).Should(Exit(0))
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(session.OutputToString()).To(ContainSubstring(u.Name))
+		Expect(session.OutputToString()).To(Equal(u.Username))
 
 		// root owns /usr
 		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "stat", "-c%u", "/usr"})
@@ -715,10 +715,10 @@ ENTRYPOINT ["sleep","99999"]
 		Expect(err).ToNot(HaveOccurred())
 		// container inside pod inherits user from infra container if --user is not set
 		// etc/passwd entry will look like USERNAME:*:1000:1000:Full User Name:/:/bin/sh
-		exec1 := podmanTest.Podman([]string{"exec", ctrName, "cat", "/etc/passwd"})
+		exec1 := podmanTest.Podman([]string{"exec", ctrName, "id", "-un"})
 		exec1.WaitWithDefaultTimeout()
 		Expect(exec1).Should(Exit(0))
-		Expect(exec1.OutputToString()).To(ContainSubstring(u.Name))
+		Expect(exec1.OutputToString()).To(Equal(u.Username))
 
 		exec2 := podmanTest.Podman([]string{"exec", ctrName, "useradd", "testuser"})
 		exec2.WaitWithDefaultTimeout()
@@ -733,7 +733,7 @@ ENTRYPOINT ["sleep","99999"]
 	It("podman pod create with --userns=auto", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -768,7 +768,7 @@ ENTRYPOINT ["sleep","99999"]
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -804,7 +804,7 @@ ENTRYPOINT ["sleep","99999"]
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -841,7 +841,7 @@ ENTRYPOINT ["sleep","99999"]
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Podman UserNS support", func() {
 	It("podman build with --userns=auto", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -157,7 +157,7 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(session).Should(Exit(0))
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(session.OutputToString()).To(ContainSubstring(u.Name))
+		Expect(session.OutputToString()).To(Equal(u.Username))
 	})
 
 	It("podman --userns=keep-id root owns /usr", func() {
@@ -201,7 +201,7 @@ var _ = Describe("Podman UserNS support", func() {
 	It("podman --userns=auto", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -239,7 +239,7 @@ var _ = Describe("Podman UserNS support", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -277,7 +277,7 @@ var _ = Describe("Podman UserNS support", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}
@@ -306,7 +306,7 @@ var _ = Describe("Podman UserNS support", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 
-		name := u.Name
+		name := u.Username
 		if name == "root" {
 			name = "containers"
 		}


### PR DESCRIPTION
Ha ha. This was supposed to be a trivial little followup to #17174:

   https://github.com/containers/podman/pull/17174#discussion_r1085963780
      (safer username check when --userns=keep-id)

It got complicated. TL;DR we need to use User.Username, not User.Name.
The latter is GECOS! Tests were working because, on Fedora, GECOS
for root is "root". Found and fixed all 'u.Name' instances, but
if there are any references with a variable other than 'u', they
still need looking into.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```