### PR TITLE
fix != filter in volume prune

### DIFF
--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -39,6 +39,11 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 				vf = append(vf, func(v *libpod.Volume) bool {
 					return pruneFilters.MatchLabelFilters([]string{filter}, v.Labels())
 				})
+			case "label!":
+				filter := val
+				vf = append(vf, func(v *libpod.Volume) bool {
+					return !pruneFilters.MatchLabelFilters([]string{filter}, v.Labels())
+				})
 			case "opt":
 				filterArray := strings.SplitN(val, "=", 2)
 				filterKey := filterArray[0]
@@ -102,6 +107,11 @@ func GeneratePruneVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, erro
 			case "label":
 				vf = append(vf, func(v *libpod.Volume) bool {
 					return pruneFilters.MatchLabelFilters([]string{filterVal}, v.Labels())
+				})
+			case "label!":
+				filter := val
+				vf = append(vf, func(v *libpod.Volume) bool {
+					return !pruneFilters.MatchLabelFilters([]string{filter}, v.Labels())
 				})
 			case "until":
 				f, err := createUntilFilterVolumeFunction(filterVal)

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -150,6 +150,14 @@ var _ = Describe("Podman volume prune", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToStringArray()).To(HaveLen(3))
 
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "testlabel", "myvol7"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label!=testlabel"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
 		podmanTest.Cleanup()
 	})
 


### PR DESCRIPTION
Signed-off-by: vyasgun <vyasgun20@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
