### PR TITLE
Logs follow-until tests: loosen checks

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -272,8 +272,7 @@ Deleted: $pauseID" "infra images gets removed as well"
     pname=$(random_string)
     run_podman create --pod new:$pname $IMAGE
 
-    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
-    pauseImage=localhost/podman-pause:$output
+    pauseImage=$(pause_image)
     run_podman inspect --format '{{.ID}}' $pauseImage
     pauseID=$output
 

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -49,8 +49,7 @@ function _require_crun() {
 
     # Remove the pod and the pause image
     run_podman pod rm $random_pod_name
-    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
-    run_podman rmi -f localhost/podman-pause:$output
+    run_podman rmi -f $(pause_image)
 }
 
 @test "podman --remote --group-add keep-groups " {
@@ -142,4 +141,5 @@ EOF
     pid=$output
     run_podman run --rm --pod $pid $IMAGE id -u
     is "${output}" "$user" "Container should run as the current user"
+    run_podman rmi -f $(pause_image)
 }

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -665,21 +665,28 @@ EOF
     if is_netavark; then
         assert "$store" == "search example.com${nl}nameserver $subnet.1" "only integrated dns nameserver is set"
     else
-        is "$store" ".*nameserver 1.1.1.1${nl}nameserver $searchIP${nl}nameserver 1.0.0.1${nl}nameserver 8.8.8.8" "nameserver order is correct"
+        assert "$store" == "search example.com
+nameserver 1.1.1.1
+nameserver $searchIP
+nameserver 1.0.0.1
+nameserver 8.8.8.8" "nameserver order is correct"
     fi
     # we should use the integrated dns server
     run_podman run --network $netname --rm $IMAGE cat /etc/resolv.conf
-    is "$output" "search dns.podman.*" "correct search domain"
-    is "$output" ".*nameserver $subnet.1.*" "integrated dns nameserver is set"
+    assert "$output" =~ "search dns.podman.*" "correct search domain"
+    assert "$output" =~ ".*nameserver $subnet.1.*" \
+           "integrated dns nameserver is set"
 
     # host network should keep localhost nameservers
     if grep 127.0.0. /etc/resolv.conf >/dev/null; then
         run_podman run --network host --rm $IMAGE cat /etc/resolv.conf
-        is "$output" ".*nameserver 127\.0\.0.*" "resolv.conf contains localhost nameserver"
+        assert "$output" =~ ".*nameserver 127\.0\.0.*" \
+               "resolv.conf contains localhost nameserver"
     fi
     # host net + dns still works
     run_podman run --network host --dns 1.1.1.1 --rm $IMAGE cat /etc/resolv.conf
-    is "$output" ".*nameserver 1\.1\.1\.1.*" "resolv.conf contains 1.1.1.1 nameserver"
+    assert "$output" =~ ".*nameserver 1\.1\.1\.1.*" \
+           "resolv.conf contains 1.1.1.1 nameserver"
 }
 
 @test "podman run port forward range" {

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -80,8 +80,7 @@ RELABEL="system_u:object_r:container_file_t:s0"
     # Make sure that the K8s pause image isn't pulled but the local podman-pause is built.
     run_podman images
     run_podman 1 image exists k8s.gcr.io/pause
-    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
-    run_podman image exists localhost/podman-pause:$output
+    run_podman image exists $(pause_image)
 
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod


### PR DESCRIPTION
...in hopes of fixing a flake with podman-remote. It's still
possible that there's a real problem with logs under remote,
and this will just sweep that under the rug.

Also, fix a nasty-red test warning (add cleanup), refactor
uses of $(pause_image), and improve a few test assertions.

Closes: #17286

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```