### PR TITLE
test/e2e: do not call setenforce

### DIFF
--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -26,23 +26,9 @@ var _ = Describe("Podman login and logout", func() {
 	)
 
 	BeforeEach(func() {
-
 		authPath = filepath.Join(podmanTest.TempDir, "auth")
 		err := os.Mkdir(authPath, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
-
-		if IsCommandAvailable("getenforce") {
-			ge := SystemExec("getenforce", []string{})
-			ge.WaitWithDefaultTimeout()
-			if ge.OutputToString() == "Enforcing" {
-				se := SystemExec("setenforce", []string{"0"})
-				se.WaitWithDefaultTimeout()
-				if se.ExitCode() != 0 {
-					Skip("Cannot disable selinux, this may cause problem for reading cert files inside container.")
-				}
-				defer SystemExec("setenforce", []string{"1"})
-			}
-		}
 
 		htpasswd := SystemExec("htpasswd", []string{"-Bbn", "podmantest", "test"})
 		htpasswd.WaitWithDefaultTimeout()

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to local registry with authorization", func() {
-		SkipIfRootless("volume-mounting a certs.d file N/A over remote")
+		SkipIfRootless("/etc/containers/certs.d not writable")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -223,18 +223,6 @@ var _ = Describe("Podman push", func() {
 		cwd, _ := os.Getwd()
 		certPath := filepath.Join(cwd, "../", "certs")
 
-		if IsCommandAvailable("getenforce") {
-			ge := SystemExec("getenforce", []string{})
-			Expect(ge).Should(Exit(0))
-			if ge.OutputToString() == "Enforcing" {
-				se := SystemExec("setenforce", []string{"0"})
-				Expect(se).Should(Exit(0))
-				defer func() {
-					se2 := SystemExec("setenforce", []string{"1"})
-					Expect(se2).Should(Exit(0))
-				}()
-			}
-		}
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
 		htpasswd := SystemExec("htpasswd", []string{"-Bbn", "podmantest", "test"})


### PR DESCRIPTION
We should not change selinux, in a parallel context this can change the behavior of other tests and we should never disable selinux anyway.

Lets see if this passes CI or not.

Fixes #18564

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
