### PR TITLE
[v4.4.1-rhel] Add file switch for pre-exec hooks

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -263,6 +263,13 @@ do_preexec_hooks_dir (const char *dir, char **argv, int argc)
 static void
 do_preexec_hooks (char **argv, int argc)
 {
+  // Access the preexec_hooks_dir indicator file
+  // return without processing if the file doesn't exist
+  char preexec_hooks_path[] = "/etc/containers/podman_preexec_hooks.txt";
+  if (access(preexec_hooks_path, F_OK) != 0) {
+    return;
+  }
+
   char *preexec_hooks = getenv ("PODMAN_PREEXEC_HOOKS_DIR");
   do_preexec_hooks_dir (LIBEXECPODMAN "/pre-exec-hooks", argv, argc);
   do_preexec_hooks_dir (ETC_PREEXEC_HOOKS, argv, argc);

--- a/test/system/950-preexec-hooks.bats
+++ b/test/system/950-preexec-hooks.bats
@@ -6,15 +6,39 @@
 load helpers
 load helpers.network
 
+# The existence of this file allows preexec hooks to run.
+preexec_hook_ok_file=/etc/containers/podman_preexec_hooks.txt
+
 function setup() {
     basic_setup
 }
 
 function teardown() {
+    if [[ -n "$preexec_hook_ok_file" ]]; then
+        sudo -n rm -f $preexec_hook_ok_file || true
+    fi
+
     basic_teardown
 }
 
 @test "podman preexec hook" {
+    # This file does not exist on any CI system nor any developer system
+    # nor actually anywhere in the universe except a small small set of
+    # places with very specific requirements. If we find this file on
+    # our test system, it could be a leftover from prior testing, or
+    # basically just something very weird. So, fail loudly if we see it.
+    # No podman developer ever wants this file to exist.
+    if [[ -e $preexec_hook_ok_file ]]; then
+        # Unset the variable, so we don't delete it in teardown
+        msg="File already exists (it should not): $preexec_hook_ok_file"
+        preexec_hook_ok_file=
+
+        die "$msg"
+    fi
+
+    # Good. File does not exist. Now see if we can TEMPORARILY create it.
+    sudo -n touch $preexec_hook_ok_file || skip "test requires sudo"
+
     preexec_hook_dir=$PODMAN_TMPDIR/auth
     mkdir -p $preexec_hook_dir
     preexec_hook_script=$preexec_hook_dir/pull_check.sh
@@ -29,5 +53,10 @@ EOF
     chmod +x $preexec_hook_script
 
     PODMAN_PREEXEC_HOOKS_DIR=$preexec_hook_dir run_podman 42 pull foobar
-    PODMAN_PREEXEC_HOOKS_DIR=$preexec_hook_dir run_podman 43 pull barfoo
+    PODMAN_PREEXEC_HOOKS_DIR=$preexec_hook_dir run_podman 43 version
+
+    sudo -n rm -f $preexec_hook_ok_file || true
+
+    # no hooks-ok file, everything should now work again (HOOKS_DIR is ignored)
+    PODMAN_PREEXEC_HOOKS_DIR=$preexec_hook_dir run_podman version
 }


### PR DESCRIPTION
The long term goal was to provide the customer with a way to turn on the
preexec_hooks processing of scripts by having some kind of configuration
that could be read. I had tried putting it into containers.conf to
start, but that turned out to be unyieldly quickly, and time is of
the essence for this fix. That is mostly due to the fact that this
code is preexecution and in C, the containers.conf file is read in
Go much further down the stack.

After first trying this process using an ENVVAR, I have
thought it over and chatted with others, and will now look for a
/etc/containers/podman_preexec_hooks.txt file to exist. If the admin
had put one in there, we will then process the files in the
directories /usr/libexec/podman/pre-exec-hooks
and /etc/containers/pre-exec-hooks.

Thoughts/suggestions gratefully accepted. This will be a 8.8/9.2 ZeroDay
fix and will need to be backported to the v4.4.1-rhel branch.

[NO NEW TESTS NEEDED]
Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
