### PR TITLE
hack: fix typo in hack/podman-registry

### DIFF
--- a/hack/podman-registry
+++ b/hack/podman-registry
@@ -20,7 +20,7 @@ PODMAN=${PODMAN:-$(dirname $0)/../bin/podman}
 ###############################################################################
 # BEGIN help messages
 
-missing=" argument is missing; see $ME --help for details"
+missing=" argument is missing; see $ME -h for details"
 usage="Usage: $ME [options] [start|stop|ps|logs]
 
 $ME manages a local instance of a container registry.


### PR DESCRIPTION
hack/podman-registry --help option does not exist.
We need to use -h option when we want to see the usage message.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
