### PR TITLE
podman.spec.rpkg: distro conditionals for modulesloaddir

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -172,7 +172,9 @@ PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDI
         install.docker \
         install.docker-docs \
         install.remote \
+%if 0%{?fedora} || 0%{?rhel} >= 10
         install.modules-load
+%endif
 
 install -d -p %{buildroot}/%{_datadir}/%{name}/test/system
 cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
@@ -225,7 +227,9 @@ fi
 %{_userunitdir}/%{name}-kube@.service
 %{_tmpfilesdir}/%{name}.conf
 %{_user_tmpfilesdir}/%{name}-docker.conf
+%if 0%{?fedora} || 0%{?rhel} >= 10
 %{_modulesloaddir}/%{name}-iptables.conf
+%endif
 
 %files docker
 %{_bindir}/docker


### PR DESCRIPTION
RHEL 8 and 9 don't have /usr/lib/modules-load.d yet.

Related dist-git commit:
https://src.fedoraproject.org/rpms/podman/c/c82d37a5b3c102088775e16bca817437e425b5d1

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@containers/podman-maintainers PTAL