### PR TITLE
[CI:DOCS] GHA: Use version instead of SHA for actions

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write  # for github/issue-labeler to create or remove labels
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@de16e742018d174ccf61d287f6ed31eb48faa64f # v2.6
+    - uses: github/issue-labeler@v3.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/issue-labeler.yml

--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -59,7 +59,7 @@ jobs:
                 SECRET_CIRRUS_API_KEY: ${{ secrets.SECRET_CIRRUS_API_KEY }}
               run: './.github/actions/check_cirrus_cron/rerun_failed_tasks.sh'
 
-            - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+            - uses: actions/upload-artifact@v3
               with:
                   name: ${{ github.job }}_artifacts
                   path: artifacts/*

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'


### PR DESCRIPTION
It's nearly impossible for humans to tell semantic-version differences by looking at a commit sha.  Since all the actions in question come from github, there's little security/safety benefit to using SHAs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
