### PR TITLE
[CI:DOCS] Document podman-machine-default behavior

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -22,7 +22,7 @@ var (
 		PersistentPreRunE: rootlessOnly,
 		RunE:              initMachine,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `podman machine init myvm`,
+		Example:           `podman machine init podman-machine-default`,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -23,7 +23,7 @@ var (
 		PersistentPreRunE: rootlessOnly,
 		RunE:              rm,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `podman machine rm myvm`,
+		Example:           `podman machine rm podman-machine-default`,
 		ValidArgsFunction: autocompleteMachine,
 	}
 )

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -22,7 +22,7 @@ var (
 		Long:              "SSH into a managed virtual machine ",
 		PersistentPreRunE: rootlessOnly,
 		RunE:              ssh,
-		Example: `podman machine ssh myvm
+		Example: `podman machine ssh podman-machine-default
   podman machine ssh myvm echo hello`,
 		ValidArgsFunction: autocompleteMachineSSH,
 	}

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -20,7 +20,7 @@ var (
 		PersistentPreRunE: rootlessOnly,
 		RunE:              start,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `podman machine start myvm`,
+		Example:           `podman machine start podman-machine-default`,
 		ValidArgsFunction: autocompleteMachine,
 	}
 	startOpts = machine.StartOptions{}

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -20,7 +20,7 @@ var (
 		PersistentPreRunE: rootlessOnly,
 		RunE:              stop,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `podman machine stop myvm`,
+		Example:           `podman machine stop podman-machine-default`,
 		ValidArgsFunction: autocompleteMachine,
 	}
 )

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -10,6 +10,9 @@ podman\-machine\-init - Initialize a new virtual machine
 
 Initialize a new virtual machine for Podman.
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then the new machine will be named `podman-machine-default`.
+
 Rootless only.
 
 Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -4,14 +4,17 @@
 podman\-machine\-inspect - Inspect one or more virtual machines
 
 ## SYNOPSIS
-**podman machine inspect** [*options*] *name* ...
+**podman machine inspect** [*options*] [*name*] ...
 
 ## DESCRIPTION
 
 Inspect one or more virtual machines
 
-Obtain greater detail about Podman virtual machines.  More than one virtual machine can be
+Obtain greater detail about Podman virtual machines. More than one virtual machine can be
 inspected at once.
+
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then `podman-machine-default` will be inspected.
 
 Rootless only.
 

--- a/docs/source/markdown/podman-machine-os-apply.1.md
+++ b/docs/source/markdown/podman-machine-os-apply.1.md
@@ -17,6 +17,9 @@ By default, Podman machines on Mac and Linux use an rpm-ostree based distrubitio
 
 For more information, please see the [rpm-ostree docs](https://coreos.github.io/rpm-ostree/container/).
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then the OS changes will be applied to `podman-machine-default`.
+
 ## OPTIONS
 
 #### **--help**

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -16,6 +16,9 @@ generated for that VM are also removed as is its image file on the filesystem.
 Users get a display of what will be deleted and are required to confirm unless the option `--force`
 is used.
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then `podman-machine-default` will be removed.
+
 Rootless only.
 
 ## OPTIONS

--- a/docs/source/markdown/podman-machine-set.1.md.in
+++ b/docs/source/markdown/podman-machine-set.1.md.in
@@ -10,6 +10,9 @@ podman\-machine\-set - Sets a virtual machine setting
 
 Change a machine setting.
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then the settings will be applied to `podman-machine-default`.
+
 Rootless only.
 
 ## OPTIONS

--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -16,6 +16,9 @@ with the virtual machine is established.
 
 The exit code from ssh command will be forwarded to the podman machine ssh caller, see [Exit Codes](#Exit-Codes).
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then `podman-machine-default` will be SSH'd into.
+
 Rootless only.
 
 ## OPTIONS

--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -17,6 +17,9 @@ containers do not run on any other OS because containers' core functionality are
 tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines,
 but can be optionally used on Linux.
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then `podman-machine-default` will be started.
+
 Only one Podman managed VM can be active at a time. If a VM is already running,
 `podman machine start` will return an error.
 

--- a/docs/source/markdown/podman-machine-stop.1.md
+++ b/docs/source/markdown/podman-machine-stop.1.md
@@ -10,6 +10,9 @@ podman\-machine\-stop - Stop a virtual machine
 
 Stops a virtual machine.
 
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then `podman-machine-default` will be stopped.
+
 Rootless only.
 
 Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -


### PR DESCRIPTION
When no name arg is given to Podman machine commands, Podman assumes the machine name is podman-machine-default. Document this behavior.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Fixes: https://github.com/containers/podman/issues/17962
