### PR TITLE
e2e: quadlet uses PODMAN env for podman binary path

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -548,8 +548,17 @@ func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegrat
 func (p *PodmanTestIntegration) Quadlet(args []string, sourceDir string) *PodmanSessionIntegration {
 	fmt.Printf("Running: %s %s with QUADLET_UNIT_DIRS=%s\n", p.QuadletBinary, strings.Join(args, " "), sourceDir)
 
+	// quadlet uses PODMAN env to get a stable podman path
+	podmanPath, found := os.LookupEnv("PODMAN")
+	if !found {
+		podmanPath = p.PodmanBinary
+	}
+
 	command := exec.Command(p.QuadletBinary, args...)
-	command.Env = []string{fmt.Sprintf("QUADLET_UNIT_DIRS=%s", sourceDir)}
+	command.Env = []string{
+		fmt.Sprintf("QUADLET_UNIT_DIRS=%s", sourceDir),
+		fmt.Sprintf("PODMAN=%s", podmanPath),
+	}
 	session, err := Start(command, GinkgoWriter, GinkgoWriter)
 	if err != nil {
 		Fail("unable to run quadlet command: " + strings.Join(args, " "))

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -459,6 +459,12 @@ var _ = Describe("quadlet system generator", func() {
 			fileName := "basic.kube"
 			testcase := loadQuadletTestcase(filepath.Join("quadlet", fileName))
 
+			// quadlet uses PODMAN env to get a stable podman path
+			podmanPath, found := os.LookupEnv("PODMAN")
+			if !found {
+				podmanPath = podmanTest.PodmanBinary
+			}
+
 			// Write the tested file to the quadlet dir
 			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0644)
 			Expect(err).ToNot(HaveOccurred())
@@ -495,8 +501,8 @@ var _ = Describe("quadlet system generator", func() {
 				"Type=notify",
 				"NotifyAccess=all",
 				"SyslogIdentifier=%N",
-				fmt.Sprintf("ExecStart=/usr/local/bin/podman kube play --replace --service-container=true %s/deployment.yml", quadletDir),
-				fmt.Sprintf("ExecStop=/usr/local/bin/podman kube down %s/deployment.yml", quadletDir),
+				fmt.Sprintf("ExecStart=%s kube play --replace --service-container=true %s/deployment.yml", podmanPath, quadletDir),
+				fmt.Sprintf("ExecStop=%s kube down %s/deployment.yml", podmanPath, quadletDir),
 			}
 
 			Expect(expected).To(Equal(current))


### PR DESCRIPTION
Adapts to pass the test even if
podman binary path is not `/usr/local/bin/podman`.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
