### PR TITLE
New ulimit test: bump up minimum nfiles

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1027,8 +1027,9 @@ EOF
 @test "podman run ulimit from containers.conf" {
     skip_if_remote "containers.conf has to be set on remote, only tested on E2E test"
     containersconf=$PODMAN_TMPDIR/containers.conf
-    nofile1=$((RANDOM % 10000 + 5))
-    nofile2=$((RANDOM % 10000 + 5))
+    # Safe minimum: anything under 27 barfs w/ "crun: ... Too many open files"
+    nofile1=$((30 + RANDOM % 10000))
+    nofile2=$((30 + RANDOM % 10000))
     cat >$containersconf <<EOF
 [containers]
 default_ulimits = [


### PR DESCRIPTION
...and add a comment explaining why. The minimum, determined via
binary search, is actually 27! Anything under that will barf:

   $ bin/podman run --ulimit nofile=26:26 --rm quay.io/libpod/testimage:20221018 true
   Error: OCI runtime error: crun: openat2 `proc/sysrq-trigger`: Too many open files

Play it safe, go with 30.

(Does this seem alarming to anyone else, or am I the only one??)

Fixes: #17860

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```