### PR TITLE
[v3.4.2-rhel] all: stop using deprecated GenerateNonCryptoID

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -179,7 +179,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 	}
 
 	// Generate an ID for our new exec session
-	sessionID := stringid.GenerateNonCryptoID()
+	sessionID := stringid.GenerateRandomID()
 	found := true
 	// This really ought to be a do-while, but Go doesn't have those...
 	for found {
@@ -191,7 +191,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 			}
 		}
 		if found {
-			sessionID = stringid.GenerateNonCryptoID()
+			sessionID = stringid.GenerateRandomID()
 		}
 	}
 

--- a/libpod/network/cni/run_test.go
+++ b/libpod/network/cni/run_test.go
@@ -122,7 +122,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {InterfaceName: intName},
 						},
@@ -152,7 +152,7 @@ var _ = Describe("run CNI", func() {
 				ip := net.ParseIP("10.88.5.5")
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -183,12 +183,12 @@ var _ = Describe("run CNI", func() {
 			protocol := proto
 			It("run with exposed ports protocol "+protocol, func() {
 				runTest(func() {
-					testdata := stringid.GenerateNonCryptoID()
+					testdata := stringid.GenerateRandomID()
 					defNet := types.DefaultNetworkName
 					intName := "eth0"
 					setupOpts := types.SetupOptions{
 						NetworkOptions: types.NetworkOptions{
-							ContainerID: stringid.GenerateNonCryptoID(),
+							ContainerID: stringid.GenerateRandomID(),
 							PortMappings: []types.PortMapping{{
 								Protocol:      protocol,
 								HostIP:        "127.0.0.1",
@@ -241,7 +241,7 @@ var _ = Describe("run CNI", func() {
 					intName := "eth0"
 					setupOpts := types.SetupOptions{
 						NetworkOptions: types.NetworkOptions{
-							ContainerID: stringid.GenerateNonCryptoID(),
+							ContainerID: stringid.GenerateRandomID(),
 							PortMappings: []types.PortMapping{{
 								Protocol:      protocol,
 								HostIP:        "127.0.0.1",
@@ -272,7 +272,7 @@ var _ = Describe("run CNI", func() {
 						port := p
 						var wg sync.WaitGroup
 						wg.Add(1)
-						testdata := stringid.GenerateNonCryptoID()
+						testdata := stringid.GenerateRandomID()
 						// start a listener in the container ns
 						err = netNSContainer.Do(func(_ ns.NetNS) error {
 							defer GinkgoRecover()
@@ -303,7 +303,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      "tcp,udp",
 							HostIP:        "127.0.0.1",
@@ -328,7 +328,7 @@ var _ = Describe("run CNI", func() {
 					// copy proto to extra var to keep correct references in the goroutines
 					protocol := proto
 
-					testdata := stringid.GenerateNonCryptoID()
+					testdata := stringid.GenerateRandomID()
 					var wg sync.WaitGroup
 					wg.Add(1)
 					// start tcp listener in the container ns
@@ -363,7 +363,7 @@ var _ = Describe("run CNI", func() {
 				intName1 := "eth0"
 				netName1 := network1.Name
 
-				containerID := stringid.GenerateNonCryptoID()
+				containerID := stringid.GenerateRandomID()
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
@@ -554,7 +554,7 @@ var _ = Describe("run CNI", func() {
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName1: {
 								InterfaceName: intName1,
@@ -681,7 +681,7 @@ var _ = Describe("run CNI", func() {
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
 						ContainerName: "mycon",
-						ContainerID:   stringid.GenerateNonCryptoID(),
+						ContainerID:   stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: interfaceName,
@@ -778,7 +778,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: intName,
@@ -865,7 +865,7 @@ var _ = Describe("run CNI", func() {
 				netName := "dualstack"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID:   stringid.GenerateNonCryptoID(),
+						ContainerID:   stringid.GenerateRandomID(),
 						ContainerName: containerName,
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
@@ -973,7 +973,7 @@ var _ = Describe("run CNI", func() {
 				ip := "1.1.1.1"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -994,7 +994,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1014,7 +1014,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1054,7 +1054,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: intName,
@@ -1073,7 +1073,7 @@ var _ = Describe("run CNI", func() {
 			runTest(func() {
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 					},
 				}
 				_, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
@@ -1087,7 +1087,7 @@ var _ = Describe("run CNI", func() {
 				defNet := types.DefaultNetworkName
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {
 								InterfaceName: "",
@@ -1128,7 +1128,7 @@ var _ = Describe("run CNI", func() {
 
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName1: {
 								InterfaceName: intName1,
@@ -1173,7 +1173,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      "someproto",
 							HostIP:        "127.0.0.1",
@@ -1197,7 +1197,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						PortMappings: []types.PortMapping{{
 							Protocol:      "",
 							HostIP:        "127.0.0.1",
@@ -1221,7 +1221,7 @@ var _ = Describe("run CNI", func() {
 				intName := "eth0"
 				setupOpts := types.SetupOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							defNet: {InterfaceName: intName},
 						},
@@ -1239,7 +1239,7 @@ var _ = Describe("run CNI", func() {
 				netName := "somenet"
 				teardownOpts := types.TeardownOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: interfaceName,
@@ -1266,7 +1266,7 @@ var _ = Describe("run CNI", func() {
 				netName := network1.Name
 				teardownOpts := types.TeardownOptions{
 					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
+						ContainerID: stringid.GenerateRandomID(),
 						Networks: map[string]types.PerNetworkOptions{
 							netName: {
 								InterfaceName: interfaceName,

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -17,7 +17,7 @@ import (
 func newPod(runtime *Runtime) *Pod {
 	pod := new(Pod)
 	pod.config = new(PodConfig)
-	pod.config.ID = stringid.GenerateNonCryptoID()
+	pod.config.ID = stringid.GenerateRandomID()
 	pod.config.Labels = make(map[string]string)
 	pod.config.CreatedTime = time.Now()
 	//	pod.config.InfraContainer = new(ContainerConfig)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -169,7 +169,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 	ctr.state = new(ContainerState)
 
 	if config == nil {
-		ctr.config.ID = stringid.GenerateNonCryptoID()
+		ctr.config.ID = stringid.GenerateRandomID()
 		size, err := units.FromHumanSize(r.config.Containers.ShmSize)
 		if err != nil {
 			return nil, errors.Wrapf(err, "converting containers.conf ShmSize %s to an int", r.config.Containers.ShmSize)
@@ -186,7 +186,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		}
 		// If the ID is empty a new name for the restored container was requested
 		if ctr.config.ID == "" {
-			ctr.config.ID = stringid.GenerateNonCryptoID()
+			ctr.config.ID = stringid.GenerateRandomID()
 			// Fixup ExitCommand with new ID
 			ctr.config.ExitCommand[len(ctr.config.ExitCommand)-1] = ctr.config.ID
 		}
@@ -435,7 +435,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		if vol.Name == "" {
 			// Anonymous volume. We'll need to create it.
 			// It needs a name first.
-			vol.Name = stringid.GenerateNonCryptoID()
+			vol.Name = stringid.GenerateRandomID()
 			isAnonymous = true
 		} else {
 			// Check if it exists already

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -40,7 +40,7 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	}
 
 	if volume.config.Name == "" {
-		volume.config.Name = stringid.GenerateNonCryptoID()
+		volume.config.Name = stringid.GenerateRandomID()
 	}
 	if volume.config.Driver == "" {
 		volume.config.Driver = define.VolumeDriverLocal

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -291,7 +291,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	}
 	if remote {
 		p.PodmanTest.RemotePodmanBinary = podmanRemoteBinary
-		uuid := stringid.GenerateNonCryptoID()
+		uuid := stringid.GenerateRandomID()
 		if !rootless.IsRootless() {
 			p.RemoteSocket = fmt.Sprintf("unix:/run/podman/podman-%s.sock", uuid)
 		} else {
@@ -785,7 +785,7 @@ func removeConf(confPath string) {
 // it returns the network name and the filepath
 func generateNetworkConfig(p *PodmanTestIntegration) (string, string) {
 	// generate a random name to prevent conflicts with other tests
-	name := "net" + stringid.GenerateNonCryptoID()
+	name := "net" + stringid.GenerateRandomID()
 	path := filepath.Join(p.CNIConfigDir, fmt.Sprintf("%s.conflist", name))
 	conf := fmt.Sprintf(`{
 		"cniVersion": "0.3.0",

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 	})
 
 	It("Podman run --mac-address with custom network", func() {
-		net := "n1" + stringid.GenerateNonCryptoID()
+		net := "n1" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -601,7 +601,7 @@ var _ = Describe("Podman create", func() {
 		pod.WaitWithDefaultTimeout()
 		Expect(pod).Should(Exit(0))
 
-		netName := "pod" + stringid.GenerateNonCryptoID()
+		netName := "pod" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -94,9 +94,9 @@ var _ = Describe("Podman diff", func() {
 	})
 
 	It("podman image diff", func() {
-		file1 := "/" + stringid.GenerateNonCryptoID()
-		file2 := "/" + stringid.GenerateNonCryptoID()
-		file3 := "/" + stringid.GenerateNonCryptoID()
+		file1 := "/" + stringid.GenerateRandomID()
+		file2 := "/" + stringid.GenerateRandomID()
+		file3 := "/" + stringid.GenerateRandomID()
 
 		// Create container image with the files
 		containerfile := fmt.Sprintf(`
@@ -153,8 +153,8 @@ RUN echo test
 	})
 
 	It("podman diff container and image with same name", func() {
-		imagefile := "/" + stringid.GenerateNonCryptoID()
-		confile := "/" + stringid.GenerateNonCryptoID()
+		imagefile := "/" + stringid.GenerateRandomID()
+		confile := "/" + stringid.GenerateRandomID()
 
 		// Create container image with the files
 		containerfile := fmt.Sprintf(`

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -152,9 +152,9 @@ var _ = Describe("Podman events", func() {
 	})
 
 	It("podman events --until future", func() {
-		name1 := stringid.GenerateNonCryptoID()
-		name2 := stringid.GenerateNonCryptoID()
-		name3 := stringid.GenerateNonCryptoID()
+		name1 := stringid.GenerateRandomID()
+		name2 := stringid.GenerateRandomID()
+		name3 := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"create", "--name", name1, ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("bad container name in network disconnect should result in error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -53,7 +53,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 
 	It("network disconnect with net mode slirp4netns should result in error", func() {
 		SkipIfRootless("network connect and disconnect are only rootful")
-		netName := "slirp" + stringid.GenerateNonCryptoID()
+		netName := "slirp" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -71,7 +71,8 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -107,7 +108,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("bad container name in network connect should result in error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -120,7 +121,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 
 	It("network connect with net mode slirp4netns should result in error", func() {
 		SkipIfRootless("network connect and disconnect are only rootful")
-		netName := "slirp" + stringid.GenerateNonCryptoID()
+		netName := "slirp" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -137,8 +138,8 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(con.ErrorToString()).To(ContainSubstring(`"slirp4netns" is not supported: invalid network mode`))
 	})
 
-	It("podman connect on a container that already is connected to the network should error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+	It("podman connect on a container that already is connected to the network should error after init", func() {
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -155,7 +156,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 
 	It("podman network connect", func() {
 		SkipIfRemote("This requires a pending PR to be merged before it will work")
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -170,7 +171,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(exec).Should(Exit(0))
 
 		// Create a second network
-		newNetName := "aliasTest" + stringid.GenerateNonCryptoID()
+		newNetName := "aliasTest" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", newNetName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -199,13 +200,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect when not running", func() {
-		netName1 := "connect1" + stringid.GenerateNonCryptoID()
+		netName1 := "connect1" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeCNINetwork(netName1)
 
-		netName2 := "connect2" + stringid.GenerateNonCryptoID()
+		netName2 := "connect2" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -238,7 +239,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect and run with network ID", func() {
-		netName := "ID" + stringid.GenerateNonCryptoID()
+		netName := "ID" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -258,7 +259,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(exec).Should(Exit(0))
 
 		// Create a second network
-		newNetName := "ID2" + stringid.GenerateNonCryptoID()
+		newNetName := "ID2" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", newNetName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -285,13 +286,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect when not running", func() {
-		netName1 := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName1 := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeCNINetwork(netName1)
 
-		netName2 := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName2 := "aliasTest" + stringid.GenerateRandomID()
 		session2 := podmanTest.Podman([]string{"network", "create", netName2})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(Exit(0))
@@ -324,7 +325,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect and run with network ID", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Podman network create", func() {
 			results []network.NcList
 		)
 
-		netName := "inspectnet-" + stringid.GenerateNonCryptoID()
+		netName := "inspectnet-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -138,7 +138,7 @@ var _ = Describe("Podman network create", func() {
 		var (
 			results []network.NcList
 		)
-		netName := "subnet-" + stringid.GenerateNonCryptoID()
+		netName := "subnet-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -181,7 +181,7 @@ var _ = Describe("Podman network create", func() {
 		var (
 			results []network.NcList
 		)
-		netName := "ipv6-" + stringid.GenerateNonCryptoID()
+		netName := "ipv6-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:1:2:3:4::/64", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -222,7 +222,7 @@ var _ = Describe("Podman network create", func() {
 		var (
 			results []network.NcList
 		)
-		netName := "dual-" + stringid.GenerateNonCryptoID()
+		netName := "dual-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:3:2:1::/64", "--ipv6", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -261,7 +261,7 @@ var _ = Describe("Podman network create", func() {
 
 		// create a second network to check the auto assigned ipv4 subnet does not overlap
 		// https://github.com/containers/podman/issues/11032
-		netName2 := "dual-" + stringid.GenerateNonCryptoID()
+		netName2 := "dual-" + stringid.GenerateRandomID()
 		nc = podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:6:3:2:1::/64", "--ipv6", netName2})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName2)
@@ -315,37 +315,37 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with ipv4 subnet and ipv6 flag", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ipv6", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ipv6", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with empty subnet and ipv6 flag", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--ipv6", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--ipv6", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with invalid IP", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with invalid gateway for subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create two networks with same name should fail", func() {
-		netName := "same-" + stringid.GenerateNonCryptoID()
+		netName := "same-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -357,13 +357,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create two networks with same subnet should fail", func() {
-		netName1 := "sub1-" + stringid.GenerateNonCryptoID()
+		netName1 := "sub1-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName1})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
-		netName2 := "sub2-" + stringid.GenerateNonCryptoID()
+		netName2 := "sub2-" + stringid.GenerateRandomID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName2})
 		ncFail.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName2)
@@ -372,13 +372,13 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman network create two IPv6 networks with same subnet should fail", func() {
 		SkipIfRootless("FIXME It needs the ip6tables modules loaded")
-		netName1 := "subipv61-" + stringid.GenerateNonCryptoID()
+		netName1 := "subipv61-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName1})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
-		netName2 := "subipv62-" + stringid.GenerateNonCryptoID()
+		netName2 := "subipv62-" + stringid.GenerateRandomID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName2})
 		ncFail.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName2)
@@ -392,7 +392,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with mtu option", func() {
-		net := "mtu-test" + stringid.GenerateNonCryptoID()
+		net := "mtu-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "mtu=9000", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -405,7 +405,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with vlan option", func() {
-		net := "vlan-test" + stringid.GenerateNonCryptoID()
+		net := "vlan-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "vlan=9", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -418,7 +418,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid option", func() {
-		net := "invalid-test" + stringid.GenerateNonCryptoID()
+		net := "invalid-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "foo=bar", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -426,7 +426,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with internal should not have dnsname", func() {
-		net := "internal-test" + stringid.GenerateNonCryptoID()
+		net := "internal-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--internal", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -441,5 +441,4 @@ var _ = Describe("Podman network create", func() {
 		Expect(nc).Should(Exit(0))
 		Expect(nc.OutputToString()).ToNot(ContainSubstring("dnsname"))
 	})
-
 })

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter labels", func() {
-		net1 := "labelnet" + stringid.GenerateNonCryptoID()
+		net1 := "labelnet" + stringid.GenerateRandomID()
 		label1 := "testlabel1=abc"
 		label2 := "abcdef"
 		session := podmanTest.Podman([]string{"network", "create", "--label", label1, net1})
@@ -100,7 +100,7 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeCNINetwork(net1)
 		Expect(session).Should(Exit(0))
 
-		net2 := "labelnet" + stringid.GenerateNonCryptoID()
+		net2 := "labelnet" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", "--label", label1, "--label", label2, net2})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net2)
@@ -120,7 +120,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter invalid value", func() {
-		net := "net" + stringid.GenerateNonCryptoID()
+		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -246,7 +246,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container single CNI network", func() {
-		netName := "net-" + stringid.GenerateNonCryptoID()
+		netName := "net-" + stringid.GenerateRandomID()
 		network := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.50.0/24", netName})
 		network.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -276,13 +276,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container two CNI networks (container not running)", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		network1 := podmanTest.Podman([]string{"network", "create", netName1})
 		network1.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		network2 := podmanTest.Podman([]string{"network", "create", netName2})
 		network2.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName2)
@@ -313,13 +313,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container two CNI networks", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		network1 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.0/25", netName1})
 		network1.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		network2 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.128/26", netName2})
 		network2.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName2)
@@ -383,7 +383,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove --force with pod", func() {
-		netName := "net-" + stringid.GenerateNonCryptoID()
+		netName := "net-" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
@@ -419,13 +419,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove with two networks", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName1)
 		Expect(session).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName2)
@@ -490,7 +490,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan", func() {
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -502,7 +502,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan as driver (-d) no device name", func() {
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -522,7 +522,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan as driver (-d) with device name", func() {
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -546,7 +546,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network exists", func() {
-		net := "net" + stringid.GenerateNonCryptoID()
+		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -556,13 +556,13 @@ var _ = Describe("Podman network", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateNonCryptoID()})
+		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(1))
 	})
 
 	It("podman network create macvlan with network info and options", func() {
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", "-o", "mtu=1500", "--gateway", "192.168.1.254", "--subnet", "192.168.1.0/24", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -606,7 +606,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network prune --filter", func() {
-		net1 := "macvlan" + stringid.GenerateNonCryptoID() + "net1"
+		net1 := "macvlan" + stringid.GenerateRandomID() + "net1"
 
 		nc := podmanTest.Podman([]string{"network", "create", net1})
 		nc.WaitWithDefaultTimeout()
@@ -657,7 +657,7 @@ var _ = Describe("Podman network", func() {
 		// Run a container on one of them
 		// Network Prune
 		// Check that one has been pruned, other remains
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		net1 := net + "1"
 		net2 := net + "2"
 		nc := podmanTest.Podman([]string{"network", "create", net1})

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2004,7 +2004,7 @@ spec:
 		err := generateKubeYaml("deployment", deployment, kubeYaml)
 		Expect(err).To(BeNil())
 
-		net := "playkube" + stringid.GenerateNonCryptoID()
+		net := "playkube" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.31.0/24", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman pod ps filter network", func() {
-		net := stringid.GenerateNonCryptoID()
+		net := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -334,12 +334,12 @@ var _ = Describe("Podman ps", func() {
 			Expect(session.OutputToString()).To(Equal("podman"))
 		}
 
-		net1 := stringid.GenerateNonCryptoID()
+		net1 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeCNINetwork(net1)
-		net2 := stringid.GenerateNonCryptoID()
+		net2 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -819,7 +819,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps filter network", func() {
-		net := stringid.GenerateNonCryptoID()
+		net := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -862,12 +862,12 @@ var _ = Describe("Podman ps", func() {
 			Expect(actual).To(Equal("podman"))
 		}
 
-		net1 := stringid.GenerateNonCryptoID()
+		net1 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeCNINetwork(net1)
-		net2 := stringid.GenerateNonCryptoID()
+		net2 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -649,7 +649,7 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run in custom CNI network with --static-ip", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		ipAddr := "10.25.30.128"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
 		create.WaitWithDefaultTimeout()
@@ -663,7 +663,7 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman cni network works across user ns", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		create := podmanTest.Podman([]string{"network", "create", netName})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
@@ -687,7 +687,7 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run with new:pod and static-ip", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		ipAddr := "10.25.40.128"
 		podname := "testpod"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})
@@ -766,7 +766,7 @@ var _ = Describe("Podman run networking", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		net := "IntTest" + stringid.GenerateNonCryptoID()
+		net := "IntTest" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)
@@ -796,7 +796,7 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run check dnsname adds dns search domain", func() {
-		net := "dnsname" + stringid.GenerateNonCryptoID()
+		net := "dnsname" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(net)

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Podman run", func() {
 	It("podman run a container with a --rootfs", func() {
 		rootfs := filepath.Join(tempdir, "rootfs")
 		uls := filepath.Join("/", "usr", "local", "share")
-		uniqueString := stringid.GenerateNonCryptoID()
+		uniqueString := stringid.GenerateRandomID()
 		testFilePath := filepath.Join(uls, uniqueString)
 		tarball := filepath.Join(tempdir, "rootfs.tar")
 

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -90,7 +90,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))
-		Expect(search.LineInOutputContains("docker.io/library/alpine")).To(BeTrue())
+		Expect(search.OutputToString()).To(ContainSubstring("alpine"))
 	})
 
 	It("podman search single registry flag", func() {
@@ -126,13 +126,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json list tags", func() {
-		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
-		Expect(search.IsJSONOutputValid()).To(BeTrue())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
-		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
-		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
+		Expect(search.OutputToString()).To(BeValidJSON())
+		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.2"))
 	})
 
 	It("podman search no-trunc flag", func() {

--- a/test/e2e/volume_exists_test.go
+++ b/test/e2e/volume_exists_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman volume exists", func() {
 	})
 
 	It("podman volume exists", func() {
-		vol := "vol" + stringid.GenerateNonCryptoID()
+		vol := "vol" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"volume", "create", vol})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -44,7 +44,7 @@ var _ = Describe("Podman volume exists", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateNonCryptoID()})
+		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(1))
 	})


### PR DESCRIPTION
Cherry-pick #15788 to v3.4.2-rhel branch per RHBZ 2157930

In view of https://github.com/containers/storage/pull/1337, do this:

	for f in $(git grep -l stringid.GenerateNonCryptoID | grep -v '^vendor/'); do
		sed -i 's/stringid.GenerateNonCryptoID/stringid.GenerateRandomID/g' $f;
	done

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
