### PR TITLE
Recover from failed podman machine start

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -771,6 +771,13 @@ func (v *MachineVM) Stop(_ string, _ machine.StopOptions) error {
 	if _, err := os.Stat(v.QMPMonitor.Address.GetPath()); os.IsNotExist(err) {
 		// Right now it is NOT an error to stop a stopped machine
 		logrus.Debugf("QMP monitor socket %v does not exist", v.QMPMonitor.Address)
+		// Fix incorrect starting state in case of crash during start
+		if v.Starting {
+			v.Starting = false
+			if err := v.writeConfig(); err != nil {
+				return fmt.Errorf("writing JSON file: %w", err)
+			}
+		}
 		return nil
 	}
 	qmpMonitor, err := qmp.NewSocketMonitor(v.QMPMonitor.Network, v.QMPMonitor.Address.GetPath(), v.QMPMonitor.Timeout)


### PR DESCRIPTION
In rare instances, if podman machine start does not exit correctly, the machine can be left in a "Starting" state, when in reality the machine is stopped. This prevents the user from actually starting the machine. This commit makes sure that on `podman machine stop`, we check if this is the case, and correctly set the starting state to false, allowing the user to start their machine again.

[NO NEW TESTS NEEDED]
since this is a concurrency/race/crash fix that's hard to reproduce

Fixes: https://github.com/containers/podman/issues/16945

```release-note
Fixed a bug where a podman machine could get stuck in the `starting` state
```
