### PR TITLE
Add missing dependency crun to the podman spec

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -65,6 +65,7 @@ Requires: conmon >= 2:2.0.30-2
 Requires: containers-common-extra >= 4:1-78
 Requires: iptables
 Requires: nftables
+Requires: crun
 Recommends: catatonit
 Suggests: qemu-user-static
 Conflicts: quadlet


### PR DESCRIPTION
quadlet uses crun as the runtime, but crun is not required in any way by podman

#### Does this PR introduce a user-facing change?

```release-note
None
```
