### PR TITLE
Quadlet: Add support for --sysctl 

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -128,6 +128,7 @@ Valid options for `[Container]` are listed below:
 | SecurityLabelFileType=usr_t    | --security-opt label=filetype:usr_t                  |
 | SecurityLabelLevel=s0:c1,c2    | --security-opt label=level:s0:c1,c2                  |
 | SecurityLabelType=spc_t        | --security-opt label=type:spc_t                      |
+| Sysctl=name=value              | --sysctl=name=value                                  |
 | Timezone=local                 | --tz local                                           |
 | Tmpfs=/work                    | --tmpfs /work                                        |
 | User=bin                       | --user bin                                           |
@@ -427,6 +428,17 @@ Set the label process type for the container processes.
 
 Use a Podman secret in the container either as a file or an environment variable.
 This is equivalent to the Podman `--secret` option and generally has the form `secret[,opt=opt ...]`
+
+### `Sysctl=`
+
+Configures namespaced kernel parameters for the container. The format is `Sysctl=name=value`.
+
+This is a space separated list of kernel parameters. This key can be listed multiple times.
+
+For example:
+```
+Sysctl=net.ipv6.conf.all.disable_ipv6=1 net.ipv6.conf.all.use_tempaddr=1
+```
 
 ### `Tmpfs=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -94,6 +94,7 @@ const (
 	KeySecurityLabelLevel    = "SecurityLabelLevel"
 	KeySecurityLabelType     = "SecurityLabelType"
 	KeySecret                = "Secret"
+	KeySysctl                = "Sysctl"
 	KeyTimezone              = "Timezone"
 	KeyTmpfs                 = "Tmpfs"
 	KeyType                  = "Type"
@@ -156,6 +157,7 @@ var (
 		KeySecurityLabelLevel:    true,
 		KeySecurityLabelType:     true,
 		KeySecret:                true,
+		KeySysctl:                true,
 		KeyTmpfs:                 true,
 		KeyTimezone:              true,
 		KeyUser:                  true,
@@ -456,6 +458,11 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	addCaps := container.LookupAllStrv(ContainerGroup, KeyAddCapability)
 	for _, caps := range addCaps {
 		podman.addf("--cap-add=%s", strings.ToLower(caps))
+	}
+
+	sysctl := container.LookupAllStrv(ContainerGroup, KeySysctl)
+	for _, sysctlItem := range sysctl {
+		podman.addf("--sysctl=%s", sysctlItem)
 	}
 
 	readOnly, ok := container.LookupBoolean(ContainerGroup, KeyReadOnly)

--- a/test/e2e/quadlet/sysctl.container
+++ b/test/e2e/quadlet/sysctl.container
@@ -1,0 +1,8 @@
+## assert-podman-args "--sysctl=net.ipv6.conf.all.disable_ipv6=1"
+## assert-podman-args "--sysctl=net.ipv6.conf.all.use_tempaddr=1"
+## assert-podman-args "--sysctl=net.ipv4.conf.lo.force_igmp_version=0"
+
+[Container]
+Image=localhost/imagename
+Sysctl=net.ipv6.conf.all.disable_ipv6=1 net.ipv6.conf.all.use_tempaddr=1
+Sysctl=net.ipv4.conf.lo.force_igmp_version=0

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -562,6 +562,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("readwrite-notmpfs.container", "readwrite-notmpfs.container"),
 		Entry("seccomp.container", "seccomp.container"),
 		Entry("shortname.container", "shortname.container"),
+		Entry("sysctl.container", "sysctl.container"),
 		Entry("timezone.container", "timezone.container"),
 		Entry("user.container", "user.container"),
 		Entry("remap-manual.container", "remap-manual.container"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
AddSysctl allows to set namespaced kernel parameters for containers.
Closes  #18727.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Yes

```release-note
Quadlet - Add support for --sysctl via AddSysctl flag for containers.
```

Signed-off-by: Laurenz Kruty <git@laurenzkruty.de>
