### PR TITLE
e2e: adapt play kube test on remote rootless

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4396,10 +4396,12 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 		initialUsernsConfig, err := os.ReadFile("/proc/self/uid_map")
 		Expect(err).ToNot(HaveOccurred())
 		if isRootless() {
-			unshare := podmanTest.Podman([]string{"unshare", "cat", "/proc/self/uid_map"})
-			unshare.WaitWithDefaultTimeout()
-			Expect(unshare).Should(Exit(0))
-			initialUsernsConfig = unshare.Out.Contents()
+			// Use podmanTest.PodmanBinary because podman-remote unshare cannot be used
+			cmd := exec.Command(podmanTest.PodmanBinary, "unshare", "cat", "/proc/self/uid_map")
+			session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session, DefaultWaitTimeout).Should(Exit(0))
+			initialUsernsConfig = session.Out.Contents()
 		}
 
 		pod := getPod()


### PR DESCRIPTION
Use `podmanTest.PodmanBinary` because podman-remote unshare
cannot be used.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
