### PR TITLE
e2e: fix run_staticip_test about no_proxy

### DIFF
--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -105,15 +105,15 @@ var _ = Describe("Podman run with --ip flag", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 
-		// We need to set "no_proxy" in proxy environment
-		if env, found := os.LookupEnv("no_proxy"); found {
-			defer os.Setenv("no_proxy", env)
-		} else {
-			defer os.Unsetenv("no_proxy")
+		// This test should not use a proxy
+		client := &http.Client{
+			Transport: &http.Transport{
+				Proxy: nil,
+			},
 		}
-		os.Setenv("no_proxy", ip)
+
 		for retries := 20; retries > 0; retries-- {
-			response, err := http.Get(fmt.Sprintf("http://%s", ip))
+			response, err := client.Get(fmt.Sprintf("http://%s", ip))
 			if err == nil && response.StatusCode == http.StatusOK {
 				break
 			}


### PR DESCRIPTION
`http.Get()` could not recognize `no_proxy` with `ginkgo -nodes <any>`.
Therefore, we set `http.Client` not to use a proxy instead of `os.Setenv()`.

Fixes #17135

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
