### PR TITLE
[v4.4] Several backports of some of my recent fixes

### DIFF
--- a/cmd/podman-mac-helper/main.go
+++ b/cmd/podman-mac-helper/main.go
@@ -53,6 +53,7 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2012,7 +2012,11 @@ func (c *Container) generateResolvConf() error {
 	// If the user provided dns, it trumps all; then dns masq; then resolv.conf
 	keepHostServers := false
 	if len(nameservers) == 0 {
-		keepHostServers = true
+		// when no network name servers or not netavark use host servers
+		// for aardvark dns we only want our single server in there
+		if len(networkNameServers) == 0 || networkBackend != string(types.Netavark) {
+			keepHostServers = true
+		}
 		// first add the nameservers from the networks status
 		nameservers = networkNameServers
 		// slirp4netns has a built in DNS forwarder.

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -38,14 +38,14 @@ func (c *Container) ReadLog(ctx context.Context, options *logs.LogOptions, logCh
 	switch c.LogDriver() {
 	case define.PassthroughLogging:
 		// if running under systemd fallback to a more native journald reading
-		if _, ok := c.config.Labels[systemdDefine.EnvVariable]; ok {
-			return c.readFromJournal(ctx, options, logChannel, colorID, true)
+		if unitName, ok := c.config.Labels[systemdDefine.EnvVariable]; ok {
+			return c.readFromJournal(ctx, options, logChannel, colorID, unitName)
 		}
 		return fmt.Errorf("this container is using the 'passthrough' log driver, cannot read logs: %w", define.ErrNoLogs)
 	case define.NoLogging:
 		return fmt.Errorf("this container is using the 'none' log driver, cannot read logs: %w", define.ErrNoLogs)
 	case define.JournaldLogging:
-		return c.readFromJournal(ctx, options, logChannel, colorID, false)
+		return c.readFromJournal(ctx, options, logChannel, colorID, "")
 	case define.JSONLogging:
 		// TODO provide a separate implementation of this when Conmon
 		// has support.

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/libpod/logs"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/coreos/go-systemd/v22/sdjournal"
 	"github.com/sirupsen/logrus"
 )
@@ -30,21 +29,6 @@ const (
 
 func init() {
 	logDrivers = append(logDrivers, define.JournaldLogging)
-}
-
-// initializeJournal will write an empty string to the journal
-// when a journal is created. This solves a problem when people
-// attempt to read logs from a container that has never had stdout/stderr
-func (c *Container) initializeJournal(ctx context.Context) error {
-	m := make(map[string]string)
-	m["SYSLOG_IDENTIFIER"] = "podman"
-	m["PODMAN_ID"] = c.ID()
-	history := events.History
-	m["PODMAN_EVENT"] = history.String()
-	container := events.Container
-	m["PODMAN_TYPE"] = container.String()
-	m["PODMAN_TIME"] = time.Now().Format(time.RFC3339Nano)
-	return journal.Send("", journal.PriInfo, m)
 }
 
 func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOptions, logChannel chan *logs.LogLine, colorID int64) error {

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -11,6 +11,6 @@ import (
 	"github.com/containers/podman/v4/libpod/logs"
 )
 
-func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, _ int64, _ bool) error {
+func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, _ int64, _ string) error {
 	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
 }

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -11,6 +11,6 @@ import (
 	"github.com/containers/podman/v4/libpod/logs"
 )
 
-func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, colorID int64) error {
+func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, _ int64, _ bool) error {
 	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
 }

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -14,7 +14,3 @@ import (
 func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, colorID int64) error {
 	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
 }
-
-func (c *Container) initializeJournal(ctx context.Context) error {
-	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
-}

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -243,36 +243,6 @@ func NewLogLine(line string) (*LogLine, error) {
 	return &l, nil
 }
 
-// NewJournaldLogLine creates a LogLine from the specified line from journald.
-// Note that if withID is set, the first item of the message is considerred to
-// be the container ID and set as such.
-func NewJournaldLogLine(line string, withID bool) (*LogLine, error) {
-	splitLine := strings.Split(line, " ")
-	if len(splitLine) < 4 {
-		return nil, fmt.Errorf("'%s' is not a valid container log line", line)
-	}
-	logTime, err := time.Parse(LogTimeFormat, splitLine[0])
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert time %s from container log: %w", splitLine[0], err)
-	}
-	var msg, id string
-	if withID {
-		id = splitLine[3]
-		msg = strings.Join(splitLine[4:], " ")
-	} else {
-		msg = strings.Join(splitLine[3:], " ")
-		// NO ID
-	}
-	l := LogLine{
-		Time:         logTime,
-		Device:       splitLine[1],
-		ParseLogType: splitLine[2],
-		Msg:          msg,
-		CID:          id,
-	}
-	return &l, nil
-}
-
 // Partial returns a bool if the log line is a partial log type
 func (l *LogLine) Partial() bool {
 	return l.ParseLogType == PartialLogType

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -541,12 +541,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	}
 
 	switch ctr.config.LogDriver {
-	case define.NoLogging, define.PassthroughLogging:
+	case define.NoLogging, define.PassthroughLogging, define.JournaldLogging:
 		break
-	case define.JournaldLogging:
-		if err := ctr.initializeJournal(ctx); err != nil {
-			return nil, fmt.Errorf("failed to initialize journal: %w", err)
-		}
 	default:
 		if ctr.config.LogPath == "" {
 			ctr.config.LogPath = filepath.Join(ctr.config.StaticDir, "ctr.log")

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -104,6 +104,9 @@ t GET networks/podman 200 \
 
 # network create docker
 t POST networks/create Name=net3\ IPAM='{"Config":[]}' 201
+# create with same name should not error unless CheckDuplicate is set
+t POST networks/create Name=net3 201
+t POST networks/create Name=net3\ CheckDuplicate=true 409
 # network delete docker
 t DELETE networks/net3 204
 

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -319,14 +319,14 @@ function _log_test_follow_since() {
 
     # Now do the same with a running container to check #16950.
     run_podman ${events_backend} run --log-driver=$driver --name $cname -d $IMAGE \
-        sh -c "sleep 0.5; while :; do echo $content && sleep 3; done"
+        sh -c "sleep 1; while :; do echo $content && sleep 5; done"
 
     # sleep is required to make sure the podman event backend no longer sees the start event in the log
     # This value must be greater or equal than the the value given in --since below
     sleep 0.2
 
     # Make sure podman logs actually follows by giving a low timeout and check that the command times out
-    PODMAN_TIMEOUT=2 run_podman 124 ${events_backend} logs --since 0.1s -f $cname
+    PODMAN_TIMEOUT=3 run_podman 124 ${events_backend} logs --since 0.1s -f $cname
     assert "$output" =~ "^$content
 timeout: sending signal TERM to command.*" "logs --since -f on running container works"
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -383,11 +383,15 @@ metadata:
 spec:
   containers:
   - command:
-    - top
+    - sh
+    - -c
+    - echo a stdout; echo a stderr 1>&2; sleep inf
     image: $IMAGE
     name: a
   - command:
-    - top
+    - sh
+    - -c
+    - echo b stdout; echo b stderr 1>&2; sleep inf
     image: $IMAGE
     name: b
 EOF
@@ -418,6 +422,10 @@ EOF
     for name in "a" "b"; do
         run_podman container inspect test_pod-${name} --format "{{.HostConfig.LogConfig.Type}}"
         assert $output != "passthrough"
+        # check that we can get the logs with passthrough when we run in a systemd unit
+        run_podman logs test_pod-$name
+        assert "$output" == "$name stdout
+$name stderr" "logs work with passthrough"
     done
 
     # Add a simple `auto-update --dry-run` test here to avoid too much redundancy

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -428,6 +428,12 @@ EOF
 $name stderr" "logs work with passthrough"
     done
 
+    # we cannot assume the ordering between a b, this depends on timing and would flake in CI
+    # use --names so we do not have to get the ID
+    run_podman pod logs --names test_pod
+    assert "$output" =~ ".*^test_pod-a a stdout.*" "logs from container a shown"
+    assert "$output" =~ ".*^test_pod-b b stdout.*" "logs from container b shown"
+
     # Add a simple `auto-update --dry-run` test here to avoid too much redundancy
     # with 255-auto-update.bats
     run_podman auto-update --dry-run --format "{{.Unit}},{{.Container}},{{.Image}},{{.Updated}},{{.Policy}}"

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -117,7 +117,7 @@ function service_cleanup() {
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
-Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; sleep inf"
 Notify=yes
 EOF
 
@@ -127,6 +127,10 @@ EOF
     # Ensure we have output. Output is synced via sd-notify (socat in Exec)
     run journalctl "--since=$STARTED_TIME" --unit="$QUADLET_SERVICE_NAME"
     is "$output" '.*STARTED CONTAINER.*'
+
+    # check that we can read the logs from the container with podman logs
+    run_podman logs $QUADLET_CONTAINER_NAME
+    assert "$output" == "STARTED CONTAINER" "podman logs works on quadlet container"
 
     run_podman container inspect  --format "{{.State.Status}}" $QUADLET_CONTAINER_NAME
     is "$output" "running" "container should be started by systemd and hence be running"

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -663,7 +663,7 @@ EOF
     is "$output" "search example.com.*" "correct search domain"
     local store=$output
     if is_netavark; then
-	is "$store" ".*nameserver $subnet.1.*" "integrated dns nameserver is set"
+        assert "$store" == "search example.com${nl}nameserver $subnet.1" "only integrated dns nameserver is set"
     else
 	is "$store" ".*nameserver 1.1.1.1${nl}nameserver $searchIP${nl}nameserver 1.0.0.1${nl}nameserver 8.8.8.8" "nameserver order is correct"
     fi


### PR DESCRIPTION
Backports of:
- https://github.com/containers/podman/pull/17781
- https://github.com/containers/podman/pull/17653
- https://github.com/containers/podman/pull/17786
- https://github.com/containers/podman/pull/17594
- https://github.com/containers/podman/pull/17578
- https://github.com/containers/podman/pull/17547
- https://github.com/containers/podman/pull/17502


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman system service --log-level=trace` will now be able to hijack the client connection and thus make `podman-remote run/attach` work correctly.
podman-mac-helper now exits with 1 on error.
The docker compat API now returns 409 if you try to create a network with the same name and CheckDuplicate is set to true.
podman run --dns ... --network ... will no longer add host nameservers to resolv.conf when aardvark-dns is used.
podman logs can now read logs with the passsthrough driver when the container is run from a systemd service.
```
