### PR TITLE
Fix invalid pod name and hostname during kube generate

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -470,8 +470,8 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 			// Since hostname is only set at pod level, set the hostname to the hostname of the first container we encounter
 			if hostname == "" {
 				// Only set the hostname if it is not set to the truncated container ID, which we do by default if no
-				// hostname is specified for the container
-				if !strings.Contains(ctr.ID(), ctr.Hostname()) {
+				// hostname is specified for the container and if it is not set to the pod name.
+				if !strings.Contains(ctr.ID(), ctr.Hostname()) && ctr.Hostname() != p.Name() {
 					hostname = ctr.Hostname()
 				}
 			}
@@ -533,9 +533,10 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 	for _, vol := range deDupPodVolumes {
 		podVolumes = append(podVolumes, *vol)
 	}
+	podName := removeUnderscores(p.Name())
 
 	return newPodObject(
-		p.Name(),
+		podName,
 		podAnnotations,
 		podInitCtrs,
 		podContainers,

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -105,7 +105,7 @@ metadata.creationTimestamp | =~ | [0-9T:-]\\+Z
 metadata.labels.app        | =  | ${pname}
 metadata.name              | =  | ${pname}
 
-spec.hostname                              | =  | $pname
+spec.hostname                              | =  | null
 
 spec.containers[0].command                 | =  | [\"top\"]
 spec.containers[0].image                   | =  | $IMAGE


### PR DESCRIPTION
Kube generate on pods was not checking for any underscores in the pod name so was creating a kube yaml with an invalid pod name when there were underscores present.
The hostname for the pod is set to the podname by default. There is no need to set that to the container's name or the pod name again in the generated yaml. So removed that field as well.

Fixes https://github.com/containers/podman/issues/18054

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix pod name when doing `kube generate [podname]`.
```
