### PR TITLE
[CI:DOCS] Improve basic tutorial

### DIFF
--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -46,8 +46,7 @@ podman inspect -l | grep IPAddress\":
             "IPAddress": "",
 ```
 
-Note: The -l is a convenience argument for **latest container**.  You can also use the container's ID instead
-of -l.
+Note: The -l or --latest option is a convenience argument for **latest container**. This option is not available with the remote Podman client; use the container name or ID instead.
 
 ### Testing the httpd server
 As we do not have the IP address of the container, we can test the network communication between the host
@@ -60,7 +59,7 @@ curl http://localhost:8080
 ### Viewing the container's logs
 You can view the container's logs with Podman as well:
 ```console
-podman logs --latest
+podman logs <container_id>
 10.88.0.1 - - [07/Feb/2018:15:22:11 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
@@ -126,7 +125,7 @@ curl http://<IP_address>:8080
 ### Stopping the container
 To stop the httpd container:
 ```console
-podman stop --latest
+podman stop <container_id>
 ```
 You can also check the status of one or more containers using the *ps* subcommand. In this case, we should
 use the *-a* argument to list all containers.
@@ -137,7 +136,7 @@ podman ps -a
 ### Removing the container
 To remove the httpd container:
 ```console
-podman rm --latest
+podman rm <container_id>
 ```
 You can verify the deletion of the container by running *podman ps -a*.
 


### PR DESCRIPTION
Finishing up the work started by @biergit in #17021

Updates the tutorial to explain the use of `-l/--latest` and converts many of the examples to use `<container_id>` as that works locally and remote while `-l` doesn't always.

Thanks for the start on this @biergit !

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
