### PR TITLE
Add --configmap to podman-remote kube play

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -161,6 +161,10 @@ func playFlags(cmd *cobra.Command) {
 	waitFlagName := "wait"
 	flags.BoolVarP(&playOptions.Wait, waitFlagName, "w", false, "Clean up all objects created when a SIGTERM is received or pods exit")
 
+	configmapFlagName := "configmap"
+	flags.StringSliceVar(&playOptions.ConfigMaps, configmapFlagName, []string{}, "`Pathname` of a YAML file containing a kubernetes configmap")
+	_ = cmd.RegisterFlagCompletionFunc(configmapFlagName, completion.AutocompleteDefault)
+
 	if !registry.IsRemote() {
 		certDirFlagName := "cert-dir"
 		flags.StringVar(&playOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")
@@ -169,10 +173,6 @@ func playFlags(cmd *cobra.Command) {
 		seccompProfileRootFlagName := "seccomp-profile-root"
 		flags.StringVar(&playOptions.SeccompProfileRoot, seccompProfileRootFlagName, defaultSeccompRoot, "Directory path for seccomp profiles")
 		_ = cmd.RegisterFlagCompletionFunc(seccompProfileRootFlagName, completion.AutocompleteDefault)
-
-		configmapFlagName := "configmap"
-		flags.StringSliceVar(&playOptions.ConfigMaps, configmapFlagName, []string{}, "`Pathname` of a YAML file containing a kubernetes configmap")
-		_ = cmd.RegisterFlagCompletionFunc(configmapFlagName, completion.AutocompleteDefault)
 
 		buildFlagName := "build"
 		flags.BoolVar(&playOptions.BuildCLI, buildFlagName, false, "Build all images in a YAML (given Containerfiles exist)")

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2386,7 +2386,6 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube test env value from configmap", func() {
-		SkipIfRemote("configmap list is not supported as a param")
 		cmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 		cm := getConfigMap(withConfigMapName("foo"), withConfigMapData("FOO", "foo"))
 		err := generateKubeYaml("configmap", cm, cmYamlPathname)
@@ -2407,7 +2406,6 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube test env value from configmap and --replace should reuse the configmap volume", func() {
-		SkipIfRemote("configmap list is not supported as a param")
 		cmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 		cm := getConfigMap(withConfigMapName("foo"), withConfigMapData("FOO", "foo"))
 		err := generateKubeYaml("configmap", cm, cmYamlPathname)
@@ -2433,7 +2431,6 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube test required env value from configmap with missing key", func() {
-		SkipIfRemote("configmap list is not supported as a param")
 		cmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 		cm := getConfigMap(withConfigMapName("foo"), withConfigMapData("FOO", "foo"))
 		err := generateKubeYaml("configmap", cm, cmYamlPathname)
@@ -2459,7 +2456,6 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube test optional env value from configmap with missing key", func() {
-		SkipIfRemote("configmap list is not supported as a param")
 		cmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 		cm := getConfigMap(withConfigMapName("foo"), withConfigMapData("FOO", "foo"))
 		err := generateKubeYaml("configmap", cm, cmYamlPathname)
@@ -2495,7 +2491,6 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube test get all key-value pairs from configmap as envs", func() {
-		SkipIfRemote("configmap list is not supported as a param")
 		cmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 		cm := getConfigMap(withConfigMapName("foo"), withConfigMapData("FOO1", "foo1"), withConfigMapData("FOO2", "foo2"))
 		err := generateKubeYaml("configmap", cm, cmYamlPathname)
@@ -4408,8 +4403,6 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 	Context("with configmap in multi-doc yaml and files", func() {
 		It("podman play kube uses env values from both sources", func() {
-			SkipIfRemote("--configmaps is not supported for remote")
-
 			fsCmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 			fsCm := getConfigMap(withConfigMapName("fooFs"), withConfigMapData("FOO_FS", "fooFS"))
 			err := generateKubeYaml("configmap", fsCm, fsCmYamlPathname)
@@ -4446,8 +4439,6 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 		})
 
 		It("podman play kube uses all env values from both sources", func() {
-			SkipIfRemote("--configmaps is not supported for remote")
-
 			fsCmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 			fsCm := getConfigMap(withConfigMapName("fooFs"),
 				withConfigMapData("FOO_FS_1", "fooFS1"),
@@ -4491,7 +4482,8 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 		})
 
 		It("podman play kube reports error when the same configmap name is present in both sources", func() {
-			SkipIfRemote("--configmaps is not supported for remote")
+			// We will never hit this error in the remote case as the configmap content is appended to the main yaml content
+			SkipIfRemote("--configmaps is appended to the main yaml for the remote case")
 
 			fsCmYamlPathname := filepath.Join(podmanTest.TempDir, "foo-cm.yaml")
 			fsCm := getConfigMap(withConfigMapName("foo"), withConfigMapData("FOO", "fooFS"))

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -653,8 +653,6 @@ spec:
 }
 
 @test "podman kube play with configmaps" {
-    skip_if_remote "the configmap argument is supported only locally"
-
     configmap_file=${PODMAN_TMPDIR}/play_kube_configmap_configmaps$(random_string 6).yaml
     echo "
 ---


### PR DESCRIPTION
Enable the --configmap flag for the remote case of podman
kube play. Users can pass in the paths to the configmap files
for kube play to use when creating the pods and containers from
a kube yaml file. The configmap file is read and the contents are
appended to the contents of the main yaml file before passed to the
remote client.

Fixes https://github.com/containers/podman/issues/17513

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add --configmap flag to podman-remote kube play.
```
