### PR TITLE
remote: return better connect error

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/checkpoint/crutils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/parallel"
@@ -109,7 +110,7 @@ func Execute() {
 			registry.SetExitCode(define.ExecErrorCodeGeneric)
 		}
 		if registry.IsRemote() {
-			if strings.Contains(err.Error(), "unable to connect to Podman") {
+			if errors.As(err, &bindings.ConnectError{}) {
 				fmt.Fprintln(os.Stderr, "Cannot connect to Podman. Please verify your connection to the Linux system using `podman system connection list`, or try `podman machine init` and `podman machine start` to manage a new Linux VM")
 			}
 		}


### PR DESCRIPTION
We have a spacial logic to create a better user error that hints at podman machine, however because we string matched it missed the case of the ssh connection.

Stop doing string comparison and return a proper error and match it with errors.As()

see https://github.com/containers/podman/discussions/18426

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
