### PR TITLE
pasta: Re-enable "Local forwarder, IPv4" test now that packages in CI images are fixed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,7 @@ env:
     DEBIAN_NAME: "debian-12"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20230223t153813z-f37f36d12"
+    IMAGE_SUFFIX: "c20230307t192532z-f37f36d12"
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"
     FEDORA_AARCH64_AMI: "fedora-podman-aws-arm64-${IMAGE_SUFFIX}"

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -319,7 +319,7 @@ function teardown() {
 @test "podman networking with pasta(1) - External resolver, IPv4" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
-    run_podman run --net=pasta $IMAGE nslookup 127.0.0.1 || :
+    run_podman '?' run --net=pasta $IMAGE nslookup 127.0.0.1
 
     assert "$output" =~ "1.0.0.127.in-addr.arpa" \
            "127.0.0.1 not resolved"
@@ -335,14 +335,12 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - Local forwarder, IPv4" {
-    skip "FIXME: #17074: some pasta dns problem"
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --dns 198.51.100.1 \
-        --net=pasta:--dns-forward,198.51.100.1 $IMAGE nslookup 127.0.0.1
+        --net=pasta:--dns-forward,198.51.100.1 $IMAGE nslookup 127.0.0.1 || :
 
-    assert "$output" =~ "1.0.0.127.in-addr.arpa" \
-           "127.0.0.1 not resolved to 1.0.0.127.in-addr.arpa"
+    assert "$output" =~ "1.0.0.127.in-addr.arpa" "No answer from resolver"
 }
 
 @test "podman networking with pasta(1) - Local forwarder, IPv6" {


### PR DESCRIPTION
This fixes #17074.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
