### PR TITLE
[CI:BUILD] Cirrus: remove copr rpm build task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -381,8 +381,6 @@ alt_build_task:
       - env:
             ALT_NAME: 'Build Without CGO'
       - env:
-            ALT_NAME: 'Test build podman-next Copr RPM'
-      - env:
             ALT_NAME: 'Alt Arch. Cross'
       - env:
             ALT_NAME: 'FreeBSD Cross'


### PR DESCRIPTION
Packit copr build tasks take care of this already so this can be safely removed.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@cevich PTAL
cc @containers/podman-maintainers 