### PR TITLE
[v4.5 backport] [CI:BUILD] Packit: Initial Enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file generated using the `post-upstream-clone`
+# action and gets used by the fix-spec-file action in .packit.yaml.
+
+set -eo pipefail
+
+# Get Version from version/version.go in HEAD
+VERSION=$(grep '^const RawVersion' version/rawversion/version.go | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball from HEAD
+git archive --prefix=podman-$VERSION/ -o podman-$VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Use the Version from version/version.go in rpm spec
+sed -i "s/^Version:.*/Version: $VERSION/" podman.spec
+
+# Use Packit's supplied variable in the Release field in rpm spec.
+# podman.spec is generated using `rpkg spec --outdir ./` as mentioned in the
+# `post-upstream-clone` action in .packit.yaml.
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" podman.spec
+
+# Use above generated tarball as Source in rpm spec
+sed -i "s/^Source:.*.tar.gz/Source: podman-$VERSION.tar.gz/" podman.spec
+
+# Use the right build dir for autosetup stage in rpm spec
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$VERSION/" podman.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,32 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: podman.spec
+
+jobs:
+  - &copr
+    job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - make
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"
+
+  - <<: *copr
+    # Run on commit to v4.5 branch
+    # The `rhcontainerbot/qm` copr needs podman v4.5 for testing on
+    # centos stream 9
+    trigger: commit
+    branch: v4.5
+    project: qm


### PR DESCRIPTION
This commit adds Packit configuration files which will trigger rpm
builds on copr:`rhcontainerbot/packit-builds` on every PR as well as on
copr:`rhcontainerbot/qm` on every commit to v4.5 branch.

This commit will ensure main branch is always buildable on all supported
Fedora and CentOS Stream versions for aarch64 and x86_64.
TODO: enable build checks for s390x and ppc64le while ensuring they
don't take too long to build.

The packit builds reuse `podman.spec.rpkg` present upstream and are
thus independent of Fedora / CentOS dist-git.

[NO NEW TESTS NEEDED]