### PR TITLE
[4.4] fix regression with runc --privileged rootless containers

### DIFF
--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -117,11 +117,12 @@ func AddPrivilegedDevices(g *generate.Generator, systemdMode bool) error {
 			 *              the rootless containers for security reasons, and
 			 *              the container runtime will create it for us
 			 *              anyway (ln -s /dev/pts/ptmx /dev/ptmx);
+			 *   /dev/tty and
 			 *   /dev/tty[0-9]+: Prevent the container from taking over the host's
 			 *                   virtual consoles, even when not in systemd mode
 			 *                   for backwards compatibility.
 			 */
-			if d.Path == "/dev/ptmx" || isVirtualConsoleDevice(d.Path) {
+			if d.Path == "/dev/ptmx" || d.Path == "/dev/tty" || isVirtualConsoleDevice(d.Path) {
 				continue
 			}
 			if _, found := mounts[d.Path]; found {


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2165875
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
