### PR TITLE
compat API: network create return 409 for duplicate

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -280,10 +280,17 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 		// FIXME can we use the IPAM driver and options?
 	}
 
+	opts := nettypes.NetworkCreateOptions{
+		IgnoreIfExists: !networkCreate.CheckDuplicate,
+	}
 	ic := abi.ContainerEngine{Libpod: runtime}
-	newNetwork, err := ic.NetworkCreate(r.Context(), network, nil)
+	newNetwork, err := ic.NetworkCreate(r.Context(), network, &opts)
 	if err != nil {
-		utils.InternalServerError(w, err)
+		if errors.Is(err, nettypes.ErrNetworkExists) {
+			utils.Error(w, http.StatusConflict, err)
+		} else {
+			utils.InternalServerError(w, err)
+		}
 		return
 	}
 

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -104,6 +104,9 @@ t GET networks/podman 200 \
 
 # network create docker
 t POST networks/create Name=net3\ IPAM='{"Config":[]}' 201
+# create with same name should not error unless CheckDuplicate is set
+t POST networks/create Name=net3 201
+t POST networks/create Name=net3\ CheckDuplicate=true 409
 # network delete docker
 t DELETE networks/net3 204
 


### PR DESCRIPTION
If the name already exists and CheckDuplicate is set we need to return 409, if CheckDuplicate is not set we return the network without error.

Fixes #17585

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The docker compat API now returns 409 if you try to create a network with the same name and CheckDuplicate is set to true.
```
