### PR TITLE
feat: compress event log entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.16.3
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/moby/term v0.0.0-20221120202655-abb19827d345
@@ -123,7 +124,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/klauspost/pgzip v1.2.6-0.20220930104621-17e8dac29df8 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect


### PR DESCRIPTION
# Compress event log entries

Compress labels and configuration inspect data that are longer that 1024 bytes.

The compressed fields:
* `PODMAN_LABELS`
* `PODMAN_CONTAINER_INSPECT_DATA`

### Compatibility notes
* Backward compatible ✅
* Forward compatible ❌

Output of `journalctl` is still the same since it automatically decompresses these fields.

```release-note
None
```

## Compression ratio example:
```sh
docker image inspect  gcr.io/paketo-buildpacks/builder | jq '.[0].Config' | wc -c              
103999
docker image inspect  gcr.io/paketo-buildpacks/builder | jq '.[0].Config' | xz --stdout | wc -c
12836
# the container config JSON is 8 time smaller after compression.
```