### PR TITLE
Don't set hostPort when generating a service

### DIFF
--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -200,7 +200,7 @@ func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string,
 
 	// Generate the kube pods from containers.
 	if len(ctrs) >= 1 {
-		po, err := libpod.GenerateForKube(ctx, ctrs)
+		po, err := libpod.GenerateForKube(ctx, ctrs, options.Service)
 		if err != nil {
 			return nil, err
 		}
@@ -249,7 +249,7 @@ func getKubePods(ctx context.Context, pods []*libpod.Pod, getService bool) ([][]
 	svcs := [][]byte{}
 
 	for _, p := range pods {
-		po, sp, err := p.GenerateForKube(ctx)
+		po, sp, err := p.GenerateForKube(ctx, getService)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
When generating a kube yaml with kube generate, do not set the hostPort in the pod spec if the service flag is set and we are generating a service kind too.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When generating service kind, don't add hostPort to the pod spec.
```
