### PR TITLE
support `--digestfile` for remote push

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -25,6 +25,7 @@ type manifestPushOptsWrapper struct {
 	CredentialsCLI             string
 	SignBySigstoreParamFileCLI string
 	SignPassphraseFileCLI      string
+	DigestFile                 string
 }
 
 var (

--- a/docs/source/markdown/options/digestfile.md
+++ b/docs/source/markdown/options/digestfile.md
@@ -5,4 +5,3 @@
 #### **--digestfile**=*Digestfile*
 
 After copying the image, write the digest of the resulting image to the file.
-(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -122,18 +122,18 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(true)
 	for {
-		var report entities.ImagePushReport
+		var stream entities.ImagePushStream
 		select {
 		case s := <-writer.Chan():
-			report.Stream = string(s)
-			if err := enc.Encode(report); err != nil {
+			stream.Stream = string(s)
+			if err := enc.Encode(stream); err != nil {
 				logrus.Warnf("Failed to encode json: %v", err)
 			}
 			flush()
 		case <-pushCtx.Done():
 			if pushError != nil {
-				report.Error = pushError.Error()
-				if err := enc.Encode(report); err != nil {
+				stream.Error = pushError.Error()
+				if err := enc.Encode(stream); err != nil {
 					logrus.Warnf("Failed to encode json: %v", err)
 				}
 			}

--- a/pkg/bindings/images/push.go
+++ b/pkg/bindings/images/push.go
@@ -69,7 +69,7 @@ func Push(ctx context.Context, source string, destination string, options *PushO
 	dec := json.NewDecoder(response.Body)
 LOOP:
 	for {
-		var report entities.ImagePushReport
+		var report entities.ImagePushStream
 		if err := dec.Decode(&report); err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/pkg/bindings/images/push.go
+++ b/pkg/bindings/images/push.go
@@ -87,6 +87,8 @@ LOOP:
 		switch {
 		case report.Stream != "":
 			fmt.Fprint(writer, report.Stream)
+		case report.ManifestDigest != "":
+			options.ManifestDigest = &report.ManifestDigest
 		case report.Error != "":
 			// There can only be one error.
 			return errors.New(report.Error)

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -158,6 +158,9 @@ type PushOptions struct {
 	Username *string `schema:"-"`
 	// Quiet can be specified to suppress progress when pushing.
 	Quiet *bool
+
+	// Manifest of the pushed image.  Set by images.Push.
+	ManifestDigest *string
 }
 
 // SearchOptions are optional options for searching images on registries

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -182,3 +182,18 @@ func (o *PushOptions) GetQuiet() bool {
 	}
 	return *o.Quiet
 }
+
+// WithManifestDigest set field ManifestDigest to given value
+func (o *PushOptions) WithManifestDigest(value string) *PushOptions {
+	o.ManifestDigest = &value
+	return o
+}
+
+// GetManifestDigest returns value of field ManifestDigest
+func (o *PushOptions) GetManifestDigest() string {
+	if o.ManifestDigest == nil {
+		var z string
+		return z
+	}
+	return *o.ManifestDigest
+}

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -20,7 +20,7 @@ type ImageEngine interface { //nolint:interfacebloat
 	Mount(ctx context.Context, images []string, options ImageMountOptions) ([]*ImageMountReport, error)
 	Prune(ctx context.Context, opts ImagePruneOptions) ([]*reports.PruneReport, error)
 	Pull(ctx context.Context, rawImage string, opts ImagePullOptions) (*ImagePullReport, error)
-	Push(ctx context.Context, source string, destination string, opts ImagePushOptions) error
+	Push(ctx context.Context, source string, destination string, opts ImagePushOptions) (*ImagePushReport, error)
 	Remove(ctx context.Context, images []string, opts ImageRemoveOptions) (*ImageRemoveReport, []error)
 	Save(ctx context.Context, nameOrID string, tags []string, options ImageSaveOptions) error
 	Scp(ctx context.Context, src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode) error

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -195,9 +195,6 @@ type ImagePushOptions struct {
 	Username string
 	// Password for authenticating against the registry.
 	Password string
-	// DigestFile, after copying the image, write the digest of the resulting
-	// image to the file.  Ignored for remote calls.
-	DigestFile string
 	// Format is the Manifest type (oci, v2s1, or v2s2) to use when pushing an
 	// image. Default is manifest type of source, with fallbacks.
 	// Ignored for remote calls.
@@ -247,9 +244,17 @@ type ImagePushOptions struct {
 	OciEncryptLayers *[]int
 }
 
+// ImagePushReport is the response from pushing an image.
+type ImagePushReport struct {
+	// The digest of the manifest of the pushed image.
+	ManifestDigest string
+}
+
 // ImagePushStream is the response from pushing an image. Only used in the
 // remote API.
 type ImagePushStream struct {
+	// ManifestDigest is the digest of the manifest of the pushed image.
+	ManifestDigest string `json:"manifestdigest,omitempty"`
 	// Stream used to provide push progress
 	Stream string `json:"stream,omitempty"`
 	// Error contains text of errors from pushing

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -247,9 +247,9 @@ type ImagePushOptions struct {
 	OciEncryptLayers *[]int
 }
 
-// ImagePushReport is the response from pushing an image.
-// Currently only used in the remote API.
-type ImagePushReport struct {
+// ImagePushStream is the response from pushing an image. Only used in the
+// remote API.
+type ImagePushStream struct {
 	// Stream used to provide push progress
 	Stream string `json:"stream,omitempty"`
 	// Error contains text of errors from pushing

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -243,12 +243,12 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 	return images.Import(ir.ClientCtx, f, options)
 }
 
-func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
+func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) (*entities.ImagePushReport, error) {
 	if opts.Signers != nil {
-		return fmt.Errorf("forwarding Signers is not supported for remote clients")
+		return nil, fmt.Errorf("forwarding Signers is not supported for remote clients")
 	}
 	if opts.OciEncryptConfig != nil {
-		return fmt.Errorf("encryption is not supported for remote clients")
+		return nil, fmt.Errorf("encryption is not supported for remote clients")
 	}
 
 	options := new(images.PushOptions)
@@ -261,7 +261,10 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 			options.WithSkipTLSVerify(false)
 		}
 	}
-	return images.Push(ir.ClientCtx, source, destination, options)
+	if err := images.Push(ir.ClientCtx, source, destination, options); err != nil {
+		return nil, err
+	}
+	return &entities.ImagePushReport{ManifestDigest: options.GetManifestDigest()}, nil
 }
 
 func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string, opts entities.ImageSaveOptions) error {

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -137,16 +137,14 @@ var _ = Describe("Podman push", func() {
 			Expect(push).Should(Exit(0))
 		}
 
-		if !IsRemote() { // Remote does not support --digestfile
-			// Test --digestfile option
-			digestFile := filepath.Join(podmanTest.TempDir, "digestfile.txt")
-			push2 := podmanTest.Podman([]string{"push", "--tls-verify=false", "--digestfile=" + digestFile, "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
-			push2.WaitWithDefaultTimeout()
-			fi, err := os.Lstat(digestFile)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fi.Name()).To(Equal("digestfile.txt"))
-			Expect(push2).Should(Exit(0))
-		}
+		// Test --digestfile option
+		digestFile := filepath.Join(podmanTest.TempDir, "digestfile.txt")
+		push2 := podmanTest.Podman([]string{"push", "--tls-verify=false", "--digestfile=" + digestFile, "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+		push2.WaitWithDefaultTimeout()
+		fi, err := os.Lstat(digestFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fi.Name()).To(Equal("digestfile.txt"))
+		Expect(push2).Should(Exit(0))
 
 		if !IsRemote() { // Remote does not support signing
 			By("pushing and pulling with --sign-by-sigstore-private-key")


### PR DESCRIPTION
Wire in support for writing the digest of the pushed image to a
user-specified file.  Requires some massaging of _internal_ APIs
and the extension of the push endpoint to integrate the raw manifest
(i.e., in bytes) in the stream.

Closes: #18216
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support the `--digestfile` flag for `podman push` on Mac OS and Windows.
```
