### PR TITLE
Use append() to add elements to a slice (restore)

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -673,7 +673,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 		}
 		ctrs = make([]*libpod.Container, 0, len(containers))
 		for i := range containers {
-			ctrs[i] = containers[i].Container
+			ctrs = append(ctrs, containers[i].Container)
 		}
 	default:
 		for _, nameOrID := range namesOrIds {


### PR DESCRIPTION
The code was not using append() to add items to a slice.

Accessing non allocated elements of the slice failed with:
```
$ podman container restore -l
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/containers/podman/v4/pkg/domain/infra/abi.(*ContainerEngine).ContainerRestore(0xc00051a8b8, {0x1dbced0, 0xc0000440d0}, {0x2a31b30, 0x0, 0x0}, {0x0, 0x0, 0x0, 0x0, ...})
        /share/go/src/github.com/containers/podman/pkg/domain/infra/abi/containers.go:676 +0x39c
github.com/containers/podman/v4/cmd/podman/containers.restore(0x28fb6c0?, {0xc0002c9080, 0x0, 0x1?})
        /share/go/src/github.com/containers/podman/cmd/podman/containers/restore.go:171 +0x4ef
github.com/spf13/cobra.(*Command).execute(0x28fb6c0, {0xc0000400b0, 0x1, 0x1})
        /share/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x291ab00)
        /share/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /share/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:968
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /share/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:961
main.Execute()
        /share/go/src/github.com/containers/podman/cmd/podman/root.go:107 +0xcc
main.main()
        /share/go/src/github.com/containers/podman/cmd/podman/main.go:41 +0x7c
```

```release-note
None
```