### PR TITLE
podman events: unhide --stream

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -72,7 +72,7 @@ func eventsFlags(cmd *cobra.Command) {
 	flags.StringVar(&eventFormat, formatFlagName, "", "format the output using a Go template")
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&events.Event{}))
 
-	flags.BoolVar(&eventOptions.Stream, "stream", true, "stream new events; for testing only")
+	flags.BoolVar(&eventOptions.Stream, "stream", true, "stream events and do not exit when returning the last known event")
 
 	sinceFlagName := "since"
 	flags.StringVar(&eventOptions.Since, sinceFlagName, "", "show all events created since timestamp")
@@ -83,8 +83,6 @@ func eventsFlags(cmd *cobra.Command) {
 	untilFlagName := "until"
 	flags.StringVar(&eventOptions.Until, untilFlagName, "", "show all events until timestamp")
 	_ = cmd.RegisterFlagCompletionFunc(untilFlagName, completion.AutocompleteNone)
-
-	_ = flags.MarkHidden("stream")
 }
 
 func eventsCmd(cmd *cobra.Command, _ []string) error {

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -128,6 +128,9 @@ Do not truncate the output (default *true*).
 
 Show all events created since the given timestamp
 
+#### **--stream**
+
+Stream events and do not exit after reading the last known event (default *true*).
 
 #### **--until**=*timestamp*
 


### PR DESCRIPTION
The --stream flag is being used extensively in the tests and some blog posts refer to it which has been causing some confusion on why the flag was hidden.  I do not see a good reason to hide it anymore, so unhide it and add some docs.

[NO NEW TESTS NEEDED] as it's already being tested.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Document the podman-events --stream flag.
```
