### PR TITLE
fix: event --filter volume=vol-name should compare the event name with volume name

### DIFF
--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -52,7 +52,8 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 			if e.Type != Volume {
 				return false
 			}
-			return strings.HasPrefix(e.ID, filterValue)
+			// Prefix match with name for consistency with docker
+			return strings.HasPrefix(e.Name, filterValue)
 		}, nil
 	case "TYPE":
 		return func(e *Event) bool {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -718,6 +718,19 @@ func (p *PodmanTestIntegration) CreatePod(options map[string][]string) (*PodmanS
 	return session, session.ExitCode(), session.OutputToString()
 }
 
+func (p *PodmanTestIntegration) CreateVolume(options map[string][]string) (*PodmanSessionIntegration, int, string) {
+	var args = []string{"volume", "create"}
+	for k, values := range options {
+		for _, v := range values {
+			args = append(args, k+"="+v)
+		}
+	}
+
+	session := p.Podman(args)
+	session.WaitWithDefaultTimeout()
+	return session, session.ExitCode(), session.OutputToString()
+}
+
 func (p *PodmanTestIntegration) RunTopContainerInPod(name, pod string) *PodmanSessionIntegration {
 	return p.RunTopContainerWithArgs(name, []string{"--pod", pod})
 }

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -382,3 +382,18 @@ EOF
         --stream=false
     is "${lines[0]}" ".* container died .* (image=$IMAGE, name=$cname, .*)"
 }
+
+@test "events - volume events" {
+    local vname=v$(random_string 10)
+    run_podman volume create $vname
+    run_podman volume rm $vname
+
+    run_podman events --since=1m --stream=false --filter volume=$vname
+    notrunc_results="$output"
+    assert "${lines[0]}" =~ ".* volume create $vname"
+    assert "${lines[1]}" =~ ".* volume remove $vname"
+
+    # Prefix test
+    run_podman events --since=1m --stream=false --filter volume=${vname:0:5}
+    assert "$output" = "$notrunc_results"
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/18618

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
