### PR TITLE
make hack/markdown-preprocess parallel-safe

### DIFF
--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -70,7 +70,7 @@ class Preprocessor():
         cross-referencing all the man pages in which they're used.
         """
         for optionfile in self.used_by:
-            tmpfile = optionfile + '.tmp'
+            tmpfile = optionfile + '.tmp.' + str(os.getpid())
             with open(optionfile, 'r', encoding='utf-8') as fh_in, open(tmpfile, 'w', encoding='utf-8', newline='\n') as fh_out:
                 fh_out.write("####> This option file is used in:\n")
                 used_by = ', '.join(x for x in self.used_by[optionfile])


### PR DESCRIPTION
One of the tmpfiles was not uniquely named, resulting in
conflicts with parallel 'make docs'. Fix that.

A better solution would be to run only one instance of the
preprocess script, but the Makefile incantation for that
is beyond me. This approach is CPU-wasteful but good enough.

Fixes: #17322

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Fixes a bug in which parallel `make docs` crashed
```