### PR TITLE
cmd/podman/pods: omit superfluous runtime.NumCPU call

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -207,16 +206,13 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	numCPU := sysinfo.NumCPU()
-	if numCPU == 0 {
-		numCPU = runtime.NumCPU()
-	}
 	if createOptions.Cpus > float64(numCPU) {
 		createOptions.Cpus = float64(numCPU)
 	}
 	copy := infraOptions.CPUSetCPUs
 	cpuSet := infraOptions.CPUS
 	if cpuSet == 0 {
-		cpuSet = float64(sysinfo.NumCPU())
+		cpuSet = float64(numCPU)
 	}
 	ret, err := parsers.ParseUintList(copy)
 	copy = ""


### PR DESCRIPTION
`sysinfo.NumCPU` already falls back to `runtime.NumCPU` in case the platform-specific `sysinfo.numCPU` returns 0, see
https://github.com/containers/common/blob/554799639fc82afeddb9e39ec27a7b85382a6db3/pkg/sysinfo/numcpu.go#L8-L13

Also omit a second call to `sysinfo.NumCPU` and use the result from the earlier call.

#### Does this PR introduce a user-facing change?

No

```release-note
None
```
