### PR TITLE
Cirrus: Fix git config permission denied

### DIFF
--- a/test/buildah-bud/run-buildah-bud-tests
+++ b/test/buildah-bud/run-buildah-bud-tests
@@ -155,7 +155,13 @@ if [[ -n $do_checkout ]]; then
     # under automation, nobody cares about this condition or message, because
     # the environment is disposable.
     if [[ "$CI" == "true" ]]; then
-      git config --system --add safe.directory $buildah_dir
+        (
+        _gc='git config --global'
+        set -x
+        $_gc user.email "TMcTestFace@example.com"
+        $_gc user.name "Testy McTestface"
+        $_gc --add safe.directory $buildah_dir
+        )
     fi
 
     cd $buildah_dir


### PR DESCRIPTION
Ref: #17643

The buildah bud tests run rootless, so attempting to bypass the ident-check with a `git config --system` fails with a permission denied error (as it should).  Update the command to use `--global` instead, which writes to `~/.gitconfig` and so works for regular users.

Also setup a fake identity for the CI-user and enable shell-debugging for the commands to inform humans of what is happening in the script.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
