### PR TITLE
api: auth: fix nil deref

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
 	github.com/containers/buildah v1.30.0
-	github.com/containers/common v0.52.0
+	github.com/containers/common v0.52.1-0.20230411124844-19b624d9a20d
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.25.0
 	github.com/containers/libhvee v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/containernetworking/plugins v1.2.0 h1:SWgg3dQG1yzUo4d9iD8cwSVh1VqI+bP
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
 github.com/containers/buildah v1.30.0 h1:mdp2COGKFFEZNEGP8VZ5ITuUFVNPFoH+iK2sSesNfTA=
 github.com/containers/buildah v1.30.0/go.mod h1:lyMLZIevpAa6zSzjRl7z4lFJMCMQLFjfo56YIefaB/U=
-github.com/containers/common v0.52.0 h1:S5GApgpNEGBuPhDHTFgMc55y5gsuxHcQeElvUpO5kp4=
-github.com/containers/common v0.52.0/go.mod h1:dNJJVNBu1wJtAH+vFIMXV+fQHBdEVNmNP3ImjbKper4=
+github.com/containers/common v0.52.1-0.20230411124844-19b624d9a20d h1:vwGEGW7uQtnTCS5qoiMsts7fn7wPRjbHiAC00Cbc22E=
+github.com/containers/common v0.52.1-0.20230411124844-19b624d9a20d/go.mod h1:dNJJVNBu1wJtAH+vFIMXV+fQHBdEVNmNP3ImjbKper4=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.25.0 h1:TJ0unmalbU+scd0i3Txap2wjGsAnv06MSCwgn6bsizk=

--- a/test/apiv2/60-auth.at
+++ b/test/apiv2/60-auth.at
@@ -27,4 +27,15 @@ t POST /v1.40/auth username=$REGISTRY_USERNAME password=$REGISTRY_PASSWORD serve
   .Status="Login Succeeded" \
   .IdentityToken=""
 
+# No username -> error
+t POST /v1.40/auth password=$REGISTRY_PASSWORD serveraddress=localhost:$REGISTRY_PORT/ \
+  500 \
+  .message~'.* cannot prompt for username without stdin'
+
+
+# No password -> error
+t POST /v1.40/auth username=$REGISTRY_USERNAME serveraddress=https://localhost:$REGISTRY_PORT/ \
+  500 \
+  .message~'.* reading password: inappropriate ioctl for device'
+
 stop_registry

--- a/vendor/github.com/containers/common/pkg/auth/auth.go
+++ b/vendor/github.com/containers/common/pkg/auth/auth.go
@@ -242,14 +242,19 @@ func replaceURLByHostPort(repository string) (string, error) {
 // using the -u and -p flags.  If the username prompt is left empty, the
 // displayed userFromAuthFile will be used instead.
 func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user, pass string, err error) {
-	reader := bufio.NewReader(opts.Stdin)
 	username := opts.Username
 	if username == "" {
+		if opts.Stdin == nil {
+			return "", "", fmt.Errorf("cannot prompt for username without stdin")
+		}
+
 		if userFromAuthFile != "" {
 			fmt.Fprintf(opts.Stdout, "Username (%s): ", userFromAuthFile)
 		} else {
 			fmt.Fprint(opts.Stdout, "Username: ")
 		}
+
+		reader := bufio.NewReader(opts.Stdin)
 		username, err = reader.ReadString('\n')
 		if err != nil {
 			return "", "", fmt.Errorf("reading username: %w", err)

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.52.0"
+const Version = "0.53.0-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.52.0
+# github.com/containers/common v0.52.1-0.20230411124844-19b624d9a20d
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
By pulling in the fixes from c/common.  Add regression tests to make sure it's not happening another time.  The error messages are not ideal and should probably be optimized in the `/auth` endpoints directly but it's already an improvement over a nil deref.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a potential nil deref in the auth REST endpoints.
```
