### PR TITLE
Fix preference of user quadlets directories

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -115,13 +115,13 @@ func getUnitDirs(rootless bool) []string {
 			return nil
 		}
 		dirs = append(dirs, path.Join(configDir, "containers/systemd"))
-		dirs = append(dirs, filepath.Join(quadlet.UnitDirAdmin, "users"))
 		u, err := user.Current()
-		if err != nil {
+		if err == nil {
+			dirs = append(dirs, filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid))
+		} else {
 			fmt.Fprintf(os.Stderr, "Warning: %v", err)
-			return dirs
 		}
-		return append(dirs, filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid))
+		return append(dirs, filepath.Join(quadlet.UnitDirAdmin, "users"))
 	}
 	dirs = append(dirs, quadlet.UnitDirAdmin)
 	return append(dirs, quadlet.UnitDirDistro)

--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -61,8 +61,8 @@ func TestUnitDirs(t *testing.T) {
 
 	rootlessDirs := []string{
 		path.Join(configDir, "containers/systemd"),
-		filepath.Join(quadlet.UnitDirAdmin, "users"),
 		filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid),
+		filepath.Join(quadlet.UnitDirAdmin, "users"),
 	}
 
 	unitDirs = getUnitDirs(true)

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -15,10 +15,9 @@ podman\-systemd.unit - systemd units using Podman Quadlet
 
 ### Podman user unit search path
 
- * /etc/containers/systemd/users/
+ * $XDG_CONFIG_HOME/containers/systemd/ or ~/.config/containers/systemd/
  * /etc/containers/systemd/users/$(UID)
- * $XDG_CONFIG_HOME/containers/systemd/
- * ~/.config/containers/systemd/
+ * /etc/containers/systemd/users/
 
 ## DESCRIPTION
 


### PR DESCRIPTION
If there's a container defined in multiple directories use the following precedence:

`$XDG_CONFIG_HOME/containers/systemd/` or `~/.config/containers/systemd/` takes precedence over `/etc/containers/systemd/users/$(UID)` and this takes precedence over `/etc/containers/systemd/users/`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

None

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]