### PR TITLE
kube play: do not teardown unconditionally on error

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -279,14 +279,19 @@ func play(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := kubeplay(reader); err != nil {
+		// FIXME: The cleanup logic below must be fixed to only remove
+		// resources that were created before a failure.  Otherwise,
+		// rerunning the same YAML file will cause an error and remove
+		// the previously created workload.
+		//
 		// teardown any containers, pods, and volumes that might have created before we hit the error
-		teardownReader, trErr := readerFromArg(args[0])
-		if trErr != nil {
-			return trErr
-		}
-		if tErr := teardown(teardownReader, entities.PlayKubeDownOptions{Force: true}, true); tErr != nil && !errorhandling.Contains(tErr, define.ErrNoSuchPod) {
-			return fmt.Errorf("error tearing down workloads %q after kube play error %q", tErr, err)
-		}
+		//		teardownReader, trErr := readerFromArg(args[0])
+		//		if trErr != nil {
+		//			return trErr
+		//		}
+		//		if tErr := teardown(teardownReader, entities.PlayKubeDownOptions{Force: true}, true); tErr != nil && !errorhandling.Contains(tErr, define.ErrNoSuchPod) {
+		//			return fmt.Errorf("error tearing down workloads %q after kube play error %q", tErr, err)
+		//		}
 		return err
 	}
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -99,6 +99,12 @@ RELABEL="system_u:object_r:container_file_t:s0"
        is "$output" "${RELABEL} $TESTDIR" "selinux relabel should have happened"
     fi
 
+    # Now rerun twice to make sure nothing gets removed
+    run_podman 125 play kube $PODMAN_TMPDIR/test.yaml
+    is "$output" ".* is in use: pod already exists"
+    run_podman 125 play kube $PODMAN_TMPDIR/test.yaml
+    is "$output" ".* is in use: pod already exists"
+
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod
 }


### PR DESCRIPTION
Commit 2f29639bd3aa9 added a UX improvement to cleanup/teardown when running the specified YAML has failed.  However, the teardown happens unconditionally such that rerunning the same YAML file will teardown the previously created workload instead of just failing with a name-conflict error (e.g., "pod already exists").  The regression popped up testing the Ansible system role with Podman v4.4.0.

For now, do not teardown at all on error to quickly fix this regression for the upcoming Podman v4.4.1 release.  The UX improvement is still desired but must be conditional and only happen on newly created resources, which probably requires moving it down to the backend.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a regression in `kube play` where existing resources got mistakenly removed.
```

@containers/podman-maintainers @umohnani8 PTAL
