### PR TITLE
Enable QEMU Podman machine on Windows

### DIFF
--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -28,6 +28,17 @@ Note: To run specific test files, add the test files to the end of the winmake c
 
 `./winmake localmachine "basic_test.go start_test.go"`
 
+### QEMU
+1. Install QEMU and add it to either user or sysmem PATH variable
+1. Install Podman release (needed to have gvproxy binary)
+1. Open a powershell as a regular user
+1. $env:CONTAINERS_MACHINE_PROVIDER="qemu"
+1. `./winmake localmachine`
+
+Note: To run specific test files, add the test files to the end of the winmake command:
+
+`./winmake localmachine "basic_test.go start_test.go"`
+
 ## MacOS
 
 ### Apple Hypervisor

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -14,7 +14,7 @@ import (
 const podmanBinary = "../../../bin/windows/podman.exe"
 
 func getDownloadLocation(p machine.VirtProvider) string {
-	if p.VMType() == define.HyperVVirt {
+	if p.VMType() == define.HyperVVirt || p.VMType() == define.QemuVirt {
 		return getFCOSDownloadLocation(p)
 	}
 	fd, err := wsl.NewFedoraDownloader(define.WSLVirt, "", defaultStream.String())

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -189,6 +189,9 @@ var _ = Describe("podman machine init", func() {
 			Skip("volumes are not supported on hyperv yet")
 		}
 		skipIfWSL("WSL volumes are much different.  This test will not pass as is")
+		if testProvider.VMType() == define.QemuVirt && runtime.GOOS == "windows" {
+			Skip("volumes are not yet supported on official qemu builds running under Windows")
+		}
 
 		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -32,6 +32,8 @@ func Get() (machine.VirtProvider, error) {
 		return wsl.VirtualizationProvider(), nil
 	case define.HyperVVirt:
 		return hyperv.VirtualizationProvider(), nil
+	case define.QemuVirt:
+		return getQemuProvider()
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}

--- a/pkg/machine/provider/platform_windows_amd64.go
+++ b/pkg/machine/provider/platform_windows_amd64.go
@@ -1,0 +1,10 @@
+package provider
+
+import (
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/qemu"
+)
+
+func getQemuProvider() (machine.VirtProvider, error) {
+	return qemu.VirtualizationProvider(), nil
+}

--- a/pkg/machine/provider/platform_windows_arm64.go
+++ b/pkg/machine/provider/platform_windows_arm64.go
@@ -1,0 +1,12 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
+)
+
+func getQemuProvider() (machine.VirtProvider, error) {
+	return nil, fmt.Errorf("unsupported virtualization provider: `%s`", define.QemuVirt.String())
+}


### PR DESCRIPTION
Fixes #13006

This simply enables new machine provider as all the required changes were implemented in separate PRs.

Technically this could be merged, but this will not be really functional before #17473 is completed and merged.

No new tests, because this doesn't introduce new unit testable functionality, but for e2e tests this would require Windows VM with nested virtualization or Windows bare metal machine, where QEMU will run.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enable QEMU Podman machine on Windows amd64 hosts
```

[NO NEW TESTS NEEDED]