### PR TITLE
TEMPORARY(?) instrumentation for unlinkat-ebusy

### DIFF
--- a/contrib/cirrus/timestamp.awk
+++ b/contrib/cirrus/timestamp.awk
@@ -7,7 +7,7 @@
 BEGIN {
     STARTTIME=systime()
     printf "[%s] START", strftime("%T")
-    printf " - All [+xxxx] lines that follow are relative to %s.\n", strftime("%FT%T")
+    printf " - All [+xxxx] lines that follow are relative to %s.\n", strftime("%FT%TZ", systime(), 1)
 }
 
 {
@@ -16,5 +16,5 @@ BEGIN {
 
 END {
     printf "[%s] END", strftime("%T")
-    printf " - [%+05ds] total duration since %s\n", systime()-STARTTIME, strftime("%FT%T")
+    printf " - [%+05ds] total duration since %s\n", systime()-STARTTIME, strftime("%FT%TZ", systime(), 1)
 }


### PR DESCRIPTION
Instrument system tests in hopes of tracking down #17216,
the unlinkat-ebusy-hosed flake.

Oh, also, timestamp.awk: timestamps have always been UTC, but                                                                                                   
add a 'Z' to make it unambiguous.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```