### PR TITLE
[v4.4] Quadlet - use the default runtime

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -295,11 +295,9 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 		"--log-driver", "passthrough",
 	)
 
-	// We use crun as the runtime and delegated groups to it
+	// We delegate groups to the runtime
 	service.Add(ServiceGroup, "Delegate", "yes")
-	podman.add(
-		"--runtime", "/usr/bin/crun",
-		"--cgroups=split")
+	podman.add("--cgroups=split")
 
 	timezone, ok := container.Lookup(ContainerGroup, KeyTimezone)
 	if ok && len(timezone) > 0 {

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --log-driver passthrough --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon  -d localhost/imagename
+## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --log-driver passthrough --cgroups=split --sdnotify=conmon  -d localhost/imagename
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -5,7 +5,6 @@
 ## assert-podman-args "--replace"
 ## assert-podman-args "-d"
 ## assert-podman-args "--log-driver" "passthrough"
-## assert-podman-args "--runtime" "/usr/bin/crun"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"


### PR DESCRIPTION
Backport of https://github.com/containers/podman/pull/17601 to 4.4.

#### Does this PR introduce a user-facing change?


```release-note
Quadlet: .container file may be used with any runtime
```
