### PR TITLE
ps: --format {{.State}} match docker output

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -351,8 +351,8 @@ func (l psReporter) Pod() string {
 	return l.ListContainer.Pod
 }
 
-// State returns the container state in human duration
-func (l psReporter) State() string {
+// Status returns the container status in the default ps output format.
+func (l psReporter) Status() string {
 	var state string
 	switch l.ListContainer.State {
 	case "running":
@@ -370,16 +370,11 @@ func (l psReporter) State() string {
 		//nolint:staticcheck
 		state = strings.Title(l.ListContainer.State)
 	}
-	return state
-}
-
-// Status is a synonym for State()
-func (l psReporter) Status() string {
 	hc := l.ListContainer.Status
 	if hc != "" {
-		return l.State() + " (" + hc + ")"
+		state += " (" + hc + ")"
 	}
-	return l.State()
+	return state
 }
 
 func (l psReporter) RunningFor() string {

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -14,8 +14,8 @@ load helpers
 
     # Special case: formatted ps
     run_podman ps --no-trunc \
-               --format '{{.ID}} {{.Image}} {{.Command}} {{.Names}}'
-    is "$output" "$cid $IMAGE sleep 5 $rand_name" "podman ps"
+               --format '{{.ID}} {{.Image}} {{.Command}} {{.Names}} {{.State}}'
+    is "$output" "$cid $IMAGE sleep 5 $rand_name running" "podman ps"
 
 
     # Plain old regular ps


### PR DESCRIPTION
We should return the raw state string without any extra formatting in this case.
`{{.Status}}` returns the nicely formatted string used in the default ps output, e.g. `Up 2 seconds ago`, while `{{.State}}` returns the state as string, e.g. `running`.

This matches the docker output and allows better use in scripts.

Fixes #18244

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman ps --format {{.State}} now returns the correct state as single string without any extra output.
```
