### PR TITLE
Allow user quadlets to be stored under /etc

### DIFF
--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"os"
+	"os/user"
+	"path"
+	"path/filepath"
 	"testing"
 
+	"github.com/containers/podman/v4/pkg/systemd/quadlet"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,4 +44,39 @@ func TestIsUnambiguousName(t *testing.T) {
 		res := isUnambiguousName(test.input)
 		assert.Equal(t, res, test.res, "%q", test.input)
 	}
+}
+
+func TestUnitDirs(t *testing.T) {
+	rootDirs := []string{
+		quadlet.UnitDirAdmin,
+		quadlet.UnitDirDistro,
+	}
+	unitDirs := getUnitDirs(false)
+	assert.Equal(t, unitDirs, rootDirs, "rootful unit dirs should match")
+
+	configDir, err := os.UserConfigDir()
+	assert.Nil(t, err)
+	u, err := user.Current()
+	assert.Nil(t, err)
+
+	rootlessDirs := []string{
+		path.Join(configDir, "containers/systemd"),
+		filepath.Join(quadlet.UnitDirAdmin, "users"),
+		filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid),
+	}
+
+	unitDirs = getUnitDirs(true)
+	assert.Equal(t, unitDirs, rootlessDirs, "rootless unit dirs should match")
+
+	name, err := os.MkdirTemp("", "dir")
+	assert.Nil(t, err)
+	// remove the temporary directory at the end of the program
+	defer os.RemoveAll(name)
+
+	t.Setenv("QUADLET_UNIT_DIRS", name)
+	unitDirs = getUnitDirs(false)
+	assert.Equal(t, unitDirs, []string{name}, "rootful should use environment variable")
+
+	unitDirs = getUnitDirs(true)
+	assert.Equal(t, unitDirs, []string{name}, "rootless should use environment variable")
 }

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2,7 +2,7 @@
 
 ## NAME
 
-podman\-systemd.unit - systemd units using Podman quadlet
+podman\-systemd.unit - systemd units using Podman Quadlet
 
 ## SYNOPSIS
 
@@ -15,6 +15,8 @@ podman\-systemd.unit - systemd units using Podman quadlet
 
 ### Podman user unit search path
 
+ * /etc/containers/systemd/users/
+ * /etc/containers/systemd/users/$(UID)
  * $XDG_CONFIG_HOME/containers/systemd/
  * ~/.config/containers/systemd/
 
@@ -37,6 +39,14 @@ The Podman files use the same format as [regular systemd unit files](https://www
 Each file type has a custom section (for example, `[Container]`) that is handled by Podman, and all
 other sections will be passed on untouched, allowing the use of any normal systemd configuration options
 like dependencies or cgroup limits.
+
+For rootless containers, when administrators place Quadlet files in the
+/etc/containers/systemd/users directory, all users sessions will execute the
+Quadlet when the login session begins. If the administrator places a Quadlet
+file in the /etc/containers/systemd/user/${UID}/ directory, then only the
+user with the matching UID will execute the Quadlet when the login
+session gets started.
+
 
 ### Enabling unit files
 
@@ -145,7 +155,7 @@ Adds a device node from the host into the container. The format of this is
 `HOST-DEVICE[:CONTAINER-DEVICE][:PERMISSIONS]`, where `HOST-DEVICE` is the path of
 the device node on the host, `CONTAINER-DEVICE` is the path of the device node in
 the container, and `PERMISSIONS` is a list of permissions combining 'r' for read,
-'w' for write, and 'm' for mknod(2). The `-` prefix tells quadlet to add the device
+'w' for write, and 'm' for mknod(2). The `-` prefix tells Quadlet to add the device
 only if it exists on the host.
 
 This key can be listed multiple times.
@@ -307,7 +317,7 @@ generally has the form `type=TYPE,TYPE-SPECIFIC-OPTION[,...]`.
 As a special case, for `type=volume` if `source` ends with `.volume`, a Podman named volume called
 `systemd-$name` will be used as the source, and the generated systemd service will contain
 a dependency on the `$name-volume.service`. Such a volume can be automatically be lazily
-created by using a `$name.volume` quadlet file.
+created by using a `$name.volume` Quadlet file.
 
 This key can be listed multiple times.
 
@@ -320,7 +330,7 @@ not set up networking in the container.
 As a special case, if the `name` of the network ends with `.network`, a Podman network called
 `systemd-$name` will be used, and the generated systemd service will contain
 a dependency on the `$name-network.service`. Such a network can be automatically
-created by using a `$name.network` quadlet file.
+created by using a `$name.network` Quadlet file.
 
 This key can be listed multiple times.
 
@@ -449,7 +459,7 @@ If `SOURCE-VOLUME` starts with `.`, Quadlet will resolve the path relative to th
 As a special case, if `SOURCE-VOLUME` ends with `.volume`, a Podman named volume called
 `systemd-$name` will be used as the source, and the generated systemd service will contain
 a dependency on the `$name-volume.service`. Such a volume can be automatically be lazily
-created by using a `$name.volume` quadlet file.
+created by using a `$name.volume` Quadlet file.
 
 This key can be listed multiple times.
 
@@ -498,7 +508,7 @@ not set up networking in the container.
 As a special case, if the `name` of the network ends with `.network`, a Podman network called
 `systemd-$name` will be used, and the generated systemd service will contain
 a dependency on the `$name-network.service`. Such a network can be automatically
-created by using a `$name.network` quadlet file.
+created by using a `$name.network` Quadlet file.
 
 This key can be listed multiple times.
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -41,7 +41,7 @@ other sections will be passed on untouched, allowing the use of any normal syste
 like dependencies or cgroup limits.
 
 For rootless containers, when administrators place Quadlet files in the
-/etc/containers/systemd/users directory, all users sessions will execute the
+/etc/containers/systemd/users directory, all users' sessions will execute the
 Quadlet when the login session begins. If the administrator places a Quadlet
 file in the /etc/containers/systemd/user/${UID}/ directory, then only the
 user with the matching UID will execute the Quadlet when the login


### PR DESCRIPTION
I would like to allow admin to control quadlet containers in users homedirs.

If an admin sets a quadlet in
/etc/containers/systemd/users, then all users will run these quadlet services when they login.

If an admin places a quadlet in /etc/containers/systemd/users/$(USERNAME) then only the USERNAME will execute this quadlet service when they login.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Rootless podman quadlet files can now be installed in /etc/containers/systemd/users/ directory.
```
[NO NEW TESTS NEEDED]