### PR TITLE
Expose Podman named pipe in Inspect output

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -373,4 +373,6 @@ type SSHConfig struct {
 type ConnectionConfig struct {
 	// PodmanSocket is the exported podman service socket
 	PodmanSocket *VMFile `json:"PodmanSocket"`
+	// PodmanPipe is the exported podman service named pipe (Windows hosts only)
+	PodmanPipe *VMFile `json:"PodmanPipe"`
 }


### PR DESCRIPTION
Fixes #16860

`PodmanPipe` structure added to `ConnectionConfig`. Named pipe address is not full equivalent of a file, but 1) it can be represented as a UNC path; 2) internally in code it used with `os.Stat` API similar to files; 3) it is logically to add it with the same shape as `PodmanSocket`; 4) it is OS specific, but `PodmanSocket` in the moment of introduction was also OS specific and was present in Windows builds, where it was not used before, I considered that this sort of overhead is acceptable, so, it is modeled with VMFile and unconditionally added.

Additional refactoring was applied to promote some utility functions for named pipe to the machine common part instead of WSL: `PipeAvailable` and `WaitPipeExists`. There 100% will be need to use former in QEMU machine, but the latter was just logical to keep next to the former.

Important note - why it is not possible to use `PodmanSocket` for this purpose. First of all there is no way to communicate transport type with VMFile structure and this would put additional complexity on clients to understand how to use this value. Another reason is that to me it looks desirable to keep `PodmanSocket` reserved for QEMU machine and unix domain socket to match QEMU on other hosts, but it will still need to expose named pipe, because NodeJS clients (most notable Podman Desktop) can't use unix domain sockets on Windows (because of the lack of support in libuv).

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Machine connection info includes named pipe address on supported hosts
```
