### PR TITLE
System tests: unverbosify a flake log

### DIFF
--- a/test/system/032-sig-proxy.bats
+++ b/test/system/032-sig-proxy.bats
@@ -3,14 +3,7 @@
 load helpers
 
 # Command to run in each of the tests.
-SLEEPLOOP='trap "echo BYE;exit 0" INT;echo READY;while :;do echo RUNNING;sleep 0.1;done'
-
-function setup() {
-    basic_setup
-
-    TESTLOG=$PODMAN_TMPDIR/container-stdout
-}
-
+SLEEPLOOP='trap "echo BYE;exit 0" INT;echo READY;while :;do sleep 0.1;done'
 
 # Main test code: wait for container to exist and be ready, send it a
 # signal, wait for container to acknowledge and exit.
@@ -33,21 +26,8 @@ function _test_sigproxy() {
           fi
     done
 
-    # Now that container exists, wait for it to declare itself RUNNING
-    timeout=10
-    while :;do
-          sleep 0.5
-          if grep -q RUNNING $TESTLOG; then
-              break
-          fi
-          timeout=$((timeout - 1))
-          if [[ $timeout -eq 0 ]]; then
-              run_podman ps -a
-              echo "log from container:"
-              cat $TESTLOG
-              die "Timed out waiting for container $cname to start"
-          fi
-    done
+    # Now that container exists, wait for it to declare itself READY
+    wait_for_ready $cname
 
     # Signal, and wait for container to exit
     kill -INT $kidpid
@@ -72,7 +52,7 @@ function _test_sigproxy() {
 
 @test "podman sigproxy test: run" {
     # We're forced to use $PODMAN because run_podman cannot be backgrounded
-    $PODMAN run -i --name c_run $IMAGE sh -c "$SLEEPLOOP" >$TESTLOG &
+    $PODMAN run -i --name c_run $IMAGE sh -c "$SLEEPLOOP" &
     local kidpid=$!
 
     _test_sigproxy c_run $kidpid
@@ -82,7 +62,7 @@ function _test_sigproxy() {
     run_podman create --name c_start $IMAGE sh -c "$SLEEPLOOP"
 
     # See above comments regarding $PODMAN and backgrounding
-    $PODMAN start --attach c_start >$TESTLOG &
+    $PODMAN start --attach c_start &
     local kidpid=$!
 
     _test_sigproxy c_start $kidpid
@@ -92,7 +72,7 @@ function _test_sigproxy() {
     run_podman run -d --name c_attach $IMAGE sh -c "$SLEEPLOOP"
 
     # See above comments regarding $PODMAN and backgrounding
-    $PODMAN attach c_attach >$TESTLOG &
+    $PODMAN attach c_attach &
     local kidpid=$!
 
     _test_sigproxy c_attach $kidpid


### PR DESCRIPTION
One of our oldest most frustrating flakes is #16091, "Timed
out waiting for BYE".

In #17489 we added some debug output to see if the problem
was a container hang of some sort. It does not seem to be
(see #17675), and the debug output makes it hard to read
failure logs, so let's remove it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```