### PR TITLE
[v4.4.1-rhel] fix slirp4netns resolv.conf ip with a userns

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1005,6 +1005,8 @@ func (c *Container) completeNetworkSetup() error {
 			nameservers = append(nameservers, server.String())
 		}
 	}
+	nameservers = c.addSlirp4netnsDNS(nameservers)
+
 	// check if we have a bindmount for /etc/hosts
 	if hostsBindMount, ok := state.BindMounts[config.DefaultHostsFile]; ok {
 		entries, err := c.getHostsEntries()

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2015,8 +2015,13 @@ func (c *Container) generateResolvConf() error {
 		keepHostServers = true
 		// first add the nameservers from the networks status
 		nameservers = networkNameServers
+
 		// slirp4netns has a built in DNS forwarder.
-		nameservers = c.addSlirp4netnsDNS(nameservers)
+		// If in userns the network is not setup here, instead we need to do that in
+		// c.completeNetworkSetup() which knows the actual slirp dns ip only at that point
+		if !c.config.PostConfigureNetNS {
+			nameservers = c.addSlirp4netnsDNS(nameservers)
+		}
 	}
 
 	// Set DNS search domains


### PR DESCRIPTION
When a userns is set we setup the network after the bind mounts, at the point where resolv.conf is generated we do not yet know the subnet. Just like the other dns servers for bridge networks we need to add the ip later in completeNetworkSetup()

Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=2182492 and https://bugzilla.redhat.com/show_bug.cgi?id=2182491

This is targeted to RHEL 8.8 and 9.2 ZeroDay

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
