### PR TITLE
[CI:BUILD] spec.rpkg: trim dependency list

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -62,11 +62,8 @@ BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: conmon >= 2:2.0.30-2
-Requires: containers-common-extra >= 4:1-78
-Requires: iptables
-Requires: nftables
+Requires: containers-common-extra >= 4:1-87
 Recommends: catatonit
-Suggests: qemu-user-static
 Conflicts: quadlet
 Provides: %{name}-quadlet
 Obsoletes: %{name}-quadlet <= 101:0.0.git.17877.f247b4d4-1


### PR DESCRIPTION
The `containers-common-extra` subpackage of `containers-common` handles all the dependencies common to podman and buildah. So, it's best to remove those from podman's spec.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


