### PR TITLE
[CI:BUILD] Ensure no buildroot macro left in /usr/bin/docker

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -176,6 +176,9 @@ PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDI
         install.modules-load
 %endif
 
+# Sanitize paths in %%{_bindir}/docker
+sed -i 's;%{buildroot}%{_sysconfdir};%{_sysconfdir}/containers;g' %{buildroot}%{_bindir}/docker
+
 install -d -p %{buildroot}/%{_datadir}/%{name}/test/system
 cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 


### PR DESCRIPTION
PR: #17791 as-is will leave the buildroot macro in /usr/bin/docker in the rpmbuild process.

This commit will sanitize the buildroot macro from /usr/bin/docker.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@rhatdan @mheon PTAL

@multimeric you can rebase on this one once merged.