### PR TITLE
rootless: support joining containers that use host ns

### DIFF
--- a/test/system/195-run-namesapces.bats
+++ b/test/system/195-run-namesapces.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Tests for the namespace options
+#
+
+load helpers
+
+@test "podman test all namespaces" {
+    # format is nsname | option name
+    tests="
+cgroup | cgroupns
+ipc    | ipc
+net    | network
+pid    | pid
+uts    | uts
+"
+
+    for nstype in private host; do
+        while read name option; do
+            local cname="c_${name}_$(random_string)"
+            # ipc is special, private does not allow joining from another container.
+            # Instead we must use "shareable".
+            local type=$nstype
+            if [ "$name" = "ipc" ] && [ "$type" = "private" ]; then
+                type="shareable"
+            fi
+
+            run_podman run --name $cname --$option $type -d $IMAGE sh -c \
+                "readlink /proc/self/ns/$name; sleep inf"
+
+            run_podman run --rm --$option container:$cname $IMAGE readlink /proc/self/ns/$name
+            con2_ns="$output"
+
+            run readlink /proc/self/ns/$name
+            host_ns="$output"
+
+            run_podman logs $cname
+            con1_ns="$output"
+
+            assert "$con1_ns" == "$con2_ns" "($name) namespace matches (type: $type)"
+            local matcher="=="
+            if [[ "$type" != "host" ]]; then
+                matcher="!="
+            fi
+            assert "$con1_ns" $matcher "$host_ns" "expected host namespace to ($matcher) (type: $type)"
+
+            run_podman rm -f -t0 $cname
+        done < <(parse_table "$tests")
+    done
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
The problem right now is that --ns contianer: syntax causes use to add the namespace path to the spec which means the runtime will try to call setns on that. This works fine for private namespaces but when the host namspace is used by the container a rootless user is not allowed to join that namespace so the setns call will return with permission denied.

The fix is to effectively switch the container to the `host` mode instead of `container:` when the mention container used the host ns. I tried to fix this deep into the libpod call when we assign these namespaces but the problem is that this does not work correctly because these namespace require much more setup. Mainly different kind of mount points to work correctly.

We already have similar work-arounds in place for pods because they also need this.

For some reason this does not work with the user namespace, I don't know why and I don't think it is really needed so I left this out just to get at least the rest working. The original issue only reported this for the network namespace.

Fixes #18027

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman run `--network container:XXX` now also works when the target container uses the host network mode. The same also works for the other namespace options (`--pid`, `--uts`, `--cgroupns`, `--ipc`). 
```
