### PR TITLE
Several e2e fixes

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -211,16 +211,10 @@ var _ = Describe("Podman build", func() {
 		Expect(os.Chdir(os.TempDir())).To(Succeed())
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
-		// Write target and fake files
-		targetPath, err := CreateTempDirInTempDir()
-		if err != nil {
-			os.Exit(1)
-		}
-
 		fakeFile := filepath.Join(os.TempDir(), "Containerfile")
 		Expect(os.WriteFile(fakeFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(Succeed())
 
-		targetFile := filepath.Join(targetPath, "Containerfile")
+		targetFile := filepath.Join(podmanTest.TempDir, "Containerfile")
 		Expect(os.WriteFile(targetFile, []byte("FROM scratch"), 0755)).To(Succeed())
 
 		defer func() {
@@ -247,11 +241,7 @@ var _ = Describe("Podman build", func() {
 		Expect(os.Chdir(os.TempDir())).To(Succeed())
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
-		targetPath, err := CreateTempDirInTempDir()
-		if err != nil {
-			os.Exit(1)
-		}
-		targetFile := filepath.Join(targetPath, "idFile")
+		targetFile := filepath.Join(podmanTest.TempDir, "idFile")
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "build/basicalpine", "--iidfile", targetFile})
 		session.WaitWithDefaultTimeout()
@@ -431,8 +421,7 @@ COPY /* /dir`, ALPINE)
 		podmanTest.AddImageToRWStore(ALPINE)
 
 		// Write target and fake files
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
+		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
 		err = os.Mkdir(targetSubPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -450,7 +439,6 @@ RUN find /test`, ALPINE)
 
 		defer func() {
 			Expect(os.Chdir(cwd)).To(Succeed())
-			Expect(os.RemoveAll(targetPath)).To(Succeed())
 		}()
 
 		// make cwd as context root path
@@ -504,8 +492,7 @@ RUN find /test`, ALPINE)
 		podmanTest.AddImageToRWStore(ALPINE)
 
 		// Write target and fake files
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
+		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
 		err = os.Mkdir(targetSubPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -518,7 +505,6 @@ RUN find /test`, ALPINE)
 
 		defer func() {
 			Expect(os.Chdir(cwd)).To(Succeed())
-			Expect(os.RemoveAll(targetPath)).To(Succeed())
 		}()
 
 		// make cwd as context root path
@@ -544,7 +530,8 @@ RUN find /test`, ALPINE)
 		podmanTest.AddImageToRWStore(ALPINE)
 
 		// Write target and fake files
-		targetPath, err := CreateTempDirInTempDir()
+		targetPath := filepath.Join(podmanTest.TempDir, "build")
+		err = os.Mkdir(targetPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		containerfile := fmt.Sprintf(`FROM %s
@@ -616,9 +603,9 @@ subdir**`
 		containerfile := filepath.Join(tempdir, "Containerfile")
 		Expect(os.WriteFile(containerfile, contents.Bytes(), 0644)).ToNot(HaveOccurred())
 
-		contextDir, err := CreateTempDirInTempDir()
+		contextDir := filepath.Join(podmanTest.TempDir, "context")
+		err = os.MkdirAll(contextDir, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
-		defer os.RemoveAll(contextDir)
 
 		Expect(os.WriteFile(filepath.Join(contextDir, "expected"), contents.Bytes(), 0644)).
 			ToNot(HaveOccurred())
@@ -665,8 +652,7 @@ subdir**`
 		podmanTest.AddImageToRWStore(ALPINE)
 
 		// Write target and fake files
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
+		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
 		err = os.Mkdir(targetSubPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -691,7 +677,6 @@ RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, ALPINE)
 
 		defer func() {
 			Expect(os.Chdir(cwd)).To(Succeed())
-			Expect(os.RemoveAll(targetPath)).To(Succeed())
 		}()
 
 		// make cwd as context root path
@@ -707,8 +692,7 @@ RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, ALPINE)
 	})
 
 	It("podman build --from, --add-host, --cap-drop, --cap-add", func() {
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
+		targetPath := podmanTest.TempDir
 
 		containerFile := filepath.Join(targetPath, "Containerfile")
 		content := `FROM scratch
@@ -738,9 +722,7 @@ RUN grep CapEff /proc/self/status`
 	})
 
 	It("podman build --isolation && --arch", func() {
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
-
+		targetPath := podmanTest.TempDir
 		containerFile := filepath.Join(targetPath, "Containerfile")
 		Expect(os.WriteFile(containerFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(Succeed())
 
@@ -798,8 +780,7 @@ RUN echo hello`, ALPINE)
 	})
 
 	It("podman build --log-rusage", func() {
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
+		targetPath := podmanTest.TempDir
 
 		containerFile := filepath.Join(targetPath, "Containerfile")
 		content := `FROM scratch`

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -411,6 +411,7 @@ COPY /* /dir`, ALPINE)
 		containerfilePath := filepath.Join(cwd, "ContainerfilePathToCopier")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
+		defer os.Remove(containerfilePath)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "-f", "ContainerfilePathToCopier", targetSubPath})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1327,6 +1327,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
+		defer os.Remove(fileName)
 
 		result := podmanTest.Podman([]string{
 			"container",
@@ -1343,8 +1344,9 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
 		// Extract checkpoint archive
-		destinationDirectory, err := CreateTempDirInTempDir()
-		Expect(err).ShouldNot(HaveOccurred())
+		destinationDirectory := filepath.Join(podmanTest.TempDir, "dest")
+		err = os.MkdirAll(destinationDirectory, os.ModePerm)
+		Expect(err).ToNot(HaveOccurred())
 
 		tarsession := SystemExec(
 			"tar",
@@ -1359,11 +1361,6 @@ var _ = Describe("Podman checkpoint", func() {
 
 		_, err = os.Stat(filepath.Join(destinationDirectory, stats.StatsDump))
 		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(os.RemoveAll(destinationDirectory)).To(Succeed())
-
-		// Remove exported checkpoint
-		os.Remove(fileName)
 	})
 
 	It("podman checkpoint and restore containers with --print-stats", func() {

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -270,12 +270,8 @@ var _ = Describe("Podman commit", func() {
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os.Chdir(os.TempDir())).To(Succeed())
-		targetPath, err := CreateTempDirInTempDir()
-		if err != nil {
-			os.Exit(1)
-		}
+		targetPath := podmanTest.TempDir
 		targetFile := filepath.Join(targetPath, "idFile")
-		defer Expect(os.RemoveAll(targetFile)).To(BeNil())
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
 		_, ec, _ := podmanTest.RunLsContainer("test1")

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -820,19 +820,14 @@ func SkipIfInContainer(reason string) {
 func SkipIfNotActive(unit string, reason string) {
 	checkReason(reason)
 
-	var buffer bytes.Buffer
 	cmd := exec.Command("systemctl", "is-active", unit)
-	cmd.Stdout = &buffer
-	err := cmd.Start()
-	Expect(err).ToNot(HaveOccurred())
-
-	err = cmd.Wait()
-	Expect(err).ToNot(HaveOccurred())
-
-	Expect(err).ToNot(HaveOccurred())
-	if strings.TrimSpace(buffer.String()) != "active" {
-		Skip(fmt.Sprintf("[systemd]: unit %s is not active: %s", unit, reason))
+	cmd.Stdout = GinkgoWriter
+	cmd.Stderr = GinkgoWriter
+	err := cmd.Run()
+	if cmd.ProcessState.ExitCode() == 0 {
+		return
 	}
+	Skip(fmt.Sprintf("[systemd]: unit %s is not active (%v): %s", unit, err, reason))
 }
 
 func SkipIfCNI(p *PodmanTestIntegration) {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -1072,9 +1072,7 @@ var _ = Describe("Podman kube generate", func() {
 		containerfile := `FROM quay.io/libpod/alpine:latest
 ENTRYPOINT ["sleep"]`
 
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
-		containerfilePath := filepath.Join(targetPath, "Containerfile")
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1126,9 +1124,7 @@ ENTRYPOINT ["sleep"]`
 		containerfile := `FROM quay.io/libpod/alpine:latest
 USER 1000`
 
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
-		containerfilePath := filepath.Join(targetPath, "Containerfile")
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1197,9 +1193,7 @@ USER 1000`
 RUN adduser -u 10001 -S test1
 USER test1`
 
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
-		containerfilePath := filepath.Join(targetPath, "Containerfile")
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -297,20 +297,17 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		podmanTest.AddImageToRWStore(ALPINE)
 		// Write target and fake files
-		targetPath, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
 		containerfile := fmt.Sprintf(`FROM %s
 HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
-		containerfilePath := filepath.Join(targetPath, "Containerfile")
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			Expect(os.Chdir(cwd)).To(Succeed())
-			Expect(os.RemoveAll(targetPath)).To(Succeed())
 		}()
 
 		// make cwd as context root path
-		Expect(os.Chdir(targetPath)).To(Succeed())
+		Expect(os.Chdir(podmanTest.TempDir)).To(Succeed())
 
 		session := podmanTest.Podman([]string{"build", "--format", "docker", "-t", "test", "."})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -134,8 +134,8 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 // MakeOptions assembles all the podman main options
 func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 	networkDir := p.NetworkConfigDir
-	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s --db-backend %s",
-		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.NetworkBackend.ToString(), p.CgroupManager, p.DatabaseBackend), " ")
+	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s --tmpdir %s --events-backend %s --db-backend %s",
+		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.NetworkBackend.ToString(), p.CgroupManager, p.TmpDir, "file", p.DatabaseBackend), " ")
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	podmanOptions = append(podmanOptions, args...)
 	return podmanOptions

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman network create with ipv4 subnet and ipv6 flag", func() {
 		name := stringid.GenerateRandomID()
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ipv6", name})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.14.0/24", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
 		defer podmanTest.removeNetwork(name)
@@ -220,7 +220,7 @@ var _ = Describe("Podman network create", func() {
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
 		Expect(nc.OutputToString()).To(ContainSubstring(`::/64`))
-		Expect(nc.OutputToString()).To(ContainSubstring(`10.11.12.0/24`))
+		Expect(nc.OutputToString()).To(ContainSubstring(`10.11.14.0/24`))
 	})
 
 	It("podman network create with empty subnet and ipv6 flag", func() {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/containers/common/libnetwork/types"
@@ -39,9 +40,7 @@ var _ = Describe("Podman network", func() {
 
 	It("podman --cni-config-dir backwards compat", func() {
 		SkipIfRemote("--cni-config-dir only works locally")
-		netDir, err := CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
-		defer os.RemoveAll(netDir)
+		netDir := filepath.Join(podmanTest.TempDir, "networks123")
 		session := podmanTest.Podman([]string{"--cni-config-dir", netDir, "network", "ls", "--noheading"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2933,8 +2933,6 @@ spec:
 		Expect(c).Should(Exit(0))
 
 		conffile := filepath.Join(podmanTest.TempDir, "kube.yaml")
-		tempdir, err = CreateTempDirInTempDir()
-		Expect(err).ToNot(HaveOccurred())
 
 		err := os.WriteFile(conffile, []byte(testyaml), 0755)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -304,11 +304,8 @@ var _ = Describe("Podman pod create", func() {
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os.Chdir(os.TempDir())).To(Succeed())
-		targetPath, err := CreateTempDirInTempDir()
-		if err != nil {
-			os.Exit(1)
-		}
-		targetFile := filepath.Join(targetPath, "idFile")
+
+		targetFile := filepath.Join(podmanTest.TempDir, "idFile")
 		defer Expect(os.RemoveAll(targetFile)).To(BeNil())
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -342,6 +342,7 @@ var _ = Describe("Podman push", func() {
 
 	It("podman push to docker daemon", func() {
 		SkipIfRemote("Remote push does not support docker-daemon transport")
+		SkipIfRootless("rootless user has no permission to use default docker.sock")
 		setup := SystemExec("bash", []string{"-c", "systemctl status docker 2>&1"})
 
 		if setup.LineInOutputContains("Active: inactive") {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -676,13 +676,9 @@ VOLUME /test/`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		// Test overlay mount when lowerdir is relative path.
-		f, err = os.Create("hello")
-		Expect(err).ToNot(HaveOccurred(), "os.Create")
-		f.Close()
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", ".:/app:O", ALPINE, "ls", "/app"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.OutputToString()).To(ContainSubstring("hello"))
+		Expect(session.OutputToString()).To(ContainSubstring(filepath.Base(CurrentGinkgoTestDescription().FileName)))
 		Expect(session).Should(Exit(0))
 
 		// Make sure modifications in container do not show up on host

--- a/test/e2e/run_working_dir_test.go
+++ b/test/e2e/run_working_dir_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -47,7 +48,8 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run a container using a --workdir under a bind mount", func() {
-		volume, err := CreateTempDirInTempDir()
+		volume := filepath.Join(podmanTest.TempDir, "vol")
+		err = os.MkdirAll(volume, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--volume", fmt.Sprintf("%s:/var_ovl/:O", volume), "--workdir", "/var_ovl/log", ALPINE, "true"})


### PR DESCRIPTION

Split out some fixes from #18163 that can be merged without ginkgo v2.
this should make review easier.  Please see the individual commits for details.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
