### PR TITLE
[CI:DOCS] Fix contradicting documentation podman commit --pause

### DIFF
--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -9,7 +9,7 @@ podman\-commit - Create new image based on the changed container
 **podman container commit** [*options*] *container* [*image*]
 
 ## DESCRIPTION
-**podman commit** creates an image based on a changed *container*. The author of the image can be set using the **--author** OPTION. Various image instructions can be configured with the **--change** OPTION and a commit message can be set using the **--message** OPTION. The *container* and its processes are paused while the image is committed. This minimizes the likelihood of data corruption when creating the new image. If this is not desired, the **--pause** OPTION can be set to *false*. When the commit is complete, Podman will print out the ID of the new image.
+**podman commit** creates an image based on a changed *container*. The author of the image can be set using the **--author** OPTION. Various image instructions can be configured with the **--change** OPTION and a commit message can be set using the **--message** OPTION. The *container* and its processes aren't paused while the image is committed. If this is not desired, the **--pause** OPTION can be set to *true*. When the commit is complete, Podman will print out the ID of the new image.
 
 If `image` does not begin with a registry name component, `localhost` will be added to the name.
 If `image` is not provided, the values for the `REPOSITORY` and `TAG` values of the created image will each be set to `<none>`.


### PR DESCRIPTION
Close #17363 

This should remove the confusion about the pause parameter default behavior.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
