### PR TITLE
[CI:DOCS] Fix simple typo in podman-network-create.md

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -86,7 +86,7 @@ View the driver in the **podman network inspect** output under the `ipam_options
 
 #### **--ipv6**
 
-Enable IPv6 (Dual Stack) networking. If not subnets are given it will allocate an ipv4 and an ipv6 subnet.
+Enable IPv6 (Dual Stack) networking. If no subnets are given it will allocate an ipv4 and an ipv6 subnet.
 
 #### **--label**=*label*
 


### PR DESCRIPTION
Found a typo today while reading documentation.

Changed wording for `podman-network-create`'s `--ipv6` option.

Simple enough change :-)

#### Does this PR introduce a user-facing change?
I don't think so?

