### PR TITLE
network create/update: allow dns servers comma separated

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -85,7 +85,7 @@ func networkCreateFlags(cmd *cobra.Command) {
 
 	flags.BoolVar(&networkCreateOptions.IgnoreIfExists, "ignore", false, "Don't fail if network already exists")
 	dnsserverFlagName := "dns"
-	flags.StringArrayVar(&networkCreateOptions.NetworkDNSServers, dnsserverFlagName, nil, "DNS servers this network will use")
+	flags.StringSliceVar(&networkCreateOptions.NetworkDNSServers, dnsserverFlagName, nil, "DNS servers this network will use")
 	_ = cmd.RegisterFlagCompletionFunc(dnsserverFlagName, completion.AutocompleteNone)
 }
 func init() {

--- a/cmd/podman/networks/update.go
+++ b/cmd/podman/networks/update.go
@@ -31,9 +31,9 @@ func networkUpdateFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	addDNSServerFlagName := "dns-add"
-	flags.StringArrayVar(&networkUpdateOptions.AddDNSServers, addDNSServerFlagName, nil, "add network level nameservers")
+	flags.StringSliceVar(&networkUpdateOptions.AddDNSServers, addDNSServerFlagName, nil, "add network level nameservers")
 	removeDNSServerFlagName := "dns-drop"
-	flags.StringArrayVar(&networkUpdateOptions.RemoveDNSServers, removeDNSServerFlagName, nil, "remove network level nameservers")
+	flags.StringSliceVar(&networkUpdateOptions.RemoveDNSServers, removeDNSServerFlagName, nil, "remove network level nameservers")
 	_ = cmd.RegisterFlagCompletionFunc(addDNSServerFlagName, completion.AutocompleteNone)
 	_ = cmd.RegisterFlagCompletionFunc(removeDNSServerFlagName, completion.AutocompleteNone)
 }


### PR DESCRIPTION
The examples show that --dns-add 8.8.8.8,1.1.1.1 is valid but it fails, fix this by using StringSliceVar which splits at commas. Added tests to ensure it is working.

Fixes #18632

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow comma separate list of dns servers in `podman network create --dns` and podman network update --dns-add/--dns-drop` 
```
