### PR TITLE
test/system/260-sdnotify.bats: fix test flake

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -338,8 +338,10 @@ ignore"
     # potential issues.
     run_podman exec --env NOTIFY_SOCKET="/run/notify/notify.sock" $container_a /usr/bin/systemd-notify --ready
 
-    # Instruct the container to stop
-    run_podman exec $container_a /bin/touch /stop
+    # Instruct the container to stop.
+    # Run detached as the `exec` session races with the cleanup process
+    # of the exiting container (see #10825).
+    run_podman exec -d $container_a /bin/touch /stop
 
     run_podman container wait $container_a
     run_podman container inspect $container_a --format "{{.State.ExitCode}}"


### PR DESCRIPTION
The `exec` session somestimes exits with 137 as the exec session races with the cleanup process of the exiting container.  Fix the flake by running a detached exec session.

Fixes: #10825

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
