### PR TITLE
libpod: support relative positions for idmaps

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -40,7 +40,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
           The idmap option supports a custom mapping that can be different than the user namespace used by the container.
           The mapping can be specified after the idmap option like: `idmap=uids=0-1-10#10-11-10;gids=0-100-10`.  For each triplet, the first value is the
           start of the backing file system IDs that are mapped to the second value on the host.  The length of this mapping is given in the third value.
-          Multiple ranges are separated with #.
+          Multiple ranges are separated with #.  If the specified mapping is prepended with a '@' then the mapping is considered relative to the container
+          user namespace. The host ID for the mapping is changed to account for the relative position of the container user in the container user namespace.
 
        Options specific to image:
 

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -18,10 +18,18 @@ import (
 var hookPath string
 
 func TestParseOptionIDs(t *testing.T) {
-	_, err := parseOptionIDs("uids=100-200-2")
+	idMap := []idtools.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      1,
+			Size:        10000,
+		},
+	}
+
+	_, err := parseOptionIDs(idMap, "uids=100-200-2")
 	assert.NotNil(t, err)
 
-	mappings, err := parseOptionIDs("100-200-2")
+	mappings, err := parseOptionIDs(idMap, "100-200-2")
 	assert.Nil(t, err)
 	assert.NotNil(t, mappings)
 
@@ -31,7 +39,7 @@ func TestParseOptionIDs(t *testing.T) {
 	assert.Equal(t, mappings[0].HostID, 200)
 	assert.Equal(t, mappings[0].Size, 2)
 
-	mappings, err = parseOptionIDs("100-200-2#300-400-5")
+	mappings, err = parseOptionIDs(idMap, "100-200-2#300-400-5")
 	assert.Nil(t, err)
 	assert.NotNil(t, mappings)
 
@@ -44,6 +52,23 @@ func TestParseOptionIDs(t *testing.T) {
 	assert.Equal(t, mappings[1].ContainerID, 300)
 	assert.Equal(t, mappings[1].HostID, 400)
 	assert.Equal(t, mappings[1].Size, 5)
+
+	mappings, err = parseOptionIDs(idMap, "@100-200-2#@300-400-5")
+	assert.Nil(t, err)
+	assert.NotNil(t, mappings)
+
+	assert.Equal(t, len(mappings), 2)
+
+	assert.Equal(t, mappings[0].ContainerID, 100)
+	assert.Equal(t, mappings[0].HostID, 201)
+	assert.Equal(t, mappings[0].Size, 2)
+
+	assert.Equal(t, mappings[1].ContainerID, 300)
+	assert.Equal(t, mappings[1].HostID, 401)
+	assert.Equal(t, mappings[1].Size, 5)
+
+	_, err = parseOptionIDs(idMap, "@10000-20000-2")
+	assert.NotNil(t, err)
 }
 
 func TestParseIDMapMountOption(t *testing.T) {


### PR DESCRIPTION
we were previously using an experimental feature in crun, but we lost this capability once we moved to using the OCI runtime spec to specify the volume mappings in fdcc2257df0fb0cb72d3fbe1b5aa8625955e1219.

Add the same feature to libpod, so that we can support relative positions for the idmaps.

Closes: https://github.com/containers/podman/issues/17517

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
It is possible to specify a relative mapping for volume mappings.
```
