### PR TITLE
cmd: do not require userns for "version"

### DIFF
--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -15,8 +15,7 @@ var (
 	imageScpCommand    = &cobra.Command{
 		Use: "scp [options] IMAGE [HOST::]",
 		Annotations: map[string]string{
-			registry.UnshareNSRequired: "",
-			registry.ParentNSRequired:  "",
+			registry.ParentNSRequired: "",
 		},
 		Long:              saveScpDescription,
 		Short:             "securely copy images",

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -81,13 +81,6 @@ func parseCommands() *cobra.Command {
 					return fmt.Errorf("cannot run command %q in rootless mode, must execute `podman unshare` first", cmd.CommandPath())
 				}
 			}
-		} else {
-			_, found = c.Command.Annotations[registry.ParentNSRequired]
-			if rootless.IsRootless() && found && c.Command.Name() != "scp" {
-				c.Command.RunE = func(cmd *cobra.Command, args []string) error {
-					return fmt.Errorf("cannot run command %q in rootless mode", cmd.CommandPath())
-				}
-			}
 		}
 		addCommand(c)
 	}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -76,7 +76,7 @@ func parseCommands() *cobra.Command {
 		// Command cannot be run rootless
 		_, found := c.Command.Annotations[registry.UnshareNSRequired]
 		if found {
-			if rootless.IsRootless() && os.Getuid() != 0 && c.Command.Name() != "scp" {
+			if rootless.IsRootless() && os.Getuid() != 0 {
 				c.Command.RunE = func(cmd *cobra.Command, args []string) error {
 					return fmt.Errorf("cannot run command %q in rootless mode, must execute `podman unshare` first", cmd.CommandPath())
 				}

--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -17,7 +17,7 @@ const (
 	// NoMoveProcess used as cobra.Annotation when command doesn't need Podman to be moved to a separate cgroup
 	NoMoveProcess = "NoMoveProcess"
 
-	// ParentNSRequired used as cobra.Annotation when command requires root access
+	// ParentNSRequired used as cobra.Annotation when a command should not be run in the podman rootless user namespace, also requires updates in `pkg/rootless/rootless_linux.c` in function `can_use_shortcut()` to exclude the command name there.
 	ParentNSRequired = "ParentNSRequired"
 
 	// UnshareNSRequired used as cobra.Annotation when command requires modified user namespace

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -22,6 +22,9 @@ var (
 		Short:             "Display the Podman version information",
 		RunE:              version,
 		ValidArgsFunction: completion.AutocompleteNone,
+		Annotations: map[string]string{
+			registry.ParentNSRequired: "",
+		},
 	}
 	versionFormat string
 )

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -386,6 +386,7 @@ can_use_shortcut (char **argv)
 
       if (strcmp (argv[argc], "mount") == 0
           || strcmp (argv[argc], "machine") == 0
+          || strcmp (argv[argc], "version") == 0
           || strcmp (argv[argc], "context") == 0
           || strcmp (argv[argc], "search") == 0
           || (strcmp (argv[argc], "system") == 0 && argv[argc+1] && strcmp (argv[argc+1], "service") != 0))


### PR DESCRIPTION
Closes: https://github.com/containers/podman/issues/17657

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman version does not join the rootless user namespace
```
