### PR TITLE
e2e: add ginkgo decorators to address flakes

### DIFF
--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -308,7 +308,8 @@ var _ = Describe("Podman exec", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 	})
 
-	It("podman exec terminal doesn't hang", func() {
+	// #10927 ("no logs from conmon"), one of our nastiest flakes
+	It("podman exec terminal doesn't hang", FlakeAttempts(3), func() {
 		setup := podmanTest.Podman([]string{"run", "-dti", "--name", "test1", fedoraMinimal, "sleep", "+Inf"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -433,7 +433,8 @@ registries = ['{{.Host}}:{{.Port}}']`
 		Expect(search).To(ExitWithError())
 	})
 
-	It("podman search with wildcards", func() {
+	// Registry is unreliable (#18484), this is another super-common flake
+	It("podman search with wildcards", FlakeAttempts(3), func() {
 		search := podmanTest.Podman([]string{"search", "registry.access.redhat.com/*openshift*"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -11,7 +11,8 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("Podman trust", func() {
+// Without Ordered, tests flake with "Getting key identity" (#18358)
+var _ = Describe("Podman trust", Ordered, func() {
 
 	BeforeEach(func() {
 		SkipIfRemote("podman-remote does not support image trust")


### PR DESCRIPTION
- trust_test: adding 'Ordered' seems to resolve a very common
  flake. I've tested this for dozens of CI runs, and haven't
  seen the flake recur (normally it fails every few runs).

- exec and search tests: add FlakeAttempts(3). This is a NOP
  under our current CI setup, in which we run ginkgo with
  a global --flake-attempts=3. I am submitting this as an
  optimistic step toward a no-flake-attempts world (#17967)

Fixes: #18358

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```