### PR TITLE
kube play: only enforce passthrough in Quadlet

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -251,15 +251,6 @@ func play(cmd *cobra.Command, args []string) error {
 		return errors.New("--force may be specified only with --down")
 	}
 
-	// When running under Systemd use passthrough as the default log-driver.
-	// When doing so, the journal socket is passed to the containers as-is which has two advantages:
-	// 1. journald can see who the actual sender of the log event is,
-	//    rather than thinking everything comes from the conmon process
-	// 2. conmon will not have to copy all the log data
-	if !cmd.Flags().Changed(logDriverFlagName) && playOptions.ServiceContainer {
-		playOptions.LogDriver = define.PassthroughLogging
-	}
-
 	reader, err := readerFromArg(args[0])
 	if err != nil {
 		return err

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -793,6 +793,9 @@ func ConvertKube(kube *parser.UnitFile, isUser bool) (*parser.UnitFile, error) {
 
 		// Use a service container
 		"--service-container=true",
+
+		// We want output to the journal, so use the log driver.
+		"--log-driver", "passthrough",
 	)
 
 	if err := handleUserRemap(kube, KubeGroup, execStart, isUser, false); err != nil {

--- a/test/e2e/quadlet/basic.kube
+++ b/test/e2e/quadlet/basic.kube
@@ -3,6 +3,7 @@
 ## assert-podman-final-args-regex .*/podman_test.*/quadlet/deployment.yml
 ## assert-podman-args "--replace"
 ## assert-podman-args "--service-container=true"
+## assert-podman-args "--log-driver" "passthrough"
 ## assert-podman-stop-args "kube"
 ## assert-podman-stop-args "down"
 ## assert-podman-stop-final-args-regex .*/podman_test.*/quadlet/deployment.yml

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -393,6 +393,7 @@ var _ = Describe("quadlet system generator", func() {
 				"## assert-podman-final-args-regex .*/podman_test.*/quadlet/deployment.yml",
 				"## assert-podman-args \"--replace\"",
 				"## assert-podman-args \"--service-container=true\"",
+				"## assert-podman-args \"--log-driver\" \"passthrough\"",
 				"## assert-podman-stop-args \"kube\"",
 				"## assert-podman-stop-args \"down\"",
 				"## assert-podman-stop-final-args-regex .*/podman_test.*/quadlet/deployment.yml",
@@ -413,7 +414,7 @@ var _ = Describe("quadlet system generator", func() {
 				"Type=notify",
 				"NotifyAccess=all",
 				"SyslogIdentifier=%N",
-				fmt.Sprintf("ExecStart=/usr/local/bin/podman kube play --replace --service-container=true %s/deployment.yml", quadletDir),
+				fmt.Sprintf("ExecStart=/usr/local/bin/podman kube play --replace --service-container=true --log-driver passthrough %s/deployment.yml", quadletDir),
 				fmt.Sprintf("ExecStop=/usr/local/bin/podman kube down %s/deployment.yml", quadletDir),
 			}
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -414,10 +414,10 @@ EOF
     run_podman 125 container rm $service_container
     is "$output" "Error: container .* is the service container of pod(s) .* and cannot be removed without removing the pod(s)"
 
-    # Verify that the log-driver for the Pod's containers is passthrough
+    # containers/podman/issues/17482: verify that the log-driver for the Pod's containers is NOT passthrough
     for name in "a" "b"; do
         run_podman container inspect test_pod-${name} --format "{{.HostConfig.LogConfig.Type}}"
-        is $output "passthrough"
+        assert $output != "passthrough"
     done
 
     # Add a simple `auto-update --dry-run` test here to avoid too much redundancy


### PR DESCRIPTION
Only enforce the passthrough log driver for Quadlet. Commit 68fbebf introduced a regression on the `podman-kube@` template as `podman logs` stopped working and settings from containers.conf were ignored.

Fixes: #17482

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where containers started via the `podman-kube@` systemd template would always use the "passthrough" log driver.
```
