### PR TITLE
Cirrus: Fix aarch64 clone_script 404 errors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -759,7 +759,9 @@ local_system_test_aarch64_task: &local_system_test_task_aarch64
     # Don't create task for tags, or if using [CI:DOCS], [CI:BUILD], multiarch
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: *not_tag_build_docs_multiarch
-    depends_on: *build_unit
+    depends_on:
+        - build_aarch64
+        - unit_test
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64


### PR DESCRIPTION
Fixes: #18040

If the `build_aarch64` task happens to fail for any reason, it will cause the `curl` command in the `clone_script` for the aarch64 system test tasks to throw a 404.  This is because the
`local_system_test_aarch64_task` depends on `build` not `build_aarch64`. As discovered in another issue long ago, the Cirrus API depends on doing some dependency-resolution magic to function properly.  Fix this by correcting the dependencies.

#### Does this PR introduce a user-facing change?

```release-note
None
```
