### PR TITLE
[CI:DOCS] troubleshooting: fix subuid example

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -272,8 +272,8 @@ You should ensure that each user has a unique range of UIDs, because overlapping
 would potentially allow one user to attack another user. In addition, make sure
 that the range of UIDs you allocate can cover all UIDs that the container
 requires. For example, if the container has a user with UID 10000, ensure you
-have at least 10001 subuids, and if the container needs to be run as a user with
-UID 1000000, ensure you have at least 1000001 subuids.
+have at least 10000 subuids, and if the container needs to be run as a user with
+UID 1000000, ensure you have at least 1000000 subuids.
 
 You could also use the `usermod` program to assign UIDs to a user.
 


### PR DESCRIPTION
Fix incorrect number of required subuids in subuid example.

Fixes: https://github.com/containers/podman/issues/18400

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
