### PR TITLE
libpod: warn if custom value is overriden by libpod

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -114,6 +114,8 @@ Overriding this option will cause the *storage-opt* settings in `containers-stor
 Storage state directory where all state information is stored (default: "/run/containers/storage" for UID 0, "/run/user/$UID/run" for other users).
 Default state dir configured in `containers-storage.conf(5)`.
 
+Note: This option is intended to be used on the first run of Podman or when `--root` is set to an entierly new path, after which its value will be set as the default until `podman system reset` is run. The default cannot be overridden without podman system reset
+
 #### **--runtime**=*value*
 
 Name of the OCI runtime as specified in containers.conf or absolute path to the OCI compatible binary used to run containers.
@@ -141,6 +143,8 @@ Storage driver.  The default storage driver for UID 0 is configured in `containe
 Overriding this option will cause the *storage-opt* settings in `containers-storage.conf(5)` to be ignored.  The user must
 specify additional options via the `--storage-opt` flag.
 
+Note: This option is intended to be used on the first run of Podman or when `--root` is set to an entierly new path, after which its value will be set as the default until `podman system reset` is run. The default cannot be overridden without podman system reset
+
 #### **--storage-opt**=*value*
 
 Specify a storage driver option. Default storage driver options are configured in `containers-storage.conf(5)`. The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options override all. Specify --storage-opt="" so no storage options will be used.
@@ -156,6 +160,8 @@ On remote clients, including Mac and Windows (excluding WSL2) machines, logging 
 Path to the tmp directory, for libpod runtime content. Defaults to `$XDG_RUNTIME_DIR/libpod/tmp` as rootless and `/run/libpod/tmp` as rootful.
 
 NOTE --tmpdir is not used for the temporary storage of downloaded images.  Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
+
+Note: This option is intended to be used on the first run of Podman or when `--root` is set to an entierly new path, after which its value will be set as the default until `podman system reset` is run. The default cannot be overridden without podman system reset
 
 #### **--transient-store**
 
@@ -205,6 +211,8 @@ Print the version
 #### **--volumepath**=*value*
 
 Volume directory where builtin volume information is stored (default: "/var/lib/containers/storage/volumes" for UID 0, "$HOME/.local/share/containers/storage/volumes" for other users). Default volume path can be overridden in `containers.conf`.
+
+Note: This option is intended to be used on the first run of Podman or when `--root` is set to an entierly new path, after which its value will be set as the default until `podman system reset` is run. The default cannot be overridden without podman system reset
 
 ## Environment Variables
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1020,7 +1020,7 @@ func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) {
 	if !r.storageSet.RunRootSet && dbConfig.StorageTmp != "" {
 		if r.storageConfig.RunRoot != dbConfig.StorageTmp &&
 			r.storageConfig.RunRoot != "" {
-			logrus.Debugf("Overriding run root %q with %q from database",
+			logrus.Warnf("Overriding run root %q with %q from database",
 				r.storageConfig.RunRoot, dbConfig.StorageTmp)
 		}
 		r.storageConfig.RunRoot = dbConfig.StorageTmp
@@ -1029,7 +1029,7 @@ func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) {
 	if !r.storageSet.GraphRootSet && dbConfig.StorageRoot != "" {
 		if r.storageConfig.GraphRoot != dbConfig.StorageRoot &&
 			r.storageConfig.GraphRoot != "" {
-			logrus.Debugf("Overriding graph root %q with %q from database",
+			logrus.Warnf("Overriding graph root %q with %q from database",
 				r.storageConfig.GraphRoot, dbConfig.StorageRoot)
 		}
 		r.storageConfig.GraphRoot = dbConfig.StorageRoot
@@ -1046,21 +1046,21 @@ func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) {
 
 	if !r.storageSet.StaticDirSet && dbConfig.LibpodRoot != "" {
 		if c.StaticDir != dbConfig.LibpodRoot && c.StaticDir != "" {
-			logrus.Debugf("Overriding static dir %q with %q from database", c.StaticDir, dbConfig.LibpodRoot)
+			logrus.Warnf("Overriding static dir %q with %q from database", c.StaticDir, dbConfig.LibpodRoot)
 		}
 		c.StaticDir = dbConfig.LibpodRoot
 	}
 
 	if !r.storageSet.TmpDirSet && dbConfig.LibpodTmp != "" {
 		if c.TmpDir != dbConfig.LibpodTmp && c.TmpDir != "" {
-			logrus.Debugf("Overriding tmp dir %q with %q from database", c.TmpDir, dbConfig.LibpodTmp)
+			logrus.Warnf("Overriding tmp dir %q with %q from database", c.TmpDir, dbConfig.LibpodTmp)
 		}
 		c.TmpDir = dbConfig.LibpodTmp
 	}
 
 	if !r.storageSet.VolumePathSet && dbConfig.VolumePath != "" {
 		if c.VolumePath != dbConfig.VolumePath && c.VolumePath != "" {
-			logrus.Debugf("Overriding volume path %q with %q from database", c.VolumePath, dbConfig.VolumePath)
+			logrus.Warnf("Overriding volume path %q with %q from database", c.VolumePath, dbConfig.VolumePath)
 		}
 		c.VolumePath = dbConfig.VolumePath
 	}

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -123,7 +123,7 @@ verify_iid_and_name() {
     run_podman image scp -q ${notme}@localhost::$newname
 
     expect="Loaded image: $newname"
-    is "$output" "$expect" "-q silences output"
+    assert "$output" =~ "$expect" "-q silences output"
 
     # Confirm that we have it, and that its digest matches our original
     run_podman image inspect --format '{{.Digest}}' $newname


### PR DESCRIPTION
* Libpod will override certain values if they are already set in backend
  database irrespective of the custom value set by the user.

* Add notes to man pages about these cli config flags

[NO NEW TESTS NEEDED]
Existing tests must pass, this is not a new feature or a bug fix.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
 llibpod: warn if custom value is overriden by libpod
```

Closes: https://github.com/containers/podman/issues/18430
