### PR TITLE
[CI:BUILD] Cirrus: Fix GraphQL ownerRepository:null error

### DIFF
--- a/.github/actions/check_cirrus_cron/cron_failures.sh
+++ b/.github/actions/check_cirrus_cron/cron_failures.sh
@@ -19,7 +19,7 @@ confirm_gha_environment
 mkdir -p ./artifacts
 cat > ./artifacts/query_raw.json << "EOF"
 query {
-  ownerRepository(platform: "LINUX", owner: "@@OWNER@@", name: "@@REPO@@") {
+  ownerRepository(platform: "github", owner: "@@OWNER@@", name: "@@REPO@@") {
     cronSettings {
       name
       lastInvocationBuild {

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -46,8 +46,7 @@ if [[ "${DISTRO_NV}" =~ fedora ]]; then
     showrun ${SCRIPT_BASE}/lib.sh.t
 
     export PREBUILD=1
-    # TODO: Disabled due to test failure breaking all PRs
-    # showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
+    showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
 fi
 
 msg "Checking 3rd party network service connectivity"

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -45,8 +45,15 @@ if [[ "${DISTRO_NV}" =~ fedora ]]; then
     # Tests for lib.sh
     showrun ${SCRIPT_BASE}/lib.sh.t
 
-    export PREBUILD=1
-    showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
+    # Run this during daily cron job to prevent a GraphQL API change/breakage
+    # from impacting every PR.  Down-side being if it does fail, a maintainer
+    # will need to do some archaeology to find it.
+    # Defined by CI system
+    # shellcheck disable=SC2154
+    if [[ "$CIRRUS_CRON" == "main" ]]; then
+      export PREBUILD=1
+      showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
+    fi
 fi
 
 msg "Checking 3rd party network service connectivity"


### PR DESCRIPTION
A semantic change to a Cirrus-CI GraphQL API parameter caused a
unit-test to fail (as it should have) with the error:

```
Query result did not pass filter '.data.ownerRepository.cronSettings':
'{"data":{"ownerRepository":null}}'
```

As per Cirrus-support, a change was introduced in schema affecting certain
fields that were incorrectly marked Nullable.  They indicated the `platform`
field was set incorrectly, and should use the value `github`.

* Fix the platform field's value to `github` instead of `LINUX`.
* Change the unit-test to only execute as part of the 'main' cirrus-cron
  job so it cannot impact PRs.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
