### PR TITLE
auto-update: log errors checking for updates

### DIFF
--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -249,16 +249,7 @@ func (t *task) report() *entities.AutoUpdateReport {
 func (t *task) updateAvailable(ctx context.Context) (bool, error) {
 	switch t.policy {
 	case PolicyRegistryImage:
-		// Errors checking for updates only should not be fatal.
-		// Especially on Edge systems, connection may be limited or
-		// there may just be a temporary downtime of the registry.
-		// But make sure to leave some breadcrumbs in the debug logs
-		// such that potential issues _can_ be analyzed if needed.
-		available, err := t.registryUpdateAvailable(ctx)
-		if err != nil {
-			logrus.Debugf("Error checking updates for image %s: %v (ignoring error)", t.rawImageName, err)
-		}
-		return available, nil
+		return t.registryUpdateAvailable(ctx)
 	case PolicyLocalImage:
 		return t.localUpdateAvailable()
 	default:


### PR DESCRIPTION
When checking for new images on registries, do not suppress            
and debug-log errors but return them.  Other images and units          
will still be processed.                                               
                                                                       
That is important to a) stop hiding flaky registries (see #18321)      
                     b) mark the updates as `failed` instead of `false`

Closes: #18321

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
