### PR TITLE
[v3.0.1-rhel] Fix attempt to use incompatible go tools

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -241,28 +241,6 @@ bindings_task:
     always: *runner_stats
 
 
-# Check that all included go modules from other sources match
-# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
-# make sure that the generated bindings in pkg/bindings/...
-# are in sync with the code.
-consistency_task:
-    name: "Test Code Consistency"
-    alias: consistency
-    skip: *tags
-    depends_on:
-        - build
-    container: *smallcontainer
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: consistency
-        TEST_ENVIRON: container
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    clone_script: *full_clone  # build-cache not available to container tasks
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
 # There are several other important variations of podman which
 # must always build successfully.  Most of them are handled in
 # this task, though a few need dedicated tasks which follow.
@@ -503,7 +481,6 @@ success_task:
         - build
         - validate
         - bindings
-        - consistency
         - alt_build
         - unit_test
         - local_integration_test

--- a/Makefile
+++ b/Makefile
@@ -577,18 +577,12 @@ uninstall:
 	rm -f ${DESTDIR}${USERSYSTEMDDIR}/podman.service
 
 .PHONY: install.tools
-install.tools: .install.goimports .install.md2man .install.ginkgo .install.golangci-lint .install.bats ## Install needed tools
+install.tools: .install.md2man .install.ginkgo .install.golangci-lint .install.bats ## Install needed tools
 
 define go-get
 	env GO111MODULE=off \
 		$(GO) get -u ${1}
 endef
-
-.install.goimports: .gopathok
-	if [ ! -x "$(GOBIN)/goimports" ]; then \
-		$(call go-get,golang.org/x/tools/cmd/goimports); \
-	fi
-	touch .install.goimports
 
 .PHONY: .install.ginkgo
 .install.ginkgo: .gopathok

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -133,13 +133,6 @@ function _run_swagger() {
     cp -v $GOSRC/pkg/api/swagger.yaml $GOSRC/
 }
 
-function _run_consistency() {
-    make vendor
-    SUGGESTION="run 'make vendor' and commit all changes" ./hack/tree_status.sh
-    make generate-bindings
-    SUGGESTION="run 'make generate-bindings' and commit all changes" ./hack/tree_status.sh
-}
-
 function _run_build() {
     # Ensure always start from clean-slate with all vendor modules downloaded
     make clean

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -213,7 +213,6 @@ case "$TEST_FLAVOR" in
 
         install_test_configs
         ;;
-    consistency) make clean ;;
     release) ;;
     *) die_unknown TEST_FLAVOR
 esac

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -125,13 +125,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json list tags", func() {
-		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Equal(0))
 		Expect(search.IsJSONOutputValid()).To(BeTrue())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
-		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
-		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
+		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.2"))
 	})
 
 	It("podman search no-trunc flag", func() {


### PR DESCRIPTION
Change breaks on this branch which depends on an older toolchain:

https://cs.opensource.google/go/x/tools/+/master:internal/gocommand/invoke.go;bpv=1;bpt=0;drc=866a2000920cc5ae9d6650c27c4b14f4654938e7;dlc=5214f412aecffbca887fc0c26f8d59e3a2342d44

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
