### PR TITLE
systests: fixes for coping with extra systemd image

### DIFF
--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -63,16 +63,6 @@ verify_iid_and_name() {
     run_podman images $fqin --format '{{.Repository}}:{{.Tag}}'
     is "${lines[0]}" "$fqin" "image preserves name across save/load"
 
-    # Load with a new tag
-    local new_name=x1$(random_string 14 | tr A-Z a-z)
-    local new_tag=t1$(random_string 6 | tr A-Z a-z)
-    run_podman rmi $fqin
-
-    run_podman load -i $archive
-    run_podman images --format '{{.Repository}}:{{.Tag}}' --sort tag
-    is "${lines[0]}" "$IMAGE"     "image is preserved"
-    is "${lines[1]}" "$fqin"      "image is reloaded with old fqin"
-
     # Clean up
     run_podman rmi $fqin
 }


### PR DESCRIPTION
We _usually_ have only one image in store, $IMAGE, but it's
perfectly fine to also have $SYSTEMD_IMAGE also. Fix a few
tests so they can handle that condition.

And, cleanup:
 - remove a no-longer-useful test ("podman load NEWNAME",
   functionality that was removed 2+ years ago in #8877)
 - reorder some tests in the image-mount test, to make
   them safer and easier to understand
 - use no-such-image, not no-such-container, in image-mount test.
   Computer don't care, but this human felt confused for a sec.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```