### PR TITLE
Track podman events in kube play

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -142,6 +142,8 @@ func playFlags(cmd *cobra.Command) {
 	flags.BoolVar(&playOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	flags.BoolVar(&playOptions.StartCLI, "start", true, "Start the pod after creating it")
 	flags.BoolVar(&playOptions.Force, "force", false, "Remove volumes as part of --down")
+	flags.BoolVar(&playOptions.PrintProgress, "print-progress", false, "Print progress")
+	flags.MarkHidden("print-progress")
 
 	authfileFlagName := "authfile"
 	flags.StringVar(&playOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -115,6 +115,8 @@ type Runtime struct {
 	noStore bool
 	// secretsManager manages secrets
 	secretsManager *secrets.SecretsManager
+
+	eventListener func(chan *events.Event, chan error, string)
 }
 
 // SetXdgDirs ensures the XDG_RUNTIME_DIR env and XDG_CONFIG_HOME variables are set.
@@ -1187,4 +1189,12 @@ func (r *Runtime) RemoteURI() string {
 // SetRemoteURI records the API server URI
 func (r *Runtime) SetRemoteURI(uri string) {
 	r.config.Engine.RemoteURI = uri
+}
+
+func (r *Runtime) SetEventListener(listener func(chan *events.Event, chan error, string)) {
+	r.eventListener = listener
+}
+
+func (r *Runtime) GetEventListener() func(chan *events.Event, chan error, string) {
+	return r.eventListener
 }

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -53,6 +53,7 @@ type PlayOptions struct {
 	// // Wait - indicates whether to return after having created the pods
 	Wait             *bool
 	ServiceContainer *bool
+	PrintProgress    *bool
 }
 
 // ApplyOptions are optional options for applying kube YAML files to a k8s cluster

--- a/pkg/bindings/kube/types_play_options.go
+++ b/pkg/bindings/kube/types_play_options.go
@@ -347,3 +347,18 @@ func (o *PlayOptions) GetServiceContainer() bool {
 	}
 	return *o.ServiceContainer
 }
+
+// WithPrintProgress set field PrintProgress to given value
+func (o *PlayOptions) WithPrintProgress(value bool) *PlayOptions {
+	o.PrintProgress = &value
+	return o
+}
+
+// GetPrintProgress returns value of field PrintProgress
+func (o *PlayOptions) GetPrintProgress() bool {
+	if o.PrintProgress == nil {
+		var z bool
+		return z
+	}
+	return *o.PrintProgress
+}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -68,7 +68,8 @@ type PlayKubeOptions struct {
 	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
 	PublishPorts []string
 	// Wait - indicates whether to return after having created the pods
-	Wait bool
+	Wait          bool
+	PrintProgress bool
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube
@@ -105,6 +106,7 @@ type PlayKubeReport struct {
 	ServiceContainerID string
 	// If set, exit with the specified exit code.
 	ExitCode *int32
+	Stream   string
 }
 
 type KubePlayReport = PlayKubeReport

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -73,6 +73,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts en
 		options.WithStart(start == types.OptionalBoolTrue)
 	}
 	options.WithPublishPorts(opts.PublishPorts)
+	options.WithPrintProgress(opts.PrintProgress)
 	return play.KubeWithBody(ic.ClientCtx, body, options)
 }
 


### PR DESCRIPTION
`podman kube play` command will send events back to client as the resources are created. 
- Added a hidden `play-progress` flag to indicate if the client wants the events to be printed
- Added a new internal field to the Runtime struct called `eventListener` which is a function that will listen for events based on the `kind=name` filters 
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Fixes https://github.com/containers/podman/issues/15902

```release-note
None
```
