### PR TITLE
e2e: skip journald test if journald is unavailable

### DIFF
--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 	})
 
 	It("using journald for container with container log_tag", func() {
-		SkipIfInContainer("journalctl inside a container doesn't work correctly")
+		SkipIfJournaldUnavailable()
 		os.Setenv("CONTAINERS_CONF", "config/containers-journald.conf")
 		if IsRemote() {
 			podmanTest.RestartRemoteService()

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -44,7 +44,6 @@ var _ = Describe("Podman logs", func() {
 		podmanTest.Cleanup()
 		f := CurrentGinkgoTestDescription()
 		processTestResult(f)
-
 	})
 
 	It("podman logs on not existent container", func() {
@@ -60,7 +59,7 @@ var _ = Describe("Podman logs", func() {
 
 		skipIfJournaldInContainer := func() {
 			if log == "journald" {
-				SkipIfInContainer("journalctl inside a container doesn't work correctly")
+				SkipIfJournaldUnavailable()
 			}
 		}
 
@@ -513,7 +512,7 @@ var _ = Describe("Podman logs", func() {
 	}
 
 	It("using journald for container with container tag", func() {
-		SkipIfInContainer("journalctl inside a container doesn't work correctly")
+		SkipIfJournaldUnavailable()
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "--log-opt=tag={{.ImageName}}", "-d", ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
 		Expect(logc).To(Exit(0))
@@ -530,7 +529,7 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("using journald container name", func() {
-		SkipIfInContainer("journalctl inside a container doesn't work correctly")
+		SkipIfJournaldUnavailable()
 		containerName := "inside-journal"
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-d", "--name", containerName, ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
@@ -560,7 +559,6 @@ var _ = Describe("Podman logs", func() {
 
 	It("podman pod logs with container names", func() {
 		SkipIfRemote("Remote can only process one container at a time")
-		SkipIfInContainer("journalctl inside a container doesn't work correctly")
 		podName := "testPod"
 		containerName1 := "container1"
 		containerName2 := "container2"
@@ -588,7 +586,6 @@ var _ = Describe("Podman logs", func() {
 	})
 	It("podman pod logs with different colors", func() {
 		SkipIfRemote("Remote can only process one container at a time")
-		SkipIfInContainer("journalctl inside a container doesn't work correctly")
 		podName := "testPod"
 		containerName1 := "container1"
 		containerName2 := "container2"


### PR DESCRIPTION
If journald is unavailable, journald logging driver tests should be skipped.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
