### PR TITLE
Add missing security options to /info response

### DIFF
--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/google/uuid"
+	"github.com/opencontainers/selinux/go-selinux"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -181,6 +182,13 @@ func getSecOpts(sysInfo *sysinfo.SysInfo) []string {
 		// FIXME: get profile name...
 		secOpts = append(secOpts, fmt.Sprintf("name=seccomp,profile=%s", "default"))
 	}
+	if rootless.IsRootless() {
+		secOpts = append(secOpts, "name=rootless")
+	}
+	if selinux.GetEnabled() {
+		secOpts = append(secOpts, "name=selinux")
+	}
+
 	return secOpts
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

The docker API reports running rootless and SELinux as security options  in the `GET /info` response, so podman should do the same for the compat API.

I'm not sure how to test this. Should I extend the python REST test? It currently only checks for status code.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
