### PR TITLE
podman: Add pasta to podman info

### DIFF
--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -87,6 +87,15 @@ host:
       spec: 1.0.0
       +SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
   os: linux
+  pasta:
+    executable: /usr/bin/passt
+    package: passt-0^20221116.gace074c-1.fc34.x86_64
+    version: |
+      passt 0^20221116.gace074c-1.fc34.x86_64
+      Copyright Red Hat
+      GNU Affero GPL version 3 or later <https://www.gnu.org/licenses/agpl-3.0.html>
+      This is free software: you are free to change and redistribute it.
+      There is NO WARRANTY, to the extent permitted by law.
   remoteSocket:
     path: /run/user/3267/podman/podman.sock
   security:
@@ -234,6 +243,11 @@ $ podman info --format json
       "executable": "/bin/slirp4netns",
       "package": "slirp4netns-1.1.12-2.fc34.x86_64",
       "version": "slirp4netns version 1.1.12\ncommit: 7a104a101aa3278a2152351a082a6df71f57c9a3\nlibslirp: 4.4.0\nSLIRP_CONFIG_VERSION_MAX: 3\nlibseccomp: 2.5.0"
+    },
+    "pasta": {
+      "executable": "/usr/bin/passt",
+      "package": "passt-0^20221116.gace074c-1.fc34.x86_64",
+      "version": "passt 0^20221116.gace074c-1.fc34.x86_64\nCopyright Red Hat\nGNU Affero GPL version 3 or later \u003chttps://www.gnu.org/licenses/agpl-3.0.html\u003e\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n"
     },
     "swapFree": 15687475200,
     "swapTotal": 16886259712,

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -54,10 +54,12 @@ type HostInfo struct {
 	ServiceIsRemote bool         `json:"serviceIsRemote"`
 	Security        SecurityInfo `json:"security"`
 	Slirp4NetNS     SlirpInfo    `json:"slirp4netns,omitempty"`
-	SwapFree        int64        `json:"swapFree"`
-	SwapTotal       int64        `json:"swapTotal"`
-	Uptime          string       `json:"uptime"`
-	Linkmode        string       `json:"linkmode"`
+	Pasta           PastaInfo    `json:"pasta,omitempty"`
+
+	SwapFree  int64  `json:"swapFree"`
+	SwapTotal int64  `json:"swapTotal"`
+	Uptime    string `json:"uptime"`
+	Linkmode  string `json:"linkmode"`
 }
 
 // RemoteSocket describes information about the API socket
@@ -68,6 +70,13 @@ type RemoteSocket struct {
 
 // SlirpInfo describes the slirp executable that is being used
 type SlirpInfo struct {
+	Executable string `json:"executable"`
+	Package    string `json:"package"`
+	Version    string `json:"version"`
+}
+
+// PastaInfo describes the pasta executable that is being used
+type PastaInfo struct {
 	Executable string `json:"executable"`
 	Package    string `json:"package"`
 	Version    string `json:"version"`

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -71,6 +71,20 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 		info.Slirp4NetNS = program
 	}
 
+	pastaPath, _ := r.config.FindHelperBinary(pastaBinaryName, true)
+	if pastaPath != "" {
+		version, err := programVersion(pastaPath)
+		if err != nil {
+			logrus.Warnf("Failed to retrieve program version for %s: %v", pastaPath, err)
+		}
+		program := define.PastaInfo{
+			Executable: pastaPath,
+			Package:    packageVersion(pastaPath),
+			Version:    version,
+		}
+		info.Pasta = program
+	}
+
 	if rootless.IsRootless() {
 		uidmappings, err := rootless.ReadMappingsProc("/proc/self/uid_map")
 		if err != nil {

--- a/libpod/networking_pasta_linux.go
+++ b/libpod/networking_pasta_linux.go
@@ -15,6 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	pastaBinaryName = "passt"
+)
+
 func (r *Runtime) setupPasta(ctr *Container, netns string) error {
 	var NoTCPInitPorts = true
 	var NoUDPInitPorts = true

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -43,6 +43,7 @@ host.conmon.package       | .*conmon.*
 host.cgroupManager        | \\\(systemd\\\|cgroupfs\\\)
 host.cgroupVersion        | v[12]
 host.ociRuntime.path      | $expr_path
+host.pasta                | .*executable.*package.*
 store.configFile          | $expr_path
 store.graphDriverName     | [a-z0-9]\\\+\\\$
 store.graphRoot           | $expr_path


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Fixes: #18561

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman info will output information about the pasta if it exists in helper_binaries_dir or $PATH
```
