### PR TITLE
Revert "Revert "pasta: Use two connections instead of three in TCP ra…

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -380,11 +380,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv4, tap" {
-    pasta_test_do 4 tap      tcp 3 0 "port"      1
+    pasta_test_do 4 tap      tcp 2 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv4, loopback" {
-    pasta_test_do 4 loopback tcp 3 0 "port"      1
+    pasta_test_do 4 loopback tcp 2 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - Translated TCP port forwarding, IPv4, tap" {
@@ -396,11 +396,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, tap" {
-    pasta_test_do 4 tap      tcp 3 1 "port"      1
+    pasta_test_do 4 tap      tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, loopback" {
-    pasta_test_do 4 loopback tcp 3 1 "port"      1
+    pasta_test_do 4 loopback tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv4, tap" {
@@ -430,7 +430,7 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv6, tap" {
-    pasta_test_do 6 tap      tcp 3 0 "port"      1
+    pasta_test_do 6 tap      tcp 2 0 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP port range forwarding, IPv6, loopback" {
@@ -446,11 +446,11 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, tap" {
-    pasta_test_do 6 tap      tcp 3 1 "port"      1
+    pasta_test_do 6 tap      tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, loopback" {
-    pasta_test_do 6 loopback tcp 3 1 "port"      1
+    pasta_test_do 6 loopback tcp 2 1 "port"      1
 }
 
 @test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv6, tap" {


### PR DESCRIPTION
…nge forward tests""

This reverts commit 1c08f2edac3f9ecf128cf8da91276e963e6ad14c: the original failure reported in #17287 persists:

  [+1306s] not ok 453 podman networking with pasta(1) - TCP translated port range forwarding, IPv4, loopback

...

  [+1306s] # 2023/03/15 14:33:33 socat[119870] E connect(8, AF=2 127.0.0.1:5127, 16): Interrupted system call
  [+1306s] # xx
  [+1306s] # #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
  [+1306s] # #|     FAIL: Mismatch between data sent and received
  [+1306s] # #| expected: = xxx
  [+1306s] # #|   actual:   xx
  [+1306s] # #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

so keep two connections instead of three as long as I'm too dumb to figure this out.

#### Does this PR introduce a user-facing change?

```release-note
None
```
