### PR TITLE
install sigproxy before start/attach

### DIFF
--- a/pkg/domain/infra/abi/terminal/terminal_common.go
+++ b/pkg/domain/infra/abi/terminal/terminal_common.go
@@ -84,21 +84,19 @@ func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, 
 		streams.AttachInput = false
 	}
 
-	if !startContainer {
-		if sigProxy {
-			ProxySignals(ctr)
-		}
+	if sigProxy {
+		// To prevent a race condition, install the signal handler
+		// before starting/attaching to the container.
+		ProxySignals(ctr)
+	}
 
+	if !startContainer {
 		return ctr.Attach(streams, detachKeys, resize)
 	}
 
 	attachChan, err := ctr.StartAndAttach(ctx, streams, detachKeys, resize, true)
 	if err != nil {
 		return err
-	}
-
-	if sigProxy {
-		ProxySignals(ctr)
 	}
 
 	if stdout == nil && stderr == nil {


### PR DESCRIPTION
Install the signal proxy before attaching to/starting the container to make sure there's no race-condition as revealed in the failing start/run tests in #16901.  The tests had the valid expectation that signal forwarding works once the container is running.

Further update the tests to account for the attach test where the expectation is that signal forwarding works once Podman has attached to container (or even before).

Fixes: #16901
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>
Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a race condition in Podman's signal proxy.
```

@edsantiago @containers/podman-maintainers PTAL
