### PR TITLE
tests: pasta: Mitigation for socat connect() getting EINTR and two other fixes

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -660,6 +660,7 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - ICMPv6 echo request" {
+    skip "Unsupported test, see the 'Local forwarder, IPv6' case for details"
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     local minuid=$(cut -f1 /proc/sys/net/ipv4/ping_group_range)
@@ -669,8 +670,8 @@ function teardown() {
         skip "ICMPv6 echo sockets not available for this UID"
     fi
 
-    run_podman run --net=pasta $IMAGE ping -6 -c3 -W1 \
-        sh -c 'ping -c3 -W1 sed -nr "s/^nameserver[ ]{1,}([^:]*):(.*)/\1:\2/p" /etc/resolv.conf | head -1'
+    run_podman run --net=pasta $IMAGE \
+        sh -c 'ping -c3 -W1 $(sed -nr "s/^nameserver[ ]{1,}([^:]*):(.*)/\1:\2/p" /etc/resolv.conf | head -1)'
 }
 
 ### Lifecycle ##################################################################

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -656,7 +656,7 @@ function teardown() {
     fi
 
     run_podman run --net=pasta $IMAGE \
-        sh -c 'ping -c3 -W1 sed -nr "s/^nameserver[ ]{1,}([^.]*).(.*)/\1.\2/p" /etc/resolv.conf | head -1'
+        sh -c 'ping -c3 -W1 $(sed -nr "s/^nameserver[ ]{1,}([^.]*).(.*)/\1.\2/p" /etc/resolv.conf | head -1)'
 }
 
 @test "podman networking with pasta(1) - ICMPv6 echo request" {

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -382,11 +382,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv4, tap" {
-    pasta_test_do 4 tap      tcp 3 0 "port"      1
+    pasta_test_do 4 tap      tcp 2 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv4, loopback" {
-    pasta_test_do 4 loopback tcp 3 0 "port"      1
+    pasta_test_do 4 loopback tcp 2 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - Translated TCP port forwarding, IPv4, tap" {
@@ -398,11 +398,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, tap" {
-    pasta_test_do 4 tap      tcp 3 1 "port"      1
+    pasta_test_do 4 tap      tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, loopback" {
-    pasta_test_do 4 loopback tcp 3 1 "port"      1
+    pasta_test_do 4 loopback tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv4, tap" {
@@ -432,7 +432,7 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv6, tap" {
-    pasta_test_do 6 tap      tcp 3 0 "port"      1
+    pasta_test_do 6 tap      tcp 2 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv6, loopback" {
@@ -448,11 +448,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, tap" {
-    pasta_test_do 6 tap      tcp 3 1 "port"      1
+    pasta_test_do 6 tap      tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, loopback" {
-    pasta_test_do 6 loopback tcp 3 1 "port"      1
+    pasta_test_do 6 loopback tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv6, tap" {


### PR DESCRIPTION
See https://github.com/containers/podman/issues/17287. This is a mitigation I want to check against CI, at the moment.

```release-note
None
```
