### PR TITLE
netavark: only use aardvark ip as nameserver

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2048,7 +2048,11 @@ func (c *Container) generateResolvConf() error {
 	// If the user provided dns, it trumps all; then dns masq; then resolv.conf
 	keepHostServers := false
 	if len(nameservers) == 0 {
-		keepHostServers = true
+		// when no network name servers or not netavark use host servers
+		// for aardvark dns we only want our single server in there
+		if len(networkNameServers) == 0 || networkBackend != string(types.Netavark) {
+			keepHostServers = true
+		}
 		// first add the nameservers from the networks status
 		nameservers = networkNameServers
 		// slirp4netns has a built in DNS forwarder.

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -663,7 +663,7 @@ EOF
     is "$output" "search example.com.*" "correct search domain"
     local store=$output
     if is_netavark; then
-        is "$store" ".*nameserver $subnet.1.*" "integrated dns nameserver is set"
+        assert "$store" == "search example.com${nl}nameserver $subnet.1" "only integrated dns nameserver is set"
     else
         is "$store" ".*nameserver 1.1.1.1${nl}nameserver $searchIP${nl}nameserver 1.0.0.1${nl}nameserver 8.8.8.8" "nameserver order is correct"
     fi


### PR DESCRIPTION
Since commit 06241077cc we use the aardvark per container dns functionality. This means we should only have the aardvark ip in resolv.conf otherwise the client resolver could skip aardvark, thus ignoring the special dns option for this container.

Fixes #17499

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman run --dns ... --network ... will no longer add host nameservers to resolv.conf when aardvark-dns is used.
```
