### PR TITLE
e2e: fix logs tests about an error message

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -305,7 +305,11 @@ var _ = Describe("Podman logs", func() {
 			if log == "journald" && !isEventBackendJournald(podmanTest) {
 				// --follow + journald log-driver is only supported with journald events-backend(PR #10431)
 				Expect(results).To(Exit(125))
-				Expect(results.ErrorToString()).To(ContainSubstring("using --follow with the journald --log-driver but without the journald --events-backend"))
+				err := "using --follow with the journald --log-driver but without the journald --events-backend"
+				if IsRemote() {
+					err = "lost synchronization with multiplexed"
+				}
+				Expect(results.ErrorToString()).To(ContainSubstring(err))
 				return
 			}
 
@@ -345,6 +349,11 @@ var _ = Describe("Podman logs", func() {
 			if log == "journald" && !isEventBackendJournald(podmanTest) {
 				// --follow + journald log-driver is only supported with journald events-backend(PR #10431)
 				Expect(results).To(Exit(125))
+				err := "using --follow with the journald --log-driver but without the journald --events-backend"
+				if IsRemote() {
+					err = "lost synchronization with multiplexed"
+				}
+				Expect(results.ErrorToString()).To(ContainSubstring(err))
 				return
 			}
 			Expect(results).To(Exit(0))


### PR DESCRIPTION
When `events_logger` is `file` or `none`, podman outputs an error message such as following:

- local environment
`using --follow with the journald --log-driver bug without the journald --events-backend`

- remote environment
`Error: channel "123" found, 0-3 supported: lost synchronization with multiplexed stream`

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

---

<details>
<summary>NG log (remote, events_logger = file)</summary>

```
~ Failure [0.652 seconds]
Podman logs
/root/podman/test/e2e/logs_test.go:27
  streaming output: journald [It]
  /root/podman/test/e2e/logs_test.go:293

  Expected
      <string>: Error: channel "123" found, 0-3 supported: lost synchronization with multiplexed stream
  to contain substring
      <string>: using --follow with the journald --log-driver but without the journald --events-backend
```
</details>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
