### PR TITLE
Quadlet system tests - fix socket notification

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -450,6 +450,7 @@ EOF
 [Container]
 Rootfs=/:O
 Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Notify=yes
 EOF
 
     run_quadlet "$quadlet_file"
@@ -467,7 +468,7 @@ EOF
 [Container]
 Image=$IMAGE
 SecurityLabelDisable=true
-Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Exec=sh -c "echo STARTED CONTAINER; top"
 EOF
 
     run_quadlet "$quadlet_file"
@@ -494,7 +495,7 @@ Image=$IMAGE
 SecurityLabelType=spc_t
 SecurityLabelLevel=s0:c100,c200
 SecurityLabelFileType=container_ro_file_t
-Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Exec=sh -c "echo STARTED CONTAINER; top"
 EOF
 
     run_quadlet "$quadlet_file"
@@ -523,6 +524,7 @@ ContainerName=$NAME
 Image=$IMAGE
 Secret=$SECRET_NAME,type=env,target=MYSECRET
 Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Notify=yes
 EOF
 
     run_quadlet "$quadlet_file"
@@ -549,6 +551,7 @@ ContainerName=$NAME
 Image=$IMAGE
 Secret=$SECRET_NAME,type=mount,target=/root/secret
 Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Notify=yes
 EOF
 
     run_quadlet "$quadlet_file"
@@ -578,6 +581,7 @@ EOF
 Image=$IMAGE
 Volume=%T/$tmp_dir:/test_content:Z
 Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; top"
+Notify=yes
 EOF
 
     run_quadlet "$quadlet_file"


### PR DESCRIPTION
In some tests use Notify=yes while in others remove the notification

Resolves: #18516


#### Does this PR introduce a user-facing change?
No

```release-note
None
```
