### PR TITLE
Add support for SecurityLabelNested flag in quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -128,6 +128,7 @@ Valid options for `[Container]` are listed below:
 | SecurityLabelDisable=true      | --security-opt label=disable                         |
 | SecurityLabelFileType=usr_t    | --security-opt label=filetype:usr_t                  |
 | SecurityLabelLevel=s0:c1,c2    | --security-opt label=level:s0:c1,c2                  |
+| SecurityLabelNested=true       | --security-opt label=nested                          |
 | SecurityLabelType=spc_t        | --security-opt label=type:spc_t                      |
 | Timezone=local                 | --tz local                                           |
 | Tmpfs=/work                    | --tmpfs /work                                        |
@@ -423,6 +424,10 @@ Set the label file type for the container files.
 ### `SecurityLabelLevel=`
 
 Set the label process level for the container processes.
+
+### `SecurityLabelNested=`
+
+Allow SecurityLabels to function within the container. This allows separation of containers created within the container.
 
 ### `SecurityLabelType=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -93,6 +93,7 @@ const (
 	KeySecurityLabelDisable  = "SecurityLabelDisable"
 	KeySecurityLabelFileType = "SecurityLabelFileType"
 	KeySecurityLabelLevel    = "SecurityLabelLevel"
+	KeySecurityLabelNested   = "SecurityLabelNested"
 	KeySecurityLabelType     = "SecurityLabelType"
 	KeySecret                = "Secret"
 	KeyTimezone              = "Timezone"
@@ -156,6 +157,7 @@ var (
 		KeySecurityLabelDisable:  true,
 		KeySecurityLabelFileType: true,
 		KeySecurityLabelLevel:    true,
+		KeySecurityLabelNested:   true,
 		KeySecurityLabelType:     true,
 		KeySecret:                true,
 		KeyTmpfs:                 true,
@@ -412,6 +414,11 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 	securityLabelDisable := container.LookupBooleanWithDefault(ContainerGroup, KeySecurityLabelDisable, false)
 	if securityLabelDisable {
 		podman.add("--security-opt", "label:disable")
+	}
+
+	securityLabelNested := container.LookupBooleanWithDefault(ContainerGroup, KeySecurityLabelNested, false)
+	if securityLabelNested {
+		podman.add("--security-opt", "label:nested")
 	}
 
 	securityLabelType, _ := container.Lookup(ContainerGroup, KeySecurityLabelType)

--- a/test/e2e/quadlet/disableselinux.container
+++ b/test/e2e/quadlet/disableselinux.container
@@ -1,3 +1,4 @@
+## assert-podman-final-args localhost/imagename
 ## assert-podman-args "--security-opt" "label:disable"
 
 [Container]

--- a/test/e2e/quadlet/nestedselinux.container
+++ b/test/e2e/quadlet/nestedselinux.container
@@ -1,0 +1,5 @@
+## assert-podman-args "--security-opt" "label:nested"
+
+[Container]
+Image=localhost/imagename
+SecurityLabelNested=true

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -537,6 +537,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("capabilities.container", "capabilities.container"),
 		Entry("capabilities2.container", "capabilities2.container"),
 		Entry("disableselinux.container", "disableselinux.container"),
+		Entry("nestedselinux.container", "nestedselinux.container"),
 		Entry("devices.container", "devices.container"),
 		Entry("env.container", "env.container"),
 		Entry("escapes.container", "escapes.container"),


### PR DESCRIPTION
This flag will allow us to run nested containers within a quadlet service.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet now supports Nested SELinux containers using the SecurityLabelNetsted=true flag.
```
