### PR TITLE
e2e tests: try writing & preserving ginkgo json artifacts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -585,6 +585,9 @@ local_integration_test_task: &local_integration_test_task
         ginkgo_node_logs_artifacts:
             path: ./test/e2e/ginkgo-node-*.log
             type: text/plain
+        ginkgo_json_artifacts:
+            path: ./ginkgo-e2e.json
+            type: application/json
 
 
 # Nearly identical to `local_integration_test` except all operations

--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,7 @@ test: localunit localintegration remoteintegration localsystem remotesystem  ## 
 .PHONY: ginkgo-run
 ginkgo-run: .install.ginkgo
 	$(GINKGO) version
-	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts 3 --trace --no-color $(if $(findstring y,$(GINKGO_PARALLEL)),-p,) $(GINKGOWHAT) $(HACK)
+	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts 3 --trace --no-color --json-report ginkgo-e2e.json $(if $(findstring y,$(GINKGO_PARALLEL)),-p,) $(GINKGOWHAT) $(HACK)
 
 .PHONY: ginkgo
 ginkgo:


### PR DESCRIPTION
ginkgo v2 has new options, --junit-report and --json-report.
The JUNIT one is utterly worthless: no timing data, no
separation between test output (podman commands) and
ginkgo output (filenames, linenumbers). JSON goes the
other direction, super-complicated, but I think I can
work with it. Let's try it.

This PR does not actually _do_ anything with the json; all
we do is save it. Over time, I'll download and play with it
and see what I can do with it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```