### PR TITLE
api: fix parsing filters

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -133,7 +133,7 @@ from alpine
 RUN >file1
 EOF
 
-podman image build -t test:test --label xyz -<<EOF
+podman image build -t test:test --label xyz --label abc -<<EOF
 from alpine
 RUN >file2
 EOF
@@ -143,7 +143,7 @@ t POST images/prune?filters='{"dangling":["true"]}' 200
 t GET images/json?filters='{"dangling":["true"]}' 200 length=0
 
 #label filter check in libpod and compat
-t GET images/json?filters='{"label":["xyz"]}' 200 length=1
+t GET images/json?filters='{"label":["xyz","abc"]}' 200 length=1
 t GET libpod/images/json?filters='{"label":["xyz"]}' 200 length=1
 
 t DELETE libpod/images/test:test 200


### PR DESCRIPTION
Podman and Docker clients split the filter map slightly different, so
account for that when parsing the filters in the image-listing endpoint.

Fixes: #18092

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix parsing multi-value filters in the REST API.
```
