### PR TITLE
Add support for confined users

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-12"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20230426t140447z-f38f37d12"
+    IMAGE_SUFFIX: "c20230614t132754z-f38f37d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"


### PR DESCRIPTION
The original SELinux support in Docker and Podman does not follow the default SELinux rules for how label transitions are supposed to be handled. Containers always switch their user and role to system_u:system_r, rather then maintain the collers user and role. For example
unconfined_u:unconfined_r:container_t:s0:c1,c2

Advanced SELinux administrators want to confine users but still allow them to create containers from their role, but not allow them to launch a privileged container like spc_t.

This means if a user running as
container_user_u:container_user_r:container_user_t:s0

Ran a container they would get

container_user_u:container_user_r:container_t:s0:c1,c2

If they run a privileged container they would run it with:

container_user_u:container_user_r:container_user_t:s0

If they want to force the label they would get an error

podman run --security-opt label=type:spc_t ...

Should fail. Because the container_user_r can not run with the spc_t.

SELinux rules would also prevent the user from forcing system_u user and the sytem_r role.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Confined SELinux users can not use podman
```