### PR TITLE
bindings, build: don't pass invalid platform in case of none

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.4
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
-	github.com/containers/buildah v1.30.0
+	github.com/containers/buildah v1.30.1-0.20230501124043-3908816d5310
 	github.com/containers/common v0.53.1-0.20230502134647-9cd0cc23c80f
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.25.0
@@ -46,7 +46,7 @@ require (
 	github.com/onsi/gomega v1.27.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
-	github.com/opencontainers/runc v1.1.5
+	github.com/opencontainers/runc v1.1.7
 	github.com/opencontainers/runtime-spec v1.1.0-rc.2
 	github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69
 	github.com/opencontainers/selinux v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.2.0 h1:SWgg3dQG1yzUo4d9iD8cwSVh1VqI+bP7mkPDoSfP9VU=
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
-github.com/containers/buildah v1.30.0 h1:mdp2COGKFFEZNEGP8VZ5ITuUFVNPFoH+iK2sSesNfTA=
-github.com/containers/buildah v1.30.0/go.mod h1:lyMLZIevpAa6zSzjRl7z4lFJMCMQLFjfo56YIefaB/U=
+github.com/containers/buildah v1.30.1-0.20230501124043-3908816d5310 h1:xYQch7NrCYPrNcrDUHPc1dE2nwg+2xHiG5l59T+m5Q4=
+github.com/containers/buildah v1.30.1-0.20230501124043-3908816d5310/go.mod h1:6A/BK0YJLXL8+AqlbceKJrhUT+NtEgsvAc51F7TAllc=
 github.com/containers/common v0.53.1-0.20230502134647-9cd0cc23c80f h1:NGr0tr+qnavYQ3m+ajnrCLCp7y/YlGj14OXsYD5RhqY=
 github.com/containers/common v0.53.1-0.20230502134647-9cd0cc23c80f/go.mod h1:uG5iTo9KbPxcyj3nsq0OPbBRTrSsrXKIMNRw4D6rt/w=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -298,6 +298,12 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	if len(options.Platforms) > 0 {
 		params.Del("platform")
 		for _, platformSpec := range options.Platforms {
+			// podman-cli will send empty struct, in such
+			// case don't add platform to param and let the
+			// build backend decide the default platform.
+			if platformSpec.OS == "" && platformSpec.Arch == "" && platformSpec.Variant == "" {
+				continue
+			}
 			platform = platformSpec.OS + "/" + platformSpec.Arch
 			if platformSpec.Variant != "" {
 				platform += "/" + platformSpec.Variant

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -192,7 +192,7 @@ conformance_task:
     gce_instance:
         image_name: "${DEBIAN_CACHE_IMAGE_NAME}"
 
-    timeout_in: 25m
+    timeout_in: 65m
 
     matrix:
         - env:

--- a/vendor/github.com/containers/buildah/Makefile
+++ b/vendor/github.com/containers/buildah/Makefile
@@ -167,7 +167,7 @@ install.runc:
 
 .PHONY: test-conformance
 test-conformance:
-	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -timeout 20m ./tests/conformance
+	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -timeout 60m ./tests/conformance
 
 .PHONY: test-integration
 test-integration: install.tools

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.30.0"
+	Version = "1.31.0-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/pkg/parse/parse.go
+++ b/vendor/github.com/containers/buildah/pkg/parse/parse.go
@@ -510,8 +510,6 @@ func PlatformsFromOptions(c *cobra.Command) (platforms []struct{ OS, Arch, Varia
 	return platforms, nil
 }
 
-const platformSep = "/"
-
 // DefaultPlatform returns the standard platform for the current system
 func DefaultPlatform() string {
 	return platforms.DefaultString()
@@ -520,21 +518,19 @@ func DefaultPlatform() string {
 // Platform separates the platform string into os, arch and variant,
 // accepting any of $arch, $os/$arch, or $os/$arch/$variant.
 func Platform(platform string) (os, arch, variant string, err error) {
-	split := strings.Split(platform, platformSep)
-	switch len(split) {
-	case 3:
-		variant = split[2]
-		fallthrough
-	case 2:
-		arch = split[1]
-		os = split[0]
-		return
-	case 1:
-		if platform == "local" {
-			return Platform(DefaultPlatform())
-		}
+	if platform == "local" || platform == "" || platform == "/" {
+		return Platform(DefaultPlatform())
 	}
-	return "", "", "", fmt.Errorf("invalid platform syntax for %q (use OS/ARCH[/VARIANT][,...])", platform)
+	if platform[len(platform)-1] == '/' || platform[0] == '/' {
+		// If --platform string has format as `some/plat/string/`
+		// or `/some/plat/string` make it `some/plat/string`
+		platform = strings.Trim(platform, "/")
+	}
+	platformSpec, err := platforms.Parse(platform)
+	if err != nil {
+		return "", "", "", fmt.Errorf("invalid platform syntax for --platform=%q: %w", platform, err)
+	}
+	return platformSpec.OS, platformSpec.Architecture, platformSpec.Variant, nil
 }
 
 func parseCreds(creds string) (string, string) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -102,7 +102,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.2.0
 ## explicit; go 1.17
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.30.0
+# github.com/containers/buildah v1.30.1-0.20230501124043-3908816d5310
 ## explicit; go 1.18
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -731,7 +731,7 @@ github.com/opencontainers/go-digest
 ## explicit; go 1.17
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runc v1.1.5 => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+# github.com/opencontainers/runc v1.1.7 => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
 ## explicit; go 1.17
 github.com/opencontainers/runc/libcontainer/apparmor
 github.com/opencontainers/runc/libcontainer/cgroups


### PR DESCRIPTION
In case of no `platform` , bindings should not add `platform` to parameters at all instead it adds `/` as platform string which is invalid.

[NO NEW TESTS NEEDED]
Exsiting test should pass with new buildah from upstream.

Closes: https://github.com/containers/buildah/issues/4768
Closes: https://github.com/containers/buildah/issues/4769

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bindings, build: don't pass invalid platform in case of none
```
