### PR TITLE
Quadlet - do not set log-driver by default

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -295,8 +295,6 @@ This key can be listed multiple times.
 Set the log-driver Podman should use when running the container.
 Equivalent to the Podman `--log-driver` option.
 
-The default value is `passthrough`.
-
 ### `Mount=`
 
 Attach a filesystem mount to the container.
@@ -487,8 +485,6 @@ This key may be used multiple times
 
 Set the log-driver Podman should use when running the container.
 Equivalent to the Podman `--log-driver` option.
-
-The default value is `passthrough`.
 
 ### `Network=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -27,9 +27,6 @@ const (
 	XKubeGroup      = "X-Kube"
 	XNetworkGroup   = "X-Network"
 	XVolumeGroup    = "X-Volume"
-
-	// Use passthough as the default log driver to output to Journal
-	defaultLogDriver = "passthrough"
 )
 
 // All the supported quadlet keys
@@ -1108,10 +1105,9 @@ func handlePublishPorts(unitFile *parser.UnitFile, groupName string, podman *Pod
 
 func handleLogDriver(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline) {
 	logDriver, found := unitFile.Lookup(groupName, KeyLogDriver)
-	if !found {
-		logDriver = defaultLogDriver
+	if found {
+		podman.add("--log-driver", logDriver)
 	}
-	podman.add("--log-driver", logDriver)
 }
 
 func handleStorageSource(quadletUnitFile, serviceUnitFile *parser.UnitFile, source string) (string, error) {

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --log-driver passthrough --cgroups=split --sdnotify=conmon  -d localhost/imagename
+## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon  -d localhost/imagename
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -4,7 +4,6 @@
 ## assert-podman-args "--rm"
 ## assert-podman-args "--replace"
 ## assert-podman-args "-d"
-## assert-podman-args "--log-driver" "passthrough"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"

--- a/test/e2e/quadlet/basic.kube
+++ b/test/e2e/quadlet/basic.kube
@@ -3,7 +3,6 @@
 ## assert-podman-final-args-regex .*/podman_test.*/quadlet/deployment.yml
 ## assert-podman-args "--replace"
 ## assert-podman-args "--service-container=true"
-## assert-podman-args "--log-driver" "passthrough"
 ## assert-podman-stop-args "kube"
 ## assert-podman-stop-args "down"
 ## assert-podman-stop-final-args-regex .*/podman_test.*/quadlet/deployment.yml

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -475,7 +475,6 @@ var _ = Describe("quadlet system generator", func() {
 				"## assert-podman-final-args-regex .*/podman_test.*/quadlet/deployment.yml",
 				"## assert-podman-args \"--replace\"",
 				"## assert-podman-args \"--service-container=true\"",
-				"## assert-podman-args \"--log-driver\" \"passthrough\"",
 				"## assert-podman-stop-args \"kube\"",
 				"## assert-podman-stop-args \"down\"",
 				"## assert-podman-stop-final-args-regex .*/podman_test.*/quadlet/deployment.yml",
@@ -496,7 +495,7 @@ var _ = Describe("quadlet system generator", func() {
 				"Type=notify",
 				"NotifyAccess=all",
 				"SyslogIdentifier=%N",
-				fmt.Sprintf("ExecStart=/usr/local/bin/podman kube play --replace --service-container=true --log-driver passthrough %s/deployment.yml", quadletDir),
+				fmt.Sprintf("ExecStart=/usr/local/bin/podman kube play --replace --service-container=true %s/deployment.yml", quadletDir),
 				fmt.Sprintf("ExecStop=/usr/local/bin/podman kube down %s/deployment.yml", quadletDir),
 			}
 

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -177,6 +177,7 @@ EOF
 Image=$IMAGE
 Exec=sh -c "echo OUTPUT: \"\$FOOBAR\" \"\$BAR\""
 Environment="FOOBAR=Foo  Bar" BAR=bar
+LogDriver=passthrough
 EOF
 
     run_quadlet "$quadlet_file"


### PR DESCRIPTION
Update e2e tests not to expect the flag
System tests - explicitly set the log driver to be able to parse the output

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet no longer sets the log-driver by default
```

Resolves: #17692 
