### PR TITLE
Add support for lock debugging

### DIFF
--- a/cmd/podman/system/locks.go
+++ b/cmd/podman/system/locks.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	locksCommand = &cobra.Command{
-		Use: "locks",
-		Short: "Debug Libpod's use of locks, identifying any potential conflicts",
-		Args: validate.NoArgs,
+		Use:    "locks",
+		Short:  "Debug Libpod's use of locks, identifying any potential conflicts",
+		Args:   validate.NoArgs,
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLocks()
@@ -24,7 +24,7 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: locksCommand,
-		Parent: systemCmd,
+		Parent:  systemCmd,
 	})
 }
 func runLocks() error {
@@ -41,7 +41,13 @@ func runLocks() error {
 	}
 
 	if len(report.LockConflicts) > 0 {
-		fmt.Printf("\nLock conflicts have been detected. Recommend immediate use of `podman system renumber` to resolve.\n")
+		fmt.Printf("\nLock conflicts have been detected. Recommend immediate use of `podman system renumber` to resolve.\n\n")
+	} else {
+		fmt.Printf("\nNo lock conflicts have been detected, system safe from deadlocks.\n\n")
+	}
+
+	for _, lockNum := range report.LocksHeld {
+		fmt.Printf("Lock %d is presently being held\n", lockNum)
 	}
 
 	return nil

--- a/cmd/podman/system/locks.go
+++ b/cmd/podman/system/locks.go
@@ -43,7 +43,7 @@ func runLocks() error {
 	if len(report.LockConflicts) > 0 {
 		fmt.Printf("\nLock conflicts have been detected. Recommend immediate use of `podman system renumber` to resolve.\n\n")
 	} else {
-		fmt.Printf("\nNo lock conflicts have been detected, system safe from deadlocks.\n\n")
+		fmt.Printf("\nNo lock conflicts have been detected.\n\n")
 	}
 
 	for _, lockNum := range report.LocksHeld {

--- a/cmd/podman/system/locks.go
+++ b/cmd/podman/system/locks.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"fmt"
+
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	locksCommand = &cobra.Command{
+		Use: "locks",
+		Short: "Debug Libpod's use of locks, identifying any potential conflicts",
+		Args: validate.NoArgs,
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLocks()
+		},
+		Example: "podman system locks",
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: locksCommand,
+		Parent: systemCmd,
+	})
+}
+func runLocks() error {
+	report, err := registry.ContainerEngine().Locks(registry.Context())
+	if err != nil {
+		return err
+	}
+
+	for lockNum, objects := range report.LockConflicts {
+		fmt.Printf("Lock %d is in use by the following\n:", lockNum)
+		for _, obj := range objects {
+			fmt.Printf("\t%s\n", obj)
+		}
+	}
+
+	if len(report.LockConflicts) > 0 {
+		fmt.Printf("\nLock conflicts have been detected. Recommend immediate use of `podman system renumber` to resolve.\n")
+	}
+
+	return nil
+}

--- a/docs/source/markdown/podman-container-inspect.1.md.in
+++ b/docs/source/markdown/podman-container-inspect.1.md.in
@@ -43,6 +43,7 @@ Valid placeholders for the Go template are listed below:
 | .IsInfra                 | Is this an infra container? (string: true/false)   |
 | .IsService               | Is this a service container? (string: true/false)  |
 | .KubeExitCodePropagation | Kube exit-code propagation (string)                |
+| .LockNumber              | Number of the container's Libpod lock              |
 | .MountLabel              | SELinux label of mount (string)                    |
 | .Mounts                  | Mounts (array of strings)                          |
 | .Name                    | Container name (string)                            |

--- a/docs/source/markdown/podman-pod-inspect.1.md.in
+++ b/docs/source/markdown/podman-pod-inspect.1.md.in
@@ -44,6 +44,7 @@ Valid placeholders for the Go template are listed below:
 | .InfraContainerID    | Pod infrastructure ID                       |
 | .InspectPodData ...  | Nested structure, for experts only          |
 | .Labels              | Pod labels                                  |
+| .LockNumber          | Number of the pod's Libpod lock             |
 | .MemoryLimit         | Memory limit, bytes                         |
 | .MemorySwap          | Memory swap limit, in bytes                 |
 | .Mounts              | Mounts                                      |

--- a/docs/source/markdown/podman-volume-inspect.1.md
+++ b/docs/source/markdown/podman-volume-inspect.1.md
@@ -33,6 +33,7 @@ Valid placeholders for the Go template are listed below:
 | .Driver             | Volume driver                                          |
 | .GID                | GID the volume was created with                        |
 | .Labels             | Label information associated with the volume           |
+| .LockNumber         | Number of the volume's Libpod lock                     |
 | .MountCount         | Number of times the volume is mounted                  |
 | .Mountpoint         | Source of volume mount point                           |
 | .Name               | Volume name                                            |

--- a/docs/source/markdown/podman-volume-ls.1.md.in
+++ b/docs/source/markdown/podman-volume-ls.1.md.in
@@ -42,6 +42,7 @@ Valid placeholders for the Go template are listed below:
 | .GID                      | GID of volume                                |
 | .InspectVolumeData ...    | Don't use                                    |
 | .Labels                   | Label information associated with the volume |
+| .LockNumber               | Number of the volume's Libpod lock           |
 | .MountCount               | Number of times the volume is mounted        |
 | .Mountpoint               | Source of volume mount point                 |
 | .Name                     | Volume name                                  |

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -166,6 +166,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		IsInfra:                 c.IsInfra(),
 		IsService:               c.IsService(),
 		KubeExitCodePropagation: config.KubeExitCodePropagation.String(),
+		LockNumber:              c.lock.ID(),
 	}
 
 	if config.RootfsImageID != "" { // May not be set if the container was created with --rootfs

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -691,6 +691,7 @@ type InspectContainerData struct {
 	IsInfra                 bool                        `json:"IsInfra"`
 	IsService               bool                        `json:"IsService"`
 	KubeExitCodePropagation string                      `json:"KubeExitCodePropagation"`
+	LockNumber              uint32                      `json:"lockNumber"`
 	Config                  *InspectContainerConfig     `json:"Config"`
 	HostConfig              *InspectContainerHostConfig `json:"HostConfig"`
 }

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -38,6 +38,7 @@ type HostInfo struct {
 	DatabaseBackend   string           `json:"databaseBackend"`
 	Distribution      DistributionInfo `json:"distribution"`
 	EventLogger       string           `json:"eventLogger"`
+	FreeLocks         *uint32          `json:"freeLocks,omitempty"`
 	Hostname          string           `json:"hostname"`
 	IDMappings        IDMappings       `json:"idMappings,omitempty"`
 	Kernel            string           `json:"kernel"`

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -85,6 +85,8 @@ type InspectPodData struct {
 	BlkioWeightDevice []InspectBlkioWeightDevice `json:"blkio_weight_device,omitempty"`
 	// RestartPolicy of the pod.
 	RestartPolicy string `json:"RestartPolicy,omitempty"`
+	// Number of the pod's Libpod lock.
+	LockNumber uint32
 }
 
 // InspectPodInfraConfig contains the configuration of the pod's infra

--- a/libpod/define/volume_inspect.go
+++ b/libpod/define/volume_inspect.go
@@ -61,6 +61,8 @@ type InspectVolumeData struct {
 	// StorageID is the ID of the container backing the volume in c/storage.
 	// Only used with Image Volumes.
 	StorageID string `json:"StorageID,omitempty"`
+	// LockNumber is the number of the volume's Libpod lock.
+	LockNumber uint32
 }
 
 type VolumeReload struct {

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -99,6 +99,12 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	locksFree, err := r.lockManager.AvailableLocks()
+	if err != nil {
+		return nil, fmt.Errorf("getting free locks: %w", err)
+	}
+
 	info := define.HostInfo{
 		Arch:            runtime.GOARCH,
 		BuildahVersion:  buildah.Version,
@@ -107,6 +113,7 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 		CPUs:            runtime.NumCPU(),
 		CPUUtilization:  cpuUtil,
 		Distribution:    hostDistributionInfo,
+		FreeLocks:       locksFree,
 		LogDriver:       r.config.Containers.LogDriver,
 		EventLogger:     r.eventer.String(),
 		Hostname:        host,

--- a/libpod/lock/file_lock_manager.go
+++ b/libpod/lock/file_lock_manager.go
@@ -79,6 +79,12 @@ func (m *FileLockManager) FreeAllLocks() error {
 	return m.locks.DeallocateAllLocks()
 }
 
+// AvailableLocks returns the number of available locks. Since this is not
+// limited in the file lock implementation, nil is returned.
+func (locks *FileLockManager) AvailableLocks() (*uint32, error) {
+	return nil, nil
+}
+
 // FileLock is an individual shared memory lock.
 type FileLock struct {
 	lockID  uint32

--- a/libpod/lock/file_lock_manager.go
+++ b/libpod/lock/file_lock_manager.go
@@ -1,6 +1,7 @@
 package lock
 
 import (
+	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/lock/file"
 )
 
@@ -81,8 +82,17 @@ func (m *FileLockManager) FreeAllLocks() error {
 
 // AvailableLocks returns the number of available locks. Since this is not
 // limited in the file lock implementation, nil is returned.
-func (locks *FileLockManager) AvailableLocks() (*uint32, error) {
+func (m *FileLockManager) AvailableLocks() (*uint32, error) {
 	return nil, nil
+}
+
+// LocksHeld returns any locks that are presently locked.
+// It is not implemented for the file lock backend.
+// It ought to be possible, but my motivation to dig into c/storage and add
+// trylock semantics to the filelocker implementation for an uncommonly-used
+// lock backend is lacking.
+func (m *FileLockManager) LocksHeld() ([]uint32, error) {
+	return nil, define.ErrNotImplemented
 }
 
 // FileLock is an individual shared memory lock.

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -116,3 +116,16 @@ func (m *InMemoryManager) FreeAllLocks() error {
 
 	return nil
 }
+
+// Get number of available locks
+func (m *InMemoryManager) AvailableLocks() (*uint32, error) {
+	var count uint32
+
+	for _, lock := range m.locks {
+		if !lock.allocated {
+			count++
+		}
+	}
+
+	return &count, nil
+}

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -129,3 +129,20 @@ func (m *InMemoryManager) AvailableLocks() (*uint32, error) {
 
 	return &count, nil
 }
+
+// Get any locks that are presently being held.
+// Useful for debugging deadlocks.
+func (m *InMemoryManager) LocksHeld() ([]uint32, error) {
+	//nolint:prealloc
+	var locks []uint32
+
+	for _, lock := range m.locks {
+		if lock.lock.TryLock() {
+			lock.lock.Unlock()
+			continue
+		}
+		locks = append(locks, lock.ID())
+	}
+
+	return locks, nil
+}

--- a/libpod/lock/lock.go
+++ b/libpod/lock/lock.go
@@ -45,6 +45,12 @@ type Manager interface {
 	// renumbering, where reasonable guarantees about other processes can be
 	// made.
 	FreeAllLocks() error
+	// NumAvailableLocks gets the number of remaining locks available to be
+	// allocated.
+	// Some lock managers do not have a maximum number of locks, and can
+	// allocate an unlimited number. These implementations should return
+	// a nil uin32.
+	AvailableLocks() (*uint32, error)
 }
 
 // Locker is similar to sync.Locker, but provides a method for freeing the lock

--- a/libpod/lock/lock.go
+++ b/libpod/lock/lock.go
@@ -51,6 +51,10 @@ type Manager interface {
 	// allocate an unlimited number. These implementations should return
 	// a nil uin32.
 	AvailableLocks() (*uint32, error)
+	// Get a list of locks that are currently locked.
+	// This may not be supported by some drivers, depending on the exact
+	// backend implementation in use.
+	LocksHeld() ([]uint32, error)
 }
 
 // Locker is similar to sync.Locker, but provides a method for freeing the lock

--- a/libpod/lock/shm/shm_lock.c
+++ b/libpod/lock/shm/shm_lock.c
@@ -568,7 +568,7 @@ int64_t available_locks(shm_struct_t *shm) {
   for (i = 0; i < shm->num_bitmaps; i++) {
     // Short-circuit to catch fully-empty bitmaps quick.
     if (shm->locks[i].bitmap == 0) {
-      free_locks += 32;
+      free_locks += sizeof(bitmap_t) * 8;
       continue;
     }
 
@@ -581,7 +581,7 @@ int64_t available_locks(shm_struct_t *shm) {
       count++;
     }
 
-    free_locks += 32 - count;
+    free_locks += (sizeof(bitmap_t) * 8) - count;
   }
 
   // Clear the mutex

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -281,6 +281,31 @@ func (locks *SHMLocks) GetFreeLocks() (uint32, error) {
 	return uint32(retCode), nil
 }
 
+// Get a list of locks that are currently taken.
+func (locks *SHMLocks) GetTakenLocks() ([]uint32, error) {
+	if !locks.valid {
+		return nil, fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
+	}
+
+	var usedLocks []uint32
+
+	// I don't think we need to lock the OS thread here, since the lock (if
+	// taken) is immediately released, and Go shouldn't reschedule the CGo
+	// to another thread before the function finished executing.
+	var i uint32
+	for i = 0; i < locks.maxLocks; i++ {
+		retCode := C.try_lock(locks.lockStruct, C.uint32_t(i))
+		if retCode < 0 {
+			return nil, syscall.Errno(-1 * retCode)
+		}
+		if retCode == 0 {
+			usedLocks = append(usedLocks, i)
+		}
+	}
+
+	return usedLocks, nil
+}
+
 func unlinkSHMLock(path string) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -266,6 +266,21 @@ func (locks *SHMLocks) UnlockSemaphore(sem uint32) error {
 	return nil
 }
 
+// GetFreeLocks gets the number of locks available to be allocated.
+func (locks *SHMLocks) GetFreeLocks() (uint32, error) {
+	if !locks.valid {
+		return 0, fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
+	}
+
+	retCode := C.available_locks(locks.lockStruct)
+	if retCode < 0 {
+		// Negative errno returned
+		return 0, syscall.Errno(-1 * retCode)
+	}
+
+	return uint32(retCode), nil
+}
+
 func unlinkSHMLock(path string) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))

--- a/libpod/lock/shm/shm_lock.h
+++ b/libpod/lock/shm/shm_lock.h
@@ -42,5 +42,6 @@ int32_t deallocate_all_semaphores(shm_struct_t *shm);
 int32_t lock_semaphore(shm_struct_t *shm, uint32_t sem_index);
 int32_t unlock_semaphore(shm_struct_t *shm, uint32_t sem_index);
 int64_t available_locks(shm_struct_t *shm);
+int32_t try_lock(shm_struct_t *shm, uint32_t sem_index);
 
 #endif

--- a/libpod/lock/shm/shm_lock.h
+++ b/libpod/lock/shm/shm_lock.h
@@ -41,5 +41,6 @@ int32_t deallocate_semaphore(shm_struct_t *shm, uint32_t sem_index);
 int32_t deallocate_all_semaphores(shm_struct_t *shm);
 int32_t lock_semaphore(shm_struct_t *shm, uint32_t sem_index);
 int32_t unlock_semaphore(shm_struct_t *shm, uint32_t sem_index);
+int64_t available_locks(shm_struct_t *shm);
 
 #endif

--- a/libpod/lock/shm/shm_lock_nocgo.go
+++ b/libpod/lock/shm/shm_lock_nocgo.go
@@ -101,3 +101,15 @@ func (locks *SHMLocks) UnlockSemaphore(sem uint32) error {
 	logrus.Error("Locks are not supported without cgo")
 	return nil
 }
+
+// GetFreeLocks gets the number of locks available to be allocated.
+func (locks *SHMLocks) GetFreeLocks() (uint32, error) {
+	logrus.Error("Locks are not supported without cgo")
+	return 0, nil
+}
+
+// Get a list of locks that are currently taken.
+func (locks *SHMLocks) GetTakenLocks() ([]uint32, error) {
+	logrus.Error("Locks are not supported without cgo")
+	return nil, nil
+}

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -98,6 +98,16 @@ func (m *SHMLockManager) FreeAllLocks() error {
 	return m.locks.DeallocateAllSemaphores()
 }
 
+// AvailableLocks returns the number of free locks in the manager.
+func (m *SHMLockManager) AvailableLocks() (*uint32, error) {
+	avail, err := m.locks.GetFreeLocks()
+	if err != nil {
+		return nil, err
+	}
+
+	return &avail, nil
+}
+
 // SHMLock is an individual shared memory lock.
 type SHMLock struct {
 	lockID  uint32

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -108,6 +108,10 @@ func (m *SHMLockManager) AvailableLocks() (*uint32, error) {
 	return &avail, nil
 }
 
+func (m *SHMLockManager) LocksHeld() ([]uint32, error) {
+	return m.locks.GetTakenLocks()
+}
+
 // SHMLock is an individual shared memory lock.
 type SHMLock struct {
 	lockID  uint32

--- a/libpod/lock/shm_lock_manager_unsupported.go
+++ b/libpod/lock/shm_lock_manager_unsupported.go
@@ -33,3 +33,13 @@ func (m *SHMLockManager) RetrieveLock(id string) (Locker, error) {
 func (m *SHMLockManager) FreeAllLocks() error {
 	return fmt.Errorf("not supported")
 }
+
+// AvailableLocks is not supported on this platform
+func (m *SHMLockManager) AvailableLocks() (*uint32, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+// LocksHeld is not supported on this platform
+func (m *SHMLockManager) LocksHeld() ([]uint32, error) {
+	return nil, fmt.Errorf("not supported")
+}

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -742,6 +742,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		BlkioDeviceWriteBps: p.BlkiThrottleWriteBps(),
 		CPUShares:           p.CPUShares(),
 		RestartPolicy:       p.config.RestartPolicy,
+		LockNumber:          p.lock.ID(),
 	}
 
 	return &inspectData, nil

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1206,12 +1206,7 @@ func (r *Runtime) LockConflicts() (map[uint32][]string, []uint32, error) {
 	for _, ctr := range ctrs {
 		lockNum := ctr.lock.ID()
 		ctrString := fmt.Sprintf("container %s", ctr.ID())
-		locksArr, ok := locksInUse[lockNum]
-		if ok {
-			locksInUse[lockNum] = append(locksArr, ctrString)
-		} else {
-			locksInUse[lockNum] = []string{ctrString}
-		}
+		locksInUse[lockNum] = append(locksInUse[lockNum], ctrString)
 	}
 
 	pods, err := r.state.AllPods()
@@ -1221,12 +1216,7 @@ func (r *Runtime) LockConflicts() (map[uint32][]string, []uint32, error) {
 	for _, pod := range pods {
 		lockNum := pod.lock.ID()
 		podString := fmt.Sprintf("pod %s", pod.ID())
-		locksArr, ok := locksInUse[lockNum]
-		if ok {
-			locksInUse[lockNum] = append(locksArr, podString)
-		} else {
-			locksInUse[lockNum] = []string{podString}
-		}
+		locksInUse[lockNum] = append(locksInUse[lockNum], podString)
 	}
 
 	volumes, err := r.state.AllVolumes()
@@ -1236,12 +1226,7 @@ func (r *Runtime) LockConflicts() (map[uint32][]string, []uint32, error) {
 	for _, vol := range volumes {
 		lockNum := vol.lock.ID()
 		volString := fmt.Sprintf("volume %s", vol.Name())
-		locksArr, ok := locksInUse[lockNum]
-		if ok {
-			locksInUse[lockNum] = append(locksArr, volString)
-		} else {
-			locksInUse[lockNum] = []string{volString}
-		}
+		locksInUse[lockNum] = append(locksInUse[lockNum], volString)
 	}
 
 	// Now go through and find any entries with >1 item associated

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -65,6 +65,7 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 	data.NeedsCopyUp = v.state.NeedsCopyUp
 	data.NeedsChown = v.state.NeedsChown
 	data.StorageID = v.config.StorageID
+	data.LockNumber = v.lock.ID()
 
 	if v.config.Timeout != nil {
 		data.Timeout = *v.config.Timeout

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -62,6 +62,7 @@ type ContainerEngine interface { //nolint:interfacebloat
 	HealthCheckRun(ctx context.Context, nameOrID string, options HealthCheckOptions) (*define.HealthCheckResults, error)
 	Info(ctx context.Context) (*define.Info, error)
 	KubeApply(ctx context.Context, body io.Reader, opts ApplyOptions) error
+	Locks(ctx context.Context) (*LocksReport, error)
 	NetworkConnect(ctx context.Context, networkname string, options NetworkConnectOptions) error
 	NetworkCreate(ctx context.Context, network types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error)
 	NetworkUpdate(ctx context.Context, networkname string, options NetworkUpdateOptions) error

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -125,4 +125,5 @@ type AuthReport struct {
 // lead to deadlocks.
 type LocksReport struct {
 	LockConflicts map[uint32][]string
+	LocksHeld     []uint32
 }

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -120,3 +120,9 @@ type AuthReport struct {
 	IdentityToken string
 	Status        string
 }
+
+// LocksReport describes any conflicts in Libpod's lock allocations that could
+// lead to deadlocks.
+type LocksReport struct {
+	LockConflicts map[uint32][]string
+}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -429,3 +429,13 @@ func (ic ContainerEngine) Version(ctx context.Context) (*entities.SystemVersionR
 	report.Client = &v
 	return &report, err
 }
+
+func (ic ContainerEngine) Locks(ctx context.Context) (*entities.LocksReport, error) {
+	var report entities.LocksReport
+	conflicts, err := ic.Libpod.LockConflicts()
+	if err != nil {
+		return nil, err
+	}
+	report.LockConflicts = conflicts
+	return &report, nil
+}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -432,10 +432,11 @@ func (ic ContainerEngine) Version(ctx context.Context) (*entities.SystemVersionR
 
 func (ic ContainerEngine) Locks(ctx context.Context) (*entities.LocksReport, error) {
 	var report entities.LocksReport
-	conflicts, err := ic.Libpod.LockConflicts()
+	conflicts, held, err := ic.Libpod.LockConflicts()
 	if err != nil {
 		return nil, err
 	}
 	report.LockConflicts = conflicts
+	report.LocksHeld = held
 	return &report, nil
 }

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -34,3 +34,7 @@ func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options e
 func (ic ContainerEngine) Version(ctx context.Context) (*entities.SystemVersionReport, error) {
 	return system.Version(ic.ClientCtx, nil)
 }
+
+func (ic ContainerEngine) Locks(ctx context.Context) (*entities.LocksReport, error) {
+	return nil, errors.New("locks is not supported on remote clients")
+}

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Podman Info", func() {
 		info1.WaitWithDefaultTimeout()
 		Expect(info1).To(Exit(0))
 		free1, err := strconv.Atoi(info1.OutputToString())
-		Expect(err).To(BeNil())
+		Expect(err).To(Not(HaveOccurred()))
 
 		ctr := podmanTest.Podman([]string{"create", ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
@@ -195,7 +195,7 @@ var _ = Describe("Podman Info", func() {
 		info2.WaitWithDefaultTimeout()
 		Expect(info2).To(Exit(0))
 		free2, err := strconv.Atoi(info2.OutputToString())
-		Expect(err).To(BeNil())
+		Expect(err).To(Not(HaveOccurred()))
 
 		Expect(free1).To(Equal(free2 + 1))
 	})

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Podman Info", func() {
 		Expect(session.OutputToString()).To(Equal(want))
 	})
 
-	It("Podman info: check lock count", func() {
+	It("Podman info: check lock count", Serial, func() {
 		// This should not run on architectures and OSes that use the file locks backend.
 		// Which, for now, is Linux + RISCV and FreeBSD, neither of which are in CI - so
 		// no skips.
@@ -197,6 +197,9 @@ var _ = Describe("Podman Info", func() {
 		free2, err := strconv.Atoi(info2.OutputToString())
 		Expect(err).To(Not(HaveOccurred()))
 
+		// Effectively, we are checking that 1 lock has been taken.
+		// We do this by comparing the number of locks after (plus 1), to the number of locks before.
+		// Don't check absolute numbers because there is a decent chance of contamination, containers that were never removed properly, etc.
 		Expect(free1).To(Equal(free2 + 1))
 	})
 })


### PR DESCRIPTION
Deadlocks are among the most annoying parts of Podman to debug (second only to the intricacies of the REST attach endpoints, in my opinion). Part of this is that there wasn't really a good way to tell what was going on - all our locks are in-memory, so an strace just shows `futex` calls on inscrutable memory addresses (which blend into the `futex` calls that the Go runtime is doing on its own, making things extra fun).

This PR attempts to remedy this in 3 ways:
* Add the number of the lock used by a container/pod/volume to the output of `podman inspect` - allows for quick spot checks to verify that numbers assigned look sane
* Add the number of available locks to `podman info` - so we can easily see if the system has run entirely out of locks (usually because folks forget to prune volumes)
* Add a new, hidden debug command, `podman system locks`, to check for potential deadlocks due to duplicate lock assignment and identify any locks that are currently in use. This is hidden because the output isn't really meant for users, but for developers attempting to debug a deadlock.

```release-note
The number of free locks available is now displayed in `podman info` to help debug lock exhaustion scenarios.
```
