### PR TITLE
Emergency fix for RHEL8 gating tests

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -84,7 +84,7 @@ function service_setup() {
     run systemctl status "$service"
     assert $status -eq $statusexit "systemctl status $service: $output"
 
-    run systemctl show -P ActiveState "$service"
+    run systemctl show --value --property=ActiveState "$service"
     assert $status -eq 0 "systemctl show $service: $output"
     is "$output" $activestate
 }


### PR DESCRIPTION
...because systemd on RHEL8 is too old, has no -P

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```