### PR TITLE
HyperV: wait on stop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containers/common v0.52.1-0.20230411124844-19b624d9a20d
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.25.0
-	github.com/containers/libhvee v0.0.4
+	github.com/containers/libhvee v0.0.5-0.20230416212920-2fc1c8ec6819
 	github.com/containers/ocicrypt v1.1.7
 	github.com/containers/psgo v1.8.0
 	github.com/containers/storage v1.46.1

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.25.0 h1:TJ0unmalbU+scd0i3Txap2wjGsAnv06MSCwgn6bsizk=
 github.com/containers/image/v5 v5.25.0/go.mod h1:EKvys0WVlRFkDw26R8y52TuhV9Tfn0yq2luLX6W52Ls=
-github.com/containers/libhvee v0.0.4 h1:pt03gr9B0mhqg/pyzGHzQzRK1XVvFODWzwBQXNPY1SY=
-github.com/containers/libhvee v0.0.4/go.mod h1:AYsyMe44w9ylWWEZNW+IOzA7oZ2i/P9TChNljavhYMI=
+github.com/containers/libhvee v0.0.5-0.20230416212920-2fc1c8ec6819 h1:2/RoHew3DNdXshJghZpUJ1QAXVteG82Is+uzu5sb3bs=
+github.com/containers/libhvee v0.0.5-0.20230416212920-2fc1c8ec6819/go.mod h1:AYsyMe44w9ylWWEZNW+IOzA7oZ2i/P9TChNljavhYMI=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -107,6 +107,10 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 	// TODO This needs to be fixed in c-common
 	m.RemoteUsername = "core"
 
+	if m.UID == 0 {
+		m.UID = 1000
+	}
+
 	sshPort, err := utils.GetRandomPort()
 	if err != nil {
 		return false, err
@@ -166,10 +170,6 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 	}
 	if err := os.WriteFile(m.ConfigPath.GetPath(), b, 0644); err != nil {
 		return false, err
-	}
-
-	if m.UID == 0 {
-		m.UID = 1000
 	}
 
 	// c/common sets the default machine user for "windows" to be "user"; this

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -84,8 +84,7 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 				Name:              ign.Name,
 				SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
 				// Set the UID of the core user inside the machine
-				UID:          IntToPtr(ign.UID),
-				PasswordHash: StrToPtr("$y$j9T$/us37H88.4.5WydimEMC3/$f0sz48KNYevw7RO8iT.9gjmqaUlpmhwfdk7nlTql8QB"),
+				UID: IntToPtr(ign.UID),
 			},
 			{
 				Name:              "root",

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
@@ -239,6 +239,17 @@ func (vm *VirtualMachine) Stop() error {
 		return translateShutdownError(int(res))
 	}
 
+	// Wait for vm to actually *be* down
+	for i := 0; i < 25; i++ {
+		refreshVM, err := vm.vmm.GetMachine(vm.ElementName)
+		if err != nil {
+			return err
+		}
+		if refreshVM.State() == Disabled {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,7 +251,7 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
-# github.com/containers/libhvee v0.0.4
+# github.com/containers/libhvee v0.0.5-0.20230416212920-2fc1c8ec6819
 ## explicit; go 1.18
 github.com/containers/libhvee/pkg/hypervctl
 github.com/containers/libhvee/pkg/kvp/ginsu


### PR DESCRIPTION
When using podman machine with hyperv, stop was releasing the terminal back top the user prematurely.  This resulted in users being able to run subsequent commands while the vm was still stopped.  Commands like machine stop were prone to failing.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
