### PR TITLE
Makefile: include `release-artifacts` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -951,6 +951,24 @@ install.tools: .install.golangci-lint ## Install needed tools
 		$(PYTHON) -m pip install --user pre-commit; \
 	fi
 
+.PHONY: release-artifacts
+release-artifacts: clean-binaries
+	mkdir -p release/
+	$(MAKE) podman-remote-release-darwin_amd64.zip
+	mv podman-remote-release-darwin_amd64.zip release/
+	$(MAKE) podman-remote-release-darwin_arm64.zip
+	mv podman-remote-release-darwin_arm64.zip release/
+	$(MAKE) podman-remote-release-windows_amd64.zip
+	mv podman-remote-release-windows_amd64.zip release/
+	$(MAKE) podman-remote-static-linux_amd64
+	tar -cvzf podman-remote-static-linux_amd64.tar.gz bin/podman-remote-static-linux_amd64
+	$(MAKE) podman-remote-static-linux_arm64
+	tar -cvzf podman-remote-static-linux_arm64.tar.gz bin/podman-remote-static-linux_arm64
+	mv podman-remote-static-linux*.tar.gz release/
+	$(MAKE) podman.msi
+	mv podman-v*.msi release/
+	cd release/; sha256sum *.zip *.tar.gz *.msi > shasums
+
 .PHONY: uninstall
 uninstall:
 	for i in $(filter %.1,$(MANPAGES_DEST)); do \

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -241,16 +241,7 @@ spelled with complete minutiae.
 
       ```shell
       $ git checkout vX.Y.Z
-      $ make podman-remote-release-darwin_amd64.zip \
-          podman-remote-release-darwin_arm64.zip \
-          podman-remote-release-windows_amd64.zip \
-          podman-remote-static-linux_amd64 \
-          podman-remote-static-linux_arm64
-      $ mv podman-* bin/
-      $ cd bin/
-      $ tar -cvzf podman-remote-static-linux_amd64.tar.gz podman-remote-static-linux_amd64
-      $ tar -cvzf podman-remote-static-linux_arm64.tar.gz podman-remote-static-linux_arm64
-      $ sha256sum *.zip *.tar.gz > shasums
+      $ make release-artifacts
       ```
 
    1. The `podman-vX.Y.Z.dmg` file is produced manually by someone in
@@ -267,9 +258,7 @@ spelled with complete minutiae.
       the release.
    1. Near the bottom of the page there is a box with the message
       “Add binaries by dropping them here or selecting them”.  Use
-      that to upload the artifacts you previously downloaded, including
-      the `shasums` file.
-
+      that to upload the artifacts in the `release/` dir generated earlier:
       * podman-remote-release-darwin_amd64.zip
       * podman-remote-release-darwin_arm64.zip
       * podman-remote-release-windows_amd64.zip


### PR DESCRIPTION
The current release artifacts generation process is still fairly manual with a bunch of steps. This commit bundles them all into a single convenient Makefile target.

The `clean-binaries` target ends up removing `bin/`. So, the artifact dir has been changed to `release/` instead of the current `bin/` to avoid breaking other Makefile targets.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@mheon @ashley-cui PTAL
