### PR TITLE
fix: podman manifest annotate help example should use image digest

### DIFF
--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -18,7 +18,7 @@ var (
 		Long:              "Adds or updates information about an entry in a manifest list or image index.",
 		RunE:              annotate,
 		Args:              cobra.ExactArgs(2),
-		Example:           `podman manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64`,
+		Example:           `podman manifest annotate --annotation left=right mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`,
 		ValidArgsFunction: common.AutocompleteImages,
 	}
 )

--- a/cmd/podman/manifest/manifest.go
+++ b/cmd/podman/manifest/manifest.go
@@ -16,7 +16,7 @@ var (
 		Example: `podman manifest add mylist:v1.11 image:v1.11-amd64
   podman manifest create localhost/list
   podman manifest inspect localhost/list
-  podman manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64
+  podman manifest annotate --annotation left=right mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736
   podman manifest push mylist:v1.11 docker://quay.io/myuser/image:v1.11
   podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736
   podman manifest rm mylist:v1.11`,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

The podman manifest annote does not support the use of image tags. When tags are used, digest.Parse(image) will fail, but the examples in the help use tags, which will mislead users. I think the examples in the help should be changed to sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
 Podman manifest annotate help example should use image digest
```
