### PR TITLE
Fix handling of .containenv on tmpfs

### DIFF
--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -31,7 +31,7 @@ file is created in each container to indicate to programs they are running in a
 container. This file is located at _/run/.containerenv_. When using the
 --privileged flag the .containerenv contains name/value pairs indicating the
 container engine version, whether the engine is running in rootless mode, the
-container name and ID, as well as the image name and ID that the container is based on.
+container name and ID, as well as the image name and ID that the container is based on. Note: _/run/.containerenv_ will not be created when a volume is mounted on /run.
 
 When running from a user defined network namespace, the _/etc/netns/NSNAME/resolv.conf_
 will be used if it exists, otherwise _/etc/resolv.conf_ will be used.

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1938,11 +1938,16 @@ func (c *Container) makeBindMounts() error {
 
 	_, hasRunContainerenv := c.state.BindMounts["/run/.containerenv"]
 	if !hasRunContainerenv {
+	Loop:
 		// check in the spec mounts
 		for _, m := range c.config.Spec.Mounts {
-			if m.Destination == "/run/.containerenv" || m.Destination == "/run" {
+			switch {
+			case m.Destination == "/run/.containerenv":
 				hasRunContainerenv = true
-				break
+				break Loop
+			case m.Destination == "/run" && m.Source != "tmpfs":
+				hasRunContainerenv = true
+				break Loop
 			}
 		}
 	}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -568,8 +568,13 @@ json-file | f
 
 @test "Verify /run/.containerenv exist" {
     # Nonprivileged container: file exists, but must be empty
-    run_podman run --rm $IMAGE stat -c '%s' /run/.containerenv
-    is "$output" "0" "file size of /run/.containerenv, nonprivileged"
+    for opt in "" "--tmpfs=/run" "--tmpfs=/run --init" "--read-only" "--systemd=always"; do
+        run_podman run --rm $opt $IMAGE stat -c '%s' /run/.containerenv
+        is "$output" "0" "/run/.containerenv exists and is empty: podman run ${opt}"
+    done
+
+    run_podman 1 run --rm -v ${PODMAN_TMPDIR}:/run:Z $IMAGE stat -c '%s' /run/.containerenv
+    is "$output" "stat: can't stat '/run/.containerenv': No such file or directory" "do not create .containerenv on bind mounts"
 
     # Prep work: get ID of image; make a cont. name; determine if we're rootless
     run_podman inspect --format '{{.ID}}' $IMAGE


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/18531

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
/run/.containerenv file is created even when a tmpfs is mounted on /run.
```
