### PR TITLE
RHEL8 gating-test skips and tweaks

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -15,6 +15,7 @@ function start_time() {
 
 function setup() {
     skip_if_remote "quadlet tests are meaningless over remote"
+    skip_if_rootless_cgroupsv1 "quadlet tests don't work rootless on RHEL8"
 
     start_time
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -241,7 +241,8 @@ EOF
     mkdir -p $TESTDIR
     echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
     run_podman kube play --network host $PODMAN_TMPDIR/test.yaml
-    is "$output" "Pod:.*" "podman kube play should work with --network host"
+    # leading ".*" handles "resource limit blah" warning with runc
+    is "$output" ".*Pod:.*" "podman kube play should work with --network host"
 
     run_podman pod inspect --format "{{.InfraConfig.HostNetwork}}" test_pod
     is "$output" "true" ".InfraConfig.HostNetwork"


### PR DESCRIPTION
...to deal with runc, cgroups v1, whatever is causing these failures on RHEL8.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Gating test fixes
```
