### PR TITLE
journald: remove initializeJournal()

### DIFF
--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/libpod/logs"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/coreos/go-systemd/v22/sdjournal"
 	"github.com/sirupsen/logrus"
 )
@@ -30,21 +29,6 @@ const (
 
 func init() {
 	logDrivers = append(logDrivers, define.JournaldLogging)
-}
-
-// initializeJournal will write an empty string to the journal
-// when a journal is created. This solves a problem when people
-// attempt to read logs from a container that has never had stdout/stderr
-func (c *Container) initializeJournal(ctx context.Context) error {
-	m := make(map[string]string)
-	m["SYSLOG_IDENTIFIER"] = "podman"
-	m["PODMAN_ID"] = c.ID()
-	history := events.History
-	m["PODMAN_EVENT"] = history.String()
-	container := events.Container
-	m["PODMAN_TYPE"] = container.String()
-	m["PODMAN_TIME"] = time.Now().Format(time.RFC3339Nano)
-	return journal.Send("", journal.PriInfo, m)
 }
 
 func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOptions, logChannel chan *logs.LogLine, colorID int64) error {

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -14,7 +14,3 @@ import (
 func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, colorID int64) error {
 	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
 }
-
-func (c *Container) initializeJournal(ctx context.Context) error {
-	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
-}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -541,12 +541,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	}
 
 	switch ctr.config.LogDriver {
-	case define.NoLogging, define.PassthroughLogging:
+	case define.NoLogging, define.PassthroughLogging, define.JournaldLogging:
 		break
-	case define.JournaldLogging:
-		if err := ctr.initializeJournal(ctx); err != nil {
-			return nil, fmt.Errorf("failed to initialize journal: %w", err)
-		}
 	default:
 		if ctr.config.LogPath == "" {
 			ctr.config.LogPath = filepath.Join(ctr.config.StaticDir, "ctr.log")


### PR DESCRIPTION
This was added as hack in commit 6b06e9b77c because the journald logs code was not able to handle an empty journal. But since commit 767947ab88 this is no longer the case, we correctly use the sd_journal API and know when the journal is empty.

Therefore we no longer need this hack and it should be removed because it just adds overhead and an empty journal entry for no good reason.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
