### PR TITLE
Cirrus: Enable labeling of EC2 VMs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -193,6 +193,9 @@ build_aarch64_task:
     # Multiarch doesn't depend on buildability in this automation context
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: "$CIRRUS_CRON != 'multiarch'"
+    # Enable labeling of EC2 VMs with cirrus task ID. TODO: This can be
+    # removed when the feature goes mainstream.
+    experimental: true
     ec2_instance: &standard_build_ec2_aarch64
         image: ${VM_IMAGE_NAME}
         type: ${EC2_INST_TYPE}
@@ -271,7 +274,7 @@ validate_aarch64_task:
     only_if: *is_pr
     depends_on:
         - build_aarch64
-    # golangci-lint is a very, very hungry beast.
+    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64
@@ -547,6 +550,7 @@ windows_smoke_test_task:
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*'
     depends_on:
       - alt_build
+    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         image: "${WINDOWS_AMI}"
         type: m5zn.metal
@@ -665,6 +669,7 @@ podman_machine_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
+    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         image: "${VM_IMAGE_NAME}"
         type: "${EC2_INST_TYPE}"
@@ -696,6 +701,7 @@ podman_machine_aarch64_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
+    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         <<: *standard_build_ec2_aarch64
     env:
@@ -762,6 +768,7 @@ local_system_test_aarch64_task: &local_system_test_task_aarch64
     depends_on:
         - build_aarch64
         - unit_test
+    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64


### PR DESCRIPTION
In GCP, user specified VM names are required upon creation.  Cirrus-CI generates helpful names containing the task-ID.  Unfortunately in EC2 the VM ID's are auto-generated, and special permissions are required to allow secondary setting of a `Name` tag.  Since this permission has been granted, enable the `experimental` flag on EC2 tasks so that cirrus can update VM name-tags.  This is especially useful in troubleshooting orphaned VMs.

Ref:
https://github.com/containers/podman/issues/18065#issuecomment-1497779159

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
