### PR TITLE
Read kube_generate_type from containers.conf

### DIFF
--- a/test/e2e/config/containers.conf
+++ b/test/e2e/config/containers.conf
@@ -62,6 +62,7 @@ no_hosts=true
 
 network_cmd_options=["allow_host_loopback=true"]
 service_timeout=1234
+kube_generate_type="deployment"
 
 volume_plugin_timeout = 15
 


### PR DESCRIPTION
Use the kube_generate_type from the containers.conf as the default value for the --type flag for kube generate. Override the default when userexplicitly sets the --type flag.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use defaults from `kube_generate_type` in containers.conf for podman kube generate --type.
```
