### PR TITLE
test/e2e: gpg keep stdout/err attached

### DIFF
--- a/test/e2e/image_sign_test.go
+++ b/test/e2e/image_sign_test.go
@@ -46,6 +46,8 @@ var _ = Describe("Podman image sign", func() {
 
 	It("podman sign image", func() {
 		cmd := exec.Command("gpg", "--import", "sign/secret-key.asc")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		err := cmd.Run()
 		Expect(err).ToNot(HaveOccurred())
 		sigDir := filepath.Join(podmanTest.TempDir, "test-sign")
@@ -60,6 +62,8 @@ var _ = Describe("Podman image sign", func() {
 
 	It("podman sign --all multi-arch image", func() {
 		cmd := exec.Command("gpg", "--import", "sign/secret-key.asc")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		err := cmd.Run()
 		Expect(err).ToNot(HaveOccurred())
 		sigDir := filepath.Join(podmanTest.TempDir, "test-sign-multi")

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -171,6 +171,8 @@ var _ = Describe("Podman save", func() {
 		}
 
 		cmd := exec.Command("gpg", "--import", "sign/secret-key.asc")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		err = cmd.Run()
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
By default go will not keep the stdout/err attach when executing commands via exec.Command(). It is required to explicitly pass the current stdout/err fds down to the child so we can see the error output in the logs to debug #17966.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
