### PR TITLE
system tests: preserve image annotations

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -73,6 +73,8 @@ function setup() {
 
 @test "podman can pull an image" {
     run_podman rmi -a
+
+    # This is a risk point: it will flake if the registry or network flake.
     run_podman pull $IMAGE
 
     # Regression test for https://github.com/containers/image/pull/1615

--- a/test/system/011-image.bats
+++ b/test/system/011-image.bats
@@ -31,7 +31,7 @@ EOF
 
 function check_signature() {
     local sigfile=$1
-    ls -laR $PODMAN_TMPDIR/signatures
+    find $PODMAN_TMPDIR/signatures
     run_podman inspect --format '{{.Digest}}' $PODMAN_TEST_IMAGE_FQN
     local repodigest=${output/:/=}
 
@@ -47,7 +47,7 @@ function check_signature() {
 
 
 @test "podman image - sign with no sigfile" {
-    GNUPGHOME=$_GNUPGHOME_TMP run_podman image sign --sign-by foo@bar.com --directory $PODMAN_TMPDIR/signatures  "docker://$PODMAN_TEST_IMAGE_FQN"
+    GNUPGHOME=$_GNUPGHOME_TMP run_podman image sign --sign-by foo@bar.com --directory $PODMAN_TMPDIR/signatures  "containers-storage:$PODMAN_TEST_IMAGE_FQN"
     check_signature "signature-1"
 }
 

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -184,10 +184,6 @@ verify_iid_and_name() {
     run_podman rmi $iid
     run_podman image load < $archive
     verify_iid_and_name "<none>:<none>"
-
-    # Cleanup: since load-by-iid doesn't preserve name, re-tag it;
-    # otherwise our global teardown will rmi and re-pull our standard image.
-    run_podman tag $iid $img_name
 }
 
 @test "podman load - by image name" {

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -11,6 +11,9 @@ SNAME_FILE=$BATS_TMPDIR/services
 function setup() {
     skip_if_remote "systemd tests are meaningless over remote"
     basic_setup
+
+    # Save time and minimize flake risk
+    _prefetch $SYSTEMD_IMAGE
 }
 
 function teardown() {

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -144,10 +144,7 @@ READY=1" "sdnotify sent MAINPID and READY"
 # These tests can fail in dev. environment because of SELinux.
 # quick fix: chcon -t container_runtime_exec_t ./bin/podman
 @test "sdnotify : container" {
-    # Pull our systemd image. Retry in case of flakes.
-    run_podman pull $SYSTEMD_IMAGE || \
-        run_podman pull $SYSTEMD_IMAGE || \
-        run_podman pull $SYSTEMD_IMAGE
+    _prefetch $SYSTEMD_IMAGE
 
     export NOTIFY_SOCKET=$PODMAN_TMPDIR/container.sock
     _start_socat
@@ -254,11 +251,7 @@ READY=1" "sdnotify sent MAINPID and READY"
 
 @test "sdnotify : play kube - with policies" {
     skip_if_journald_unavailable
-
-    # Pull that image. Retry in case of flakes.
-    run_podman pull $SYSTEMD_IMAGE || \
-        run_podman pull $SYSTEMD_IMAGE || \
-        run_podman pull $SYSTEMD_IMAGE
+    _prefetch $SYSTEMD_IMAGE
 
     # Create the YAMl file
     yaml_source="$PODMAN_TMPDIR/test.yaml"

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -33,7 +33,7 @@ json.dump(yaml.safe_load(sys.stdin), sys.stdout)'
     cname=c$(random_string 15)
     run_podman container create --cap-drop fowner --cap-drop setfcap --name $cname $IMAGE top
     run_podman kube generate $cname
-    assert "$output" !~ "Kubernetes only allows 63 characters"
+
     # Convert yaml to json, and dump to stdout (to help in case of errors)
     json=$(yaml2json <<<"$output")
     jq . <<<"$json"


### PR DESCRIPTION
Fun, fun: the tests in 120-load.bats were corrupting our
test image, merely by saving and reloading it: the save
was being done using docker format, and that loses
annotations, and it turns out that annotations are
important. Their presence/absence affects the outcome
of subsequent tests.

Solution:
 - in 120-load tests, add setup/teardown that will
   preserve $IMAGE using OCI format

 - in global setup, add an emergency check to confirm
   that $IMAGE has at least some annotations. If it
   doesn't, re-fetch it.

 - in 710-kube tests, remove an invalid assertion.
   (If the desire is to make podman shut up about
   the Kubernetes-63 issue, then fine, someone can
   fix that properly later).

Fixes: #17911

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```