### PR TITLE
Pass build args in annotations on `kube play`.

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -369,7 +369,13 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 				if define.IsReservedAnnotation(k) || annotations.IsReservedAnnotation(k) {
 					continue
 				}
-				podAnnotations[fmt.Sprintf("%s/%s", k, removeUnderscores(ctr.Name()))] = TruncateKubeAnnotation(v)
+
+				if strings.HasPrefix(k, util.BuildArgumentsAnnotationPrefix) {
+					// Build arguments should output the same way they were created.
+					podAnnotations[k] = TruncateKubeAnnotation(v)
+				} else {
+					podAnnotations[fmt.Sprintf("%s/%s", k, removeUnderscores(ctr.Name()))] = TruncateKubeAnnotation(v)
+				}
 			}
 			// Convert auto-update labels into kube annotations
 			for k, v := range getAutoUpdateAnnotations(ctr.Name(), ctr.Labels()) {

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -915,6 +915,7 @@ func (ic *ContainerEngine) getImageAndLabelInfo(ctx context.Context, cwd string,
 		buildOpts.CommonBuildOpts = commonOpts
 		buildOpts.Output = container.Image
 		buildOpts.ContextDirectory = filepath.Dir(buildFile)
+		buildOpts.Args = getBuildArgs(annotations, container.Name)
 		if _, _, err := ic.Libpod.Build(ctx, *buildOpts, []string{buildFile}...); err != nil {
 			return nil, nil, err
 		}

--- a/pkg/domain/infra/abi/play_utils.go
+++ b/pkg/domain/infra/abi/play_utils.go
@@ -1,6 +1,11 @@
 package abi
 
-import "github.com/containers/podman/v4/libpod/define"
+import (
+	"strings"
+
+	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/util"
+)
 
 // getSdNotifyMode returns the `sdNotifyAnnotation/$name` for the specified
 // name. If name is empty, it'll only look for `sdNotifyAnnotation`.
@@ -13,4 +18,22 @@ func getSdNotifyMode(annotations map[string]string, name string) (string, error)
 		mode = annotations[sdNotifyAnnotation+"/"+name]
 	}
 	return mode, define.ValidateSdNotifyMode(mode)
+}
+
+// getBuildArgs returns a map of `arg=value` for any annotation that starts
+// with `BuildArgumentsAnnotationPrefix/`, as long as the resulting `arg` is not empty.
+func getBuildArgs(annotations map[string]string, name string) map[string]string {
+	buildArgs := make(map[string]string)
+
+	for k, v := range annotations {
+		if strings.HasPrefix(k, util.BuildArgumentsAnnotationPrefix+".") && (strings.HasSuffix(k, "/"+name) || !strings.Contains(k, "/")) {
+			arg := strings.TrimPrefix(k, util.BuildArgumentsAnnotationPrefix+".")
+			arg = strings.TrimSuffix(arg, "/"+name)
+			if len(arg) > 0 {
+				buildArgs[arg] = v
+			}
+		}
+	}
+
+	return buildArgs
 }

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -15,4 +15,6 @@ const (
 	VolumeMountOptsAnnotation = "volume.podman.io/mount-options"
 	// Kube annotation for podman volume import source.
 	VolumeImportSourceAnnotation = "volume.podman.io/import-source"
+	// Kube annotation prefix for buildah build arguments.
+	BuildArgumentsAnnotationPrefix = "io.podman.build-args"
 )


### PR DESCRIPTION
Hey! I'm trying to find more reasons to use `kube play` over something like podman/docker compose. Those build systems allow build arguments to be passed to the builder when using a Containerfile/Dockerfile as a source.

During my search to find if there was a documented (or undocumented!) way to apply these build arguments from a provided kube.yaml file, I ended up getting familiar with the code enough to write a patch.

## Use Case

Providing different build-time arguments for the SHA commits of cloned repositories that are used in specific kube files.

Providing the same Containerfile different GPU architectures to build for depending on the kube file used.

## Example

Given the setup:
`test.yaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    io.podman.build-args.MESSAGE/test1: Hello from test1!
    io.podman.build-args.MESSAGE/test2: Hello from test2!
    io.podman.build-args.COMMON: BUILD
  name: test
spec:
  containers:
  - image: test1:latest
    name: test1
  - image: test2:latest
    name: test2
```

`test1/Containerfile`
```Dockerfile
FROM alpine:latest
ARG MESSAGE="Please override me!"
ARG COMMON="test1"
RUN echo $COMMON: $MESSAGE > message.txt
CMD cat message.txt
```

`test2/Containerfile`
```Dockerfile
FROM alpine:latest
ARG MESSAGE="Please override me as well!"
ARG COMMON="test2"
RUN echo $COMMON: $MESSAGE > message.txt
CMD cat message.txt
```

Without change:
```
❯ podman play kube test.yaml --build
<snip>
❯ podman run --rm test1
test1: Please override me!
❯ podman run --rm test2
test2: Please override me as well!
```

With change:
```
❯ podman kube play test.yaml --build
<snip>
❯ podman run --rm test1
BUILD: Hello from test1!
❯ podman run --rm test2
BUILD: Hello from test2!
```

## Questions

Build arguments are probably not the only parameter someone might want to provide to the builder. Should all types of arguments be handled similarly?

What of the 63 character limit? Since this is used only for Podman, does it matter?

Sometimes build arguments are used to pass secrets. Should these labels be removed? Example showing build value is preserved:

```
❯ podman generate kube test                         
# Save the output of this file and use kubectl create -f to import
# it into Kubernetes.
#
# Created with podman-4.5.0-dev
apiVersion: v1
kind: Pod
metadata:
  annotations:
    io.podman.build-args.COMMON: BUILD
    io.podman.build-args.MESSAGE/test1: Hello from test1!
    io.podman.build-args.MESSAGE/test2: Hello from test2!
    org.opencontainers.image.base.digest/test-test1: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e1
    org.opencontainers.image.base.digest/test-test2: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e1
    org.opencontainers.image.base.name/test-test1: docker.io/library/alpine:latest
    org.opencontainers.image.base.name/test-test2: docker.io/library/alpine:latest
<snip>
```

#### Does this PR introduce a user-facing change?

```release-note
Yes, but let's review this before we get this far. Documentation changes would also be needed.
```
