### PR TITLE
[CI:DOCS] docs: update network tutorial with netavark DHCP support

### DIFF
--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -167,23 +167,53 @@ is leased from a DHCP server like most other network clients on the network.  If
 the laptop is running a firewall, such as firewalld, then accommodations will need
 to be made for proper access.
 
+Note that Podman has to be run as root in order to use macvlan.
+
 #### Example
 
 The following example demonstrates how to set up a web container on a macvlan and
 how to access that container from outside the host.  First, create the macvlan network.
  You need to know the network interface on the host that connects to the routable
-network.  In the example case, it is eth0.  In Podman v4.0 if you need to use a leasable
-address, you should continue to use CNI instead of netavark.
+network.  In the example case, it is eth0.
 
 ```
 $ sudo podman network create -d macvlan -o parent=eth0 webnetwork
 webnetwork
 ```
-The next step is to ensure that the DHCP CNI plugin is running.  This plugin facilitates
-the DHCP lease from the network.
+
+The next step is to ensure that the DHCP service is running. This handles
+the DHCP leases from the network. If DHCP is not needed, the `--subnet` option
+can be used to assign a static subnet in the `network create` command above.
+
+CNI and netavark both use their own DHCP service; therefore, you need to know
+what backend you are using. To see what you are using, run this command:
+```
+$ sudo podman info --format {{.Host.NetworkBackend}}
+```
+If this command does not work, you are using an older version prior to Podman
+v4.0 which means you are using CNI.
+If the netavark backend is used, at least Podman v4.5 with netavark v1.6 is
+required to use DHCP.
+
+For netavark use:
+```
+$ sudo systemctl enable --now netavark-dhcp-proxy.socket
+```
+Or if the system doesn't use systemd, start the daemon manually:
+```
+$ /usr/libexec/podman/netavark dhcp-proxy --activity-timeout 0
+```
+
+With CNI use:
+```
+$ sudo systemctl enable --now cni-dhcp.socket
+```
+Or if the system doesn't use systemd, start the daemon manually:
 ```
 $ sudo /usr/libexec/cni/dhcp daemon
 ```
+Note that depending on the distribution, the binary location may differ.
+
 Now run the container and be certain to attach it to the network we created earlier.
 ```
 $ sudo podman run -dt --name webserver --network webnetwork quay.io/libpod/banner


### PR DESCRIPTION
Add instructions on how to start the netavark dhcp proxy. Also list version requirements.

Fixes #17635

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated the basic_networking tutorial with netavark DHCP support.
```
