### PR TITLE
Don't use bytes.NewBuffer to read data

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -257,7 +257,7 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 	if err != nil {
 		return fmt.Errorf("reading stdout: %s: %w", ctr.ID(), err)
 	}
-	if err := json.NewDecoder(bytes.NewBuffer(out)).Decode(state); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(out)).Decode(state); err != nil {
 		return fmt.Errorf("decoding container status for container %s: %w", ctr.ID(), err)
 	}
 	ctr.state.PID = state.Pid

--- a/pkg/domain/infra/abi/play_test.go
+++ b/pkg/domain/infra/abi/play_test.go
@@ -99,7 +99,7 @@ binaryData:
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			buf := bytes.NewBufferString(test.configMapContent)
+			buf := bytes.NewReader([]byte(test.configMapContent))
 			cm, err := readConfigMapFromFile(buf)
 
 			if test.expectError {


### PR DESCRIPTION
The documentation says
> The new Buffer takes ownership of buf, and the
> caller should not use buf after this call.

so use the more directly applicable, and simpler, bytes.Reader instead, to avoid this potentially risky use.

#### Does this PR introduce a user-facing change?

```release-note
None
```
