### PR TITLE
compat: accept tag in /images/create?fromSrc

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -181,7 +181,8 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 		FromSrc  string   `schema:"fromSrc"`
 		Message  string   `schema:"message"`
 		Platform string   `schema:"platform"`
-		Repo     string   `shchema:"repo"`
+		Repo     string   `schema:"repo"`
+		Tag      string   `schema:"tag"`
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -208,7 +209,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 
 	reference := query.Repo
 	if query.Repo != "" {
-		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, reference)
+		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, mergeNameAndTagOrDigest(reference, query.Tag))
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("normalizing image: %w", err))
 			return

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -66,6 +66,13 @@ podman untag docker.io/library/alpine:latest
 
 t POST "images/create?fromImage=quay.io/libpod/alpine&tag=sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f" 200
 
+# create image from source with tag
+# Note the "-" is used to use an empty body and not "{}" which is the default.
+t POST "images/create?fromSrc=-&repo=myimage&tag=mytag" - 200
+t GET "images/myimage:mytag/json" 200 \
+  .Id~'^sha256:[0-9a-f]\{64\}$' \
+  .RepoTags[0]="docker.io/library/myimage:mytag"
+
 # Display the image history
 t GET libpod/images/nonesuch/history 404
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -255,6 +255,10 @@ function t() {
 
         for arg; do
             case "$arg" in
+                # This is just some hack to avoid adding `-d {}` to curl for endpoints where we really need an empty body.
+                # --disable makes curl not lookup the curlrc file, it't should't effect the tests in any way.
+                -)                curl_args+=(--disable);
+                                  shift;;
                 *=*)              post_args+=("$arg");
                                   shift;;
                 *.json)           _add_curl_args $arg;


### PR DESCRIPTION
Accept a tag in the compat api endpoint. For the fromImage param we already parse it but for fromSrc we did not.

Fixes #18597

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The compat API now correctly accpets a tag in the images/create?fromSrc endpoint.
```
