### PR TITLE
[CI:DOCS] Document update for docker network options via CLI

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -93,6 +93,8 @@ Additionally the `bridge` driver supports the following options:
 
 - `vlan`: This option assign VLAN tag and enables vlan\_filtering. Defaults to none.
 - `isolate`: This option isolates networks by blocking traffic between those that have this option enabled.
+- `com.docker.network.bridge.name`: This option assigns the given name to the created Linux Bridge
+- `com.docker.network.driver.mtu`: Sets the Maximum Transmission Unit (MTU) and takes an integer value.
 
 The `macvlan` and `ipvlan` driver support the following options:
 


### PR DESCRIPTION
Doc update to support docker-specific network create options via CLI

Closes: https://github.com/containers/podman/issues/15830

Signed-off-by: T K Chandra Hasan <t.k.chandra.hasan@ibm.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```
Support for following docker network options via CLI
1. com.docker.network.bridge.name
2. com.docker.network.driver.mtu
```
