### PR TITLE
system reset: show graphRoot/runRoot before removal

### DIFF
--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -66,6 +66,13 @@ func reset(cmd *cobra.Command, args []string) {
         - all machines
         - all volumes`)
 
+		info, _ := registry.ContainerEngine().Info(registry.Context())
+		// lets not hard fail in case of an error
+		if info != nil {
+			fmt.Printf("        - the graphRoot directory: %q\n", info.Store.GraphRoot)
+			fmt.Printf("        - the runRoot directory: %q\n", info.Store.RunRoot)
+		}
+
 		if len(listCtn) > 0 {
 			fmt.Println(`WARNING! The following external containers will be purged:`)
 			// print first 12 characters of ID and first configured name alias

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -8,6 +8,8 @@ podman\-system\-reset - Reset storage back to initial state
 
 ## DESCRIPTION
 **podman system reset** removes all pods, containers, images, networks and volumes, and machines.
+It also removes the configured graphRoot and runRoot directories. Make sure these are not set to
+some important directory.
 
 This command must be run **before** changing any of the following fields in the
 `containers.conf` or `storage.conf` files: `driver`, `static_dir`, `tmp_dir`
@@ -38,6 +40,8 @@ WARNING! This will remove:
         - all build cache
         - all machines
         - all volumes
+        - the graphRoot directory: /var/lib/containers/storage
+        - the runRoot directory: /run/containers/storage
 Are you sure you want to continue? [y/N] y
 ```
 


### PR DESCRIPTION
system reset it says it will delete containers, images, networks, etc... However it will also delete the graphRoot and runRoot directories. Normally this is not an issue, however in same cases these directories were set to the users home directory or some other important system directory.

As first step simply show the directories that are configured and thus will be deleted by reset. As future step we could implement some safeguard will will not delete some known important directories however I tried to keep it simple for now.

see #18349 and #18295

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Show the graphRoot and runRoot directories when running podman system reset before we ask for confirmation as these directories will be deleted.
```
