### PR TITLE
test/e2e: do not remove CNI directory

### DIFF
--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -24,8 +24,6 @@ var _ = Describe("Podman create with --ip flag", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		// Clean up the CNI networks used by the tests
-		os.RemoveAll("/var/lib/cni/networks/podman")
 	})
 
 	AfterEach(func() {

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -24,8 +24,6 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		// Clean up the CNI networks used by the tests
-		os.RemoveAll("/var/lib/cni/networks/podman")
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -28,8 +28,6 @@ var _ = Describe("Podman run with --ip flag", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		// Clean up the CNI networks used by the tests
-		os.RemoveAll("/var/lib/cni/networks/podman")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This is not safe at all when run in parallel, CNI needs that directory to detect duplicated ips and also stores other important network info in it. Removing it while container network is setup is not safe at all and could cause a lot of weird flakes.

This "hack" was added in commit 55508c11 but provides zero context what this was supposed to fix so I don't know what the actual issue is or was.

Fixes #18399

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
