### PR TITLE
test/system: fix wait_for_port() to wait for bind

### DIFF
--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -113,7 +113,7 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true" \
                         system service -t 99 tcp://localhost:$_SERVICE_PORT &
     _SERVICE_PID=$!
     # Wait for the port and the podman-service to be ready.
-    wait_for_port localhost $_SERVICE_PORT
+    wait_for_port 127.0.0.1 $_SERVICE_PORT
     local timeout=10
     while [[ $timeout -gt 1 ]]; do
         _run_podman_remote '?' info --format '{{.Host.RemoteSocket.Path}}'

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -93,7 +93,8 @@ function __ipv4_to_procfs() {
 # ipv4_to_procfs() - IPv4 address representation to big-endian procfs format
 # $1:	Text representation of IPv4 address
 function ipv4_to_procfs() {
-    IFS='.' __ipv4_to_procfs ${1}
+    IFS='.' read -r o1 o2 o3 o4 <<< $1
+    __ipv4_to_procfs $o1 $o2 $o3 $o4
 }
 
 
@@ -268,7 +269,7 @@ function port_is_free() {
     ! port_is_bound ${@}
 }
 
-# wait_for_port() - Return once port is available on the host
+# wait_for_port() - Return once port is bound (available for use by clients)
 # $1:	Host or address to check for possible binding
 # $2:	Port number
 # $3:	Optional timeout, 5 seconds if not given
@@ -279,7 +280,7 @@ function wait_for_port() {
 
     # Wait
     while [ $_timeout -gt 0 ]; do
-        port_is_free ${port} "${host}" && return
+        port_is_bound ${port} "${host}" && return
         sleep 1
         _timeout=$(( $_timeout - 1 ))
     done


### PR DESCRIPTION
The goal of the wait_for_port() function is to return when the port is bound. This is to make sure we wait for application startup time. This can be seen in some comments of the callers.

Commit 7e3d04fb caused this regression while reworking the logic to read ports from /proc. I doesn't seem to cause problems in CI, properly because the function returns before the port is bound. I have not seen any flakes related to this but I only see the ones on PRs where I rerun tests so it is best to wait for Ed to take a look.

Also fixes the broken ipv4_to_procfs() which only passes one argument to
__ipv4_to_procfs(), this results in the ipv4 not beeing inverted.
Therefore all bind checks against a direct ipv4 did not work.
This function accepts only an ipv4 but one caller passes localhost
which is invalid.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
