### PR TITLE
sqlite: disable WAL mode

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -32,10 +32,6 @@ type SQLiteState struct {
 const (
 	// Deal with timezone automatically.
 	sqliteOptionLocation = "_loc=auto"
-	// Set the journal mode (https://www.sqlite.org/pragma.html#pragma_journal_mode).
-	sqliteOptionJournal = "&_journal=WAL"
-	// Force WAL mode to fsync after each transaction (https://www.sqlite.org/pragma.html#pragma_synchronous).
-	sqliteOptionSynchronous = "&_sync=FULL"
 	// Allow foreign keys (https://www.sqlite.org/pragma.html#pragma_foreign_keys).
 	sqliteOptionForeignKeys = "&_foreign_keys=1"
 	// Make sure that transactions happen exclusively.
@@ -44,8 +40,6 @@ const (
 	// Assembled sqlite options used when opening the database.
 	sqliteOptions = "db.sql?" +
 		sqliteOptionLocation +
-		sqliteOptionJournal +
-		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
 		sqliteOptionTXLock
 )


### PR DESCRIPTION
Disable the write-ahead log [1] for sqlite.  Performance testing suggests that WAL mode has a negative impact on Podman.  While most docs suggest that WAL mode improves performance, it does not seem to apply to Podman which tends to have very short-lived processes.

What I found most curious is that commands with many writes are faster without WAL mode, for instance, `rm`, `stop`, `start`, etc.

Hence, let's move to as-close-to-default config of sqlite and enable options only after thorough testing.

[NO NEW TESTS NEEDED] as it's a non-functional change.

[1] https://www.sqlite.org/wal.html

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
