### PR TITLE
compat: Translate `noprune` into ImageRemoveOptions.NoPrune

### DIFF
--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -29,11 +29,6 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
-	if _, found := r.URL.Query()["noprune"]; found {
-		if query.NoPrune {
-			utils.UnSupportedParameter("noprune")
-		}
-	}
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
@@ -44,7 +39,8 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
 	options := entities.ImageRemoveOptions{
-		Force: query.Force,
+		Force:   query.Force,
+		NoPrune: query.NoPrune,
 	}
 	report, rmerrors := imageEngine.Remove(r.Context(), []string{possiblyNormalizedName}, options)
 	if len(rmerrors) > 0 && rmerrors[0] != nil {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -229,7 +229,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: noprune
 	//    type: boolean
-	//    description: not supported. will be logged as an invalid parameter if enabled
+	//    description: do not remove dangling images
 	// produces:
 	//  - application/json
 	// responses:


### PR DESCRIPTION
#15093 implemented support for `NoPrune` in the `ImageRemoveOptions`, this PR simply brings that also to the compat API.

I tried to look for a nice way to test this, but couldn't really find a simple enough way -- maybe adding something to the `.at` files to produce images that should not be pruned with this option, and then verify that?

#### Does this PR introduce a user-facing change?

```release-note
The compat API now supports `noprune` when deleting images.
```

Note: The contributing docs talk about running `podman build -t gate -f contrib/gate/Dockerfile .`, but that produces `Error: stat /home/andreas/project/podman/contrib/gate/Dockerfile: no such file or directory` since c2c7dd8ff removed these -- I have no idea whether the fix here is to remove the entry in the docs, or fix it to point to somewhere else?