### PR TITLE
[CI:BUILD] GHA: Fix bad job-names & links in monitoring emails

### DIFF
--- a/.github/actions/check_cirrus_cron/make_email_body.sh
+++ b/.github/actions/check_cirrus_cron/make_email_body.sh
@@ -9,24 +9,26 @@ set -eo pipefail
 source $(dirname "${BASH_SOURCE[0]}")/lib.sh
 
 _errfmt="Expecting %s value to not be empty"
-# NAME_ID_FILEPATH is defined by workflow YAML
+# ID_NAME_FILEPATH is defined by workflow YAML
 # shellcheck disable=SC2154
 if [[ -z "$GITHUB_REPOSITORY" ]]; then
     err $(printf "$_errfmt" "\$GITHUB_REPOSITORY")
-elif [[ ! -r "$NAME_ID_FILEPATH" ]]; then
-    err "Expecting \$NAME_ID_FILEPATH value ($NAME_ID_FILEPATH) to be a readable file"
+elif [[ ! -r "$ID_NAME_FILEPATH" ]]; then
+    err "Expecting \$ID_NAME_FILEPATH value ($ID_NAME_FILEPATH) to be a readable file"
 fi
 
 confirm_gha_environment
 
-mkdir -p artifacts
+# GITHUB_WORKSPACE confirmed by confirm_gha_environment()
+# shellcheck disable=SC2154
+mkdir -p "$GITHUB_WORKSPACE/artifacts"
 (
     echo "Detected one or more Cirrus-CI cron-triggered jobs have failed recently:"
     echo ""
 
-    while read -r NAME BID; do
+    while read -r BID NAME; do
         echo "Cron build '$NAME' Failed: https://cirrus-ci.com/build/$BID"
-    done < "$NAME_ID_FILEPATH"
+    done < "$ID_NAME_FILEPATH"
 
     echo ""
     # Defined by github-actions
@@ -35,4 +37,4 @@ mkdir -p artifacts
     # Separate content from sendgrid.com automatic footer.
     echo ""
     echo ""
-) > ./artifacts/email_body.txt
+) > $GITHUB_WORKSPACE/artifacts/email_body.txt

--- a/.github/actions/check_cirrus_cron/rerun_failed_tasks.sh
+++ b/.github/actions/check_cirrus_cron/rerun_failed_tasks.sh
@@ -14,33 +14,35 @@ set -eo pipefail
 #    For example, from https://cirrus-ci.com/github/containers/podman/main
 #    (pick an old one from the bottom, since re-running it won't affect anybody)
 # 3. Create a temp. file, like /tmp/fail with a single line, of the form:
-#    <branch> <cirrus build id number>
-# 4. export NAME_ID_FILEPATH=/tmp/fail
+#    <cirrus build id number> <cirrus-cron name>
+# 4. export ID_NAME_FILEPATH=/tmp/fail
 # 5. execute this script, and refresh the build in the WebUI, all unsuccessful
 #    tasks should change status to running or scheduled.  Note: some later
 #    tasks may remain red as they wait for dependencies to run and pass.
-# 6. After each run, cleanup with 'rm -rf ./artifacts'
+# 6. After each run, cleanup with 'rm -rf $GITHUB_WORKSPACE/artifacts'
 #    (unless you want to examine them)
 
 source $(dirname "${BASH_SOURCE[0]}")/lib.sh
 
 _errfmt="Expecting %s value to not be empty"
-# NAME_ID_FILEPATH is defined by workflow YAML
+# ID_NAME_FILEPATH is defined by workflow YAML
 # shellcheck disable=SC2154
 if [[ -z "$SECRET_CIRRUS_API_KEY" ]]; then
     err $(printf "$_errfmt" "\$SECRET_CIRRUS_API_KEY")
-elif [[ ! -r "$NAME_ID_FILEPATH" ]]; then  # output from cron_failures.sh
-    err $(printf "Expecting %s value to be a readable file" "\$NAME_ID_FILEPATH")
+elif [[ ! -r "$ID_NAME_FILEPATH" ]]; then  # output from cron_failures.sh
+    err $(printf "Expecting %s value to be a readable file" "\$ID_NAME_FILEPATH")
 fi
 
 confirm_gha_environment
 
-mkdir -p artifacts
+# GITHUB_WORKSPACE confirmed by confirm_gha_environment()
+# shellcheck disable=SC2154
+mkdir -p $GITHUB_WORKSPACE/artifacts
 # If there are no tasks, don't fail reading the file
-truncate -s 0 ./artifacts/rerun_tids.txt
+truncate -s 0 $GITHUB_WORKSPACE/artifacts/rerun_tids.txt
 
-cat "$NAME_ID_FILEPATH" | \
-    while read -r NAME BID; do
+cat "$ID_NAME_FILEPATH" | \
+    while read -r BID NAME; do
         if [[ -z "$NAME" ]]; then
             err $(printf "$_errfmt" "\$NAME")
         elif [[ -z "$BID" ]]; then
@@ -80,11 +82,11 @@ cat "$NAME_ID_FILEPATH" | \
                     msg "Rerunning build $BID task $TID"
                     # Must send result through a file into rerun_tasks array
                     # because this section is executing in a child-shell
-                    echo "$TID" >> ./artifacts/rerun_tids.txt
+                    echo "$TID" >> $GITHUB_WORKSPACE/artifacts/rerun_tids.txt
                 fi
             done
         declare -a rerun_tasks
-        mapfile rerun_tasks <./artifacts/rerun_tids.txt
+        mapfile rerun_tasks <$GITHUB_WORKSPACE/artifacts/rerun_tids.txt
         msg "::endgroup::"
 
         if [[ "${#rerun_tasks[*]}" -eq 0 ]]; then

--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -32,9 +32,9 @@ on:
 env:
     # CSV listing of e-mail addresses for delivery failure or error notices
     RCPTCSV: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
-    # Filename for table of cron-name to build-id data
+    # Filename for table of build-id to cron-name data
     # (must be in $GITHUB_WORKSPACE/artifacts/)
-    NAME_ID_FILEPATH: './artifacts/name_id.txt'
+    ID_NAME_FILEPATH: './artifacts/id_name.txt'
 
 permissions:
   contents: read

--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -31,9 +31,9 @@ on:
 env:
     # CSV listing of e-mail addresses for delivery failure or error notices
     RCPTCSV: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
-    # Filename for table of cron-name to build-id data
+    # Filename for table of build-id to cron-name data
     # (must be in $GITHUB_WORKSPACE/artifacts/)
-    NAME_ID_FILEPATH: './artifacts/name_id.txt'
+    ID_NAME_FILEPATH: './artifacts/id_name.txt'
 
 permissions:
   contents: read


### PR DESCRIPTION
Due to a bad file-format design, if a cirrus-cron job happened to have a name w/ spaces, the generated e-mail text would be broken.  [For example](https://github.com/containers/automation_images/actions/runs/5195573071/jobs/9368432815#step:3:31):

```
Cron build 'VM' Failed: https://cirrus-ci.com/build/Image Maintenance
5630822628196352
```

Fix this by flipping the field-order in an intermediate file, so the build ID comes first, then the job name.  This makes it much easier for `read` to process, since all words will be stored into the final variable (now the job name).

Also change all variables that reference this intermediate file such that they continue to reflect the expected field order.  Update script tests and add a new test to confirm expected file processing and output.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
