### PR TITLE
sqlite: disable WAL mode

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -32,9 +32,7 @@ type SQLiteState struct {
 const (
 	// Deal with timezone automatically.
 	sqliteOptionLocation = "_loc=auto"
-	// Set the journal mode (https://www.sqlite.org/pragma.html#pragma_journal_mode).
-	sqliteOptionJournal = "&_journal=WAL"
-	// Force WAL mode to fsync after each transaction (https://www.sqlite.org/pragma.html#pragma_synchronous).
+	// Force an fsync after each transaction (https://www.sqlite.org/pragma.html#pragma_synchronous).
 	sqliteOptionSynchronous = "&_sync=FULL"
 	// Allow foreign keys (https://www.sqlite.org/pragma.html#pragma_foreign_keys).
 	sqliteOptionForeignKeys = "&_foreign_keys=1"
@@ -44,7 +42,6 @@ const (
 	// Assembled sqlite options used when opening the database.
 	sqliteOptions = "db.sql?" +
 		sqliteOptionLocation +
-		sqliteOptionJournal +
 		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
 		sqliteOptionTXLock


### PR DESCRIPTION
As shown in #17831, WAL mode plays a role in causing `database is locked` errors.  Those are errors, in theory, should not happen as the DB should busy wait.  mattn/go-sqlite3/issues/274 has some comments indicating that the busy handler behaves differently in WAL mode which may be an explanation to the error.

For now, let's disable WAL mode and only re-enable it when we have clearer understanding of what's going on.  The upstream issue along with the SQLite documentation do not give me the clear guidance that I would need.

[NO NEW TESTS NEEDED] - flake is only reproducible in CI.

Fixes: #18356

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
