### PR TITLE
quadlet: implement `Tmpfs` option

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -121,6 +121,7 @@ Valid options for `[Container]` are listed below:
 | SecurityLabelLevel=s0:c1,c2      | --security-opt label=level:s0:c1,c2    |
 | SecurityLabelType=spc_t          | --security-opt label=type:spc_t        |
 | Timezone=local                   | --tz local                             |
+| Tmpfs=/work                      | --tmpfs /work                          |
 | User=bin                         | --user bin                             |
 | VolatileTmp=true                 | --tmpfs /tmp                           |
 | Volume=/source:/dest             | --volume /source:/dest                 |
@@ -449,6 +450,13 @@ Set the label process type for the container processes.
 
 Use a Podman secret in the container either as a file or an environment variable.
 This is equivalent to the Podman `--secret` option and generally has the form `secret[,opt=opt ...]`
+
+### `Tmpfs=`
+
+Mount a tmpfs in the container. This is equivalent to the Podman `--tmpfs` option, and
+generally has the form `CONTAINER-DIR[:OPTIONS]`.
+
+This key can be listed multiple times.
 
 ### `Timezone=` (if unset uses system-configured default)
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -94,6 +94,7 @@ const (
 	KeySecurityLabelType     = "SecurityLabelType"
 	KeySecret                = "Secret"
 	KeyTimezone              = "Timezone"
+	KeyTmpfs                 = "Tmpfs"
 	KeyType                  = "Type"
 	KeyUser                  = "User"
 	KeyVolatileTmp           = "VolatileTmp"
@@ -152,6 +153,7 @@ var (
 		KeySecurityLabelLevel:    true,
 		KeySecurityLabelType:     true,
 		KeySecret:                true,
+		KeyTmpfs:                 true,
 		KeyTimezone:              true,
 		KeyUser:                  true,
 		KeyVolatileTmp:           true,
@@ -472,6 +474,15 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 
 	if err := handleUserRemap(container, ContainerGroup, podman, isUser, true); err != nil {
 		return nil, err
+	}
+
+	tmpfsValues := container.LookupAll(ContainerGroup, KeyTmpfs)
+	for _, tmpfs := range tmpfsValues {
+		if strings.Count(tmpfs, ":") > 1 {
+			return nil, fmt.Errorf("invalid tmpfs format '%s'", tmpfs)
+		}
+
+		podman.add("--tmpfs", tmpfs)
 	}
 
 	volumes := container.LookupAll(ContainerGroup, KeyVolume)


### PR DESCRIPTION
This commit adds an quadlet option `Tmpfs` which can be used to mount a tmpfs in the container.

Closes #17907

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet container files now support a new `Tmpfs` option.
```
