### PR TITLE
Run generate.CompleteSpec() for initContainers as well

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -727,6 +727,16 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// ensure the environment is setup for initContainers as well: https://github.com/containers/podman/issues/18384
+		warn, err := generate.CompleteSpec(ctx, ic.Libpod, specGen)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, w := range warn {
+			logrus.Warn(w)
+		}
+
 		specGen.SdNotifyMode = define.SdNotifyModeIgnore
 		rtSpec, spec, opts, err := generate.MakeContainer(ctx, ic.Libpod, specGen, false, nil)
 		if err != nil {
@@ -792,7 +802,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			return nil, nil, err
 		}
 		for _, w := range warn {
-			fmt.Fprintf(os.Stderr, "%s\n", w)
+			logrus.Warn(w)
 		}
 
 		specGen.RawImageName = container.Image

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2210,7 +2210,7 @@ var _ = Describe("Podman play kube", func() {
 	// With annotation set to always
 	It("podman play kube test with init containers and annotation set", func() {
 		// With the init container type annotation set to always
-		pod := getPod(withAnnotation("io.podman.annotations.init.container.type", "always"), withPodInitCtr(getCtr(withImage(ALPINE), withCmd([]string{"echo", "hello"}), withInitCtr(), withName("init-test"))), withCtr(getCtr(withImage(ALPINE), withCmd([]string{"top"}))))
+		pod := getPod(withAnnotation("io.podman.annotations.init.container.type", "always"), withPodInitCtr(getCtr(withImage(ALPINE), withCmd([]string{"printenv", "container"}), withInitCtr(), withName("init-test"))), withCtr(getCtr(withImage(ALPINE), withCmd([]string{"top"}))))
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -2233,6 +2233,12 @@ var _ = Describe("Podman play kube", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
 		Expect(inspect.OutputToString()).To(ContainSubstring("running"))
+
+		// Init containers need environment too! #18384
+		logs := podmanTest.Podman([]string{"logs", "testPod-init-test"})
+		logs.WaitWithDefaultTimeout()
+		Expect(logs).Should(Exit(0))
+		Expect(logs.OutputToString()).To(Equal("podman"))
 	})
 
 	// If you have an init container in the pod yaml, podman should create and run the init container with play kube


### PR DESCRIPTION
initContainers in kubernetes deployments had no call to CompleteSpec in the generation, which means that the default environment is not configured for these. This causes issues with missing default environment variables like `$HOME` or `$PATH`.

This fixes https://github.com/containers/podman/issues/18384

#### Does this PR introduce a user-facing change?

```release-note
- ensure that initContainers in k8s deployments have a correctly setup default environment
```
