### PR TITLE
test/e2e: use custom network config dir where needed

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -904,6 +904,7 @@ RUN ls /dev/test1`, ALPINE)
 
 	It("podman system reset must clean host shared cache", func() {
 		SkipIfRemote("podman-remote does not have system reset -f")
+		useCustomNetworkDir(podmanTest, tempdir)
 		podmanTest.AddImageToRWStore(ALPINE)
 		session := podmanTest.Podman([]string{"build", "--pull-never", "--file", "build/cache/Dockerfilecachewrite", "build/cache/"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1198,3 +1198,15 @@ func WaitForService(address url.URL) {
 	}
 	Expect(err).ShouldNot(HaveOccurred())
 }
+
+// useCustomNetworkDir makes sure this test uses a custom network dir.
+// This needs to be called for all test they may remove networks from other tests,
+// so netwokr prune, system prune, or system reset.
+// see https://github.com/containers/podman/issues/17946
+func useCustomNetworkDir(podmanTest *PodmanTestIntegration, tempdir string) {
+	// set custom network directory to prevent flakes since the dir is shared with all tests by default
+	podmanTest.NetworkConfigDir = tempdir
+	if IsRemote() {
+		podmanTest.RestartRemoteService()
+	}
+}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -726,11 +726,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network prune --filter", func() {
-		// set custom network directory to prevent flakes since the dir is shared with all tests by default
-		podmanTest.NetworkConfigDir = tempdir
-		if IsRemote() {
-			podmanTest.RestartRemoteService()
-		}
+		useCustomNetworkDir(podmanTest, tempdir)
 		net1 := "macvlan" + stringid.GenerateRandomID() + "net1"
 
 		nc := podmanTest.Podman([]string{"network", "create", net1})
@@ -774,11 +770,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network prune", func() {
-		// set custom network directory to prevent flakes since the dir is shared with all tests by default
-		podmanTest.NetworkConfigDir = tempdir
-		if IsRemote() {
-			podmanTest.RestartRemoteService()
-		}
+		useCustomNetworkDir(podmanTest, tempdir)
 		// Create two networks
 		// Check they are there
 		// Run a container on one of them

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system image prune unused images", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		podmanTest.AddImageToRWStore(ALPINE)
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
 		prune := podmanTest.Podman([]string{"system", "prune", "-a", "--force"})
@@ -260,12 +261,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune networks", func() {
-		// set custom network directory to prevent flakes since the dir is shared with all tests by default
-		podmanTest.NetworkConfigDir = tempdir
-		if IsRemote() {
-			podmanTest.RestartRemoteService()
-		}
-
+		useCustomNetworkDir(podmanTest, tempdir)
 		// Create new network.
 		session := podmanTest.Podman([]string{"network", "create", "test"})
 		session.WaitWithDefaultTimeout()
@@ -308,6 +304,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune - pod,container stopped", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -340,6 +337,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune with running, exited pod and volume prune set true", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		// Start and stop a pod to get it in exited state.
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
@@ -417,6 +415,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune - with dangling images true", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -465,6 +464,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune --volumes --filter", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -531,6 +531,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune --external leaves referenced containers", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		containerStorageDir := filepath.Join(podmanTest.Root, podmanTest.ImageCacheFS+"-containers")
 
 		create := podmanTest.Podman([]string{"create", "--name", "test", BB})
@@ -561,6 +562,7 @@ var _ = Describe("Podman prune", func() {
 
 	It("podman system prune --external removes unreferenced containers", func() {
 		SkipIfRemote("Can't drop database while daemon running")
+		useCustomNetworkDir(podmanTest, tempdir)
 
 		containerStorageDir := filepath.Join(podmanTest.Root, podmanTest.ImageCacheFS+"-containers")
 

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -36,10 +36,7 @@ var _ = Describe("podman system reset", func() {
 	It("podman system reset", func() {
 		SkipIfRemote("system reset not supported on podman --remote")
 		// system reset will not remove additional store images, so need to grab length
-
-		// change the network dir so that we do not conflict with other tests
-		// that would use the same network dir and cause unnecessary flakes
-		podmanTest.NetworkConfigDir = tempdir
+		useCustomNetworkDir(podmanTest, tempdir)
 
 		session := podmanTest.Podman([]string{"rmi", "--force", "--all"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Since commit f250560a8043 the play kube command uses its own network. this is racy be disgn because we create the network followed by creating/running pod/containers. This means in the meantime another prune or reset process could wipe out the network config because we have to share the network config directory by desgin in the test.

The problem is we only have one host netns which is shared between tests. If the network config dir is not shared we cannot make conflict checks for interface names and ip address. This results in different tests trying to use the same interface and/or ip address which will cause runtime failures in CNI and netavark.

The only solution I see is to make sure only the reset/prune tests are using a custom network dir. This makes sure they do not wipe configs that are otherwise required by other parallel running tests.

Fixes #17946

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
