### PR TITLE
rootless: drop preexec hook error message

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -163,20 +163,11 @@ exec_binary (const char *path, char **argv, int argc)
       exit (EXIT_FAILURE);
     }
   if (WIFEXITED(status) && WEXITSTATUS (status))
-    {
-      fprintf (stderr, "external preexec hook %s failed\n", path);
-      exit (WEXITSTATUS(status));
-    }
+    exit (WEXITSTATUS(status));
   if (WIFSIGNALED (status))
-    {
-      fprintf (stderr, "external preexec hook %s failed\n", path);
-      exit (127+WTERMSIG (status));
-    }
+    exit (127+WTERMSIG (status));
   if (WIFSTOPPED (status))
-    {
-      fprintf (stderr, "external preexec hook %s failed\n", path);
       exit (EXIT_FAILURE);
-    }
 }
 
 static void


### PR DESCRIPTION
the exec hooks already print the error message, so there is no need to print another one.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
