### PR TITLE
libpod: do not Cleanup() more than once

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -765,6 +765,11 @@ func (c *Container) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("container %s is running or paused, refusing to clean up: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
+	// if the container was not created in the oci runtime or was already cleaned up, then do nothing
+	if c.ensureState(define.ContainerStateConfigured, define.ContainerStateExited) {
+		return nil
+	}
+
 	// Handle restart policy.
 	// Returns a bool indicating whether we actually restarted.
 	// If we did, don't proceed to cleanup - just exit.

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -126,6 +126,12 @@ var _ = Describe("Podman stop", func() {
 		finalCtrs.WaitWithDefaultTimeout()
 		Expect(finalCtrs).Should(Exit(0))
 		Expect(strings.TrimSpace(finalCtrs.OutputToString())).To(Equal(""))
+
+		// make sure we only have one cleanup event for this container
+		events := podmanTest.Podman([]string{"events", "--since=30s", "--stream=false"})
+		events.WaitWithDefaultTimeout()
+		Expect(events).Should(Exit(0))
+		Expect(strings.Count(events.OutputToString(), "container cleanup")).To(Equal(1), "cleanup event should show up exactly once")
 	})
 
 	It("podman stop all containers -t", func() {


### PR DESCRIPTION
If the container was already cleaned up we should not try to do it again. Podman stop will always try to call Cleanup() if you look at the podman event log and just keep calling podman stop --all you see a cleanup event every time. This is not wanted. Also in case of the host pidns we report a error every single time, see the linked issue.

Fixes #18460

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Containers created with --pid=host will no longer print errors on podman stop.
```
