### PR TITLE
Makefile: add ginkgo FOCUS/FOCUS_FILE options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,9 @@ test: localunit localintegration remoteintegration localsystem remotesystem  ## 
 .PHONY: ginkgo-run
 ginkgo-run: .install.ginkgo
 	$(GINKGO) version
-	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts 3 --trace --no-color $(GINKGO_JSON) $(if $(findstring y,$(GINKGO_PARALLEL)),-p,) $(GINKGOWHAT) $(HACK)
+	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts 3 --trace --no-color \
+		$(GINKGO_JSON) $(if $(findstring y,$(GINKGO_PARALLEL)),-p,) $(if $(FOCUS),--focus "$(FOCUS)",) \
+		$(if $(FOCUS_FILE),--focus-file "$(FOCUS_FILE)",) $(GINKGOWHAT) $(HACK)
 
 .PHONY: ginkgo
 ginkgo:

--- a/test/README.md
+++ b/test/README.md
@@ -95,10 +95,13 @@ The following environment variables are supported by the test setup:
 You can run a single file of integration tests using the go test command:
 
 ```
-go test -v test/e2e/libpod_suite_test.go test/e2e/common_test.go test/e2e/config.go test/e2e/config_amd64.go test/e2e/your_test.go
+make localintegration FOCUS_FILE=your_test.go
 ```
 
-If you want to run the tests with the podman-remote client, make sure to replace `test/e2e/libpod_suite_test.go` with `test/e2e/libpod_suite_remote_test.go`.
+`FOCUS_FILE` file maps to ginkgo's `--focus-file` option, see the ginkgo
+[docs](https://onsi.github.io/ginkgo/#location-based-filtering) for the accepted syntax.
+
+For remote tests use the `remoteintegration` Makefile target instead.
 
 ### Running a single integration test
 Before running the test suite, you have to declare which test you want run in the test
@@ -112,17 +115,16 @@ It("podman inspect bogus pod", func() {
 ```
 
 To mark this as the test you want run, you simply change the *It* description to *FIt*. Please note how
-both the `F` and `I` are capitalized.
-
-You can run a single integration test using the same command we used to run all the tests in a single
-file.
-
-```
-go test -v test/e2e/libpod_suite_test.go test/e2e/common_test.go test/e2e/config.go test/e2e/config_amd64.go test/e2e/your_test.go
-```
+both the `F` and `I` are capitalized. Also see the ginkgo [docs](https://onsi.github.io/ginkgo/#focused-specs).
 
 *Note*: Be sure you remove the `F` from the tests before committing your changes or you will skip all tests
 in that file except the one with the `FIt` denotation.
+
+Alternatively you can use the `FOCUS` option which maps to `--focus`, again see the ginkgo
+[docs](https://onsi.github.io/ginkgo/#description-based-filtering) for more info about the syntax.
+```
+make localintegration FOCUS="podman inspect bogus pod"
+```
 
 # System tests
 System tests are used for testing the *podman* CLI in the context of a complete system. It


### PR DESCRIPTION
When running ginkgo tests locally we often only want to test a small subset. I think most people just add the `FIt` block but then you need to remember to undo that before pushing the changes.

With this change you can just run:
```
make localintegration FOCUS="test name here"
make localintegration FOCUS_FILE="some_test.go"
```
I updated the test Readme to use this new syntax.
The options just map to the ginkgo options, see the upstream docs linked in the readme for more information about syntax.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
