### PR TITLE
[CI:DOCS] docs: specify order preference for FROM

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -255,7 +255,7 @@ option.
 Specifies a Containerfile which contains instructions for building the image,
 either a local file or an **http** or **https** URL.  If more than one
 Containerfile is specified, *FROM* instructions will only be accepted from the
-first specified file.
+last specified file.
 
 If a build context is not specified, and at least one Containerfile is a
 local file, the directory in which it resides will be used as the build


### PR DESCRIPTION
When multiple files are specified buildah considers `FROM` instruction from the last file specified and so does `buildkit` and `docker` so lets specify that in docs.

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Similar to: https://github.com/containers/buildah/pull/4546

```release-note
docs: specify order preference for FROM
```