### PR TITLE
macos pkginstaller: fix regression which caused the installer to fail

### DIFF
--- a/cmd/podman-mac-helper/install.go
+++ b/cmd/podman-mac-helper/install.go
@@ -93,7 +93,8 @@ func install(cmd *cobra.Command, args []string) error {
 	fileName := filepath.Join("/Library", "LaunchDaemons", labelName)
 
 	if _, err := os.Stat(fileName); err == nil || !os.IsNotExist(err) {
-		return errors.New("helper is already installed, uninstall first")
+		fmt.Fprintln(os.Stderr, "helper is already installed, skipping the install, uninstall first if you want to reinstall")
+		return nil
 	}
 
 	prog, err := installExecutable(userName)

--- a/contrib/pkginstaller/scripts/postinstall
+++ b/contrib/pkginstaller/scripts/postinstall
@@ -7,4 +7,5 @@ echo "/opt/podman/bin" > /etc/paths.d/podman-pkg
 ln -s /opt/podman/bin/podman-mac-helper /opt/podman/qemu/bin/podman-mac-helper
 ln -s /opt/podman/bin/gvproxy /opt/podman/qemu/bin/gvproxy
 
-/opt/podman/bin/podman-mac-helper install
+# make sure to ignore errors, this is not a hard requirement to use podman
+/opt/podman/bin/podman-mac-helper install || :


### PR DESCRIPTION
podman-mac-helper: install: do not error if already installed

Since commit https://github.com/containers/podman/commit/bae07b6ea2c29d113b21edcbcfbabd4e15296d60 we exit with 1 one errors. This caused problem
for the mac installer which fails because of the error now.
If the helper is already installed do not treat this as hard error and
just log it instead.

macos pkginstaller: do not fail when podman-mac-helper fails

Make sure we can install podman even when the podman-mac-helper install
command fails. This used to be the behavior but commit https://github.com/containers/podman/commit/bae07b6ea2c29d113b21edcbcfbabd4e15296d60 caused
the regression because the binary now returns 1 as exit code on errors.

Fixes https://github.com/containers/podman/issues/17910

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a regression which caused the macos installer to fail.
```
