### PR TITLE
stats compat API: return "id" lowercase

### DIFF
--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -202,7 +202,14 @@ streamLabel: // A label to flatten the scope
 			Networks: net,
 		}
 
-		if err := coder.Encode(s); err != nil {
+		var jsonOut interface{}
+		if utils.IsLibpodRequest(r) {
+			jsonOut = s
+		} else {
+			jsonOut = DockerStatsJSON(s)
+		}
+
+		if err := coder.Encode(jsonOut); err != nil {
 			logrus.Errorf("Unable to encode stats: %v", err)
 			return
 		}

--- a/pkg/api/handlers/compat/types.go
+++ b/pkg/api/handlers/compat/types.go
@@ -53,3 +53,16 @@ type StatsJSON struct {
 	// Networks request version >=1.21
 	Networks map[string]docker.NetworkStats `json:"networks,omitempty"`
 }
+
+// DockerStatsJSON is the same as StatsJSON except for the lowercase
+// "id" in the JSON tag. This is needed for docker compat but we should
+// not change the libpod API output for backwards compat reasons.
+type DockerStatsJSON struct {
+	Stats
+
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+
+	// Networks request version >=1.21
+	Networks map[string]docker.NetworkStats `json:"networks,omitempty"`
+}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -113,7 +113,13 @@ if root; then
     podman run --name $CTRNAME -d -m 512m -v /tmp:/tmp $IMAGE top
 
     t GET libpod/containers/$CTRNAME/stats?stream=false 200 \
-    .memory_stats.limit=536870912
+    .memory_stats.limit=536870912 \
+    .Id~[0-9a-f]\\{64\\}
+
+    # Make sure docker compat endpoint shows "id" lowercase
+    t GET containers/$CTRNAME/stats?stream=false 200 \
+    .memory_stats.limit=536870912 \
+    .id~[0-9a-f]\\{64\\}
 
     podman rm -f $CTRNAME
 fi


### PR DESCRIPTION
We use the same endpoint for libpod and docker compat API. However as reported docker returns "id" lowercase. Because we cannot break the libpod API right now keep the output for the libpod endpoint and only change the docker one.

To do so simply use two types that we can cast with different JSON tags.

Fixes #17869

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The docker compat API stats endpoint now returns the `Id` key as lowercase `id` to match docker.
```
