### PR TITLE
test/system: quadlet use correct systemd restart policy

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -668,10 +668,6 @@ EOF
 [Kube]
 Yaml=$yaml_file
 ExitCodePropagation=$exit_code_prop
-
-# Never restart the service as we only want to test exit codes.
-[Service]
-Restart=never
 EOF
 
       run_quadlet "$quadlet_file"


### PR DESCRIPTION
Systemd doesn't support `never` and logs a warning, systemd uses no as default so we do not have to specify it at all.

Check systemd.service(5) for the systemd docs.

Fixes #18743

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
