### PR TITLE
system tests: minor fix for RHEL8 incompatibility

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -78,14 +78,20 @@ function service_setup() {
         local activestate="inactive"
     fi
 
+    echo "$_LOG_PROMPT systemctl $startargs start $service"
     run systemctl $startargs start "$service"
-    assert $status -eq 0 "Error starting systemd unit $service: $output"
+    echo "$output"
+    assert $status -eq 0 "Error starting systemd unit $service"
 
+    echo "$_LOG_PROMPT systemctl status $service"
     run systemctl status "$service"
-    assert $status -eq $statusexit "systemctl status $service: $output"
+    echo "$output"
+    assert $status -eq $statusexit "systemctl status $service"
 
-    run systemctl show -P ActiveState "$service"
-    assert $status -eq 0 "systemctl show $service: $output"
+    echo "$_LOG_PROMPT systemctl show --value --property=ActiveState $service"
+    run systemctl show --value --property=ActiveState "$service"
+    echo "$output"
+    assert $status -eq 0 "systemctl show $service"
     is "$output" $activestate
 }
 


### PR DESCRIPTION
quadlet tests were using 'systemctl show -P', a shortcut
that doesn't exist on RHEL8. Translate to old-systemd
language.

And, minor tweaks to make future test diagnosing easier.

This is a frontport of #17311; bringing from release branch
to main. Except that was an emergency, so it was a one-line
fix. This is a better long-term fix, not as trivial to review.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```