### PR TITLE
Revert "pasta: Use two connections instead of three in TCP range forward tests"

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -380,11 +380,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv4, tap" {
-    pasta_test_do 4 tap      tcp 2 0 "port"      1
+    pasta_test_do 4 tap      tcp 3 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv4, loopback" {
-    pasta_test_do 4 loopback tcp 2 0 "port"      1
+    pasta_test_do 4 loopback tcp 3 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - Translated TCP port forwarding, IPv4, tap" {
@@ -396,11 +396,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, tap" {
-    pasta_test_do 4 tap      tcp 2 1 "port"      1
+    pasta_test_do 4 tap      tcp 3 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, loopback" {
-    pasta_test_do 4 loopback tcp 2 1 "port"      1
+    pasta_test_do 4 loopback tcp 3 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv4, tap" {
@@ -430,7 +430,7 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv6, tap" {
-    pasta_test_do 6 tap      tcp 2 0 "port"      1
+    pasta_test_do 6 tap      tcp 3 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv6, loopback" {
@@ -446,11 +446,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, tap" {
-    pasta_test_do 6 tap      tcp 2 1 "port"      1
+    pasta_test_do 6 tap      tcp 3 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, loopback" {
-    pasta_test_do 6 loopback tcp 2 1 "port"      1
+    pasta_test_do 6 loopback tcp 3 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv6, tap" {


### PR DESCRIPTION
This reverts commit e33f4e0bc7429038ba6aa82285ae8749c9037c88, going back to three connections (not two) for each range in TCP tests. I'm not sure yet what caused the original issue, but it might be fixed now. If it does, this fixes #17287.

```release-note
None
```
