### PR TITLE
network ls: handle removed container

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -74,6 +74,9 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network *netty
 	for _, con := range cons {
 		data, err := con.Inspect(false)
 		if err != nil {
+			if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved) {
+				continue
+			}
 			return nil, err
 		}
 		if netData, ok := data.NetworkSettings.Networks[network.Name]; ok {


### PR DESCRIPTION
Handle a race condition in the REST API when listing networks. In between listing all containers and inspecting them, they may have already been removed, so handle this case gracefully.

[NO TESTS NEEDED] as it's a race condition.

Fixes: #17341
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the REST API when listing networks while a container has just been removed.
```
