### PR TITLE
fix os.IsNotExist() CI check

### DIFF
--- a/contrib/cirrus/check_go_changes.sh
+++ b/contrib/cirrus/check_go_changes.sh
@@ -59,5 +59,5 @@ check_diffs \
     "^(\\+[^#]+io/ioutil)|(\\+.+ioutil\\..+)"
 
 check_diffs \
-    "use of os.IsNotExists(err) vs recommended errors.Is(err, os.ErrNotExist)" \
-    "^\\+[^#]*os\\.IsNotExists\\("
+    "use of os.IsNotExist(err) vs recommended errors.Is(err, fs.ErrNotExist)" \
+    "^\\+[^#]*os\\.IsNotExist\\("


### PR DESCRIPTION
The os.IsNotExist() function comment mentions that new code should use `errors.Is(err, fs.ErrNotExist)` instead.

The check was already in CI but used the wrong function name (extra s.)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
