### PR TITLE
Cirrus: Fix bud tests failing to apply patches

### DIFF
--- a/test/buildah-bud/run-buildah-bud-tests
+++ b/test/buildah-bud/run-buildah-bud-tests
@@ -149,6 +149,15 @@ if [[ -n $do_checkout ]]; then
     failhint="'git clone' failed - this should never happen!"
     (set -x;git clone -q $shallow_checkout https://$BUILDAH_REPO $buildah_dir)
 
+    # Recent versions of git (like `2.39`) disallow some operations (like `am`)
+    # without an identity being set.  In this case, git will throw an error
+    # with a helpful error message for humans to ponder.  However, when running
+    # under automation, nobody cares about this condition or message, because
+    # the environment is disposable.
+    if [[ "$CI" == "true" ]]; then
+      git config --system --add safe.directory $buildah_dir
+    fi
+
     cd $buildah_dir
     if [[ -z $shallow_checkout ]]; then
         # extract the SHA (rightmost field) from, e.g., v1.2-YYYMMDD-<sha>


### PR DESCRIPTION
For some weeks or longer, the buildah bud tests have been failing under cirrus-cron with the message:

```
+ git am --reject
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for
<some30462dude@cirrus-task-5479994827210752.c.libpod-218412.internal>)
not allowed
```

Fix this by marking the clone directory "safe" when the script is running under CI.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
