### PR TITLE
sqlite: move first read into a transaction

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -78,18 +78,11 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 		}
 	}()
 
-	state.conn = conn
-
-	// Migrate schema (if necessary)
-	if err := state.migrateSchemaIfNecessary(); err != nil {
+	if err := initSQLiteDB(conn); err != nil {
 		return nil, err
 	}
 
-	// Set up tables
-	if err := sqliteInitTables(state.conn); err != nil {
-		return nil, fmt.Errorf("creating tables: %w", err)
-	}
-
+	state.conn = conn
 	state.valid = true
 	state.runtime = runtime
 


### PR DESCRIPTION
According to an old upstream issue [1]: "If the first statement after BEGIN DEFERRED is a SELECT, then a read transaction is started. Subsequent write statements will upgrade the transaction to a write transaction if possible, or return SQLITE_BUSY."

So let's move the first SELECT under the same transaction as the table initialization.

[NO NEW TESTS NEEDED] as it's a hard to cause race.

[1] https://github.com/mattn/go-sqlite3/issues/274#issuecomment-1429054597

Fixes: #17859

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the sqlite database backend where the first read access may fail.
```
