### PR TITLE
Cirrus: Store podman machine benchmark data

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -700,6 +700,29 @@ podman_machine_aarch64_task:
     always: *machine_logs_benchmarks
 
 
+bench_stuff_task:
+    name: Record machine benchmarks
+    alias: bench_stuff
+    # Only run on merge and never for cirrus-cron.
+    only_if: $CIRRUS_BRANCH == 'main' && $CIRRUS_CRON == ''
+    depends_on:
+        - podman_machine
+        - podman_machine_aarch64
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        PR: podman run -it --rm -v /tmp/data:/tmp/data:Z -w /tmp/data
+        GACJSON: ENCRYPTED[acd4a8bd843dab6dd135c379a2819546187fd2c7ce43e5839c6db4c798ed652f5b456f5d1716afef662554ee94e098ee]
+    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
+    script:
+        - mkdir /tmp/data
+        # Download benchmark.env and benchmark.csv from podman-machine tasks
+        - $PR quay.io/libpod/ccia $CIRRUS_BUILD_ID benchmark/data
+        - podman secret create --env GACJSON GACJSON
+        # Parse and upload benchmark data to GCE firestore database
+        - $PR --secret GACJSON -e GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/GACJSON quay.io/libpod/bench_stuff ./$CIRRUS_BUILD_ID
+
+
 # Always run subsequent to integration tests.  While parallelism is lost
 # with runtime, debugging system-test failures can be more challenging
 # for some golang developers.  Otherwise the following tasks run across
@@ -957,7 +980,7 @@ meta_task:
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]
         GCPNAME: ENCRYPTED[2f9738ef295a706f66a13891b40e8eaa92a89e0e87faf8bed66c41eca72bf76cfd190a6f2d0e8444c631fdf15ed32ef6]
         GCPPROJECT: libpod-218412
-    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
+    clone_script: *noop
     script: /usr/local/bin/entrypoint.sh
 
 

--- a/contrib/cirrus/cirrus_yaml_test.py
+++ b/contrib/cirrus/cirrus_yaml_test.py
@@ -26,7 +26,7 @@ class TestCaseBase(unittest.TestCase):
 class TestDependsOn(TestCaseBase):
 
     ALL_TASK_NAMES = None
-    SUCCESS_DEPS_EXCLUDE = set(['success', 'artifacts',
+    SUCCESS_DEPS_EXCLUDE = set(['success', 'bench_stuff', 'artifacts',
         'test_image_build', 'release', 'release_test'])
 
     def setUp(self):


### PR DESCRIPTION
Future work will present podman-machine benchmark data in some useful
format for analysis.  However, this data is currently only stored as CI
artifacts.  When CI runs on the main branch, after a PR merges, utilize
a pair of purpose-built containers to retrieve then upload the data into
a GCE firestore database.  This operation should not be critical, such
that any faults will not cause the entire CI build to be marked as a
failure.

***Note***: This uses a container with [code from the containers/automation repo. to do the actual database insertion.](https://github.com/containers/automation/blob/main/bench_stuff/bench_stuff.py)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
