### PR TITLE
Quadlet tests: enable device.volume and remove socketactivated.container

### DIFF
--- a/test/e2e/quadlet/socketactivated.container
+++ b/test/e2e/quadlet/socketactivated.container
@@ -1,9 +1,0 @@
-## assert-podman-args --preserve-fds=1
-## assert-podman-args --env LISTEN_FDS=1
-## assert-podman-args --env LISTEN_PID=2
-## assert-key-is "Service" "Type" "notify"
-## assert-key-is "Service" "NotifyAccess" "all"
-
-[Container]
-Image=localhost/imagename
-SocketActivated=yes

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -563,7 +563,8 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("basic.volume", "basic.volume"),
 		Entry("label.volume", "label.volume"),
 		Entry("uid.volume", "uid.volume"),
-		Entry("device.volume", "device-copy.volume"),
+		Entry("device-copy.volume", "device-copy.volume"),
+		Entry("device.volume", "device.volume"),
 
 		Entry("Basic kube", "basic.kube"),
 		Entry("Syslog Identifier", "syslog.identifier.kube"),


### PR DESCRIPTION
These files

* _test/e2e/quadlet/device.volume_
* _test/e2e/quadlet/device-copy.volume_

were added in
https://github.com/containers/podman/pull/17217/files

but only the test for  _test/e2e/quadlet/device-copy.volume_
was enabled.

I assume that was a mistake. Let's enable 
_test/e2e/quadlet/device.volume_
too.

Remove unused file
_test/e2e/quadlet/socketactivated.container_

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
