### PR TITLE
fix: move filter flags from StringSliceVar to StringArrayVar

### DIFF
--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -63,7 +63,7 @@ func pauseFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(cidfileFlagName, completion.AutocompleteDefault)
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	if registry.IsRemote() {

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -76,7 +76,7 @@ func listFlagSet(cmd *cobra.Command) {
 	flags.BoolVar(&listOpts.External, "external", false, "Show containers in storage not controlled by Podman")
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	formatFlagName := "format"

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -66,7 +66,7 @@ func restartFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(cidfileFlagName, completion.AutocompleteDefault)
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	timeFlagName := "time"

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -75,7 +75,7 @@ func rmFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(cidfileFlagName, completion.AutocompleteDefault)
 
 	filterFlagName := "filter"
-	flags.StringSliceVar(&filters, filterFlagName, []string{}, "Filter output based on conditions given")
+	flags.StringArrayVar(&filters, filterFlagName, []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	if !registry.IsRemote() {

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -61,7 +61,7 @@ func startFlags(cmd *cobra.Command) {
 	flags.BoolVar(&startOptions.SigProxy, "sig-proxy", false, "Proxy received signals to the process (default true if attaching, false otherwise)")
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	flags.BoolVar(&startOptions.All, "all", false, "Start all containers regardless of their state or configuration")

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -71,7 +71,7 @@ func stopFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(timeFlagName, completion.AutocompleteNone)
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	if registry.IsRemote() {

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -64,7 +64,7 @@ func unpauseFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(cidfileFlagName, completion.AutocompleteDefault)
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	if registry.IsRemote() {

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -89,7 +89,7 @@ func imageListFlagSet(cmd *cobra.Command) {
 	flags.BoolVarP(&listOptions.All, "all", "a", false, "Show all images (default hides intermediate images)")
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&listOptions.Filter, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
+	flags.StringArrayVarP(&listOptions.Filter, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteImageFilters)
 
 	formatFlagName := "format"

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -84,7 +84,7 @@ func searchFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&searchOptions.Filters, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
+	flags.StringArrayVarP(&searchOptions.Filters, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
 	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteImageSearchFilters)
 
 	formatFlagName := "format"

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -53,7 +53,7 @@ func init() {
 	flags.BoolVar(&psInput.CtrStatus, "ctr-status", false, "Display the container status")
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&inputFilters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	flags.StringArrayVarP(&inputFilters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
 	_ = psCmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePodPsFilters)
 
 	formatFlagName := "format"

--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -50,7 +50,7 @@ func init() {
 	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.SecretInfoReport{}))
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&listFlag.filter, filterFlagName, "f", []string{}, "Filter secret output")
+	flags.StringArrayVarP(&listFlag.filter, filterFlagName, "f", []string{}, "Filter secret output")
 	_ = lsCmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteSecretFilters)
 
 	noHeadingFlagName := "noheading"

--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -48,7 +48,7 @@ func init() {
 	_ = createCommand.RegisterFlagCompletionFunc(driverFlagName, completion.AutocompleteNone)
 
 	labelFlagName := "label"
-	flags.StringSliceVarP(&opts.Label, labelFlagName, "l", []string{}, "Set metadata for a volume (default [])")
+	flags.StringArrayVarP(&opts.Label, labelFlagName, "l", []string{}, "Set metadata for a volume (default [])")
 	_ = createCommand.RegisterFlagCompletionFunc(labelFlagName, completion.AutocompleteNone)
 
 	optFlagName := "opt"

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -51,7 +51,7 @@ func init() {
 	flags := lsCommand.Flags()
 
 	filterFlagName := "filter"
-	flags.StringSliceVarP(&cliOpts.Filter, filterFlagName, "f", []string{}, "Filter volume output")
+	flags.StringArrayVarP(&cliOpts.Filter, filterFlagName, "f", []string{}, "Filter volume output")
 	_ = lsCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteVolumeFilters)
 
 	formatFlagName := "format"

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -392,6 +392,16 @@ LABEL "com.example.vendor"="Example Vendor"
 		Expect(output).To(Equal("[]"))
 	})
 
+	It("podman images --filter label=with,comma", func() {
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+`
+		podmanTest.BuildImageWithLabel(dockerfile, "foobar.com/before:latest", "false", "test=with,comma")
+		result := podmanTest.Podman([]string{"images", "--filter", "label=test=with,comma"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToStringArray()).To(HaveLen(2))
+	})
+
 	It("podman images --filter readonly", func() {
 		dockerfile := `FROM quay.io/libpod/alpine:latest
 `

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -437,7 +437,7 @@ var _ = Describe("Podman pause", func() {
 		Expect(session1).Should(Exit(0))
 		cid2 := session1.OutputToString()
 
-		session1 = podmanTest.RunTopContainer("")
+		session1 = podmanTest.RunTopContainerWithArgs("", []string{"--label", "test=with,comma"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 		cid3 := session1.OutputToString()
@@ -450,6 +450,16 @@ var _ = Describe("Podman pause", func() {
 		session1 = podmanTest.Podman([]string{"unpause", cid1, "-f", "status=paused"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(125))
+
+		session1 = podmanTest.Podman([]string{"pause", "-a", "--filter", "label=test=with,comma"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
+
+		session1 = podmanTest.Podman([]string{"unpause", "-a", "--filter", "label=test=with,comma"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
 
 		session1 = podmanTest.Podman([]string{"pause", "-a", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Podman ps", func() {
 
 	It("podman pod ps --filter until", func() {
 		name := "mypod"
-		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}})
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}, "--label": {"test=with,comma"}})
 		Expect(ec).To(Equal(0))
 
 		result := podmanTest.Podman([]string{"pod", "ps", "--filter", "until=50"})
@@ -96,6 +96,11 @@ var _ = Describe("Podman ps", func() {
 		Expect(result.OutputToString()).To(Not(ContainSubstring(name)))
 
 		result = podmanTest.Podman([]string{"pod", "ps", "--filter", "until=5000000000"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToString()).To(ContainSubstring(name))
+
+		result = podmanTest.Podman([]string{"pod", "ps", "--filter", "label=test=with,comma"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 		Expect(result.OutputToString()).To(ContainSubstring(name))

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -190,6 +190,26 @@ var _ = Describe("Podman ps", func() {
 		Expect(actual).ToNot(ContainSubstring("table"))
 	})
 
+	It("podman ps --filter label=test=with,comma", func() {
+		ctrAlpha := "first"
+		container := podmanTest.Podman([]string{"run", "-dt", "--label", "test=with,comma", "--name", ctrAlpha, ALPINE, "top"})
+		container.WaitWithDefaultTimeout()
+		Expect(container).Should(Exit(0))
+
+		ctrBravo := "second"
+		containerBravo := podmanTest.Podman([]string{"run", "-dt", "--name", ctrBravo, ALPINE, "top"})
+		containerBravo.WaitWithDefaultTimeout()
+		Expect(containerBravo).Should(Exit(0))
+
+		result := podmanTest.Podman([]string{"ps", "-a", "--format", "table {{.Names}}", "--filter", "label=test=with,comma"})
+		result.WaitWithDefaultTimeout()
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		actual := result.OutputToString()
+		Expect(actual).To(ContainSubstring("first"))
+		Expect(actual).ToNot(ContainSubstring("table"))
+	})
+
 	It("podman ps namespace flag", func() {
 		_, ec, _ := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Podman restart", func() {
 		Expect(session1).Should(Exit(0))
 		cid2 := session1.OutputToString()
 
-		session1 = podmanTest.RunTopContainer("")
+		session1 = podmanTest.RunTopContainerWithArgs("", []string{"--label", "test=with,comma"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 		cid3 := session1.OutputToString()
@@ -327,6 +327,11 @@ var _ = Describe("Podman restart", func() {
 		Expect(session1.OutputToString()).To(HaveLen(0))
 
 		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", fmt.Sprintf("id=%s", shortCid3)})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
+
+		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", "label=test=with,comma"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -292,6 +292,11 @@ var _ = Describe("Podman rm", func() {
 		cid3 := session1.OutputToString()
 		shortCid3 := cid3[0:5]
 
+		session1 = podmanTest.RunTopContainerWithArgs("test4", []string{"--label", "test=with,comma"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		cid4 := session1.OutputToString()
+
 		session1 = podmanTest.Podman([]string{"rm", cid1, "-f", "--filter", "status=running"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(125))
@@ -311,5 +316,10 @@ var _ = Describe("Podman rm", func() {
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid2))
+
+		session1 = podmanTest.Podman([]string{"rm", "-f", "--filter", "label=test=with,comma"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		Expect(session1.OutputToString()).To(BeEquivalentTo(cid4))
 	})
 })

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Podman secret", func() {
 		Expect(list.OutputToStringArray()).To(HaveLen(2))
 		Expect(list.OutputToStringArray()[1]).To(ContainSubstring(secrID2))
 
-		list = podmanTest.Podman([]string{"secret", "ls", "--filter", fmt.Sprintf("name=%s,name=%s", secret1, secret2)})
+		list = podmanTest.Podman([]string{"secret", "ls", "--filter", fmt.Sprintf("name=%s", secret1), "--filter", fmt.Sprintf("name=%s", secret2)})
 		list.WaitWithDefaultTimeout()
 		Expect(list).Should(Exit(0))
 		Expect(list.OutputToStringArray()).To(HaveLen(3))

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -208,6 +208,11 @@ var _ = Describe("Podman start", func() {
 		cid3 := session1.OutputToString()
 		shortCid3 := cid3[0:5]
 
+		session1 = podmanTest.Podman([]string{"container", "create", "--label", "test=with,comma", ALPINE})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		cid4 := session1.OutputToString()
+
 		session1 = podmanTest.Podman([]string{"start", cid1, "-f", "status=running"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
@@ -222,6 +227,11 @@ var _ = Describe("Podman start", func() {
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
+
+		session1 = podmanTest.Podman([]string{"start", "--all", "--filter", "label=test=with,comma"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		Expect(session1.OutputToString()).To(BeEquivalentTo(cid4))
 
 		session1 = podmanTest.Podman([]string{"start", "-f", fmt.Sprintf("id=%s", cid2)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -382,6 +382,11 @@ var _ = Describe("Podman stop", func() {
 		cid3 := session1.OutputToString()
 		shortCid3 := cid3[0:5]
 
+		session1 = podmanTest.Podman([]string{"container", "create", "--label", "test=with,comma", ALPINE})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		cid4 := session1.OutputToString()
+
 		session1 = podmanTest.Podman([]string{"start", "--all"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
@@ -399,6 +404,11 @@ var _ = Describe("Podman stop", func() {
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
+
+		session1 = podmanTest.Podman([]string{"stop", "-a", "--filter", "label=test=with,comma"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(Exit(0))
+		Expect(session1.OutputToString()).To(BeEquivalentTo(cid4))
 
 		session1 = podmanTest.Podman([]string{"stop", "-f", fmt.Sprintf("id=%s", cid2)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -26,6 +26,17 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
+	It("podman ls volume filter with comma label", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "test=with,comma", "myvol3"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=test=with,comma"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+	})
+
 	It("podman ls volume filter with a key pattern", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "helloworld=world", "myvol2"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
User's won't be able to use `--filter label=a,label=b` but will need to specify multiple `--filter` flags
```

Currently using some complex filters (for example in `podman ps`) leads to parsing failures, for example:

```console
podman ps -q -a --filter label=dev.containers.id=devpod --filter 'label=devcontainer.metadata=[{"id":"ghcr.io/devcontainers/features/common-utils:2"},{"id":"ghcr.io/devcontainers/features/git:1"},{"id":"ghcr.io/devcontainers/features/go:1","customizations":{"vscode":{"extensions":["golang.Go"]}},"init":true,"capAdd":["SYS_PTRACE"],"securityOpt":["seccomp=unconfined"]},{"id":"ghcr.io/devcontainers/features/node:1","customizations":{"vscode":{"extensions":["dbaeumer.vscode-eslint"]}}},{"remoteUser":"vscode","customizations":{"vscode":{"extensions":["golang.Go"],"settings":{"go.gopath":"/go","go.toolsManagement.checkForUpdates":"local","go.useLanguageServer":true}}}},{"entrypoint":"/usr/local/share/docker-init.sh","customizations":{"vscode":{"extensions":["ms-azuretools.vscode-docker"]}},"mounts":[{"type":"volume","source":"dind-var-lib-docker-${devcontainerId}","target":"/var/lib/docker"}],"privileged":true},{"mounts":[{"type":"volume","source":"devpod","target":"/home/vscode"}]}]'
Error: invalid argument "label=devcontainer.metadata=[{\"id\":\"ghcr.io/devcontainers/features/common-utils:2\"},{\"id\":\"ghcr.io/devcontainers/features/git:1\"},{\"id\":\"ghcr.io/devcontainers/features/go:1\",\"customizations\":{\"vscode\":{\"extensions\":[\"golang.Go\"]}},\"init\":true,\"capAdd\":[\"SYS_PTRACE\"],\"securityOpt\":[\"seccomp=unconfined\"]},{\"id\":\"ghcr.io/devcontainers/features/node:1\",\"customizations\":{\"vscode\":{\"extensions\":[\"dbaeumer.vscode-eslint\"]}}},{\"remoteUser\":\"vscode\",\"customizations\":{\"vscode\":{\"extensions\":[\"golang.Go\"],\"settings\":{\"go.gopath\":\"/go\",\"go.toolsManagement.checkForUpdates\":\"local\",\"go.useLanguageServer\":true}}}},{\"entrypoint\":\"/usr/local/share/docker-init.sh\",\"customizations\":{\"vscode\":{\"extensions\":[\"ms-azuretools.vscode-docker\"]}},\"mounts\":[{\"type\":\"volume\",\"source\":\"dind-var-lib-docker-${devcontainerId}\",\"target\":\"/var/lib/docker\"}],\"privileged\":true},{\"mounts\":[{\"type\":\"volume\",\"source\":\"devpod\",\"target\":\"/home/vscode\"}]}]" for "-f, --filter" 
flag: parse error on line 1, column 31: bare " in non-quoted-field
See 'podman ps --help'
```
This PR aims to fix problems with StringSliceVar, moving it to StringArrayVar, like was done in #2582 for label parsing.

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>

