### PR TITLE
[CI:DOCS] --creds and registries

### DIFF
--- a/docs/source/markdown/options/creds.md
+++ b/docs/source/markdown/options/creds.md
@@ -7,3 +7,8 @@
 The [username[:password]] to use to authenticate with the registry, if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered. The password is entered without echo.
+
+Note that the specified credentials are only used to authenticate against
+target registries.  They are not used for mirrors or when the registry gets
+rewritten (see `containers-registries.conf(5)`); to authenticate against those
+consider using a `containers-auth.json(5)` file.


### PR DESCRIPTION
Mention that specified credentials are only used to authenticate against target registries (e.g., during `pull` or `build`) and are not used to authenticat against mirrors etc.

Closes: #17185

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Refine the man pages for the `--creds` CLI flag.
```

@mtrmac @rhatdan PTAL
