### PR TITLE
CI: test and confirm DESIRED_DATABASE

### DIFF
--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -181,4 +181,19 @@ var _ = Describe("Podman Info", func() {
 		Expect(session).To(Exit(0))
 		Expect(session.OutputToString()).To(Equal(want))
 	})
+
+	It("Podman info: check desired database backend", func() {
+		// defined in .cirrus.yml
+		want := os.Getenv("CI_DESIRED_DATABASE")
+		if want == "" {
+			if os.Getenv("CIRRUS_CI") == "" {
+				Skip("CI_DESIRED_DATABASE is not set--this is OK because we're not running under Cirrus")
+			}
+			Fail("CIRRUS_CI is set, but CI_DESIRED_DATABASE is not! See #16389")
+		}
+		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.DatabaseBackend}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+		Expect(session.OutputToString()).To(Equal(want))
+	})
 })

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -50,6 +50,7 @@ function setup() {
         'Logdriver:{{.Host.LogDriver}}'
         'Cgroups:{{.Host.CgroupsVersion}}+{{.Host.CgroupManager}}'
         'Net:{{.Host.NetworkBackend}}'
+        'DB:{{.Host.DatabaseBackend}}'
     )
     run_podman info --format "$(IFS='/' echo ${want[@]})"
     echo "# $output" >&3

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -93,6 +93,26 @@ host.slirp4netns.executable | $expr_path
     is "$output" "$CI_DESIRED_NETWORK" "CI_DESIRED_NETWORK (from .cirrus.yml)"
 }
 
+@test "podman info - confirm desired database" {
+    skip "FIXME: no way yet (2023-03-16) to override DB in system tests"
+    if [[ -z "$CI_DESIRED_DATABASE" ]]; then
+        # When running in Cirrus, CI_DESIRED_DATABASE *must* be defined
+        # in .cirrus.yml so we can double-check that all CI VMs are
+        # using netavark or cni as desired.
+        if [[ -n "$CIRRUS_CI" ]]; then
+            die "CIRRUS_CI is set, but CI_DESIRED_DATABASE is not! See #16389"
+        fi
+
+        # Not running under Cirrus (e.g., gating tests, or dev laptop).
+        # Totally OK to skip this test.
+        skip "CI_DESIRED_DATABASE is unset--OK, because we're not in Cirrus"
+    fi
+
+    run_podman info --format '{{.Host.DatabaseBackend}}'
+    is "$output" "$CI_DESIRED_DATABASE" "CI_DESIRED_DATABASE (from .cirrus.yml)"
+}
+
+
 # 2021-04-06 discussed in watercooler: RHEL must never use crun, even if
 # using cgroups v2.
 @test "podman info - RHEL8 must use runc" {


### PR DESCRIPTION
Just like we do with RUNTIME and NETWORK. Skipped for now in
system tests because there's no way yet to actually set the
database backend.

Also, in system test oneliner (first test), include DB

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```