### PR TITLE
[CI:BUILD] Packit: set propose-downstream action type to pre-sync

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,11 +33,9 @@ jobs:
     update_release: false
     dist_git_branches:
       - fedora-all
-    #TODO use the right action to update the goimports
-    # For whatever reason, none of the actions seem to work
-    #actions:
-    #    create-patches:
-    #      - "cd rpm && bash update-spec-provides.sh"
+    actions:
+        pre-sync:
+          - "cd rpm && bash update-spec-provides.sh"
 
   - job: koji_build
     trigger: commit

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,7 +1,7 @@
+.PHONY: rpm
 rpm:
 	$(shell /usr/bin/bash ./update-spec-version.sh)
 	spectool -g podman.spec
-	sudo dnf -y builddep podman.spec
 	rpmbuild -ba \
 		--define '_sourcedir $(shell pwd)' \
 		--define '_rpmdir %{_sourcedir}/RPMS' \

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -154,8 +154,6 @@ Recommends: %{name}-gvproxy = %{epoch}:%{version}-%{release}
 Provides: %{name}-quadlet
 Obsoletes: %{name}-quadlet <= 5:4.4.0-1
 Provides: %{name}-quadlet = %{epoch}:%{version}-%{release}
-# TODO: need to find the right action in packit propose-downstream to update
-# the goimports here. None of the actions seem to work so far.
 # DO NOT DELETE BELOW LINE - used for updating downstream goimports
 # vendored libraries
 

--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -4,6 +4,8 @@
 # packaging, via the `propose-downstream` packit action.
 # The goimports don't need to be present upstream.
 
+set -e
+
 SPEC_FILE=$(pwd)/podman.spec
 
 sed -i '/Provides: bundled(golang.*/d' $SPEC_FILE

--- a/rpm/update-spec-version.sh
+++ b/rpm/update-spec-version.sh
@@ -4,6 +4,8 @@
 # default. Useful for local manual rpm builds where the Version needs to be set
 # correctly.
 
+set -e
+
 SPEC_FILE=$(pwd)/podman.spec
 LATEST_TAG=$(git tag --sort=creatordate | tail -1)
 LATEST_VERSION=$(echo $LATEST_TAG | sed -e 's/^v//')


### PR DESCRIPTION
Also address review concerns in pr#18675.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
