### PR TITLE
e2e: serialize gpg tests

### DIFF
--- a/test/e2e/image_sign_test.go
+++ b/test/e2e/image_sign_test.go
@@ -26,10 +26,17 @@ var _ = Describe("Podman image sign", func() {
 	})
 
 	AfterEach(func() {
+		// There's no way to run gpg without an agent, so, clean up
+		// after every test. No need to check error status.
+		cmd := exec.Command("gpgconf", "--kill", "gpg-agent")
+		cmd.Stdout = GinkgoWriter
+		cmd.Stderr = GinkgoWriter
+		_ = cmd.Run()
+
 		os.Setenv("GNUPGHOME", origGNUPGHOME)
 	})
 
-	It("podman sign image", func() {
+	It("podman sign image", Serial, func() {
 		cmd := exec.Command("gpg", "--import", "sign/secret-key.asc")
 		cmd.Stdout = GinkgoWriter
 		cmd.Stderr = GinkgoWriter
@@ -45,7 +52,7 @@ var _ = Describe("Podman image sign", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("podman sign --all multi-arch image", func() {
+	It("podman sign --all multi-arch image", Serial, func() {
 		cmd := exec.Command("gpg", "--import", "sign/secret-key.asc")
 		cmd.Stdout = GinkgoWriter
 		cmd.Stderr = GinkgoWriter


### PR DESCRIPTION
Reason: gpg tests all run with a different GNUPGHOME, and gpg-agent
does not like that, and there's no longer any way to run gpg
without the agent. So, do not run these tests in parallel, and
clean up agent after each test.

Fixes: #17966 (I hope)

May also fix #18358 but it will take some time to be sure.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```