### PR TITLE
libpod: always use PostConfigureNetNS option

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -384,6 +384,8 @@ type ContainerMiscConfig struct {
 	// PostConfigureNetNS needed when a user namespace is created by an OCI runtime
 	// if the network namespace is created before the user namespace it will be
 	// owned by the wrong user namespace.
+	// Deprecated: Do not use this anymore. Always set to true for new containers to
+	// allow compatibility in case of a downgrade.
 	PostConfigureNetNS bool `json:"postConfigureNetNS"`
 	// OCIRuntime used to create the container
 	OCIRuntime string `json:"runtime,omitempty"`

--- a/libpod/container_freebsd.go
+++ b/libpod/container_freebsd.go
@@ -7,8 +7,5 @@ func networkDisabled(c *Container) (bool, error) {
 	if c.config.CreateNetNS {
 		return false, nil
 	}
-	if !c.config.PostConfigureNetNS {
-		return c.state.NetNS != "", nil
-	}
-	return false, nil
+	return c.state.NetNS != "", nil
 }

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/buildah/pkg/overlay"
 	butil "github.com/containers/buildah/util"
 	"github.com/containers/common/libnetwork/etchosts"
-	"github.com/containers/common/libnetwork/resolvconf"
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/common/pkg/chown"
 	"github.com/containers/common/pkg/config"
@@ -313,11 +312,6 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 		}
 	}()
 	if err := c.prepare(); err != nil {
-		return false, err
-	}
-
-	// set up slirp4netns again because slirp4netns will die when conmon exits
-	if err := c.setupRootlessNetwork(); err != nil {
 		return false, err
 	}
 
@@ -983,52 +977,33 @@ func (c *Container) checkDependenciesRunning() ([]string, error) {
 	return notRunning, nil
 }
 
-func (c *Container) completeNetworkSetup() error {
-	var nameservers []string
+func (c *Container) completeNetworkSetup(restore bool) error {
 	netDisabled, err := c.NetworkDisabled()
 	if err != nil {
 		return err
 	}
-	if !c.config.PostConfigureNetNS || netDisabled {
+	if netDisabled {
+		// with net=none we still want to set up /etc/hosts
+		return c.addHosts()
+	}
+	if c.config.NetNsCtr != "" {
 		return nil
 	}
-	if err := c.syncContainer(); err != nil {
-		return err
-	}
-	if err := c.runtime.setupNetNS(c); err != nil {
-		return err
-	}
-	if err := c.save(); err != nil {
-		return err
-	}
-	state := c.state
-	// collect any dns servers that the network backend tells us to use
-	for _, status := range c.getNetworkStatus() {
-		for _, server := range status.DNSServerIPs {
-			nameservers = append(nameservers, server.String())
-		}
-	}
-	nameservers = c.addSlirp4netnsDNS(nameservers)
-
-	// check if we have a bindmount for /etc/hosts
-	if hostsBindMount, ok := state.BindMounts[config.DefaultHostsFile]; ok {
-		entries, err := c.getHostsEntries()
-		if err != nil {
+	if c.config.CreateNetNS {
+		if err := c.runtime.setupNetNS(c, restore); err != nil {
 			return err
 		}
-		// add new container ips to the hosts file
-		if err := etchosts.Add(hostsBindMount, entries); err != nil {
+		if err := c.save(); err != nil {
 			return err
 		}
 	}
 
-	// check if we have a bindmount for resolv.conf
-	resolvBindMount := state.BindMounts[resolvconf.DefaultResolvConf]
-	if len(nameservers) < 1 || resolvBindMount == "" || len(c.config.NetNsCtr) > 0 {
-		return nil
+	// add /etc/hosts entries
+	if err := c.addHosts(); err != nil {
+		return err
 	}
-	// write and return
-	return resolvconf.Add(resolvBindMount, nameservers)
+
+	return c.addResolvConf()
 }
 
 // Initialize a container, creating it in the runtime
@@ -1128,7 +1103,7 @@ func (c *Container) init(ctx context.Context, retainRetries bool) error {
 	}
 
 	defer c.newContainerEvent(events.Init)
-	return c.completeNetworkSetup()
+	return c.completeNetworkSetup(false)
 }
 
 // Clean up a container in the OCI runtime.

--- a/libpod/container_linux.go
+++ b/libpod/container_linux.go
@@ -11,11 +11,9 @@ func networkDisabled(c *Container) (bool, error) {
 	if c.config.CreateNetNS {
 		return false, nil
 	}
-	if !c.config.PostConfigureNetNS {
-		for _, ns := range c.config.Spec.Linux.Namespaces {
-			if ns.Type == spec.NetworkNamespace {
-				return ns.Path == "", nil
-			}
+	for _, ns := range c.config.Spec.Linux.Namespaces {
+		if ns.Type == spec.NetworkNamespace {
+			return ns.Path == "", nil
 		}
 	}
 	return false, nil

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -206,9 +206,8 @@ func (r *Runtime) reloadContainerNetwork(ctr *Container) (map[string]types.Statu
 		}
 		networkOpts[network] = perNetOpts
 	}
-	ctr.perNetworkOpts = networkOpts
 
-	return r.configureNetNS(ctr, ctr.state.NetNS)
+	return r.setUpNetwork(ctr.state.NetNS, ctr.getNetworkOptions(networkOpts))
 }
 
 // Produce an InspectNetworkSettings containing information on the container

--- a/libpod/networking_freebsd.go
+++ b/libpod/networking_freebsd.go
@@ -267,7 +267,3 @@ func (c *Container) inspectJoinedNetworkNS(networkns string) (q types.StatusBloc
 func (c *Container) reloadRootlessRLKPortMapping() error {
 	return errors.New("unsupported (*Container).reloadRootlessRLKPortMapping")
 }
-
-func (c *Container) setupRootlessNetwork() error {
-	return nil
-}

--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -28,10 +28,6 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	return nil, errors.New("not implemented (*Container) getContainerNetworkInfo")
 }
 
-func (c *Container) setupRootlessNetwork() error {
-	return errors.New("not implemented (*Container) setupRootlessNetwork")
-}
-
 func (r *Runtime) setupNetNS(ctr *Container) error {
 	return errors.New("not implemented (*Runtime) setupNetNS")
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1094,13 +1094,14 @@ func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 // namespace with a minimal configuration.
 // An optional array of port mappings can be provided.
 // Conflicts with WithNetNSFrom().
-func WithNetNS(portMappings []nettypes.PortMapping, exposedPorts map[uint16][]string, postConfigureNetNS bool, netmode string, networks map[string]nettypes.PerNetworkOptions) CtrCreateOption {
+func WithNetNS(portMappings []nettypes.PortMapping, exposedPorts map[uint16][]string, netmode string, networks map[string]nettypes.PerNetworkOptions) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return define.ErrCtrFinalized
 		}
 
-		ctr.config.PostConfigureNetNS = postConfigureNetNS
+		// allow compatibility in case of downgrade by setting this to always true
+		ctr.config.PostConfigureNetNS = true
 		ctr.config.NetMode = namespaces.NetworkMode(netmode)
 		ctr.config.CreateNetNS = true
 		ctr.config.PortMappings = portMappings

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -293,7 +293,6 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 		toReturn = append(toReturn, libpod.WithCgroupsMode(s.CgroupsMode))
 	}
 
-	postConfigureNetNS := !s.UserNS.IsHost()
 	// when we are rootless we default to slirp4netns
 	if rootless.IsRootless() && (s.NetNS.IsPrivate() || s.NetNS.IsDefault()) {
 		s.NetNS.NSMode = specgen.Slirp
@@ -326,14 +325,14 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 		if s.NetNS.Value != "" {
 			val = fmt.Sprintf("slirp4netns:%s", s.NetNS.Value)
 		}
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, val, nil))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, val, nil))
 	case specgen.Pasta:
 		portMappings, expose, err := createPortMappings(s, imageData)
 		if err != nil {
 			return nil, err
 		}
 		val := "pasta"
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, val, nil))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, val, nil))
 	case specgen.Bridge, specgen.Private, specgen.Default:
 		portMappings, expose, err := createPortMappings(s, imageData)
 		if err != nil {
@@ -366,7 +365,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 			s.Networks[rtConfig.Network.DefaultNetwork] = opts
 			delete(s.Networks, "default")
 		}
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, "bridge", s.Networks))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, "bridge", s.Networks))
 	}
 
 	if s.UseImageHosts {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -582,7 +582,13 @@ load helpers.network
     run_podman network create $netname
     is "$output" "$netname" "output of 'network create'"
 
-    for network in "slirp4netns" "$netname"; do
+    # pasta only work as rootless
+    pasta=
+    if is_rootless; then
+        pasta=pasta
+    fi
+
+    for network in "slirp4netns" "$netname" $pasta; do
         # Start container with the restart always policy
         run_podman run -d --name myweb -p "$HOST_PORT:80" \
                 --restart always \


### PR DESCRIPTION
Maintaining two code paths for network setup has been difficult, I had
to deal with many bugs because of that. Often the PostConfigureNetNS was
not as tested. Overall the code has quite a bit of complexity because of
this option. Just look at this commit how much simpler the code now
looks.

The main advantage of this is that we no longer have to test everything
twice, i.e. with userns and without one.

The downside is that mount and netns setup is no longer parallel but I
think this is fine, it didn't seem to make a measurable difference.

To preserve compatibility in case of an downgrade we keep the
PostConfigureNetNS bool and set it always to true.

This turned out to be much more complicated that thought due to our
spaghetti code. The restart=always case is special because we reuse the
netns. But the slirp4netns and rootlessport process are bound to the
conmon process so they have to be restarted. Given the the network is
now setup in completeNetworkSetup() which is always called by init()
which is called in handleRestartPolicy(). Therefore we can get rid of
the special rootless setup function to restart slirp and rootlessport.
Instead we let one single network setup function take care of that which
is used in all cases.

[NO NEW TESTS NEEDED] Existing test should all pass.

Fixes #17965

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
