### PR TITLE
Ensure the consistent setting of the HOME env variable on container start

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -459,15 +459,9 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		g.AddMount(overlayMount)
 	}
 
-	hasHomeSet := false
-	for _, s := range c.config.Spec.Process.Env {
-		if strings.HasPrefix(s, "HOME=") {
-			hasHomeSet = true
-			break
-		}
-	}
-	if !hasHomeSet && execUser.Home != "" {
-		c.config.Spec.Process.Env = append(c.config.Spec.Process.Env, fmt.Sprintf("HOME=%s", execUser.Home))
+	err = c.setHomeEnvIfNeeded()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if c.config.User != "" {
@@ -2432,6 +2426,41 @@ func (c *Container) generateCurrentUserPasswdEntry() (string, int, int, error) {
 	return pwd, uid, rootless.GetRootlessGID(), nil
 }
 
+// Sets the HOME env. variable with precedence: existing home env. variable, execUser home
+func (c *Container) setHomeEnvIfNeeded() error {
+	getExecUserHome := func() (string, error) {
+		overrides := c.getUserOverrides()
+		execUser, err := lookup.GetUserGroupInfo(c.state.Mountpoint, c.config.User, overrides)
+		if err != nil {
+			if cutil.StringInSlice(c.config.User, c.config.HostUsers) {
+				execUser, err = lookupHostUser(c.config.User)
+			}
+
+			if err != nil {
+				return "", err
+			}
+		}
+
+		return execUser.Home, nil
+	}
+
+	// Ensure HOME is not already set in Env
+	home := ""
+	for _, s := range c.config.Spec.Process.Env {
+		if strings.HasPrefix(s, "HOME=") {
+			return nil
+		}
+	}
+
+	home, err := getExecUserHome()
+	if err != nil {
+		return err
+	}
+
+	c.config.Spec.Process.Env = append(c.config.Spec.Process.Env, fmt.Sprintf("HOME=%s", home))
+	return nil
+}
+
 func (c *Container) userPasswdEntry(u *user.User) (string, error) {
 	// Look up the user to see if it exists in the container image.
 	_, err := lookup.GetUser(c.state.Mountpoint, u.Username)
@@ -2464,17 +2493,7 @@ func (c *Container) userPasswdEntry(u *user.User) (string, error) {
 			}
 		}
 	}
-	// Set HOME environment if not already set
-	hasHomeSet := false
-	for _, s := range c.config.Spec.Process.Env {
-		if strings.HasPrefix(s, "HOME=") {
-			hasHomeSet = true
-			break
-		}
-	}
-	if !hasHomeSet {
-		c.config.Spec.Process.Env = append(c.config.Spec.Process.Env, fmt.Sprintf("HOME=%s", homeDir))
-	}
+
 	if c.config.PasswdEntry != "" {
 		return c.passwdEntry(u.Username, u.Uid, u.Gid, u.Name, homeDir), nil
 	}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
Fixes an issue where the HOME environment variable would be configured inconsistently between container starts if a new passwd entry had to be created for the container
```

#### Description
Podman sets the HOME environment variable to the home directory of the user executing the podman command (if it is mounted) only if a new passwd entry has to be added on start. After a container restart, HOME is set to the home directory of the user configured with the `--user` flag.
#### Reproduction/Example
![Screenshot from 2023-05-05 21-39-36](https://user-images.githubusercontent.com/5425433/236554362-82d8eca7-aa00-459b-9968-8342fc688792.png)
#### Impact
This impacts tools such as VSCode Dev Containers as they use this variable to decide where to place files (the vscode server in this case). This issue is particularly annoying for people using Dev Containers and toolbox as a restart causes VSCode to place the server in a different place, often `/root` where it does not have write permissions.
#### Solution
Set the HOME env variable on container creation, prioritized in the following order:
1. Existing HOME env variable
2. Home folder of the user executing the podman command
3. Home folder of the user specified with the `--user` flag