### PR TITLE
[CI:DOCS] fix cmd `set DOCKER_HOST` suggestion

### DIFF
--- a/docs/tutorials/podman-for-windows.md
+++ b/docs/tutorials/podman-for-windows.md
@@ -183,7 +183,7 @@ following PowerShell command in your terminal session:
 
 Or in a classic CMD prompt:
 
-        set DOCKER_HOST = 'npipe:////./pipe/podman-machine-default'
+        set DOCKER_HOST=npipe:////./pipe/podman-machine-default
 
 Alternatively, terminate the other process and restart podman machine.
 Machine "podman-machine-default" started successfully

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1060,8 +1060,8 @@ func (v *MachineVM) Start(name string, opts machine.StartOptions) error {
 				fmt.Printf("following powershell command in your terminal session:\n")
 				fmt.Printf("\n\t$Env:DOCKER_HOST = '%s'\n", pipeName)
 				fmt.Printf("\nOr in a classic CMD prompt:\n")
-				fmt.Printf("\n\tset DOCKER_HOST = '%s'\n", pipeName)
-				fmt.Printf("\nAlternatively terminate the other process and restart podman machine.\n")
+				fmt.Printf("\n\tset DOCKER_HOST=%s\n", pipeName)
+				fmt.Printf("\nAlternatively, terminate the other process and restart podman machine.\n")
 			}
 		}
 	}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
```release-note
None
```
---

I presume the commands provided are intended to be copy-pasted. In that case, the command to set `DOCKER_HOST` env variable in cmd context is incorrect.
