### PR TITLE
e2e: healthcheck on stopped container: fix flake

### DIFF
--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck on stopped container", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", HEALTHCHECK_IMAGE, "ls"})
+		session := podmanTest.Podman([]string{"run", "--name", "hc", HEALTHCHECK_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 


### PR DESCRIPTION
Test has been flaking. Reason: container was run with -d, so
there's a small window in which podman-healthcheck ran on
a running container. Solution: remove -d

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```