### PR TITLE
e2e tests: fix racy flakes

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -244,13 +244,14 @@ Start the pod after creating it, set to false to only create it.
 
 Run pods and containers in the foreground. Default is false.
 
-At  any time you can run `podman pod ps` in the other shell to view a list of
+At  any time you can run `podman pod ps` in another shell to view a list of
 the running pods and containers.
 
 When  attached  in the tty mode, you can kill the pods and containers by pressing
 Ctrl-C or receiving any other interrupt signals.
 
-Volumes created with `podman kube play` will be removed when `--wait=true`.
+All pods, containers, and volumes created with `podman kube play` will be removed
+upon exit.
 
 ## EXAMPLES
 

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -84,6 +84,10 @@ var _ = Describe("Podman logs", func() {
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
 
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
+
 			results := podmanTest.Podman([]string{"logs", "--tail", "2", cid})
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(Exit(0))
@@ -98,6 +102,10 @@ var _ = Describe("Podman logs", func() {
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
 
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
+
 			results := podmanTest.Podman([]string{"logs", "--tail", "0", cid})
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(Exit(0))
@@ -111,6 +119,10 @@ var _ = Describe("Podman logs", func() {
 			logc := podmanTest.Podman([]string{"run", "--name", name, "--log-driver", log, ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 			logc.WaitWithDefaultTimeout()
 			Expect(logc).To(Exit(0))
+
+			wait := podmanTest.Podman([]string{"wait", name})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
 
 			results := podmanTest.Podman([]string{"logs", "--tail", "99", name})
 			results.WaitWithDefaultTimeout()
@@ -146,6 +158,10 @@ var _ = Describe("Podman logs", func() {
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
 
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
+
 			results := podmanTest.Podman([]string{"logs", "--tail", "2", "-t", cid})
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(Exit(0))
@@ -159,6 +175,10 @@ var _ = Describe("Podman logs", func() {
 			logc.WaitWithDefaultTimeout()
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
+
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
 
 			results := podmanTest.Podman([]string{"logs", "--since", "2017-08-07T10:10:09.056611202-04:00", cid})
 			results.WaitWithDefaultTimeout()
@@ -174,6 +194,10 @@ var _ = Describe("Podman logs", func() {
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
 
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
+
 			results := podmanTest.Podman([]string{"logs", "--since", "10m", cid})
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(Exit(0))
@@ -188,6 +212,10 @@ var _ = Describe("Podman logs", func() {
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
 
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
+
 			results := podmanTest.Podman([]string{"logs", "--until", "10m", cid})
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(Exit(0))
@@ -201,6 +229,10 @@ var _ = Describe("Podman logs", func() {
 			logc.WaitWithDefaultTimeout()
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
+
+			wait := podmanTest.Podman([]string{"wait", cid})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
 
 			now := time.Now()
 			now = now.Add(time.Minute * 1)
@@ -232,6 +264,10 @@ var _ = Describe("Podman logs", func() {
 			log2.WaitWithDefaultTimeout()
 			Expect(log2).Should(Exit(0))
 			cid2 := log2.OutputToString()
+
+			wait := podmanTest.Podman([]string{"wait", cid1, cid2})
+			wait.WaitWithDefaultTimeout()
+			Expect(wait).To(Exit(0))
 
 			results := podmanTest.Podman([]string{"logs", cid1, cid2})
 			results.WaitWithDefaultTimeout()

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2021,6 +2021,11 @@ var _ = Describe("Podman play kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(0))
 
+		wait := podmanTest.Podman([]string{"wait", "test-symlink-test-symlink"})
+		wait.WaitWithDefaultTimeout()
+		Expect(wait).Should(Exit(0))
+		Expect(wait.OutputToString()).To(Equal("0"))
+
 		logs := podmanTest.Podman([]string{"pod", "logs", "-c", "test-symlink-test-symlink", "test-symlink"})
 		logs.WaitWithDefaultTimeout()
 		Expect(logs).Should(Exit(0))


### PR DESCRIPTION
...mostly just test code that wasn't doing the required waits.

My first approach in the kube-play test was to add "--wait".
Bit mistake! The --wait flag, counterintuitively and counter to
documentation, actually destroys all pods+containers+everything
on exit. (Or tries -- see #17803). Since this violates POLA
and is undocumented, I include here a fix to the man page.

Despite my best intentions, I can't reasonably check every single
test for missing waits, especially in kube-play where failing
containers will get retried forever so we can't wait. We'll
just have to fix flakes as we see them.

Fixes: #17958
Fixes: #18071

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```