### PR TITLE
Quadlet: Add support for the Mount key in .container files

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -89,6 +89,7 @@ Valid options for `[Container]` are listed below:
 | Image=ubi8                       | Image specification - ubi8             |
 | Label="YXZ"                      | --label "XYZ"                          |
 | LogDriver=journald               | --log-driver journald                  |
+| Mount=type=bind,source=/path/on/host,destination=/path/in/container | --mount type=bind,source=/path/on/host,destination=/path/in/container |
 | Network=host                     | --net host                             |
 | NoNewPrivileges=true             | --security-opt no-new-privileges       |
 | Rootfs=/var/lib/rootfs           | --rootfs /var/lib/rootfs               |
@@ -216,6 +217,19 @@ Set the log-driver Podman should use when running the container.
 Equivalent to the Podman `--log-driver` option.
 
 The default value is `passthrough`.
+
+### `Mount=`
+
+Attach a filesystem mount to the container.
+This is equivalent to the Podman `--mount` option, and
+generally has the form `type=TYPE,TYPE-SPECIFIC-OPTION[,...]`.
+
+As a special case, for `type=volume` if `source` ends with `.volume`, a Podman named volume called
+`systemd-$name` will be used as the source, and the generated systemd service will contain
+a dependency on the `$name-volume.service`. Such a volume can be automatically be lazily
+created by using a `$name.volume` quadlet file.
+
+This key can be listed multiple times.
 
 ### `Network=`
 

--- a/test/e2e/quadlet/mount.container
+++ b/test/e2e/quadlet/mount.container
@@ -1,0 +1,20 @@
+[Container]
+Image=localhost/imagename
+## assert-podman-args-key-val "--mount" "," "type=bind,source=/path/on/host,destination=/path/in/container"
+Mount=type=bind,source=/path/on/host,destination=/path/in/container
+## assert-podman-args-key-val "--mount" "," "type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared"
+Mount=type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
+## assert-podman-args-key-val "--mount" "," "type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true"
+Mount=type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
+## assert-podman-args-key-val "--mount" "," "type=volume,source=vol1,destination=/path/in/container,ro=true"
+Mount=type=volume,source=vol1,destination=/path/in/container,ro=true
+## assert-podman-args-key-val "--mount" "," "type=volume,source=systemd-vol2,destination=/path/in/container,ro=true"
+## assert-key-is "Unit" "Requires" "vol2-volume.service"
+## assert-key-is "Unit" "After" "vol2-volume.service"
+Mount=type=volume,source=vol2.volume,destination=/path/in/container,ro=true
+## assert-podman-args-key-val "--mount" "," "type=tmpfs,tmpfs-size=512M,destination=/path/in/container"
+Mount=type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+## assert-podman-args-key-val "--mount" "," "type=image,source=fedora,destination=/fedora-image,rw=true"
+Mount=type=image,source=fedora,destination=/fedora-image,rw=true
+## assert-podman-args-key-val "--mount" "," "type=devpts,destination=/dev/pts"
+Mount=type=devpts,destination=/dev/pts


### PR DESCRIPTION
Handle the Mount key
Reuse code from the handling of the Volume key
Add E2E Test
E2E Test - Add checker for KeyValue string
Update man page

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet: Add support for the Mount key in .container files
```

Resolves: #17632 
