### PR TITLE
Support systemd optional prefix '-' for devices.

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -145,7 +145,8 @@ Adds a device node from the host into the container. The format of this is
 `HOST-DEVICE[:CONTAINER-DEVICE][:PERMISSIONS]`, where `HOST-DEVICE` is the path of
 the device node on the host, `CONTAINER-DEVICE` is the path of the device node in
 the container, and `PERMISSIONS` is a list of permissions combining 'r' for read,
-'w' for write, and 'm' for mknod(2).
+'w' for write, and 'm' for mknod(2). The `-` prefix tells quadlet to add the device
+only if it exists on the host.
 
 This key can be listed multiple times.
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1,7 +1,9 @@
 package quadlet
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -421,6 +423,13 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	// But allow overrides with AddCapability
 	devices := container.LookupAllStrv(ContainerGroup, KeyAddDevice)
 	for _, device := range devices {
+		if device[0] == '-' {
+			device = device[1:]
+			_, err := os.Stat(strings.Split(device, ":")[0])
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+		}
 		podman.addf("--device=%s", device)
 	}
 

--- a/test/e2e/quadlet/devices.container
+++ b/test/e2e/quadlet/devices.container
@@ -1,7 +1,14 @@
 ## assert-podman-args --device=/dev/fuse
 ## assert-podman-args --device=/dev/loop0:r
+## assert-podman-args --device=/dev/null:/dev/test
+## !assert-podman-args --device=/dev/bogus:r
+## !assert-podman-args --device=/dev/bogus
+## !assert-podman-args --device=/dev/bogus1
 
 [Container]
 Image=localhost/imagename
 AddDevice=/dev/fuse
 AddDevice=/dev/loop0:r
+AddDevice=-/dev/null:/dev/test
+AddDevice=-/dev/bogus:r
+AddDevice=-/dev/bogus1


### PR DESCRIPTION
Systemd supports unit files with a prefix '-' which tells the system to check if the content exists before using it. This would allow the QM project to specify AddDevice=-/dev/kvm, which would add the /dev/kvm device to the container iff it exists on the host.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet now supports optional devices in the unit file.
```
