### PR TITLE
Return title fields as a list

### DIFF
--- a/pkg/api/handlers/compat/containers_top.go
+++ b/pkg/api/handlers/compat/containers_top.go
@@ -63,7 +63,7 @@ loop: // break out of for/select infinite` loop
 		case <-r.Context().Done():
 			break loop
 		default:
-			output, err := c.Top([]string{query.PsArgs})
+			output, err := c.Top(strings.Split(query.PsArgs, ","))
 			if err != nil {
 				logrus.Infof("Error from %s %q : %v", r.Method, r.URL, err)
 				break loop
@@ -71,7 +71,8 @@ loop: // break out of for/select infinite` loop
 
 			if len(output) > 0 {
 				body := handlers.ContainerTopOKBody{}
-				body.Titles = strings.Split(output[0], "\t")
+				body.Titles = utils.PSTitles(output[0])
+
 				for i := range body.Titles {
 					body.Titles[i] = strings.TrimSpace(body.Titles[i])
 				}

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -413,7 +413,7 @@ loop: // break out of for/select infinite` loop
 
 			if len(output) > 0 {
 				body := handlers.PodTopOKBody{}
-				body.Titles = strings.Split(output[0], "\t")
+				body.Titles = utils.PSTitles(output[0])
 				for i := range body.Titles {
 					body.Titles[i] = strings.TrimSpace(body.Titles[i])
 				}

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/containers/podman/v4/libpod/events"
@@ -237,4 +238,24 @@ func containerExists(ctx context.Context, name string) (bool, error) {
 		return false, err
 	}
 	return ctrExistRep.Value, nil
+}
+
+// PSTitles merges CAPS headers from ps output. All PS headers are single words, except for
+// CAPS. Function compines CAP Headers into single field separated by a space.
+func PSTitles(output string) []string {
+	var titles []string
+
+	for _, title := range strings.Fields(output) {
+		switch title {
+		case "AMBIENT", "INHERITED", "PERMITTED", "EFFECTIVE", "BOUNDING":
+			{
+				titles = append(titles, title+" CAPS")
+			}
+		case "CAPS":
+			continue
+		default:
+			titles = append(titles, title)
+		}
+	}
+	return titles
 }

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -121,6 +121,14 @@ if root; then
     .memory_stats.limit=536870912 \
     .id~[0-9a-f]\\{64\\}
 
+    t GET containers/$CTRNAME/top?stream=false 200 \
+      .Titles='[
+  "PID",
+  "USER",
+  "TIME",
+  "COMMAND"
+]'
+
     podman rm -f $CTRNAME
 fi
 


### PR DESCRIPTION
Podman is attempting to split the headers returned by the ps
command into a list of headers. Problem is that some headers
are multi-word, and headers are not guaranteed to be split via
a tab. This PR splits the headers bases on white space, and for
the select group of CAPS headers which are multi-word, combines
them back together.

Fixes: https://github.com/containers/podman/issues/17524

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix top Titles return in compatible API.
```
