### PR TITLE
Ensure that SQLite state handles name-ID collisions

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -718,4 +718,21 @@ var _ = Describe("Podman create", func() {
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 	})
+
+	It("create container with name subset of existing ID", func() {
+		create1 := podmanTest.Podman([]string{"create", "-t", ALPINE, "top"})
+		create1.WaitWithDefaultTimeout()
+		Expect(create1).Should(Exit(0))
+		ctr1ID := create1.OutputToString()
+
+		ctr2Name := ctr1ID[:5]
+		create2 := podmanTest.Podman([]string{"create", "-t", "--name", ctr2Name, ALPINE, "top"})
+		create2.WaitWithDefaultTimeout()
+		Expect(create2).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{.Name}}", ctr2Name})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).Should(Equal(ctr2Name))
+	})
 })

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1199,4 +1199,20 @@ ENTRYPOINT ["sleep","99999"]
 		Expect(strings[0]).Should(ContainSubstring("size=10240k"))
 	})
 
+	It("create pod with name subset of existing ID", func() {
+		create1 := podmanTest.Podman([]string{"pod", "create"})
+		create1.WaitWithDefaultTimeout()
+		Expect(create1).Should(Exit(0))
+		pod1ID := create1.OutputToString()
+
+		pod2Name := pod1ID[:5]
+		create2 := podmanTest.Podman([]string{"pod", "create", pod2Name})
+		create2.WaitWithDefaultTimeout()
+		Expect(create2).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{.Name}}", pod2Name})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).Should(Equal(pod2Name))
+	})
 })


### PR DESCRIPTION
If a container with an ID starting with "db1" exists, and a container named "db1" also exists, and they are different containers - if I run `podman inspect db1` the container named "db1" should be inspected, and there should not be an error that multiple containers matched the name or id "db1". This was already handled by BoltDB, and now is properly managed by SQLite.

Fixes #17905

```release-note
NONE
```
