### PR TITLE
auto update system tests: help debug #17607

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -338,11 +338,13 @@ EOF
         fi
     done
 
-    # Only check that the last service is started. Previous services should already be activated.
-    _wait_service_ready container-$cname.service
+    # Make sure all services are ready.
+    for cname in "${cnames[@]}"; do
+        _wait_service_ready container-$cname.service
+    done
     run_podman commit --change CMD=/bin/bash $local_cname quay.io/libpod/localtest:latest
     # Exit code is expected, due to invalid 'fakevalue'
-    run_podman 125 auto-update
+    run_podman 125 auto-update --rollback=false
     update_log=$output
     is "$update_log" ".*invalid auto-update policy.*" "invalid policy setup"
     is "$update_log" ".*Error: invalid auto-update policy.*" "invalid policy setup"

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -171,7 +171,7 @@ function _confirm_update() {
     is "$output" ".* system auto-update"
 
     since=$(date --iso-8601=seconds)
-    run_podman auto-update --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    run_podman auto-update --rollback=false --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" "Trying to pull.*" "Image is updated."
     is "$output" ".*container-$cname.service,quay.io/libpod/alpine:latest,true,registry.*" "Image is updated."
     run_podman events --filter type=system --since $since --stream=false
@@ -248,7 +248,7 @@ function _confirm_update() {
     run_podman auto-update --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" ".*container-$cname.service,quay.io/libpod/localtest:latest,pending,local.*" "Image update is pending."
 
-    run_podman auto-update --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    run_podman auto-update --rollback=false --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" ".*container-$cname.service,quay.io/libpod/localtest:latest,true,local.*" "Image is updated."
 
     _confirm_update $cname $ori_image


### PR DESCRIPTION
Two changes to help debug the flakes on Debian tracked in #17607.  Please refer to the individual commit messages for details.

@edsantiago PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
