### PR TITLE
[CI:BUILD] Packit: Initial Enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file generated using the `post-upstream-clone`
+# action and gets used by the fix-spec-file action in .packit.yaml.
+
+set -eo pipefail
+
+# Get Version from version/version.go in HEAD
+VERSION=$(grep '^const RawVersion' version/rawversion/version.go | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball from HEAD
+git archive --prefix=podman-$VERSION/ -o podman-$VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Use the Version from version/version.go in rpm spec
+sed -i "s/^Version:.*/Version: $VERSION/" podman.spec
+
+# Use Packit's supplied variable in the Release field in rpm spec.
+# podman.spec is generated using `rpkg spec --outdir ./` as mentioned in the
+# `post-upstream-clone` action in .packit.yaml.
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" podman.spec
+
+# Use above generated tarball as Source in rpm spec
+sed -i "s/^Source:.*.tar.gz/Source: podman-$VERSION.tar.gz/" podman.spec
+
+# Use the right build dir for autosetup stage in rpm spec
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$VERSION/" podman.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,30 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: podman.spec
+
+jobs:
+  - &copr
+    job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - make
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"
+
+  - <<: *copr
+    # Run on commit to main branch
+    trigger: commit
+    branch: main
+    project: podman-next

--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -181,6 +181,9 @@ PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDI
         install.modules-load
 %endif
 
+# Sanitize paths in %%{_bindir}/docker
+sed -i 's;%{buildroot}%{_sysconfdir};%{_sysconfdir}/containers;g' %{buildroot}%{_bindir}/docker
+
 install -d -p %{buildroot}/%{_datadir}/%{name}/test/system
 cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 


### PR DESCRIPTION
This commit adds Packit configuration files which will trigger rpm builds on copr:`rhcontainerbot/packit-builds` on every PR as well as on copr:`rhcontainerbot/podman-next` on every commit to main branch.

This commit will ensure main branch is always buildable on all supported Fedora and CentOS Stream versions for aarch64 and x86_64. TODO: enable build checks for s390x and ppc64le while ensuring they don't take too long to build.

The packit builds reuse `buildah.spec.rpkg` present upstream and are thus independent of Fedora / CentOS dist-git.

This change will remove the need for the current webhook based triggering of rpm builds on rhcontainerbot/podman-next after commit to main. That will be instead handled by the `trigger: commit` action added in this PR. New builds will continue to get posted to the same link so users don't need to change any existing copr repo configuration.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

EDIT: I plan to run packit copr-builds for about a week, twice at least everyday, and report back with the build and total times for every run, so reviewers can feel at ease RE: total gating time.
