### PR TITLE
quadlet tests: skip on RHEL8 rootless

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -15,7 +15,10 @@ function start_time() {
 
 function setup() {
     skip_if_remote "quadlet tests are meaningless over remote"
-    skip_if_rootless_cgroupsv1 "quadlet tests don't work rootless on RHEL8"
+    skip_if_rootless_cgroupsv1 "Can't use --cgroups=split w/ CGv1 (#17456)"
+    skip_if_journald_unavailable "quadlet isn't really usable without journal"
+
+    test -x "$QUADLET" || die "Cannot run quadlet tests without executable \$QUADLET ($QUADLET)"
 
     start_time
 

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -244,6 +244,8 @@ READY=1" "sdnotify sent MAINPID and READY"
 }
 
 @test "sdnotify : play kube - with policies" {
+    skip_if_journald_unavailable
+
     # Pull that image. Retry in case of flakes.
     run_podman pull $SYSTEMD_IMAGE || \
         run_podman pull $SYSTEMD_IMAGE || \


### PR DESCRIPTION
skip in setup() if journald unavailable.

To be pedantic, this is overkill: some quadlet tests pass because they don't run journald. Too bad.

Also skip a play-kube test that requires journal

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```
