### PR TITLE
[CI:DOCS] docs/podman-systemd.unit: Update example to work out of the box + Explicitely mention '.network' units

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -551,12 +551,14 @@ Example `test.container`:
 ```
 [Unit]
 Description=A minimal container
-Before=local-fs.target
 
 [Container]
 # Use the centos image
 Image=quay.io/centos/centos:latest
+
+# Use volume and network defined below
 Volume=test.volume:/data
+Network=test.network
 
 # In the container we just run sleep
 Exec=sleep 60
@@ -589,7 +591,7 @@ Example `test.volume`:
 ```
 [Volume]
 User=root
-Group=projectname
+Group=root
 Label=org.test.Key=value
 ```
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -6,7 +6,7 @@ podman\-systemd.unit - systemd units using Podman quadlet
 
 ## SYNOPSIS
 
-*name*.container, *name*.volume
+*name*.container, *name*.volume, *name*.network, `*.kube`
 
 ### Podman unit search path
 
@@ -26,8 +26,10 @@ These files are read during boot (and when `systemctl daemon-reload` is run) and
 corresponding regular systemd service unit files. Both system and user systemd units are supported.
 
 The Podman generator reads the search paths above and reads files with the extensions `.container`
-and `.volume`, and for each file generates a similarly named `.service` file. These units can be started
-and managed with systemctl like any other systemd service.
+`.volume` and `*.kube`, and for each file generates a similarly named `.service` file. These units
+can be started and managed with systemctl like any other systemd service.
+
+Files with the `.network` extension are only read if they are mentioned in a `.container` file. See the `Network=` key.
 
 The Podman files use the same format as [regular systemd unit files](https://www.freedesktop.org/software/systemd/man/systemd.syntax.html).
 Each file type has a custom section (for example, `[Container]`) that is handled by Podman, and all


### PR DESCRIPTION
docs/podman-systemd.unit: Update example to work out of the box

- Don't order the container unit before local-fs.target as that creates
  an ordering cycle that triggers other issues.
- Use the example network in the container unit
- Only use groups that exists by default for the volume

Signed-off-by: Timothée Ravier <tim@siosm.fr>

---

docs/podman-systemd.unit: Explicitely mention '.network' units

Make the relation between '.container' and '.network' units more
explicit at the beginning.

Signed-off-by: Timothée Ravier <tim@siosm.fr>

---

#### Does this PR introduce a user-facing change?

No, docs only.

```release-note
None
```
