### PR TITLE
[v4.4.1-rhel] [CI:DOCS] Touch up secret man page

### DIFF
--- a/docs/source/markdown/options/secret.md
+++ b/docs/source/markdown/options/secret.md
@@ -37,10 +37,16 @@ Secret Options
 Examples
 
 Mount at `/my/location/mysecret` with UID 1.
-```--secret mysecret,target=/my/location/mysecret,uid=1```
+```
+--secret mysecret,target=/my/location/mysecret,uid=1
+```
 
 Mount at `/run/secrets/customtarget` with mode 0777.
-```--secret mysecret,target=customtarget,mode=0777```
+```
+--secret mysecret,target=customtarget,mode=0777
+```
 
 Create a secret environment variable called `ENVSEC`.
-```--secret mysecret,type=env,target=ENVSEC```
+```
+--secret mysecret,type=env,target=ENVSEC
+```


### PR DESCRIPTION
This is a working theory fix.  The man pages including the secret.md option are not resolving properly.  The secret.md file is the only one with a text line with three back ticks on the start and end of the line.  Elsewhere we have the backticks on separate lines and the text in its own line.

This might not fix the issue, but at the very least it makes things consistent.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
