### PR TITLE
[CI:DOCS] swagger: fix Info name conflict

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -6,6 +6,7 @@ import (
 
 // Info is the overall struct that describes the host system
 // running libpod/podman
+// swagger:model LibpodInfo
 type Info struct {
 	Host       *HostInfo              `json:"host"`
 	Store      *StoreInfo             `json:"store"`


### PR DESCRIPTION
go swagger has a flat namespace so it doesn't handle name conflicts at all. The libpod info response uses the Info struct from some docker dep instead. Because we cannot change the docker dependency simply rename the Info struct, but only via swagger comment not the go actual struct.

I verified locally that this works.

Fixes #18228

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the `/libpod/info` response sample in the swagger API docs.
```
