### PR TITLE
Specify format to buildah before commit

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -68,6 +68,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 		PreferredManifestType: options.PreferredManifestType,
 	}
 	importBuilder, err := buildah.ImportBuilder(ctx, c.runtime.store, builderOptions)
+	importBuilder.Format = options.PreferredManifestType
 	if err != nil {
 		return nil, err
 	}

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -309,4 +309,17 @@ Deleted: $pauseID"
     is "$output" "" "Should print no output"
 }
 
+@test "podman images - commit docker with comment" {
+    run_podman run --name my-container -itd $IMAGE sleep 1d
+    run_podman 125 commit -m comment my-container my-test-image
+    assert "$output" == "Error: messages are only compatible with the docker image format (-f docker)" "podman should fail unless docker format"
+    run_podman commit my-container --format docker -m comment my-test-image
+    run_podman commit -q my-container --format docker -m comment my-test-image
+    assert "$output" =~ "^[0-9a-f]{64}\$" \
+           "Output is a commit ID, no warnings or other output"
+
+    run_podman rmi my-test-image
+    run_podman rm my-container --force -t 0
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
If user specifies commit --format, we were not setting it before commit, this caused warning messages that made no sense to be printed that made no sense.

Fixes: https://github.com/containers/podman/issues/17773

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Incorrect warning fixed, when committing images with docker format and -m options"
```
