### PR TITLE
[CI:DOCS] Quadlet: clarify overriding user/system services

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -26,8 +26,10 @@ These files are read during boot (and when `systemctl daemon-reload` is run) and
 corresponding regular systemd service unit files. Both system and user systemd units are supported.
 
 The Podman generator reads the search paths above and reads files with the extensions `.container`
-`.volume` and `*.kube`, and for each file generates a similarly named `.service` file. These units
-can be started and managed with systemctl like any other systemd service.
+`.volume` and `*.kube`, and for each file generates a similarly named `.service` file. Be aware that
+existing vendor services (i.e., in `/usr/`) are replaced if they have the same name. The generated unit files can
+be started and managed with `systemctl` like any other systemd service. `systemctl {--user} list-unit-files`
+lists existing unit files on the system.
 
 Files with the `.network` extension are only read if they are mentioned in a `.container` file. See the `Network=` key.
 


### PR DESCRIPTION
Highlight that existing user and system services may be overridden if they have same name as the Quadlet file.  Also point the user to systemctl and how to list existing files.

Closes: #18275

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
