### PR TITLE
Machine refactor for QEMU/AppleHV

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -1,0 +1,52 @@
+//go:build arm64 && darwin
+// +build arm64,darwin
+
+package applehv
+
+import "github.com/containers/podman/v4/pkg/machine"
+
+type Virtualization struct {
+	artifact    machine.Artifact
+	compression machine.ImageCompression
+	format      machine.ImageFormat
+}
+
+func (v Virtualization) Artifact() machine.Artifact {
+	return machine.None
+}
+
+func (v Virtualization) CheckExclusiveActiveVM() (bool, string, error) {
+	return false, "", machine.ErrNotImplemented
+}
+
+func (v Virtualization) Compression() machine.ImageCompression {
+	return v.compression
+}
+
+func (v Virtualization) Format() machine.ImageFormat {
+	return v.format
+}
+
+func (v Virtualization) IsValidVMName(name string) (bool, error) {
+	return false, machine.ErrNotImplemented
+}
+
+func (v Virtualization) List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
+	return nil, machine.ErrNotImplemented
+}
+
+func (v Virtualization) LoadVMByName(name string) (machine.VM, error) {
+	return nil, machine.ErrNotImplemented
+}
+
+func (v Virtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
+	return nil, machine.ErrNotImplemented
+}
+
+func (v Virtualization) RemoveAndCleanMachines() error {
+	return machine.ErrNotImplemented
+}
+
+func (v Virtualization) VMType() string {
+	return vmtype
+}

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1,5 +1,5 @@
-//go:build arm64 && !windows && !linux
-// +build arm64,!windows,!linux
+//go:build arm64 && darwin
+// +build arm64,darwin
 
 package applehv
 
@@ -9,16 +9,17 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 )
 
-type Provider struct{}
-
 var (
-	hvProvider = &Provider{}
 	// vmtype refers to qemu (vs libvirt, krun, etc).
 	vmtype = "apple"
 )
 
 func GetVirtualizationProvider() machine.VirtProvider {
-	return hvProvider
+	return &Virtualization{
+		artifact:    machine.None,
+		compression: machine.Xz,
+		format:      machine.Qcow,
+	}
 }
 
 const (
@@ -41,30 +42,4 @@ const (
 	dockerGlobal
 )
 
-func (p *Provider) NewMachine(opts machine.InitOptions) (machine.VM, error) {
-	return nil, machine.ErrNotImplemented
-}
-
-func (p *Provider) LoadVMByName(name string) (machine.VM, error) {
-	return nil, machine.ErrNotImplemented
-}
-
-func (p *Provider) List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
-	return nil, machine.ErrNotImplemented
-}
-
-func (p *Provider) IsValidVMName(name string) (bool, error) {
-	return false, machine.ErrNotImplemented
-}
-
-func (p *Provider) CheckExclusiveActiveVM() (bool, string, error) {
-	return false, "", machine.ErrNotImplemented
-}
-
-func (p *Provider) RemoveAndCleanMachines() error {
-	return machine.ErrNotImplemented
-}
-
-func (p *Provider) VMType() string {
-	return vmtype
 }

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -48,11 +48,14 @@ const (
 )
 
 type VirtProvider interface {
-	NewMachine(opts InitOptions) (VM, error)
-	LoadVMByName(name string) (VM, error)
-	List(opts ListOptions) ([]*ListResponse, error)
-	IsValidVMName(name string) (bool, error)
+	Artifact() Artifact
 	CheckExclusiveActiveVM() (bool, string, error)
+	Compression() ImageCompression
+	Format() ImageFormat
+	IsValidVMName(name string) (bool, error)
+	List(opts ListOptions) ([]*ListResponse, error)
+	LoadVMByName(name string) (VM, error)
+	NewMachine(opts InitOptions) (VM, error)
 	RemoveAndCleanMachines() error
 	VMType() string
 }
@@ -72,10 +75,10 @@ var (
 
 type Download struct {
 	Arch                  string
-	Artifact              artifact
+	Artifact              Artifact
 	CompressionType       string
 	CacheDir              string
-	Format                imageFormat
+	Format                ImageFormat
 	ImageName             string
 	LocalPath             string
 	LocalUncompressedFile string

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/qemu"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -21,7 +22,7 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	defaultStream string = "testing"
+	defaultStream machine.FCOSStream = machine.Testing
 )
 
 var (
@@ -43,7 +44,8 @@ func TestMachine(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	fcd, err := machine.GetFCOSDownload(defaultStream, machine.Xz)
+	qemuVP := qemu.GetVirtualizationProvider()
+	fcd, err := machine.GetFCOSDownload(qemuVP, defaultStream)
 	if err != nil {
 		Fail("unable to get virtual machine image")
 	}

--- a/pkg/machine/fcos_test.go
+++ b/pkg/machine/fcos_test.go
@@ -9,7 +9,7 @@ func Test_compressionFromFile(t *testing.T) {
 	var tests = []struct {
 		name string
 		args args
-		want imageCompression
+		want ImageCompression
 	}{
 		{
 			name: "xz",
@@ -52,7 +52,7 @@ func Test_compressionFromFile(t *testing.T) {
 func TestImageCompression_String(t *testing.T) {
 	tests := []struct {
 		name string
-		c    imageCompression
+		c    ImageCompression
 		want string
 	}{
 		{
@@ -93,17 +93,17 @@ func TestImageCompression_String(t *testing.T) {
 func TestImageFormat_String(t *testing.T) {
 	tests := []struct {
 		name string
-		imf  imageFormat
+		imf  ImageFormat
 		want string
 	}{
 		{
 			name: "vhdx.zip",
-			imf:  vhdx,
+			imf:  Vhdx,
 			want: "vhdx.zip",
 		},
 		{
 			name: "qcow2",
-			imf:  qcow,
+			imf:  Qcow,
 			want: "qcow2.xz",
 		},
 	}
@@ -119,7 +119,7 @@ func TestImageFormat_String(t *testing.T) {
 func Test_artifact_String(t *testing.T) {
 	tests := []struct {
 		name string
-		a    artifact
+		a    Artifact
 		want string
 	}{
 		{
@@ -136,6 +136,42 @@ func Test_artifact_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.a.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFCOSStream_String(t *testing.T) {
+	tests := []struct {
+		name string
+		st   FCOSStream
+		want string
+	}{
+		{
+			name: "testing",
+			st:   Testing,
+			want: "testing",
+		},
+		{
+			name: "stable",
+			st:   Stable,
+			want: "stable",
+		},
+		{
+			name: "next",
+			st:   Next,
+			want: "next",
+		},
+		{
+			name: "default is stable",
+			st:   99,
+			want: "stable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.st.String(); got != tt.want {
 				t.Errorf("String() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -212,7 +212,7 @@ func Decompress(localPath, uncompressedPath string) error {
 	return decompressEverythingElse(localPath, uncompressedFileWriter)
 }
 
-// Will error out if file without .xz already exists
+// Will error out if file without .Xz already exists
 // Maybe extracting then renaming is a good idea here..
 // depends on Xz: not pre-installed on mac, so it becomes a brew dependency
 func decompressXZ(src string, output io.WriteCloser) error {

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -6,20 +6,11 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 )
 
-const (
-	// FCOS streams
-	// Testing FCOS stream
-	Testing string = "testing"
-	// Next FCOS stream
-	Next string = "next"
-	// Stable FCOS stream
-	Stable string = "stable"
-
-	// Max length of fully qualified socket path
-
-)
-
-type Virtualization struct{}
+type Virtualization struct {
+	artifact    machine.Artifact
+	compression machine.ImageCompression
+	format      machine.ImageFormat
+}
 
 // Deprecated: MachineVMV1 is being deprecated in favor a more flexible and informative
 // structure

--- a/pkg/machine/wsl/fedora.go
+++ b/pkg/machine/wsl/fedora.go
@@ -1,5 +1,5 @@
-//go:build amd64 || arm64
-// +build amd64 arm64
+//go:build windows
+// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -28,7 +28,6 @@ import (
 )
 
 var (
-	wslProvider = &Virtualization{}
 	// vmtype refers to qemu (vs libvirt, krun, etc)
 	vmtype = "wsl"
 )
@@ -204,7 +203,23 @@ const (
 	globalPipe     = "docker_engine"
 )
 
-type Virtualization struct{}
+type Virtualization struct {
+	artifact    machine.Artifact
+	compression machine.ImageCompression
+	format      machine.ImageFormat
+}
+
+func (p *Virtualization) Artifact() machine.Artifact {
+	return p.artifact
+}
+
+func (p *Virtualization) Compression() machine.ImageCompression {
+	return p.compression
+}
+
+func (p *Virtualization) Format() machine.ImageFormat {
+	return p.format
+}
 
 type MachineVM struct {
 	// ConfigPath is the path to the configuration file
@@ -236,7 +251,11 @@ func (e *ExitCodeError) Error() string {
 }
 
 func GetWSLProvider() machine.VirtProvider {
-	return wslProvider
+	return &Virtualization{
+		artifact:    machine.None,
+		compression: machine.Xz,
+		format:      machine.Tar,
+	}
 }
 
 // NewMachine initializes an instance of a wsl machine

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package wsl
 
 import (
@@ -12,11 +15,10 @@ import (
 	"unicode/utf16"
 	"unsafe"
 
+	"github.com/containers/storage/pkg/homedir"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
-
-	"github.com/containers/storage/pkg/homedir"
 )
 
 // nolint


### PR DESCRIPTION
in preparation for adding hyper as a machine option, several common functions needed to be moved specifically from qemu to a common area in pkg/machine.  this usually involved functions and variables related to using fcos as a machine image as well as its compression, artifact, and image format

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
