### PR TITLE
Add sha256: to images history id for docker compatibility

### DIFF
--- a/pkg/api/handlers/compat/images_history.go
+++ b/pkg/api/handlers/compat/images_history.go
@@ -33,12 +33,16 @@ func HistoryImage(w http.ResponseWriter, r *http.Request) {
 	allHistory := make([]handlers.HistoryResponse, 0, len(history))
 	for _, h := range history {
 		l := handlers.HistoryResponse{
-			ID:        h.ID,
 			Created:   h.Created.Unix(),
 			CreatedBy: h.CreatedBy,
 			Tags:      h.Tags,
 			Size:      h.Size,
 			Comment:   h.Comment,
+		}
+		if utils.IsLibpodRequest(r) {
+			l.ID = h.ID
+		} else {
+			l.ID = "sha256:" + h.ID
 		}
 		allHistory = append(allHistory, l)
 	}

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -78,6 +78,15 @@ for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
     .[0].Comment=
 done
 
+for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
+  t GET images/$i/history 200 \
+    .[0].Id="sha256:"$iid \
+    .[0].Created~[0-9]\\{10\\} \
+    .[0].Tags=null \
+    .[0].Size=0 \
+    .[0].Comment=
+done
+
 # Export an image on the local
 t GET libpod/images/nonesuch/get 404
 t GET libpod/images/$iid/get?format=foo 500

--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -70,12 +70,11 @@ class TestImages(common.DockerTestCase):
         """Image history"""
         img = self.docker.images.get(constant.ALPINE)
         history = img.history()
-        image_id = img.id[7:] if img.id.startswith("sha256:") else img.id
 
         found = False
         for change in history:
-            found |= image_id in change.values()
-        self.assertTrue(found, f"image id {image_id} not found in history")
+            found |= img.id in change.values()
+        self.assertTrue(found, f"image id {img.id} not found in history")
 
     def test_get_image_exists_not(self):
         """Negative test for get image"""


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/17762

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Docker compatibility images/history api returns id with sha256: prefix 
```
