### PR TITLE
kube play: set service container as main PID when possible

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -399,7 +399,7 @@ EOF
 
     # Make sure that Podman is the service's MainPID
     run systemctl show --property=MainPID --value $service_name
-    is "$(</proc/$output/comm)" "podman" "podman is the service mainPID"
+    is "$(</proc/$output/comm)" "conmon" "podman is the service mainPID"
 
     # The name of the service container is predictable: the first 12 characters
     # of the hash of the YAML file followed by the "-service" suffix
@@ -433,12 +433,13 @@ EOF
     run_podman pod kill test_pod
     for i in {0..20}; do
         run systemctl is-active $service_name
-        if [[ $output == "inactive" ]]; then
+        if [[ $output == "failed" ]]; then
             break
         fi
         sleep 0.5
     done
-    is "$output" "inactive" "systemd service transitioned to 'inactive' state: $service_name"
+    # The service is marked as failed as the service container exits non-zero.
+    is "$output" "failed" "systemd service transitioned to 'inactive' state: $service_name"
 
     # Now stop and start the service again.
     systemctl stop $service_name

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -420,7 +420,8 @@ EOF
     run_podman container inspect  --format "{{.State.Status}}" test_pod-test
     is "$output" "running" "container should be started by systemd and hence be running"
 
-    service_cleanup $QUADLET_SERVICE_NAME inactive
+    # The service is marked as failed as the service container exits non-zero.
+    service_cleanup $QUADLET_SERVICE_NAME failed
     run_podman rmi $(pause_image)
 }
 

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -218,8 +218,14 @@ EOF
     _start_socat
     wait_for_file $_SOCAT_LOG
 
-    # Will run until all containers have stopped.
     run_podman play kube --service-container=true --log-driver journald $yaml_source
+
+    # The service container is the main PID since no container has a custom
+    # sdnotify policy.
+    run_podman container inspect $service_container --format "{{.State.ConmonPid}}"
+    main_pid="$output"
+
+    # Will run until all containers have stopped.
     run_podman container wait $service_container test_pod-test
 
     # Make sure the containers have the correct policy.
@@ -233,7 +239,7 @@ ignore"
     echo "$output"
 
     # The "with policies" test below checks the MAINPID.
-    is "$output" "MAINPID=.*
+    is "$output" "MAINPID=$main_pid
 READY=1" "sdnotify sent MAINPID and READY"
 
     _stop_socat


### PR DESCRIPTION
Commit 4fa307f14923 fixed a number of issues in the sdnotify proxies. Whenever a container runs with a custom sdnotify policy, the proxies need to keep running which in turn required Podman to run and wait for the service container to stop.  Improve on that behavior and set the service container as the main PID (instead of Podman) when no container needs sdnotify.

Fixes: #17345
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@rhatdan @ygalblum @alexlarsson PTAL
This optimization will also benefit Quadlet.  If we plan on cutting a Podman v4.4.2, this may be a nice candidate.