### PR TITLE
make docs: sanity check for broken man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,11 +469,9 @@ $(MANPAGES): %: %.md .install.md2man docdir
 	       -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g'    \
 	       -e 's/\\$$/  /g' $<                         |\
 	$(GOMD2MAN) -out $(subst source/markdown,build/man,$@)
-# FIXME: 2023-02-16: we may need a multi-commit approach to
-# enable this.
-#	@if grep 'included file options/' docs/build/man/*; then \
-#		echo "FATAL: man pages must not contain ^^^^"; exit 1; \
-#	fi
+	@if grep 'included file options/' docs/build/man/*; then \
+		echo "FATAL: man pages must not contain ^^^^"; exit 1; \
+	fi
 
 .PHONY: docdir
 docdir:


### PR DESCRIPTION
A recent commit to an included option file resulted in
completely broken man pages, where the markdown processor
just choked and sent the "included file blah blah" markdown
straight through to the nroff source. Hilarity ensued.

The string "included file options/" should never appear
in nroff. This adds a last-minute check to make sure
a similar error never happens again.

(As suggested by @Luap99 we should also add validators for
markdown and/or nroff.)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```