### PR TITLE
[v4.0-rhel] all: stop using deprecated GenerateNonCryptoID

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -180,7 +180,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 	}
 
 	// Generate an ID for our new exec session
-	sessionID := stringid.GenerateNonCryptoID()
+	sessionID := stringid.GenerateRandomID()
 	found := true
 	// This really ought to be a do-while, but Go doesn't have those...
 	for found {
@@ -192,7 +192,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 			}
 		}
 		if found {
-			sessionID = stringid.GenerateNonCryptoID()
+			sessionID = stringid.GenerateRandomID()
 		}
 	}
 

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -17,7 +17,7 @@ import (
 func newPod(runtime *Runtime) *Pod {
 	pod := new(Pod)
 	pod.config = new(PodConfig)
-	pod.config.ID = stringid.GenerateNonCryptoID()
+	pod.config.ID = stringid.GenerateRandomID()
 	pod.config.Labels = make(map[string]string)
 	pod.config.CreatedTime = time.Now()
 	//	pod.config.InfraContainer = new(ContainerConfig)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -167,7 +167,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 	ctr.state = new(ContainerState)
 
 	if config == nil {
-		ctr.config.ID = stringid.GenerateNonCryptoID()
+		ctr.config.ID = stringid.GenerateRandomID()
 		size, err := units.FromHumanSize(r.config.Containers.ShmSize)
 		if err != nil {
 			return nil, errors.Wrapf(err, "converting containers.conf ShmSize %s to an int", r.config.Containers.ShmSize)
@@ -184,7 +184,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		}
 		// If the ID is empty a new name for the restored container was requested
 		if ctr.config.ID == "" {
-			ctr.config.ID = stringid.GenerateNonCryptoID()
+			ctr.config.ID = stringid.GenerateRandomID()
 		}
 		// Reset the log path to point to the default
 		ctr.config.LogPath = ""
@@ -453,7 +453,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		if vol.Name == "" {
 			// Anonymous volume. We'll need to create it.
 			// It needs a name first.
-			vol.Name = stringid.GenerateNonCryptoID()
+			vol.Name = stringid.GenerateRandomID()
 			isAnonymous = true
 		} else {
 			// Check if it exists already

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -37,7 +37,7 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	}
 
 	if volume.config.Name == "" {
-		volume.config.Name = stringid.GenerateNonCryptoID()
+		volume.config.Name = stringid.GenerateRandomID()
 	}
 	if volume.config.Driver == "" {
 		volume.config.Driver = define.VolumeDriverLocal

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -304,7 +304,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		// happens. So, use a podman-%s.sock-lock empty file as a marker.
 		tries := 0
 		for {
-			uuid := stringid.GenerateNonCryptoID()
+			uuid := stringid.GenerateRandomID()
 			lockPath := fmt.Sprintf("%s-%s.sock-lock", pathPrefix, uuid)
 			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
 			if err == nil {
@@ -904,7 +904,7 @@ func generateNetworkConfig(p *PodmanTestIntegration) (string, string) {
 		conf string
 	)
 	// generate a random name to prevent conflicts with other tests
-	name := "net" + stringid.GenerateNonCryptoID()
+	name := "net" + stringid.GenerateRandomID()
 	if p.NetworkBackend != Netavark {
 		path = filepath.Join(p.NetworkConfigDir, fmt.Sprintf("%s.conflist", name))
 		conf = fmt.Sprintf(`{
@@ -1040,5 +1040,5 @@ func ncz(port int) bool {
 }
 
 func createNetworkName(name string) string {
-	return name + stringid.GenerateNonCryptoID()[:10]
+	return name + stringid.GenerateRandomID()[:10]
 }

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 	})
 
 	It("Podman run --mac-address with custom network", func() {
-		net := "n1" + stringid.GenerateNonCryptoID()
+		net := "n1" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -594,7 +594,7 @@ var _ = Describe("Podman create", func() {
 		pod.WaitWithDefaultTimeout()
 		Expect(pod).Should(Exit(0))
 
-		netName := "pod" + stringid.GenerateNonCryptoID()
+		netName := "pod" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -94,9 +94,9 @@ var _ = Describe("Podman diff", func() {
 	})
 
 	It("podman image diff", func() {
-		file1 := "/" + stringid.GenerateNonCryptoID()
-		file2 := "/" + stringid.GenerateNonCryptoID()
-		file3 := "/" + stringid.GenerateNonCryptoID()
+		file1 := "/" + stringid.GenerateRandomID()
+		file2 := "/" + stringid.GenerateRandomID()
+		file3 := "/" + stringid.GenerateRandomID()
 
 		// Create container image with the files
 		containerfile := fmt.Sprintf(`
@@ -153,8 +153,8 @@ RUN echo test
 	})
 
 	It("podman diff container and image with same name", func() {
-		imagefile := "/" + stringid.GenerateNonCryptoID()
-		confile := "/" + stringid.GenerateNonCryptoID()
+		imagefile := "/" + stringid.GenerateRandomID()
+		confile := "/" + stringid.GenerateRandomID()
 
 		// Create container image with the files
 		containerfile := fmt.Sprintf(`

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -157,9 +157,9 @@ var _ = Describe("Podman events", func() {
 	})
 
 	It("podman events --until future", func() {
-		name1 := stringid.GenerateNonCryptoID()
-		name2 := stringid.GenerateNonCryptoID()
-		name3 := stringid.GenerateNonCryptoID()
+		name1 := stringid.GenerateRandomID()
+		name2 := stringid.GenerateRandomID()
+		name3 := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"create", "--name", name1, ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("bad container name in network disconnect should result in error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -54,7 +54,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("network disconnect with net mode slirp4netns should result in error", func() {
-		netName := "slirp" + stringid.GenerateNonCryptoID()
+		netName := "slirp" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -72,7 +72,8 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -123,7 +124,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("bad container name in network connect should result in error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -135,7 +136,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("network connect with net mode slirp4netns should result in error", func() {
-		netName := "slirp" + stringid.GenerateNonCryptoID()
+		netName := "slirp" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -152,8 +153,8 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(con.ErrorToString()).To(ContainSubstring(`"slirp4netns" is not supported: invalid network mode`))
 	})
 
-	It("podman connect on a container that already is connected to the network should error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+	It("podman connect on a container that already is connected to the network should error after init", func() {
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -176,7 +177,8 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -192,7 +194,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(exec).Should(Exit(0))
 
 		// Create a second network
-		newNetName := "aliasTest" + stringid.GenerateNonCryptoID()
+		newNetName := "aliasTest" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", newNetName, "--subnet", "10.11.100.0/24"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -245,13 +247,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect when not running", func() {
-		netName1 := "connect1" + stringid.GenerateNonCryptoID()
+		netName1 := "connect1" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(netName1)
 
-		netName2 := "connect2" + stringid.GenerateNonCryptoID()
+		netName2 := "connect2" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -284,7 +286,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect and run with network ID", func() {
-		netName := "ID" + stringid.GenerateNonCryptoID()
+		netName := "ID" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -304,7 +306,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(exec).Should(Exit(0))
 
 		// Create a second network
-		newNetName := "ID2" + stringid.GenerateNonCryptoID()
+		newNetName := "ID2" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", newNetName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -331,13 +333,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect when not running", func() {
-		netName1 := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName1 := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(netName1)
 
-		netName2 := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName2 := "aliasTest" + stringid.GenerateRandomID()
 		session2 := podmanTest.Podman([]string{"network", "create", netName2})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(Exit(0))
@@ -376,7 +378,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect and run with network ID", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and subnet", func() {
-		netName := "subnet-" + stringid.GenerateNonCryptoID()
+		netName := "subnet-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ip-range", "10.11.12.0/26", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -85,7 +85,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and IPv6 subnet", func() {
-		netName := "ipv6-" + stringid.GenerateNonCryptoID()
+		netName := "ipv6-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:1:2:3:4::/64", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -124,7 +124,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and IPv6 flag (dual-stack)", func() {
-		netName := "dual-" + stringid.GenerateNonCryptoID()
+		netName := "dual-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:3:2::/64", "--ipv6", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -157,7 +157,7 @@ var _ = Describe("Podman network create", func() {
 
 		// create a second network to check the auto assigned ipv4 subnet does not overlap
 		// https://github.com/containers/podman/issues/11032
-		netName2 := "dual-" + stringid.GenerateNonCryptoID()
+		netName2 := "dual-" + stringid.GenerateRandomID()
 		nc = podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:10:3:2::/64", "--ipv6", netName2})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -205,13 +205,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with ipv4 subnet and ipv6 flag", func() {
-		name := stringid.GenerateNonCryptoID()
+		name := stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
@@ -225,7 +225,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with empty subnet and ipv6 flag", func() {
-		name := stringid.GenerateNonCryptoID()
+		name := stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
@@ -239,19 +239,19 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid IP", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with invalid gateway for subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create two networks with same name should fail", func() {
-		netName := "same-" + stringid.GenerateNonCryptoID()
+		netName := "same-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -263,13 +263,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create two networks with same subnet should fail", func() {
-		netName1 := "sub1-" + stringid.GenerateNonCryptoID()
+		netName1 := "sub1-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName1})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
-		netName2 := "sub2-" + stringid.GenerateNonCryptoID()
+		netName2 := "sub2-" + stringid.GenerateRandomID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName2})
 		ncFail.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -277,13 +277,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create two IPv6 networks with same subnet should fail", func() {
-		netName1 := "subipv61-" + stringid.GenerateNonCryptoID()
+		netName1 := "subipv61-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName1})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
-		netName2 := "subipv62-" + stringid.GenerateNonCryptoID()
+		netName2 := "subipv62-" + stringid.GenerateRandomID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName2})
 		ncFail.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -297,7 +297,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with mtu option", func() {
-		net := "mtu-test" + stringid.GenerateNonCryptoID()
+		net := "mtu-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "mtu=9000", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -310,7 +310,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with vlan option", func() {
-		net := "vlan-test" + stringid.GenerateNonCryptoID()
+		net := "vlan-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "vlan=9", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -323,7 +323,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid option", func() {
-		net := "invalid-test" + stringid.GenerateNonCryptoID()
+		net := "invalid-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "foo=bar", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -332,7 +332,7 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman CNI network create with internal should not have dnsname", func() {
 		SkipIfNetavark(podmanTest)
-		net := "internal-test" + stringid.GenerateNonCryptoID()
+		net := "internal-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--internal", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -350,7 +350,7 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman Netavark network create with internal should have dnsname", func() {
 		SkipIfCNI(podmanTest)
-		net := "internal-test" + stringid.GenerateNonCryptoID()
+		net := "internal-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--internal", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -376,7 +376,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with multiple subnets", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.0.0/24"
 		subnet2 := "10.10.1.0/24"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--subnet", subnet2, name})
@@ -394,7 +394,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with multiple subnets dual stack", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.2.0/24"
 		subnet2 := "fd52:2a5a:747e:3acd::/64"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--subnet", subnet2, name})
@@ -412,7 +412,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with multiple subnets dual stack with gateway and range", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.3.0/24"
 		gw1 := "10.10.3.10"
 		range1 := "10.10.3.0/26"
@@ -437,7 +437,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create invalid options with multiple subnets", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.3.0/24"
 		gw1 := "10.10.3.10"
 		gw2 := "fd52:2a5a:747e:3acd::10"

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter labels", func() {
-		net1 := "labelnet" + stringid.GenerateNonCryptoID()
+		net1 := "labelnet" + stringid.GenerateRandomID()
 		label1 := "testlabel1=abc"
 		label2 := "abcdef"
 		session := podmanTest.Podman([]string{"network", "create", "--label", label1, net1})
@@ -121,7 +121,7 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(net1)
 		Expect(session).Should(Exit(0))
 
-		net2 := "labelnet" + stringid.GenerateNonCryptoID()
+		net2 := "labelnet" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", "--label", label1, "--label", label2, net2})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net2)
@@ -141,7 +141,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter invalid value", func() {
-		net := "net" + stringid.GenerateNonCryptoID()
+		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -274,7 +274,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container single CNI network", func() {
-		netName := "net-" + stringid.GenerateNonCryptoID()
+		netName := "net-" + stringid.GenerateRandomID()
 		network := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.50.0/24", netName})
 		network.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -304,13 +304,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container two CNI networks (container not running)", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		network1 := podmanTest.Podman([]string{"network", "create", netName1})
 		network1.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		network2 := podmanTest.Podman([]string{"network", "create", netName2})
 		network2.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -341,13 +341,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container two CNI networks", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		network1 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.0/25", netName1})
 		network1.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		network2 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.128/26", netName2})
 		network2.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -383,7 +383,7 @@ var _ = Describe("Podman network", func() {
 
 	It("podman network remove after disconnect when container initially created with the network", func() {
 		container := "test"
-		network := "foo" + stringid.GenerateNonCryptoID()
+		network := "foo" + stringid.GenerateRandomID()
 
 		session := podmanTest.Podman([]string{"network", "create", network})
 		session.WaitWithDefaultTimeout()
@@ -410,7 +410,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove --force with pod", func() {
-		netName := "net-" + stringid.GenerateNonCryptoID()
+		netName := "net-" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -446,13 +446,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove with two networks", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(session).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -571,7 +571,7 @@ var _ = Describe("Podman network", func() {
 	It("podman network create/remove macvlan", func() {
 		// Netavark currently does not do dhcp so the this test fails
 		SkipIfNetavark(podmanTest)
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -585,7 +585,7 @@ var _ = Describe("Podman network", func() {
 	It("podman network create/remove macvlan as driver (-d) no device name", func() {
 		// Netavark currently does not do dhcp so the this test fails
 		SkipIfNetavark(podmanTest)
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -612,7 +612,7 @@ var _ = Describe("Podman network", func() {
 	It("podman network create/remove macvlan as driver (-d) with device name", func() {
 		// Netavark currently does not do dhcp so the this test fails
 		SkipIfNetavark(podmanTest)
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -639,7 +639,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network exists", func() {
-		net := "net" + stringid.GenerateNonCryptoID()
+		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -649,13 +649,13 @@ var _ = Describe("Podman network", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateNonCryptoID()})
+		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(1))
 	})
 
 	It("podman network create macvlan with network info and options", func() {
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", "-o", "mtu=1500", "--gateway", "192.168.1.254", "--subnet", "192.168.1.0/24", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -691,7 +691,7 @@ var _ = Describe("Podman network", func() {
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
 		}
-		net1 := "macvlan" + stringid.GenerateNonCryptoID() + "net1"
+		net1 := "macvlan" + stringid.GenerateRandomID() + "net1"
 
 		nc := podmanTest.Podman([]string{"network", "create", net1})
 		nc.WaitWithDefaultTimeout()
@@ -744,7 +744,7 @@ var _ = Describe("Podman network", func() {
 		// Run a container on one of them
 		// Network Prune
 		// Check that one has been pruned, other remains
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		net1 := net + "1"
 		net2 := net + "2"
 		nc := podmanTest.Podman([]string{"network", "create", net1})

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2187,7 +2187,7 @@ spec:
 		err := generateKubeYaml("deployment", deployment, kubeYaml)
 		Expect(err).To(BeNil())
 
-		net := "playkube" + stringid.GenerateNonCryptoID()
+		net := "playkube" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.31.0/24", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -2229,8 +2229,8 @@ spec:
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
-		net1 := "net1" + stringid.GenerateNonCryptoID()
-		net2 := "net2" + stringid.GenerateNonCryptoID()
+		net1 := "net1" + stringid.GenerateRandomID()
+		net2 := "net2" + stringid.GenerateRandomID()
 
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "10.0.11.0/24", net1})
 		net.WaitWithDefaultTimeout()

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman pod ps filter network", func() {
-		net := stringid.GenerateNonCryptoID()
+		net := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -334,12 +334,12 @@ var _ = Describe("Podman ps", func() {
 			Expect(session.OutputToString()).To(Equal("podman"))
 		}
 
-		net1 := stringid.GenerateNonCryptoID()
+		net1 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(net1)
-		net2 := stringid.GenerateNonCryptoID()
+		net2 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -818,7 +818,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps filter network", func() {
-		net := stringid.GenerateNonCryptoID()
+		net := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -861,12 +861,12 @@ var _ = Describe("Podman ps", func() {
 			Expect(actual).To(Equal("podman"))
 		}
 
-		net1 := stringid.GenerateNonCryptoID()
+		net1 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(net1)
-		net2 := stringid.GenerateNonCryptoID()
+		net2 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -702,7 +702,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run in custom CNI network with --static-ip", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		ipAddr := "10.25.30.128"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
 		create.WaitWithDefaultTimeout()
@@ -717,7 +717,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	It("podman CNI network works across user ns", func() {
 		SkipIfNetavark(podmanTest)
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		create := podmanTest.Podman([]string{"network", "create", netName})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
@@ -766,7 +766,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run with new:pod and static-ip", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		ipAddr := "10.25.40.128"
 		podname := "testpod"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})
@@ -954,7 +954,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	// see https://github.com/containers/podman/issues/12972
 	It("podman run check network-alias works on networks without dns", func() {
-		net := "dns" + stringid.GenerateNonCryptoID()
+		net := "dns" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", "--disable-dns", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with specified static IPv6 has correct IP", func() {
-		netName := "ipv6-" + stringid.GenerateNonCryptoID()
+		netName := "ipv6-" + stringid.GenerateRandomID()
 		ipv6 := "fd46:db93:aa76:ac37::10"
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "fd46:db93:aa76:ac37::/64", netName})
 		net.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Podman run", func() {
 	It("podman run a container with a --rootfs", func() {
 		rootfs := filepath.Join(tempdir, "rootfs")
 		uls := filepath.Join("/", "usr", "local", "share")
-		uniqueString := stringid.GenerateNonCryptoID()
+		uniqueString := stringid.GenerateRandomID()
 		testFilePath := filepath.Join(uls, uniqueString)
 		tarball := filepath.Join(tempdir, "rootfs.tar")
 

--- a/test/e2e/volume_exists_test.go
+++ b/test/e2e/volume_exists_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman volume exists", func() {
 	})
 
 	It("podman volume exists", func() {
-		vol := "vol" + stringid.GenerateNonCryptoID()
+		vol := "vol" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"volume", "create", vol})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -44,7 +44,7 @@ var _ = Describe("Podman volume exists", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateNonCryptoID()})
+		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(1))
 	})


### PR DESCRIPTION
Cherry-pick #15788 to v4.0-rhel branch per RHBZ 2157930

In view of https://github.com/containers/storage/pull/1337, do this:

	for f in $(git grep -l stringid.GenerateNonCryptoID | grep -v '^vendor/'); do
		sed -i 's/stringid.GenerateNonCryptoID/stringid.GenerateRandomID/g' $f;
	done

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
