### PR TITLE
man pages and command help: unify verb forms

### DIFF
--- a/cmd/podman-mac-helper/install.go
+++ b/cmd/podman-mac-helper/install.go
@@ -72,8 +72,8 @@ type launchParams struct {
 
 var installCmd = &cobra.Command{
 	Use:    "install",
-	Short:  "installs the podman helper agent",
-	Long:   "installs the podman helper agent, which manages the /var/run/docker.sock link",
+	Short:  "Install the podman helper agent",
+	Long:   "Install the podman helper agent, which manages the /var/run/docker.sock link",
 	PreRun: silentUsage,
 	RunE:   install,
 }

--- a/cmd/podman-mac-helper/service.go
+++ b/cmd/podman-mac-helper/service.go
@@ -21,8 +21,8 @@ const (
 
 var serviceCmd = &cobra.Command{
 	Use:    "service",
-	Short:  "services requests",
-	Long:   "services requests",
+	Short:  "Service requests",
+	Long:   "Service requests",
 	PreRun: silentUsage,
 	Run:    serviceRun,
 	Hidden: true,

--- a/cmd/podman-mac-helper/uninstall.go
+++ b/cmd/podman-mac-helper/uninstall.go
@@ -14,8 +14,8 @@ import (
 
 var uninstallCmd = &cobra.Command{
 	Use:    "uninstall",
-	Short:  "uninstalls the podman helper agent",
-	Long:   "uninstalls the podman helper agent, which manages the /var/run/docker.sock link",
+	Short:  "Uninstall the podman helper agent",
+	Long:   "Uninstall the podman helper agent, which manages the /var/run/docker.sock link",
 	PreRun: silentUsage,
 	RunE:   uninstall,
 }

--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -27,7 +27,7 @@ var (
 `
 	checkpointCommand = &cobra.Command{
 		Use:   "checkpoint [options] CONTAINER [CONTAINER...]",
-		Short: "Checkpoints one or more containers",
+		Short: "Checkpoint one or more containers",
 		Long:  checkpointDescription,
 		RunE:  checkpoint,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -23,7 +23,7 @@ var (
 `
 	restoreCommand = &cobra.Command{
 		Use:   "restore [options] CONTAINER|IMAGE [CONTAINER|IMAGE...]",
-		Short: "Restores one or more containers from a checkpoint",
+		Short: "Restore one or more containers from a checkpoint",
 		Long:  restoreDescription,
 		RunE:  restore,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -23,7 +23,7 @@ var (
 		Annotations: map[string]string{registry.EngineMode: registry.ABIMode},
 		Use:         "unmount [options] CONTAINER [CONTAINER...]",
 		Aliases:     []string{"umount"},
-		Short:       "Unmounts working container's root filesystem",
+		Short:       "Unmount working container's root filesystem",
 		Long:        description,
 		RunE:        unmount,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/containers/update.go
+++ b/cmd/podman/containers/update.go
@@ -19,7 +19,7 @@ var (
 
 	updateCommand = &cobra.Command{
 		Use:               "update [options] CONTAINER",
-		Short:             "update an existing container",
+		Short:             "Update an existing container",
 		Long:              updateDescription,
 		RunE:              update,
 		Args:              cobra.ExactArgs(1),

--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -46,7 +46,7 @@ var (
 
 	systemdCmd = &cobra.Command{
 		Use:               "systemd [options] {CONTAINER|POD}",
-		Short:             "Generate systemd units.",
+		Short:             "Generate systemd units",
 		Long:              systemdDescription,
 		RunE:              systemd,
 		Args:              cobra.ExactArgs(1),

--- a/cmd/podman/healthcheck/run.go
+++ b/cmd/podman/healthcheck/run.go
@@ -14,8 +14,8 @@ import (
 var (
 	runCmd = &cobra.Command{
 		Use:               "run CONTAINER",
-		Short:             "run the health check of a container",
-		Long:              "run the health check of a container",
+		Short:             "Run the health check of a container",
+		Long:              "Run the health check of a container",
 		Example:           `podman healthcheck run mywebapp`,
 		RunE:              run,
 		Args:              cobra.ExactArgs(1),

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -19,7 +19,7 @@ var (
 	rmDescription = "Removes one or more previously pulled or locally created images."
 	rmCmd         = &cobra.Command{
 		Use:               "rm [options] IMAGE [IMAGE...]",
-		Short:             "Removes one or more images from local storage",
+		Short:             "Remove one or more images from local storage",
 		Long:              rmDescription,
 		RunE:              rm,
 		ValidArgsFunction: common.AutocompleteImages,

--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -18,7 +18,7 @@ var (
 			registry.ParentNSRequired: "",
 		},
 		Long:              saveScpDescription,
-		Short:             "securely copy images",
+		Short:             "Securely copy images",
 		RunE:              scp,
 		Args:              cobra.RangeArgs(1, 2),
 		ValidArgsFunction: common.AutocompleteScp,

--- a/cmd/podman/images/tree.go
+++ b/cmd/podman/images/tree.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	treeDescription = "Prints layer hierarchy of an image in a tree format"
+	treeDescription = "Print layer hierarchy of an image in a tree format"
 	treeCmd         = &cobra.Command{
 		Use:               "tree [options] IMAGE",
 		Args:              cobra.ExactArgs(1),

--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -19,7 +19,7 @@ var (
 
 	downCmd = &cobra.Command{
 		Use:               "down [options] KUBEFILE|-",
-		Short:             "Remove pods based on Kubernetes YAML.",
+		Short:             "Remove pods based on Kubernetes YAML",
 		Long:              downDescription,
 		RunE:              down,
 		Args:              cobra.ExactArgs(1),

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -50,7 +50,7 @@ var (
 
 	playCmd = &cobra.Command{
 		Use:               "play [options] KUBEFILE|-",
-		Short:             "Play a pod or volume based on Kubernetes YAML.",
+		Short:             "Play a pod or volume based on Kubernetes YAML",
 		Long:              playDescription,
 		RunE:              play,
 		Args:              cobra.ExactArgs(1),
@@ -65,7 +65,7 @@ var (
 var (
 	playKubeCmd = &cobra.Command{
 		Use:               "kube [options] KUBEFILE|-",
-		Short:             "Play a pod or volume based on Kubernetes YAML.",
+		Short:             "Play a pod or volume based on Kubernetes YAML",
 		Long:              playDescription,
 		Hidden:            true,
 		RunE:              playKube,

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -21,8 +21,8 @@ var (
 	loginOptions = loginOptionsWrapper{}
 	loginCommand = &cobra.Command{
 		Use:               "login [options] [REGISTRY]",
-		Short:             "Login to a container registry",
-		Long:              "Login to a container registry on a specified server.",
+		Short:             "Log in to a container registry",
+		Long:              "Log in to a container registry on a specified server.",
 		RunE:              login,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: common.AutocompleteRegistries,

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -15,7 +15,7 @@ var (
 	logoutOptions = auth.LogoutOptions{}
 	logoutCommand = &cobra.Command{
 		Use:               "logout [options] [REGISTRY]",
-		Short:             "Logout of a container registry",
+		Short:             "Log out of a container registry",
 		Long:              "Remove the cached username and password for the registry.",
 		RunE:              logout,
 		Args:              cobra.MaximumNArgs(1),

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -18,7 +18,7 @@ var (
 	initCmd = &cobra.Command{
 		Use:               "init [options] [NAME]",
 		Short:             "Initialize a virtual machine",
-		Long:              "initialize a virtual machine ",
+		Long:              "Initialize a virtual machine",
 		PersistentPreRunE: rootlessOnly,
 		RunE:              initMachine,
 		Args:              cobra.MaximumNArgs(1),

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -16,8 +16,8 @@ import (
 var (
 	setCmd = &cobra.Command{
 		Use:               "set [options] [NAME]",
-		Short:             "Sets a virtual machine setting",
-		Long:              "Sets an updatable virtual machine setting",
+		Short:             "Set a virtual machine setting",
+		Long:              "Set an updatable virtual machine setting",
 		PersistentPreRunE: rootlessOnly,
 		RunE:              setMachine,
 		Args:              cobra.MaximumNArgs(1),

--- a/cmd/podman/networks/connect.go
+++ b/cmd/podman/networks/connect.go
@@ -15,7 +15,7 @@ var (
 	networkConnectDescription = `Add container to a network`
 	networkConnectCommand     = &cobra.Command{
 		Use:               "connect [options] NETWORK CONTAINER",
-		Short:             "network connect",
+		Short:             "Add container to a network",
 		Long:              networkConnectDescription,
 		RunE:              networkConnect,
 		Example:           `podman network connect web secondary`,

--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -17,10 +17,10 @@ import (
 )
 
 var (
-	networkCreateDescription = `create networks for containers and pods`
+	networkCreateDescription = `Create networks for containers and pods`
 	networkCreateCommand     = &cobra.Command{
 		Use:               "create [options] [NAME]",
-		Short:             "network create",
+		Short:             "Create networks for containers and pods",
 		Long:              networkCreateDescription,
 		RunE:              networkCreate,
 		Args:              cobra.MaximumNArgs(1),

--- a/cmd/podman/networks/exists.go
+++ b/cmd/podman/networks/exists.go
@@ -10,7 +10,7 @@ var (
 	networkExistsDescription = `If the named network exists, podman network exists exits with 0, otherwise the exit code will be 1.`
 	networkExistsCommand     = &cobra.Command{
 		Use:               "exists NETWORK",
-		Short:             "network exists",
+		Short:             "Check if network exists",
 		Long:              networkExistsDescription,
 		RunE:              networkExists,
 		Example:           `podman network exists net1`,

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -23,7 +23,7 @@ var (
 	networklistCommand     = &cobra.Command{
 		Use:               "ls [options]",
 		Args:              validate.NoArgs,
-		Short:             "network list",
+		Short:             "List networks",
 		Long:              networklistDescription,
 		RunE:              networkList,
 		ValidArgsFunction: completion.AutocompleteNone,

--- a/cmd/podman/networks/prune.go
+++ b/cmd/podman/networks/prune.go
@@ -20,7 +20,7 @@ var (
 	networkPruneDescription = `Prune unused networks`
 	networkPruneCommand     = &cobra.Command{
 		Use:               "prune [options]",
-		Short:             "network prune",
+		Short:             "Prune unused networks",
 		Long:              networkPruneDescription,
 		RunE:              networkPrune,
 		Example:           `podman network prune`,

--- a/cmd/podman/networks/reload.go
+++ b/cmd/podman/networks/reload.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	networkReloadDescription = `reload container networks, recreating firewall rules`
+	networkReloadDescription = `Reload container networks, recreating firewall rules`
 	networkReloadCommand     = &cobra.Command{
 		Annotations: map[string]string{registry.EngineMode: registry.ABIMode},
 		Use:         "reload [options] [CONTAINER...]",

--- a/cmd/podman/networks/rm.go
+++ b/cmd/podman/networks/rm.go
@@ -20,7 +20,7 @@ var (
 	networkrmCommand     = &cobra.Command{
 		Use:               "rm [options] NETWORK [NETWORK...]",
 		Aliases:           []string{"remove"},
-		Short:             "network rm",
+		Short:             "Remove networks",
 		Long:              networkrmDescription,
 		RunE:              networkRm,
 		Example:           `podman network rm podman`,

--- a/cmd/podman/networks/update.go
+++ b/cmd/podman/networks/update.go
@@ -14,7 +14,7 @@ var (
 	networkUpdateDescription = `Update an existing podman network`
 	networkUpdateCommand     = &cobra.Command{
 		Use:               "update [options] NETWORK",
-		Short:             "update an existing podman network",
+		Short:             "Update an existing podman network",
 		Long:              networkUpdateDescription,
 		RunE:              networkUpdate,
 		Args:              cobra.ExactArgs(1),

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -16,7 +16,7 @@ var (
 
 	inspectCmd = &cobra.Command{
 		Use:               "inspect [options] POD [POD...]",
-		Short:             "Displays a pod configuration",
+		Short:             "Display a pod configuration",
 		Long:              inspectDescription,
 		RunE:              inspectExec,
 		ValidArgsFunction: common.AutocompletePods,

--- a/cmd/podman/volumes/exists.go
+++ b/cmd/podman/volumes/exists.go
@@ -10,7 +10,7 @@ var (
 	volumeExistsDescription = `If the given volume exists, podman volume exists exits with 0, otherwise the exit code will be 1.`
 	volumeExistsCommand     = &cobra.Command{
 		Use:               "exists VOLUME",
-		Short:             "Volume exists",
+		Short:             "Check if volume exists",
 		Long:              volumeExistsDescription,
 		RunE:              volumeExists,
 		Example:           `podman volume exists myvol`,

--- a/cmd/podman/volumes/reload.go
+++ b/cmd/podman/volumes/reload.go
@@ -17,7 +17,7 @@ var (
 	reloadCommand = &cobra.Command{
 		Use:               "reload",
 		Args:              validate.NoArgs,
-		Short:             "reload all volumes from volume plugins",
+		Short:             "Reload all volumes from volume plugins",
 		Long:              reloadDescription,
 		RunE:              reload,
 		ValidArgsFunction: completion.AutocompleteNone,

--- a/commands-demo.md
+++ b/commands-demo.md
@@ -10,12 +10,12 @@
 | [podman-build(1)](https://podman.readthedocs.io/en/latest/markdown/podman-build.1.html)                               | Build a container image using a Containerfile                              |
 | [podman-commit(1)](https://podman.readthedocs.io/en/latest/markdown/podman-commit.1.html)                             | Create new image based on the changed container                            |
 | [podman-container(1)](https://podman.readthedocs.io/en/latest/managecontainers.html)                                  | Manage Containers                                                          |
-| [podman-container-checkpoint(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-checkpoint.1.html) | Checkpoints one or more running containers                                 |
+| [podman-container-checkpoint(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-checkpoint.1.html) | Checkpoint one or more running containers                                  |
 | [podman-container-cleanup(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-cleanup.1.html)       | Clean up the container's network and mountpoints                           |
 | [podman-container-exists(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-exists.1.html)         | Check if a container exists in local storage                              |
 | [podman-container-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-prune.1.html)           | Remove all stopped containers from local storage                           |
-| [podman-container-restore(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-restore.1.html)       | Restores one or more containers from a checkpoint                          |
-| [podman-container-runlabel(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-runlabel.1.html)     | Executes a command as described by a container image label                 |
+| [podman-container-restore(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-restore.1.html)       | Restore one or more containers from a checkpoint                           |
+| [podman-container-runlabel(1)](https://podman.readthedocs.io/en/latest/markdown/podman-container-runlabel.1.html)     | Execute a command as described by a container image label                  |
 | [podman-cp(1)](https://podman.readthedocs.io/en/latest/markdown/podman-cp.1.html)                                     | Copy files/folders between a container and the local filesystem            |
 | [podman-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-create.1.html)                             | Create a new container                                                     |
 | [podman-diff(1)](https://podman.readthedocs.io/en/latest/markdown/podman-diff.1.html)                                 | Inspect changes on a container or image's filesystem                       |
@@ -25,31 +25,31 @@
 | [podman-generate(1)](https://podman.readthedocs.io/en/latest/generate.html)                                           | Generate structured output based on Podman containers and pods             |
 | [podman-generate-kube(1)](https://podman.readthedocs.io/en/latest/markdown/podman-generate-kube.1.html)               | Generate Kubernetes YAML based on a pod or container                       |
 | [podman-generate-systemd(1)](https://podman.readthedocs.io/en/latest/markdown/podman-generate-systemd.1.html)         | Generate systemd unit file(s) for a container or pod. Not supported for the remote client  |
-| [podman-history(1)](https://podman.readthedocs.io/en/latest/markdown/podman-history.1.html)                           | Shows the history of an image                                              |
+| [podman-history(1)](https://podman.readthedocs.io/en/latest/markdown/podman-history.1.html)                           | Show the history of an image                                               |
 | [podman-image(1)](https://podman.readthedocs.io/en/latest/image.html)                                                 | Manage Images                                                              |
 | [podman-image-diff(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-diff.html)                       | Inspect changes on an image's filesystem.                                  |
 | [podman-image-exists(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-exists.1.html)                 | Check if an image exists in local storage                                  |
 | [podman-image-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-prune.1.html)                   | Remove all unused images from the local store                              |
 | [podman-image-search(1)](https://podman.readthedocs.io/en/latest/markdown/podman-search.1.html)                       | Search a registry for an image.                                            |
 | [podman-image-sign(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-sign.1.html)                     | Create a signature for an image                                            |
-| [podman-image-tree(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-tree.1.html)                     | Prints layer hierarchy of an image in a tree format                        |
+| [podman-image-tree(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-tree.1.html)                     | Print layer hierarchy of an image in a tree format                         |
 | [podman-image-trust(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-trust.1.html)                   | Manage container registry image trust policy                               |
 | [podman-images(1)](https://podman.readthedocs.io/en/latest/markdown/podman-images.1.html)                             | List images in local storage                                               | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/images/)        | [Here](https://github.com/containers/Demos/blob/main/podman_cli/podman_images.sh) |
 | [podman-import(1)](https://podman.readthedocs.io/en/latest/markdown/podman-import.1.html)                             | Import a tarball and save it as a filesystem image                         |
-| [podman-info(1)](https://podman.readthedocs.io/en/latest/markdown/podman-info.1.html)                                 | Displays Podman related system information                                 |
+| [podman-info(1)](https://podman.readthedocs.io/en/latest/markdown/podman-info.1.html)                                 | Display Podman related system information                                  |
 | [podman-init(1)](https://podman.readthedocs.io/en/latest/markdown/podman-init.1.html)                                 | Initialize one or more containers                                          |
 | [podman-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-inspect.1.html)                           | Display a container or image's configuration                               | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/inspect/)         | [Here](https://github.com/containers/Demos/blob/main/podman_cli/podman_inspect.sh) |
 | [podman-kill(1)](https://podman.readthedocs.io/en/latest/markdown/podman-kill.1.html)                                 | Kill the main process in one or more running containers                    |
 | [podman-load(1)](https://podman.readthedocs.io/en/latest/markdown/podman-load.1.html)                                 | Load an image from a container image archive into container storage        |
-| [podman-login(1)](https://podman.readthedocs.io/en/latest/markdown/podman-login.1.html)                               | Login to a container registry                                              |
-| [podman-logout(1)](https://podman.readthedocs.io/en/latest/markdown/podman-logout.1.html)                             | Logout of a container registry                                             |
+| [podman-login(1)](https://podman.readthedocs.io/en/latest/markdown/podman-login.1.html)                               | Log in to a container registry                                             |
+| [podman-logout(1)](https://podman.readthedocs.io/en/latest/markdown/podman-logout.1.html)                             | Log out of a container registry                                            |
 | [podman-logs(1)](https://podman.readthedocs.io/en/latest/markdown/podman-logs.1.html)                                 | Display the logs of one or more containers                                 |
 | [podman-mount(1)](https://podman.readthedocs.io/en/latest/markdown/podman-mount.1.html)                               | Mount a working container's root filesystem                                |
 | [podman-network(1)](https://podman.readthedocs.io/en/latest/network.html)                                             | Manage Podman networks                                                 |
 | [podman-network-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-create.1.html)             | Create a network                                                       |
 | [podman-network-connect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-connect.1.html)           | Connect a container to a network                                       |
 | [podman-network-disconnect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-disconnect.1.html)             | Disconnect a container from a network                                  |
-| [podman-network-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-inspect.1.html)           | Displays the network configuration for one or more networks        |
+| [podman-network-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-inspect.1.html)           | Display the network configuration for one or more networks                 |
 | [podman-network-ls(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-ls.1.html)                     | Display a summary of networks                                          |
 | [podman-network-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-rm.1.html)                     | Remove one or more networks                                            |
 | [podman-pause(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pause.1.html)                               | Pause one or more running containers                                       | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/pause_unpause/)        | [Here](https://github.com/containers/Demos/blob/main/podman_cli/podman_pause_unpause.sh) |
@@ -58,11 +58,11 @@
 | [podman-pod(1)](https://podman.readthedocs.io/en/latest/pod.html)                                                     | Manage pods                                                                |
 | [podman-pod-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-create.1.html)                     | Create a new pod                                                           |
 | [podman-pod-exists(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-exists.1.html)                     | Check if a pod exists in local storage                                     |
-| [podman-pod-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-inspect.1.html)                   | Displays information describing a pod                                      |
+| [podman-pod-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-inspect.1.html)                   | Display information describing a pod                                       |
 | [podman-pod-kill(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-kill.1.html)                         | Kill the main process of each container in one or more pods                |
 | [podman-pod-pause(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pause.1.html)                           | Pause one or more containers                                               |
 | [podman-pod-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-prune.1.html)                       | Remove all stopped pods and their containers                               |
-| [podman-pod-ps(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-ps.1.html)                             | Prints out information about pods                                          |
+| [podman-pod-ps(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-ps.1.html)                             | Print out information about pods                                           |
 | [podman-pod-restart](https://podman.readthedocs.io/en/latest/markdown/podman-pod-restart.1.html)                      | Restart one or more pods                                                   |
 | [podman-pod-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-rm.1.html)                             | Remove one or more stopped pods and containers                             |
 | [podman-pod-start(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-start.1.html)                       | Start one or more pods                                                     |
@@ -71,12 +71,12 @@
 | [podman-pod-top(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-top.1.html)                           | Display the running processes of containers in a pod                       |
 | [podman-pod-unpause(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-unpause.1.html)                   | Unpause one or more pods.                                                  |
 | [podman-port(1)](https://podman.readthedocs.io/en/latest/markdown/podman-port.1.html)                                 | List port mappings for a container                                         |
-| [podman-ps(1)](https://podman.readthedocs.io/en/latest/markdown/podman-ps.1.html)                                     | Prints out information about containers                                    |
+| [podman-ps(1)](https://podman.readthedocs.io/en/latest/markdown/podman-ps.1.html)                                     | Print out information about containers                                     |
 | [podman-pull(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pull.1.html)                                 | Pull an image from a registry                                              |
 | [podman-push(1)](https://podman.readthedocs.io/en/latest/markdown/podman-push.1.html)                                 | Push an image from local storage to elsewhere                              | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/133276)                    |
-| [podman-restart(1)](https://podman.readthedocs.io/en/latest/markdown/podman-restart.1.html)                           | Restarts one or more containers                                            | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/jiqxJAxcVXw604xdzMLTkQvHM) |
-| [podman-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-rm.1.html)                                     | Removes one or more containers                                             |
-| [podman-rmi(1)](https://podman.readthedocs.io/en/latest/markdown/podman-rmi.1.html)                                   | Removes one or more locally stored images                                  |
+| [podman-restart(1)](https://podman.readthedocs.io/en/latest/markdown/podman-restart.1.html)                           | Restart one or more containers                                             | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/jiqxJAxcVXw604xdzMLTkQvHM) |
+| [podman-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-rm.1.html)                                     | Remove one or more containers                                              |
+| [podman-rmi(1)](https://podman.readthedocs.io/en/latest/markdown/podman-rmi.1.html)                                   | Remove one or more locally stored images                                   |
 | [podman-run(1)](https://podman.readthedocs.io/en/latest/markdown/podman-run.1.html)                                   | Run a command in a new container                                           |
 | [podman-save(1)](https://podman.readthedocs.io/en/latest/markdown/podman-save.1.html)                                 | Save an image to a container archive                                       |
 | [podman-search(1)](https://podman.readthedocs.io/en/latest/markdown/podman-search.1.html)                             | Search a registry for an image                                             |
@@ -90,8 +90,8 @@
 | [podman-stop(1)](https://podman.readthedocs.io/en/latest/markdown/podman-stop.1.html)                                 | Stops one or more running containers                                       |
 | [podman-system(1)](https://podman.readthedocs.io/en/latest/system.html)                                               | Manage podman                                                              |
 | [podman-system-df(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-df.1.html)                       | Show podman disk usage.                                                    |
-| [podman-system-events(1)](https://podman.readthedocs.io/en/latest/markdown/podman-events.1.html)                          | Displays Podman related system events.                                |
-| [podman-system-info(1)](https://podman.readthedocs.io/en/latest/markdown/podman-info.1.html)                          | Displays Podman related system information.                                |
+| [podman-system-events(1)](https://podman.readthedocs.io/en/latest/markdown/podman-events.1.html)                      | Display Podman related system events.                                      |
+| [podman-system-info(1)](https://podman.readthedocs.io/en/latest/markdown/podman-info.1.html)                          | Display Podman related system information.                                 |
 | [podman-system-migrate(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-migrate.1.html)             | Migrate existing containers to a new podman version                        |
 | [podman-system-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-prune.1.html)                 | Remove all unused container, image and volume data                         |
 | [podman-system-renumber(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-renumber.1.html)           | Migrate lock numbers to handle a change in maximum number of locks         |

--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -51,9 +51,9 @@ Commands
 
 :doc:`load <markdown/podman-load.1>` Load an image from container archive
 
-:doc:`login <markdown/podman-login.1>` Login to a container registry
+:doc:`login <markdown/podman-login.1>` Log in to a container registry
 
-:doc:`logout <markdown/podman-logout.1>` Logout of a container registry
+:doc:`logout <markdown/podman-logout.1>` Log out of a container registry
 
 :doc:`logs <markdown/podman-logs.1>` Fetch the logs of a container
 
@@ -83,7 +83,7 @@ Commands
 
 :doc:`rm <markdown/podman-rm.1>` Remove one or more containers
 
-:doc:`rmi <markdown/podman-rmi.1>` Removes one or more images from local storage
+:doc:`rmi <markdown/podman-rmi.1>` Remove one or more images from local storage
 
 :doc:`run <markdown/podman-run.1>` Run a command in a new container
 
@@ -105,13 +105,13 @@ Commands
 
 :doc:`top <markdown/podman-top.1>` Display the running processes of a container
 
-:doc:`unmount <markdown/podman-unmount.1>` Unmounts working container's root filesystem
+:doc:`unmount <markdown/podman-unmount.1>` Unmount working container's root filesystem
 
 :doc:`unpause <markdown/podman-unpause.1>` Unpause the processes in one or more containers
 
 :doc:`unshare <markdown/podman-unshare.1>` Run a command in a modified user namespace
 
-:doc:`untag <markdown/podman-untag.1>` Removes one or more names from a locally-stored image
+:doc:`untag <markdown/podman-untag.1>` Remove one or more names from a locally-stored image
 
 :doc:`version <markdown/podman-version.1>` Display the Podman Version Information
 

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -1,7 +1,7 @@
 % podman-container-checkpoint 1
 
 ## NAME
-podman\-container\-checkpoint - Checkpoints one or more running containers
+podman\-container\-checkpoint - Checkpoint one or more running containers
 
 ## SYNOPSIS
 **podman container checkpoint** [*options*] *container* [*container* ...]

--- a/docs/source/markdown/podman-container-clone.1.md.in
+++ b/docs/source/markdown/podman-container-clone.1.md.in
@@ -1,7 +1,7 @@
 % podman-container-clone 1
 
 ## NAME
-podman\-container\-clone - Creates a copy of an existing container
+podman\-container\-clone - Create a copy of an existing container
 
 ## SYNOPSIS
 **podman container clone** [*options*] *container* *name* *image*

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -1,7 +1,7 @@
 % podman-container-restore 1
 
 ## NAME
-podman\-container\-restore - Restores one or more containers from a checkpoint
+podman\-container\-restore - Restore one or more containers from a checkpoint
 
 ## SYNOPSIS
 **podman container restore** [*options*] *name* [...]
@@ -160,7 +160,7 @@ connections.\
 The default is **false**.
 
 ## EXAMPLE
-Restores the container "mywebserver".
+Restore the container "mywebserver".
 ```
 # podman container restore mywebserver
 ```

--- a/docs/source/markdown/podman-container-runlabel.1.md.in
+++ b/docs/source/markdown/podman-container-runlabel.1.md.in
@@ -1,7 +1,7 @@
 % podman-container-runlabel 1
 
 ## NAME
-podman-container-runlabel - Executes a command as described by a container-image label
+podman-container-runlabel - Execute a command as described by a container-image label
 
 ## SYNOPSIS
 **podman container runlabel** [*options*] *label* *image* [*arg...*]

--- a/docs/source/markdown/podman-container.1.md
+++ b/docs/source/markdown/podman-container.1.md
@@ -14,9 +14,9 @@ The container command allows management of containers
 | Command    | Man Page                                            | Description                                                                  |
 | ---------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | attach     | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
-| checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more running containers.                  |
+| checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoint one or more running containers.                   |
 | cleanup    | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Clean up the container's network and mountpoints.                |
-| clone      | [podman-container-clone(1)](podman-container-clone.1.md)      |  Creates a copy of an existing container.                          |
+| clone      | [podman-container-clone(1)](podman-container-clone.1.md)      |  Create a copy of an existing container.                           |
 | commit     | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
 | cp         | [podman-cp(1)](podman-cp.1.md)                      | Copy files/folders between a container and the local filesystem.             |
 | create     | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |
@@ -33,20 +33,20 @@ The container command allows management of containers
 | pause      | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
 | port       | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
 | prune      | [podman-container-prune(1)](podman-container-prune.1.md)| Remove all stopped containers from local storage.                        |
-| ps         | [podman-ps(1)](podman-ps.1.md)                      | Prints out information about containers.                                     |
+| ps         | [podman-ps(1)](podman-ps.1.md)                      | Print out information about containers.                                      |
 | rename     | [podman-rename(1)](podman-rename.1.md)              | Rename an existing container.                                                |
 | restart    | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
-| restore    | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
+| restore    | [podman-container-restore(1)](podman-container-restore.1.md)  | Restore one or more containers from a checkpoint.                  |
 | rm         | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |
 | run        | [podman-run(1)](podman-run.1.md)                    | Run a command in a container.                                                |
-| runlabel   | [podman-container-runlabel(1)](podman-container-runlabel.1.md)  | Executes a command as described by a container-image label.      |
-| start      | [podman-start(1)](podman-start.1.md)                | Starts one or more containers.                                               |
+| runlabel   | [podman-container-runlabel(1)](podman-container-runlabel.1.md)  | Execute a command as described by a container-image label.       |
+| start      | [podman-start(1)](podman-start.1.md)                | Start one or more containers.                                                |
 | stats      | [podman-stats(1)](podman-stats.1.md)                | Display a live stream of one or more container's resource usage statistics.  |
 | stop       | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |
 | top        | [podman-top(1)](podman-top.1.md)                    | Display the running processes of a container.                                |
 | unmount    | [podman-unmount(1)](podman-unmount.1.md)            | Unmount a working container's root filesystem.(Alias unmount)                |
 | unpause    | [podman-unpause(1)](podman-unpause.1.md)            | Unpause one or more containers.                                              |
-| update     | [podman-update(1)](podman-update.1.md)              | Updates the cgroup configuration of a given container.                      |
+| update     | [podman-update(1)](podman-update.1.md)              | Update the cgroup configuration of a given container.                        |
 | wait       | [podman-wait(1)](podman-wait.1.md)                  | Wait on one or more containers to stop and print their exit codes.           |
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-image-tree.1.md
+++ b/docs/source/markdown/podman-image-tree.1.md
@@ -1,7 +1,7 @@
 % podman-image-tree 1
 
 ## NAME
-podman\-image\-tree - Prints layer hierarchy of an image in a tree format
+podman\-image\-tree - Print layer hierarchy of an image in a tree format
 
 ## SYNOPSIS
 **podman image tree** [*options*] *image:tag*|*image-id*

--- a/docs/source/markdown/podman-image.1.md
+++ b/docs/source/markdown/podman-image.1.md
@@ -25,16 +25,16 @@ The image command allows the management of images
 | prune    | [podman-image-prune(1)](podman-image-prune.1.md)    | Remove all unused images from the local store.                          |
 | pull     | [podman-pull(1)](podman-pull.1.md)                  | Pull an image from a registry.                                          |
 | push     | [podman-push(1)](podman-push.1.md)                  | Push an image from local storage to elsewhere.                          |
-| rm       | [podman-rmi(1)](podman-rmi.1.md)                    | Removes one or more locally stored images.                              |
+| rm       | [podman-rmi(1)](podman-rmi.1.md)                    | Remove one or more locally stored images.                               |
 | save     | [podman-save(1)](podman-save.1.md)                  | Save an image to docker-archive or oci.                                 |
 | scp      | [podman-image-scp(1)](podman-image-scp.1.md)        | Securely copy an image from one host to another.                        |
 | search   | [podman-search(1)](podman-search.1.md)              | Search a registry for an image.                                         |
 | sign     | [podman-image-sign(1)](podman-image-sign.1.md)      | Create a signature for an image.                                        |
 | tag      | [podman-tag(1)](podman-tag.1.md)                    | Add an additional name to a local image.                                |
-| tree     | [podman-image-tree(1)](podman-image-tree.1.md)      | Prints layer hierarchy of an image in a tree format.                    |
+| tree     | [podman-image-tree(1)](podman-image-tree.1.md)      | Print layer hierarchy of an image in a tree format.                     |
 | trust    | [podman-image-trust(1)](podman-image-trust.1.md)    | Manage container registry image trust policy.                           |
 | unmount   | [podman-image-unmount(1)](podman-image-unmount.1.md)  | Unmount an image's root filesystem.                                  |
-| untag    | [podman-untag(1)](podman-untag.1.md)                | Removes one or more names from a locally-stored image.                  |
+| untag    | [podman-untag(1)](podman-untag.1.md)                | Remove one or more names from a locally-stored image.                   |
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -1,7 +1,7 @@
 % podman-info 1
 
 ## NAME
-podman\-info - Displays Podman related system information
+podman\-info - Display Podman related system information
 
 ## SYNOPSIS
 **podman info** [*options*]

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -1,7 +1,7 @@
 % podman-login 1
 
 ## NAME
-podman\-login - Login to a container registry
+podman\-login - Log in to a container registry
 
 ## SYNOPSIS
 **podman login** [*options*] [*registry*]

--- a/docs/source/markdown/podman-logout.1.md.in
+++ b/docs/source/markdown/podman-logout.1.md.in
@@ -1,7 +1,7 @@
 % podman-logout 1
 
 ## NAME
-podman\-logout - Logout of a container registry
+podman\-logout - Log out of a container registry
 
 ## SYNOPSIS
 **podman logout** [*options*] *registry*

--- a/docs/source/markdown/podman-machine-set.1.md.in
+++ b/docs/source/markdown/podman-machine-set.1.md.in
@@ -1,7 +1,7 @@
 % podman-machine-set 1
 
 ## NAME
-podman\-machine\-set - Sets a virtual machine setting
+podman\-machine\-set - Set a virtual machine setting
 
 ## SYNOPSIS
 **podman machine set** [*options*] [*name*]

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -30,7 +30,7 @@ environment variable while the machines are running can lead to unexpected behav
 | list    | [podman-machine-list(1)](podman-machine-list.1.md)        | List virtual machines                |
 | os      | [podman-machine-os(1)](podman-machine-os.1.md)            | Manage a Podman virtual machine's OS |
 | rm      | [podman-machine-rm(1)](podman-machine-rm.1.md)            | Remove a virtual machine             |
-| set     | [podman-machine-set(1)](podman-machine-set.1.md)          | Sets a virtual machine setting       |
+| set     | [podman-machine-set(1)](podman-machine-set.1.md)          | Set a virtual machine setting        |
 | ssh     | [podman-machine-ssh(1)](podman-machine-ssh.1.md)          | SSH into a virtual machine           |
 | start   | [podman-machine-start(1)](podman-machine-start.1.md)      | Start a virtual machine              |
 | stop    | [podman-machine-stop(1)](podman-machine-stop.1.md)        | Stop a virtual machine               |

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -1,7 +1,7 @@
 % podman-network-inspect 1
 
 ## NAME
-podman\-network\-inspect - Displays the network configuration for one or more networks
+podman\-network\-inspect - Display the network configuration for one or more networks
 
 ## SYNOPSIS
 **podman network inspect** [*options*] *network* [*network* ...]

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -28,7 +28,7 @@ so networks have to be created again after a backend change.
 | create     | [podman-network-create(1)](podman-network-create.1.md)         | Create a Podman network                                         |
 | disconnect | [podman-network-disconnect(1)](podman-network-disconnect.1.md) | Disconnect a container from a network                           |
 | exists     | [podman-network-exists(1)](podman-network-exists.1.md)         | Check if the given network exists                               |
-| inspect    | [podman-network-inspect(1)](podman-network-inspect.1.md)       | Displays the network configuration for one or more networks     |
+| inspect    | [podman-network-inspect(1)](podman-network-inspect.1.md)       | Display the network configuration for one or more networks      |
 | ls         | [podman-network-ls(1)](podman-network-ls.1.md)                 | Display a summary of networks                                   |
 | prune      | [podman-network-prune(1)](podman-network-prune.1.md)           | Remove all unused networks                                      |
 | reload     | [podman-network-reload(1)](podman-network-reload.1.md)         | Reload network configuration for containers                     |

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -1,7 +1,7 @@
 % podman-pod-clone 1
 
 ## NAME
-podman\-pod\-clone - Creates a copy of an existing pod
+podman\-pod\-clone - Create a copy of an existing pod
 
 ## SYNOPSIS
 **podman pod clone** [*options*] *pod* *name*

--- a/docs/source/markdown/podman-pod-inspect.1.md.in
+++ b/docs/source/markdown/podman-pod-inspect.1.md.in
@@ -1,7 +1,7 @@
 % podman-pod-inspect 1
 
 ## NAME
-podman\-pod\-inspect - Displays information describing a pod
+podman\-pod\-inspect - Display information describing a pod
 
 ## SYNOPSIS
 **podman pod inspect** [*options*] *pod* ...

--- a/docs/source/markdown/podman-pod-logs.1.md.in
+++ b/docs/source/markdown/podman-pod-logs.1.md.in
@@ -1,7 +1,7 @@
 % podman-pod-logs 1
 
 ## NAME
-podman\-pod\-logs - Displays logs for pod with one or more containers
+podman\-pod\-logs - Display logs for pod with one or more containers
 
 ## SYNOPSIS
 **podman pod logs** [*options*] *pod*

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -1,7 +1,7 @@
 % podman-pod-ps 1
 
 ## NAME
-podman\-pod\-ps - Prints out information about pods
+podman\-pod\-ps - Print out information about pods
 
 ## SYNOPSIS
 **podman pod ps** [*options*]

--- a/docs/source/markdown/podman-pod.1.md
+++ b/docs/source/markdown/podman-pod.1.md
@@ -13,15 +13,15 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 
 | Command | Man Page                                          | Description                                                                       |
 | ------- | ------------------------------------------------- | --------------------------------------------------------------------------------- |
-| clone   | [podman-pod-clone(1)](podman-pod-clone.1.md)      | Creates a copy of an existing pod.                                                             |
+| clone   | [podman-pod-clone(1)](podman-pod-clone.1.md)      | Create a copy of an existing pod.                                                 |
 | create  | [podman-pod-create(1)](podman-pod-create.1.md)    | Create a new pod.                                                                 |
 | exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)    | Check if a pod exists in local storage.                                           |
-| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Displays information describing a pod.                                            |
+| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Display information describing a pod.                                             |
 | kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in one or more pods.                      |
-| logs    | [podman-pod-logs(1)](podman-pod-logs.1.md)        | Displays logs for pod with one or more containers.                                |
+| logs    | [podman-pod-logs(1)](podman-pod-logs.1.md)        | Display logs for pod with one or more containers.                                 |
 | pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                           |
 | prune   | [podman-pod-prune(1)](podman-pod-prune.1.md)      | Remove all stopped pods and their containers.                                     |
-| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Prints out information about pods.                                                |
+| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Print out information about pods.                                                 |
 | restart | [podman-pod-restart(1)](podman-pod-restart.1.md)  | Restart one or more pods.                                                         |
 | rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more stopped pods and containers.                                   |
 | start   | [podman-pod-start(1)](podman-pod-start.1.md)      | Start one or more pods.                                                           |

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -1,7 +1,7 @@
 % podman-ps 1
 
 ## NAME
-podman\-ps - Prints out information about containers
+podman\-ps - Print out information about containers
 
 ## SYNOPSIS
 **podman ps** [*options*]

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -157,7 +157,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-image(1)](podman-image.1.md)             | Manage images.                                                              |
 | [podman-images(1)](podman-images.1.md)           | List images in local storage.                                               |
 | [podman-import(1)](podman-import.1.md)           | Import a tarball and save it as a filesystem image.                         |
-| [podman-info(1)](podman-info.1.md)               | Displays Podman related system information.                                 |
+| [podman-info(1)](podman-info.1.md)               | Display Podman related system information.                                  |
 | [podman-init(1)](podman-init.1.md)               | Initialize a container                                                      |
 | [podman-inspect(1)](podman-inspect.1.md)         | Display a container or image's configuration.                               |
 | [podman-kill(1)](podman-kill.1.md)               | Kill the main process in one or more containers.                            |
@@ -166,12 +166,12 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-pause(1)](podman-pause.1.md)             | Pause one or more containers.                                               |
 | [podman-pod(1)](podman-pod.1.md)                 | Management tool for groups of containers, called pods.                      |
 | [podman-port(1)](podman-port.1.md)               | List port mappings for a container.                                         |
-| [podman-ps(1)](podman-ps.1.md)                   | Prints out information about containers.                                    |
+| [podman-ps(1)](podman-ps.1.md)                   | Print out information about containers.                                     |
 | [podman-pull(1)](podman-pull.1.md)               | Pull an image from a registry.                                              |
 | [podman-push(1)](podman-push.1.md)               | Push an image from local storage to elsewhere.                              |
 | [podman-restart(1)](podman-restart.1.md)         | Restart one or more containers.                                             |
 | [podman-rm(1)](podman-rm.1.md)                   | Remove one or more containers.                                              |
-| [podman-rmi(1)](podman-rmi.1.md)                 | Removes one or more locally stored images.                                  |
+| [podman-rmi(1)](podman-rmi.1.md)                 | Remove one or more locally stored images.                                   |
 | [podman-run(1)](podman-run.1.md)                 | Run a command in a new container.                                           |
 | [podman-save(1)](podman-save.1.md)               | Save an image to a container archive.                                       |
 | [podman-start(1)](podman-start.1.md)             | Start one or more containers.                                               |

--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -1,7 +1,7 @@
 % podman-rmi 1
 
 ## NAME
-podman\-rmi - Removes one or more locally stored images
+podman\-rmi - Remove one or more locally stored images
 
 ## SYNOPSIS
 **podman rmi** [*options*] *image* [...]

--- a/docs/source/markdown/podman-system.1.md
+++ b/docs/source/markdown/podman-system.1.md
@@ -16,7 +16,7 @@ The system command allows management of the podman systems
 | connection | [podman-system-connection(1)](podman-system-connection.1.md) | Manage the destination(s) for Podman service(s)                          |
 | df         | [podman-system-df(1)](podman-system-df.1.md)                 | Show podman disk usage.                                                  |
 | events     | [podman-events(1)](podman-events.1.md)                       | Monitor Podman events                                                    |
-| info       | [podman-info(1)](podman-info.1.md)                           | Displays Podman related system information.                              |
+| info       | [podman-info(1)](podman-info.1.md)                           | Display Podman related system information.                               |
 | migrate    | [podman-system-migrate(1)](podman-system-migrate.1.md)       | Migrate existing containers to a new podman version.                     |
 | prune      | [podman-system-prune(1)](podman-system-prune.1.md)           | Remove all unused pods, containers, images, networks, and volume data.   |
 | renumber   | [podman-system-renumber(1)](podman-system-renumber.1.md)     | Migrate lock numbers to handle a change in maximum number of locks.      |

--- a/docs/source/markdown/podman-untag.1.md
+++ b/docs/source/markdown/podman-untag.1.md
@@ -1,7 +1,7 @@
 % podman-untag 1
 
 ## NAME
-podman\-untag - Removes one or more names from a locally-stored image
+podman\-untag - Remove one or more names from a locally-stored image
 
 ## SYNOPSIS
 **podman untag** *image* [*name*[:*tag*]...]

--- a/docs/source/markdown/podman-update.1.md.in
+++ b/docs/source/markdown/podman-update.1.md.in
@@ -1,7 +1,7 @@
 % podman-update 1
 
 ## NAME
-podman\-update - Updates the cgroup configuration of a given container
+podman\-update - Update the cgroup configuration of a given container
 
 ## SYNOPSIS
 **podman update** [*options*] *container*

--- a/docs/source/markdown/podman-volume-export.1.md
+++ b/docs/source/markdown/podman-volume-export.1.md
@@ -1,7 +1,7 @@
 % podman-volume-export 1
 
 ## NAME
-podman\-volume\-export - Exports volume to external tar
+podman\-volume\-export - Export volume to external tar
 
 ## SYNOPSIS
 **podman volume export** [*options*] *volume*

--- a/docs/source/markdown/podman-volume.1.md
+++ b/docs/source/markdown/podman-volume.1.md
@@ -15,7 +15,7 @@ podman volume is a set of subcommands that manage volumes.
 | ------- | ------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | create  | [podman-volume-create(1)](podman-volume-create.1.md)   | Create a new volume.                                                           |
 | exists  | [podman-volume-exists(1)](podman-volume-exists.1.md)   | Check if the given volume exists.                                              |
-| export  | [podman-volume-export(1)](podman-volume-export.1.md)   | Exports volume to external tar.                                                |
+| export  | [podman-volume-export(1)](podman-volume-export.1.md)   | Export volume to external tar.                                                 |
 | import  | [podman-volume-import(1)](podman-volume-import.1.md)   | Import tarball contents into an existing podman volume.                        |
 | inspect | [podman-volume-inspect(1)](podman-volume-inspect.1.md) | Get detailed information on one or more volumes.                               |
 | ls      | [podman-volume-ls(1)](podman-volume-ls.1.md)           | List all the available volumes.                                                |

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -323,13 +323,13 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-image(1)](podman-image.1.md)             | Manage images.                                                              |
 | [podman-images(1)](podman-images.1.md)           | List images in local storage.                                               |
 | [podman-import(1)](podman-import.1.md)           | Import a tarball and save it as a filesystem image.                         |
-| [podman-info(1)](podman-info.1.md)               | Displays Podman related system information.                                 |
+| [podman-info(1)](podman-info.1.md)               | Display Podman related system information.                                  |
 | [podman-init(1)](podman-init.1.md)               | Initialize one or more containers                                           |
 | [podman-inspect(1)](podman-inspect.1.md)         | Display a container, image, volume, network, or pod's configuration.        |
 | [podman-kill(1)](podman-kill.1.md)               | Kill the main process in one or more containers.                            |
 | [podman-load(1)](podman-load.1.md)               | Load image(s) from a tar archive into container storage.                    |
-| [podman-login(1)](podman-login.1.md)             | Login to a container registry.                                              |
-| [podman-logout(1)](podman-logout.1.md)           | Logout of a container registry.                                             |
+| [podman-login(1)](podman-login.1.md)             | Log in to a container registry.                                             |
+| [podman-logout(1)](podman-logout.1.md)           | Log out of a container registry.                                            |
 | [podman-logs(1)](podman-logs.1.md)               | Display the logs of one or more containers.                                 |
 | [podman-machine(1)](podman-machine.1.md)         | Manage Podman's virtual machine                                             |
 | [podman-manifest(1)](podman-manifest.1.md)       | Create and manipulate manifest lists and image indexes.                     |
@@ -339,13 +339,13 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-kube(1)](podman-kube.1.md)               | Play containers, pods or volumes based on a structured input file.          |
 | [podman-pod(1)](podman-pod.1.md)                 | Management tool for groups of containers, called pods.                      |
 | [podman-port(1)](podman-port.1.md)               | List port mappings for a container.                                         |
-| [podman-ps(1)](podman-ps.1.md)                   | Prints out information about containers.                                    |
+| [podman-ps(1)](podman-ps.1.md)                   | Print out information about containers.                                     |
 | [podman-pull(1)](podman-pull.1.md)               | Pull an image from a registry.                                              |
 | [podman-push(1)](podman-push.1.md)               | Push an image, manifest list or image index from local storage to elsewhere.|
 | [podman-rename(1)](podman-rename.1.md)           | Rename an existing container.                                               |
 | [podman-restart(1)](podman-restart.1.md)         | Restart one or more containers.                                             |
 | [podman-rm(1)](podman-rm.1.md)                   | Remove one or more containers.                                              |
-| [podman-rmi(1)](podman-rmi.1.md)                 | Removes one or more locally stored images.                                  |
+| [podman-rmi(1)](podman-rmi.1.md)                 | Remove one or more locally stored images.                                   |
 | [podman-run(1)](podman-run.1.md)                 | Run a command in a new container.                                           |
 | [podman-save(1)](podman-save.1.md)               | Save image(s) to an archive.                                                |
 | [podman-search(1)](podman-search.1.md)           | Search a registry for an image.                                             |
@@ -359,8 +359,8 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-unmount(1)](podman-unmount.1.md)         | Unmount a working container's root filesystem.                              |
 | [podman-unpause(1)](podman-unpause.1.md)         | Unpause one or more containers.                                             |
 | [podman-unshare(1)](podman-unshare.1.md)         | Run a command inside of a modified user namespace.                          |
-| [podman-untag(1)](podman-untag.1.md)             | Removes one or more names from a locally-stored image.                      |
-| [podman-update(1)](podman-update.1.md)           | Updates the cgroup configuration of a given container.                      |
+| [podman-untag(1)](podman-untag.1.md)             | Remove one or more names from a locally-stored image.                       |
+| [podman-update(1)](podman-update.1.md)           | Update the cgroup configuration of a given container.                       |
 | [podman-version(1)](podman-version.1.md)         | Display the Podman version information.                                     |
 | [podman-volume(1)](podman-volume.1.md)           | Simple management tool for volumes.                                         |
 | [podman-wait(1)](podman-wait.1.md)               | Wait on one or more containers to stop and print their exit codes.          |


### PR DESCRIPTION
man pages and command help: clean up descriptions

Short description in man pages:
* Use imperative form

Command help (cobra.Command.Short):
* Capitalize first letter
* Use imperative form
* Remove ending full stop when the short description
  only contains one sentence without any commas

Command help (cobra.Command.Long):
* Capitalize first letter unless the sentence starts
  with a command "podman command ..."
* Use imperative form when the long description is
  identical or almost identical to the short description.
  This modification was only done in a few places.

Command tables
* Use imperative form in the "Description" column
    


    

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
