### PR TITLE
manifest, push: use `source` as `destination` if not specified

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -36,7 +36,7 @@ var (
 		Long:              "Pushes manifest lists and image indexes to registries.",
 		RunE:              push,
 		Example:           `podman manifest push mylist:v1.11 docker://quay.io/myuser/image:v1.11`,
-		Args:              cobra.ExactArgs(2),
+		Args:              cobra.RangeArgs(1, 2),
 		ValidArgsFunction: common.AutocompleteImages,
 	}
 )
@@ -114,7 +114,7 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	listImageSpec := args[0]
-	destSpec := args[1]
+	destSpec := args[len(args)-1]
 	if listImageSpec == "" {
 		return fmt.Errorf(`invalid image name "%s"`, listImageSpec)
 	}
@@ -155,7 +155,7 @@ func push(cmd *cobra.Command, args []string) error {
 		}
 		manifestPushOpts.SkipTLSVerify = types.NewOptionalBool(manifestPushOpts.Insecure)
 	}
-	digest, err := registry.ImageEngine().ManifestPush(registry.Context(), args[0], args[1], manifestPushOpts.ImagePushOptions)
+	digest, err := registry.ImageEngine().ManifestPush(registry.Context(), listImageSpec, destSpec, manifestPushOpts.ImagePushOptions)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Podman manifest", func() {
 		f := CurrentGinkgoTestDescription()
 		processTestResult(f)
 	})
-	It("create w/o image", func() {
+	It("create w/o image and attempt push w/o dest", func() {
 		for _, amend := range []string{"--amend", "-a"} {
 			session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 			session.WaitWithDefaultTimeout()
@@ -55,6 +55,13 @@ var _ = Describe("Podman manifest", func() {
 			session = podmanTest.Podman([]string{"manifest", "create", "foo"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).To(ExitWithError())
+
+			session = podmanTest.Podman([]string{"manifest", "push", "--all", "foo"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).To(ExitWithError())
+			// Push should actually fail since its not valid registry
+			Expect(session.ErrorToString()).To(ContainSubstring("requested access to the resource is denied"))
+			Expect(session.OutputToString()).To(Not(ContainSubstring("accepts 2 arg(s), received 1")))
 
 			session = podmanTest.Podman([]string{"manifest", "create", amend, "foo"})
 			session.WaitWithDefaultTimeout()

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -313,6 +313,16 @@ var _ = Describe("Podman push", func() {
 		push.WaitWithDefaultTimeout()
 		Expect(push).Should(Exit(0))
 		Expect(push.ErrorToString()).To(ContainSubstring("Writing manifest to image destination"))
+
+		// create and push manifest
+		session = podmanTest.Podman([]string{"manifest", "create", "localhost:5000/manifesttest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"manifest", "push", "--creds=podmantest:test", "--tls-verify=false", "--all", "localhost:5000/manifesttest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("Writing manifest list to image destination"))
 	})
 
 	It("podman push and encrypt to oci", func() {


### PR DESCRIPTION
`manifest push <source>` must work as-is if `source` is actually a valid path and no destination is provided, `podman` must internally choose `source` as its `destination` just like `podman push`

See: https://github.com/containers/podman/blob/main/cmd/podman/images/push.go#L161
Closes: https://github.com/containers/podman/issues/18360

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
manifest, push: use `source` as `destination` if not specified
```
