### PR TITLE
Add suport for a --user flag to allow the user to be passed in to pod…

### DIFF
--- a/cmd/podman-mac-helper/install.go
+++ b/cmd/podman-mac-helper/install.go
@@ -80,11 +80,22 @@ var installCmd = &cobra.Command{
 
 func init() {
 	addPrefixFlag(installCmd)
+	addUserFlag(installCmd)
 	rootCmd.AddCommand(installCmd)
 }
 
 func install(cmd *cobra.Command, args []string) error {
-	userName, uid, homeDir, err := getUser()
+
+	var err error
+	inputUser := cmd.Flag("user").Value.String()
+
+	if inputUser == "" {
+		inputUser, err = lookupUser()
+		if err != nil {
+			return err
+		}
+	}
+	userName, uid, homeDir, err := getUser(inputUser)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman-mac-helper/main.go
+++ b/cmd/podman-mac-helper/main.go
@@ -72,20 +72,26 @@ func getUserInfo(name string) (string, string, string, error) {
 	entry := readCapped(output)
 	elements := strings.Split(entry, ":")
 	if len(elements) < 9 || elements[0] != name {
-		return "", "", "", errors.New("Could not look up user")
+		return "", "", "", errors.New("could not look up user")
 	}
 
 	return elements[0], elements[2], elements[8], nil
 }
 
-func getUser() (string, string, string, error) {
+func lookupUser() (string, error) {
+
 	name, found := os.LookupEnv("SUDO_USER")
 	if !found {
 		name, found = os.LookupEnv("USER")
 		if !found {
-			return "", "", "", errors.New("could not determine user")
+			return "", errors.New("could not determine user")
 		}
 	}
+
+	return name, nil
+}
+
+func getUser(name string) (string, string, string, error) {
 
 	_, uid, home, err := getUserInfo(name)
 	if err != nil {
@@ -140,6 +146,17 @@ func readCapped(reader io.Reader) string {
 
 func addPrefixFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&installPrefix, "prefix", defaultPrefix, "Sets the install location prefix")
+}
+
+func addUserFlag(cmd *cobra.Command) {
+	switch cmd.Name() {
+	case "install":
+		cmd.Flags().StringVar(&installPrefix, "user", "", "Install the helper for the provided user")
+	case "uninstall":
+		cmd.Flags().StringVar(&installPrefix, "user", "", "Uninstall the helper for the provided user")
+	default:
+		cmd.Flags().StringVar(&installPrefix, "user", "", "Runs the helper on behalf of the provided user")
+	}
 }
 
 func silentUsage(cmd *cobra.Command, args []string) {

--- a/cmd/podman-mac-helper/uninstall.go
+++ b/cmd/podman-mac-helper/uninstall.go
@@ -22,11 +22,23 @@ var uninstallCmd = &cobra.Command{
 
 func init() {
 	addPrefixFlag(uninstallCmd)
+	addUserFlag(uninstallCmd)
 	rootCmd.AddCommand(uninstallCmd)
 }
 
 func uninstall(cmd *cobra.Command, args []string) error {
-	userName, _, _, err := getUser()
+
+	var err error
+	inputUser := cmd.Flag("user").Value.String()
+
+	if inputUser == "" {
+		inputUser, err = lookupUser()
+		if err != nil {
+			return err
+		}
+	}
+
+	userName, _, _, err := getUser(inputUser)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…man-mac-helper

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added --user flag to podman-mac-helper cli tool to allow the helper to be installed for a specific user other than the user running the tool. This will allow admin users to install the helper on behalf of a standard user. 
```
