### PR TITLE
[skip ci] EMERGENCY: Revert "Cirrus: Enable labeling of EC2 VMs"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -193,9 +193,6 @@ build_aarch64_task:
     # Multiarch doesn't depend on buildability in this automation context
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: "$CIRRUS_CRON != 'multiarch'"
-    # Enable labeling of EC2 VMs with cirrus task ID. TODO: This can be
-    # removed when the feature goes mainstream.
-    experimental: true
     ec2_instance: &standard_build_ec2_aarch64
         image: ${VM_IMAGE_NAME}
         type: ${EC2_INST_TYPE}
@@ -274,7 +271,7 @@ validate_aarch64_task:
     only_if: *is_pr
     depends_on:
         - build_aarch64
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
+    # golangci-lint is a very, very hungry beast.
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64
@@ -550,7 +547,6 @@ windows_smoke_test_task:
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*'
     depends_on:
       - alt_build
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         image: "${WINDOWS_AMI}"
         type: m5zn.metal
@@ -669,7 +665,6 @@ podman_machine_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         image: "${VM_IMAGE_NAME}"
         type: "${EC2_INST_TYPE}"
@@ -701,7 +696,6 @@ podman_machine_aarch64_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         <<: *standard_build_ec2_aarch64
     env:
@@ -768,7 +762,6 @@ local_system_test_aarch64_task: &local_system_test_task_aarch64
     depends_on:
         - build_aarch64
         - unit_test
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64


### PR DESCRIPTION
Seeing CI failures in VM.keepalive:

   ERROR: Failed to update one or more image timestamps: fedora-aws-etc

This reverts commit 56e7b511e1d1568809e7b4066b97adb2d498fed1.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```