### PR TITLE
Implement machine provider selection

### DIFF
--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -101,7 +101,10 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 	host.Arch = runtime.GOARCH
 	host.OS = runtime.GOOS
 
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return nil, err
+	}
 	var listOpts machine.ListOptions
 	listResponse, err := provider.List(listOpts)
 	if err != nil {

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -30,7 +30,6 @@ var (
 	initOptionalFlags  = InitOptionalFlags{}
 	defaultMachineName = machine.DefaultMachineName
 	now                bool
-	defaultProvider    = GetSystemDefaultProvider()
 )
 
 // Flags which have a meaning when unspecified that differs from the flag default
@@ -129,7 +128,10 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		vm  machine.VM
 	)
 
-	provider := defaultProvider
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	initOpts.Name = defaultMachineName
 	if len(args) > 0 {
 		if len(args[0]) > maxMachineNameSize {

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -51,7 +51,10 @@ func inspect(cmd *cobra.Command, args []string) error {
 		args = append(args, defaultMachineName)
 	}
 	vms := make([]machine.InspectInfo, 0, len(args))
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	for _, vmName := range args {
 		vm, err := provider.LoadVMByName(vmName)
 		if err != nil {

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -66,7 +66,10 @@ func list(cmd *cobra.Command, args []string) error {
 		err          error
 	)
 
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	listResponse, err = provider.List(opts)
 	if err != nil {
 		return fmt.Errorf("listing vms: %w", err)

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -64,7 +64,10 @@ func autocompleteMachine(cmd *cobra.Command, args []string, toComplete string) (
 
 func getMachines(toComplete string) ([]string, cobra.ShellCompDirective) {
 	suggestions := []string{}
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 	machines, err := provider.List(machine.ListOptions{})
 	if err != nil {
 		cobra.CompErrorln(err.Error())

--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -48,7 +48,10 @@ func machineOSManager(opts ManagerOpts) (pkgOS.Manager, error) {
 	if opts.VMName == "" {
 		vmName = pkgMachine.DefaultMachineName
 	}
-	provider := machine.GetSystemDefaultProvider()
+	provider, err := machine.GetSystemProvider()
+	if err != nil {
+		return nil, err
+	}
 	vm, err := provider.LoadVMByName(vmName)
 	if err != nil {
 		return nil, err

--- a/cmd/podman/machine/platform.go
+++ b/cmd/podman/machine/platform.go
@@ -4,10 +4,34 @@
 package machine
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/qemu"
+	"github.com/sirupsen/logrus"
 )
 
-func GetSystemDefaultProvider() machine.VirtProvider {
-	return qemu.GetVirtualizationProvider()
+func GetSystemProvider() (machine.VirtProvider, error) {
+	cfg, err := config.Default()
+	if err != nil {
+		return nil, err
+	}
+	provider := cfg.Machine.Provider
+	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
+		provider = providerOverride
+	}
+	resolvedVMType, err := machine.ParseVMType(provider, machine.QemuVirt)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
+	switch resolvedVMType {
+	case machine.QemuVirt:
+		return qemu.GetVirtualizationProvider(), nil
+	default:
+		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
+	}
 }

--- a/cmd/podman/machine/platform_windows.go
+++ b/cmd/podman/machine/platform_windows.go
@@ -1,19 +1,37 @@
 package machine
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/hyperv"
 	"github.com/containers/podman/v4/pkg/machine/wsl"
+	"github.com/sirupsen/logrus"
 )
 
-func GetSystemDefaultProvider() machine.VirtProvider {
-	// This is a work-around for default provider on windows while
-	// hyperv is one developer.
-	// TODO this needs to be changed back
-	if _, exists := os.LookupEnv("HYPERV"); exists {
-		return hyperv.GetVirtualizationProvider()
+func GetSystemProvider() (machine.VirtProvider, error) {
+	cfg, err := config.Default()
+	if err != nil {
+		return nil, err
 	}
-	return wsl.GetWSLProvider()
+	provider := cfg.Machine.Provider
+	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
+		provider = providerOverride
+	}
+	resolvedVMType, err := machine.ParseVMType(provider, machine.WSLVirt)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
+	switch resolvedVMType {
+	case machine.WSLVirt:
+		return wsl.GetWSLProvider(), nil
+	case machine.HyperVVirt:
+		return hyperv.GetVirtualizationProvider(), nil
+	default:
+		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
+	}
 }

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -63,7 +63,10 @@ func rm(_ *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -89,7 +89,10 @@ func setMachine(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
 	}
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -53,7 +53,10 @@ func ssh(cmd *cobra.Command, args []string) error {
 
 	// Set the VM to default
 	vmName := defaultMachineName
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 
 	// If len is greater than 0, it means we may have been
 	// provided the VM name.  If so, we check.  The VM name,

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -53,7 +53,11 @@ func start(_ *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
+
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -42,7 +42,10 @@ func stop(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
 	}
-	provider := GetSystemDefaultProvider()
+	provider, err := GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -8,6 +8,9 @@ import (
 )
 
 func resetMachine() error {
-	provider := cmdMach.GetSystemDefaultProvider()
+	provider, err := cmdMach.GetSystemProvider()
+	if err != nil {
+		return err
+	}
 	return provider.RemoveAndCleanMachines()
 }

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containers/storage/pkg/homedir"
@@ -413,3 +414,20 @@ const (
 	MachineLocal
 	DockerGlobal
 )
+
+func ParseVMType(input string, emptyFallback VMType) (VMType, error) {
+	switch strings.TrimSpace(strings.ToLower(input)) {
+	case "qemu":
+		return QemuVirt, nil
+	case "wsl":
+		return WSLVirt, nil
+	case "applehv":
+		return AppleHvVirt, nil
+	case "hyperv":
+		return HyperVVirt, nil
+	case "":
+		return emptyFallback, nil
+	default:
+		return QemuVirt, fmt.Errorf("unknown VMType `%s`", input)
+	}
+}


### PR DESCRIPTION
Fixes #17116 

GetSystemDefaultProvider reworked to accept input parameter with the desired virtualization provider. All callers adjusted to read this from the config before requesting virtualization provider instance.

Additional environment variable CONTAINERS_MACHINE_PROVIDER is supported to override the config for testing purposes.

Motivation for this signature is that it could be later extended to not only using config, but also to accept CLI switches. It could be changed to have config reading inside platform method to remove it from every caller, but this will not significantly reduce code lines in the callers, because this would change the signature of the method in platform to report possible errors and then callers should still check and handle the errors.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

[NO NEW TESTS NEEDED]

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enable Podman Machine provider configuration via config
```
