### PR TITLE
quadlet: add ExecStop

### DIFF
--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -14,7 +14,8 @@
 ## assert-key-is "Service" "Type" "notify"
 ## assert-key-is "Service" "NotifyAccess" "all"
 ## assert-key-is "Service" "SyslogIdentifier" "%N"
-## assert-key-is-regex "Service" "ExecStopPost" "-.*/podman rm -f -i --cidfile=%t/%N.cid" "-rm -f %t/%N.cid"
+## assert-key-is-regex "Service" "ExecStopPost" "-.*/podman rm -f -i --cidfile=%t/%N.cid"
+## assert-key-is-regex "Service" "ExecStop" ".*/podman rm -f -i --cidfile=%t/%N.cid"
 ## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
 
 [Container]


### PR DESCRIPTION
Remove the container in ExecStop to make sure that Quadlet's adheres to Podman's customizable stop signal/timeout.  Certain programs ignore SIGTERM which renders the services generated by Quadlet less user friendly compared to the ones from podman-generate-systemd.

Previously, `systemctl stop` would just hang until systemd's stop timeout is hit.  Since `podman rm` also removes the CID file, the additional `rm` can be removed.  Note that `podman rm` will return immediately if the specified CID file isn't present.

I am working on a short tutorial on Quadlet and hit the issue with a simple container running `sleep`.  `sleep` ignores SIGTERM and stopping the service would take forever even with `PodmanArgs=--stop-timeout=0`.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@rhatdan @ygalblum @alexlarsson PTAL