### PR TITLE
libpod: configureNetNS() tear down on errors

### DIFF
--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -115,7 +115,7 @@ func (r *Runtime) teardownNetworkBackend(ns string, opts types.NetworkOptions) e
 		// execute the network setup in the rootless net ns
 		err = rootlessNetNS.Do(tearDownPod)
 		if cerr := rootlessNetNS.Cleanup(r); cerr != nil {
-			logrus.WithError(err).Error("failed to clean up rootless netns")
+			logrus.WithError(cerr).Error("failed to clean up rootless netns")
 		}
 		rootlessNetNS.Lock.Unlock()
 	} else {

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -592,6 +592,14 @@ func (r *Runtime) configureNetNS(ctr *Container, ctrNS string) (status map[strin
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		// do not forget to tear down the netns when a later error happened.
+		if rerr != nil {
+			if err := r.teardownNetworkBackend(ctrNS, netOpts); err != nil {
+				logrus.Warnf("failed to teardown network after failed setup: %v", err)
+			}
+		}
+	}()
 
 	// set up rootless port forwarder when rootless with ports and the network status is empty,
 	// if this is called from network reload the network status will not be empty and we should


### PR DESCRIPTION
Make sure to tear down the netns again on errors. This is needed when a
later call fails and we do not have already stored the netns in the
container state.

Fixes #18205

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Correctly tear down the network stack again when an error happened during the setup.
```
