### PR TITLE
machine: qemu only remove connection after confirmation

### DIFF
--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
@@ -91,24 +90,5 @@ func rm(_ *cobra.Command, args []string) error {
 		return err
 	}
 	newMachineEvent(events.Remove, events.Event{Name: vmName})
-	err = updateDefaultMachineInConfig(vmName)
-	if err != nil {
-		return fmt.Errorf("failed to update default machine: %v", err)
-	}
 	return nil
-}
-
-func updateDefaultMachineInConfig(vmName string) error {
-	cfg, err := config.ReadCustomConfig()
-	if err != nil {
-		return err
-	}
-	if cfg.Engine.ActiveService == vmName {
-		cfg.Engine.ActiveService = ""
-		for machine := range cfg.Engine.ServiceDestinations {
-			cfg.Engine.ActiveService = machine
-			break
-		}
-	}
-	return cfg.Write()
 }

--- a/pkg/machine/connection.go
+++ b/pkg/machine/connection.go
@@ -65,15 +65,25 @@ func ChangeDefault(name string) error {
 	return cfg.Write()
 }
 
-func RemoveConnection(name string) error {
+func RemoveConnections(names ...string) error {
 	cfg, err := config.ReadCustomConfig()
 	if err != nil {
 		return err
 	}
-	if _, ok := cfg.Engine.ServiceDestinations[name]; ok {
-		delete(cfg.Engine.ServiceDestinations, name)
-	} else {
-		return fmt.Errorf("unable to find connection named %q", name)
+	for _, name := range names {
+		if _, ok := cfg.Engine.ServiceDestinations[name]; ok {
+			delete(cfg.Engine.ServiceDestinations, name)
+		} else {
+			return fmt.Errorf("unable to find connection named %q", name)
+		}
+
+		if cfg.Engine.ActiveService == name {
+			cfg.Engine.ActiveService = ""
+			for service := range cfg.Engine.ServiceDestinations {
+				cfg.Engine.ActiveService = service
+				break
+			}
+		}
 	}
 	return cfg.Write()
 }

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -358,10 +358,7 @@ func (m *HyperVMachine) Remove(_ string, opts machine.RemoveOptions) (string, fu
 				logrus.Error(err)
 			}
 		}
-		if err := machine.RemoveConnection(m.Name); err != nil {
-			logrus.Error(err)
-		}
-		if err := machine.RemoveConnection(m.Name + "-root"); err != nil {
+		if err := machine.RemoveConnections(m.Name, m.Name+"-root"); err != nil {
 			logrus.Error(err)
 		}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -964,13 +964,6 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 	files = append(files, socketPath.Path)
 	files = append(files, v.archRemovalFiles()...)
 
-	if err := machine.RemoveConnection(v.Name); err != nil {
-		logrus.Error(err)
-	}
-	if err := machine.RemoveConnection(v.Name + "-root"); err != nil {
-		logrus.Error(err)
-	}
-
 	vmConfigDir, err := machine.GetConfDir(vmtype)
 	if err != nil {
 		return "", nil, err
@@ -1000,6 +993,12 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 			if err := os.Remove(f); err != nil && !errors.Is(err, os.ErrNotExist) {
 				logrus.Error(err)
 			}
+		}
+		if err := machine.RemoveConnection(v.Name); err != nil {
+			logrus.Error(err)
+		}
+		if err := machine.RemoveConnection(v.Name + "-root"); err != nil {
+			logrus.Error(err)
 		}
 		return nil
 	}, nil

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -994,10 +994,7 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 				logrus.Error(err)
 			}
 		}
-		if err := machine.RemoveConnection(v.Name); err != nil {
-			logrus.Error(err)
-		}
-		if err := machine.RemoveConnection(v.Name + "-root"); err != nil {
+		if err := machine.RemoveConnections(v.Name, v.Name+"-root"); err != nil {
 			logrus.Error(err)
 		}
 		return nil

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1368,10 +1368,7 @@ func (v *MachineVM) Remove(name string, opts machine.RemoveOptions) (string, fun
 
 	confirmationMessage += "\n"
 	return confirmationMessage, func() error {
-		if err := machine.RemoveConnection(v.Name); err != nil {
-			logrus.Error(err)
-		}
-		if err := machine.RemoveConnection(v.Name + "-root"); err != nil {
+		if err := machine.RemoveConnections(v.Name, v.Name+"-root"); err != nil {
 			logrus.Error(err)
 		}
 		if err := runCmdPassThrough("wsl", "--unregister", toDist(v.Name)); err != nil {


### PR DESCRIPTION
The connection remove call must be done inside the function that is
returned so that we wait until the user confirmed it.

Fixes https://github.com/containers/podman/issues/18330
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman machine rm with the qemu backend now correctly removes the machine connection after the confirmation message not before.
```
