### PR TITLE
remote: exec inspect update exec session status

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -893,6 +893,17 @@ func (c *Container) execSessionNoCopy(id string) (*ExecSession, error) {
 		return nil, fmt.Errorf("no exec session with ID %s found in container %s: %w", id, c.ID(), define.ErrNoSuchExecSession)
 	}
 
+	// make sure to update the exec session if needed #18424
+	alive, err := c.ociRuntime.ExecUpdateStatus(c, id)
+	if err != nil {
+		return nil, err
+	}
+	if !alive {
+		if err := retrieveAndWriteExecExitCode(c, session.ID()); err != nil {
+			return nil, err
+		}
+	}
+
 	return session, nil
 }
 

--- a/pkg/bindings/test/exec_test.go
+++ b/pkg/bindings/test/exec_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Podman containers exec", func() {
 		bt.cleanup()
 	})
 
-	It("Podman exec create makes an exec session", func() {
+	It("Podman exec create+start makes an exec session", func() {
 		name := "testCtr"
 		cid, err := bt.RunTopContainer(&name, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -48,6 +48,15 @@ var _ = Describe("Podman containers exec", func() {
 		Expect(inspectOut.ProcessConfig.Entrypoint).To(Equal("echo"))
 		Expect(inspectOut.ProcessConfig.Arguments).To(HaveLen(1))
 		Expect(inspectOut.ProcessConfig.Arguments[0]).To(Equal("hello world"))
+
+		err = containers.ExecStart(bt.conn, sessionID, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		inspectOut, err = containers.ExecInspect(bt.conn, sessionID, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectOut.ContainerID).To(Equal(cid))
+		Expect(inspectOut.Running).To(BeFalse(), "session should not be running")
+		Expect(inspectOut.ExitCode).To(Equal(0), "exit code from echo")
 	})
 
 	It("Podman exec create with bad command fails", func() {


### PR DESCRIPTION
The remote API will wait 300s by default before conmon will call the cleanup. In the meantime when you inspect an exec session started with ExecStart() (so not attached) and it did exit we do not know that. If a caller inspects it they think it is still running. To prevent this we should sync the session based on the exec pid and update the state accordingly.

For a reproducer see the test in this commit or the issue.

Fixes #18424

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The remote API exec inspect call will now correctly displays updated information, e.g. when the exec process died.
```
