### PR TITLE
pasta: Correct handling of unknown protocols

### DIFF
--- a/libpod/networking_pasta_linux.go
+++ b/libpod/networking_pasta_linux.go
@@ -48,7 +48,7 @@ func (r *Runtime) setupPasta(ctr *Container, netns string) error {
 				cmdArgs = append(cmdArgs, "-t")
 			case "udp":
 				cmdArgs = append(cmdArgs, "-u")
-			case "default":
+			default:
 				return fmt.Errorf("can't forward protocol: %s", protocol)
 			}
 

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -681,3 +681,11 @@ function teardown() {
     sleep 1
     ! ps -p $(cat "${pidfile}") && rm "${pidfile}"
 }
+
+### Options ####################################################################
+@test "podman networking with pasta(1) - Unsupported protocol in port forwarding" {
+    local port=$(random_free_port "" "" tcp)
+
+    run_podman 126 run --net=pasta -p "${port}:${port}/sctp" $IMAGE true
+    is "$output" "Error: .*can't forward protocol: sctp"
+}


### PR DESCRIPTION
setupPasta() has logic to handle forwarding of TCP or UDP ports.  It has what looks like logic to give an error if trying to forward ports of any other protocol.  However, there's a straightforward error in this that it will in fact only give the error if you try to use a protocol called "default".  Other unknown protocols will fall through and result in a nonsensical pasta command line which will almost certainly cause a cryptic error later on.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
