### PR TITLE
libpod: mount safely subpaths

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1035,10 +1035,11 @@ func (c *Container) init(ctx context.Context, retainRetries bool) error {
 	}
 
 	// Generate the OCI newSpec
-	newSpec, err := c.generateSpec(ctx)
+	newSpec, cleanupFunc, err := c.generateSpec(ctx)
 	if err != nil {
 		return err
 	}
+	defer cleanupFunc()
 
 	// Make sure the workdir exists while initializing container
 	if err := c.resolveWorkDir(); err != nil {

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -6,6 +6,7 @@ package libpod
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -315,4 +316,23 @@ func (c *Container) jailName() string {
 	} else {
 		return c.ID()
 	}
+}
+
+type safeMountInfo struct {
+	// mountPoint is the mount point.
+	mountPoint string
+}
+
+// Close releases the resources allocated with the safe mount info.
+func (s *safeMountInfo) Close() {
+}
+
+// safeMountSubPath securely mounts a subpath inside a volume to a new temporary location.
+// The function checks that the subpath is a valid subpath within the volume and that it
+// does not escape the boundaries of the mount point (volume).
+//
+// The caller is responsible for closing the file descriptor and unmounting the subpath
+// when it's no longer needed.
+func (c *Container) safeMountSubPath(mountPoint, subpath string) (s *safeMountInfo, err error) {
+	return &safeMountInfo{mountPoint: filepath.Join(mountPoint, subpath)}, nil
 }

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -44,7 +44,10 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 				continue
 			}
 		}
-
+		if strings.HasPrefix(splitOpt[0], "subpath") {
+			newOptions = append(newOptions, opt)
+			continue
+		}
 		if strings.HasPrefix(splitOpt[0], "idmap") {
 			if foundIdmap {
 				return nil, fmt.Errorf("the 'idmap' option can only be set once: %w", ErrDupeMntOption)


### PR DESCRIPTION
add a function to securely mount a subpath inside a volume.  We cannot trust that the subpath is safe since it is beneath a volume that could be controlled by a separate container.  To avoid TOCTOU races between when we check the subpath and when the OCI runtime mounts it, we open the subpath, validate it, bind mount to a temporary directory and use it instead of the original path.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
