### PR TITLE
[FEAT] Support sysctl configurations from Pod Spec

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -107,6 +107,17 @@ func ToPodOpt(ctx context.Context, podName string, p entities.PodCreateOptions, 
 			p.Net.DNSOptions = dnsOptions
 		}
 	}
+
+	if pscConfig := podYAML.Spec.SecurityContext; pscConfig != nil {
+		// Extract sysctl list from pod security context
+		if options := pscConfig.Sysctls; len(options) > 0 {
+			sysctlOptions := make([]string, 0, len(options))
+			for _, opts := range options {
+				sysctlOptions = append(sysctlOptions, opts.Name+"="+opts.Value)
+			}
+			p.Sysctl = sysctlOptions
+		}
+	}
 	return p, nil
 }
 

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -264,6 +264,10 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 		p.InfraContainerSpec.ConmonPidFile = p.InfraConmonPidFile
 	}
 
+	if p.Sysctl != nil && len(p.Sysctl) > 0 {
+		p.InfraContainerSpec.Sysctl = p.Sysctl
+	}
+
 	p.InfraContainerSpec.Image = p.InfraImage
 	return p.InfraContainerSpec, nil
 }


### PR DESCRIPTION
Signed-off-by: T K Chandra Hasan <t.k.chandra.hasan@ibm.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Fixes: #16711 

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support sysctl options from Pod Spec via podman kube play CLI
```
