### PR TITLE
filters: better handling of id=

### DIFF
--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -290,7 +290,7 @@ func sortPodPsOutput(sortBy string, lprs []*entities.ListPodsReport) error {
 	case "status":
 		sort.Sort(podPsSortedStatus{lprs})
 	default:
-		return errors.New("invalid option for --sort, options are: id, names, or number")
+		return errors.New("invalid option for --sort, options are: created, id, name, number, or status")
 	}
 	return nil
 }

--- a/docs/source/markdown/podman-pause.1.md.in
+++ b/docs/source/markdown/podman-pause.1.md.in
@@ -28,20 +28,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 @@option latest
 

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -48,18 +48,18 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-|   Filter    |   Description                                                                                      |
-| ----------  | -------------------------------------------------------------------------------------------------- |
-| *ctr-ids*   | Filter by container ID within the pod.                                                             |
-| *ctr-names* | Filter by container name within the pod.                                                           |
-| *ctr-number*| Filter by number of containers in the pod.                                                         |
-| *ctr-status*| Filter by container status within the pod.                                                         |
-| *id*        | Filter by pod ID.                                                                                  |
-| *label*     | Filter by container with (or without, in the case of label!=[...] is used) the specified labels.   |
-| *name*      | Filter by pod name.                                                                                |
-| *network*   | Filter by network name or full ID of network.                                                      |
-| *status*    | Filter by pod status.                                                                              |
-| *until*     | Filter by pods created before given timestamp.                                                     |
+| Filter       | Description                                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------|
+| *ctr-ids*    | Filter by container ID within the pod. (CID prefix match by default; accepts regex)              |
+| *ctr-names*  | Filter by container name within the pod.                                                         |
+| *ctr-number* | Filter by number of containers in the pod.                                                       |
+| *ctr-status* | Filter by container status within the pod.                                                       |
+| *id*         | Filter by pod ID. (Prefix match by default; accepts regex)                                       |
+| *label*      | Filter by container with (or without, in the case of label!=[...] is used) the specified labels. |
+| *name*       | Filter by pod name.                                                                              |
+| *network*    | Filter by network name or full ID of network.                                                    |
+| *status*     | Filter by pod status.                                                                            |
+| *until*      | Filter by pods created before given timestamp.                                                   |
 
 The `ctr-ids`, `ctr-names`, `id`, `name` filters accept `regex` format.
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -45,20 +45,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container (accepts regex)         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container (accepts regex)         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 
 #### **--format**=*format*

--- a/docs/source/markdown/podman-restart.1.md.in
+++ b/docs/source/markdown/podman-restart.1.md.in
@@ -31,20 +31,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 @@option latest
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -33,20 +33,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-start.1.md.in
+++ b/docs/source/markdown/podman-start.1.md.in
@@ -36,20 +36,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 @@option interactive
 

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -32,20 +32,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 @@option ignore
 

--- a/docs/source/markdown/podman-unpause.1.md.in
+++ b/docs/source/markdown/podman-unpause.1.md.in
@@ -28,20 +28,20 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID (accepts regex)                                              |
-| name            | [Name] Container's name (accepts regex)                                          |
-| label           | [Key] or [Key=Value] Label assigned to a container                               |
-| exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
-| before          | [ID] or [Name] Containers created before this container                          |
-| since           | [ID] or [Name] Containers created since this container                           |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health          | [Status] healthy or unhealthy                                                    |
-| pod             | [Pod] name or full or partial ID of pod                                          |
-| network         | [Network] name or full ID of network                                             |
+| **Filter** | **Description**                                                                  |
+|------------|----------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
+| name       | [Name] Container's name (accepts regex)                                          |
+| label      | [Key] or [Key=Value] Label assigned to a container                               |
+| exited     | [Int] Container's exit code                                                      |
+| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                         |
+| before     | [ID] or [Name] Containers created before this container                          |
+| since      | [ID] or [Name] Containers created since this container                           |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health     | [Status] healthy or unhealthy                                                    |
+| pod        | [Pod] name or full or partial ID of pod                                          |
+| network    | [Network] name or full ID of network                                             |
 
 @@option latest
 

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/storage/pkg/regexp"
 )
 
 var (
@@ -17,6 +18,9 @@ var (
 	// This must NOT be changed from outside of Libpod. It should be a
 	// constant, but Go won't let us do that.
 	NameRegex = types.NameRegex
+	// NotHexRegex is a regular expression to check if a string is
+	// a hexadecimal string.
+	NotHexRegex = regexp.Delayed(`[^0-9a-fA-F]`)
 	// RegexError is thrown in presence of an invalid container/pod name.
 	RegexError = types.RegexError
 )


### PR DESCRIPTION
For filter=id=XXX:

  if XXX is only hex characters, treat it as a PREFIX
  otherwise, treat it as a REGEX

Fixes: #18471

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Filtering by 'id=xxx' will now treat xxx as a CID prefix, not a regular expression
```