### PR TITLE
pkginstaller: bump Qemu to version 7.2.0

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -7,7 +7,7 @@ else
 	GOARCH:=$(ARCH)
 endif
 GVPROXY_VERSION ?= 0.5.0
-QEMU_VERSION ?= 7.1.0-1
+QEMU_VERSION ?= 7.2.0-1
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
 QEMU_RELEASE_URL ?= https://github.com/containers/podman-machine-qemu/releases/download/v$(QEMU_VERSION)/podman-machine-qemu-$(ARCH)-$(QEMU_VERSION).tar.xz
 PACKAGE_DIR ?= out/packaging


### PR DESCRIPTION
this updates the Makefile qemu version to make use new qemu released at https://github.com/containers/podman-machine-qemu/releases/tag/v7.2.0-1

[NO NEW TESTS NEEDED]

Fixes #17490 
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
