### PR TITLE
quadlet system tests: add useful defaults, logging

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -16,6 +16,8 @@ function start_time() {
 function setup() {
     skip_if_remote "quadlet tests are meaningless over remote"
 
+    test -x "$QUADLET" || die "Cannot run quadlet tests without executable \$QUADLET ($QUADLET)"
+
     start_time
 
     basic_setup
@@ -47,7 +49,9 @@ function run_quadlet() {
     local quadlet_tmpdir=$(mktemp -d --tmpdir=$PODMAN_TMPDIR quadlet.XXXXXX)
     cp $sourcefile $quadlet_tmpdir/
 
+    echo "$_LOG_PROMPT $QUADLET $_DASHUSER $UNIT_DIR"
     QUADLET_UNIT_DIRS="$quadlet_tmpdir" run $QUADLET $_DASHUSER $UNIT_DIR
+    echo "$output"
     assert $status -eq 0 "Failed to convert quadlet file: $sourcefile"
     is "$output" "" "quadlet should report no errors"
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -2,7 +2,7 @@
 
 # Podman command to run; may be podman-remote
 PODMAN=${PODMAN:-podman}
-QUADLET=${QUADLET:-quadlet}
+QUADLET=${QUADLET:-/usr/libexec/podman/quadlet}
 
 # Standard image to use for most tests
 PODMAN_TEST_IMAGE_REGISTRY=${PODMAN_TEST_IMAGE_REGISTRY:-"quay.io"}


### PR DESCRIPTION
Tests constantly fail with zero indication of why. Fix that.
 - add correct default for $QUADLET path
 - add check to make sure it exists
 - log quadlet commands and their output

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```