### PR TITLE
Fix a potential UID/GID collision in unit tests

### DIFF
--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -15,7 +15,7 @@ func TestGenerateUserPasswdEntry(t *testing.T) {
 		config: &ContainerConfig{
 			Spec: &spec.Spec{},
 			ContainerSecurityConfig: ContainerSecurityConfig{
-				User: "123:456",
+				User: "123456:456789",
 			},
 		},
 		state: &ContainerState{
@@ -26,14 +26,14 @@ func TestGenerateUserPasswdEntry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, user, "123:*:123:456:container user:/:/bin/sh\n")
+	assert.Equal(t, user, "123456:*:123456:456789:container user:/:/bin/sh\n")
 
-	c.config.User = "567"
+	c.config.User = "567890"
 	user, err = c.generateUserPasswdEntry(0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, user, "567:*:567:0:container user:/:/bin/sh\n")
+	assert.Equal(t, user, "567890:*:567890:0:container user:/:/bin/sh\n")
 }
 
 func TestGenerateUserGroupEntry(t *testing.T) {
@@ -41,7 +41,7 @@ func TestGenerateUserGroupEntry(t *testing.T) {
 		config: &ContainerConfig{
 			Spec: &spec.Spec{},
 			ContainerSecurityConfig: ContainerSecurityConfig{
-				User: "123:456",
+				User: "123456:456789",
 			},
 		},
 		state: &ContainerState{
@@ -52,12 +52,12 @@ func TestGenerateUserGroupEntry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, group, "456:x:456:123\n")
+	assert.Equal(t, group, "456789:x:456789:123456\n")
 
-	c.config.User = "567"
+	c.config.User = "567890"
 	group, err = c.generateUserGroupEntry(0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, group, "567:x:567:567\n")
+	assert.Equal(t, group, "567890:x:567890:567890\n")
 }


### PR DESCRIPTION
The tests for generating username/passwd entries assume that UID/GID 123/456 do not exist, which is not a safe assumption on Debian. If a /etc/passwd entry with that UID/GID already exists, the test will not add a new one with the same UID/GID, and will fail. Change UID and GID to be 6 digits, because we're a lot less likely to collide with UIDs and GIDs in use on the system that way. Could also go further and randomly generate the UID/GID, but that feels like overkill.

Fixes #17366

```release-note
NONE
```
