### PR TITLE
Cirrus: Omit functions in env. file

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -328,16 +328,19 @@ remove_packaged_podman_files() {
 # Execute make localbenchmarks in $CIRRUS_WORKING_DIR/data
 # for preserving as a task artifact.
 localbenchmarks() {
-    local datadir
+    local datadir envnames envname
     req_env_vars DISTRO_NV PODBIN_NAME PRIV_NAME TEST_ENVIRON TEST_FLAVOR
     req_env_vars VM_IMAGE_NAME EC2_INST_TYPE
 
     datadir=$CIRRUS_WORKING_DIR/data
     mkdir -p $datadir
 
+    envnames=$(passthrough_envars | sort);
     (
       echo "# Env. var basis for benchmarks benchmarks."
-      printenv | grep -Ev "$SECRET_ENV_RE" | sort
+      for envname in $envnames; do
+        printf "$envname=%q\n" "${!envname}"
+      done
 
       echo "# Machine details for data-comparison sake, not actual env. vars."
       # Checked above in req_env_vars

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -346,10 +346,12 @@ localbenchmarks() {
       # Checked above in req_env_vars
       # shellcheck disable=SC2154
       echo "\
+BENCH_ENV_VER=1
 CPUTOTAL=$(grep -ce '^processor' /proc/cpuinfo)
-INST_TYPE=$EC2_INST_TYPE  # one day may include other cloud's VM types.
-MEMTOTAL=$(awk -F: '$1 == "MemTotal" { print $2 }' </proc/meminfo | sed -e "s/^ *//")
-UNAME_RM=$(uname -r -m)
+INST_TYPE=$EC2_INST_TYPE
+MEMTOTALKB=$(awk -F: '$1 == "MemTotal" { print $2 }' </proc/meminfo | sed -e "s/^ *//" | cut -d ' ' -f 1)
+UNAME_R=$(uname -r)
+UNAME_M=$(uname -m)
 "
     ) > $datadir/benchmarks.env
     make localbenchmarks | tee $datadir/benchmarks.raw


### PR DESCRIPTION
The `localbenchmarks()` function stores a `.env` file containing current environment variables for benchmark-classification purposes.  However its naked use of `printenv` means it was logging the contents of library functions and (worse) trying to stort all the lines.  This results in an unusable mess inside `benchmarks.env`.  Fix this by re-using the purpose-built passthrough_envars() which is designed to only print useful, safe, env. vars.

Also

The `benchmarks.env` file is intended for machine consumption. Including things like a `kB` unit label (like `$MEMTOTAL`) make items difficult to parse.  Additionally, multi-value keys (like `$UNAME_RM`) make extra/unnecessary work for the interpreter.  Simplify these items and include a data-schema version marker so an interpreter can be made aware/support future format changes.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
