### PR TITLE
[CI:DOCS] issue template: mention `su`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -70,7 +70,7 @@ body:
     id: privileged_rootless
     attributes:
       label: Privileged Or Rootless
-      description: Are you running the containers as privileged or non-root user?
+      description: Are you running the containers as privileged or non-root user?  Note that using `su` or `sudo` does not establish a proper login session required for running Podman as a non-root user.  Please refer to the [troubleshooting guide](https://github.com/containers/podman/blob/main/troubleshooting.md#solution-28) for alternatives.
       options:
         - Privileged
         - Rootless


### PR DESCRIPTION
Mention that using `su` does not establish a proper login session required for running rootless Podman.  It is a common and reoccurring issue.  Mentioning that in the issue template may guide users into resolving the issue before opening an issue.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
@containers/podman-maintainers PTAL