### PR TITLE
Do not include image annotations when building spec

### DIFF
--- a/test/e2e/build/basicalpine/Containerfile.with_label
+++ b/test/e2e/build/basicalpine/Containerfile.with_label
@@ -1,0 +1,2 @@
+FROM quay.io/libpod/alpine:latest
+LABEL testlabel=testvalue

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2099,4 +2099,30 @@ WORKDIR /madethis`, BB)
 		Expect(t).To(BeTrue(), "found /run/lock")
 		Expect(strings[0]).Should(ContainSubstring("size=10240k"))
 	})
+
+	It("podman run does not preserve image annotations", func() {
+		annoName := "test.annotation.present"
+		annoValue := "annovalue"
+		imgName := "basicalpine"
+		build := podmanTest.Podman([]string{"build", "-f", "build/basicalpine/Containerfile.with_label", "--annotation", fmt.Sprintf("%s=%s", annoName, annoValue), "-t", imgName})
+		build.WaitWithDefaultTimeout()
+		Expect(build).Should(Exit(0))
+		Expect(build.ErrorToString()).To(BeEmpty(), "build error logged")
+
+		ctrName := "ctr1"
+		run := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, imgName, "top"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+		Expect(run.ErrorToString()).To(BeEmpty(), "run error logged")
+
+		inspect := podmanTest.Podman([]string{"inspect", ctrName})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.ErrorToString()).To(BeEmpty(), "inspect error logged")
+
+		inspectData := inspect.InspectContainerToJSON()
+		Expect(inspectData).To(HaveLen(1))
+		Expect(inspectData[0].Config.Annotations).To(Not(HaveKey(annoName)))
+		Expect(inspectData[0].Config.Annotations).To(Not(HaveKey("testlabel")))
+	})
 })


### PR DESCRIPTION
These annotations can have security implications - crun, for example, allows rootless containers to preserve the user's groups through an annotation. We absolutely should not include annotations from an untrusted image off the internet by default.

We may consider whitelisting some annotations (e.g. the legacy WASM annotations), but given that there is now a more explicit way of specifying an image uses the WASM runtime in the OCI image spec, I'm just tearing this out entirely for now.

```release-note
Security: annotations from images are no longer applied to containers.
```
