### PR TITLE
[CI:DOCS] Cirrus: Fix version-check to only run on `main` job

### DIFF
--- a/docs/tutorials/mac_win_client.md
+++ b/docs/tutorials/mac_win_client.md
@@ -17,7 +17,7 @@ The remote client uses a client-server model. You need Podman installed on a Lin
 ### Windows
 
 Installing the Windows Podman client begins by downloading the Podman Windows installer. The Windows installer is built with each Podman release and is downloadable from its [release description page](https://github.com/containers/podman/releases/latest).  The Windows installer file is named `podman-#.#.#-setup.exe`, where the `#` symbols represent the version number of Podman.
-As of 2023-01-16 the latest version is [v4.3.1](https://github.com/containers/podman/releases/download/v4.3.1/podman-4.3.1-setup.exe).
+As of 2023-02-16 the latest version is [v4.4.1](https://github.com/containers/podman/releases/download/v4.4.1/podman-4.4.1-setup.exe).
 
 Once you have downloaded the installer to your Windows host, simply double click the installer and Podman will be installed.  The path is also set to put `podman` in the default user path.
 

--- a/docs/tutorials/podman-for-windows.md
+++ b/docs/tutorials/podman-for-windows.md
@@ -44,7 +44,7 @@ downloaded from the official
 Windows installer file is named podman-#.#.#-setup.exe, where the # symbols
 represent the version number of Podman. Be sure to download a 4.1 or later
 release for the capabilities discussed in this guide.
-As of 2023-01-16 the latest version is [v4.3.1](https://github.com/containers/podman/releases/download/v4.3.1/podman-4.3.1-setup.exe).
+As of 2023-02-16 the latest version is [v4.4.1](https://github.com/containers/podman/releases/download/v4.4.1/podman-4.4.1-setup.exe).
 
 ![Installing Podman 4.1.0](podman-win-install.jpg)
 

--- a/docs/version-check
+++ b/docs/version-check
@@ -21,17 +21,19 @@ function warn() {
     echo "$ME: $*" >&2
 }
 
-# Setup check: exit gracefully unless we're in the desired environment
-if [[ -n "$CIRRUS_PR" ]]; then
-    warn "we don't run on PRs"
-    exit 0
-fi
+if [[ -n "$CIRRUS_CI" ]]; then
 
-if [[ -n "$CIRRUS_CRON" ]]; then
-    if [[ "$CIRRUS_CRON" != "nightly" ]]; then
-        warn "Only meaningful when CIRRUS_CRON=nightly (it is '$CIRRUS_CRON')"
-        exit 0
-    fi
+  # Setup check: exit gracefully unless we're in the desired environment
+  if [[ -n "$CIRRUS_PR" ]]; then
+      warn "we don't run on PRs"
+      exit 0
+  fi
+
+  if [[ "$CIRRUS_CRON" != "main" ]]; then
+      warn "Only meaningful in CI when CIRRUS_CRON=main (it is '$CIRRUS_CRON')"
+      exit 0
+  fi
+
 fi
 
 # No sense running on release branches


### PR DESCRIPTION
A conditional in `version-check` bypasses the test for PRs.  However, it appears it was intended to execute during the daily cirrus-cron runs. However, the cron-job it references (`nightly`) doesn't exist.  This is causing the test to run for every merge into `main`, and never run for `main` branch cirrus-cron job.  Fix the name so the test **ONLY** runs for the `main` branch cron-job.

Also, [since the test is currently failing](https://cirrus-ci.com/task/6183669669298176), update the docs as per the output instructions.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
