### PR TITLE
[CI:DOCS] Add restriction to option README

### DIFF
--- a/docs/source/markdown/options/README.md
+++ b/docs/source/markdown/options/README.md
@@ -45,3 +45,19 @@ This allows the shared use of examples in the option file:
 As a special case, `podman-pod-X` becomes just `X` (the "pod" is removed).
 This makes the `pod-id-file` man page more useful. To get the full
 subcommand including 'pod', use `<<fullsubcommand>>`.
+
+Restrictions
+============
+
+There is a restriction for having a single text line with three
+back-ticks in the front and the end of the line.  For instance:
+
+\`\`\`Some man page text\`\`\`
+
+This is currently not allowed and will cause a corruption of the
+compiled man page.  Instead, put the three back-ticks on separate
+lines like:
+
+\`\`\`
+Some man page text
+\`\`\`


### PR DESCRIPTION
Add a note about the restriction of the use of
three back-ticks in the md files in the options directory. If this is not done properly, it can quietly corrupt the compliled man pages.

[NO NEW TESTS NEEDED]
Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NO
```
