### PR TITLE
[v4.4.1-rhel] compat: /auth: parse server address correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
 	github.com/containers/buildah v1.29.0
-	github.com/containers/common v0.51.0
+	github.com/containers/common v0.51.2
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.24.1
 	github.com/containers/ocicrypt v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/containernetworking/plugins v1.2.0 h1:SWgg3dQG1yzUo4d9iD8cwSVh1VqI+bP
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
 github.com/containers/buildah v1.29.0 h1:rA3S2SXJffrJjvY2kyxOsAaIseDY6Ib77FsD7n88Mj4=
 github.com/containers/buildah v1.29.0/go.mod h1:mah+CGmpOjkBJJ5rhOP0M2ETnODhiuhtnXusfh0hc6Q=
-github.com/containers/common v0.51.0 h1:Ax4YHNTG8cEPHZJcMYRoP7sfBgOISceeyOvmZzmSucg=
-github.com/containers/common v0.51.0/go.mod h1:3W2WIdalgQfrsX/T5tjX+6CxgT3ThJVN2G9sNuFjuCM=
+github.com/containers/common v0.51.2 h1:tJ6Nt+zAC6t8nm8qvlVKNjpp/uh3ane80gyj63BwP0Y=
+github.com/containers/common v0.51.2/go.mod h1:3W2WIdalgQfrsX/T5tjX+6CxgT3ThJVN2G9sNuFjuCM=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.24.1 h1:XaRw3FJmvZtI297uBVTJluUVH4AQJ//YpHviaOw0C4M=

--- a/pkg/api/handlers/compat/auth.go
+++ b/pkg/api/handlers/compat/auth.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
+	"github.com/containers/common/pkg/auth"
 	DockerClient "github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/libpod"
@@ -15,13 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	docker "github.com/docker/docker/api/types"
 )
-
-func stripAddressOfScheme(address string) string {
-	for _, s := range []string{"https", "http"} {
-		address = strings.TrimPrefix(address, s+"://")
-	}
-	return address
-}
 
 func Auth(w http.ResponseWriter, r *http.Request) {
 	var authConfig docker.AuthConfig
@@ -41,9 +36,13 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 	sysCtx := runtime.SystemContext()
 	sysCtx.DockerInsecureSkipTLSVerify = skipTLS
 
-	fmt.Println("Authenticating with existing credentials...")
-	registry := stripAddressOfScheme(authConfig.ServerAddress)
-	if err := DockerClient.CheckAuth(r.Context(), sysCtx, authConfig.Username, authConfig.Password, registry); err == nil {
+	loginOpts := &auth.LoginOptions{
+		Username:    authConfig.Username,
+		Password:    authConfig.Password,
+		Stdout:      io.Discard,
+		NoWriteBack: true, // to prevent credentials to be written on disk
+	}
+	if err := auth.Login(r.Context(), sysCtx, loginOpts, []string{authConfig.ServerAddress}); err == nil {
 		utils.WriteResponse(w, http.StatusOK, entities.AuthReport{
 			IdentityToken: "",
 			Status:        "Login Succeeded",

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -494,7 +494,7 @@ var _ = Describe("Podman run", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--user", "bin", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000800005fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000800405fb"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "bin", ALPINE, "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
@@ -509,12 +509,12 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000800005fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000800405fb"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000800005fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000800405fb"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
@@ -524,12 +524,12 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000800005fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000800405fb"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000800005fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000800405fb"))
 
 		session = podmanTest.Podman([]string{"run", "--user=1000:1000", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
@@ -597,7 +597,7 @@ USER bin`, BB)
 		session := podmanTest.Podman([]string{"run", "--rm", "--user", "bin", "test", "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000800005fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000800405fb"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "bin", "test", "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()

--- a/vendor/github.com/containers/common/libnetwork/netavark/config.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/config.go
@@ -57,6 +57,17 @@ func (n *netavarkNetwork) NetworkUpdate(name string, options types.NetworkUpdate
 	if err != nil {
 		return err
 	}
+	// Nameservers must be IP Addresses.
+	for _, dnsServer := range options.AddDNSServers {
+		if net.ParseIP(dnsServer) == nil {
+			return fmt.Errorf("unable to parse ip %s specified in AddDNSServer: %w", dnsServer, types.ErrInvalidArg)
+		}
+	}
+	for _, dnsServer := range options.RemoveDNSServers {
+		if net.ParseIP(dnsServer) == nil {
+			return fmt.Errorf("unable to parse ip %s specified in RemoveDNSServer: %w", dnsServer, types.ErrInvalidArg)
+		}
+	}
 	networkDNSServersBefore := network.NetworkDNSServers
 	networkDNSServersAfter := []string{}
 	for _, server := range networkDNSServersBefore {

--- a/vendor/github.com/containers/common/pkg/auth/cli.go
+++ b/vendor/github.com/containers/common/pkg/auth/cli.go
@@ -26,6 +26,7 @@ type LoginOptions struct {
 	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows login with unspecified registry
+	NoWriteBack               bool      // set to true to not write the credentials to the authfile/cred helpers
 }
 
 // LogoutOptions represents the results for flags in logout

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -63,6 +63,7 @@
 #  "SETGID",
 #  "SETPCAP",
 #  "SETUID",
+#  "SYS_CHROOT",
 #]
 
 # A list of sysctls to be set in containers by default,

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -60,6 +60,7 @@ var (
 		"CAP_SETGID",
 		"CAP_SETPCAP",
 		"CAP_SETUID",
+		"CAP_SYS_CHROOT",
 	}
 
 	// Search these locations in which CNIPlugins can be installed.

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.51.0"
+const Version = "0.51.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,7 +121,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.51.0
+# github.com/containers/common v0.51.2
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
Use `auth.Login` as `podman login` does which parses and normalizes the input addresses correctly, especially for docker.io.

This Cherry Picks https://github.com/containers/podman/pull/17581 and brings in necessary changes to run_test.go from i
https://github.com/containers/podman/commit/5f86fae71fb5793de78a5dc09ffa357fb536771c

Addreses: https://bugzilla.redhat.com/show_bug.cgi?id=2183601 and https://bugzilla.redhat.com/show_bug.cgi?id=2183602 for the RHEL 8.8 and 9.2 ZeroDay

The original Fixed: #17571

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the Docker-compatible REST APIs `/auth` endpoint to correctly log into Docker Hub.
```
