### PR TITLE
podman: Added find slirp4netns binary file from helper_binaries_dir

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -438,7 +438,8 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		pFlags.StringVar(&podmanConfig.ConmonPath, conmonFlagName, "", "Path of the conmon binary")
 		_ = cmd.RegisterFlagCompletionFunc(conmonFlagName, completion.AutocompleteDefault)
 
-		// TODO (5.0): remove this option with the next major release after https://github.com/containers/podman/issues/18560 was implemented
+		// TODO (5.0): --network-cmd-path is deprecated, remove this option with the next major release
+		// We need to find all the places that use r.config.Engine.NetworkCmdPath and remove it
 		networkCmdPathFlagName := "network-cmd-path"
 		pFlags.StringVar(&podmanConfig.ContainersConf.Engine.NetworkCmdPath, networkCmdPathFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.NetworkCmdPath, "Path to the command for configuring the network")
 		_ = cmd.RegisterFlagCompletionFunc(networkCmdPathFlagName, completion.AutocompleteDefault)

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -83,7 +83,9 @@ Remote connections use local containers.conf for default.
 Log messages at and above specified level: debug, info, warn, error, fatal or panic (default: "warn")
 
 #### **--network-cmd-path**=*path*
-Path to the `slirp4netns(1)` command binary to use for setting up a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
+Path to the `slirp4netns(1)` command binary to use for setting up a slirp4netns network.
+If "" is used, then the binary will first be searched using the `helper_binaries_dir` option in `containers.conf`, and second using the `$PATH` environment variable.
+**Note:** This option is deprecated and will be removed with Podman 5.0. Use the `helper_binaries_dir` option in `containers.conf` instead.
 
 #### **--network-config-dir**=*directory*
 

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -57,7 +56,7 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 
 	slirp4netnsPath := r.config.Engine.NetworkCmdPath
 	if slirp4netnsPath == "" {
-		slirp4netnsPath, _ = exec.LookPath("slirp4netns")
+		slirp4netnsPath, _ = r.config.FindHelperBinary(slirp4netnsBinaryName, true)
 	}
 	if slirp4netnsPath != "" {
 		version, err := programVersion(slirp4netnsPath)

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -392,7 +392,7 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 		path := r.config.Engine.NetworkCmdPath
 		if path == "" {
 			var err error
-			path, err = exec.LookPath("slirp4netns")
+			path, err = r.config.FindHelperBinary(slirp4netnsBinaryName, true)
 			if err != nil {
 				return nil, err
 			}

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -61,7 +61,10 @@ type slirp4netnsNetworkOptions struct {
 	outboundAddr6       string
 }
 
-const ipv6ConfDefaultAcceptDadSysctl = "/proc/sys/net/ipv6/conf/default/accept_dad"
+const (
+	ipv6ConfDefaultAcceptDadSysctl = "/proc/sys/net/ipv6/conf/default/accept_dad"
+	slirp4netnsBinaryName          = "slirp4netns"
+)
 
 func checkSlirpFlags(path string) (*slirpFeatures, error) {
 	cmd := exec.Command(path, "--help")
@@ -216,7 +219,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container, netns string) error {
 	path := r.config.Engine.NetworkCmdPath
 	if path == "" {
 		var err error
-		path, err = exec.LookPath("slirp4netns")
+		path, err = r.config.FindHelperBinary(slirp4netnsBinaryName, true)
 		if err != nil {
 			return fmt.Errorf("could not find slirp4netns, the network namespace can't be configured: %w", err)
 		}
@@ -234,7 +237,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container, netns string) error {
 
 	ctrNetworkSlipOpts := []string{}
 	if ctr.config.NetworkOptions != nil {
-		ctrNetworkSlipOpts = append(ctrNetworkSlipOpts, ctr.config.NetworkOptions["slirp4netns"]...)
+		ctrNetworkSlipOpts = append(ctrNetworkSlipOpts, ctr.config.NetworkOptions[slirp4netnsBinaryName]...)
 	}
 	netOptions, err := parseSlirp4netnsNetworkOptions(r, ctrNetworkSlipOpts)
 	if err != nil {


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Fixes: #18568

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If --network-cmd-path is not set, then slirp4netns binary will first be searched using the `helper_binaries_dir` option in `containers.conf`, and second using the `$ PATH` environment variable.
```
