### PR TITLE
Quadlet - Support setting UID and GID for --userns=keep-id

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -549,13 +549,17 @@ This key can be listed multiple times.
 
 ### `RemapGid=`
 
-If `RemapUsers` is enabled, this specifies a gid mapping of the form `container_gid:from_gid:amount`,
+If `RemapUsers` is enabled, this specifies a gid mapping.
+If `RemapUsers` is set to `keep-id` the value should be a single GID and should appear only once.
+Otherwise, the value takes the form `container_gid:from_gid:amount`,
 which will map `amount` number of gids on the host starting at `from_gid` into the container, starting
 at `container_gid`.
 
 ### `RemapUid=`
 
-If `RemapUsers` is enabled, this specifies a uid mapping of the form `container_uid:from_uid:amount`,
+If `RemapUsers` is enabled, this specifies a uid mapping.
+If `RemapUsers` is set to `keep-id` the value should be a single UID and should appear only once.
+Otherwise, the value takes the form `container_uid:from_uid:amount`,
 which will map `amount` number of uids on the host starting at `from_uid` into the container, starting
 at `container_uid`.
 
@@ -573,8 +577,10 @@ host uids/gids to use for the container. By default this will try to estimate a 
 to remap, but `RemapUidSize` can be specified to use an explicit size. Use `RemapUid` and
 `RemapGid` key to force a particular host uid to be mapped to the container.
 
-In `keep-id` mode, the running user is mapped to the same id in the container. This is supported
-only on user systemd units.
+In `keep-id` mode, if `RemapUid` or `RemapGid` are set the running user is mapped
+to the corresponding ids in the container.
+Otherwise, the user is mapped to the user's host machine ids in the container.
+This is supported only on user systemd units.
 
 ### `Yaml=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -933,7 +933,23 @@ func handleUserRemap(unitFile *parser.UnitFile, groupName string, podman *Podman
 		if !isUser {
 			return fmt.Errorf("RemapUsers=keep-id is unsupported for system units")
 		}
-		podman.addf("--userns=keep-id")
+
+		keepidOpts := make([]string, 0)
+		if len(uidMaps) > 0 {
+			if len(uidMaps) > 1 {
+				return fmt.Errorf("RemapUsers=keep-id supports only a single value for UID mapping")
+			}
+			keepidOpts = append(keepidOpts, "uid="+uidMaps[0])
+		}
+		if len(gidMaps) > 0 {
+			if len(gidMaps) > 1 {
+				return fmt.Errorf("RemapUsers=keep-id supports only a single value for GID mapping")
+			}
+			keepidOpts = append(keepidOpts, "gid="+gidMaps[0])
+		}
+
+		podman.addf("--userns=" + usernsOpts("keep-id", keepidOpts))
+
 	default:
 		return fmt.Errorf("unsupported RemapUsers option '%s'", remapUsers)
 	}

--- a/test/e2e/quadlet/remap-keep-id.container
+++ b/test/e2e/quadlet/remap-keep-id.container
@@ -1,0 +1,5 @@
+## assert-podman-args --userns=keep-id
+
+[Container]
+Image=localhost/imagename
+RemapUsers=keep-id

--- a/test/e2e/quadlet/remap-keep-id2.container
+++ b/test/e2e/quadlet/remap-keep-id2.container
@@ -1,0 +1,7 @@
+## assert-podman-args "--userns=keep-id:uid=200,gid=210"
+
+[Container]
+Image=localhost/imagename
+RemapUsers=keep-id
+RemapUid=200
+RemapGid=210

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -551,6 +551,8 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("remap-manual.container", "remap-manual.container"),
 		Entry("remap-auto.container", "remap-auto.container"),
 		Entry("remap-auto2.container", "remap-auto2.container"),
+		Entry("remap-keep-id.container", "remap-keep-id.container"),
+		Entry("remap-keep-id2.container", "remap-keep-id2.container"),
 		Entry("volume.container", "volume.container"),
 		Entry("env-file.container", "env-file.container"),
 		Entry("env-host.container", "env-host.container"),

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -503,7 +503,7 @@ var _ = Describe("quadlet system generator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Run quadlet to convert the file
-			session := podmanTest.Quadlet([]string{"-no-kmsg-log", generatedDir}, quadletDir)
+			session := podmanTest.Quadlet([]string{"--user", "-no-kmsg-log", generatedDir}, quadletDir)
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - Support setting UID and GID for --userns=keep-id
```

Resolves: #17908