### PR TITLE
Quadlet: add support for setting --ip and --ip6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ release.txt
 /test/version/version
 /test/testvol/testvol
 /test/tools/build
+/test/e2e/ginkgo-node-*
 .vscode*
 tags
 result

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -87,6 +87,8 @@ Valid options for `[Container]` are listed below:
 | ExposeHostPort=50-59             | --expose 50-59                         |
 | Group=1234                       | --user UID:1234                        |
 | Image=ubi8                       | Image specification - ubi8             |
+| IP=192.5.0.1                     | --ip 192.5.0.0                         |
+| IP6=fd46:db93:aa76:ac37::10      | --ip6 2001:db8::1                      |
 | Label="YXZ"                      | --label "XYZ"                          |
 | LogDriver=journald               | --log-driver journald                  |
 | Mount=type=bind,source=/path/on/host,destination=/path/in/container | --mount type=bind,source=/path/on/host,destination=/path/in/container |
@@ -203,6 +205,16 @@ performance and robustness reasons.
 
 The format of the name is the same as when passed to `podman run`, so it supports e.g., using
 `:tag` or using digests guarantee a specific image version.
+
+### `IP=`
+
+Specify a static IPv4 address for the container, for example **10.88.64.128**.
+Equivalent to the Podman `--ip` option.
+
+### `IP6=`
+
+Specify a static IPv6 address for the container, for example **fd46:db93:aa76:ac37::10**.
+Equivalent to the Podman `--ip6` option.
 
 ### `Label=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -49,6 +49,8 @@ const (
 	KeyExposeHostPort        = "ExposeHostPort"
 	KeyGroup                 = "Group"
 	KeyImage                 = "Image"
+	KeyIP                    = "IP"
+	KeyIP6                   = "IP6"
 	KeyLabel                 = "Label"
 	KeyLogDriver             = "LogDriver"
 	KeyMount                 = "Mount"
@@ -105,6 +107,8 @@ var (
 		KeyExposeHostPort:        true,
 		KeyGroup:                 true,
 		KeyImage:                 true,
+		KeyIP:                    true,
+		KeyIP6:                   true,
 		KeyLabel:                 true,
 		KeyLogDriver:             true,
 		KeyMount:                 true,
@@ -493,6 +497,16 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	}
 
 	podman.addEnv(podmanEnv)
+
+	ip, ok := container.Lookup(ContainerGroup, KeyIP)
+	if ok && len(ip) > 0 {
+		podman.add("--ip", ip)
+	}
+
+	ip6, ok := container.Lookup(ContainerGroup, KeyIP6)
+	if ok && len(ip6) > 0 {
+		podman.add("--ip6", ip6)
+	}
 
 	labels := container.LookupAllKeyVal(ContainerGroup, KeyLabel)
 	podman.addLabels(labels)

--- a/test/e2e/quadlet/ip.container
+++ b/test/e2e/quadlet/ip.container
@@ -1,0 +1,8 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--ip" "10.88.64.128"
+## assert-podman-args "--ip6" "fd46:db93:aa76:ac37::10"
+
+[Container]
+Image=localhost/imagename
+IP=10.88.64.128
+IP6=fd46:db93:aa76:ac37::10

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -500,6 +500,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("exec.container", "exec.container"),
 		Entry("image.container", "image.container"),
 		Entry("install.container", "install.container"),
+		Entry("ip.container", "ip.container"),
 		Entry("label.container", "label.container"),
 		Entry("name.container", "name.container"),
 		Entry("network.container", "network.container"),


### PR DESCRIPTION
Add support for `IP=` and `IP6=`.

```release-note
Added support for specifying static IPv4 and IPv6 addresses in Quadlet .container files via the IP= and IP6= options.
```
