### PR TITLE
Quadlet - add support for PodmanArgs to all groups

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -370,8 +370,9 @@ of what unexpected interactions can be caused by these arguments, is not recomme
 this option.
 
 The format of this is a space separated list of arguments, which can optionally be individually
-escaped to allow inclusion of whitespace and other control characters. This key can be listed
-multiple times.
+escaped to allow inclusion of whitespace and other control characters.
+
+This key can be listed multiple times.
 
 ### `PublishPort=`
 
@@ -480,14 +481,15 @@ There is only one required key, `Yaml`, which defines the path to the Kubernetes
 
 Valid options for `[Kube]` are listed below:
 
-| **[Kube] options**               | **podman kube play equivalent**        |
-| -----------------                | ------------------                     |
-| ConfigMap=/tmp/config.map        | --config-map /tmp/config.map           |
-| LogDriver=journald               | --log-driver journald                  |
-| Network=host                     | --net host                             |
-| PublishPort=59-60                | --publish=59-60                        |
-| UserNS=keep-id:uid=200,gid=210   | --userns keep-id:uid=200,gid=210       |
-| Yaml=/tmp/kube.yaml              | podman kube play /tmp/kube.yaml        |
+| **[Kube] options**                | **podman kube play equivalent**        |
+| -----------------                 | ------------------                     |
+| ConfigMap=/tmp/config.map         | --config-map /tmp/config.map           |
+| LogDriver=journald                | --log-driver journald                  |
+| Network=host                      | --net host                             |
+| PodmanArgs=--annotation=key=value | --annotation=key=value                 |
+| PublishPort=59-60                 | --publish=59-60                        |
+| UserNS=keep-id:uid=200,gid=210    | --userns keep-id:uid=200,gid=210       |
+| Yaml=/tmp/kube.yaml               | podman kube play /tmp/kube.yaml        |
 
 Supported keys in the `[Kube]` section are:
 
@@ -514,6 +516,19 @@ As a special case, if the `name` of the network ends with `.network`, a Podman n
 `systemd-$name` is used, and the generated systemd service contains
 a dependency on the `$name-network.service`. Such a network can be automatically
 created by using a `$name.network` Quadlet file.
+
+This key can be listed multiple times.
+
+### `PodmanArgs=`
+
+This key contains a list of arguments passed directly to the end of the `podman kube play` command
+in the generated file (right before the path to the yaml file in the command line). It can be used to
+access Podman features otherwise unsupported by the generator. Since the generator is unaware
+of what unexpected interactions can be caused by these arguments, is not recommended to use
+this option.
+
+The format of this is a space separated list of arguments, which can optionally be individually
+escaped to allow inclusion of whitespace and other control characters.
 
 This key can be listed multiple times.
 
@@ -568,6 +583,7 @@ Valid options for `[Network]` are listed below:
 | IPv6=true                        | --ipv6                                 |
 | Label="YXZ"                      | --label "XYZ"                          |
 | Options=isolate                  | --opt isolate                          |
+| PodmanArgs=--dns=192.168.55.1    | --dns=192.168.55.1                     |
 | Subnet=192.5.0.0/16              | --subnet 192.5.0.0/16                  |
 
 Supported keys in `[Network]` section are:
@@ -631,6 +647,19 @@ Set driver specific options.
 
 This is equivalent to the Podman `--opt` option
 
+### `PodmanArgs=`
+
+This key contains a list of arguments passed directly to the end of the `podman network create` command
+in the generated file (right before the name of the network in the command line). It can be used to
+access Podman features otherwise unsupported by the generator. Since the generator is unaware
+of what unexpected interactions can be caused by these arguments, is not recommended to use
+this option.
+
+The format of this is a space separated list of arguments, which can optionally be individually
+escaped to allow inclusion of whitespace and other control characters.
+
+This key can be listed multiple times.
+
 ### `Subnet=`
 
 The subnet in CIDR notation.
@@ -661,6 +690,7 @@ Valid options for `[Volume]` are listed below:
 | Group=192                        | --opt group=192                       |
 | Label="foo=bar"                  | --label "foo=bar"                     |
 | Options=XYZ                      | --opt XYZ                             |
+| PodmanArgs=--driver=image        | --driver=image                        |
 
 Supported keys in `[Volume]` section are:
 
@@ -687,6 +717,19 @@ This key can be listed multiple times.
 ### `Options=`
 
 The mount options to use for a filesystem as used by the **mount(8)** command `-o` option.
+
+### `PodmanArgs=`
+
+This key contains a list of arguments passed directly to the end of the `podman volume create` command
+in the generated file (right before the name of the network in the command line). It can be used to
+access Podman features otherwise unsupported by the generator. Since the generator is unaware
+of what unexpected interactions can be caused by these arguments, is not recommended to use
+this option.
+
+The format of this is a space separated list of arguments, which can optionally be individually
+escaped to allow inclusion of whitespace and other control characters.
+
+This key can be listed multiple times.
 
 ### `Type=`
 

--- a/test/e2e/quadlet/podmanargs.kube
+++ b/test/e2e/quadlet/podmanargs.kube
@@ -5,8 +5,8 @@
 ## assert-podman-args "--with-space" "yes"
 
 
-[Container]
-Image=localhost/imagename
+[Kube]
+Yaml=kube.yaml
 PodmanArgs="--foo" \
   --bar
 PodmanArgs=--also

--- a/test/e2e/quadlet/podmanargs.network
+++ b/test/e2e/quadlet/podmanargs.network
@@ -5,8 +5,7 @@
 ## assert-podman-args "--with-space" "yes"
 
 
-[Container]
-Image=localhost/imagename
+[Network]
 PodmanArgs="--foo" \
   --bar
 PodmanArgs=--also

--- a/test/e2e/quadlet/podmanargs.volume
+++ b/test/e2e/quadlet/podmanargs.volume
@@ -5,8 +5,7 @@
 ## assert-podman-args "--with-space" "yes"
 
 
-[Container]
-Image=localhost/imagename
+[Volume]
 PodmanArgs="--foo" \
   --bar
 PodmanArgs=--also

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -565,6 +565,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("uid.volume", "uid.volume"),
 		Entry("device-copy.volume", "device-copy.volume"),
 		Entry("device.volume", "device.volume"),
+		Entry("podmanargs.volume", "podmanargs.volume"),
 
 		Entry("Basic kube", "basic.kube"),
 		Entry("Syslog Identifier", "syslog.identifier.kube"),
@@ -578,6 +579,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("Kube - Publish IPv4 ports", "ports.kube"),
 		Entry("Kube - Publish IPv6 ports", "ports_ipv6.kube"),
 		Entry("Kube - Logdriver", "logdriver.kube"),
+		Entry("Kube - PodmanArgs", "podmanargs.kube"),
 
 		Entry("Network - Basic", "basic.network"),
 		Entry("Network - Label", "label.network"),
@@ -597,6 +599,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("Network - IPv6", "ipv6.network"),
 		Entry("Network - Options", "options.network"),
 		Entry("Network - Multiple Options", "options.multiple.network"),
+		Entry("Network - PodmanArgs", "podmanargs.network"),
 	)
 
 })


### PR DESCRIPTION
PodmanArgs allows users to pass arguments not explicitly supported by Quadlet.

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - add support for PodmanArgs to all groups
```
