### PR TITLE
Revert "Resolve symlink path for qemu directory if possible"

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -46,23 +46,13 @@ func getOvmfDir(imagePath, vmName string) string {
  */
 func getEdk2CodeFdPathFromQemuBinaryPath() string {
 	cfg, err := config.Default()
-	if err != nil {
-		return ""
+	if err == nil {
+		execPath, err := cfg.FindHelperBinary(QemuCommand, true)
+		if err == nil {
+			return filepath.Clean(filepath.Join(filepath.Dir(execPath), "..", "share", "qemu"))
+		}
 	}
-	execPath, err := cfg.FindHelperBinary(QemuCommand, true)
-	if err != nil {
-		return ""
-	}
-
-	sharePath := func(path string) string {
-		return filepath.Clean(filepath.Join(filepath.Dir(path), "..", "share", "qemu"))
-	}
-
-	symlinkedPath, err := filepath.EvalSymlinks(execPath)
-	if err != nil {
-		return sharePath(execPath)
-	}
-	return sharePath(symlinkedPath)
+	return ""
 }
 
 /*


### PR DESCRIPTION
[This](This) reverts commit 6b6458916eaa51f0dbbcfeccd740706697697ad3 (Resolve
symlink path for qemu directory if possible).

Fully resolving the symlink to qemu solves some issues for
aarch64-darwin nix with regards to finding `edk2-aarch64-code.fd`, but
unfortunately the fully resolved path includes the version number,
making it so that even patch updates break the path to
homebrew-installed qemu files.

Fixes https://github.com/containers/podman/issues/18111

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not fully resolve symlinks in the path to `edk2-aarch64-code.fd` to prevent
breakage with qemu updates.
```
