### PR TITLE
Add `--publish-all` flag for `kube play`

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -158,6 +158,10 @@ func playFlags(cmd *cobra.Command) {
 	flags.StringSliceVar(&playOptions.PublishPorts, publishPortsFlagName, []string{}, "Publish a container's port, or a range of ports, to the host")
 	_ = cmd.RegisterFlagCompletionFunc(publishPortsFlagName, completion.AutocompleteNone)
 
+	publishAllFlagName := "publish-all"
+	flags.BoolVar(&playOptions.PublishAll, publishAllFlagName, false, "Publish all containerPorts from the YAML file without a matching hostPort")
+	_ = cmd.RegisterFlagCompletionFunc(publishAllFlagName, completion.AutocompleteNone)
+
 	waitFlagName := "wait"
 	flags.BoolVarP(&playOptions.Wait, waitFlagName, "w", false, "Clean up all objects created when a SIGTERM is received or pods exit")
 

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -221,6 +221,10 @@ Define or override a port definition in the YAML file.
 The lists of ports in the YAML file and the command line are merged. Matching is done by using the **containerPort** field.
 If **containerPort** exists in both the YAML file and the option, the latter takes precedence.
 
+#### **--publish-all**
+
+Allow container port publication without specifying a `hostPort` pair
+
 #### **--quiet**, **-q**
 
 Suppress output information when pulling images

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -28,6 +28,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		StaticIPs        []string          `schema:"staticIPs"`
 		StaticMACs       []string          `schema:"staticMACs"`
 		NoHosts          bool              `schema:"noHosts"`
+		PublishAll       bool              `schema:"publishAll"`
 		PublishPorts     []string          `schema:"publishPorts"`
 		Wait             bool              `schema:"wait"`
 		ServiceContainer bool              `schema:"serviceContainer"`
@@ -100,6 +101,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		PublishPorts:     query.PublishPorts,
 		Wait:             query.Wait,
 		ServiceContainer: query.ServiceContainer,
+		PublishAll:       query.PublishAll,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -64,6 +64,8 @@ type PlayKubeOptions struct {
 	Force bool
 	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
 	PublishPorts []string
+	// PublishAll - expose all container ports without a host pair
+	PublishAll bool
 	// Wait - indicates whether to return after having created the pods
 	Wait bool
 }

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -143,6 +143,7 @@ type PodCreateOptions struct {
 	Userns             specgen.Namespace `json:"-"`
 	Volume             []string          `json:"volume,omitempty"`
 	VolumesFrom        []string          `json:"volumes_from,omitempty"`
+	PublishAll         bool              ``
 	SecurityOpt        []string          `json:"security_opt,omitempty"`
 	Sysctl             []string          `json:"sysctl,omitempty"`
 }

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -417,6 +417,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		Infra:      true,
 		Net:        &entities.NetOptions{NoHosts: options.NoHosts},
 		ExitPolicy: string(config.PodExitPolicyStop),
+		PublishAll: options.PublishAll,
 	}
 	podOpt, err = kube.ToPodOpt(ctx, podName, podOpt, podYAML)
 	if err != nil {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -77,7 +77,7 @@ func ToPodOpt(ctx context.Context, podName string, p entities.PodCreateOptions, 
 		}
 		p.Net.AddHosts = hosts
 	}
-	podPorts := getPodPorts(podYAML.Spec.Containers)
+	podPorts := getPodPorts(podYAML.Spec.Containers, p.PublishAll)
 	p.Net.PublishPorts = podPorts
 
 	if dnsConfig := podYAML.Spec.DNSConfig; dnsConfig != nil {
@@ -1044,7 +1044,7 @@ func getContainerResources(container v1.Container) (v1.ResourceRequirements, err
 
 // getPodPorts converts a slice of kube container descriptions to an
 // array of portmapping
-func getPodPorts(containers []v1.Container) []types.PortMapping {
+func getPodPorts(containers []v1.Container, publishAll bool) []types.PortMapping {
 	var infraPorts []types.PortMapping
 	for _, container := range containers {
 		for _, p := range container.Ports {
@@ -1052,7 +1052,9 @@ func getPodPorts(containers []v1.Container) []types.PortMapping {
 				p.ContainerPort = p.HostPort
 			}
 			if p.HostPort == 0 && p.ContainerPort != 0 {
-				p.HostPort = p.ContainerPort
+				if publishAll {
+					p.HostPort = p.ContainerPort
+				}
 			}
 			if p.Protocol == "" {
 				p.Protocol = "tcp"


### PR DESCRIPTION

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--publish-all` flag for CLI, which prevents container port publication without specifying a `hostPort` pair.

Added `publishAll` query parameter for API, which prevents container port publication without specifying a `hostPort` pair.
```

Closes #17028