### PR TITLE
[CI:BUILD] No buildroot macro needed in ETCDIR

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -164,7 +164,7 @@ export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag
 make docs docker-docs
 
 %install
-PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
+PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDIR=%{_sysconfdir}/containers \
         install.bin \
         install.man \
         install.systemd \


### PR DESCRIPTION
Starting with PR: #17791 ETCDIR will be used in /usr/bin/docker so adding the buildroot macro to ETCDIR will make rpmbuild cry.

No files will actually be installed to /etc/ by the Podman rpms.

Setting ETCDIR to `/etc/containers` should thus be sufficient.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
