### PR TITLE
system tests: timeoutize quadlet, systemd

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -52,7 +52,9 @@ function run_quadlet() {
     cp $sourcefile $quadlet_tmpdir/
 
     echo "$_LOG_PROMPT $QUADLET $_DASHUSER $UNIT_DIR"
-    QUADLET_UNIT_DIRS="$quadlet_tmpdir" run $QUADLET $_DASHUSER $UNIT_DIR
+    QUADLET_UNIT_DIRS="$quadlet_tmpdir" run \
+                     timeout --foreground -v --kill=10 $PODMAN_TIMEOUT \
+                     $QUADLET $_DASHUSER $UNIT_DIR
     echo "$output"
     assert $status -eq 0 "Failed to convert quadlet file: $sourcefile"
     is "$output" "" "quadlet should report no errors"

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -22,15 +22,15 @@ fi
 mkdir -p $UNIT_DIR
 
 systemctl() {
-    command systemctl $_DASHUSER "$@"
+    timeout --foreground -v --kill=10 $PODMAN_TIMEOUT systemctl $_DASHUSER "$@"
 }
 
 journalctl() {
-    command journalctl $_DASHUSER "$@"
+    timeout --foreground -v --kill=10 $PODMAN_TIMEOUT journalctl $_DASHUSER "$@"
 }
 
 systemd-run() {
-    command systemd-run $_DASHUSER "$@";
+    timeout --foreground -v --kill=10 $PODMAN_TIMEOUT systemd-run $_DASHUSER "$@";
 }
 
 install_kube_template() {


### PR DESCRIPTION
Run $QUADLET and all systemctl/journalctl commands using 'timeout'.
Nothing should ever, ever take more than the default 2 minutes.

Followup to #18514, in which quadlet tests are found to be
taking 9-10 minutes.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```