### PR TITLE
e2e: GetPort(): safer allocation of random ports

### DIFF
--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -318,7 +318,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 
 		Expect(search).Should(Exit(125))
 		Expect(search.OutputToString()).Should(BeEmpty())
-		Expect(search.ErrorToString()).To(ContainSubstring("error"))
+		Expect(search.ErrorToString()).To(ContainSubstring("http: server gave HTTP response to HTTPS client"))
 
 		// cleanup
 		resetRegistriesConfigEnv()
@@ -363,13 +363,14 @@ registries = ['{{.Host}}:{{.Port}}']`
 
 		Expect(search).Should(Exit(125))
 		Expect(search.OutputToString()).Should(BeEmpty())
-		Expect(search.ErrorToString()).To(ContainSubstring("error"))
+		Expect(search.ErrorToString()).To(ContainSubstring("http: server gave HTTP response to HTTPS client"))
 
 		// cleanup
 		resetRegistriesConfigEnv()
 	})
 
 	It("podman search doesn't attempt HTTP if one registry is not listed as insecure", func() {
+		Skip("FIXME FIXME FIXME #18768: This test is a NOP")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}


### PR DESCRIPTION
Intended to fix an obscure, unlikely race condition in which (I
think) two parallel jobs called GetPort() and were assigned the
same port.

Also, add actual proper testing to two HTTP-registry tests, and
Skip a third that's a waste of cycles (filed #18768)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```