### PR TITLE
Copr: fix build deps for /usr/bin/envsubst

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -36,6 +36,11 @@ Source:     {{{ git_dir_pack }}}
 BuildRequires: btrfs-progs-devel
 %endif
 BuildRequires: gcc
+%if 0%{?fedora} >= 37
+BuildRequires: gettext-envsubst
+%else
+BuildRequires: gettext
+%endif
 BuildRequires: golang >= 1.16.6
 BuildRequires: glib2-devel
 BuildRequires: glibc-devel


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


Fixed build: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/5744558/ (ignore epel-9-next for now)