### PR TITLE
Add console mode to podman machine

### DIFF
--- a/pkg/machine/applehv/vfkit.go
+++ b/pkg/machine/applehv/vfkit.go
@@ -22,6 +22,9 @@ func getDefaultDevices(imagePath, logPath string) []string {
 		"virtio-net,nat,mac=72:20:43:d4:38:62",
 		fmt.Sprintf("virtio-blk,path=%s", imagePath),
 		fmt.Sprintf("virtio-serial,logFilePath=%s", logPath),
+		fmt.Sprintf("virtio-input,pointing"),
+		fmt.Sprintf("virtio-input,keyboard"),
+		fmt.Sprintf("virtio-gpu"),
 	}
 	return defaultDevices
 }
@@ -67,6 +70,9 @@ func (vf *VfkitHelper) toCmdLine(cpus, memory string) []string {
 		// this is on for development but can probably be disabled later, or
 		// we can leave it as optional.
 		//"--log-level", "debug",
+	}
+	if vf.LogLevel == logrus.DebugLevel {
+		cmd = append(cmd, "--gui")
 	}
 	for _, d := range vf.Devices {
 		cmd = append(cmd, "--device", d)


### PR DESCRIPTION
Add the functionality for a console to be dipslayed when the user runs `podman --log-level debug machine start` on MacOS. This mimics the behavior that currently exists on Linux.

Associated with: https://github.com/crc-org/vfkit/pull/44

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds the functionality for a user to create a console window to display the virtual machine while booting
```
