### PR TITLE
auto-update test: wait for service to be ready

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -239,11 +239,12 @@ function _confirm_update() {
 
 @test "podman auto-update - label io.containers.autoupdate=local" {
     generate_service localtest local
+    _wait_service_ready container-$cname.service
+
     image=quay.io/libpod/localtest:latest
     run_podman commit --change CMD=/bin/bash $cname $image
     run_podman image inspect --format "{{.ID}}" $image
 
-    _wait_service_ready container-$cname.service
     run_podman auto-update --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" ".*container-$cname.service,quay.io/libpod/localtest:latest,pending,local.*" "Image update is pending."
 

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -112,7 +112,7 @@ function _confirm_update() {
     local old_iid=$2
 
     # Image has already been pulled, so this shouldn't take too long
-    local timeout=5
+    local timeout=10
     while [[ $timeout -gt 0 ]]; do
         sleep 1
         run_podman '?' inspect --format "{{.Image}}" $cname


### PR DESCRIPTION
The symptoms in #17607 point to some race since it does not always flake on Debian (and Debian only).  Hence, wait for the service to be ready before building the image to make sure that the service is started with the old image and that everything's in order.

Fixes: #17607

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
