### PR TITLE
[CI:DOCS] man page xref: validate displayed man page names

### DIFF
--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -33,7 +33,7 @@ so networks have to be created again after a backend change.
 | prune      | [podman-network-prune(1)](podman-network-prune.1.md)           | Remove all unused networks                                      |
 | reload     | [podman-network-reload(1)](podman-network-reload.1.md)         | Reload network configuration for containers                     |
 | rm         | [podman-network-rm(1)](podman-network-rm.1.md)                 | Remove one or more networks                                     |
-| update     | [podman-network-update(1)](podman-network-update.1.md)          | Update an existing Podman network                               |
+| update     | [podman-network-update(1)](podman-network-update.1.md)         | Update an existing Podman network                               |
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**

--- a/docs/source/markdown/podman-system.1.md
+++ b/docs/source/markdown/podman-system.1.md
@@ -15,8 +15,8 @@ The system command allows management of the podman systems
 | -------    | ------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | connection | [podman-system-connection(1)](podman-system-connection.1.md) | Manage the destination(s) for Podman service(s)                          |
 | df         | [podman-system-df(1)](podman-system-df.1.md)                 | Show podman disk usage.                                                  |
-| events     | [podman-system-events(1)](podman-events.1.md)		    | Monitor Podman events                                                    |
-| info       | [podman-system-info(1)](podman-info.1.md)                    | Displays Podman related system information.                              |
+| events     | [podman-events(1)](podman-events.1.md)                       | Monitor Podman events                                                    |
+| info       | [podman-info(1)](podman-info.1.md)                           | Displays Podman related system information.                              |
 | migrate    | [podman-system-migrate(1)](podman-system-migrate.1.md)       | Migrate existing containers to a new podman version.                     |
 | prune      | [podman-system-prune(1)](podman-system-prune.1.md)           | Remove all unused pods, containers, images, networks, and volume data.   |
 | renumber   | [podman-system-renumber(1)](podman-system-renumber.1.md)     | Migrate lock numbers to handle a change in maximum number of locks.      |

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -429,15 +429,27 @@ sub podman_man {
             }
 
             # In podman-<subcommand>.1.md
-            elsif ($line =~ /^\|\s+(\S+)\s+\|\s+\[\S+\]\((\S+)\.1\.md\)/) {
+            #                      1   1        2  3   3    4   4         2
+            elsif ($line =~ /^\|\s+(\S+)\s+\|\s+(\[(\S+)\]\((\S+)\.1\.md\))/) {
                 # $1 will be changed by recursion _*BEFORE*_ left-hand assignment
-                my $subcmd = $1;
+                my ($subcmd, $blob, $shown_name, $link_name) = ($1, $2, $3, $4);
                 if ($previous_subcmd gt $subcmd) {
                     warn "$ME: $subpath:$.: '$previous_subcmd' and '$subcmd' are out of order\n";
                     ++$Errs;
                 }
                 $previous_subcmd = $subcmd;
-                $man{$subcmd} = podman_man($2);
+                $man{$subcmd} = podman_man($link_name);
+
+                # Check for inconsistencies between the displayed man page name
+                # and the actual man page name, e.g.
+                #  '[podman-bar(1)](podman-baz.1.md)
+                $shown_name =~ s/\(\d\)$//;
+                $shown_name =~ s/\\//g;         # backslashed hyphens
+                (my $should_be = $link_name) =~ s/\.1\.md$//;
+                if ($shown_name ne $should_be) {
+                    warn "$ME: $subpath:$.: '$shown_name' should be '$should_be' in '$blob'\n";
+                    ++$Errs;
+                }
             }
         }
 


### PR DESCRIPTION
command tables are chock full of duplication, hence they break.
Look for inconsistencies between the displayed man page name
and the actual man page name:

    |  foo    | [podman-foo(1)](podman-cmd-foo.1.md) | ...
                        ^^^

Inspired by #17474.

We can't actually check the subcommand name (the plain "foo")
because there are many existing subcommands whose name does
not match the man page: rmi vs image-rm, list vs podman-ps.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```