### PR TITLE
podman: add support for splitting imagestore using `--imagestore`

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -507,6 +507,10 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		pFlags.StringVar(&podmanConfig.Runroot, runrootFlagName, "", "Path to the 'run directory' where all state information is stored")
 		_ = cmd.RegisterFlagCompletionFunc(runrootFlagName, completion.AutocompleteDefault)
 
+		imageStoreFlagName := "imagestore"
+		pFlags.StringVar(&podmanConfig.ImageStore, imageStoreFlagName, "", "Path to the `image store`, different from `graph root`, use this to split storing the image into a separate `image store`, see `man containers-storage.conf` for details")
+		_ = cmd.RegisterFlagCompletionFunc(imageStoreFlagName, completion.AutocompleteDefault)
+
 		pFlags.BoolVar(&podmanConfig.TransientStore, "transient-store", false, "Enable transient container storage")
 
 		runtimeFlagName := "runtime"

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -78,6 +78,12 @@ Identity value resolution precedence:
  - `containers.conf`
 Remote connections use local containers.conf for default.
 
+#### **--imagestore**=*path*
+
+Path of the imagestore where images are stored.  By default, the storage library stores all the images in the graphroot but if an imagestore is provided, then the storage library will store newly pulled images in the provided imagestore and keep using the graphroot for everything else. If the user is using the overlay driver, then the images which were already part of the graphroot will still be accessible.
+
+This will override *imagestore* option in `containers-storage.conf(5)`, refer to `containers-storage.conf(5)` for more details.
+
 #### **--log-level**=*level*
 
 Log messages at and above specified level: debug, info, warn, error, fatal or panic (default: "warn")

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containers/libhvee v0.0.5
 	github.com/containers/ocicrypt v1.1.7
 	github.com/containers/psgo v1.8.0
-	github.com/containers/storage v1.46.2-0.20230613134951-e424b6649be3
+	github.com/containers/storage v1.46.2-0.20230616083707-cc0d208e5e1c
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/coreos/stream-metadata-go v0.4.2
 	github.com/crc-org/vfkit v0.0.5-0.20230602131541-3d57f09010c9

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/containers/ocicrypt v1.1.7/go.mod h1:7CAhjcj2H8AYp5YvEie7oVSK2AhBY8Ns
 github.com/containers/psgo v1.8.0 h1:2loGekmGAxM9ir5OsXWEfGwFxorMPYnc6gEDsGFQvhY=
 github.com/containers/psgo v1.8.0/go.mod h1:T8ZxnX3Ur4RvnhxFJ7t8xJ1F48RhiZB4rSrOaR/qGHc=
 github.com/containers/storage v1.43.0/go.mod h1:uZ147thiIFGdVTjMmIw19knttQnUCl3y9zjreHrg11s=
-github.com/containers/storage v1.46.2-0.20230613134951-e424b6649be3 h1:nSCnnrCMocJDsNUU4EDPT8GkW7ToU43/QbXGRC+ciEs=
-github.com/containers/storage v1.46.2-0.20230613134951-e424b6649be3/go.mod h1:pRp3lkRo2qodb/ltpnudoXggrviRmaCmU5a5GhTBae0=
+github.com/containers/storage v1.46.2-0.20230616083707-cc0d208e5e1c h1:hJP+UF9OzDaThxavD5isFbAFxbvb25TdFtjohAhH/dc=
+github.com/containers/storage v1.46.2-0.20230616083707-cc0d208e5e1c/go.mod h1:pRp3lkRo2qodb/ltpnudoXggrviRmaCmU5a5GhTBae0=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -126,6 +126,18 @@ func WithTransientStore(transientStore bool) RuntimeOption {
 	}
 }
 
+func WithImageStore(imageStore string) RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return define.ErrRuntimeFinalized
+		}
+
+		rt.storageConfig.ImageStore = imageStore
+
+		return nil
+	}
+}
+
 // WithSignaturePolicy specifies the path of a file which decides how trust is
 // managed for images we've pulled.
 // If this is not specified, the system default configuration will be used

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -52,6 +52,7 @@ type PodmanConfig struct {
 	URI                      string         // URI to RESTful API Service
 
 	Runroot        string
+	ImageStore     string
 	StorageDriver  string
 	StorageOpts    []string
 	SSHMode        string

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -153,6 +153,10 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		storageSet = true
 		storageOpts.RunRoot = cfg.Runroot
 	}
+	if fs.Changed("imagestore") {
+		storageOpts.ImageStore = cfg.ImageStore
+		options = append(options, libpod.WithImageStore(cfg.ImageStore))
+	}
 	if len(storageOpts.RunRoot) > 50 {
 		return nil, errors.New("the specified runroot is longer than 50 characters")
 	}

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -285,6 +285,9 @@ func CreateExitCommandArgs(storageConfig storageTypes.StoreOptions, config *conf
 		"--db-backend", config.Engine.DBBackend,
 		fmt.Sprintf("--transient-store=%t", storageConfig.TransientStore),
 	}
+	if storageConfig.ImageStore != "" {
+		command = append(command, []string{"--imagestore", storageConfig.ImageStore}...)
+	}
 	if config.Engine.OCIRuntime != "" {
 		command = append(command, []string{"--runtime", config.Engine.OCIRuntime}...)
 	}

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -62,6 +62,73 @@ var _ = Describe("Podman pull", func() {
 		Expect(session).Should(Exit(0))
 	})
 
+	It("podman pull and run on split imagestore", func() {
+		SkipIfRemote("podman-remote does not support setting external imagestore")
+		imgName := "splitstoretest"
+
+		// Make alpine write-able
+		session := podmanTest.Podman([]string{"build", "--pull=never", "--tag", imgName, "build/basicalpine"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		tmpDir := filepath.Join(podmanTest.TempDir, "splitstore")
+		outfile := filepath.Join(podmanTest.TempDir, "image.tar")
+
+		save := podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-archive", imgName})
+		save.WaitWithDefaultTimeout()
+		Expect(save).Should(Exit(0))
+
+		rmi := podmanTest.Podman([]string{"rmi", imgName})
+		rmi.WaitWithDefaultTimeout()
+		Expect(rmi).Should(Exit(0))
+
+		// load to splitstore
+		result := podmanTest.Podman([]string{"load", "--imagestore", tmpDir, "-q", "-i", outfile})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+
+		// tag busybox to busybox-test in graphroot since we can delete readonly busybox
+		session = podmanTest.Podman([]string{"tag", "quay.io/libpod/busybox:latest", "busybox-test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"images", "--imagestore", tmpDir})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring(imgName))
+		Expect(session.OutputToString()).To(ContainSubstring("busybox-test"))
+
+		// Test deleting image in graphroot even when `--imagestore` is set
+		session = podmanTest.Podman([]string{"rmi", "--imagestore", tmpDir, "busybox-test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// Images without --imagestore should not contain alpine
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Not(ContainSubstring(imgName)))
+
+		// Set `imagestore` in `storage.conf` and container should run.
+		configPath := filepath.Join(podmanTest.TempDir, ".config", "containers", "storage.conf")
+		os.Setenv("CONTAINERS_STORAGE_CONF", configPath)
+		defer func() {
+			os.Unsetenv("CONTAINERS_STORAGE_CONF")
+		}()
+
+		err = os.MkdirAll(filepath.Dir(configPath), os.ModePerm)
+		Expect(err).ToNot(HaveOccurred())
+		storageConf := []byte(fmt.Sprintf("[storage]\nimagestore=\"%s\"", tmpDir))
+		err = os.WriteFile(configPath, storageConf, os.ModePerm)
+		Expect(err).ToNot(HaveOccurred())
+
+		session = podmanTest.Podman([]string{"run", "--name", "test", "--rm",
+			imgName, "echo", "helloworld"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("helloworld"))
+	})
+
 	It("podman pull by digest", func() {
 		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/testdigest_v2s2@sha256:755f4d90b3716e2bf57060d249e2cd61c9ac089b1233465c5c2cb2d7ee550fdb"})
 		session.WaitWithDefaultTimeout()

--- a/vendor/github.com/containers/storage/.cirrus.yml
+++ b/vendor/github.com/containers/storage/.cirrus.yml
@@ -18,12 +18,12 @@ env:
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
     FEDORA_NAME: "fedora-38"
-    DEBIAN_NAME: "debian-12"
+    DEBIAN_NAME: "debian-13"
 
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
     # VM Image built in containers/automation_images
-    IMAGE_SUFFIX: "c20230601t145439z-f38f37d12"
+    IMAGE_SUFFIX: "c20230614t132754z-f38f37d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     DEBIAN_CACHE_IMAGE_NAME: "debian-${IMAGE_SUFFIX}"
 

--- a/vendor/github.com/containers/storage/drivers/overlay/overlay.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/overlay.go
@@ -1029,7 +1029,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 			}
 			if imageStore != "" {
 				if err2 := os.RemoveAll(workDirBase); err2 != nil {
-					logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", dir, err2)
+					logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", workDirBase, err2)
 				}
 			}
 		}

--- a/vendor/github.com/containers/storage/layers.go
+++ b/vendor/github.com/containers/storage/layers.go
@@ -314,9 +314,6 @@ type rwLayerStore interface {
 
 	// Clean up unreferenced layers
 	GarbageCollect() error
-
-	// supportsShifting() returns true if the driver.Driver.SupportsShifting().
-	supportsShifting() bool
 }
 
 type layerStore struct {
@@ -2470,10 +2467,6 @@ func (r *layerStore) LayersByCompressedDigest(d digest.Digest) ([]Layer, error) 
 // Requires startReading or startWriting.
 func (r *layerStore) LayersByUncompressedDigest(d digest.Digest) ([]Layer, error) {
 	return r.layersByDigestMap(r.byuncompressedsum, d)
-}
-
-func (r *layerStore) supportsShifting() bool {
-	return r.driver.SupportsShifting()
 }
 
 func closeAll(closes ...func() error) (rErr error) {

--- a/vendor/github.com/containers/storage/types/options.go
+++ b/vendor/github.com/containers/storage/types/options.go
@@ -300,6 +300,7 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 	// present.
 	if defaultConfigFileSet {
 		opts.GraphDriverOptions = systemOpts.GraphDriverOptions
+		opts.ImageStore = systemOpts.ImageStore
 	} else if opts.GraphDriverName == overlayDriver {
 		for _, o := range systemOpts.GraphDriverOptions {
 			if strings.Contains(o, "ignore_chown_errors") {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -287,7 +287,7 @@ github.com/containers/psgo/internal/dev
 github.com/containers/psgo/internal/host
 github.com/containers/psgo/internal/proc
 github.com/containers/psgo/internal/process
-# github.com/containers/storage v1.46.2-0.20230613134951-e424b6649be3
+# github.com/containers/storage v1.46.2-0.20230616083707-cc0d208e5e1c
 ## explicit; go 1.19
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
Add support for `--imagestore` in podman which allows users to split the filesystem of containers vs image store, imagestore if configured will pull images in image storage instead of the graphRoot while keeping the other parts still in the originally configured graphRoot.

This is an implementation of
https://github.com/containers/storage/pull/1549 in podman.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman: add support for splitting imagestore using `--imagestore`
```
