### PR TITLE
Quadlet - add support for relative path in Volume key in .container file

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -467,6 +467,8 @@ If enabled, the container will have a fresh tmpfs mounted on `/tmp`.
 Mount a volume in the container. This is equivalent to the Podman `--volume` option, and
 generally has the form `[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]`.
 
+If `SOURCE-VOLUME` starts with `.`, Quadlet will resolve the path relative to the location of the unit file.
+
 As a special case, if `SOURCE-VOLUME` ends with `.volume`, a Podman named volume called
 `systemd-$name` will be used as the source, and the generated systemd service will contain
 a dependency on the `$name-volume.service`. Such a volume can be automatically be lazily

--- a/test/e2e/quadlet/mount.container
+++ b/test/e2e/quadlet/mount.container
@@ -18,3 +18,5 @@ Mount=type=tmpfs,tmpfs-size=512M,destination=/path/in/container
 Mount=type=image,source=fedora,destination=/fedora-image,rw=true
 ## assert-podman-args-key-val "--mount" "," "type=devpts,destination=/dev/pts"
 Mount=type=devpts,destination=/dev/pts
+## assert-podman-args-key-val-regex "--mount" "," "type=bind,source=.*/podman_test.*/quadlet/path/on/host,destination=/path/in/container"
+Mount=type=bind,source=./path/on/host,destination=/path/in/container

--- a/test/e2e/quadlet/volume.container
+++ b/test/e2e/quadlet/volume.container
@@ -1,5 +1,6 @@
 ## assert-podman-args -v /host/dir:/container/volume
 ## assert-podman-args -v /host/dir2:/container/volume2:Z
+## assert-podman-args-regex -v .*/podman_test.*/quadlet/host/dir3:/container/volume3
 ## assert-podman-args -v named:/container/named
 ## assert-podman-args -v systemd-quadlet:/container/quadlet localhost/imagename
 
@@ -7,6 +8,7 @@
 Image=localhost/imagename
 Volume=/host/dir:/container/volume
 Volume=/host/dir2:/container/volume2:Z
+Volume=./host/dir3:/container/volume3
 Volume=/container/empty
 Volume=named:/container/named
 Volume=quadlet.volume:/container/quadlet


### PR DESCRIPTION
If the volume source starts with . resolve the path relative to the location of the unit file

Update the test code to allow verification of regex for the value in key value arguments
Add the usage of relative paths to the volume and mount test cases Update the man page

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - add support for relative path in Volume key in .container file
```

Fixes: #17418
