### PR TITLE
Quadlet: exit 0 when there are no files to process

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -327,8 +327,10 @@ func main() {
 	}
 
 	if len(units) == 0 {
+		// containers/podman/issues/17374: exit cleanly but log that we
+		// had nothing to do
 		Debugf("No files to parse from %s", sourcePaths)
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	if !dryRun {

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -365,7 +365,7 @@ var _ = Describe("quadlet system generator", func() {
 
 			session := podmanTest.Quadlet([]string{"-dryrun"}, "/something")
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(1))
+			Expect(session).Should(Exit(0))
 
 			current := session.ErrorToStringArray()
 			expected := "No files to parse from [/something]"


### PR DESCRIPTION
Quadlet should not exit with failure if no files to process have been found.  Otherwise, even simple operations such as reloading systemd will fail as it retriggers generators.

Fixes: #17374
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
