### PR TITLE
Do not display the resource limits warning message

### DIFF
--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -236,7 +236,6 @@ EOF
 }
 
 @test "podman kube --network" {
-    skip_if_rootless_cgroupsv1 "Test will never be supported, see #17582."
     TESTDIR=$PODMAN_TMPDIR/testdir
     mkdir -p $TESTDIR
     echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml


### PR DESCRIPTION
If resource limits is not set, do not display the following warning message:
`Resource limits are not supported and ignored on cgroups V1 rootless systems`

Ref: #17582

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
