### PR TITLE
Fix a copy/paste error in an error message

### DIFF
--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -146,7 +146,7 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	}
 	digest, err := manifests.Push(ir.ClientCtx, name, destination, options)
 	if err != nil {
-		return "", fmt.Errorf("adding to manifest list %s: %w", name, err)
+		return "", fmt.Errorf("pushing manifest list %s: %w", name, err)
 	}
 
 	if opts.Rm {


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
podman will no longer incorrectly claim that an error encountered while pushing a manifest list was actually encountered while adding an item to the list.
```