### PR TITLE
Added the "--out" parameter and fixed an issue with "--noout" which prevented stdout from being written to.

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -48,12 +48,8 @@ var (
 )
 
 var (
-	runOpts = entities.ContainerRunOptions{
-		OutputStream: os.Stdout,
-		InputStream:  os.Stdin,
-		ErrorStream:  os.Stderr,
-	}
-	runRmi bool
+	runOpts entities.ContainerRunOptions
+	runRmi  bool
 )
 
 func runFlags(cmd *cobra.Command) {
@@ -153,6 +149,11 @@ func run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+
+	// First set the default streams before they get modified by any flags.
+	runOpts.OutputStream = os.Stdout
+	runOpts.InputStream = os.Stdin
+	runOpts.ErrorStream = os.Stderr
 
 	// If -i is not set, clear stdin
 	if !cliVals.Interactive {

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -79,17 +79,24 @@ var (
 
 	useSyslog      bool
 	requireCleanup = true
-	noOut          = false
+
+	// Defaults for capturing/redirecting the command output since (the) cobra is
+	// global-hungry and doesn't allow you to attach anything that allows us to
+	// transform the noStdout BoolVar to a string that we can assign to useStdout.
+	noStdout  = false
+	useStdout = ""
 )
 
 func init() {
-	// Hooks are called before PersistentPreRunE()
+	// Hooks are called before PersistentPreRunE(). These hooks affect global
+	// state and are executed after processing the command-line, but before
+	// actually running the command.
 	cobra.OnInitialize(
+		stdOutHook, // Caution, this hook redirects stdout and output from any following hooks may be affected.
 		loggingHook,
 		syslogHook,
 		earlyInitHook,
 		configHook,
-		noOutHook,
 	)
 
 	rootFlags(rootCmd, registry.PodmanConfig())
@@ -376,10 +383,23 @@ func loggingHook() {
 	}
 }
 
-func noOutHook() {
-	if noOut {
-		null, _ := os.Open(os.DevNull)
-		os.Stdout = null
+// used for capturing podman's formatted output to some file as per the -out and -noout flags.
+func stdOutHook() {
+	// if noStdOut was specified, then assign /dev/null as the standard file for output.
+	if noStdout {
+		useStdout = os.DevNull
+	}
+	// if we were given a filename for output, then open that and use it. we end up leaking
+	// the file since it's intended to be in scope as long as our process is running.
+	if useStdout != "" {
+		if fd, err := os.OpenFile(useStdout, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm); err == nil {
+			os.Stdout = fd
+
+			// if we couldn't open the file for write, then just bail with an error.
+		} else {
+			fmt.Fprintf(os.Stderr, "unable to open file for standard output: %s\n", err.Error())
+			os.Exit(1)
+		}
 	}
 }
 
@@ -415,7 +435,14 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 	lFlags.StringVar(&podmanConfig.Identity, identityFlagName, ident, "path to SSH identity file, (CONTAINER_SSHKEY)")
 	_ = cmd.RegisterFlagCompletionFunc(identityFlagName, completion.AutocompleteDefault)
 
-	lFlags.BoolVar(&noOut, "noout", false, "do not output to stdout")
+	// Flags that control or influence any kind of output.
+	outFlagName := "out"
+	lFlags.StringVar(&useStdout, outFlagName, "", "Send output (stdout) from podman to a file")
+	_ = cmd.RegisterFlagCompletionFunc(outFlagName, completion.AutocompleteDefault)
+
+	lFlags.BoolVar(&noStdout, "noout", false, "do not output to stdout")
+	_ = lFlags.MarkHidden("noout") // Superseded by --out
+
 	lFlags.BoolVarP(&podmanConfig.Remote, "remote", "r", registry.IsRemote(), "Access remote Podman service")
 	pFlags := cmd.PersistentFlags()
 	if registry.IsRemote() {

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -95,9 +95,8 @@ and "$graphroot/networks" as rootless.
 For the CNI backend the default is "/etc/cni/net.d" as root
 and "$HOME/.config/cni/net.d" as rootless. CNI is deprecated from Podman in the future, use netavark.
 
-#### **--noout**
-
-Redirect stdout to /dev/null. This command prevents all stdout from the Podman command. The **--noout**  option is not block stderr or stdout from containers.
+#### **--out**=*path*
+Redirect the output of podman to the specified path without affecting the container output or its logs. This parameter can be used to capture the output from any of podman's commands directly into a file and enable suppression of podman's output by specifying /dev/null as the path. To explicitly disable the container logging, the **--log-driver** option should be used.
 
 #### **--remote**, **-r**
 When true, access to the Podman service is remote. Defaults to false.

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -510,6 +510,37 @@ json-file | f
     is "$output" "" "output should be empty"
 }
 
+@test "podman --out run should save the container id" {
+    outfile=${PODMAN_TMPDIR}/out-results
+
+    # first we'll need to run something, write its output to a file, and then read its contents.
+    run_podman --out $outfile run -d --name test $IMAGE echo hola
+    is "$output" "" "output should be redirected"
+    run_podman wait test
+
+    # compare the container id against the one in the file
+    run_podman container inspect --format '{{.Id}}' test
+    is "$output" "$(<$outfile)" "container id should match"
+
+    run_podman --out /dev/null rm test
+    is "$output" "" "output should be empty"
+}
+
+@test "podman --out create should save the container id" {
+    outfile=${PODMAN_TMPDIR}/out-results
+
+    # first we'll need to run something, write its output to a file, and then read its contents.
+    run_podman --out $outfile create --name test $IMAGE echo hola
+    is "$output" "" "output should be redirected"
+
+    # compare the container id against the one in the file
+    run_podman container inspect --format '{{.Id}}' test
+    is "$output" "$(<$outfile)" "container id should match"
+
+    run_podman --out /dev/null rm test
+    is "$output" "" "output should be empty"
+}
+
 # Regression test for issue #8082
 @test "podman run : look up correct image name" {
     # Create a 2nd tag for the local image. Force to lower case, and apply it.


### PR DESCRIPTION
This adds an additional parameter, "--out", which can be used to capture the output of any part of podman. This is similar to the original "--noout", but instead of redirecting stdout to "/dev/null" it allows the user to choose the file that is being written to. Thus using the parameter as in `podman --out /dev/null ...` corresponds to the same logic. The original "--noout" parameter was left alone as I expect someone is already depending on this functionality. The original "--noout" parameter had a bug in that "/dev/null" was not being opened as writable. This results in an EBADF error being returned everytime the fd being written to gets used.

The PR adds the additional parameter using the same logic as "--noout", fixes the prior-mentioned issue with "--noout", and adds testcases for each of them. To perform the test for the "--noout" error, the only symptom I could identify (without running `strace`) was that golang would complain to stderr if it couldn't write to stdout when running podman without any parameters. Hence the test is written against this symptom.

This fixes issue #18120.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
All Podman commands now support a new option, `--out`, that allows redirection or suppression of STDOUT.
```
