### PR TITLE
quadlet: support `HostName`

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -109,6 +109,7 @@ Valid options for `[Container]` are listed below:
 | HealthStartupSuccess=2           | --health-startup-success=2             |
 | HealthStartupTimeout=1m33s       | --health-startup-timeout=1m33s         |
 | HealthTimeout=20s                | --health-timeout=20s                   |
+| HostName=new-host-name           | --hostname="new-host-name"             |
 | Image=ubi8                       | Image specification - ubi8             |
 | IP=192.5.0.1                     | --ip 192.5.0.0                         |
 | IP6=fd46:db93:aa76:ac37::10      | --ip6 2001:db8::1                      |
@@ -275,6 +276,11 @@ Equivalent to the Podman `--health-startup-timeout` option.
 
 The maximum time allowed to complete the healthcheck before an interval is considered failed.
 Equivalent to the Podman `--health-timeout` option.
+
+### `HostName=`
+
+Sets the host name that is available inside the container.
+Equivalent to the Podman `--hostname` option.
 
 ### `Image=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -58,6 +58,7 @@ const (
 	KeyHealthStartupSuccess  = "HealthStartupSuccess"
 	KeyHealthStartupTimeout  = "HealthStartupTimeout"
 	KeyHealthTimeout         = "HealthTimeout"
+	KeyHostName              = "HostName"
 	KeyImage                 = "Image"
 	KeyIP                    = "IP"
 	KeyIP6                   = "IP6"
@@ -129,6 +130,7 @@ var (
 		KeyHealthStartupSuccess:  true,
 		KeyHealthStartupTimeout:  true,
 		KeyHealthTimeout:         true,
+		KeyHostName:              true,
 		KeyImage:                 true,
 		KeyIP:                    true,
 		KeyIP6:                   true,
@@ -613,6 +615,10 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	}
 
 	handleHealth(container, ContainerGroup, podman)
+
+	if hostname, ok := container.Lookup(ContainerGroup, KeyHostName); ok {
+		podman.add("--hostname", hostname)
+	}
 
 	podmanArgs := container.LookupAllArgs(ContainerGroup, KeyPodmanArgs)
 	podman.add(podmanArgs...)

--- a/test/e2e/quadlet/hostname.container
+++ b/test/e2e/quadlet/hostname.container
@@ -1,0 +1,4 @@
+[Container]
+Image=localhost/imagename
+## assert-podman-args "--hostname" "\"quadlet-host\""
+HostName="quadlet-host"

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -575,6 +575,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("logdriver.container", "logdriver.container"),
 		Entry("mount.container", "mount.container"),
 		Entry("health.container", "health.container"),
+		Entry("hostname.container", "hostname.container"),
 
 		Entry("basic.volume", "basic.volume"),
 		Entry("label.volume", "label.volume"),


### PR DESCRIPTION
Add a new `HostName` field to Quadlet `.container` files.

Fixes: #18486

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet now supports a `HostName` field in `.container` files to set container's host name.
```
