### PR TITLE
Fix daily run CI failures on win installer task

### DIFF
--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -29,13 +29,13 @@ function DownloadFile {
     }
 }
 # Drop global envs which have unix paths, defaults are fine
-Remove-Item Env:\GOPATH
-Remove-Item Env:\GOSRC
-Remove-Item Env:\GOCACHE
+Remove-Item Env:\GOPATH -ErrorAction:Ignore
+Remove-Item Env:\GOSRC -ErrorAction:Ignore
+Remove-Item Env:\GOCACHE -ErrorAction:Ignore
 
 # Drop large known env variables (an env > 32k will break MSI/ICE validation)
-Remove-Item Env:\CIRRUS_COMMIT_MESSAGE
-Remove-Item Env:\CIRRUS_PR_BODY
+Remove-Item Env:\CIRRUS_COMMIT_MESSAGE -ErrorAction:Ignore
+Remove-Item Env:\CIRRUS_PR_BODY -ErrorAction:Ignore
 
 Set-Location contrib\win-installer
 

--- a/contrib/cirrus/win-podman-machine-main.ps1
+++ b/contrib/cirrus/win-podman-machine-main.ps1
@@ -10,9 +10,9 @@ function CheckExit {
 }
 
 # Drop global envs which have unix paths, defaults are fine
-Remove-Item Env:\GOPATH
-Remove-Item Env:\GOSRC
-Remove-Item Env:\GOCACHE
+Remove-Item Env:\GOPATH -ErrorAction:Ignore
+Remove-Item Env:\GOSRC -ErrorAction:Ignore
+Remove-Item Env:\GOCACHE -ErrorAction:Ignore
 
 mkdir tmp
 Set-Location tmp


### PR DESCRIPTION
Fixes #18048 

This is a regression from #18018: CIRRUS_PR_BODY doesn't exist on a non-PR run, so it wasn't triggered in PR verification. Change this and all other env removals to ignore non-existing entries.

```release-note
none
```
