### PR TITLE
Implement `podman push --all-tags`

### DIFF
--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -80,6 +80,9 @@ func pushFlags(cmd *cobra.Command) {
 
 	// For now default All flag to true, for pushing of manifest lists
 	pushOptions.All = true
+
+	flags.BoolVarP(&pushOptions.AllTags, "all-tags", "a", false, "Push all tagged images in the repository")
+
 	authfileFlagName := "authfile"
 	flags.StringVar(&pushOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -47,6 +47,10 @@ $ podman push myimage oci-archive:/tmp/myimage
 
 ## OPTIONS
 
+#### **--all-tags**, **-a**
+
+Push all tags of an image to the repository
+
 @@option authfile
 
 @@option cert-dir

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -181,6 +181,9 @@ type ImagePullReport struct {
 type ImagePushOptions struct {
 	// All indicates that all images referenced in an manifest list should be pushed
 	All bool
+	// AllTags indicates that all tags of the specified image are to be pushed to
+	// the registry
+	AllTags bool
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
 	Authfile string

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -395,4 +395,22 @@ var _ = Describe("Podman push", func() {
 		Expect(session).Should(Exit(0))
 	})
 
+	It("podman push all tags to container-storage", func() {
+		SkipIfRemote("Remote push does not support containers-storage transport")
+
+		session := podmanTest.Podman([]string{"pull", ALPINELISTTAG})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"push", "-a", "alpine", "containers-storage:test-image"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"images", "test-image"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		testimageCount := strings.Count(session.OutputToString(), "test-image")
+		Expect(testimageCount).To(Equal(2))
+	})
 })


### PR DESCRIPTION
Implemented the `--all-tags` flag for `podman push`.

Example: `podman push -a demo docker://docker.io/<user>/demo`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds the `--all-tags` flag to `podman push`
```
