### PR TITLE
Add user-mode networking feature to Windows/WSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ endif
 # include this lightweight helper binary.
 #
 GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
-GV_SHA=aab0ac9367fc5142f5857c36ac2352bcb3c60ab7
+GV_SHA=407efb5dcdb0f4445935f7360535800b60447544
 
 ###
 ### Primary entry-point targets

--- a/cmd/podman-wslkerninst/main.go
+++ b/cmd/podman-wslkerninst/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/containers/podman/v4/pkg/machine/wsl"
+	"github.com/containers/podman/v4/pkg/machine/wsl/wutil"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/svc/eventlog"
 )
@@ -49,7 +49,7 @@ func installWslKernel() error {
 	)
 	backoff := 500 * time.Millisecond
 	for i := 1; i < 6; i++ {
-		err = wsl.SilentExec("wsl", "--update")
+		err = wutil.SilentExec("wsl", "--update")
 		if err == nil {
 			break
 		}
@@ -87,7 +87,7 @@ func warn(title string, caption string) int {
 func main() {
 	args := os.Args
 	setupLogging(path.Base(args[0]))
-	if wsl.IsWSLInstalled() {
+	if wutil.IsWSLInstalled() {
 		// nothing to do
 		logrus.Info("WSL Kernel already installed")
 		return

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -178,6 +178,7 @@ func toMachineFormat(vms []*machine.ListResponse) ([]*entities.ListReporter, err
 		response.RemoteUsername = vm.RemoteUsername
 		response.IdentityPath = vm.IdentityPath
 		response.Starting = vm.Starting
+		response.UserModeNetworking = vm.UserModeNetworking
 
 		machineResponses = append(machineResponses, response)
 	}

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -32,10 +32,11 @@ var (
 )
 
 type SetFlags struct {
-	CPUs     uint64
-	DiskSize uint64
-	Memory   uint64
-	Rootful  bool
+	CPUs               uint64
+	DiskSize           uint64
+	Memory             uint64
+	Rootful            bool
+	UserModeNetworking bool
 }
 
 func init() {
@@ -72,6 +73,10 @@ func init() {
 		"Memory in MB",
 	)
 	_ = setCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
+
+	userModeNetFlagName := "user-mode-networking"
+	flags.BoolVar(&setFlags.UserModeNetworking, userModeNetFlagName, false, // defaults not-relevant due to use of Changed()
+		"Whether this machine should use user-mode networking, routing traffic through a host user-space process")
 }
 
 func setMachine(cmd *cobra.Command, args []string) error {
@@ -101,6 +106,9 @@ func setMachine(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("disk-size") {
 		setOpts.DiskSize = &setFlags.DiskSize
+	}
+	if cmd.Flags().Changed("user-mode-networking") {
+		setOpts.UserModeNetworking = &setFlags.UserModeNetworking
 	}
 
 	setErrs, lasterr := vm.Set(vmName, setOpts)

--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -19,7 +19,9 @@ podman-kube-play.1.md
 podman-login.1.md
 podman-logout.1.md
 podman-logs.1.md
+podman-machine-init.1.md
 podman-machine-list.1.md
+podman-machine-set.1.md
 podman-manifest-add.1.md
 podman-manifest-annotate.1.md
 podman-manifest-create.1.md

--- a/docs/source/markdown/options/user-mode-networking.md
+++ b/docs/source/markdown/options/user-mode-networking.md
@@ -1,0 +1,21 @@
+####> This option file is used in:
+####>   podman machine init, machine set
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--user-mode-networking**
+
+Whether this machine should relay traffic from the guest through a user-space
+process running on the host. In some VPN configurations the VPN may drop
+traffic from alternate network interfaces, including VM network devices. By
+enabling user-mode networking (a setting of `true`), VPNs will observe all
+podman machine traffic as coming from the host, bypassing the problem.
+
+When the qemu backend is used (Linux, Mac), user-mode networking is
+mandatory and the only allowed value is `true`. In contrast, The Windows/WSL
+backend defaults to `false`, and follows the standard WSL network setup.
+Changing this setting to `true` on Windows/WSL will inform Podman to replace
+the WSL networking setup on start of this machine instance with a user-mode
+networking distribution. Since WSL shares the same kernel across
+distributions, all other running distributions will reuse this network.
+Likewise, when the last machine instance with a `true` setting stops, the
+original networking setup will be restored.

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -76,6 +76,8 @@ Set the timezone for the machine and containers.  Valid values are `local` or
 a `timezone` such as `America/Chicago`.  A value of `local`, which is the default,
 means to use the timezone of the machine host.
 
+@@option user-mode-networking
+
 #### **--username**
 
 Username to use for executing commands in remote VM. Default value is `core`

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -31,6 +31,7 @@ Print results with a Go template.
 | .Resources ...      | Resources used by the machine                         |
 | .SSHConfig ...      | SSH configuration info for communitating with machine |
 | .State ...          | Machine state                                         |
+| .UserModeNetworking | Whether this machine uses user-mode networking        |
 
 #### **--help**
 

--- a/docs/source/markdown/podman-machine-list.1.md.in
+++ b/docs/source/markdown/podman-machine-list.1.md.in
@@ -32,22 +32,23 @@ Change the default output format.  This can be of a supported type like 'json'
 or a Go template.
 Valid placeholders for the Go template are listed below:
 
-| **Placeholder** | **Description**                 |
-| --------------- | ------------------------------- |
-| .CPUs           | Number of CPUs                  |
-| .Created        | Time since VM creation          |
-| .Default        | Is default machine              |
-| .DiskSize       | Disk size of machine            |
-| .IdentityPath   | Path to ssh identity file       |
-| .LastUp         | Time machine was last up        |
-| .LastUp         | Time since the VM was last run  |
-| .Memory         | Allocated memory for machine   |
-| .Name           | VM name                         |
-| .Port           | SSH Port to use to connect to VM|
-| .RemoteUsername | VM Username for rootless Podman |
-| .Running        | Is machine running              |
-| .Stream         | Stream name                     |
-| .VMType         | VM type                         |
+| **Placeholder**     | **Description**                           |
+| ------------------- | ----------------------------------------- |
+| .CPUs               | Number of CPUs                            |
+| .Created            | Time since VM creation                    |
+| .Default            | Is default machine                        |
+| .DiskSize           | Disk size of machine                      |
+| .IdentityPath       | Path to ssh identity file                 |
+| .LastUp             | Time machine was last up                  |
+| .LastUp             | Time since the VM was last run            |
+| .Memory             | Allocated memory for machine              |
+| .Name               | VM name                                   |
+| .Port               | SSH Port to use to connect to VM          |
+| .RemoteUsername     | VM Username for rootless Podman           |
+| .Running            | Is machine running                        |
+| .Stream             | Stream name                               |
+| .UserModeNetworking | Whether machine uses user-mode networking |
+| .VMType             | VM type                                   |
 
 #### **--help**
 

--- a/docs/source/markdown/podman-machine-set.1.md.in
+++ b/docs/source/markdown/podman-machine-set.1.md.in
@@ -40,6 +40,8 @@ container execution. This option will also update the current podman
 remote connection default if it is currently pointing at the specified
 machine name (or `podman-machine-default` if no name is specified).
 
+@@option user-mode-networking
+
 Unlike [**podman system connection default**](podman-system-connection-default.1.md)
 this option will also make the API socket, if available, forward to the rootful/rootless
 socket in the VM.

--- a/pkg/domain/entities/machine.go
+++ b/pkg/domain/entities/machine.go
@@ -3,20 +3,21 @@ package entities
 import "github.com/containers/podman/v4/libpod/define"
 
 type ListReporter struct {
-	Name           string
-	Default        bool
-	Created        string
-	Running        bool
-	Starting       bool
-	LastUp         string
-	Stream         string
-	VMType         string
-	CPUs           uint64
-	Memory         string
-	DiskSize       string
-	Port           int
-	RemoteUsername string
-	IdentityPath   string
+	Name               string
+	Default            bool
+	Created            string
+	Running            bool
+	Starting           bool
+	LastUp             string
+	Stream             string
+	VMType             string
+	CPUs               uint64
+	Memory             string
+	DiskSize           string
+	Port               int
+	RemoteUsername     string
+	IdentityPath       string
+	UserModeNetworking bool
 }
 
 // MachineInfo contains info on the machine host and version info

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -17,22 +17,22 @@ import (
 )
 
 type InitOptions struct {
-	CPUS         uint64
-	DiskSize     uint64
-	IgnitionPath string
-	ImagePath    string
-	Volumes      []string
-	VolumeDriver string
-	IsDefault    bool
-	Memory       uint64
-	Name         string
-	TimeZone     string
-	URI          url.URL
-	Username     string
-	ReExec       bool
-	Rootful      bool
-	// The numerical userid of the user that called machine
-	UID string
+	CPUS               uint64
+	DiskSize           uint64
+	IgnitionPath       string
+	ImagePath          string
+	Volumes            []string
+	VolumeDriver       string
+	IsDefault          bool
+	Memory             uint64
+	Name               string
+	TimeZone           string
+	URI                url.URL
+	Username           string
+	ReExec             bool
+	Rootful            bool
+	UID                string // uid of the user that called machine
+	UserModeNetworking *bool  // nil = use backend/system default, false = disable, true = enable
 }
 
 type Status = string
@@ -91,26 +91,28 @@ type Download struct {
 type ListOptions struct{}
 
 type ListResponse struct {
-	Name           string
-	CreatedAt      time.Time
-	LastUp         time.Time
-	Running        bool
-	Starting       bool
-	Stream         string
-	VMType         string
-	CPUs           uint64
-	Memory         uint64
-	DiskSize       uint64
-	Port           int
-	RemoteUsername string
-	IdentityPath   string
+	Name               string
+	CreatedAt          time.Time
+	LastUp             time.Time
+	Running            bool
+	Starting           bool
+	Stream             string
+	VMType             string
+	CPUs               uint64
+	Memory             uint64
+	DiskSize           uint64
+	Port               int
+	RemoteUsername     string
+	IdentityPath       string
+	UserModeNetworking bool
 }
 
 type SetOptions struct {
-	CPUs     *uint64
-	DiskSize *uint64
-	Memory   *uint64
-	Rootful  *bool
+	CPUs               *uint64
+	DiskSize           *uint64
+	Memory             *uint64
+	Rootful            *bool
+	UserModeNetworking *bool
 }
 
 type SSHOptions struct {
@@ -151,15 +153,16 @@ type DistributionDownload interface {
 	CleanCache() error
 }
 type InspectInfo struct {
-	ConfigPath     VMFile
-	ConnectionInfo ConnectionConfig
-	Created        time.Time
-	Image          ImageConfig
-	LastUp         time.Time
-	Name           string
-	Resources      ResourceConfig
-	SSHConfig      SSHConfig
-	State          Status
+	ConfigPath         VMFile
+	ConnectionInfo     ConnectionConfig
+	Created            time.Time
+	Image              ImageConfig
+	LastUp             time.Time
+	Name               string
+	Resources          ResourceConfig
+	SSHConfig          SSHConfig
+	State              Status
+	UserModeNetworking bool
 }
 
 func (rc RemoteConnectionType) MakeSSHURL(host, path, port, userName string) url.URL {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -364,6 +364,11 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	if err := v.resizeDisk(opts.DiskSize, originalDiskSize>>(10*3)); err != nil {
 		return false, err
 	}
+
+	if opts.UserModeNetworking != nil && !*opts.UserModeNetworking {
+		logrus.Warn("ignoring init option to disable user-mode networking: this mode is not supported by the QEMU backend")
+	}
+
 	// If the user provides an ignition file, we need to
 	// copy it into the conf dir
 	if len(opts.IgnitionPath) > 0 {
@@ -1145,6 +1150,7 @@ func getVMInfos() ([]*machine.ListResponse, error) {
 			listEntry.IdentityPath = vm.IdentityPath
 			listEntry.CreatedAt = vm.Created
 			listEntry.Starting = vm.Starting
+			listEntry.UserModeNetworking = true // always true
 
 			if listEntry.CreatedAt.IsZero() {
 				listEntry.CreatedAt = time.Now()
@@ -1602,15 +1608,16 @@ func (v *MachineVM) Inspect() (*machine.InspectInfo, error) {
 	}
 	connInfo.PodmanSocket = podmanSocket
 	return &machine.InspectInfo{
-		ConfigPath:     v.ConfigPath,
-		ConnectionInfo: *connInfo,
-		Created:        v.Created,
-		Image:          v.ImageConfig,
-		LastUp:         v.LastUp,
-		Name:           v.Name,
-		Resources:      v.ResourceConfig,
-		SSHConfig:      v.SSHConfig,
-		State:          state,
+		ConfigPath:         v.ConfigPath,
+		ConnectionInfo:     *connInfo,
+		Created:            v.Created,
+		Image:              v.ImageConfig,
+		LastUp:             v.LastUp,
+		Name:               v.Name,
+		Resources:          v.ResourceConfig,
+		SSHConfig:          v.SSHConfig,
+		State:              state,
+		UserModeNetworking: true, // always true
 	}, nil
 }
 

--- a/pkg/machine/wsl/filelock.go
+++ b/pkg/machine/wsl/filelock.go
@@ -1,0 +1,73 @@
+//go:build windows
+// +build windows
+
+package wsl
+
+import (
+	"io/fs"
+	"math"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+type fileLock struct {
+	file *os.File
+}
+
+// Locks a file path, creating or overwriting a file if necessary. This API only
+// supports dedicated empty lock files. Locking is not advisory, once a file is
+// locked, additional opens will block on read/write.
+func lockFile(path string) (*fileLock, error) {
+	// In the future we may want to switch this to an async open vs the win32 API
+	// to bring support for timeouts, so we don't export the current underlying
+	// File object.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, &fs.PathError{
+			Op:   "lock",
+			Path: path,
+			Err:  err,
+		}
+	}
+
+	const max = uint32(math.MaxUint32)
+	overlapped := new(windows.Overlapped)
+	lockType := windows.LOCKFILE_EXCLUSIVE_LOCK
+	// Lock largest possible length (all 64 bits (lo + hi) set)
+	err = windows.LockFileEx(windows.Handle(file.Fd()), uint32(lockType), 0, max, max, overlapped)
+	if err != nil {
+		file.Close()
+		return nil, &fs.PathError{
+			Op:   "lock",
+			Path: file.Name(),
+			Err:  err,
+		}
+	}
+
+	return &fileLock{file: file}, nil
+}
+
+func (flock *fileLock) unlock() error {
+	if flock == nil || flock.file == nil {
+		return nil
+	}
+
+	defer func() {
+		flock.file.Close()
+		flock.file = nil
+	}()
+
+	const max = uint32(math.MaxUint32)
+	overlapped := new(windows.Overlapped)
+	err := windows.UnlockFileEx(windows.Handle(flock.file.Fd()), 0, max, max, overlapped)
+	if err != nil {
+		return &fs.PathError{
+			Op:   "unlock",
+			Path: flock.file.Name(),
+			Err:  err,
+		}
+	}
+
+	return nil
+}

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -1,0 +1,326 @@
+//go:build windows
+// +build windows
+
+package wsl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/specgen"
+	"github.com/sirupsen/logrus"
+)
+
+const startUserModeNet = `
+set -e
+STATE=/mnt/wsl/podman-usermodenet
+mkdir -p $STATE
+cp -f /mnt/wsl/resolv.conf $STATE/resolv.orig
+ip route show default > $STATE/route.dat
+ROUTE=$(<$STATE/route.dat)
+if [[ $ROUTE =~ .*192\.168\.127\.1.* ]]; then
+	exit 2
+fi
+if [[ ! $ROUTE =~ default\ via ]]; then
+	exit 3
+fi
+nohup /usr/local/bin/vm -iface podman-usermode -stop-if-exist ignore -url "stdio:$GVPROXY?listen-stdio=accept" > /var/log/vm.log 2> /var/log/vm.err  < /dev/null &
+echo $! > $STATE/vm.pid
+sleep 1
+ps -eo args | grep -q -m1 ^/usr/local/bin/vm || exit 42
+`
+
+const stopUserModeNet = `
+STATE=/mnt/wsl/podman-usermodenet
+if [[ ! -f "$STATE/vm.pid" || ! -f "$STATE/route.dat" ]]; then
+	exit 2
+fi
+cp -f $STATE/resolv.orig /mnt/wsl/resolv.conf
+GPID=$(<$STATE/vm.pid)
+kill $GPID > /dev/null
+while kill -0 $GPID > /dev/null 2>&1; do
+	sleep 1
+done
+ip route del default > /dev/null 2>&1
+ROUTE=$(<$STATE/route.dat)
+if [[ ! $ROUTE =~ default\ via ]]; then
+	exit 3
+fi
+ip route add $ROUTE
+rm -rf /mnt/wsl/podman-usermodenet
+`
+
+func (v *MachineVM) startUserModeNetworking() error {
+	if !v.UserModeNetworking {
+		return nil
+	}
+
+	exe, err := findExecutablePeer(gvProxy)
+	if err != nil {
+		return fmt.Errorf("could not locate %s, which is necessary for user-mode networking, please reinstall", gvProxy)
+	}
+
+	flock, err := v.obtainUserModeNetLock()
+	if err != nil {
+		return err
+	}
+	defer flock.unlock()
+
+	running, err := isWSLRunning(userModeDist)
+	if err != nil {
+		return err
+	}
+	running = running && isGvProxyVMRunning()
+
+	// Start or reuse
+	if !running {
+		if err := v.launchUserModeNetDist(exe); err != nil {
+			return err
+		}
+	}
+
+	if err := createUserModeResolvConf(toDist(v.Name)); err != nil {
+		return err
+	}
+
+	// Register in-use
+	err = v.addUserModeNetEntry()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *MachineVM) stopUserModeNetworking(dist string) error {
+	if !v.UserModeNetworking {
+		return nil
+	}
+
+	flock, err := v.obtainUserModeNetLock()
+	if err != nil {
+		return err
+	}
+	defer flock.unlock()
+
+	err = v.removeUserModeNetEntry()
+	if err != nil {
+		return err
+	}
+
+	count, err := v.cleanupAndCountNetEntries()
+	if err != nil {
+		return err
+	}
+
+	// Leave running if still in-use
+	if count > 0 {
+		return nil
+	}
+
+	fmt.Println("Stopping user-mode networking...")
+
+	err = wslPipe(stopUserModeNet, userModeDist, "bash")
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			switch exitErr.ExitCode() {
+			case 2:
+				err = fmt.Errorf("startup state was missing")
+			case 3:
+				err = fmt.Errorf("route state is missing a default route")
+			}
+		}
+		logrus.Warnf("problem tearing down user-mode networking cleanly, forcing: %s", err.Error())
+	}
+
+	return terminateDist(userModeDist)
+}
+
+func isGvProxyVMRunning() bool {
+	return wslInvoke(userModeDist, "bash", "-c", "ps -eo args | grep -q -m1 ^/usr/local/bin/vm || exit 42") == nil
+}
+
+func (v *MachineVM) launchUserModeNetDist(exeFile string) error {
+	fmt.Println("Starting user-mode networking...")
+
+	exe, err := specgen.ConvertWinMountPath(exeFile)
+	if err != nil {
+		return err
+	}
+
+	cmdStr := fmt.Sprintf("GVPROXY=%q\n%s", exe, startUserModeNet)
+	if err := wslPipe(cmdStr, userModeDist, "bash"); err != nil {
+		_ = terminateDist(userModeDist)
+
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			switch exitErr.ExitCode() {
+			case 2:
+				return fmt.Errorf("another user-mode network is running, only one can be used at a time: shut down all machines and run wsl --shutdown if this is unexpected")
+			case 3:
+				err = fmt.Errorf("route state is missing a default route: shutdown all machines and run wsl --shutdown to recover")
+			}
+		}
+
+		return fmt.Errorf("error setting up user-mode networking: %w", err)
+	}
+
+	return nil
+}
+
+func installUserModeDist(dist string, imagePath string) error {
+	exists, err := isWSLExist(userModeDist)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		if err := wslInvoke(dist, "test", "-f", "/usr/local/bin/vm"); err != nil {
+			return fmt.Errorf("existing machine is too old, can't install user-mode networking dist until machine is reinstalled (using podman machine rm, then podman machine init)")
+		}
+
+		const prompt = "Installing user-mode networking distribution..."
+		if _, err := provisionWSLDist(userModeDist, imagePath, prompt); err != nil {
+			return err
+		}
+
+		_ = terminateDist(userModeDist)
+	}
+
+	return nil
+}
+
+func createUserModeResolvConf(dist string) error {
+	err := wslPipe(resolvConfUserNet, dist, "bash", "-c", "(rm -f /etc/resolv.conf; cat > /etc/resolv.conf)")
+	if err != nil {
+		return fmt.Errorf("could not create resolv.conf: %w", err)
+	}
+	return err
+}
+
+func (v *MachineVM) getUserModeNetDir() (string, error) {
+	vmDataDir, err := machine.GetDataDir(vmtype)
+	if err != nil {
+		return "", err
+	}
+
+	dir := filepath.Join(vmDataDir, userModeDist)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("could not create %s directory: %w", userModeDist, err)
+	}
+
+	return dir, nil
+}
+
+func (v *MachineVM) getUserModeNetEntriesDir() (string, error) {
+	netDir, err := v.getUserModeNetDir()
+	if err != nil {
+		return "", err
+	}
+
+	dir := filepath.Join(netDir, "entries")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("could not create %s/entries directory: %w", userModeDist, err)
+	}
+
+	return dir, nil
+}
+
+func (v *MachineVM) addUserModeNetEntry() error {
+	entriesDir, err := v.getUserModeNetEntriesDir()
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(entriesDir, toDist(v.Name))
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("could not add user-mode networking registration: %w", err)
+	}
+	file.Close()
+	return nil
+}
+
+func (v *MachineVM) removeUserModeNetEntry() error {
+	entriesDir, err := v.getUserModeNetEntriesDir()
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(entriesDir, toDist(v.Name))
+	return os.Remove(path)
+}
+
+func (v *MachineVM) cleanupAndCountNetEntries() (uint, error) {
+	entriesDir, err := v.getUserModeNetEntriesDir()
+	if err != nil {
+		return 0, err
+	}
+
+	allDists, err := getAllWSLDistros(true)
+	if err != nil {
+		return 0, err
+	}
+
+	var count uint = 0
+	files, err := os.ReadDir(entriesDir)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, file := range files {
+		_, running := allDists[file.Name()]
+		if !running {
+			_ = os.Remove(filepath.Join(entriesDir, file.Name()))
+			continue
+		}
+		count++
+	}
+
+	return count, nil
+}
+
+func (v *MachineVM) obtainUserModeNetLock() (*fileLock, error) {
+	dir, err := v.getUserModeNetDir()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var flock *fileLock
+	lockPath := filepath.Join(dir, "podman-usermodenet.lck")
+	if flock, err = lockFile(lockPath); err != nil {
+		return nil, fmt.Errorf("could not lock user-mode networking lock file: %w", err)
+	}
+
+	return flock, nil
+}
+
+func changeDistUserModeNetworking(dist string, user string, image string, enable bool) error {
+	// Only install if user-mode is being enabled and there was an image path passed
+	if enable && len(image) > 0 {
+		if err := installUserModeDist(dist, image); err != nil {
+			return err
+		}
+	}
+
+	if err := writeWslConf(dist, user); err != nil {
+		return err
+	}
+
+	if enable {
+		return appendDisableAutoResolve(dist)
+	}
+
+	return nil
+}
+
+func appendDisableAutoResolve(dist string) error {
+	if err := wslPipe(wslConfUserNet, dist, "sh", "-c", "cat >> /etc/wsl.conf"); err != nil {
+		return fmt.Errorf("could not append resolv config to wsl.conf: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -344,18 +343,4 @@ func sendQuit(tid uint32) {
 	user32 := syscall.NewLazyDLL("user32.dll")
 	postMessage := user32.NewProc("PostThreadMessageW")
 	postMessage.Call(uintptr(tid), WM_QUIT, 0, 0)
-}
-
-func SilentExec(command string, args ...string) error {
-	cmd := exec.Command(command, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000}
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	return cmd.Run()
-}
-
-func SilentExecCmd(command string, args ...string) *exec.Cmd {
-	cmd := exec.Command(command, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000}
-	return cmd
 }

--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -1,0 +1,55 @@
+//go:build windows
+// +build windows
+
+package wutil
+
+import (
+	"bufio"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+func SilentExec(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000}
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
+}
+
+func SilentExecCmd(command string, args ...string) *exec.Cmd {
+	cmd := exec.Command(command, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000}
+	return cmd
+}
+
+func IsWSLInstalled() bool {
+	cmd := SilentExecCmd("wsl", "--status")
+	out, err := cmd.StdoutPipe()
+	cmd.Stderr = nil
+	if err != nil {
+		return false
+	}
+	if err = cmd.Start(); err != nil {
+		return false
+	}
+	scanner := bufio.NewScanner(transform.NewReader(out, unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder()))
+	result := true
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Windows 11 does not set an error exit code when a kernel is not avail
+		if strings.Contains(line, "kernel file is not found") {
+			result = false
+			break
+		}
+	}
+	if err := cmd.Wait(); !result || err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Certain VPN setups or other specialized networking configs will block traffic from the virtual WSL networking device, resulting in the podman WSL backend from being unable to contact systems on the VPN, and potentially losing internet access altogether. While some VPN providers provide configuration options to allow traffic from VMs, users may be prevented by policy from changing these options, or they may require networking infrastructure changes that require time to implement.

This PR adds a user-mode networking capability to podman machine on Windows, that works around this issue by rerouting all traffic over a user-space process running on the host, similar to the setup in use on Linux and Mac. 

It adds  a `--user-mode-networking` flag to `podman machine init` and `podman machine set` to configure the specified machine instance for user-mode networking.

When specified, `init` will provision an additional WSL distribution for dynamically configuring and running the user-mode networking environment. The user-mode network dist replaces the WSL network configuration with a tap device that is tunneled to a gvproxy.exe process running on the host (using the stdio transport, which was recently contributed to gvisor-tap-vsock by the wsl-vpnkit author).  All traffic from all running WSL distributions (including DNS) is rerouted over this process. `podman machine start` launches this special dist along with any machine instance configured to require it. The usage of the user-mode env dist is reference counted with cooperative file-locking: subsequent machine starts will share the same instance, and the last user-mode-net requiring machine will stop the networking dist, restoring the standard WSL network as part of its shutdown.

Machine instances that do not require user-mode networking will still participate in the user-mode network when running (required since the kernel is shared across all WSL dists), but they will not prevent the user-mode network from closing. Instead, traffic will begin to flow over the standard WSL network setup.

Since the qemu backend on Linux and Mac are designed around user-mode networking, this option is restricted to always be true on those platforms. 

This PR also includes a commit to address an unrelated win installer CI failure that was showing up in the verification of this PR (an environment-varying go build issue can be triggered where it over-eagerly builds unnessecary transitive deps, including gpgme that won't normally build cleanly on Windows)

A follow-up PR will add a section to the Windows tutorial.

```release-note
Windows: Add a user-mode networking option to improve interop with VPN configs that drop traffic from WSL networking
```

[NO NEW TESTS NEEDED]