### PR TITLE
Implement Unix domain socket support for VLAN

### DIFF
--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -36,3 +36,12 @@ Note: To run specific test files, add the test files to the end of the winmake c
 1. `export CONTAINERS_MACHINE_PROVIDER="applehv"`
 1. `export MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"`
 1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)
+
+### QEMU
+
+1. Install Podman and QEMU for MacOS bundle using latest release from https://github.com/containers/podman/releases
+1. `make podman-remote`
+1. `export CONTAINERS_MACHINE_PROVIDER="qemu"`
+1. Add bundled QEMU to path `export PATH=/opt/podman/qemu/bin:$PATH`
+1. Set search path to gvproxy from bundle `export CONTAINERS_HELPER_BINARY_DIR=/opt/podman/bin`
+1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)

--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -37,11 +37,21 @@ Note: To run specific test files, add the test files to the end of the winmake c
 1. `export MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"`
 1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)
 
-### QEMU
+### QEMU (fd vlan)
 
 1. Install Podman and QEMU for MacOS bundle using latest release from https://github.com/containers/podman/releases
 1. `make podman-remote`
 1. `export CONTAINERS_MACHINE_PROVIDER="qemu"`
 1. Add bundled QEMU to path `export PATH=/opt/podman/qemu/bin:$PATH`
 1. Set search path to gvproxy from bundle `export CONTAINERS_HELPER_BINARY_DIR=/opt/podman/bin`
+1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)
+
+### QEMU (UNIX domain socket vlan)
+
+1. Install Podman and QEMU for MacOS bundle using latest release from https://github.com/containers/podman/releases
+1. `make podman-remote`
+1. `export CONTAINERS_MACHINE_PROVIDER="qemu"`
+1. Add bundled QEMU to path `export PATH=/opt/podman/qemu/bin:$PATH`
+1. Set search path to gvproxy from bundle `export CONTAINERS_HELPER_BINARY_DIR=/opt/podman/bin`
+1. `export CONTAINERS_USE_SOCKET_VLAN=true`
 1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -157,7 +157,7 @@ func StopWinProxy(name string, vmtype define.VMType) error {
 	if err != nil {
 		return nil
 	}
-	sendQuit(tid)
+	SendQuit(tid)
 	_ = waitTimeout(proc, 20*time.Second)
 	_ = os.Remove(tidFile)
 
@@ -200,7 +200,7 @@ func waitTimeout(proc *os.Process, timeout time.Duration) bool {
 	return ret
 }
 
-func sendQuit(tid uint32) {
+func SendQuit(tid uint32) {
 	user32 := syscall.NewLazyDLL("user32.dll")
 	postMessage := user32.NewProc("PostThreadMessageW")
 	postMessage.Call(uintptr(tid), WM_QUIT, 0, 0)

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -53,7 +53,6 @@ func (q *QemuCmd) SetNetwork() {
 	*q = append(*q, "-netdev", "socket,id=vlan,fd=3", "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee")
 }
 
-// SetNetwork adds a network device to the machine
 func (q *QemuCmd) SetUSBHostPassthrough(usbs []USBConfig) {
 	if len(usbs) == 0 {
 		return

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,11 @@ import (
 	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine/define"
+)
+
+const (
+	FdVlanNetdev = "socket,id=vlan,fd=3"
+	vlanMac      = "5a:94:ef:e4:0c:ee"
 )
 
 // QemuCmd is an alias around a string slice to prevent the need to migrate the
@@ -47,10 +53,23 @@ func (q *QemuCmd) SetQmpMonitor(monitor Monitor) {
 }
 
 // SetNetwork adds a network device to the machine
-func (q *QemuCmd) SetNetwork() {
+func (q *QemuCmd) SetNetwork(vlanSocket *define.VMFile) error {
 	// Right now the mac address is hardcoded so that the host networking gives it a specific IP address.  This is
 	// why we can only run one vm at a time right now
-	*q = append(*q, "-netdev", "socket,id=vlan,fd=3", "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee")
+	if UseFdVLan() {
+		*q = append(*q, []string{"-netdev", FdVlanNetdev}...)
+	} else {
+		if vlanSocket == nil {
+			return errors.New("vlanSocket is undefined")
+		}
+		*q = append(*q, []string{"-netdev", socketVlanNetdev(vlanSocket.GetPath())}...)
+	}
+	*q = append(*q, []string{"-device", "virtio-net-pci,netdev=vlan,mac=" + vlanMac}...)
+	return nil
+}
+
+func socketVlanNetdev(path string) string {
+	return fmt.Sprintf("stream,id=vlan,server=off,addr.type=unix,addr.path=%s", path)
 }
 
 func (q *QemuCmd) SetUSBHostPassthrough(usbs []USBConfig) {

--- a/pkg/machine/qemu/command/command_unix.go
+++ b/pkg/machine/qemu/command/command_unix.go
@@ -1,0 +1,13 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package command
+
+import (
+	"os"
+	"strings"
+)
+
+func UseFdVLan() bool {
+	return strings.ToUpper(os.Getenv("CONTAINERS_USE_SOCKET_VLAN")) != "TRUE"
+}

--- a/pkg/machine/qemu/command/command_windows.go
+++ b/pkg/machine/qemu/command/command_windows.go
@@ -1,0 +1,5 @@
+package command
+
+func UseFdVLan() bool {
+	return false
+}

--- a/pkg/machine/qemu/command/qemu_command_test.go
+++ b/pkg/machine/qemu/command/qemu_command_test.go
@@ -40,7 +40,8 @@ func TestQemuCmd(t *testing.T) {
 	cmd.SetCPUs(4)
 	cmd.SetIgnitionFile(*ignFile)
 	cmd.SetQmpMonitor(monitor)
-	cmd.SetNetwork()
+	err = cmd.SetNetwork(nil)
+	assert.NoError(t, err)
 	cmd.SetSerialPort(*readySocket, *vmPidFile, "test-machine")
 	cmd.SetVirtfsMount("/tmp/path", "vol10", "none", true)
 	cmd.SetBootableImage(bootableImagePath)
@@ -53,6 +54,72 @@ func TestQemuCmd(t *testing.T) {
 		"-fw_cfg", fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignPath),
 		"-qmp", fmt.Sprintf("unix:%s,server=on,wait=off", addrFilePath),
 		"-netdev", "socket,id=vlan,fd=3",
+		"-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee",
+		"-device", "virtio-serial",
+		"-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=atest-machine_ready", readySocketPath),
+		"-device", "virtserialport,chardev=atest-machine_ready,name=org.fedoraproject.port.0",
+		"-pidfile", vmPidFilePath,
+		"-virtfs", "local,path=/tmp/path,mount_tag=vol10,security_model=none,readonly",
+		"-drive", fmt.Sprintf("if=virtio,file=%s", bootableImagePath),
+		"-display", "none"}
+
+	require.Equal(t, cmd.Build(), expected)
+}
+
+func TestQemuCmdUnixVlanMissingSocket(t *testing.T) {
+	t.Setenv("CONTAINERS_USE_SOCKET_VLAN", "true")
+	cmd := NewQemuBuilder("/usr/bin/qemu-system-x86_64", []string{})
+	err := cmd.SetNetwork(nil)
+	assert.Error(t, err)
+}
+
+func TestQemuCmdUnixVlan(t *testing.T) {
+	t.Setenv("CONTAINERS_USE_SOCKET_VLAN", "true")
+	ignFile, err := define.NewMachineFile(t.TempDir()+"demo-ignition-file.ign", nil)
+	assert.NoError(t, err)
+
+	machineAddrFile, err := define.NewMachineFile(t.TempDir()+"tmp.sock", nil)
+	assert.NoError(t, err)
+
+	vlanSocket, err := define.NewMachineFile(t.TempDir()+"vlan.sock", nil)
+	assert.NoError(t, err)
+
+	readySocket, err := define.NewMachineFile(t.TempDir()+"readySocket.sock", nil)
+	assert.NoError(t, err)
+
+	vmPidFile, err := define.NewMachineFile(t.TempDir()+"vmpidfile.pid", nil)
+	assert.NoError(t, err)
+
+	monitor := Monitor{
+		Address: *machineAddrFile,
+		Network: "unix",
+		Timeout: 3,
+	}
+	ignPath := ignFile.GetPath()
+	addrFilePath := machineAddrFile.GetPath()
+	readySocketPath := readySocket.GetPath()
+	vmPidFilePath := vmPidFile.GetPath()
+	bootableImagePath := t.TempDir() + "test-machine_fedora-coreos-38.20230918.2.0-qemu.x86_64.qcow2"
+
+	cmd := NewQemuBuilder("/usr/bin/qemu-system-x86_64", []string{})
+	cmd.SetMemory(2048)
+	cmd.SetCPUs(4)
+	cmd.SetIgnitionFile(*ignFile)
+	cmd.SetQmpMonitor(monitor)
+	err = cmd.SetNetwork(vlanSocket)
+	assert.NoError(t, err)
+	cmd.SetSerialPort(*readySocket, *vmPidFile, "test-machine")
+	cmd.SetVirtfsMount("/tmp/path", "vol10", "none", true)
+	cmd.SetBootableImage(bootableImagePath)
+	cmd.SetDisplay("none")
+
+	expected := []string{
+		"/usr/bin/qemu-system-x86_64",
+		"-m", "2048",
+		"-smp", "4",
+		"-fw_cfg", fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignPath),
+		"-qmp", fmt.Sprintf("unix:%s,server=on,wait=off", addrFilePath),
+		"-netdev", socketVlanNetdev(vlanSocket.GetPath()),
 		"-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee",
 		"-device", "virtio-serial",
 		"-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=atest-machine_ready", readySocketPath),

--- a/pkg/machine/qemu/machine_unix.go
+++ b/pkg/machine/qemu/machine_unix.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/podman/v4/pkg/machine/define"
 	"golang.org/x/sys/unix"
 )
@@ -48,6 +49,10 @@ func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) er
 		// child exited
 		return fmt.Errorf("%s exited unexpectedly with exit code %d, stderr: %s", processHint, status.ExitStatus(), stderrBuf.String())
 	}
+	return nil
+}
+
+func forwardPipeArgs(cmd *gvproxy.GvproxyCommand, name string, destPath string, identityPath string, user string) error {
 	return nil
 }
 

--- a/pkg/machine/qemu/machine_unix.go
+++ b/pkg/machine/qemu/machine_unix.go
@@ -8,27 +8,50 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"golang.org/x/sys/unix"
 )
 
-func isProcessAlive(pid int) bool {
+func isProcessAlive(pid int) (bool, error) {
 	err := unix.Kill(pid, syscall.Signal(0))
 	if err == nil || err == unix.EPERM {
-		return true
+		return true, nil
 	}
-	return false
+	return false, err
+}
+
+func pingProcess(pid int) (int, error) {
+	alive, err := isProcessAlive(pid)
+	if !alive {
+		if err == unix.ESRCH {
+			return -1, nil
+		}
+		return -1, fmt.Errorf("pinging QEMU process: %w", err)
+	}
+	return pid, nil
+}
+
+func killProcess(pid int, force bool) error {
+	if force {
+		return unix.Kill(pid, unix.SIGKILL)
+	}
+	return unix.Kill(pid, unix.SIGTERM)
 }
 
 func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) error {
 	var status syscall.WaitStatus
 	pid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
 	if err != nil {
-		return fmt.Errorf("failed to read qem%su process status: %w", processHint, err)
+		return fmt.Errorf("failed to read %s process status: %w", processHint, err)
 	}
 	if pid > 0 {
 		// child exited
 		return fmt.Errorf("%s exited unexpectedly with exit code %d, stderr: %s", processHint, status.ExitStatus(), stderrBuf.String())
 	}
+	return nil
+}
+
+func podmanPipe(name string) *define.VMFile {
 	return nil
 }
 
@@ -41,18 +64,4 @@ func extractTargetPath(paths []string) string {
 		return paths[1]
 	}
 	return paths[0]
-}
-
-func sigKill(pid int) error {
-	return unix.Kill(pid, unix.SIGKILL)
-}
-
-func findProcess(pid int) (int, error) {
-	if err := unix.Kill(pid, 0); err != nil {
-		if err == unix.ESRCH {
-			return -1, nil
-		}
-		return -1, fmt.Errorf("pinging QEMU process: %w", err)
-	}
-	return pid, nil
 }

--- a/pkg/machine/qemu/machine_windows.go
+++ b/pkg/machine/qemu/machine_windows.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/define"
 )
@@ -39,6 +40,18 @@ func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) er
 			return fmt.Errorf("%s exited unexpectedly, exit code: %d", processHint, exitCode)
 		}
 	}
+	return nil
+}
+
+func forwardPipeArgs(cmd *gvproxy.GvproxyCommand, name string, destPath string, identityPath string, user string) error {
+	machinePipe := toPipeName(name)
+	if !machine.PipeNameAvailable(machinePipe) {
+		return fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
+	}
+	cmd.AddForwardSock(fmt.Sprintf("npipe:////./pipe/%s", machinePipe))
+	cmd.AddForwardDest(destPath)
+	cmd.AddForwardUser(user)
+	cmd.AddForwardIdentity(identityPath)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #15852 

This change adds support for new QEMU stream netdev added in 7.2.0. It is implemented as an opt-in mode for previously supported platforms and the only supported mode on Windows.

Old FD netdev has changes only on podman side. Instead of previously used QMP socket address, it now has VLAN dedicated socket address to make both implementations more similar.

As VLAN socket address has short lifespan (it exists only after forwarder has been started and before QEMU has finished startup), it is not promoted to persisted machine settings, but is rather calculated inside Start method.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

I tried to highlight everything significant in the commit message. This indeed fixes #15852, but it has a lot more added that the change required to fix it. I needed other changes to actually check the desired behavior of the fix for the issue mentioned above, if the team will insist I can split it up into series of commits (I would prefer not to, though 😅 ).

VLAN socket address is not persisted anywhere in machine socket, so, the logic decides on the mode by checking the command line. Actually the way how QEMU command line is stored is dictating a lot of how QEMU and in turn gvproxy and Podman should operate. So, it might look dirty, but to me looked like a reasonable implementation (at least at this point in time).

**Machine Init**

When in SOCKET VLAN mode (on platforms, where FD supported it has to be enabled via env var) the Init will create QEMU command line compatible with new QEMU 7.2.0 feature.

**Machine Start**

Podman will ignore the current settings, but will rely on what was create by Machine Init (analyze command line)

**Named pipes**

Now gvproxy will also expose named pipe on Windows (no-op for non-Windows paths). The name of the pipe is of the format `qemu-podman-...` For default machine it will result in `qemu-podman-machine-default`. This prefix is needed
to prevent name collision with WSL machine. Clients could read pipe name from `podman machine inspect` output (the change is already merged to Podman Desktop).

**Mode switch**

Current implementation is using opt-in via env var, but alternative implementations (like checking QEMU version or config files) could exist. Socket VLAN is more cross platform, but it can't replace old implementation, because
it is only available starting from QEMU 7.2.0 (which means baseline RHEL 10 😅 )

**Configuration mismatch warning**

When mode switch has happened between Init and Start - like machine was created with FD settings, but then Start is
called, when SOCKET VLAN usage is requested - there will be WARN output what could be changed to fix the mismatch.
Works in both directions.

**Socket VLAN gvproxy readiness check**

It is impossible to use the Dial, because then we could not pass it forward as FD. The most common reason for failed start
would be socket address unavailable. In this case gvproxy will terminate. Readiness check algorithm looks like this:
1. Initial delay (small sleep) to account for gvproxy starting up in the background.
2. Start loop for up to max attempts
3. Check if process is alive using PID
  3.1. If not, then short circuit to failure
  3.2. If process is running continue to the next check
4. Check if we can `os.Stat` the socket address
 4.1. If not then sleep and go to the next loop iteration
 4.4. If ok, then break the look and continue
 
Refactorings
* startHostNetworking private method is now more sophisticated implementation: accepts input param, returns in addition Process data and has logic changes to account for name pipe functionality.

Additional fixes
* use "reasonable" UID on Windows (no platform check, but we rather check for the invalid return value)
* fixed type in Errorf in `checkProcessStatus` in _unix sources
* use stored `v.ReadySock.Path` instead of making it up again in Start method using the same rules

Local testing

Acceptance test: start the machine and run nginx with port forwarding to host machine.

* Tested on Windows applying all other pending changes for Windows support first
* Tested on Apple Silicon Mac

Output from Apple Silicon Mac:
**Running FD created machine (created with release version of Podman) w/ FD mode**
```
podman % ./bin/darwin/podman --log-level=debug machine start
INFO[0000] ./bin/darwin/podman filtering at log level debug
Starting machine "podman-machine-default"
[/Users/username/git/podman/bin/libexec/podman/gvproxy -listen-qemu unix:///var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/vlan_podman-machine-default.sock -pid-file /var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/podman-machine-default_proxy.pid -ssh-port 64042 -forward-sock /Users/username/.local/share/containers/podman/machine/podman-machine-default/podman.sock -forward-dest /run/user/501/podman/podman.sock -forward-user core -forward-identity /Users/username/.ssh/podman-machine-default --debug]
DEBU[0000] qemu cmd: [/opt/homebrew/bin/qemu-system-aarch64 -m 8192 -smp 4 -fw_cfg name=opt/com.coreos/config,file=/Users/username/.config/containers/podman/machine/qemu/podman-machine-default.ign -qmp unix:/var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/qmp_podman-machine-default.sock,server=on,wait=off -netdev socket,id=vlan,fd=3 -device virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee -device virtio-serial -chardev socket,path=/var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/podman-machine-default_ready.sock,server=on,wait=off,id=apodman-machine-default_ready -device virtserialport,chardev=apodman-machine-default_ready,name=org.fedoraproject.port.0 -pidfile /var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/podman-machine-default_vm.pid -accel hvf -accel tcg -cpu host -M virt,highmem=on -drive file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd,if=pflash,format=raw,readonly=on -drive file=/Users/username/.local/share/containers/podman/machine/qemu/podman-machine-default_ovmf_vars.fd,if=pflash,format=raw -virtfs local,path=/Users/username,mount_tag=vol0,security_model=mapped-xattr -drive if=virtio,file=/Users/username/.local/share/containers/podman/machine/qemu/podman-machine-default_fedora-coreos-37.20230110.2.0-qemu.aarch64.qcow2] 
Waiting for VM ...
...
```

**Running FD created machine (created with release version of Podman) w/ socket VLAN mode**
```
podman % CONTAINERS_USE_SOCKET_VLAN=true ./bin/darwin/podman --log-level=debug machine start
INFO[0000] ./bin/darwin/podman filtering at log level debug 
Starting machine "podman-machine-default"
WARN[0000] Stored Podman Machine configuration doesn't match current settings 
WARN[0000] Consider replacing "socket,id=vlan,fd=3" with "stream,id=vlan,server=off,addr.type=unix,addr.path=/var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/vlan_podman-machine-default.sock" in machine config 
[/Users/username/git/podman/bin/libexec/podman/gvproxy -listen-qemu unix:///var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/vlan_podman-machine-default.sock -pid-file /var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/podman-machine-default_proxy.pid -ssh-port 64042 -forward-sock /Users/username/.local/share/containers/podman/machine/podman-machine-default/podman.sock -forward-dest /run/user/501/podman/podman.sock -forward-user core -forward-identity /Users/username/.ssh/podman-machine-default --debug]
DEBU[0000] qemu cmd: [/opt/homebrew/bin/qemu-system-aarch64 -m 8192 -smp 4 -fw_cfg name=opt/com.coreos/config,file=/Users/username/.config/containers/podman/machine/qemu/podman-machine-default.ign -qmp unix:/var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/qmp_podman-machine-default.sock,server=on,wait=off -netdev socket,id=vlan,fd=3 -device virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee -device virtio-serial -chardev socket,path=/var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/podman-machine-default_ready.sock,server=on,wait=off,id=apodman-machine-default_ready -device virtserialport,chardev=apodman-machine-default_ready,name=org.fedoraproject.port.0 -pidfile /var/folders/9n/358_gdmn3fxfnyttwys8k1dm0000gn/T/podman/podman-machine-default_vm.pid -accel hvf -accel tcg -cpu host -M virt,highmem=on -drive file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd,if=pflash,format=raw,readonly=on -drive file=/Users/username/.local/share/containers/podman/machine/qemu/podman-machine-default_ovmf_vars.fd,if=pflash,format=raw -virtfs local,path=/Users/username,mount_tag=vol0,security_model=mapped-xattr -drive if=virtio,file=/Users/username/.local/share/containers/podman/machine/qemu/podman-machine-default_fedora-coreos-37.20230110.2.0-qemu.aarch64.qcow2] 
Waiting for VM ...
...
```

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman Machine now supports QEMU 7.2.0 stream netdev for VLAN socket
```
