### PR TITLE
Support running nested SELinux container separation

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -257,7 +257,7 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 					if registry.IsRemote() {
 						return vals, errors.New("the '--group-add keep-groups' option is not supported in remote mode")
 					}
-					vals.Annotation = append(vals.Annotation, "run.oci.keep_original_groups=1")
+					vals.Annotation = append(vals.Annotation, fmt.Sprintf("%s=1", define.RunOCIKeepOriginalGroups))
 				} else {
 					groups = append(groups, g)
 				}

--- a/docs/source/markdown/options/security-opt.md
+++ b/docs/source/markdown/options/security-opt.md
@@ -18,6 +18,8 @@ Security Options
 
 Note: Labeling can be disabled for all <<|pods/>>containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
+- **label=nested**: Allows SELinux modifications within the container. Containers are allowed to modify SELinux labels on files and processes, as long as SELinux policy allows. Without **nested**, containers view SELinux as disabled, even when it is enabled on the host. Containers are prevented from setting any labels.
+
 - **mask**=_/path/1:/path/2_: The paths to mask separated by a colon. A masked path cannot be accessed inside the container<<s within the pod|>>.
 
 - **no-new-privileges**: Disable container processes from gaining additional privileges.

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -219,6 +219,8 @@ type ContainerSecurityConfig struct {
 	// Libpod - mostly used in rootless containers where the user running
 	// Libpod wants to retain their UID inside the container.
 	AddCurrentUserPasswdEntry bool `json:"addCurrentUserPasswdEntry,omitempty"`
+	// LabelNested, allow labeling separation from within a container
+	LabelNested bool `json:"label_nested"`
 }
 
 // ContainerNameSpaceConfig is an embedded sub-config providing

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -32,8 +32,13 @@ var (
 )
 
 func (c *Container) mountSHM(shmOptions string) error {
+	contextType := "context"
+	if c.config.LabelNested {
+		contextType = "rootcontext"
+	}
+
 	if err := unix.Mount("shm", c.config.ShmDir, "tmpfs", unix.MS_NOEXEC|unix.MS_NOSUID|unix.MS_NODEV,
-		label.FormatMountLabel(shmOptions, c.config.MountLabel)); err != nil {
+		label.FormatMountLabelByType(shmOptions, c.config.MountLabel, contextType)); err != nil {
 		return fmt.Errorf("failed to mount shm tmpfs %q: %w", c.config.ShmDir, err)
 	}
 	return nil

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -1,6 +1,12 @@
 package define
 
 const (
+	// RunOCIMountContextType tells the OCI runtime which context mount
+	// type to use. context, rootcontext, fscontext, defcontext
+	RunOCIMountContextType = "run.oci.mount_context_type"
+	// RunOCIKeepOriginalGroups tells the OCI runtime to leak the users
+	// current groups into the container
+	RunOCIKeepOriginalGroups = "run.oci.keep_original_groups"
 	// InspectAnnotationCIDFile is used by Inspect to determine if a
 	// container ID file was created for the container.
 	// If an annotation with this key is found in the OCI spec, it will be
@@ -58,7 +64,6 @@ const (
 	// If an annotation with this key is found in the OCI spec, it will be
 	// used in the output of Inspect().
 	InspectAnnotationApparmor = "io.podman.annotations.apparmor"
-
 	// InspectResponseTrue is a boolean True response for an inspect
 	// annotation.
 	InspectResponseTrue = "TRUE"

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2341,3 +2341,16 @@ func WithMountAllDevices() CtrCreateOption {
 		return nil
 	}
 }
+
+// WithLabelNested sets the LabelNested flag allowing label separation within container
+func WithLabelNested(nested bool) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.LabelNested = nested
+
+		return nil
+	}
+}

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -120,15 +120,13 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 		volume.config.StorageImageID = image.ID()
 
 		// Create a backing container in c/storage.
-		storageConfig := storage.ContainerOptions{
-			LabelOpts: []string{"filetype:container_file_t:s0"},
-		}
+		storageConfig := storage.ContainerOptions{}
 		if len(volume.config.MountLabel) > 0 {
 			context, err := selinux.NewContext(volume.config.MountLabel)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get SELinux context from %s: %w", volume.config.MountLabel, err)
 			}
-			storageConfig.LabelOpts = []string{fmt.Sprintf("filetype:%s:s0", context["type"])}
+			storageConfig.LabelOpts = []string{fmt.Sprintf("filetype:%s", context["type"])}
 		}
 		if _, err := r.storageService.CreateContainerStorage(ctx, r.imageContext, imgString, image.ID(), volume.config.StorageName, volume.config.StorageID, storageConfig); err != nil {
 			return nil, fmt.Errorf("creating backing storage for image driver: %w", err)

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -482,6 +482,9 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 			options = append(options, libpod.WithLogDriver(s.LogConfiguration.Driver))
 		}
 	}
+	if s.ContainerSecurityConfig.LabelNested {
+		options = append(options, libpod.WithLabelNested(s.ContainerSecurityConfig.LabelNested))
+	}
 	// Security options
 	if len(s.SelinuxOpts) > 0 {
 		options = append(options, libpod.WithSecLabels(s.SelinuxOpts))

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -396,6 +396,10 @@ type ContainerSecurityConfig struct {
 	// mount temporary file systems
 	ReadWriteTmpfs bool `json:"read_write_tmpfs,omitempty"`
 
+	// LabelNested indicates whether or not the container is allowed to
+	// run fully nested containers including labelling
+	LabelNested bool `json:"label_nested,omitempty"`
+
 	// Umask is the umask the init process of the container will be run with.
 	Umask string `json:"umask,omitempty"`
 	// ProcOpts are the options used for the proc mount.


### PR DESCRIPTION
Currently Podman prevents SELinux container separation, when running within a container. This PR adds a new 

--security-opt label=nested

When setting this option, Podman unmasks and mountsi /sys/fs/selinux into the containers making /sys/fs/selinux fully exposed. Secondly Podman sets the attribute
run.oci.mount_context_type=rootcontext

This attribute tells crun to mount volumes with rootcontext=MOUNTLABEL as opposed to context=MOUNTLABEL.

With these two settings Podman inside the container is allowed to set its own SELinux labels on tmpfs file systems mounted into its parents container, while still being confined by SELinux. Thus you can have nested SELinux labeling inside of a container.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman create/run now support new option --security-opt label=nested, which allows SELinux labeling from within a confined container.
```
