### PR TITLE
Fix package restore of shadow-utils on Windows

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -513,7 +513,7 @@ func provisionWSLDist(v *MachineVM) (string, error) {
 	}
 
 	// Fixes newuidmap
-	if err = wslInvoke(dist, "rpm", "-q", "--restore", "shadow-utils", "2>/dev/null"); err != nil {
+	if err = wslInvoke(dist, "rpm", "--restore", "shadow-utils"); err != nil {
 		return "", fmt.Errorf("package permissions restore of shadow-utils on guest OS failed: %w", err)
 	}
 


### PR DESCRIPTION
The wsl machine code was passing an erroneous "-q" with  a "--restore" rpm operation, which previously was ignored by rpm, but recent versions of F37 now favor the package query operation over the restore, leading to the restore operation being skipped. This leads to broken file perms on newuidmap.

The underlying issue blocks podman machine from updating to F37 on x86. 

```release-note
NONE
```

[NO NEW TESTS NEEDED]