### PR TITLE
Update podman-image-exists.1.md

### DIFF
--- a/docs/source/markdown/podman-image-exists.1.md
+++ b/docs/source/markdown/podman-image-exists.1.md
@@ -35,6 +35,25 @@ $ echo $?
 1
 $
 ```
+When used in a script with errexit set, a non-zero return code from `podman image exists`can cause
+the script to fail unexpectedly unless handled correctly. The script below checks if an image called
+`webbackend` exists in local storage and displays a message. This is just one of several alternative
+methods to handle nonzero return codes in a script.
+```
+#!/usr/bin/env bash
+set -o errexit
+
+rc=0
+(podman image exists webbackend) || rc=$?
+
+if [[ "${rc}" -eq "0" ]]
+then
+  echo "webbackend exists"
+else
+  echo "webbackend does not exist"
+fi
+echo "The scripted completed normally"
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-image(1)](podman-image.1.md)**


### PR DESCRIPTION
Adds an example of using podman image exists in a script that also has errexit set.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
