### PR TITLE
Cirrus: Record the buildah version for reference

### DIFF
--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -36,6 +36,7 @@ case $1 in
     packages)
         # These names are common to Fedora and Debian
         PKG_NAMES=(\
+                    buildah
                     conmon
                     containernetworking-plugins
                     containers-common


### PR DESCRIPTION
Apparently this matters, see
https://github.com/containers/podman/pull/18510#discussion_r1189812306

#### Does this PR introduce a user-facing change?

```release-note
None
```
