### PR TITLE
podman-registry: simpler, safer invocations

### DIFF
--- a/hack/podman-registry
+++ b/hack/podman-registry
@@ -99,6 +99,9 @@ function podman() {
         fi
     fi
 
+    # Reset $PODMAN, so ps/logs/stop use same args as the initial start
+    PODMAN="$(<${PODMAN_REGISTRY_WORKDIR}/PODMAN)"
+
     ${PODMAN} --root    ${PODMAN_REGISTRY_WORKDIR}/root        \
               --runroot ${PODMAN_REGISTRY_WORKDIR}/runroot     \
               "$@"
@@ -173,6 +176,10 @@ function do_start() {
     set -e
 
     mkdir -p ${PODMAN_REGISTRY_WORKDIR}
+
+    # Preserve initial podman path & args, so all subsequent invocations
+    # of this script are consistent with the first one.
+    echo "$PODMAN" >${PODMAN_REGISTRY_WORKDIR}/PODMAN
 
     local AUTHDIR=${PODMAN_REGISTRY_WORKDIR}/auth
     mkdir -p $AUTHDIR

--- a/hack/podman-registry-go/registry_test.go
+++ b/hack/podman-registry-go/registry_test.go
@@ -13,10 +13,14 @@ func TestStartAndStopMultipleRegistries(t *testing.T) {
 
 	registries := []*Registry{}
 
+	registryOptions := &Options{
+		PodmanPath: "../../bin/podman",
+	}
+
 	// Start registries.
 	var errors *multierror.Error
 	for i := 0; i < 3; i++ {
-		reg, err := Start()
+		reg, err := StartWithOptions(registryOptions)
 		if err != nil {
 			errors = multierror.Append(errors, err)
 			continue

--- a/pkg/bindings/test/auth_test.go
+++ b/pkg/bindings/test/auth_test.go
@@ -22,10 +22,14 @@ var _ = Describe("Podman images", func() {
 	)
 
 	BeforeEach(func() {
+		registryOptions := &podmanRegistry.Options{
+			PodmanPath: getPodmanBinary(),
+		}
+
 		// Note: we need to start the registry **before** setting up
 		// the test. Otherwise, the registry is not reachable for
 		// currently unknown reasons.
-		registry, err = podmanRegistry.Start()
+		registry, err = podmanRegistry.StartWithOptions(registryOptions)
 		Expect(err).ToNot(HaveOccurred())
 
 		bt = newBindingTest()

--- a/pkg/bindings/test/images_test.go
+++ b/pkg/bindings/test/images_test.go
@@ -388,7 +388,10 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("Image Push", func() {
-		registry, err := podmanRegistry.Start()
+		registryOptions := &podmanRegistry.Options{
+			PodmanPath: getPodmanBinary(),
+		}
+		registry, err := podmanRegistry.StartWithOptions(registryOptions)
 		Expect(err).ToNot(HaveOccurred())
 
 		var writer bytes.Buffer

--- a/pkg/bindings/test/manifests_test.go
+++ b/pkg/bindings/test/manifests_test.go
@@ -176,7 +176,10 @@ var _ = Describe("Podman manifests", func() {
 	})
 
 	It("Manifest Push", func() {
-		registry, err := podmanRegistry.Start()
+		registryOptions := &podmanRegistry.Options{
+			PodmanPath: getPodmanBinary(),
+		}
+		registry, err := podmanRegistry.StartWithOptions(registryOptions)
 		Expect(err).ToNot(HaveOccurred())
 
 		name := "quay.io/libpod/foobar:latest"

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -115,7 +115,7 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 	}
 }
 
-// MakeOptions assembles all the podman main options
+// getRemoteOptions assembles all the podman main options
 func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 	networkDir := p.NetworkConfigDir
 	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s --tmpdir %s --events-backend %s --db-backend %s",


### PR DESCRIPTION
First: fix podman-registry script so it preserves the initial $PODMAN,
so all subsequent invocations of ps, logs, and stop will use the
same binary and arguments. Until now we've handled this by requiring
that our caller manage $PODMAN (and keep it the same), but that's
just wrong.

Next, simplify the golang interface: move the $PODMAN setting into
registry.go, instead of requiring e2e callers to set it. (This
could use some work: the local/remote conditional is icky)

And, minor cleanup: comments, and add an actual error-message check

Reason for this PR is a recurring flake, #18355, whose multiple
failure modes I truly can't understand. I don't think this PR
is going to fix it, but this is still necessary work.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```