### PR TITLE
Add netavark and aardvark-dns to podman info

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -27,26 +27,27 @@ type SecurityInfo struct {
 
 // HostInfo describes the libpod host
 type HostInfo struct {
-	Arch              string           `json:"arch"`
-	BuildahVersion    string           `json:"buildahVersion"`
-	CgroupManager     string           `json:"cgroupManager"`
-	CgroupsVersion    string           `json:"cgroupVersion"`
-	CgroupControllers []string         `json:"cgroupControllers"`
-	Conmon            *ConmonInfo      `json:"conmon"`
-	CPUs              int              `json:"cpus"`
-	CPUUtilization    *CPUUsage        `json:"cpuUtilization"`
-	DatabaseBackend   string           `json:"databaseBackend"`
-	Distribution      DistributionInfo `json:"distribution"`
-	EventLogger       string           `json:"eventLogger"`
-	Hostname          string           `json:"hostname"`
-	IDMappings        IDMappings       `json:"idMappings,omitempty"`
-	Kernel            string           `json:"kernel"`
-	LogDriver         string           `json:"logDriver"`
-	MemFree           int64            `json:"memFree"`
-	MemTotal          int64            `json:"memTotal"`
-	NetworkBackend    string           `json:"networkBackend"`
-	OCIRuntime        *OCIRuntimeInfo  `json:"ociRuntime"`
-	OS                string           `json:"os"`
+	Arch               string           `json:"arch"`
+	BuildahVersion     string           `json:"buildahVersion"`
+	CgroupManager      string           `json:"cgroupManager"`
+	CgroupsVersion     string           `json:"cgroupVersion"`
+	CgroupControllers  []string         `json:"cgroupControllers"`
+	Conmon             *ConmonInfo      `json:"conmon"`
+	CPUs               int              `json:"cpus"`
+	CPUUtilization     *CPUUsage        `json:"cpuUtilization"`
+	DatabaseBackend    string           `json:"databaseBackend"`
+	Distribution       DistributionInfo `json:"distribution"`
+	EventLogger        string           `json:"eventLogger"`
+	Hostname           string           `json:"hostname"`
+	IDMappings         IDMappings       `json:"idMappings,omitempty"`
+	Kernel             string           `json:"kernel"`
+	LogDriver          string           `json:"logDriver"`
+	MemFree            int64            `json:"memFree"`
+	MemTotal           int64            `json:"memTotal"`
+	NetworkBackend     string           `json:"networkBackend"`
+	NetworkBackendInfo *NetavarkInfo    `json:"networkBackendInfo,omitempty"`
+	OCIRuntime         *OCIRuntimeInfo  `json:"ociRuntime"`
+	OS                 string           `json:"os"`
 	// RemoteSocket returns the UNIX domain socket the Podman service is listening on
 	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
 	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`
@@ -101,6 +102,16 @@ type ConmonInfo struct {
 	Package string `json:"package"`
 	Path    string `json:"path"`
 	Version string `json:"version"`
+}
+
+// NetavarkInfo describes the netavark executable being used
+type NetavarkInfo struct {
+	Package    string `json:"package"`
+	Path       string `json:"path"`
+	Version    string `json:"version"`
+	DNSPackage string `json:"dnsPackage,omitempty"`
+	DNSPath    string `json:"dnsPath,omitempty"`
+	DNSVersion string `json:"dnsVersion,omitempty"`
 }
 
 // OCIRuntimeInfo describes the runtime (crun or runc) being

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -276,6 +276,14 @@ load helpers.network
     run_podman 1 network rm $mynetname
 }
 
+@test "podman info netavark" {
+        if !is_netavark; then
+	   skip "only meaningful for netavark"
+	fi
+	run_podman info --format '{{ .Host.NetworkBackendInfo }}'
+	assert "$output" =~ "netavark" "NetworkBackendInfo should contain inforamation about netavark"
+}
+
 @test "podman network reload" {
     skip_if_remote "podman network reload does not have remote support"
 


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/18443

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman info will list netavark and aardvark-dns package info if podman is using them.
```
