### PR TITLE
completion: fix panic in simplePathJoinUnix()

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -362,6 +362,11 @@ func getPathCompletion(root string, toComplete string) ([]string, cobra.ShellCom
 // We cannot use path.Join() for the completions logic because this one always calls Clean() on
 // the path which changes it from the input.
 func simplePathJoinUnix(p1, p2 string) string {
+	if len(p1) == 0 {
+		// Special case if p1 is not set just return p2 as is
+		// and do not add a slash as the input didn't contain one either.
+		return p2
+	}
 	if p1[len(p1)-1] == '/' {
 		return p1 + p2
 	}

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -353,6 +353,11 @@ function _check_no_suggestions() {
         run_completion $cmd $IMAGE "/etc/os-"
         assert "$output" =~ ".*^/etc/os-release\$.*" "/etc files suggested (cmd: podman $cmd /etc/os-)"
 
+        # regression check for https://bugzilla.redhat.com/show_bug.cgi?id=2209809
+        # check for relative directory without slash in path.
+        run_completion $cmd $IMAGE "e"
+        assert "$output" =~ ".*^etc/\$.*" "etc dir suggested (cmd: podman $cmd e)"
+
         # check completion with relative path components
         # It is important the we will still use the image root and not escape to the host
         run_completion $cmd $IMAGE "../../"


### PR DESCRIPTION
When we do path completion in images a user could try to complete a simple relative path, e.g. podman run $IMAGE e... should complete to etc if this path exists in the image. Right now we panic in this case as the current check didn't account for an empty string in simplePathJoinUnix(). In such a case return the path directly because we can not alter what the user typed on the cli and must return a path without slash as well in order for the shell to suggest the completion.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2209809

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a possible panic in the shell completion code when relative paths are completed. 
```
