### PR TITLE
add netavark plugin support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@
 - Defaults for the `--cgroup-config` option for `podman create` and `podman run` can now be set in `containers.conf`.
 - Podman now supports auto updates for containers running inside a pod ([#17181](https://github.com/containers/podman/issues/17181)).
 - Podman can now use a SQLite database as a backend for increased stability. The default remains the old database, BoltDB. The database to use is selected through the `database_backend` field in `containers.conf`.
+- Netavark plugin support is added, the netavark network backend now allows users to create custom network drivers. `podman network create -d <plugin>` can be used to create a network config for your plugin and then podman will use it like any other config and takes care of setup/teardown on container start/stop. This requires at least netavark version 1.6.
 
 ### Changes
 - Remote builds using the `podman build` command no longer allows `.containerignore` or `.dockerignore` files to be symlinks outside the build context.

--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -77,6 +77,10 @@ func networkCreateFlags(cmd *cobra.Command) {
 	flags.StringArrayVar(&networkCreateOptions.Subnets, subnetFlagName, nil, "subnets in CIDR format")
 	_ = cmd.RegisterFlagCompletionFunc(subnetFlagName, completion.AutocompleteNone)
 
+	interfaceFlagName := "interface-name"
+	flags.StringVar(&networkCreateOptions.InterfaceName, interfaceFlagName, "", "interface name which is used by the driver")
+	_ = cmd.RegisterFlagCompletionFunc(interfaceFlagName, completion.AutocompleteNone)
+
 	flags.BoolVar(&networkCreateOptions.DisableDNS, "disable-dns", false, "disable dns plugin")
 
 	flags.BoolVar(&networkCreateOptions.IgnoreIfExists, "ignore", false, "Don't fail if network already exists")
@@ -118,6 +122,7 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 		DNSEnabled:        !networkCreateOptions.DisableDNS,
 		NetworkDNSServers: networkCreateOptions.NetworkDNSServers,
 		Internal:          networkCreateOptions.Internal,
+		NetworkInterface:  networkCreateOptions.InterfaceName,
 	}
 
 	if cmd.Flags().Changed(ipamDriverFlagName) {

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -8,8 +8,8 @@ podman\-network-create - Create a Podman network
 
 ## DESCRIPTION
 Create a network configuration for use with Podman. By default, Podman creates a bridge connection.
-A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan can
-be designated with the *-o parent=`<device>`* or *--network-interface=`<device>`* option.
+A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan or
+ipvlan can be designated with the *-o parent=`<device>`* or *--network-interface=`<device>`* option.
 
 If no options are provided, Podman will assign a free subnet and name for the network.
 
@@ -22,29 +22,35 @@ release because it is used as a special network mode in **podman run/create --ne
 #### **--disable-dns**
 
 Disables the DNS plugin for this network which if enabled, can perform container to container name
-resolution.
+resolution. It is only supported with the `bridge` driver, for other drivers it will be always disabled.
 
 #### **--dns**=*ip*
 
 Set network-scoped DNS resolver/nameserver for containers in this network. If not set, the host servers from `/etc/resolv.conf` will be used.  It can be overwritten on the container level with the `podman run/create --dns` option. This option can be specified multiple times to set more than one IP.
 
-#### **--driver**, **-d**
+#### **--driver**, **-d**=*driver*
 
 Driver to manage the network. Currently `bridge`, `macvlan` and `ipvlan` are supported. Defaults to `bridge`.
 As rootless the `macvlan` and `ipvlan` driver have no access to the host network interfaces because rootless networking requires a separate network namespace.
 
-Special considerations for the *netavark* backend:
+The netavark backend allows the use of so called *netavark plugins*, see the
+[plugin-API.md](https://github.com/containers/netavark/blob/main/plugin-API.md)
+documentation in netavark. The binary must be placed in a specified directory
+so podman can discover it, this list is set in `netavark_plugin_dirs` in
+**[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**
+under the `[network]` section.
 
-- The `macvlan` driver requires the `--subnet` option, DHCP is currently not supported.
-- The `ipvlan` driver is not currently supported.
+The name of the plugin can then be used as driver to create a network for your plugin.
+The list of all supported drivers and plugins can be seen with `podman info --format {{.Plugins.Network}}`.
 
-#### **--gateway**
+#### **--gateway**=*ip*
 
 Define a gateway for the subnet. To provide a gateway address, a
 *subnet* option is required. Can be specified multiple times.
 The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
 
 #### **--ignore**
+
 Ignore the create request if a network with the same name already exists instead of failing.
 Note, trying to create a network with an existing name and different parameters, will not change the configuration of the existing one
 
@@ -59,7 +65,7 @@ For `macvlan` and `ipvlan` this will be the parent device on the host. It is the
 Restrict external access of this network. Note when using this option, the dnsname plugin will be
 automatically disabled.
 
-#### **--ip-range**
+#### **--ip-range**=*range*
 
 Allocate container IP from a range.  The range must be a complete subnet and in CIDR notation.  The *ip-range* option
 must be used with a *subnet* option. Can be specified multiple times.
@@ -82,7 +88,7 @@ View the driver in the **podman network inspect** output under the `ipam_options
 
 Enable IPv6 (Dual Stack) networking. If not subnets are given it will allocate an ipv4 and an ipv6 subnet.
 
-#### **--label**
+#### **--label**=*label*
 
 Set metadata for a network (e.g., --label mykey=value).
 
@@ -109,7 +115,7 @@ The `macvlan` and `ipvlan` driver support the following options:
   - Supported values for `macvlan` are `bridge`, `private`, `vepa`, `passthru`. Defaults to `bridge`.
   - Supported values for `ipvlan` are `l2`, `l3`, `l3s`. Defaults to `l2`.
 
-#### **--subnet**
+#### **--subnet**=*subnet*
 
 The subnet in CIDR notation. Can be specified multiple times to allocate more than one subnet for this network.
 The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
@@ -160,7 +166,7 @@ newnet
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-network(1)](podman-network.1.md)**, **[podman-network-inspect(1)](podman-network-inspect.1.md)**, **[podman-network-ls(1)](podman-network-ls.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-network(1)](podman-network.1.md)**, **[podman-network-inspect(1)](podman-network-inspect.1.md)**, **[podman-network-ls(1)](podman-network-ls.1.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**
 
 ## HISTORY
 August 2021, Updated with the new network format by Paul Holzinger <pholzing@redhat.com>

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -9,7 +9,7 @@ podman\-network-create - Create a Podman network
 ## DESCRIPTION
 Create a network configuration for use with Podman. By default, Podman creates a bridge connection.
 A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan can
-be designated with the *-o parent=`<device>`* option.
+be designated with the *-o parent=`<device>`* or *--network-interface=`<device>`* option.
 
 If no options are provided, Podman will assign a free subnet and name for the network.
 
@@ -47,6 +47,12 @@ The argument order of the **--subnet**, **--gateway** and **--ip-range** options
 #### **--ignore**
 Ignore the create request if a network with the same name already exists instead of failing.
 Note, trying to create a network with an existing name and different parameters, will not change the configuration of the existing one
+
+#### **--interface-name**=*name*
+
+This option maps the the *network_interface* option in the network config, see **podman network inspect**.
+Depending on the driver this can have different effects, for `bridge` it will be the bridge interface name.
+For `macvlan` and `ipvlan` this will be the parent device on the host. It is the same as `--opt parent=...`.
 
 #### **--internal**
 

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -55,6 +55,8 @@ type NetworkCreateOptions struct {
 	Options map[string]string
 	// IgnoreIfExists if true, do not fail if the network already exists
 	IgnoreIfExists bool
+	// InterfaceName sets the NetworkInterface in the network config
+	InterfaceName string
 }
 
 // NetworkUpdateOptions describes options to update a network

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -477,59 +477,7 @@ var _ = Describe("Podman network", func() {
 		Expect(lines[1]).To(Equal(netName2))
 	})
 
-	It("podman CNI network with multiple aliases", func() {
-		SkipIfNetavark(podmanTest)
-		var worked bool
-		netName := createNetworkName("aliasTest")
-		session := podmanTest.Podman([]string{"network", "create", netName})
-		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeNetwork(netName)
-		Expect(session).Should(Exit(0))
-
-		interval := 250 * time.Millisecond
-		for i := 0; i < 6; i++ {
-			n := podmanTest.Podman([]string{"network", "exists", netName})
-			n.WaitWithDefaultTimeout()
-			worked = n.ExitCode() == 0
-			if worked {
-				break
-			}
-			time.Sleep(interval)
-			interval *= 2
-		}
-
-		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", NGINX_IMAGE})
-		top.WaitWithDefaultTimeout()
-		Expect(top).Should(Exit(0))
-		interval = 250 * time.Millisecond
-		// Wait for the nginx service to be running
-		for i := 0; i < 6; i++ {
-			// Test curl against the container's name
-			c1 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web"})
-			c1.WaitWithDefaultTimeout()
-			worked = c1.ExitCode() == 0
-			if worked {
-				break
-			}
-			time.Sleep(interval)
-			interval *= 2
-		}
-		Expect(worked).To(BeTrue())
-
-		// Nginx is now running so no need to do a loop
-		// Test against the first alias
-		c2 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web1"})
-		c2.WaitWithDefaultTimeout()
-		Expect(c2).Should(Exit(0))
-
-		// Test against the second alias
-		c3 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web2"})
-		c3.WaitWithDefaultTimeout()
-		Expect(c3).Should(Exit(0))
-	})
-
-	It("podman Netavark network with multiple aliases", func() {
-		SkipIfCNI(podmanTest)
+	It("podman network with multiple aliases", func() {
 		var worked bool
 		netName := createNetworkName("aliasTest")
 		session := podmanTest.Podman([]string{"network", "create", netName})

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -961,8 +961,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(run.OutputToString()).To(ContainSubstring(ipAddr))
 	})
 
-	It("podman CNI network works across user ns", func() {
-		SkipIfNetavark(podmanTest)
+	It("podman network works across user ns", func() {
 		netName := stringid.GenerateRandomID()
 		create := podmanTest.Podman([]string{"network", "create", netName})
 		create.WaitWithDefaultTimeout()
@@ -1085,8 +1084,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		pingTest("--net=private")
 	})
 
-	It("podman run check dnsname plugin with CNI", func() {
-		SkipIfNetavark(podmanTest)
+	It("podman run check dns", func() {
 		pod := "testpod"
 		session := podmanTest.Podman([]string{"pod", "create", "--name", pod})
 		session.WaitWithDefaultTimeout()
@@ -1157,8 +1155,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(session).Should(Exit(0))
 	})
 
-	It("podman run check dnsname adds dns search domain with CNI", func() {
-		SkipIfNetavark(podmanTest)
+	It("podman network adds dns search domain with dns", func() {
 		net := createNetworkName("dnsname")
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Add netavark plugins and netavark macvlan dhcp support (was already merged with c/common but this fixes tests and docs).

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Netavark plugin support is added, the netavark network backend now allows users to create custom network drivers. `podman network create -d <plugin>` can be used to create a network config for your plugin and then podman will use it like any other config and takes care of setup/teardown on container start/stop. This requires at least netavark version 1.6.
```
