### PR TITLE
Move `clean-binaries` before `podman-remote` in podman-remote-docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,7 +490,8 @@ docs: $(MANPAGES) ## Generate documentation
 # in addition to the target-architecture binary (if different). That's
 # what the NATIVE_GOOS make does in the first line.
 podman-remote-%-docs: podman-remote
-	$(MAKE) clean-binaries podman-remote GOOS=$(NATIVE_GOOS) GOARCH=$(NATIVE_GOARCH)
+	$(MAKE) clean-binaries
+	$(MAKE) podman-remote GOOS=$(NATIVE_GOOS) GOARCH=$(NATIVE_GOARCH)
 	$(eval GOOS := $*)
 	$(MAKE) docs $(MANPAGES)
 	rm -rf docs/build/remote


### PR DESCRIPTION
When run make with muitiple jobs, `clean-binaries` could run after the `podman-remote` target thus delete the newly built `podman-remote` binary file. And this would cause the error later in the `docs/remote-docs.sh` script.

I feel like build podman-remote here is unnecessary, make should build it automatically if it's changed.
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
