### PR TITLE
[CI:DOCS] authfile.md: add default path of file for Windows/macOS.

### DIFF
--- a/docs/source/markdown/options/authfile.md
+++ b/docs/source/markdown/options/authfile.md
@@ -4,7 +4,7 @@
 ####> are applicable to all of those.
 #### **--authfile**=*path*
 
-Path of the authentication file. Default is `${XDG_RUNTIME_DIR}/containers/auth.json`, which is set using **[podman login](podman-login.1.md)**.
-If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using **docker login**.
+Path of the authentication file. Default is `${XDG_RUNTIME_DIR}/containers/auth.json` on Linux, and `$HOME/.config/containers/auth.json` on Windows/macOS.
+The file is created by **[podman login](podman-login.1.md)**. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using **docker login**.
 
 Note: There is also the option to override the default path of the authentication file by setting the `REGISTRY_AUTH_FILE` environment variable. This can be done with **export REGISTRY_AUTH_FILE=_path_**.


### PR DESCRIPTION
@rhatdan @mheon @vrothberg ptal.

I have not checked this is the location actually being used on Windows/macOS. I got the information from the Arch docs here: https://man.archlinux.org/man/containers-auth.json.5.