### PR TITLE
Add service ctr cleanup to PlayKubeDown

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1366,6 +1366,15 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 		}
 	}
 
+	// Remove the service container to ensure it is removed before we return for the remote case
+	// Needed for the clean up with podman kube play --wait in the remote case
+	if reports.ServiceContainerID != "" {
+		_, err = ic.ContainerRm(ctx, []string{reports.ServiceContainerID}, entities.RmOptions{})
+		if err != nil && !errors.Is(err, define.ErrNoSuchCtr) {
+			return nil, err
+		}
+	}
+
 	return reports, nil
 }
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -619,8 +619,8 @@ spec:
     - name: server
       image: $IMAGE
       command:
-      - sleep
-      - "5"
+      - echo
+      - "hello"
 " > $fname
 
     run_podman kube play --wait $fname


### PR DESCRIPTION
Since we can't guarantee when the worker queue will come
and clean up the service container in the remote case when
podman kube play --wait is called, cleanup the service container
at the end of PlayKubeDown() to ensure that it is removed right
after all the containers, pods, volumes, etc are removed.

[NO NEW TESTS NEEDED]

Fixes https://github.com/containers/podman/issues/17803
Foxes https://github.com/containers/podman/issues/17820

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
