### PR TITLE
Remove replicas field from kubernetes deployment support doc

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -161,15 +161,15 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 
 ## Deployment Fields
 
-| Field                                 | Support |
-|---------------------------------------|---------|
-| replicas                              | ✅      |
-| selector                              | ✅      |
-| template                              | ✅      |
-| minReadySeconds                       |         |
-| strategy.type                         |         |
-| strategy.rollingUpdate.maxSurge       |         |
-| strategy.rollingUpdate.maxUnavailable |         |
-| revisionHistoryLimit                  |         |
-| progressDeadlineSeconds               |         |
-| paused                                |         |
+| Field                                 | Support                                               |
+|---------------------------------------|-------------------------------------------------------|
+| replicas                              | ✅ (the actual replica count is ignored and set to 1) |
+| selector                              | ✅                                                    |
+| template                              | ✅                                                    |
+| minReadySeconds                       |                                                       |
+| strategy.type                         |                                                       |
+| strategy.rollingUpdate.maxSurge       |                                                       |
+| strategy.rollingUpdate.maxUnavailable |                                                       |
+| revisionHistoryLimit                  |                                                       |
+| progressDeadlineSeconds               |                                                       |
+| paused                                |                                                       |


### PR DESCRIPTION
Support for this field has been effectively removed via https://github.com/containers/podman/pull/17082, this addresses the issue raised in https://github.com/containers/podman/pull/17082#issuecomment-1445314415


#### Does this PR introduce a user-facing change?

```release-note
None
```
