### PR TITLE
Inspecting Containers without health checks return health nil

### DIFF
--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -239,11 +239,11 @@ func (s *InspectContainerState) Healthcheck() HealthCheckResults {
 // HealthCheckResults describes the results/logs from a healthcheck
 type HealthCheckResults struct {
 	// Status starting, healthy or unhealthy
-	Status string `json:"Status"`
+	Status string `json:"Status,omitempty"`
 	// FailingStreak is the number of consecutive failed healthchecks
-	FailingStreak int `json:"FailingStreak"`
+	FailingStreak int `json:"FailingStreak,omitzero,omitempty"`
 	// Log describes healthcheck attempts and results
-	Log []HealthCheckLog `json:"Log"`
+	Log []HealthCheckLog `json:"Log,omitempty"`
 }
 
 // HealthCheckLog describes the results of a single healthcheck

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -34,10 +34,10 @@ var _ = Describe("Podman healthcheck run", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.State.Health.Status}}", "hc"})
+		hc := podmanTest.Podman([]string{"container", "inspect", "hc"})
 		hc.WaitWithDefaultTimeout()
 		Expect(hc).Should(Exit(0))
-		Expect(hc.OutputToString()).To(Not(ContainSubstring("starting")))
+		Expect(hc.OutputToString()).To(ContainSubstring("\"Health\": {},"))
 	})
 
 	It("podman run healthcheck and logs should contain healthcheck output", func() {

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -43,7 +43,7 @@ function _check_health {
 
     _check_health "All healthy" "
 Status           | \"healthy\"
-FailingStreak    | 0
+FailingStreak    | null
 Log[-1].ExitCode | 0
 Log[-1].Output   | \"Life is Good on stdout\\\nLife is Good on stderr\"
 "


### PR DESCRIPTION
Fixed: https://github.com/containers/podman/issues/18792

This will match Docker behaviour.
`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Inspecting containers without healthchecks will return nil for heath field.
```
