### PR TITLE
system tests: instrument, to try to catch unlinkat-ebusy

### DIFF
--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -53,10 +53,12 @@ function _require_crun() {
 }
 
 @test "podman --remote --group-add keep-groups " {
-    if is_remote; then
-        run_podman 125 run --rm --group-add keep-groups $IMAGE id
-        is "$output" ".*not supported in remote mode" "Remote check --group-add keep-groups"
+    if ! is_remote; then
+        skip "this test only meaningful under podman-remote"
     fi
+
+    run_podman 125 run --rm --group-add keep-groups $IMAGE id
+    is "$output" ".*not supported in remote mode" "Remote check --group-add keep-groups"
 }
 
 @test "podman --group-add without keep-groups " {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -168,7 +168,7 @@ load helpers.network
     is "${lines[0]}" "$pod_name" "hostname is the pod hostname"
     is "${lines[1]}" "$pod_name" "/etc/hostname contains correct pod hostname"
 
-    run_podman pod rm $pod_name
+    run_podman pod rm -f -t0 $pod_name
     is "$output" "$pid" "Only ID in output (no extra errors)"
 
     # Clean up


### PR DESCRIPTION
Several tweaks to see if we can track down #17216, the unlinkat-ebusy
flake:

 - teardown(): if a cleanup command fails, display it and its
   output to the debug channel. This should never happen, but
   it can and does (see #18180, dependent containers). We
   need to know about it.

 - selinux tests: use unique pod names. This should help when
   scanning journal logs.

 - many tests: add "-f -t0" to "pod rm"

And, several unrelated changes caught by accident:
 - images-commit-with-comment test: was leaving a stray image
   behind. Clean it up, and make a few more readability tweaks

 - podman-remote-group-add test: add an explicit skip()
   when not remote. (Otherwise, test passes cleanly on
   podman local, which is misleading)

 - lots of container cleanup and/or adding "--rm" to run commands,
   to avoid leaving stray containers

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```