### PR TITLE
Cirrus: Add support for podman-next magic

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -300,7 +300,6 @@ bindings_task:
     only_if: >-
         $CIRRUS_PR != '' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
     depends_on:
         - build
@@ -459,7 +458,6 @@ docker-py_test_task:
     only_if: &not_tag_branch_build_docs >-
         $CIRRUS_PR != '' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
 
     depends_on:
@@ -566,7 +564,6 @@ windows_smoke_test_task:
         $CIRRUS_TAG == '' &&
         $CIRRUS_CRON != 'multiarch' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
         $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
     depends_on:
@@ -684,7 +681,6 @@ podman_machine_task:
     only_if: &not_tag_build_docs_multiarch >-
         $CIRRUS_TAG == '' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*' &&
         $CIRRUS_CRON != 'multiarch'
     depends_on:
@@ -1090,7 +1086,6 @@ artifacts_task:
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: >-
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CRON != 'multiarch' &&
         $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
         $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'

--- a/contrib/cirrus/CIModes.md
+++ b/contrib/cirrus/CIModes.md
@@ -79,13 +79,6 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + meta
 + success
 
-### Intended `[CI:COPR]` PR Tasks:
-+ *build*
-+ validate
-+ swagger
-+ meta
-+ success
-
 ### Intended `[CI:BUILD]` PR Tasks:
 + *build*
 + validate

--- a/contrib/cirrus/CIModes.md
+++ b/contrib/cirrus/CIModes.md
@@ -89,13 +89,13 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + success
 + artifacts
 
-### Intended `[CI:NVAV=update]` or `[CI:NVAV=main]` behavior:
+### Intended `[CI:NEXT]` behavior:
 
-If and only if the PR is in **draft-mode**, either update Fedora CI VMs to the
-latest Netavark/Aardvark-dns RPMs ("update" keyword), or install the most
-recent package builds from their `main` branch ("main" keyword).  These are
-**runtime changes** only, and will not persist or impact other PRs
-in any way.
+If and only if the PR is in **draft-mode**, update Fedora CI VMs at runtime
+to the latest packages available in the podman-next COPR repo.  These packages
+represent primary podman dependencies, and are regularly built from their
+upstream repos.  These are **runtime changes** only, and will not persist
+or impact other PRs in any way.
 
 The intent is to temporarily support testing of updates with the latest podman
 code & tests.  To help prevent accidents, when the PR is not in draft-mode, the

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -256,39 +256,6 @@ use_netavark() {
     # N/B: The CNI packages are still installed and available. This is
     # on purpose, since CI needs to verify the selection mechanisms are
     # functional when both are available.
-
-    # See ./contrib/cirrus/CIModes.md.
-    # Vars defined by cirrus-ci
-    # shellcheck disable=SC2154
-    if [[ ! "$OS_RELEASE_ID" =~ "debian" ]] && \
-       [[ "$CIRRUS_CHANGE_TITLE" =~ CI:[AN]V[AN]V= ]]
-    then
-        # shellcheck disable=SC2154
-        if [[ "$CIRRUS_PR_DRAFT" != "true" ]]; then
-            die "Magic 'CI:NVAV=*' string can only be used on DRAFT PRs"
-        fi
-
-        magickind=$(sed -r -e 's~(.*CI:[AN]V[AN]V=)(\w+)(.*)~\2~' <<<"$CIRRUS_CHANGE_TITLE")
-
-        # The update source scheme is defined during VM image build.
-        # See c/automation_images repo. cache_images/fedora_packaging.sh
-        repokind="updates-testing"  # $DISTRO_NV==$FEDORA_NAME
-        # shellcheck disable=SC2154
-        if [[ "$DISTRO_NV" =~ $PRIOR_FEDORA_NAME ]]; then
-            repokind="updates"
-        # else we're not running fedora, or .cirrus.yml env. vars are setup wrong.
-        fi
-
-        if [[ "$magickind" == "update" ]]; then
-            warn "Updating netavark/aardvark RPM packages from ***the fedora $repokind repo.***"
-        elif [[ "$magickind" == "main" ]]; then
-            warn "Installing latest netavark/aardvark packages from their main branches using ***the podman-next COPR repo***"
-            showrun dnf copr enable rhcontainerbot/podman-next -y
-        else
-            die "Unknown CI:NVAV= '$magickind' keyword.  Only 'update' and 'main' are supported."
-        fi
-        showrun dnf upgrade -y netavark aardvark-dns
-    fi
 }
 
 # Remove all files provided by the distro version of podman.


### PR DESCRIPTION
Rather than supporting a special-mode *just* for netavark/aardvark
testing [in podman CI], support testing with all the latest
`podman-next` COPR packages with a `[CI:NEXT]` magic string in ***DRAFT*** PRs.

The idea here is very similar to the netavark/aardvark special mode it
replaces.  Most podman-dependencies do not have the level of
comprehensive CI as exist here.  This new CI-mode allows testing
upstream updates to podman-dependencies without needing to roll out
a whole new package/release for them.

Also update documentation for this new mode.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
