### PR TITLE
Do not mount /dev/tty into rootless containers

### DIFF
--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -117,11 +117,12 @@ func AddPrivilegedDevices(g *generate.Generator, systemdMode bool) error {
 			 *              the rootless containers for security reasons, and
 			 *              the container runtime will create it for us
 			 *              anyway (ln -s /dev/pts/ptmx /dev/ptmx);
+			 *   /dev/tty and
 			 *   /dev/tty[0-9]+: Prevent the container from taking over the host's
 			 *                   virtual consoles, even when not in systemd mode
 			 *                   for backwards compatibility.
 			 */
-			if d.Path == "/dev/ptmx" || isVirtualConsoleDevice(d.Path) {
+			if d.Path == "/dev/ptmx" || d.Path == "/dev/tty" || isVirtualConsoleDevice(d.Path) {
 				continue
 			}
 			if _, found := mounts[d.Path]; found {


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2165875

#### Does this PR introduce a user-facing change?

```release-note
Rootless privileged containers will not mount /dev/tty in the container
```

This PR should superseed https://github.com/containers/podman/pull/17301.

@giuseppe: This should address the regression, without needing to revert the commits (which were themselves fixing a regression).