### PR TITLE
Add a note for exposing ports while using CNI.

### DIFF
--- a/docs/source/markdown/options/publish.md
+++ b/docs/source/markdown/options/publish.md
@@ -23,7 +23,7 @@ If it is not, the container port will be randomly assigned a port on the host.
 Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
 
 Note for CNI networking: 
-By default using **--publish**, **-p**=*[hostPort]:containerPort[/protocol]* will expose the port **only for IPv4**. 
-For IPv6 please do the following - **-p**=*[[::]:[hostPort]:]containerPort[/protocol]*.
+By default using `--publish`, `-p=[hostPort]:containerPort[/protocol]` will expose the port **only for IPv4**. 
+For IPv6 please do the following - `-p=[[::]:[hostPort]:]containerPort[/protocol]` - where `[::]` is exposing the port onto IPv6.
 
 

--- a/docs/source/markdown/options/publish.md
+++ b/docs/source/markdown/options/publish.md
@@ -21,3 +21,9 @@ Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
 If it is not, the container port will be randomly assigned a port on the host.
 
 Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
+
+Note for CNI networking: 
+By default using **--publish**, **-p**=*[hostPort]:containerPort[/protocol]* will expose the port **only for IPv4**. 
+For IPv6 please do the following - **-p**=*[[::]:[hostPort]:]containerPort[/protocol]*.
+
+


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

action required

Pull request is about adding a note to docs about dealing with port exposing while using CNI networking.
Additional changes might be needed for fitting into the docs page formatting style.
