### PR TITLE
Add debug to --wait test

### DIFF
--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -625,8 +625,10 @@ spec:
 
     run_podman kube play --wait $fname
 
+    # debug to see what container is being left behind after the cleanup
     # there should be no containers running or created
-    run_podman ps -aq
+    run_podman ps -a --noheading
     is "$output" "" "There should be no containers"
+    run_podman pod ps
     run_podman rmi $(pause_image)
 }


### PR DESCRIPTION
Add a debug line to the wait to test to see which container is being left behind after the cleaup where the race is happening.

To test what is going on with flake https://github.com/containers/podman/issues/17803. Will revert this once I figure out what is being left behind.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
