### PR TITLE
libpod: Podman info output more network information

### DIFF
--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -77,6 +77,20 @@ host:
   logDriver: journald
   memFree: 1833385984
   memTotal: 16401895424
+  networkBackend: cni
+  networkBackendInfo:
+    backend: cni
+    dns:
+      package: podman-plugins-3.4.4-1.fc34.x86_64
+      path: /usr/libexec/cni/dnsname
+      version: |-
+        CNI dnsname plugin
+        version: 1.3.1
+        commit: unknown
+    package: |-
+      containernetworking-plugins-1.0.1-1.fc34.x86_64
+      podman-plugins-3.4.4-1.fc34.x86_64
+    path: /usr/libexec/cni
   ociRuntime:
     name: crun
     package: crun-1.0-1.fc34.x86_64
@@ -220,6 +234,17 @@ $ podman info --format json
     "logDriver": "journald",
     "memFree": 1785753600,
     "memTotal": 16401895424,
+    "networkBackend": "cni",
+    "networkBackendInfo": {
+      "backend": "cni",
+      "package": "containernetworking-plugins-1.0.1-1.fc34.x86_64\npodman-plugins-3.4.4-1.fc34.x86_64",
+      "path": "/usr/libexec/cni",
+      "dns": {
+        "version": "CNI dnsname plugin\nversion: 1.3.1\ncommit: unknown",
+        "package": "podman-plugins-3.4.4-1.fc34.x86_64",
+        "path": "/usr/libexec/cni/dnsname"
+      }
+    },
     "ociRuntime": {
       "name": "crun",
       "package": "crun-1.0-1.fc34.x86_64",

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/storage/pkg/idtools"
 )
 
@@ -27,27 +28,28 @@ type SecurityInfo struct {
 
 // HostInfo describes the libpod host
 type HostInfo struct {
-	Arch              string           `json:"arch"`
-	BuildahVersion    string           `json:"buildahVersion"`
-	CgroupManager     string           `json:"cgroupManager"`
-	CgroupsVersion    string           `json:"cgroupVersion"`
-	CgroupControllers []string         `json:"cgroupControllers"`
-	Conmon            *ConmonInfo      `json:"conmon"`
-	CPUs              int              `json:"cpus"`
-	CPUUtilization    *CPUUsage        `json:"cpuUtilization"`
-	DatabaseBackend   string           `json:"databaseBackend"`
-	Distribution      DistributionInfo `json:"distribution"`
-	EventLogger       string           `json:"eventLogger"`
-	FreeLocks         *uint32          `json:"freeLocks,omitempty"`
-	Hostname          string           `json:"hostname"`
-	IDMappings        IDMappings       `json:"idMappings,omitempty"`
-	Kernel            string           `json:"kernel"`
-	LogDriver         string           `json:"logDriver"`
-	MemFree           int64            `json:"memFree"`
-	MemTotal          int64            `json:"memTotal"`
-	NetworkBackend    string           `json:"networkBackend"`
-	OCIRuntime        *OCIRuntimeInfo  `json:"ociRuntime"`
-	OS                string           `json:"os"`
+	Arch               string            `json:"arch"`
+	BuildahVersion     string            `json:"buildahVersion"`
+	CgroupManager      string            `json:"cgroupManager"`
+	CgroupsVersion     string            `json:"cgroupVersion"`
+	CgroupControllers  []string          `json:"cgroupControllers"`
+	Conmon             *ConmonInfo       `json:"conmon"`
+	CPUs               int               `json:"cpus"`
+	CPUUtilization     *CPUUsage         `json:"cpuUtilization"`
+	DatabaseBackend    string            `json:"databaseBackend"`
+	Distribution       DistributionInfo  `json:"distribution"`
+	EventLogger        string            `json:"eventLogger"`
+	FreeLocks          *uint32           `json:"freeLocks,omitempty"`
+	Hostname           string            `json:"hostname"`
+	IDMappings         IDMappings        `json:"idMappings,omitempty"`
+	Kernel             string            `json:"kernel"`
+	LogDriver          string            `json:"logDriver"`
+	MemFree            int64             `json:"memFree"`
+	MemTotal           int64             `json:"memTotal"`
+	NetworkBackend     string            `json:"networkBackend"`
+	NetworkBackendInfo types.NetworkInfo `json:"networkBackendInfo"`
+	OCIRuntime         *OCIRuntimeInfo   `json:"ociRuntime"`
+	OS                 string            `json:"os"`
 	// RemoteSocket returns the UNIX domain socket the Podman service is listening on
 	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
 	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/util"
+	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/linkmode"
@@ -106,24 +107,25 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 	}
 
 	info := define.HostInfo{
-		Arch:            runtime.GOARCH,
-		BuildahVersion:  buildah.Version,
-		DatabaseBackend: r.config.Engine.DBBackend,
-		Linkmode:        linkmode.Linkmode(),
-		CPUs:            runtime.NumCPU(),
-		CPUUtilization:  cpuUtil,
-		Distribution:    hostDistributionInfo,
-		FreeLocks:       locksFree,
-		LogDriver:       r.config.Containers.LogDriver,
-		EventLogger:     r.eventer.String(),
-		Hostname:        host,
-		Kernel:          kv,
-		MemFree:         mi.MemFree,
-		MemTotal:        mi.MemTotal,
-		NetworkBackend:  r.config.Network.NetworkBackend,
-		OS:              runtime.GOOS,
-		SwapFree:        mi.SwapFree,
-		SwapTotal:       mi.SwapTotal,
+		Arch:               runtime.GOARCH,
+		BuildahVersion:     buildah.Version,
+		DatabaseBackend:    r.config.Engine.DBBackend,
+		Linkmode:           linkmode.Linkmode(),
+		CPUs:               runtime.NumCPU(),
+		CPUUtilization:     cpuUtil,
+		Distribution:       hostDistributionInfo,
+		LogDriver:          r.config.Containers.LogDriver,
+		EventLogger:        r.eventer.String(),
+		FreeLocks:          locksFree,
+		Hostname:           host,
+		Kernel:             kv,
+		MemFree:            mi.MemFree,
+		MemTotal:           mi.MemTotal,
+		NetworkBackend:     r.config.Network.NetworkBackend,
+		NetworkBackendInfo: r.network.NetworkInfo(),
+		OS:                 runtime.GOOS,
+		SwapFree:           mi.SwapFree,
+		SwapTotal:          mi.SwapTotal,
 	}
 	if err := r.setPlatformHostInfo(&info); err != nil {
 		return nil, err
@@ -241,14 +243,14 @@ func (r *Runtime) storeInfo() (*define.StoreInfo, error) {
 	for _, o := range r.store.GraphOptions() {
 		split := strings.SplitN(o, "=", 2)
 		if strings.HasSuffix(split[0], "mount_program") {
-			version, err := programVersion(split[1])
+			version, err := cutil.ProgramVersion(split[1])
 			if err != nil {
 				logrus.Warnf("Failed to retrieve program version for %s: %v", split[1], err)
 			}
 			program := map[string]interface{}{}
 			program["Executable"] = split[1]
 			program["Version"] = version
-			program["Package"] = packageVersion(split[1])
+			program["Package"] = cutil.PackageVersion(split[1])
 			graphOptions[split[0]] = program
 		} else {
 			graphOptions[split[0]] = split[1]

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/common/pkg/seccomp"
+	"github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -59,13 +60,13 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 		slirp4netnsPath, _ = r.config.FindHelperBinary(slirp4netnsBinaryName, true)
 	}
 	if slirp4netnsPath != "" {
-		version, err := programVersion(slirp4netnsPath)
+		version, err := util.ProgramVersion(slirp4netnsPath)
 		if err != nil {
 			logrus.Warnf("Failed to retrieve program version for %s: %v", slirp4netnsPath, err)
 		}
 		program := define.SlirpInfo{
 			Executable: slirp4netnsPath,
-			Package:    packageVersion(slirp4netnsPath),
+			Package:    util.PackageVersion(slirp4netnsPath),
 			Version:    version,
 		}
 		info.Slirp4NetNS = program
@@ -73,13 +74,13 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 
 	pastaPath, _ := r.config.FindHelperBinary(pastaBinaryName, true)
 	if pastaPath != "" {
-		version, err := programVersion(pastaPath)
+		version, err := util.ProgramVersion(pastaPath)
 		if err != nil {
 			logrus.Warnf("Failed to retrieve program version for %s: %v", pastaPath, err)
 		}
 		program := define.PastaInfo{
 			Executable: pastaPath,
-			Package:    packageVersion(pastaPath),
+			Package:    util.PackageVersion(pastaPath),
 			Version:    version,
 		}
 		info.Pasta = program

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -945,8 +945,8 @@ func (r *ConmonOCIRuntime) ExitFilePath(ctr *Container) (string, error) {
 
 // RuntimeInfo provides information on the runtime.
 func (r *ConmonOCIRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error) {
-	runtimePackage := packageVersion(r.path)
-	conmonPackage := packageVersion(r.conmonPath)
+	runtimePackage := cutil.PackageVersion(r.path)
+	conmonPackage := cutil.PackageVersion(r.conmonPath)
 	runtimeVersion, err := r.getOCIRuntimeVersion()
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting version of OCI runtime %s: %w", r.name, err)

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -160,6 +160,11 @@ var _ = Describe("Podman Info", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(Exit(0))
 		Expect(session.OutputToString()).To(Equal(want))
+
+		session = podmanTest.Podman([]string{"info", "--format", "{{.Host.NetworkBackendInfo.Backend}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+		Expect(session.OutputToString()).To(Equal(want))
 	})
 
 	It("Podman info: check desired database backend", func() {

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -42,6 +42,7 @@ host.conmon.path          | $expr_path
 host.conmon.package       | .*conmon.*
 host.cgroupManager        | \\\(systemd\\\|cgroupfs\\\)
 host.cgroupVersion        | v[12]
+host.networkBackendInfo   | .*dns.*package.*
 host.ociRuntime.path      | $expr_path
 host.pasta                | .*executable.*package.*
 store.configFile          | $expr_path


### PR DESCRIPTION
podman info prints the network information about binary path,
package version, program version and DNS information.

Fixes: #18443

<details>
<summary>cni info</summary>

```yaml
  networkBackendInfo:
    backend: cni
    dns:
      package: podman-plugins-4.5.0-1.fc38.x86_64
      path: /usr/libexec/cni/dnsname
      version: |-
        CNI dnsname plugin
        version: 1.3.1
        commit: unknown
    package: |-
      containernetworking-plugins-1.1.1-16.fc38.x86_64
      podman-plugins-4.5.0-1.fc38.x86_64
    path: /usr/libexec/cni
```
</details>

<details>
<summary>netavark info</summary>

```yaml
  networkBackendInfo:
    backend: netavark
    dns:
      package: aardvark-dns-1.6.0-1.fc38.x86_64
      path: /usr/libexec/podman/aardvark-dns
      version: aardvark-dns 1.6.0
    package: netavark-1.6.0-2.fc38.x86_64
    path: /usr/libexec/podman/netavark
    version: netavark 1.6.0
```
</details>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now podman info prints the network information about binary path, package version, program version and DNS information.
```
