### PR TITLE
Use a sane polling interval in WaitContainerDocker

### DIFF
--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -43,7 +43,7 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	interval := time.Nanosecond
+	interval := time.Millisecond * 250
 
 	condition := "not-running"
 	if _, found := r.URL.Query()["condition"]; found {


### PR DESCRIPTION
When using the docker REST API to wait for a container to be removed, for example, WaitContainerDocker uses a one microsecond interval between poll requests. This ends up being effectively a busy-wait, with the podman system service spinning at > 100% CPU time.

The equivalent Podman method uses a 250ms default. Use that for the docker variant, too.

I'm going to optimistically assert [NO NEW TESTS NEEDED] - given there's no functional change here, and a test will require some form of mocking or strac'ing the binary for evidence that it's polling less frequently, unless someone who is familiar with podman can briefly explain what kind of test would be appropriate here.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
