### PR TITLE
Fix Win install task failures with large PR bodies

### DIFF
--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -33,6 +33,10 @@ Remove-Item Env:\GOPATH
 Remove-Item Env:\GOSRC
 Remove-Item Env:\GOCACHE
 
+# Drop large known env variables (an env > 32k will break MSI/ICE validation)
+Remove-Item Env:\CIRRUS_COMMIT_MESSAGE
+Remove-Item Env:\CIRRUS_PR_BODY
+
 Set-Location contrib\win-installer
 
 # Download and extract alt_build win release zip


### PR DESCRIPTION
MSI Validation will fail if the process env is > 32k chars Remove CIRRUS_COMMIT_MESSAGE and CIRRUS_PR_BODY, which can easily exceed this limit

An example of this occuring is: #17473
[NO NEW TESTS NEEDED]

```release-note
none
```
