### PR TITLE
fix volume-plugin-test flake

### DIFF
--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -66,6 +66,10 @@ var _ = Describe("Podman volume plugins", func() {
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
 
+		// Make sure the socket is available (see #17956)
+		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
+		Expect(err).ToNot(HaveOccurred())
+
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
@@ -107,6 +111,10 @@ var _ = Describe("Podman volume plugins", func() {
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
 
+		// Make sure the socket is available (see #17956)
+		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
+		Expect(err).ToNot(HaveOccurred())
+
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
@@ -131,6 +139,10 @@ var _ = Describe("Podman volume plugins", func() {
 		plugin := podmanTest.Podman([]string{"run", "--name", ctrName, "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
+
+		// Make sure the socket is available (see #17956)
+		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
+		Expect(err).ToNot(HaveOccurred())
 
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
@@ -172,6 +184,10 @@ var _ = Describe("Podman volume plugins", func() {
 		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
+
+		// Make sure the socket is available (see #17956)
+		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
+		Expect(err).ToNot(HaveOccurred())
 
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
@@ -218,6 +234,10 @@ testvol5 = "/run/docker/plugins/testvol5.sock"`), 0o644)
 			"-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
+
+		// Make sure the socket is available (see #17956)
+		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
+		Expect(err).ToNot(HaveOccurred())
 
 		localvol := "local-" + stringid.GenerateRandomID()
 		// create local volume
@@ -276,6 +296,10 @@ Removed:
 		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
+
+		// Make sure the socket is available (see #17956)
+		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
+		Expect(err).ToNot(HaveOccurred())
 
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})


### PR DESCRIPTION
Wait for the socket to be ready befor trying to create a volume with the driver.

Fixes: #17956

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@edsantiago PTAL
