### PR TITLE
podman inspect list network when using --net=host or none

### DIFF
--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -240,18 +240,26 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 		return nil, err
 	}
 
+	setDefaultNetworks := func() {
+		settings.Networks = make(map[string]*define.InspectAdditionalNetwork, 1)
+		name := c.NetworkMode()
+		addedNet := new(define.InspectAdditionalNetwork)
+		addedNet.NetworkID = name
+		settings.Networks[name] = addedNet
+	}
+
 	if c.state.NetNS == "" {
 		if networkNSPath := c.joinedNetworkNSPath(); networkNSPath != "" {
 			if result, err := c.inspectJoinedNetworkNS(networkNSPath); err == nil {
 				// fallback to dummy configuration
 				settings.InspectBasicNetworkConfig = resultToBasicNetworkConfig(result)
-				return settings, nil
+			} else {
+				// do not propagate error inspecting a joined network ns
+				logrus.Errorf("Inspecting network namespace: %s of container %s: %v", networkNSPath, c.ID(), err)
 			}
-			// do not propagate error inspecting a joined network ns
-			logrus.Errorf("Inspecting network namespace: %s of container %s: %v", networkNSPath, c.ID(), err)
+			return settings, nil
 		}
 		// We can't do more if the network is down.
-
 		// We still want to make dummy configurations for each network
 		// the container joined.
 		if len(networks) > 0 {
@@ -262,6 +270,8 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 				cniNet.Aliases = opts.Aliases
 				settings.Networks[net] = cniNet
 			}
+		} else {
+			setDefaultNetworks()
 		}
 
 		return settings, nil
@@ -282,7 +292,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 			return nil, fmt.Errorf("network inspection mismatch: asked to join %d network(s) %v, but have information on %d network(s): %w", len(networks), networks, len(netStatus), define.ErrInternal)
 		}
 
-		settings.Networks = make(map[string]*define.InspectAdditionalNetwork)
+		settings.Networks = make(map[string]*define.InspectAdditionalNetwork, len(networks))
 
 		for name, opts := range networks {
 			result := netStatus[name]
@@ -300,6 +310,8 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 		if !(len(networks) == 1 && isDefaultNet) {
 			return settings, nil
 		}
+	} else {
+		setDefaultNetworks()
 	}
 
 	// If not joining networks, we should have at most 1 result

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -51,7 +51,7 @@ t GET libpod/containers/json?all=true 200 \
   .[0].IsInfra=false
 
 # Test compat API for Network Settings (.Network is N/A when rootless)
-network_expect="Networks=null"
+network_expect="Networks.slirp4netns.NetworkID=slirp4netns"
 if root; then
     network_expect="Networks.podman.NetworkID=podman"
 fi


### PR DESCRIPTION
This will match Docker behaviour.

Fixes: https://github.com/containers/podman/issues/17385

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman inspect lists networks on all network modes.
```
