### PR TITLE
Enabled network over vsock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containers/common v0.52.1-0.20230411124844-19b624d9a20d
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.25.0
-	github.com/containers/libhvee v0.0.2
+	github.com/containers/libhvee v0.0.4
 	github.com/containers/ocicrypt v1.1.7
 	github.com/containers/psgo v1.8.0
 	github.com/containers/storage v1.46.1

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.25.0 h1:TJ0unmalbU+scd0i3Txap2wjGsAnv06MSCwgn6bsizk=
 github.com/containers/image/v5 v5.25.0/go.mod h1:EKvys0WVlRFkDw26R8y52TuhV9Tfn0yq2luLX6W52Ls=
-github.com/containers/libhvee v0.0.2 h1:eWtbOvpT8bD9jvksMES2yXUmEpcE0zENWkci+bbP7U8=
-github.com/containers/libhvee v0.0.2/go.mod h1:bV1MfbuXk/ZLWHiWZpm8aePOR6iJGD1q55guYhH4CnA=
+github.com/containers/libhvee v0.0.4 h1:pt03gr9B0mhqg/pyzGHzQzRK1XVvFODWzwBQXNPY1SY=
+github.com/containers/libhvee v0.0.4/go.mod h1:AYsyMe44w9ylWWEZNW+IOzA7oZ2i/P9TChNljavhYMI=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/pkg/machine/hyperv/vsock.go
+++ b/pkg/machine/hyperv/vsock.go
@@ -239,7 +239,7 @@ func LoadHVSockRegistryEntry(port uint64) (*HVSockRegistryEntry, error) {
 	}, nil
 }
 
-// Listen s used on the windows side to listen for anything to come
+// Listen is used on the windows side to listen for anything to come
 // over the hvsock as a signal the vm is booted
 func (hv *HVSockRegistryEntry) Listen() error {
 	n := winio.HvsockAddr{

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -29,7 +29,7 @@ const (
 )
 
 // Convenience function to convert int to ptr
-func intToPtr(i int) *int {
+func IntToPtr(i int) *int {
 	return &i
 }
 
@@ -43,11 +43,11 @@ func BoolToPtr(b bool) *bool {
 	return &b
 }
 
-func getNodeUsr(usrName string) NodeUser {
+func GetNodeUsr(usrName string) NodeUser {
 	return NodeUser{Name: &usrName}
 }
 
-func getNodeGrp(grpName string) NodeGroup {
+func GetNodeGrp(grpName string) NodeGroup {
 	return NodeGroup{Name: &grpName}
 }
 
@@ -84,7 +84,8 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 				Name:              ign.Name,
 				SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
 				// Set the UID of the core user inside the machine
-				UID: intToPtr(ign.UID),
+				UID:          IntToPtr(ign.UID),
+				PasswordHash: StrToPtr("$y$j9T$/us37H88.4.5WydimEMC3/$f0sz48KNYevw7RO8iT.9gjmqaUlpmhwfdk7nlTql8QB"),
 			},
 			{
 				Name:              "root",
@@ -117,10 +118,10 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 		}
 		tzLink := Link{
 			Node: Node{
-				Group:     getNodeGrp("root"),
+				Group:     GetNodeGrp("root"),
 				Path:      "/etc/localtime",
 				Overwrite: BoolToPtr(false),
-				User:      getNodeUsr("root"),
+				User:      GetNodeUsr("root"),
 			},
 			LinkEmbedded1: LinkEmbedded1{
 				Hard:   BoolToPtr(false),
@@ -240,11 +241,11 @@ func getDirs(usrName string) []Directory {
 	for i, d := range newDirs {
 		newDir := Directory{
 			Node: Node{
-				Group: getNodeGrp(usrName),
+				Group: GetNodeGrp(usrName),
 				Path:  d,
-				User:  getNodeUsr(usrName),
+				User:  GetNodeUsr(usrName),
 			},
-			DirectoryEmbedded1: DirectoryEmbedded1{Mode: intToPtr(0755)},
+			DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0755)},
 		}
 		dirs[i] = newDir
 	}
@@ -256,11 +257,11 @@ func getDirs(usrName string) []Directory {
 	// as a workaround.
 	dirs = append(dirs, Directory{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/containers/registries.conf.d",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
-		DirectoryEmbedded1: DirectoryEmbedded1{Mode: intToPtr(0755)},
+		DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0755)},
 	})
 
 	// The directory is used by envset-fwcfg.service
@@ -268,18 +269,18 @@ func getDirs(usrName string) []Directory {
 	// from a host
 	dirs = append(dirs, Directory{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/systemd/system.conf.d",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
-		DirectoryEmbedded1: DirectoryEmbedded1{Mode: intToPtr(0755)},
+		DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0755)},
 	}, Directory{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/environment.d",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
-		DirectoryEmbedded1: DirectoryEmbedded1{Mode: intToPtr(0755)},
+		DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0755)},
 	})
 
 	return dirs
@@ -312,16 +313,16 @@ Delegate=memory pids cpu io
 	// Add a fake systemd service to get the user socket rolling
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp(usrName),
+			Group: GetNodeGrp(usrName),
 			Path:  "/home/" + usrName + "/.config/systemd/user/linger-example.service",
-			User:  getNodeUsr(usrName),
+			User:  GetNodeUsr(usrName),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr(lingerExample),
+				Source: EncodeDataURLPtr(lingerExample),
 			},
-			Mode: intToPtr(0744),
+			Mode: IntToPtr(0744),
 		},
 	})
 
@@ -329,16 +330,16 @@ Delegate=memory pids cpu io
 	// by default
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp(usrName),
+			Group: GetNodeGrp(usrName),
 			Path:  "/home/" + usrName + "/.config/containers/containers.conf",
-			User:  getNodeUsr(usrName),
+			User:  GetNodeUsr(usrName),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr(containers),
+				Source: EncodeDataURLPtr(containers),
 			},
-			Mode: intToPtr(0744),
+			Mode: IntToPtr(0744),
 		},
 	})
 
@@ -346,17 +347,17 @@ Delegate=memory pids cpu io
 	for _, sub := range []string{"/etc/subuid", "/etc/subgid"} {
 		files = append(files, File{
 			Node: Node{
-				Group:     getNodeGrp("root"),
+				Group:     GetNodeGrp("root"),
 				Path:      sub,
-				User:      getNodeUsr("root"),
+				User:      GetNodeUsr("root"),
 				Overwrite: BoolToPtr(true),
 			},
 			FileEmbedded1: FileEmbedded1{
 				Append: nil,
 				Contents: Resource{
-					Source: encodeDataURLPtr(fmt.Sprintf(subUID, usrName)),
+					Source: EncodeDataURLPtr(fmt.Sprintf(subUID, usrName)),
 				},
-				Mode: intToPtr(0744),
+				Mode: IntToPtr(0744),
 			},
 		})
 	}
@@ -365,59 +366,59 @@ Delegate=memory pids cpu io
 	// by default
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/systemd/system/user@.service.d/delegate.conf",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr(delegateConf),
+				Source: EncodeDataURLPtr(delegateConf),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	})
 
 	// Add a file into linger
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp(usrName),
+			Group: GetNodeGrp(usrName),
 			Path:  "/var/lib/systemd/linger/core",
-			User:  getNodeUsr(usrName),
+			User:  GetNodeUsr(usrName),
 		},
-		FileEmbedded1: FileEmbedded1{Mode: intToPtr(0644)},
+		FileEmbedded1: FileEmbedded1{Mode: IntToPtr(0644)},
 	})
 
 	// Set deprecated machine_enabled to true to indicate we're in a VM
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/containers/containers.conf",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr(rootContainers),
+				Source: EncodeDataURLPtr(rootContainers),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	})
 
 	// Set machine marker file to indicate podman is in a qemu based machine
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/containers/podman-machine",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
 				// TODO this should be fixed for all vmtypes
-				Source: encodeDataURLPtr("qemu\n"),
+				Source: EncodeDataURLPtr("qemu\n"),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	})
 
@@ -428,16 +429,16 @@ Delegate=memory pids cpu io
 	// as a workaround.
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/containers/registries.conf.d/999-podman-machine.conf",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr("unqualified-search-registries=[\"docker.io\"]\n"),
+				Source: EncodeDataURLPtr("unqualified-search-registries=[\"docker.io\"]\n"),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	})
 
@@ -450,9 +451,9 @@ Delegate=memory pids cpu io
 			// Create a symlink from the docker socket to the podman socket.
 			// Taken from https://github.com/containers/podman/blob/main/contrib/systemd/system/podman-docker.conf
 			Contents: Resource{
-				Source: encodeDataURLPtr("L+  /run/docker.sock   -    -    -     -   /run/podman/podman.sock\n"),
+				Source: EncodeDataURLPtr("L+  /run/docker.sock   -    -    -     -   /run/podman/podman.sock\n"),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	})
 
@@ -461,16 +462,16 @@ Delegate=memory pids cpu io
 
 	files = append(files, File{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/profile.d/docker-host.sh",
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr(setDockerHost),
+				Source: EncodeDataURLPtr(setDockerHost),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	})
 
@@ -507,13 +508,13 @@ Delegate=memory pids cpu io
 
 	files = append(files, File{
 		Node: Node{
-			User:  getNodeUsr("root"),
-			Group: getNodeGrp("root"),
+			User:  GetNodeUsr("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/chrony.conf",
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: []Resource{{
-				Source: encodeDataURLPtr("\nconfdir /etc/chrony.d\n"),
+				Source: EncodeDataURLPtr("\nconfdir /etc/chrony.d\n"),
 			}},
 		},
 	})
@@ -522,13 +523,13 @@ Delegate=memory pids cpu io
 	// far from NTP time.
 	files = append(files, File{
 		Node: Node{
-			User:  getNodeUsr("root"),
-			Group: getNodeGrp("root"),
+			User:  GetNodeUsr("root"),
+			Group: GetNodeGrp("root"),
 			Path:  "/etc/chrony.d/50-podman-makestep.conf",
 		},
 		FileEmbedded1: FileEmbedded1{
 			Contents: Resource{
-				Source: encodeDataURLPtr("makestep 1 -1\n"),
+				Source: EncodeDataURLPtr("makestep 1 -1\n"),
 			},
 		},
 	})
@@ -587,16 +588,16 @@ func prepareCertFile(path string, name string) (File, error) {
 
 	file := File{
 		Node: Node{
-			Group: getNodeGrp("root"),
+			Group: GetNodeGrp("root"),
 			Path:  targetPath,
-			User:  getNodeUsr("root"),
+			User:  GetNodeUsr("root"),
 		},
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: encodeDataURLPtr(string(b)),
+				Source: EncodeDataURLPtr(string(b)),
 			},
-			Mode: intToPtr(0644),
+			Mode: IntToPtr(0644),
 		},
 	}
 	return file, nil
@@ -615,9 +616,9 @@ func GetProxyVariables() map[string]string {
 func getLinks(usrName string) []Link {
 	return []Link{{
 		Node: Node{
-			Group: getNodeGrp(usrName),
+			Group: GetNodeGrp(usrName),
 			Path:  "/home/" + usrName + "/.config/systemd/user/default.target.wants/linger-example.service",
-			User:  getNodeUsr(usrName),
+			User:  GetNodeUsr(usrName),
 		},
 		LinkEmbedded1: LinkEmbedded1{
 			Hard:   BoolToPtr(false),
@@ -625,10 +626,10 @@ func getLinks(usrName string) []Link {
 		},
 	}, {
 		Node: Node{
-			Group:     getNodeGrp("root"),
+			Group:     GetNodeGrp("root"),
 			Path:      "/usr/local/bin/docker",
 			Overwrite: BoolToPtr(true),
-			User:      getNodeUsr("root"),
+			User:      GetNodeUsr("root"),
 		},
 		LinkEmbedded1: LinkEmbedded1{
 			Hard:   BoolToPtr(false),
@@ -637,6 +638,6 @@ func getLinks(usrName string) []Link {
 	}}
 }
 
-func encodeDataURLPtr(contents string) *string {
+func EncodeDataURLPtr(contents string) *string {
 	return StrToPtr(fmt.Sprintf("data:,%s", url.PathEscape(contents)))
 }

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1069,25 +1069,7 @@ func (v *MachineVM) SSH(_ string, opts machine.SSHOptions) error {
 		username = v.RemoteUsername
 	}
 
-	sshDestination := username + "@localhost"
-	port := strconv.Itoa(v.Port)
-
-	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination,
-		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
-	if len(opts.Args) > 0 {
-		args = append(args, opts.Args...)
-	} else {
-		fmt.Printf("Connecting to vm %s. To close connection, use `~.` or `exit`\n", v.Name)
-	}
-
-	cmd := exec.Command("ssh", args...)
-	logrus.Debugf("Executing: ssh %v\n", args)
-
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-
-	return cmd.Run()
+	return machine.CommonSSH(username, v.IdentityPath, v.Name, v.Port, opts.Args)
 }
 
 // executes qemu-image info to get the virtual disk size

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -1,0 +1,34 @@
+package machine
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CommonSSH is a common function for ssh'ing to a podman machine using system-connections
+// and a port
+func CommonSSH(username, identityPath, name string, sshPort int, inputArgs []string) error {
+	sshDestination := username + "@localhost"
+	port := strconv.Itoa(sshPort)
+
+	args := []string{"-i", identityPath, "-p", port, sshDestination,
+		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
+	if len(inputArgs) > 0 {
+		args = append(args, inputArgs...)
+	} else {
+		fmt.Printf("Connecting to vm %s. To close connection, use `~.` or `exit`\n", name)
+	}
+
+	cmd := exec.Command("ssh", args...)
+	logrus.Debugf("Executing: ssh %v\n", args)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	return cmd.Run()
+}

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
@@ -395,9 +395,6 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 
-	//if err := vmm.CreateVhdxFile(config.DiskPath, config.DiskSize*1024*1024*1024); err != nil {
-	//	return err
-	//}
 	if err := NewDriveSettingsBuilder(systemSettings).
 		AddScsiController().
 		AddSyntheticDiskDrive(0).
@@ -416,13 +413,15 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 	// Add default network connection
-	if err := NewNetworkSettingsBuilder(systemSettings).
-		AddSyntheticEthernetPort(nil).
-		AddEthernetPortAllocation(""). // "" = connect to default switch
-		Finish().                      // allocation
-		Finish().                      // port
-		Complete(); err != nil {
-		return err
+	if config.Network {
+		if err := NewNetworkSettingsBuilder(systemSettings).
+			AddSyntheticEthernetPort(nil).
+			AddEthernetPortAllocation(""). // "" = connect to default switch
+			Finish().                      // allocation
+			Finish().                      // port
+			Complete(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm_config.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm_config.go
@@ -98,6 +98,9 @@ type HardwareConfig struct {
 	DiskSize uint64
 	// Memory in megabytes assigned to the vm
 	Memory int32
+	// Network is bool to add a Network Connection to the
+	// default network switch in Microsoft HyperV
+	Network bool
 }
 
 type Statuses struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
-# github.com/containers/libhvee v0.0.2
+# github.com/containers/libhvee v0.0.4
 ## explicit; go 1.18
 github.com/containers/libhvee/pkg/hypervctl
 github.com/containers/libhvee/pkg/kvp/ginsu


### PR DESCRIPTION
podman machine with Microsoft HyperV will use hvsock on the guest and vsock on the guest for its networking.  this pr enables the basics for this to happen as well as changes to ignition to automatically set this up with network manager.

the vm binary referenced in this pr is in containers/gvisor-tap-vsock and will need to be added to distributions.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
