### PR TITLE
CI: enable sqlite system tests

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -94,7 +94,6 @@ host.slirp4netns.executable | $expr_path
 }
 
 @test "podman info - confirm desired database" {
-    skip "FIXME: no way yet (2023-03-16) to override DB in system tests"
     if [[ -z "$CI_DESIRED_DATABASE" ]]; then
         # When running in Cirrus, CI_DESIRED_DATABASE *must* be defined
         # in .cirrus.yml so we can double-check that all CI VMs are


### PR DESCRIPTION
In setup, write a containers.conf.d file with db_backend
as specified in .cirrus.yml.

This is actually much scarier and more achy-breaky than
merely "sqlite system tests": it enables sqlite in e2e
tests. ("But wait, we already do that!" -- no, not really.
sqlite in e2e is being done via --db-backend option, and
some podman commands in e2e do not use the standard options.
See #17904.

This is unlikely to get merged any time soon (March, maybe
even April) because sqlite is still too fragile; this will
trigger more flakes than are currently acceptable. Also,
the nasty auto-update flake seems to trigger much more
reliably with sqlite. We need that one fixed.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```