### PR TITLE
update golangci-lint to version 1.51.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - lll
     - gosec
     - maligned
+    - musttag # way to many warnings to fix for now, also some false positives
     - gomoddirectives
     - containedctx
     - contextcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,3 +74,13 @@ linters-settings:
   nolintlint:
     allow-leading-space: false
     require-specific: true
+
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -929,7 +929,7 @@ install.tools: .install.golangci-lint ## Install needed tools
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
-	VERSION=1.50.1 ./hack/install_golangci.sh
+	VERSION=1.51.1 ./hack/install_golangci.sh
 
 .PHONY: .install.swagger
 .install.swagger:

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -91,7 +91,7 @@ func (e EventLogFile) writeString(s string) error {
 
 func (e EventLogFile) getTail(options ReadOptions) (*tail.Tail, error) {
 	reopen := true
-	seek := tail.SeekInfo{Offset: 0, Whence: os.SEEK_END}
+	seek := tail.SeekInfo{Offset: 0, Whence: io.SeekEnd}
 	if options.FromStart || !options.Stream {
 		seek.Whence = 0
 		reopen = false

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1702,10 +1702,10 @@ func testHTTPServer(port string, shouldErr bool, expectedResponse string) {
 		time.Sleep(interval)
 		interval *= 2
 	}
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 
 	body, err := io.ReadAll(resp.Body)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(string(body)).Should(Equal(expectedResponse))
 }
 


### PR DESCRIPTION
The new version contains the ginkgolinter, which makes sure the assertions are more helpful.

Also replace the deprecated os.SEEK_END with io.SeekEnd.

There is also a new `musttag` linter which checks if struct that are un/marshalled all have json tags. This results in many warnings so I disabled the check for now. We can reenable it if we think it is worth it but for now it way to much work to fix all report problems.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
