### PR TITLE
e2e: stop podman.service test: wait for server

### DIFF
--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,6 +78,7 @@ var _ = Describe("Systemd activate", func() {
 
 		activateSession := testUtils.StartSystemExec(activate, systemdArgs)
 		Expect(activateSession.Exited).ShouldNot(Receive(), "Failed to start podman service")
+		WaitForService(url.URL{Scheme: "tcp", Host: addr})
 		defer activateSession.Signal(syscall.SIGTERM)
 
 		// Create custom functions for running podman and


### PR DESCRIPTION
Another low-hanging fruit: test flakes because podman-remote
trying to contact a server that hadn't come up.

Fixes: #17940

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```