### PR TITLE
Allow specification of podman --remote build -f -

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -218,7 +218,11 @@ func build(cmd *cobra.Command, args []string) error {
 	var containerFiles []string
 	for _, f := range buildOpts.File {
 		if f == "-" {
-			containerFiles = append(containerFiles, "/dev/stdin")
+			if len(args) == 0 {
+				args = append(args, "-")
+			} else {
+				containerFiles = append(containerFiles, "/dev/stdin")
+			}
 		} else {
 			containerFiles = append(containerFiles, f)
 		}

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -101,6 +101,12 @@ EOF
     is "$output"   "$rand_content"   "reading generated file in image"
 
     run_podman rmi -f build_test
+
+    # Now try without specifying a context dir
+    run_podman build -t build_test -f - < $containerfile
+    is "$output" ".*COMMIT" "COMMIT seen in log"
+
+    run_podman rmi -f build_test
 }
 
 @test "podman build - global runtime flags test" {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/17495

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman --remote build -f -` now works.
```
