### PR TITLE
test/e2e: use custom network config v2

### DIFF
--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -228,6 +228,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune pods", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -162,6 +162,7 @@ var _ = Describe("Podman volume prune", func() {
 	})
 
 	It("podman system prune --volume", func() {
+		useCustomNetworkDir(podmanTest, tempdir)
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
Adds two custom config dirs to tests that were missed in commit dc9a65e348.

Fixes #17946 (hopefully finally)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
