### PR TITLE
Add --restart flag to pod create

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -386,14 +386,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(requiresFlagName, AutocompleteContainers)
 
-		restartFlagName := "restart"
-		createFlags.StringVar(
-			&cf.Restart,
-			restartFlagName, "",
-			`Restart policy to apply when a container exits ("always"|"no"|"on-failure"|"unless-stopped")`,
-		)
-		_ = cmd.RegisterFlagCompletionFunc(restartFlagName, AutocompleteRestartOption)
-
 		createFlags.BoolVar(
 			&cf.Rm,
 			"rm", false,
@@ -635,6 +627,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 	}
 	if mode == entities.InfraMode || (mode == entities.CreateMode) { // infra container flags, create should also pick these up
+		restartFlagName := "restart"
+		createFlags.StringVar(
+			&cf.Restart,
+			restartFlagName, "",
+			`Restart policy to apply when a container exits ("always"|"no"|"never"|"on-failure"|"unless-stopped")`,
+		)
+		_ = cmd.RegisterFlagCompletionFunc(restartFlagName, AutocompleteRestartOption)
+
 		shmSizeFlagName := "shm-size"
 		createFlags.String(
 			shmSizeFlagName, shmSize(),

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -137,6 +137,7 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 		cliVals.InitContainerType = initctr
 	}
+	// TODO: v5.0 block users from setting restart policy for a container if the container is in a pod
 
 	cliVals, err := CreateInit(cmd, cliVals, false)
 	if err != nil {
@@ -405,6 +406,7 @@ func createPodIfNecessary(cmd *cobra.Command, s *specgen.SpecGenerator, netOpts 
 		CpusetCpus:    cliVals.CPUSetCPUs,
 		Pid:           cliVals.PID,
 		Userns:        uns,
+		Restart:       cliVals.Restart,
 	}
 	// Unset config values we passed to the pod to prevent them being used twice for the container and pod.
 	s.ContainerBasicConfig.Hostname = ""

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -300,6 +301,7 @@ func createPsOut() ([]map[string]string, string) {
 		"PIDNS":        "pidns",
 		"Pod":          "pod id",
 		"PodName":      "podname", // undo camelcase space break
+		"Restarts":     "restarts",
 		"RunningFor":   "running for",
 		"UTS":          "uts",
 		"User":         "userns",
@@ -375,6 +377,10 @@ func (l psReporter) Status() string {
 		state += " (" + hc + ")"
 	}
 	return state
+}
+
+func (l psReporter) Restarts() string {
+	return strconv.Itoa(int(l.ListContainer.Restarts))
 }
 
 func (l psReporter) RunningFor() string {

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -259,6 +259,7 @@ func create(cmd *cobra.Command, args []string) error {
 		podSpec.InfraContainerSpec = specgen.NewSpecGenerator(imageName, false)
 		podSpec.InfraContainerSpec.RawImageName = rawImageName
 		podSpec.InfraContainerSpec.NetworkOptions = podSpec.NetworkOptions
+		podSpec.InfraContainerSpec.RestartPolicy = podSpec.RestartPolicy
 		err = specgenutil.FillOutSpecGen(podSpec.InfraContainerSpec, &infraOptions, []string{})
 		if err != nil {
 			return err

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -147,6 +148,7 @@ func pods(cmd *cobra.Command, _ []string) error {
 			"ContainerStatuses":  "STATUS",
 			"Cgroup":             "CGROUP",
 			"Namespace":          "NAMESPACES",
+			"Restarts":           "RESTARTS",
 		})
 
 		if err := rpt.Execute(headers); err != nil {
@@ -178,6 +180,7 @@ func podPsFormat() string {
 	if !psInput.CtrStatus && !psInput.CtrNames && !psInput.CtrIds {
 		row = append(row, "{{.NumberOfContainers}}")
 	}
+
 	return "{{range . }}" + strings.Join(row, "\t") + "\n" + "{{end -}}"
 }
 
@@ -263,6 +266,15 @@ func (l ListPodReporter) ContainerStatuses() string {
 		statuses = append(statuses, c.Status)
 	}
 	return strings.Join(statuses, ",")
+}
+
+// Restarts returns the total number of restarts for all the containers in the pod
+func (l ListPodReporter) Restarts() string {
+	restarts := 0
+	for _, c := range l.Containers {
+		restarts += int(c.RestartCount)
+	}
+	return strconv.Itoa(restarts)
 }
 
 func sortPodPsOutput(sortBy string, lprs []*entities.ListPodsReport) error {

--- a/docs/source/markdown/options/restart.md
+++ b/docs/source/markdown/options/restart.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman create, run
+####>   podman create, pod clone, pod create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--restart**=*policy*
@@ -10,6 +10,7 @@ Restart policy will not take effect if a container is stopped via the **podman k
 Valid _policy_ values are:
 
 - `no`                       : Do not restart containers on exit
+- `never`                    : Synonym for **no**; do not restart containers on exit
 - `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
 - `unless-stopped`           : Identical to **always**

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -67,6 +67,10 @@ Set a custom name for the cloned pod. The default if not specified is of the syn
 
 @@option pid.pod
 
+@@option restart
+
+Default restart policy for all the containers in a pod.
+
 @@option security-opt
 
 @@option shm-size

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -143,6 +143,10 @@ but only by the pod itself.
 
 @@option replace
 
+@@option restart
+
+Default restart policy for all the containers in a pod.
+
 @@option security-opt
 
 #### **--share**=*namespace*

--- a/docs/source/markdown/podman-pod-inspect.1.md.in
+++ b/docs/source/markdown/podman-pod-inspect.1.md.in
@@ -50,6 +50,7 @@ Valid placeholders for the Go template are listed below:
 | .Name                | Pod name                                    |
 | .Namespace           | Namespace                                   |
 | .NumContainers       | Number of containers in the pod             |
+| .RestartPolicy       | Restart policy of the pod                   |
 | .SecurityOpts        | Security options                            |
 | .SharedNamespaces    | Pod shared namespaces                       |
 | .State               | Pod state                                   |

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -77,20 +77,21 @@ Pretty-print containers to JSON or using a Go template
 
 Valid placeholders for the Go template are listed below:
 
-| **Placeholder**     | **Description**                                    |
-|---------------------|----------------------------------------------------|
-| .Cgroup             | Cgroup path of pod                                 |
-| .ContainerIds       | Comma-separated list of container IDs in the pod   |
-| .ContainerNames     | Comma-separated list of container names in the pod |
-| .ContainerStatuses  | Comma-separated list of container statuses         |
-| .Created            | Creation time of pod                               |
-| .ID                 | Container ID                                       |
-| .InfraID            | Pod infra container ID                             |
-| .Labels             | All the labels assigned to the pod                 |
-| .Name               | Name of pod                                        |
-| .Networks           | Show all networks connected to the infra container |
-| .NumberOfContainers | Show the number of containers attached to pod      |
-| .Status             | Status of pod                                      |
+| **Placeholder**     | **Description**                                      |
+|---------------------|------------------------------------------------------|
+| .Cgroup             | Cgroup path of pod                                   |
+| .ContainerIds       | Comma-separated list of container IDs in the pod     |
+| .ContainerNames     | Comma-separated list of container names in the pod   |
+| .ContainerStatuses  | Comma-separated list of container statuses           |
+| .Created            | Creation time of pod                                 |
+| .ID                 | Container ID                                         |
+| .InfraID            | Pod infra container ID                               |
+| .Labels             | All the labels assigned to the pod                   |
+| .Name               | Name of pod                                          |
+| .Networks           | Show all networks connected to the infra container   |
+| .NumberOfContainers | Show the number of containers attached to pod        |
+| .Restarts           | Show the total number of container restarts in a pod |
+| .Status             | Status of pod                                        |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -89,6 +89,7 @@ Valid placeholders for the Go template are listed below:
 | .Pod               | Pod the container is associated with (SHA)   |
 | .PodName           | Seems to be empty no matter what             |
 | .Ports             | Exposed ports                                |
+| .Restarts          | Display the container restart count          |
 | .RunningFor        | Time elapsed since container was started     |
 | .Size              | Size of container                            |
 | .StartedAt         | Time (epoch seconds) the container started   |

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -203,7 +203,6 @@ type ContainerState struct {
 	// restart policy. This is NOT incremented by normal container restarts
 	// (only by restart policy).
 	RestartCount uint `json:"restartCount,omitempty"`
-
 	// StartupHCPassed indicates that the startup healthcheck has
 	// succeeded and the main healthcheck can begin.
 	StartupHCPassed bool `json:"startupHCPassed,omitempty"`
@@ -728,6 +727,18 @@ func (c *Container) State() (define.ContainerStatus, error) {
 		}
 	}
 	return c.state.State, nil
+}
+
+func (c *Container) RestartCount() (uint, error) {
+	if !c.batched {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		if err := c.syncContainer(); err != nil {
+			return 0, err
+		}
+	}
+	return c.state.RestartCount, nil
 }
 
 // Mounted returns whether the container is mounted and the path it is mounted

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -83,6 +83,8 @@ type InspectPodData struct {
 	BlkioWeight uint64 `json:"blkio_weight,omitempty"`
 	// BlkioWeightDevice contains the blkio weight device limits for the pod
 	BlkioWeightDevice []InspectBlkioWeightDevice `json:"blkio_weight_device,omitempty"`
+	// RestartPolicy of the pod.
+	RestartPolicy string `json:"RestartPolicy,omitempty"`
 }
 
 // InspectPodInfraConfig contains the configuration of the pod's infra

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2020,6 +2020,40 @@ func WithPodExitPolicy(policy string) PodCreateOption {
 	}
 }
 
+// WithPodRestartPolicy sets the restart policy of the pod.
+func WithPodRestartPolicy(policy string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+
+		switch policy {
+		//TODO: v5.0 if no restart policy is set, follow k8s convention and default to Always
+		case define.RestartPolicyNone, define.RestartPolicyNo, define.RestartPolicyOnFailure, define.RestartPolicyAlways, define.RestartPolicyUnlessStopped:
+			pod.config.RestartPolicy = policy
+		default:
+			return fmt.Errorf("%q is not a valid restart policy: %w", policy, define.ErrInvalidArg)
+		}
+
+		return nil
+	}
+}
+
+// WithPodRestartRetries sets the number of retries to use when restarting a
+// container with the "on-failure" restart policy.
+// 0 is an allowed value, and indicates infinite retries.
+func WithPodRestartRetries(tries uint) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+
+		pod.config.RestartRetries = &tries
+
+		return nil
+	}
+}
+
 // WithPodHostname sets the hostname of the pod.
 func WithPodHostname(hostname string) PodCreateOption {
 	return func(pod *Pod) error {

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -81,6 +81,12 @@ type PodConfig struct {
 	// The pod's exit policy.
 	ExitPolicy config.PodExitPolicy `json:"ExitPolicy,omitempty"`
 
+	// The pod's restart policy
+	RestartPolicy string `json:"RestartPolicy,omitempty"`
+
+	// The max number of retries for a pod based on restart policy
+	RestartRetries *uint `json:"RestartRetries,omitempty"`
+
 	// ID of the pod's lock
 	LockID uint32 `json:"lockID"`
 
@@ -521,4 +527,11 @@ func (p *Pod) Config() (*PodConfig, error) {
 	err := JSONDeepCopy(p.config, conf)
 
 	return conf, err
+}
+
+// ConfigNoCopy returns the configuration used by the pod.
+// Note that the returned value is not a copy and must hence
+// only be used in a reading fashion.
+func (p *Pod) ConfigNoCopy() *PodConfig {
+	return p.config
 }

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -741,6 +741,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		CPUSetMems:          p.CPUSetMems(),
 		BlkioDeviceWriteBps: p.BlkiThrottleWriteBps(),
 		CPUShares:           p.CPUShares(),
+		RestartPolicy:       p.config.RestartPolicy,
 	}
 
 	return &inspectData, nil

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -55,6 +55,10 @@ type ListContainer struct {
 	PodName string
 	// Port mappings
 	Ports []types.PortMapping
+	// Restarts is how many times the container was restarted by its
+	// restart policy. This is NOT incremented by normal container restarts
+	// (only by restart policy).
+	Restarts uint
 	// Size of the container rootfs.  Requires the size boolean to be true
 	Size *define.ContainerSize
 	// Time when container started

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -38,9 +38,10 @@ type ListPodsReport struct {
 }
 
 type ListPodContainer struct {
-	Id     string //nolint:revive,stylecheck
-	Names  string
-	Status string
+	Id           string //nolint:revive,stylecheck
+	Names        string
+	Status       string
+	RestartCount uint
 }
 
 type PodPauseOptions struct {

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -135,6 +135,7 @@ type PodCreateOptions struct {
 	Net                *NetOptions       `json:"net,omitempty"`
 	Share              []string          `json:"share,omitempty"`
 	ShareParent        *bool             `json:"share_parent,omitempty"`
+	Restart            string            `json:"restart,omitempty"`
 	Pid                string            `json:"pid,omitempty"`
 	Cpus               float64           `json:"cpus,omitempty"`
 	CpusetCpus         string            `json:"cpuset_cpus,omitempty"`
@@ -375,6 +376,14 @@ func ToPodSpecGen(s specgen.PodSpecGenerator, p *PodCreateOptions) (*specgen.Pod
 	s.ShareParent = p.ShareParent
 	s.PodCreateCommand = p.CreateCommand
 	s.VolumesFrom = p.VolumesFrom
+	if p.Restart != "" {
+		policy, retries, err := util.ParseRestartPolicy(p.Restart)
+		if err != nil {
+			return nil, err
+		}
+		s.RestartPolicy = policy
+		s.RestartRetries = &retries
+	}
 
 	// Networking config
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -592,16 +592,16 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		return nil, nil, err
 	}
 
-	var ctrRestartPolicy string
+	// Set the restart policy from the kube yaml at the pod level in podman
 	switch podYAML.Spec.RestartPolicy {
 	case v1.RestartPolicyAlways:
-		ctrRestartPolicy = define.RestartPolicyAlways
+		podSpec.PodSpecGen.RestartPolicy = define.RestartPolicyAlways
 	case v1.RestartPolicyOnFailure:
-		ctrRestartPolicy = define.RestartPolicyOnFailure
+		podSpec.PodSpecGen.RestartPolicy = define.RestartPolicyOnFailure
 	case v1.RestartPolicyNever:
-		ctrRestartPolicy = define.RestartPolicyNo
+		podSpec.PodSpecGen.RestartPolicy = define.RestartPolicyNo
 	default: // Default to Always
-		ctrRestartPolicy = define.RestartPolicyAlways
+		podSpec.PodSpecGen.RestartPolicy = define.RestartPolicyAlways
 	}
 
 	if podOpt.Infra {
@@ -775,7 +775,6 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			PodName:            podName,
 			PodSecurityContext: podYAML.Spec.SecurityContext,
 			ReadOnly:           readOnly,
-			RestartPolicy:      ctrRestartPolicy,
 			SeccompPaths:       seccompPaths,
 			SecretsManager:     secretsManager,
 			UserNSIsHost:       p.Userns.IsHost(),

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -429,10 +429,15 @@ func (ic *ContainerEngine) listPodReportFromPod(p *libpod.Pod) (*entities.ListPo
 		if err != nil {
 			return nil, err
 		}
+		restartCount, err := c.RestartCount()
+		if err != nil {
+			return nil, err
+		}
 		lpcs[i] = &entities.ListPodContainer{
-			Id:     c.ID(),
-			Names:  c.Name(),
-			Status: state.String(),
+			Id:           c.ID(),
+			Names:        c.Name(),
+			Status:       state.String(),
+			RestartCount: restartCount,
 		}
 	}
 	infraID, err := p.InfraContainerID()

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -145,6 +145,7 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		portMappings                            []libnetworkTypes.PortMapping
 		networks                                []string
 		healthStatus                            string
+		restartCount                            uint
 	)
 
 	batchErr := ctr.Batch(func(c *libpod.Container) error {
@@ -189,6 +190,11 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		}
 
 		healthStatus, err = c.HealthCheckStatus()
+		if err != nil {
+			return err
+		}
+
+		restartCount, err = c.RestartCount()
 		if err != nil {
 			return err
 		}
@@ -251,6 +257,7 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		StartedAt:  startedTime.Unix(),
 		State:      conState.String(),
 		Status:     healthStatus,
+		Restarts:   restartCount,
 	}
 	if opts.Pod && len(conConfig.Pod) > 0 {
 		podName, err := rt.GetPodName(conConfig.Pod)

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -555,12 +555,24 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 	}
 	// Default used if not overridden on command line
 
-	if s.RestartPolicy != "" {
-		if s.RestartRetries != nil {
-			options = append(options, libpod.WithRestartRetries(*s.RestartRetries))
+	var (
+		restartPolicy string
+		retries       uint
+	)
+	// If the container is running in a pod, use the pod's restart policy for all the containers
+	if pod != nil {
+		podConfig := pod.ConfigNoCopy()
+		if podConfig.RestartRetries != nil {
+			retries = *podConfig.RestartRetries
 		}
-		options = append(options, libpod.WithRestartPolicy(s.RestartPolicy))
+		restartPolicy = podConfig.RestartPolicy
+	} else if s.RestartPolicy != "" {
+		if s.RestartRetries != nil {
+			retries = *s.RestartRetries
+		}
+		restartPolicy = s.RestartPolicy
 	}
+	options = append(options, libpod.WithRestartRetries(retries), libpod.WithRestartPolicy(restartPolicy))
 
 	if s.ContainerHealthCheckConfig.HealthConfig != nil {
 		options = append(options, libpod.WithHealthCheck(s.ContainerHealthCheckConfig.HealthConfig))

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -165,6 +165,10 @@ func createPodOptions(p *specgen.PodSpecGenerator) ([]libpod.PodCreateOption, er
 	}
 
 	options = append(options, libpod.WithPodExitPolicy(p.ExitPolicy))
+	options = append(options, libpod.WithPodRestartPolicy(p.RestartPolicy))
+	if p.RestartRetries != nil {
+		options = append(options, libpod.WithPodRestartRetries(*p.RestartRetries))
+	}
 
 	return options, nil
 }

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -64,6 +64,17 @@ type PodBasicConfig struct {
 	// Conflicts with NoInfra=true.
 	// Optional.
 	SharedNamespaces []string `json:"shared_namespaces,omitempty"`
+	// RestartPolicy is the pod's restart policy - an action which
+	// will be taken when one or all the containers in the pod exits.
+	// If not given, the default policy will be set to Always, which
+	// restarts the containers in the pod when they exit indefinitely.
+	// Optional.
+	RestartPolicy string `json:"restart_policy,omitempty"`
+	// RestartRetries is the number of attempts that will be made to restart
+	// the container.
+	// Only available when RestartPolicy is set to "on-failure".
+	// Optional.
+	RestartRetries *uint `json:"restart_tries,omitempty"`
 	// PodCreateCommand is the command used to create this pod.
 	// This will be shown in the output of Inspect() on the pod, and may
 	// also be used by some tools that wish to recreate the pod

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -528,18 +528,21 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("podman generate kube on pod with restartPolicy", func() {
+	It("podman generate kube on pod with restartPolicy set for container in a pod", func() {
+		//TODO: v5.0 - change/remove test once we block --restart on container when it is in a pod
 		// podName,  set,  expect
 		testSli := [][]string{
 			{"testPod1", "", ""}, // some pod create from cmdline, so set it to an empty string and let k8s default it to Always
 			{"testPod2", "always", "Always"},
 			{"testPod3", "on-failure", "OnFailure"},
 			{"testPod4", "no", "Never"},
+			{"testPod5", "never", "Never"},
 		}
 
 		for k, v := range testSli {
 			podName := v[0]
-			podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
+			// Need to set --restart during pod creation as gen kube only picks up the pod's restart policy
+			podSession := podmanTest.Podman([]string{"pod", "create", "--restart", v[1], "--name", podName})
 			podSession.WaitWithDefaultTimeout()
 			Expect(podSession).Should(Exit(0))
 
@@ -558,6 +561,67 @@ var _ = Describe("Podman kube generate", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(string(pod.Spec.RestartPolicy)).To(Equal(v[2]))
+		}
+	})
+
+	It("podman generate kube on pod with restartPolicy", func() {
+		// podName,  set,  expect
+		testSli := [][]string{
+			{"testPod1", "", ""},
+			{"testPod2", "always", "Always"},
+			{"testPod3", "on-failure", "OnFailure"},
+			{"testPod4", "no", "Never"},
+			{"testPod5", "never", "Never"},
+		}
+
+		for k, v := range testSli {
+			podName := v[0]
+			podSession := podmanTest.Podman([]string{"pod", "create", "--restart", v[1], podName})
+			podSession.WaitWithDefaultTimeout()
+			Expect(podSession).Should(Exit(0))
+
+			ctrName := "ctr" + strconv.Itoa(k)
+			ctr1Session := podmanTest.Podman([]string{"create", "--name", ctrName, "--pod", podName, ALPINE, "top"})
+			ctr1Session.WaitWithDefaultTimeout()
+			Expect(ctr1Session).Should(Exit(0))
+
+			kube := podmanTest.Podman([]string{"generate", "kube", podName})
+			kube.WaitWithDefaultTimeout()
+			Expect(kube).Should(Exit(0))
+
+			pod := new(v1.Pod)
+			err := yaml.Unmarshal(kube.Out.Contents(), pod)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(pod.Spec.RestartPolicy)).To(Equal(v[2]))
+		}
+	})
+
+	It("podman generate kube on ctr with restartPolicy", func() {
+		// podName,  set,  expect
+		testSli := [][]string{
+			{"", ""}, // some ctr created from cmdline, set it to "" and let k8s default it to Always
+			{"always", "Always"},
+			{"on-failure", "OnFailure"},
+			{"no", "Never"},
+			{"never", "Never"},
+		}
+
+		for k, v := range testSli {
+			ctrName := "ctr" + strconv.Itoa(k)
+			ctrSession := podmanTest.Podman([]string{"create", "--restart", v[0], "--name", ctrName, ALPINE, "top"})
+			ctrSession.WaitWithDefaultTimeout()
+			Expect(ctrSession).Should(Exit(0))
+
+			kube := podmanTest.Podman([]string{"generate", "kube", ctrName})
+			kube.WaitWithDefaultTimeout()
+			Expect(kube).Should(Exit(0))
+
+			pod := new(v1.Pod)
+			err := yaml.Unmarshal(kube.Out.Contents(), pod)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(pod.Spec.RestartPolicy)).To(Equal(v[1]))
 		}
 	})
 
@@ -1465,13 +1529,12 @@ USER test1`
 	})
 
 	It("podman generate kube on pod with --type=deployment and --restart=no should fail", func() {
-		// TODO: When we add --restart for pods, fix this test to reflect that
 		podName := "test-pod"
-		session := podmanTest.Podman([]string{"pod", "create", podName})
+		session := podmanTest.Podman([]string{"pod", "create", "--restart", "no", podName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"create", "--pod", podName, "--restart", "no", ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2382,7 +2382,7 @@ var _ = Describe("Podman play kube", func() {
 			kube.WaitWithDefaultTimeout()
 			Expect(kube).Should(Exit(0))
 
-			inspect := podmanTest.Podman([]string{"inspect", getCtrNameInPod(pod), "--format", "{{.HostConfig.RestartPolicy.Name}}"})
+			inspect := podmanTest.Podman([]string{"inspect", pod.Name, "--format", "{{.RestartPolicy}}"})
 			inspect.WaitWithDefaultTimeout()
 			Expect(inspect).Should(Exit(0))
 			Expect(inspect.OutputToString()).To(Equal(v[2]))


### PR DESCRIPTION
Add --restart flag to pod create to allow users to set the restart policy for the pod, which applies to all the containers in the pod. This reuses the restart policy already there for containers and has the same restart policy options. Add "never" to the restart policy options to match k8s syntax. It is a synonym for "no" and does the exact same thing where the containers are not restarted once exited.
Only the containers that have exited will be restarted based on the restart policy, running containers will not be restarted when an exited container is restarted in the same pod (same as is done in k8s).

Add Restarts column to the podman ps and podman pod ps output to show how many times a
container was restarted based on its restart policy when --format={{.Restarts}}.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add --restart flag to pod create to be able to set the restart policy for all the containers in a pod.
Add Restarts column to the output of podman ps to show the number of times a container has been restarted based on its restart policy when --format={{.Restarts}}.
Add Restarts column to the output of podman pod ps when --format={{.Restarts}} to show the total number of container restarts in a pod.
```
