### PR TITLE
Fixes format inconsistencies with docker for certain history fields

### DIFF
--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -3,9 +3,7 @@ package images
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
-	"unicode"
 
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -149,9 +147,7 @@ func (h historyReporter) Created() string {
 }
 
 func (h historyReporter) Size() string {
-	s := units.HumanSizeWithPrecision(float64(h.ImageHistoryLayer.Size), 3)
-	i := strings.LastIndexFunc(s, unicode.IsNumber)
-	return s[:i+1] + " " + s[i+1:]
+	return units.HumanSizeWithPrecision(float64(h.ImageHistoryLayer.Size), 3)
 }
 
 func (h historyReporter) CreatedBy() string {
@@ -169,7 +165,7 @@ func (h historyReporter) ID() string {
 }
 
 func (h historyReporter) CreatedAt() string {
-	return time.Unix(h.ImageHistoryLayer.Created.Unix(), 0).UTC().String()
+	return time.Unix(h.ImageHistoryLayer.Created.Unix(), 0).Format(time.RFC3339)
 }
 
 func (h historyReporter) CreatedSince() string {

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -44,6 +44,11 @@ var _ = Describe("Podman history", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
+
+		session = podmanTest.Podman([]string{"history", "--format", "{{.CreatedAt}};{{.Size}}", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(MatchRegexp("[0-9-]{10}T[0-9:]{8}[Z0-9+:-]+;[0-9.]+[MG]*B( .+)?"))
 	})
 
 	It("podman history with human flag", func() {


### PR DESCRIPTION
Closes #17767
Closes #17768

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a format inconsistency where podman and docker return slightly different output for `history --format {{.CreatedAt}}` and `history --format {{.Size}}` (#17767, #17768)
```
