### PR TITLE
Revert "Skip all pasta tests"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,7 @@ env:
     DEBIAN_NAME: "debian-12"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20230221t162829z-f37f36d12"
+    IMAGE_SUFFIX: "c20230223t153813z-f37f36d12"
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"
     FEDORA_AARCH64_AMI: "fedora-podman-aws-arm64-${IMAGE_SUFFIX}"

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -12,7 +12,6 @@ load helpers.network
 
 function setup() {
     basic_setup
-    skip_if_rootless "FIXME: #17598 all pasta tests skipped for new version in new CI VM images."
     skip_if_not_rootless "pasta networking only available in rootless mode"
     skip_if_no_pasta "pasta not found: install pasta(1) to run these tests"
 


### PR DESCRIPTION
This reverts commit 81f116c59c291793742e10ea84b77511902a0338: the passt package for Fedora 37 images is now fixed in the c20230223t153813z-f37f36d12 image.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
