### PR TITLE
libpod.storageService.CreateContainerStorage(): retrieve ID maps

### DIFF
--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -164,8 +164,8 @@ func (r *storageService) CreateContainerStorage(ctx context.Context, systemConte
 	logrus.Debugf("Container %q has run directory %q", container.ID, containerRunDir)
 
 	return ContainerInfo{
-		UIDMap:       options.UIDMap,
-		GIDMap:       options.GIDMap,
+		UIDMap:       container.UIDMap,
+		GIDMap:       container.GIDMap,
 		Dir:          containerDir,
 		RunDir:       containerRunDir,
 		Config:       imageConfig,


### PR DESCRIPTION
When creating storage for a container using ID maps, read the ID maps that are assigned to the container from the returned container structure, rather than from the options structure that we passed to the storage library, which it previously modified in error.

#### Does this PR introduce a user-facing change?

```release-note
None
```