### PR TITLE
run: block PODMAN_USERNS and --pod

### DIFF
--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -4,7 +4,7 @@
 ####> are applicable to all of those.
 #### **--userns**=*mode*
 
-Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.
+Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable unless `--pod` is specified. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.
 
 This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
 

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -220,9 +220,9 @@ func setNamespaces(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions)
 			return err
 		}
 	}
-	userns := os.Getenv("PODMAN_USERNS")
-	if c.UserNS != "" {
-		userns = c.UserNS
+	userns := c.UserNS
+	if userns == "" && c.Pod == "" {
+		userns = os.Getenv("PODMAN_USERNS")
 	}
 	// userns must be treated differently
 	if userns != "" {

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -395,6 +395,11 @@ var _ = Describe("Podman UserNS support", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect.OutputToString()).To(Not(Equal("<nil>")))
 
+		// --pod should work.
+		result = podmanTest.Podman([]string{"create", "--pod=new:new-pod", ALPINE, "true"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
 		}


### PR DESCRIPTION
the combination --pod and --userns is already blocked.  The PODMAN_USERNS environment variable instead circumvents the check. Make sure the combination is also blocked, otherwise we end up creating containers in a different user namespace than their pod.

Ideally a container should be able to do that, but its user namespace must be a child of the pod user namespace, not a sibling.  Since nested user namespaces are not allowed in the OCI runtime specs, disallow this case, since the end result is just confusing for the user.

Closes: https://github.com/containers/podman/issues/18580

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now PODMAN_USERNS is ignored if --pod is specified
```
