### PR TITLE
remote-save: fix permissions and dir formats

### DIFF
--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/containers/podman/v4/pkg/domain/utils"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	utils2 "github.com/containers/podman/v4/utils"
+	"github.com/containers/storage/pkg/archive"
 )
 
 func (ir *ImageEngine) Exists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
@@ -329,7 +329,8 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 	default:
 		return err
 	}
-	return utils2.UntarToFileSystem(opts.Output, f, nil)
+
+	return archive.Untar(f, opts.Output, nil)
 }
 
 func (ir *ImageEngine) Search(ctx context.Context, term string, opts entities.ImageSearchOptions) ([]entities.ImageSearchReport, error) {

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -87,31 +87,30 @@ var _ = Describe("Podman save", func() {
 	})
 
 	It("podman save to directory with oci format", func() {
-		if isRootless() {
-			Skip("Requires a fix in containers image for chown/lchown")
-		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
 		save := podmanTest.Podman([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save).Should(Exit(0))
+
+		// Smoke test if it looks like an OCI dir
+		Expect(filepath.Join(outdir, "oci-layout")).Should(BeAnExistingFile())
+		Expect(filepath.Join(outdir, "index.json")).Should(BeAnExistingFile())
+		Expect(filepath.Join(outdir, "blobs")).Should(BeAnExistingFile())
 	})
 
 	It("podman save to directory with v2s2 docker format", func() {
-		if isRootless() {
-			Skip("Requires a fix in containers image for chown/lchown")
-		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
 		save := podmanTest.Podman([]string{"save", "--format", "docker-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save).Should(Exit(0))
+
+		// Smoke test if it looks like a docker dir
+		Expect(filepath.Join(outdir, "version")).Should(BeAnExistingFile())
 	})
 
 	It("podman save to directory with docker format and compression", func() {
-		if isRootless() && podmanTest.RemoteTest {
-			Skip("Requires a fix in containers image for chown/lchown")
-		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
 		save := podmanTest.Podman([]string{"save", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
@@ -120,9 +119,6 @@ var _ = Describe("Podman save", func() {
 	})
 
 	It("podman save to directory with --compress but not use docker-dir and oci-dir", func() {
-		if isRootless() && podmanTest.RemoteTest {
-			Skip("Requires a fix in containers image for chown/lchown")
-		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
 		save := podmanTest.Podman([]string{"save", "--compress", "--format", "docker-archive", "-o", outdir, ALPINE})


### PR DESCRIPTION
Make sure that the directory formats are not just substituted with their archive counterparts but actually tar'ed up directories.  Also make sure that the clients don't get chown errors by setting rootless user and group ID instead of O when running in the user namespace.

Fixes: #15897

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix permissions and format errors when using the oci-dir and docker-dir format in the libpod/images/export REST API.
```
