### PR TITLE
Replace egrep/fgrep with grep -E/-F

### DIFF
--- a/.github/actions/check_cirrus_cron/test.sh
+++ b/.github/actions/check_cirrus_cron/test.sh
@@ -18,7 +18,7 @@ expect_regex() {
     local input_file
     expected_regex="$1"
     input_file="$2"
-    egrep -q "$expected_regex" $input_file || \
+    grep -E -q "$expected_regex" $input_file || \
         die "No match to '$expected_regex' in '$(<$input_file)'"
 }
 
@@ -48,7 +48,7 @@ trap "rm -rf $GITHUB_OUTPUT $GITHUB_WORKSPACE $NAME_ID_FILEPATH" EXIT
 #####
 
 cd /tmp || fail
-# Replace newlines and indentation to make egrep easier
+# Replace newlines and indentation to make grep easier
 if ! $base/cron_failures.sh |& \
         tr -s '[:space:]' ' ' > $GITHUB_WORKSPACE/output; then
     die "Failed: $base/cron_failures.sh with output '$(<$GITHUB_WORKSPACE/output)'"

--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ tests-included:
 
 .PHONY: tests-expect-exit
 tests-expect-exit:
-	@if egrep --line-number 'Expect.*ExitCode' test/e2e/*.go | egrep -v ', ".*"\)'; then \
+	@if grep -E --line-number 'Expect.*ExitCode' test/e2e/*.go | grep -E -v ', ".*"\)'; then \
 		echo "^^^ Unhelpful use of Expect(ExitCode())"; \
 		echo "   Please use '.Should(Exit(...))' pattern instead."; \
 		echo "   If that's not possible, please add an annotation (description) to your assertion:"; \

--- a/contrib/cirrus/check_go_changes.sh
+++ b/contrib/cirrus/check_go_changes.sh
@@ -23,10 +23,10 @@ check_diffs() {
     regex="$2"
     check_msg "Confirming changes have no $check"
     req_env_vars check regex diffs
-    if egrep -q "$regex"<<<"$diffs"; then
+    if grep -E -q "$regex"<<<"$diffs"; then
         # Show 5 context lines before/after as compromise for script simplicity
         die "Found $check:
-$(egrep -B 5 -A 5 "$regex"<<<"$diffs")"
+$(grep -E -B 5 -A 5 "$regex"<<<"$diffs")"
     fi
 }
 

--- a/contrib/cirrus/pr-removes-fixed-skips
+++ b/contrib/cirrus/pr-removes-fixed-skips
@@ -111,7 +111,7 @@ sub unremoved_skips {
     my $re = "(^\\s\+skip|fixme).*#($issues)[^0-9]";
     # FIXME FIXME FIXME: use File::Find instead of enumerating directories
     # (the important thing here is to exclude vendor)
-    my @grep = ('egrep', '-rin', $re, "test", "cmd", "libpod", "pkg");
+    my @grep = ('grep', '-E', '-rin', $re, "test", "cmd", "libpod", "pkg");
 
     my @skips;
     open my $grep_fh, '-|', @grep

--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -23,37 +23,37 @@ base=$(git merge-base ${DEST_BRANCH:-main} $head)
 #    M    bar.c
 # We look for Added or Modified (not Deleted!) files under 'test'.
 # --no-renames ensures that renamed tests (#9420) show up as 'A'dded.
-if git diff --name-status --no-renames $base $head | egrep -q '^[AM]\s+(test/|.*_test\.go)'; then
+if git diff --name-status --no-renames $base $head | grep -E -q '^[AM]\s+(test/|.*_test\.go)'; then
     exit 0
 fi
 
 # Nothing changed under test subdirectory.
 #
 # This is OK if the only files being touched are "safe" ones.
-filtered_changes=$(git diff --name-only $base $head      |
-                       fgrep -vx .cirrus.yml             |
-                       fgrep -vx .pre-commit-config.yaml |
-                       fgrep -vx .gitignore              |
-                       fgrep -vx go.mod                  |
-                       fgrep -vx go.sum                  |
-                       fgrep -vx podman.spec.rpkg        |
-                       fgrep -vx .golangci.yml           |
-                       egrep -v  '/*Makefile$'           |
-                       egrep -v  '^[^/]+\.md$'           |
-                       egrep -v  '^.github'              |
-                       egrep -v  '^contrib/'             |
-                       egrep -v  '^docs/'                |
-                       egrep -v  '^hack/'                |
-                       egrep -v  '^nix/'                 |
-                       egrep -v  '^vendor/'              |
-                       egrep -v  '^version/')
+filtered_changes=$(git diff --name-only $base $head        |
+                       grep -F -vx .cirrus.yml             |
+                       grep -F -vx .pre-commit-config.yaml |
+                       grep -F -vx .gitignore              |
+                       grep -F -vx go.mod                  |
+                       grep -F -vx go.sum                  |
+                       grep -F -vx podman.spec.rpkg        |
+                       grep -F -vx .golangci.yml           |
+                       grep -E -v  '/*Makefile$'           |
+                       grep -E -v  '^[^/]+\.md$'           |
+                       grep -E -v  '^.github'              |
+                       grep -E -v  '^contrib/'             |
+                       grep -E -v  '^docs/'                |
+                       grep -E -v  '^hack/'                |
+                       grep -E -v  '^nix/'                 |
+                       grep -E -v  '^vendor/'              |
+                       grep -E -v  '^version/')
 if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
 
 # One last chance: perhaps the developer included the magic '[NO NEW TESTS NEEDED]'
 # string in an amended commit.
-if git log --format=%B ${base}..${head} | fgrep '[NO NEW TESTS NEEDED]'; then
+if git log --format=%B ${base}..${head} | grep -F '[NO NEW TESTS NEEDED]'; then
    exit 0
 fi
 

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -80,7 +80,7 @@ cat ${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/required_host_ports.txt | \
 # Verify we can pull metadata from a few key testing images on quay.io
 # in the 'libpod' namespace.  This is mostly aimed at validating the
 # quay.io service is up and responsive.  Images were hand-picked with
-# egrep -ro 'quay.io/libpod/.+:latest' test | sort -u
+# grep -E -ro 'quay.io/libpod/.+:latest' test | sort -u
 TEST_IMGS=(\
     alpine:latest
     busybox:latest

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -435,7 +435,7 @@ function _bail_if_test_can_be_skipped() {
 
     # If PR touches any files in an argument directory, we cannot skip
     for subdir in "$@"; do
-        if egrep -q "^$subdir/" <<<"$diffs"; then
+        if grep -E -q "^$subdir/" <<<"$diffs"; then
             return 0
         fi
     done
@@ -445,7 +445,7 @@ function _bail_if_test_can_be_skipped() {
     # filtering these out from the diff results.
     for subdir in docs test; do
         # || true needed because we're running with set -e
-        diffs=$(egrep -v "^$subdir/" <<<"$diffs" || true)
+        diffs=$(grep -E -v "^$subdir/" <<<"$diffs" || true)
     done
 
     # If we still have diffs, they indicate files outside of docs & test.

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -26,7 +26,7 @@ for md in *.1.md;do
     # There may be more than one name, e.g. podman-info.1.md has
     # podman-system-info then another line with podman-info. We
     # care only about the first.
-    name=$(egrep -A1 '^#* NAME' $md|tail -1|awk '{print $1}' | tr -d \\\\)
+    name=$(grep -E -A1 '^#* NAME' $md|tail -1|awk '{print $1}' | tr -d \\\\)
 
     expect=$(basename $md .1.md)
     if [ "$name" != "$expect" ]; then
@@ -43,7 +43,7 @@ done
 # in the table in podman.1.md. podman-remote is not a podman subcommand,
 # so it is excluded here.
 for md in $(ls -1 *-*.1.md | grep -v remote);do
-    desc=$(egrep -A1 '^#* NAME' $md|tail -1|sed -e 's/^podman[^ ]\+ - //')
+    desc=$(grep -E -A1 '^#* NAME' $md|tail -1|sed -e 's/^podman[^ ]\+ - //')
 
     # podman.1.md has a two-column table; podman-*.1.md all have three.
     parent=$(echo $md | sed -e 's/^\(.*\)-.*$/\1.1.md/')
@@ -141,7 +141,7 @@ for md in *.1.md;do
     #        To view those:
     #           $ less $(for i in docs/*.1.md;do x=$(grep -A2 '^#* SYNOPSIS' $i|tail -1); if [ -n "$x" ]; then echo $i;fi;done)
     #
-    synopsis=$(egrep -A1 '^#* SYNOPSIS' $md|tail -1)
+    synopsis=$(grep -E -A1 '^#* SYNOPSIS' $md|tail -1)
 
     # Command name must be bracketed by double asterisks; options and
     # arguments are bracketed by single ones.

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -342,7 +342,7 @@ function t() {
     # Show returned headers (without trailing ^M or empty lines) in log file.
     # Sometimes -- I can't remember why! -- we don't get headers.
     if [[ -e $WORKDIR/curl.headers.out ]]; then
-        tr -d '\015' < $WORKDIR/curl.headers.out | egrep '.' >>$LOG
+        tr -d '\015' < $WORKDIR/curl.headers.out | grep -E '.' >>$LOG
     fi
 
     IFS='^' read actual_code content_type time_total <<<"$response"

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -45,7 +45,7 @@ function errmsg() {
     local msg_new=${1//\//\\/};  shift
 
     for t in "$@"; do
-        if fgrep -qx "@test \"$t\" {" $BUD; then
+        if grep -F -qx "@test \"$t\" {" $BUD; then
             $ECHO "@test \"$t\" : updating to \"$msg_new\""
             t=${t//\//\\/}
             # FIXME: emit error if msg_orig not found
@@ -68,7 +68,7 @@ function _skip() {
     fi
 
     for t in "$@"; do
-        if fgrep -qx "@test \"$t\" {" $BUD; then
+        if grep -F -qx "@test \"$t\" {" $BUD; then
             $ECHO "@test \"$t\" : $skip \"$reason\""
             # Escape slash in test name, 'custom files in /run/'
             t=${t//\//\\/}

--- a/test/buildah-bud/make-new-buildah-diffs
+++ b/test/buildah-bud/make-new-buildah-diffs
@@ -38,7 +38,7 @@ if [[ $n_commits -gt 1 ]]; then
 fi
 
 # Scope check: make sure the only files changed is helpers.bash
-changes=$(git diff --name-status [BASETAG]..HEAD | egrep -v '\stests/helpers.bash')
+changes=$(git diff --name-status [BASETAG]..HEAD | grep -E -v '\stests/helpers.bash')
 if [[ -n "$changes" ]]; then
     echo $changes
     die "Found modified files other than 'tests/helpers.bash'"

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1071,7 +1071,7 @@ EOF
 
     skip_if_remote "userns=auto is set on the server"
 
-    egrep -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
+    grep -E -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
 
     # check if the underlying file system supports idmapped mounts
     check_dir=$PODMAN_TMPDIR/idmap-check

--- a/test/system/140-diff.bats
+++ b/test/system/140-diff.bats
@@ -30,7 +30,7 @@ load helpers
         # PR is https://github.com/containers/podman/pull/8561
         # Anyhow, without the egrep below, this test fails about 50% of the
         # time on rootless RHEL8. (No, I don't know why it's not 100%).
-        result=$(jq -r -c ".${field}[]" <<<"$output" | egrep -v '^/sys/fs')
+        result=$(jq -r -c ".${field}[]" <<<"$output" | grep -E -v '^/sys/fs')
         is "$result" "${expect[$field]}" "$field"
     done
 

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -73,9 +73,9 @@ function _require_crun() {
     skip_if_remote "userns=auto is set on the server"
 
     if is_rootless; then
-        egrep -q "^$(id -un):" /etc/subuid || skip "no IDs allocated for current user"
+        grep -E -q "^$(id -un):" /etc/subuid || skip "no IDs allocated for current user"
     else
-        egrep -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
+        grep -E -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
     fi
 
     cat > $PODMAN_TMPDIR/userns_auto.conf <<EOF
@@ -100,7 +100,7 @@ EOF
     if is_rootless; then
         ns_user=$(id -un)
     fi
-    egrep -q "${ns_user}:" /etc/subuid || skip "no IDs allocated for user ${ns_user}"
+    grep -E -q "${ns_user}:" /etc/subuid || skip "no IDs allocated for user ${ns_user}"
     test_name="test_$(random_string 12)"
     secret_file=$PODMAN_TMPDIR/secret$(random_string 12)
     secret_content=$(random_string)
@@ -114,7 +114,7 @@ EOF
 @test "podman userns=nomap" {
     if is_rootless; then
         ns_user=$(id -un)
-        baseuid=$(egrep "${ns_user}:" /etc/subuid | cut -f2 -d:)
+        baseuid=$(grep -E "${ns_user}:" /etc/subuid | cut -f2 -d:)
         test ! -z ${baseuid} ||  skip "no IDs allocated for user ${ns_user}"
 
         test_name="test_$(random_string 12)"

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -13,7 +13,7 @@ kubernetes_63='Truncation Annotation: .* Kubernetes only allows 63 characters'
 
 # filter: convert yaml to json, because bash+yaml=madness
 function yaml2json() {
-    egrep -v "$kubernetes_63" | python3 -c 'import yaml
+    grep -E -v "$kubernetes_63" | python3 -c 'import yaml
 import json
 import sys
 json.dump(yaml.safe_load(sys.stdin), sys.stdout)'

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -128,7 +128,7 @@ function random_rfc1918_subnet() {
     while [ "$retries" -gt 0 ];do
         local cidr=172.$(( 16 + $RANDOM % 16 )).$(( $RANDOM & 255 ))
 
-        in_use=$(ip route list | fgrep $cidr)
+        in_use=$(ip route list | grep -F $cidr)
         if [ -z "$in_use" ]; then
             echo "$cidr"
             return


### PR DESCRIPTION
There are days when I really, really, really hate GNU. Remember
when someone decided that 'head -1' would no longer work, and
that it was OK to break an infinite number of legacy production
scripts? Someone now decided that egrep/fgrep are deprecated,
and our CI logs (especially pr-should-include-tests) are now
filled with hundreds of warning lines, making it difficult
to find actual errors.

I expect that those warnings will be removed quickly after
furious community backlash, just like the 'head -1' fiasco
was quietly reverted, but ITM the warnings are annoying
so I capitulate.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```