### PR TITLE
generate systemd: error on init containers

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -144,6 +144,10 @@ func generateContainerInfo(ctr *libpod.Container, options entities.GenerateSyste
 	}
 
 	config := ctr.Config()
+	if len(config.InitContainerType) > 0 {
+		return nil, fmt.Errorf("unsupported container %s: cannot generate systemd units for init containers", ctr.ID())
+	}
+
 	conmonPidFile := config.ConmonPidFile
 	if conmonPidFile == "" {
 		return nil, errors.New("conmon PID file path is empty, try to recreate the container with --conmon-pidfile flag")

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -170,6 +170,7 @@ func PodUnits(pod *libpod.Pod, options entities.GenerateSystemdOptions) (map[str
 		if ctr.ID() == infraID {
 			continue
 		}
+
 		ctrInfo, err := generateContainerInfo(ctr, options)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Init containers are currently not properly supported in generate-systemd and there are no plans to do so since all focus lies on Quadlet going forward.

Hence, generate systemd should through an error.

Closes: #18585

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
