### PR TITLE
podman run --authfile do not stat file

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -118,12 +118,6 @@ func run(cmd *cobra.Command, args []string) error {
 		logrus.Warnf("The input device is not a TTY. The --tty and --interactive flags might not work properly")
 	}
 
-	if af := cliVals.Authfile; len(af) > 0 {
-		if _, err := os.Stat(af); err != nil {
-			return err
-		}
-	}
-
 	runOpts.CIDFile = cliVals.CIDFile
 	runOpts.Rm = cliVals.Rm
 	cliVals, err := CreateInit(cmd, cliVals, false)

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -257,10 +257,6 @@ var _ = Describe("Podman login and logout", func() {
 		setup.WaitWithDefaultTimeout()
 		defer os.RemoveAll(certDir)
 
-		// FIXME: #18405, podman-run barfs if $REGISTRY_AUTH_FILE missing
-		err = os.WriteFile(os.Getenv("REGISTRY_AUTH_FILE"), []byte(`{"auths": {}}`), 0600)
-		Expect(err).ToNot(HaveOccurred(), "touching authfile")
-
 		// N/B: This second registry container shares the same auth and cert dirs
 		//      as the registry started from BeforeEach().  Since this one starts
 		//      second, re-labeling the volumes should keep SELinux happy.


### PR DESCRIPTION
No other commands do this, it makes no sense to fail hard if the given authfile does not exists. We do not even know if we have to pull anything at that point. I expect the code to error at some later point if the auth file is really needed but does not exists.

Fixes #18405

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
