### PR TITLE
[CI:DOCS] Fix documentation of `--network-cmd-path` CLI option

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -438,6 +438,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		pFlags.StringVar(&podmanConfig.ConmonPath, conmonFlagName, "", "Path of the conmon binary")
 		_ = cmd.RegisterFlagCompletionFunc(conmonFlagName, completion.AutocompleteDefault)
 
+		// TODO (5.0): remove this option with the next major release after https://github.com/containers/podman/issues/18560 was implemented
 		networkCmdPathFlagName := "network-cmd-path"
 		pFlags.StringVar(&podmanConfig.ContainersConf.Engine.NetworkCmdPath, networkCmdPathFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.NetworkCmdPath, "Path to the command for configuring the network")
 		_ = cmd.RegisterFlagCompletionFunc(networkCmdPathFlagName, completion.AutocompleteDefault)

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -83,7 +83,7 @@ Remote connections use local containers.conf for default.
 Log messages at and above specified level: debug, info, warn, error, fatal or panic (default: "warn")
 
 #### **--network-cmd-path**=*path*
-Path to the command binary to use for setting up a network.  It is currently only used for setting up a slirp4netns(1) or pasta(1) network.  If "" is used then the binary is looked up using the $PATH environment variable.
+Path to the `slirp4netns(1)` command binary to use for setting up a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
 
 #### **--network-config-dir**=*directory*
 


### PR DESCRIPTION
The `--network-cmd-path` CLI option only affects rootless networks using `slirp4netns(1)`, not `pasta(1)`.  Following #18568 Podman should rather use the more generic `r.config.FindHelperBinary()` method (and therefore honour the `helper_binaries_dir` config) to find the path to the `slirp4netns` binary and deprecate the misleading `--network-cmd-path` CLI option.  However, since this wasn't implemented yet we can't deprecate `--network-cmd-path` as of now.  Adding a note anyway.

Fixes #18560

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Cc: @Luap99 