### PR TITLE
[CI:BUILD] Cirrus: Fix & remove GraphQL API tests

### DIFF
--- a/.github/actions/check_cirrus_cron/cron_failures.sh
+++ b/.github/actions/check_cirrus_cron/cron_failures.sh
@@ -19,7 +19,7 @@ confirm_gha_environment
 mkdir -p ./artifacts
 cat > ./artifacts/query_raw.json << "EOF"
 query {
-  ownerRepository(platform: "LINUX", owner: "@@OWNER@@", name: "@@REPO@@") {
+  ownerRepository(platform: "github", owner: "@@OWNER@@", name: "@@REPO@@") {
     cronSettings {
       name
       lastInvocationBuild {

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -44,9 +44,6 @@ if [[ "${DISTRO_NV}" =~ fedora ]]; then
 
     # Tests for lib.sh
     showrun ${SCRIPT_BASE}/lib.sh.t
-
-    export PREBUILD=1
-    showrun bash ${CIRRUS_WORKING_DIR}/.github/actions/check_cirrus_cron/test.sh
 fi
 
 msg "Checking 3rd party network service connectivity"


### PR DESCRIPTION
These tests don't need to run for every PR, and the thing they're testing never runs on any branch except `main`.  Stop them from running on this branch.  In case someone decides to try and use them, also fix the errant API call which triggered the original problem.

Ref: https://github.com/containers/podman/pull/17383

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
