### PR TITLE
machine: add ability to insert new disks to the VM

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -60,6 +60,28 @@ func init() {
 
 	_ = initCmd.RegisterFlagCompletionFunc(diskSizeFlagName, completion.AutocompleteNone)
 
+	extraDiskNumFlagName := "extra-disk-num"
+	flags.Uint64VarP(
+		&initOpts.ExtraDiskNum,
+		// TODO: change me once I commit this to https://github.com/containers/common/blob/main/pkg/config/config.go
+		// extraDiskNumFlagName, cfg.ContainersConfDefaultsRO.Machine.ExtraDiskNum,
+		extraDiskNumFlagName, "d", 0,
+		"Number of extra disks to create",
+	)
+
+	_ = initCmd.RegisterFlagCompletionFunc(extraDiskNumFlagName, completion.AutocompleteNone)
+
+	extraDiskSizeFlagName := "extra-disk-size"
+	flags.Uint64VarP(
+		&initOpts.ExtraDiskSize,
+		// TODO (leseb): change me once I commit a change to https://github.com/containers/common/blob/main/pkg/config/config.go
+		// extraDiskSizeFlagName, cfg.ContainersConfDefaultsRO.Machine.ExtraDiskSize,
+		extraDiskSizeFlagName, "s", cfg.ContainersConfDefaultsRO.Machine.DiskSize,
+		"Extra disk size in GB",
+	)
+
+	_ = initCmd.RegisterFlagCompletionFunc(extraDiskSizeFlagName, completion.AutocompleteNone)
+
 	memoryFlagName := "memory"
 	flags.Uint64VarP(
 		&initOpts.Memory,

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -51,6 +51,9 @@ func init() {
 
 	imageFlagName := "save-image"
 	flags.BoolVar(&destroyOptions.SaveImage, imageFlagName, false, "Do not delete the image file")
+
+	diskFlagName := "save-disks"
+	flags.BoolVar(&destroyOptions.SaveDisks, diskFlagName, false, "Do not delete the disk file(s)")
 }
 
 func rm(_ *cobra.Command, args []string) error {

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -32,10 +32,12 @@ var (
 )
 
 type SetFlags struct {
-	CPUs     uint64
-	DiskSize uint64
-	Memory   uint64
-	Rootful  bool
+	CPUs          uint64
+	DiskSize      uint64
+	Memory        uint64
+	Rootful       bool
+	ExtraDiskNum  uint64
+	ExtraDiskSize uint64
 }
 
 func init() {
@@ -72,6 +74,22 @@ func init() {
 		"Memory in MB",
 	)
 	_ = setCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
+
+	extraDiskNumFlagName := "extra-disk-num"
+	flags.Uint64VarP(
+		&setFlags.ExtraDiskNum,
+		extraDiskNumFlagName, "d", 0,
+		"Number of extra disks to create",
+	)
+	_ = setCmd.RegisterFlagCompletionFunc(extraDiskNumFlagName, completion.AutocompleteNone)
+
+	extraDiskSizeFlagName := "extra-disk-size"
+	flags.Uint64VarP(
+		&setFlags.ExtraDiskSize,
+		extraDiskSizeFlagName, "s", 0,
+		"Extra disk size in GB",
+	)
+	_ = setCmd.RegisterFlagCompletionFunc(extraDiskSizeFlagName, completion.AutocompleteNone)
 }
 
 func setMachine(cmd *cobra.Command, args []string) error {
@@ -101,6 +119,12 @@ func setMachine(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("disk-size") {
 		setOpts.DiskSize = &setFlags.DiskSize
+	}
+	if cmd.Flags().Changed("extra-disk-num") {
+		setOpts.ExtraDiskNum = &setFlags.ExtraDiskNum
+	}
+	if cmd.Flags().Changed("extra-disk-size") {
+		setOpts.ExtraDiskSize = &setFlags.ExtraDiskSize
 	}
 
 	setErrs, lasterr := vm.Set(vmName, setOpts)

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -35,6 +35,16 @@ Number of CPUs.
 
 Size of the disk for the guest VM in GB.
 
+#### **--extra-disk-num**=*number*, **-d**=*number*
+
+Number of extra disk(s) to add to the guest VM.
+Can only be increased. Only supported for QEMU machines.
+
+#### **--extra-disk-size**=*number*, **-s**=*number*
+
+Size of the extra disk(s) for the guest VM in GB.
+Cannot be changed on already added disk. Only supported for QEMU machines.
+
 #### **--help**
 
 Print usage statement.
@@ -128,6 +138,7 @@ $ podman machine init
 $ podman machine init myvm
 $ podman machine init --rootful
 $ podman machine init --disk-size 50
+$ podman machine init --extra-disk-num 3 --extra-disk-size 200
 $ podman machine init --memory=1024 myvm
 $ podman machine init -v /Users:/mnt/Users
 ```

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -41,6 +41,10 @@ Do not delete the VM image.
 Do not delete the SSH keys for the VM.  The system connection is always
 deleted.
 
+#### **--save-disks**
+
+Do not delete the VM disk(s).
+
 ## EXAMPLES
 
 Remove a VM named "test1":

--- a/docs/source/markdown/podman-machine-set.1.md
+++ b/docs/source/markdown/podman-machine-set.1.md
@@ -24,6 +24,16 @@ Only supported for QEMU machines.
 Size of the disk for the guest VM in GB.
 Can only be increased. Only supported for QEMU machines.
 
+#### **--extra-disk-num**=*number*, **-d**=*number*
+
+Number of extra disk(s) to add to the guest VM.
+Can only be increased. Only supported for QEMU machines.
+
+#### **--extra-disk-size**=*number*, **-s**=*number*
+
+Size of the extra disk(s) for the guest VM in GB.
+Cannot be changed on already added disk. Only supported for QEMU machines.
+
 #### **--help**
 
 Print usage statement.
@@ -66,6 +76,11 @@ $ podman machine set --rootful=false
 To switch the VM `myvm` from rootless to rootful:
 ```
 $ podman machine set --rootful myvm
+```
+
+To add more two additional disks of 50GiB to the VM `myvm`:
+```
+$ podman machine set --extra-disk-num 2 --extra-disk-size 50 myvm
 ```
 
 ## SEE ALSO

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -33,6 +33,10 @@ type InitOptions struct {
 	Rootful      bool
 	// The numerical userid of the user that called machine
 	UID string
+	// ExtraDiskNum is the number of extra disks to create
+	ExtraDiskNum uint64
+	// ExtraDiskSize is the size in gigabytes of the extra disks to create
+	ExtraDiskSize uint64
 }
 
 type Status = string
@@ -107,10 +111,12 @@ type ListResponse struct {
 }
 
 type SetOptions struct {
-	CPUs     *uint64
-	DiskSize *uint64
-	Memory   *uint64
-	Rootful  *bool
+	CPUs          *uint64
+	DiskSize      *uint64
+	Memory        *uint64
+	Rootful       *bool
+	ExtraDiskNum  *uint64
+	ExtraDiskSize *uint64
 }
 
 type SSHOptions struct {
@@ -130,6 +136,7 @@ type RemoveOptions struct {
 	SaveKeys     bool
 	SaveImage    bool
 	SaveIgnition bool
+	SaveDisks    bool
 }
 
 type InspectOptions struct{}
@@ -155,6 +162,7 @@ type InspectInfo struct {
 	ConnectionInfo ConnectionConfig
 	Created        time.Time
 	Image          ImageConfig
+	Disks          []VMFile
 	LastUp         time.Time
 	Name           string
 	Resources      ResourceConfig
@@ -260,6 +268,10 @@ type ResourceConfig struct {
 	CPUs uint64
 	// Disk size in gigabytes assigned to the vm
 	DiskSize uint64
+	// ExtraDiskNum is the number of extra disks to create
+	ExtraDiskNum uint64
+	// ExtraDiskSize is the size in gigabytes of the extra disks to create
+	ExtraDiskSize uint64
 	// Memory in megabytes assigned to the vm
 	Memory uint64
 }

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -19,16 +19,18 @@ type initMachine struct {
 	      --volume-driver string   Optional volume driver
 
 	*/
-	cpus         *uint
-	diskSize     *uint
-	ignitionPath string
-	username     string
-	imagePath    string
-	memory       *uint
-	now          bool
-	timezone     string
-	rootful      bool //nolint:unused
-	volumes      []string
+	cpus          *uint
+	diskSize      *uint
+	ignitionPath  string
+	username      string
+	imagePath     string
+	memory        *uint
+	now           bool
+	timezone      string
+	rootful       bool //nolint:unused
+	volumes       []string
+	extraDiskNum  *uint
+	extraDiskSize *uint
 
 	cmd []string
 }
@@ -40,6 +42,12 @@ func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
 	}
 	if i.diskSize != nil {
 		cmd = append(cmd, "--disk-size", strconv.Itoa(int(*i.diskSize)))
+	}
+	if i.extraDiskNum != nil {
+		cmd = append(cmd, "--extra-disk-num", strconv.Itoa(int(*i.extraDiskNum)))
+	}
+	if i.extraDiskSize != nil {
+		cmd = append(cmd, "--extra-disk-size", strconv.Itoa(int(*i.extraDiskSize)))
 	}
 	if l := len(i.ignitionPath); l > 0 {
 		cmd = append(cmd, "--ignition-path", i.ignitionPath)
@@ -108,5 +116,15 @@ func (i *initMachine) withTimezone(tz string) *initMachine {
 
 func (i *initMachine) withVolume(v string) *initMachine {
 	i.volumes = append(i.volumes, v)
+	return i
+}
+
+func (i *initMachine) withExtraDiskNum(num uint) *initMachine {
+	i.extraDiskNum = &num
+	return i
+}
+
+func (i *initMachine) withExtraDiskSize(num uint) *initMachine {
+	i.extraDiskSize = &num
 	return i
 }

--- a/pkg/machine/e2e/config_rm_test.go
+++ b/pkg/machine/e2e/config_rm_test.go
@@ -2,16 +2,17 @@ package e2e_test
 
 type rmMachine struct {
 	/*
-	  -f, --force           Stop and do not prompt before rming
-	      --save-ignition   Do not delete ignition file
-	      --save-image      Do not delete the image file
-	      --save-keys       Do not delete SSH keys
-
+	   -f, --force           Stop and do not prompt before rming
+	       --save-ignition   Do not delete ignition file
+	       --save-image      Do not delete the image file
+	       --save-keys       Do not delete SSH keys
+	       --save-disks      Do not delete the disk file(s)
 	*/
 	force        bool
 	saveIgnition bool
 	saveImage    bool
 	saveKeys     bool
+	saveDisks    bool
 
 	cmd []string
 }
@@ -29,6 +30,9 @@ func (i *rmMachine) buildCmd(m *machineTestBuilder) []string {
 	}
 	if i.saveKeys {
 		cmd = append(cmd, "--save-keys")
+	}
+	if i.saveDisks {
+		cmd = append(cmd, "--save-disks")
 	}
 	cmd = append(cmd, m.name)
 	i.cmd = cmd
@@ -52,5 +56,10 @@ func (i *rmMachine) withSaveImage() *rmMachine { //nolint:unused
 
 func (i *rmMachine) withSaveKeys() *rmMachine { //nolint:unused
 	i.saveKeys = true
+	return i
+}
+
+func (i *rmMachine) withSaveDisks() *rmMachine {
+	i.saveDisks = true
 	return i
 }

--- a/pkg/machine/e2e/config_set_test.go
+++ b/pkg/machine/e2e/config_set_test.go
@@ -5,9 +5,11 @@ import (
 )
 
 type setMachine struct {
-	cpus     *uint
-	diskSize *uint
-	memory   *uint
+	cpus          *uint
+	diskSize      *uint
+	memory        *uint
+	extraDiskNum  *uint
+	extraDiskSize *uint
 
 	cmd []string
 }
@@ -22,6 +24,12 @@ func (i *setMachine) buildCmd(m *machineTestBuilder) []string {
 	}
 	if i.memory != nil {
 		cmd = append(cmd, "--memory", strconv.Itoa(int(*i.memory)))
+	}
+	if i.extraDiskNum != nil {
+		cmd = append(cmd, "--extra-disk-num", strconv.Itoa(int(*i.extraDiskNum)))
+	}
+	if i.extraDiskSize != nil {
+		cmd = append(cmd, "--extra-disk-size", strconv.Itoa(int(*i.extraDiskSize)))
 	}
 	cmd = append(cmd, m.name)
 	i.cmd = cmd
@@ -39,5 +47,15 @@ func (i *setMachine) withDiskSize(size uint) *setMachine {
 
 func (i *setMachine) withMemory(num uint) *setMachine {
 	i.memory = &num
+	return i
+}
+
+func (i *setMachine) withExtraDiskNum(num uint) *setMachine {
+	i.extraDiskNum = &num
+	return i
+}
+
+func (i *setMachine) withExtraDiskSize(num uint) *setMachine {
+	i.extraDiskSize = &num
 	return i
 }

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -54,7 +54,7 @@ var _ = Describe("podman machine stop", func() {
 	It("inspect with go format", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withExtraDiskNum(1)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -68,6 +68,7 @@ var _ = Describe("podman machine stop", func() {
 		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(strings.HasSuffix(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath(), "podman.sock"))
+		Expect(inspectInfo[0].Disks[0].GetPath()).ToNot(BeEmpty())
 
 		inspect := new(inspectMachine)
 		inspect = inspect.withFormat("{{.Name}}")

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -1,6 +1,11 @@
 package e2e_test
 
 import (
+	"io/fs"
+	"os"
+
+	"github.com/containers/podman/v4/pkg/machine"
+	jsoniter "github.com/json-iterator/go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -64,5 +69,42 @@ var _ = Describe("podman machine rm", func() {
 		_, ec, err := mb.toQemuInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
+	})
+
+	It("Remove running machine but leave extra disks intact", func() {
+		i := new(initMachine)
+		session, err := mb.setCmd(i.withImagePath(mb.imagePath).withExtraDiskNum(1).withNow()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+		rm := new(rmMachine)
+
+		// regular inspect should
+		inspectJSON := new(inspectMachine)
+		inspectSession, err := mb.setCmd(inspectJSON).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+
+		var inspectInfo []machine.InspectInfo
+		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectInfo[0].Disks[0].GetPath()).ToNot(BeEmpty())
+
+		defer os.Remove(inspectInfo[0].Disks[0].GetPath())
+
+		// Removing again with force
+		stopAgain, err := mb.setCmd(rm.withForce().withSaveDisks()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopAgain).To(Exit(0))
+
+		// Inspect to be dead sure
+		_, ec, err := mb.toQemuInspectInfo()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ec).To(Equal(125))
+
+		// Make sure the extra disk is still there
+		var f fs.FileInfo
+		f, err = os.Stat(inspectInfo[0].Disks[0].GetPath())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(f.Name()).ToNot(BeEmpty())
 	})
 })

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -29,7 +29,7 @@ var _ = Describe("podman machine set", func() {
 		Expect(session).To(Exit(0))
 
 		set := setMachine{}
-		setSession, err := mb.setName(name).setCmd(set.withCPUs(2).withDiskSize(102).withMemory(4096)).run()
+		setSession, err := mb.setName(name).setCmd(set.withCPUs(2).withDiskSize(102).withMemory(4096).withExtraDiskNum(2).withExtraDiskSize(50)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(setSession).To(Exit(0))
 
@@ -54,6 +54,13 @@ var _ = Describe("podman machine set", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(diskSession).To(Exit(0))
 		Expect(diskSession.outputToString()).To(ContainSubstring("102 GiB"))
+
+		sshExtraDisks := sshMachine{}
+		extraDisksSession, err := mb.setName(name).setCmd(sshExtraDisks.withSSHCommand([]string{"sudo", "lsblk", "-o", "NAME,SIZE", "|", "grep", "vd[b-z]"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(extraDisksSession).To(Exit(0))
+		Expect(extraDisksSession.outputToStringSlice()).To(HaveLen(2))
+		Expect(extraDisksSession.outputToString()).To(ContainSubstring("50G"))
 
 		sshMemory := sshMachine{}
 		memorySession, err := mb.setName(name).setCmd(sshMemory.withSSHCommand([]string{"cat", "/proc/meminfo", "|", "grep", "-i", "'memtotal'", "|", "grep", "-o", "'[[:digit:]]*'"})).run()

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -78,6 +78,8 @@ type MachineVM struct {
 	Created time.Time
 	// LastUp contains the last recorded uptime
 	LastUp time.Time
+	// ExtraDiskPaths is the list of extra disks attached to the VM
+	ExtraDiskPaths []machine.VMFile
 }
 
 type Monitorv1 struct {

--- a/pkg/machine/qemu/machine_test.go
+++ b/pkg/machine/qemu/machine_test.go
@@ -24,6 +24,16 @@ func TestEditCmd(t *testing.T) {
 	require.Equal(t, vm.CmdLine, []string{"command", "-flag", "newvalue", "-anotherflag", "anothervalue"})
 }
 
+func TestAppendCmd(t *testing.T) {
+	vm := new(MachineVM)
+	vm.CmdLine = []string{"command", "-flag", "value"}
+
+	vm.appendCmdLine("-drive", "foo")
+	vm.appendCmdLine("-drive", "bar")
+
+	require.Equal(t, vm.CmdLine, []string{"command", "-flag", "value", "-drive", "foo", "-drive", "bar"})
+}
+
 func TestPropagateHostEnv(t *testing.T) {
 	t.Setenv("SSL_CERT_FILE", "/some/foo.cert")
 	t.Setenv("SSL_CERT_DIR", "/some/my/certs")

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1013,6 +1013,10 @@ func (v *MachineVM) Set(_ string, opts machine.SetOptions) ([]error, error) {
 		setErrors = append(setErrors, errors.New("changing Disk Size not supported for WSL machines"))
 	}
 
+	if opts.ExtraDiskNum != nil {
+		setErrors = append(setErrors, errors.New("adding more disk(s) is not supported for WSL machines"))
+	}
+
 	return setErrors, v.writeConfig()
 }
 


### PR DESCRIPTION
We can now add more disks to the podman machine with the following flags:

 *--extra-disk-num

Number of extra disk(s) to add to the guest VM.
Can only be increased. Only supported for QEMU machines.

*--extra-disk-size
Size of the extra disk(s) for the guest VM in GB.
Cannot be changed on already added disk. Only supported for QEMU machines.

The `init`, `set`, `rm`, `inspect` CLI arguments have been implemented. Can be run like so:

```
podman machine init myvm --extra-disk-num 3 --extra-disk-size 50
```

Right now, the default size is the same as the default root disk. I need to update the https://github.com/containers/common repo.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The podman-machine utility has gained the ability to attach additional disks to the virtual machine. The number and the size of the extra added disks are configurable. The support is limited to QEMU.
```
