### PR TITLE
sqlite: do not `Ping()` after connecting

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -80,10 +80,6 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 
 	state.conn = conn
 
-	if err := state.conn.Ping(); err != nil {
-		return nil, fmt.Errorf("cannot connect to database: %w", err)
-	}
-
 	// Migrate schema (if necessary)
 	if err := state.migrateSchemaIfNecessary(); err != nil {
 		return nil, err


### PR DESCRIPTION
`Ping()` requires the DB lock, so we had to move it into a transaction to fix #17859. Since we try to access the DB directly afterwards, I prefer to let that fail instead of paying the cost of a transaction which would lock the DB for _all_ processes.

[NO NEW TESTS NEEDED] as it's a hard to reproduce race.

Fixes: #17859

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
@mheon @baude @giuseppe @edsantiago PTAL
