### PR TITLE
[NO NEW TESTS NEEDED] Fixes port collision issue on use of --publish-all

### DIFF
--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -311,6 +311,8 @@ func ParsePortMapping(portMappings []types.PortMapping, exposePorts map[uint16][
 						return nil, err
 					}
 					portMappings = append(portMappings, p)
+					// Mark this port as used so it doesn't get re-generated
+					allPorts[p.HostPort] = true
 				} else {
 					newProtocols = append(newProtocols, protocol)
 				}


### PR DESCRIPTION
This PR fixes a small bug which comes from usage of the `--publish-all` command line flag when using `podman container create`. When choosing random ports for each of the exposed ports on the container the offending function did not add each port it was "generating" to the list of used ports. This would (on very rare occasions) cause a collision when two of the same ports were generated. This issue was found in a testing environment which repeatedly stood up containers, an example of the `Ports` portion of a `podman inspect` command run on a container with this issue is shown below:

```json
"Ports": {
     "1999/tcp": [
          {
               "HostIp": "",
               "HostPort": "37643"
          }
     ],
     "443/tcp": [
          {
               "HostIp": "",
               "HostPort": "37643"
          }
     ],
     "444/tcp": [
          {
               "HostIp": "",
               "HostPort": "39563"
          }
     ],
     "5432/tcp": [
          {
               "HostIp": "",
               "HostPort": "44683"
          }
     ]
}
```

No tests were added in this PR due to the cost/benefit ratio in testing a difficult/rare condition like this, and the simplicity of the change. If a reviewer thinks that the tests are necessary please let me know.

#### Does this PR introduce a user-facing change?

```release-note
None
```