### PR TITLE
system tests: safer container-stop signaling

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -347,7 +347,7 @@ echo $rand        |   0 | $rand
 # #6991 : /etc/passwd is modifiable
 @test "podman run : --userns=keep-id: passwd file is modifiable" {
     skip_if_not_rootless "--userns=keep-id only works in rootless mode"
-    run_podman run -d --userns=keep-id --cap-add=dac_override $IMAGE sh -c 'while ! test -e /tmp/stop; do sleep 0.1; done'
+    run_podman run -d --userns=keep-id --cap-add=dac_override $IMAGE top
     cid="$output"
 
     # Assign a UID that is (a) not in our image /etc/passwd and (b) not
@@ -368,8 +368,7 @@ echo $rand        |   0 | $rand
     is "$output" "newuser3:x:$uid:999:$gecos:/home/newuser3:/bin/sh" \
        "newuser3 added to /etc/passwd in container"
 
-    run_podman exec $cid touch /tmp/stop
-    run_podman wait $cid
+    run_podman rm -f -t0 $cid
 }
 
 # For #7754: json-file was equating to 'none'

--- a/test/system/320-system-df.bats
+++ b/test/system/320-system-df.bats
@@ -82,8 +82,7 @@ Size           |   ~12.*MB |         0B |            0B
 
 @test "podman system df - with active containers and volumes" {
     run_podman run    -v /myvol1 --name c1 $IMAGE true
-    run_podman run -d -v /myvol2 --name c2 $IMAGE \
-               sh -c 'while ! test -e /stop; do sleep 0.1;done'
+    run_podman run -d -v /myvol2 --name c2 $IMAGE top
 
     run_podman system df --format '{{ .Type }}:{{ .Total }}:{{ .Active }}'
     is "${lines[0]}" "Images:1:1"        "system df : Images line"
@@ -124,8 +123,7 @@ Size           |   ~12.*MB |         0B |            0B
     run_podman system df --format '{{.Reclaimable}}'
     is "${lines[0]}" "0B (0%)" "cannot reclaim image data as it's still used by the containers"
 
-    run_podman exec c2 touch /stop
-    run_podman wait c2
+    run_podman stop c2
 
     # Create a second image by committing a container.
     run_podman container commit -q c1

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -99,12 +99,11 @@ function check_label() {
                --security-opt seccomp=unconfined \
                --security-opt label=type:spc_t \
                --security-opt label=level:s0 \
-               $IMAGE sh -c 'while test ! -e /stop; do sleep 0.1; done'
+               $IMAGE top
     run_podman inspect --format='{{ .HostConfig.SecurityOpt }}' myc
     is "$output" "[label=type:spc_t,label=level:s0 seccomp=unconfined]" \
       "'podman inspect' preserves all --security-opts"
 
-    run_podman exec myc touch /stop
     run_podman rm -t 0 -f myc
 }
 

--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -211,7 +211,9 @@ function teardown() {
     is "$output" "$cid" "podman container restore"
 
     # Signal the container to continue; this is where the 1-2-3s will come from
-    run_podman exec $cid rm /wait
+    # The '-d' is because container exit is racy: the exec process itself
+    # could get caught and killed by cleanup, causing this step to exit 137
+    run_podman exec -d $cid rm /wait
 
     # Wait for the container to stop
     run_podman wait $cid


### PR DESCRIPTION
Having a container spin-wait on a /stop file, then exit, is
unsafe: 'podman exec $ctr touch /stop' can get sucked into
container cleanup before the exec terminates, resulting in
the podman-exec failing and hence the test failing.

Most existing instances of this pattern are unnecessary.
Replace those with just 'podman rm -f'.

When necessary, use a variety of safer alternatives.

Re-Closes: #10825 (already closed; this addresses remaining cases)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```