### PR TITLE
compat: Translate `noprune` into ImageRemoveOptions.NoPrune

### DIFF
--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -29,11 +29,6 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
-	if _, found := r.URL.Query()["noprune"]; found {
-		if query.NoPrune {
-			utils.UnSupportedParameter("noprune")
-		}
-	}
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
@@ -44,7 +39,8 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
 	options := entities.ImageRemoveOptions{
-		Force: query.Force,
+		Force:   query.Force,
+		NoPrune: query.NoPrune,
 	}
 	report, rmerrors := imageEngine.Remove(r.Context(), []string{possiblyNormalizedName}, options)
 	if len(rmerrors) > 0 && rmerrors[0] != nil {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -229,7 +229,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: noprune
 	//    type: boolean
-	//    description: not supported. will be logged as an invalid parameter if enabled
+	//    description: do not remove dangling parent images
 	// produces:
 	//  - application/json
 	// responses:

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -266,4 +266,34 @@ t GET "libpod/events?stream=false&since=$START"  200  \
 t GET "events?stream=false&since=$START"  200  \
   'select(.status | contains("delete")).Action=delete'
 
+# Test image removal with `noprune={true,false}`
+podman create --name c_test1 $IMAGE true
+podman commit -q c_test1 i_test1
+podman create --name c_test2 i_test1 true
+podman commit -q c_test2 i_test2
+podman create --name c_test3 i_test2 true
+podman commit -q c_test3 i_test3
+
+t GET libpod/images/i_test1/json 200
+iid_test1=$(jq -r '.Id' <<<"$output")
+t GET libpod/images/i_test2/json 200
+iid_test2=$(jq -r '.Id' <<<"$output")
+t GET libpod/images/i_test3/json 200
+iid_test3=$(jq -r '.Id' <<<"$output")
+
+podman untag $iid_test1
+podman untag $iid_test2
+
+podman rm -af
+
+# Deleting i_test3 with --no-prune must not remove _2 and _1.
+t DELETE images/$iid_test3?noprune=true  200
+t GET libpod/images/i_test3/exists    404
+t GET libpod/images/$iid_test1/exists 204
+t GET libpod/images/$iid_test2/exists 204
+
+t DELETE images/$iid_test2?noprune=false 200
+t GET libpod/images/$iid_test1/exists 404
+t GET libpod/images/$iid_test2/exists 404
+
 # vim: filetype=sh


### PR DESCRIPTION
PR #15093 implemented support for NoPrune in the ImageRemoveOptions, this PR simply brings that also to the compat API along with regression tests.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for the `noprune` image-removal parameter in the compat API.
```

Replaces #18004. @ankon @mheon @Luap99 PTAL
