### PR TITLE
Cirrus: Emergency fix to un-stuck PRs

### DIFF
--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -46,7 +46,8 @@ if [[ "${DISTRO_NV}" =~ fedora ]]; then
     showrun ${SCRIPT_BASE}/lib.sh.t
 
     export PREBUILD=1
-    showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
+    # TODO: Disabled due to test failure breaking all PRs
+    # showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
 fi
 
 msg "Checking 3rd party network service connectivity"


### PR DESCRIPTION
All PRs are broken because this test fails, presumably due to a GraphQL API change.  Disable the test temporarily until a permanent solution can be found.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
