### PR TITLE
Quadlet - treat paths starting with systemd specifiers as absolute

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -968,8 +968,22 @@ func addNetworks(quadletUnitFile *parser.UnitFile, groupName string, serviceUnit
 	}
 }
 
+// Systemd Specifiers start with % with the exception of %%
+func startsWithSystemdSpecifier(filePath string) bool {
+	if len(filePath) == 0 || filePath[0] != '%' {
+		return false
+	}
+
+	if len(filePath) > 1 && filePath[1] == '%' {
+		return false
+	}
+
+	return true
+}
+
 func getAbsolutePath(quadletUnitFile *parser.UnitFile, filePath string) (string, error) {
-	if !filepath.IsAbs(filePath) {
+	// When the path starts with a Systemd specifier do not resolve what looks like a relative address
+	if !startsWithSystemdSpecifier(filePath) && !filepath.IsAbs(filePath) {
 		if len(quadletUnitFile.Path) > 0 {
 			filePath = filepath.Join(filepath.Dir(quadletUnitFile.Path), filePath)
 		} else {

--- a/test/e2e/quadlet/env-file.container
+++ b/test/e2e/quadlet/env-file.container
@@ -1,9 +1,12 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --env-file /opt/env/abs-1 --env-file /opt/env/abs-2
+## assert-podman-args --env-file /opt/env/abs-1
+## assert-podman-args --env-file /opt/env/abs-2
 ## assert-podman-args-regex --env-file /.*/podman_test.*/quadlet/rel-1
+## assert-podman-args --env-file %h/env
 
 [Container]
 Image=localhost/imagename
 EnvironmentFile=/opt/env/abs-1
 EnvironmentFile=/opt/env/abs-2
 EnvironmentFile=rel-1
+EnvironmentFile=%h/env

--- a/test/e2e/quadlet/volume.container
+++ b/test/e2e/quadlet/volume.container
@@ -2,7 +2,8 @@
 ## assert-podman-args -v /host/dir2:/container/volume2:Z
 ## assert-podman-args-regex -v .*/podman_test.*/quadlet/host/dir3:/container/volume3
 ## assert-podman-args -v named:/container/named
-## assert-podman-args -v systemd-quadlet:/container/quadlet localhost/imagename
+## assert-podman-args -v systemd-quadlet:/container/quadlet
+## assert-podman-args -v %h/container:/container/volume4
 
 [Container]
 Image=localhost/imagename
@@ -12,3 +13,4 @@ Volume=./host/dir3:/container/volume3
 Volume=/container/empty
 Volume=named:/container/named
 Volume=quadlet.volume:/container/quadlet
+Volume=%h/container:/container/volume4


### PR DESCRIPTION
If a path (Yaml, ConfigMap, EnvFile) starts with a systemd path specifier, treat the path as absolute
Add tests - unit, e2e and bats

Resolves: #17906 

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - treat paths starting with systemd specifiers as absolute
```
