### PR TITLE
system tests: prevent leading tabs

### DIFF
--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -28,6 +28,11 @@ msg "Checking Cirrus YAML"
 # shellcheck disable=SC2154
 showrun $SCRIPT_BASE/cirrus_yaml_test.py
 
+msg "Checking for leading tabs in system tests"
+if grep -n ^$'\t' test/system/*; then
+    die "Found leading tabs in system tests. Use spaces to indent, not tabs."
+fi
+
 # Defined by CI config.
 # shellcheck disable=SC2154
 if [[ "${DISTRO_NV}" =~ fedora ]]; then

--- a/test/system/020-tag.bats
+++ b/test/system/020-tag.bats
@@ -14,41 +14,41 @@ function _tag_and_check() {
 }
 
 @test "podman tag/untag" {
-	# Test a fully-qualified image reference.
-	_tag_and_check registry.com/image:latest registry.com/image:latest
+    # Test a fully-qualified image reference.
+    _tag_and_check registry.com/image:latest registry.com/image:latest
 
-	# Test a reference without tag and make sure ":latest" is appended.
-	_tag_and_check registry.com/image registry.com/image:latest
+    # Test a reference without tag and make sure ":latest" is appended.
+    _tag_and_check registry.com/image registry.com/image:latest
 
-	# Test a tagged short image and make sure "localhost/" is prepended.
-	_tag_and_check image:latest localhost/image:latest
+    # Test a tagged short image and make sure "localhost/" is prepended.
+    _tag_and_check image:latest localhost/image:latest
 
-	# Test a short image without tag and make sure "localhost/" is
-	# prepended and ":latest" is appended.
-	_tag_and_check image localhost/image:latest
+    # Test a short image without tag and make sure "localhost/" is
+    # prepended and ":latest" is appended.
+    _tag_and_check image localhost/image:latest
 
-	# Test error case.
-	run_podman 125 untag $IMAGE registry.com/foo:bar
-	is "$output" "Error: registry.com/foo:bar: tag not known"
+    # Test error case.
+    run_podman 125 untag $IMAGE registry.com/foo:bar
+    is "$output" "Error: registry.com/foo:bar: tag not known"
 }
 
 @test "podman untag all" {
-	# First get the image ID
-	run_podman inspect --format '{{.ID}}' $IMAGE
-	iid=$output
+    # First get the image ID
+    run_podman inspect --format '{{.ID}}' $IMAGE
+    iid=$output
 
-	# Add a couple of tags
-	run_podman tag $IMAGE registry.com/1:latest registry.com/2:latest registry.com/3:latest
+    # Add a couple of tags
+    run_podman tag $IMAGE registry.com/1:latest registry.com/2:latest registry.com/3:latest
 
-	# Untag with arguments to for all tags to be removed
-	run_podman untag $iid
+    # Untag with arguments to for all tags to be removed
+    run_podman untag $iid
 
-	# Now make sure all tags are removed
-	run_podman image inspect $iid --format "{{.RepoTags}}"
-	is "$output" "\[\]" "untag by ID leaves empty set of tags"
+    # Now make sure all tags are removed
+    run_podman image inspect $iid --format "{{.RepoTags}}"
+    is "$output" "\[\]" "untag by ID leaves empty set of tags"
 
-	# Restore image
-	run_podman tag $iid $IMAGE
+    # Restore image
+    run_podman tag $iid $IMAGE
 }
 
 # vim: filetype=sh

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -639,10 +639,10 @@ json-file | f
         run_podman run --name=$randomname --rootfs $romount:O echo "Hello world"
         is "$output" "Hello world"
 
-	run_podman container inspect $randomname --format "{{.ImageDigest}}"
-	is "$output" "" "Empty image digest for --rootfs container"
+        run_podman container inspect $randomname --format "{{.ImageDigest}}"
+        is "$output" "" "Empty image digest for --rootfs container"
 
-	run_podman rm -f -t0 $randomname
+        run_podman rm -f -t0 $randomname
         run_podman image unmount $IMAGE
     fi
 }

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -178,7 +178,7 @@ function __run_healthcheck_container() {
             break
         fi
 
-	sleep 0.5
+        sleep 0.5
     done
 
     run_podman rm -f $cname

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -275,7 +275,7 @@ load helpers
         run_podman exec $destcontainer cat "/$dest_fullname"
         is "$output" "${randomcontent[$id]}" "$description (cp ctr:$src to /$dest)"
 
-	# To CREATED container
+        # To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
         destcontainers+=($destcontainer)
@@ -303,7 +303,7 @@ load helpers
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman exec $destcontainer cat "/$dest_fullname"
         is "$output" "${randomcontent[$id]}" "$description (cp ctr:$src to /$dest)"
-	# To CREATED container
+        # To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
         destcontainers+=($destcontainer)
@@ -518,7 +518,7 @@ load helpers
         is "$output" "${randomcontent[0]}
 ${randomcontent[1]}" "$description"
 
-	# To CREATED container
+        # To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
         destcontainers+=($destcontainer)
@@ -545,7 +545,7 @@ ${randomcontent[1]}" "$description"
             unset dest_fullname
         fi
 
-	# To RUNNING container
+        # To RUNNING container
         run_podman run -d $IMAGE sleep infinity
         destcontainer="$output"
         destcontainers+=($destcontainer)
@@ -554,7 +554,7 @@ ${randomcontent[1]}" "$description"
         is "$output" "${randomcontent[0]}
 ${randomcontent[1]}" "$description"
 
-	# To CREATED container
+        # To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
         destcontainers+=($destcontainer)

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -397,7 +397,7 @@ EOF
     if is_remote; then
         ENVHOST=""
     else
-	ENVHOST="--env-host"
+        ENVHOST="--env-host"
     fi
 
     # Run without args - should run the above script. Verify its output.
@@ -584,7 +584,7 @@ EOF
 
         # Build an image. For .dockerignore
         local -a ignoreflag
-	unset ignoreflag
+        unset ignoreflag
         if [[ $ignorefile != ".dockerignore" ]]; then
             ignoreflag="--ignorefile $tmpdir/$ignorefile"
         fi
@@ -1029,14 +1029,14 @@ EOF
 
     touch $tmpdir/empty-file.txt
     if is_remote && ! is_rootless ; then
-	# TODO: set this file's owner to a UID:GID that will not be mapped
-	# in the context where the remote server is running, which generally
-	# requires us to be root (or running with more mapped IDs) on the
-	# client, but not root (or running with fewer mapped IDs) on the
-	# remote server
-	# 4294967292:4294967292 (0xfffffffc:0xfffffffc) isn't that, but
-	# it will catch errors where a remote server doesn't apply the right
-	# default as it copies content into the container
+        # TODO: set this file's owner to a UID:GID that will not be mapped
+        # in the context where the remote server is running, which generally
+        # requires us to be root (or running with more mapped IDs) on the
+        # client, but not root (or running with fewer mapped IDs) on the
+        # remote server
+        # 4294967292:4294967292 (0xfffffffc:0xfffffffc) isn't that, but
+        # it will catch errors where a remote server doesn't apply the right
+        # default as it copies content into the container
         chown 4294967292:4294967292 $tmpdir/empty-file.txt
     fi
     cat >$tmpdir/Dockerfile <<EOF

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -448,13 +448,13 @@ NeedsChown    | true
         # and does not work remotely
         run_podman volume mount ${myvolume}
         mnt=${output}
-	echo $mytext >$mnt/$myfile
+        echo $mytext >$mnt/$myfile
         run_podman run -v ${myvolume}:/vol:z $IMAGE cat /vol/$myfile
-	is "$output" "$mytext" "$myfile should exist within the containers volume and contain $mytext"
+        is "$output" "$mytext" "$myfile should exist within the containers volume and contain $mytext"
         run_podman volume unmount ${myvolume}
     else
         run_podman 125 volume mount ${myvolume}
-	is "$output" "Error: cannot run command \"podman volume mount\" in rootless mode, must execute.*podman unshare.*first" "Should fail and complain about unshare"
+        is "$output" "Error: cannot run command \"podman volume mount\" in rootless mode, must execute.*podman unshare.*first" "Should fail and complain about unshare"
     fi
 }
 

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -113,12 +113,12 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
     img="healthcheck_i"
 
     for policy in none kill restart stop;do
-	if [[ $policy == "none" ]];then
-	    # Do not remove the /uh-oh file for `none` as we want to
-	    # demonstrate that no action was taken
-            _build_health_check_image $img
+        if [[ $policy == "none" ]];then
+           # Do not remove the /uh-oh file for `none` as we want to
+           # demonstrate that no action was taken
+           _build_health_check_image $img
         else
-            _build_health_check_image $img cleanfile
+           _build_health_check_image $img cleanfile
         fi
 
         # Run that healthcheck image.
@@ -140,19 +140,19 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
         is "$output" "unhealthy" "output from 'podman healthcheck run' (policy: $policy)"
 
         run_podman inspect $ctr --format "{{.State.Status}} {{.Config.HealthcheckOnFailureAction}}"
-	if [[ $policy == "restart" ]];then
-	    # Container has been restarted and health check works again
-            is "$output" "running $policy" "container has been restarted"
-            run_podman container inspect $ctr --format "{{.State.Healthcheck.FailingStreak}}"
-            is "$output" "0" "Failing streak of restarted container should be 0 again"
-            run_podman healthcheck run $ctr
+        if [[ $policy == "restart" ]];then
+           # Container has been restarted and health check works again
+           is "$output" "running $policy" "container has been restarted"
+           run_podman container inspect $ctr --format "{{.State.Healthcheck.FailingStreak}}"
+           is "$output" "0" "Failing streak of restarted container should be 0 again"
+           run_podman healthcheck run $ctr
         elif [[ $policy == "none" ]];then
             # Container is still running and health check still broken
             is "$output" "running $policy" "container continued running"
             run_podman 1 healthcheck run $ctr
             is "$output" "unhealthy" "output from 'podman healthcheck run' (policy: $policy)"
-	else
-	    # kill and stop yield the container into a non-running state
+        else
+            # kill and stop yield the container into a non-running state
             is "$output" ".* $policy" "container was stopped/killed (policy: $policy)"
             assert "$output" != "running $policy"
             # also make sure that it's not stuck in the stopping state

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -189,10 +189,10 @@ function check_listen_env() {
     local stdenv="$1"
     local context="$2"
     if is_remote; then
-	is "$output" "$stdenv" "LISTEN Environment did not pass: $context"
+        is "$output" "$stdenv" "LISTEN Environment did not pass: $context"
     else
-	out=$(for o in $output; do echo $o; done| sort)
-	std=$(echo "$stdenv
+        out=$(for o in $output; do echo $o; done| sort)
+        std=$(echo "$stdenv
 LISTEN_PID=1
 LISTEN_FDS=1
 LISTEN_FDNAMES=listen_fdnames" | sort)

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -226,7 +226,7 @@ load helpers.network
        "sdfsdf"
 
     run_podman run -d --network $mynetname -p 127.0.0.1:$myport:$myport \
-	       $IMAGE nc -l -n -v -p $myport
+               $IMAGE nc -l -n -v -p $myport
     cid="$output"
 
     # FIXME: debugging for #11871
@@ -663,9 +663,9 @@ EOF
     is "$output" "search example.com.*" "correct search domain"
     local store=$output
     if is_netavark; then
-	is "$store" ".*nameserver $subnet.1.*" "integrated dns nameserver is set"
+        is "$store" ".*nameserver $subnet.1.*" "integrated dns nameserver is set"
     else
-	is "$store" ".*nameserver 1.1.1.1${nl}nameserver $searchIP${nl}nameserver 1.0.0.1${nl}nameserver 8.8.8.8" "nameserver order is correct"
+        is "$store" ".*nameserver 1.1.1.1${nl}nameserver $searchIP${nl}nameserver 1.0.0.1${nl}nameserver 8.8.8.8" "nameserver order is correct"
     fi
     # we should use the integrated dns server
     run_podman run --network $netname --rm $IMAGE cat /etc/resolv.conf

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -567,7 +567,7 @@ EOF
     run_podman kube play $YAML
     if selinux_enabled; then
         run_podman inspect pod1-test1 --format "{{ .MountLabel }}"
-	is "$output" "system_u:object_r:usr_t:s0:c1,c2" "Generated container should use filetype usr_t"
+        is "$output" "system_u:object_r:usr_t:s0:c1,c2" "Generated container should use filetype usr_t"
     fi
     run_podman kube down $YAML
 }

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -62,7 +62,7 @@ EOF
     # container" errors from podman wait.
     CONTAINERS_CONF="$conf_tmp" run_podman '?' wait "$cid"
     if [[ $status != 0 ]]; then
-	is "$output" "Error:.*no such container" "unexpected error from podman wait"
+        is "$output" "Error:.*no such container" "unexpected error from podman wait"
     fi
 
     # The --rm option means the container should no longer exist.


### PR DESCRIPTION
Replace existing tab indentations with spaces, and add
a test to CI to prevent new ones from sneaking in.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```