### PR TITLE
[v4.4.1-rhel] Backport #17528

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -34,7 +34,7 @@ import (
 	"github.com/containers/podman/v4/pkg/systemd/notifyproxy"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage"
-	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/mount"
@@ -763,7 +763,7 @@ func (c *Container) export(out io.Writer) error {
 		}()
 	}
 
-	input, err := archive.Tar(mountPoint, archive.Uncompressed)
+	input, err := chrootarchive.Tar(mountPoint, nil, mountPoint)
 	if err != nil {
 		return fmt.Errorf("reading container directory %q: %w", c.ID(), err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 )
@@ -63,7 +64,7 @@ func CreateTarFromSrc(source string, dest string) error {
 		return fmt.Errorf("could not create tarball file '%s': %w", dest, err)
 	}
 	defer file.Close()
-	return TarToFilesystem(source, file)
+	return TarChrootToFilesystem(source, file)
 }
 
 // TarToFilesystem creates a tarball from source and writes to an os.file
@@ -85,6 +86,28 @@ func TarToFilesystem(source string, tarball *os.File) error {
 func Tar(source string) (io.ReadCloser, error) {
 	logrus.Debugf("creating tarball of %s", source)
 	return archive.Tar(source, archive.Uncompressed)
+}
+
+// TarChrootToFilesystem creates a tarball from source and writes to an os.file
+// provided while chrooted to the source.
+func TarChrootToFilesystem(source string, tarball *os.File) error {
+	tb, err := TarWithChroot(source)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(tarball, tb)
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("wrote tarball file %s", tarball.Name())
+	return nil
+}
+
+// TarWithChroot creates a tarball from source and returns a readcloser of it
+// while chrooted to the source.
+func TarWithChroot(source string) (io.ReadCloser, error) {
+	logrus.Debugf("creating tarball of %s", source)
+	return chrootarchive.Tar(source, nil, source)
 }
 
 // RemoveScientificNotationFromFloat returns a float without any


### PR DESCRIPTION
Cherry-pick #17528 to v4.4.1-rhel per RHBZ 2169618

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
