### PR TITLE
podman machine: Adjust Chrony makestep config

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -513,6 +513,34 @@ Delegate=memory pids cpu io
 		}
 	}
 
+	files = append(files, File{
+		Node: Node{
+			User:  getNodeUsr("root"),
+			Group: getNodeGrp("root"),
+			Path:  "/etc/chrony.conf",
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: []Resource{{
+				Source: encodeDataURLPtr("\nconfdir /etc/chrony.d\n"),
+			}},
+		},
+	})
+
+	// Issue #11541: allow Chrony to update the system time when it has drifted
+	// far from NTP time.
+	files = append(files, File{
+		Node: Node{
+			User:  getNodeUsr("root"),
+			Group: getNodeGrp("root"),
+			Path:  "/etc/chrony.d/50-podman-makestep.conf",
+		},
+		FileEmbedded1: FileEmbedded1{
+			Contents: Resource{
+				Source: encodeDataURLPtr("makestep 1 -1\n"),
+			},
+		},
+	})
+
 	return files
 }
 


### PR DESCRIPTION
This allows Chrony to update the system time when it has drifted far from NTP time. By default Chrony only makes slight adjustments, but in the case where a user's laptop lid has been shut for a while and then the machine is resumed, the VM system time could be hours or days behind real time, and it my never catch up if Chrony only makes slight changes.

Fixes #11541

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman machine VMs could have their system time drift behind real time. New machines will no longer be affected by this.
```
