### PR TITLE
pkg/rootless: correctly handle proxy signals on reexec

### DIFF
--- a/test/system/032-sig-proxy.bats
+++ b/test/system/032-sig-proxy.bats
@@ -1,54 +1,9 @@
 #!/usr/bin/env bats
 
 load helpers
+load helpers.sig-proxy
 
-# Command to run in each of the tests.
-SLEEPLOOP='trap "echo BYE;exit 0" INT;echo READY;while :;do sleep 0.1;done'
-
-# Main test code: wait for container to exist and be ready, send it a
-# signal, wait for container to acknowledge and exit.
-function _test_sigproxy() {
-    local cname=$1
-    local kidpid=$2
-
-    # Wait for container to appear
-    local timeout=10
-    while :;do
-          sleep 0.5
-          run_podman '?' container exists $cname
-          if [[ $status -eq 0 ]]; then
-              break
-          fi
-          timeout=$((timeout - 1))
-          if [[ $timeout -eq 0 ]]; then
-              run_podman ps -a
-              die "Timed out waiting for container $cname to start"
-          fi
-    done
-
-    # Now that container exists, wait for it to declare itself READY
-    wait_for_ready $cname
-
-    # Signal, and wait for container to exit
-    kill -INT $kidpid
-    timeout=20
-    while :;do
-          sleep 0.5
-          run_podman logs $cname
-          if [[ "$output" =~ BYE ]]; then
-              break
-          fi
-          timeout=$((timeout - 1))
-          if [[ $timeout -eq 0 ]]; then
-              run_podman ps -a
-              die "Timed out waiting for BYE from container"
-          fi
-    done
-
-    run_podman rm -f -t0 $cname
-}
-
-# Each of the tests below does some setup, then invokes the above helper.
+# Each of the tests below does some setup, then invokes the helper from helpers.sig-proxy.bash.
 
 @test "podman sigproxy test: run" {
     # We're forced to use $PODMAN because run_podman cannot be backgrounded

--- a/test/system/helpers.sig-proxy.bash
+++ b/test/system/helpers.sig-proxy.bash
@@ -1,0 +1,50 @@
+# -*- bash -*-
+#
+# BATS helpers for sig-proxy functionality
+#
+
+# Command to run in each of the tests.
+SLEEPLOOP='trap "echo BYE;exit 0" INT;echo READY;while :;do sleep 0.1;done'
+
+# Main test code: wait for container to exist and be ready, send it a
+# signal, wait for container to acknowledge and exit.
+function _test_sigproxy() {
+    local cname=$1
+    local kidpid=$2
+
+    # Wait for container to appear
+    local timeout=10
+    while :;do
+          sleep 0.5
+          run_podman '?' container exists $cname
+          if [[ $status -eq 0 ]]; then
+              break
+          fi
+          timeout=$((timeout - 1))
+          if [[ $timeout -eq 0 ]]; then
+              run_podman ps -a
+              die "Timed out waiting for container $cname to start"
+          fi
+    done
+
+    # Now that container exists, wait for it to declare itself READY
+    wait_for_ready $cname
+
+    # Signal, and wait for container to exit
+    kill -INT $kidpid
+    timeout=20
+    while :;do
+          sleep 0.5
+          run_podman logs $cname
+          if [[ "$output" =~ BYE ]]; then
+              break
+          fi
+          timeout=$((timeout - 1))
+          if [[ $timeout -eq 0 ]]; then
+              run_podman ps -a
+              die "Timed out waiting for BYE from container"
+          fi
+    done
+
+    run_podman rm -f -t0 $cname
+}


### PR DESCRIPTION
There are quite a lot of places in podman were we have some signal
handlers, most notably libpod/shutdown/handler.go.

However when we rexec we do not want any of that and just send all
signals we get down to the child obviously. So before we install our
signal handler we must first reset all others with signal.Reset().

Also while at it fix a problem were the joinUserAndMountNS() code path
would not forward signals at all. This code path is used when you have
running containers but the pause process was killed.

Fixes https://github.com/containers/podman/issues/16091
Given that signal handlers run in different goroutines parallel it would
explain why it flakes sometimes in CI. However to my understanding this
flake can only happen when the pause process is dead before we run the
podman command. So the question still is what kills the pause process?

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in the rootless podman reexec logic were signals were not forwarded correctly.
```
