### PR TITLE
recursive call in user directories for unit files

### DIFF
--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -47,10 +47,9 @@ func TestIsUnambiguousName(t *testing.T) {
 }
 
 func TestUnitDirs(t *testing.T) {
-	rootDirs := []string{
-		quadlet.UnitDirAdmin,
-		quadlet.UnitDirDistro,
-	}
+	rootDirs := []string{}
+	rootDirs = appendSubPaths(rootDirs, quadlet.UnitDirAdmin, false, userLevelFilter)
+	rootDirs = appendSubPaths(rootDirs, quadlet.UnitDirDistro, false, userLevelFilter)
 	unitDirs := getUnitDirs(false)
 	assert.Equal(t, unitDirs, rootDirs, "rootful unit dirs should match")
 
@@ -59,11 +58,12 @@ func TestUnitDirs(t *testing.T) {
 	u, err := user.Current()
 	assert.Nil(t, err)
 
-	rootlessDirs := []string{
-		path.Join(configDir, "containers/systemd"),
-		filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid),
-		filepath.Join(quadlet.UnitDirAdmin, "users"),
-	}
+	rootlessDirs := []string{}
+
+	rootlessDirs = appendSubPaths(rootlessDirs, path.Join(configDir, "containers/systemd"), false, nil)
+	rootlessDirs = appendSubPaths(rootlessDirs, filepath.Join(quadlet.UnitDirAdmin, "users"), true, nonNumericFilter)
+	rootlessDirs = appendSubPaths(rootlessDirs, filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid), true, userLevelFilter)
+	rootlessDirs = append(rootlessDirs, filepath.Join(quadlet.UnitDirAdmin, "users"))
 
 	unitDirs = getUnitDirs(true)
 	assert.Equal(t, unitDirs, rootlessDirs, "rootless unit dirs should match")

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -44,7 +44,9 @@ For rootless containers, when administrators place Quadlet files in the
 Quadlet when the login session begins. If the administrator places a Quadlet
 file in the /etc/containers/systemd/users/${UID}/ directory, then only the
 user with the matching UID execute the Quadlet when the login
-session gets started.
+session gets started. For unit files placed in subdirectories within
+/etc/containers/systemd/user/${UID}/ and the other user unit search paths,
+Quadlet will recursively search and run the unit files present in these subdirectories.
 
 
 ### Enabling unit files

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"net/url"
@@ -15,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1320,4 +1322,90 @@ func useCustomNetworkDir(podmanTest *PodmanTestIntegration, tempdir string) {
 	if IsRemote() {
 		podmanTest.RestartRemoteService()
 	}
+}
+
+// copy directories recursively from source path to destination path
+func CopyDirectory(srcDir, dest string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(srcDir, entry.Name())
+		destPath := filepath.Join(dest, entry.Name())
+
+		fileInfo, err := os.Stat(sourcePath)
+		if err != nil {
+			return err
+		}
+
+		stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("failed to get raw syscall.Stat_t data for %q", sourcePath)
+		}
+
+		switch fileInfo.Mode() & os.ModeType {
+		case os.ModeDir:
+			if err := os.MkdirAll(destPath, 0755); err != nil {
+				return fmt.Errorf("failed to create directory: %q, error: %q", destPath, err.Error())
+			}
+			if err := CopyDirectory(sourcePath, destPath); err != nil {
+				return err
+			}
+		case os.ModeSymlink:
+			if err := CopySymLink(sourcePath, destPath); err != nil {
+				return err
+			}
+		default:
+			if err := Copy(sourcePath, destPath); err != nil {
+				return err
+			}
+		}
+
+		if err := os.Lchown(destPath, int(stat.Uid), int(stat.Gid)); err != nil {
+			return err
+		}
+
+		fInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		isSymlink := fInfo.Mode()&os.ModeSymlink != 0
+		if !isSymlink {
+			if err := os.Chmod(destPath, fInfo.Mode()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func Copy(srcFile, dstFile string) error {
+	out, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+
+	in, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	return nil
+}
+
+func CopySymLink(source, dest string) error {
+	link, err := os.Readlink(source)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(link, dest)
 }

--- a/test/e2e/quadlet/test_subdir/mysleep.container
+++ b/test/e2e/quadlet/test_subdir/mysleep.container
@@ -1,0 +1,11 @@
+[Unit]
+Description=The sleep container
+After=local-fs.target
+
+[Container]
+Image=registry.access.redhat.com/ubi9-minimal:latest
+Exec=sleep 1000
+
+[Install]
+# Start by default on boot
+WantedBy=multi-user.target default.target

--- a/test/e2e/quadlet/test_subdir/sub_one/mysleep_1.container
+++ b/test/e2e/quadlet/test_subdir/sub_one/mysleep_1.container
@@ -1,0 +1,11 @@
+[Unit]
+Description=The sleep container
+After=local-fs.target
+
+[Container]
+Image=registry.access.redhat.com/ubi9-minimal:latest
+Exec=sleep 1000
+
+[Install]
+# Start by default on boot
+WantedBy=multi-user.target default.target

--- a/test/e2e/quadlet/test_subdir/sub_two/mysleep_2.container
+++ b/test/e2e/quadlet/test_subdir/sub_two/mysleep_2.container
@@ -1,0 +1,11 @@
+[Unit]
+Description=The sleep container
+After=local-fs.target
+
+[Container]
+Image=registry.access.redhat.com/ubi9-minimal:latest
+Exec=sleep 1000
+
+[Install]
+# Start by default on boot
+WantedBy=multi-user.target default.target

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -471,6 +471,28 @@ BOGUS=foo
 			Expect(session).Should(Exit(1))
 		})
 
+		It("Should scan and return output for files in subdirectories", func() {
+			dirName := "test_subdir"
+
+			err = CopyDirectory(filepath.Join("quadlet", dirName), quadletDir)
+
+			if err != nil {
+				GinkgoWriter.Println("error:", err)
+			}
+
+			session := podmanTest.Quadlet([]string{"-dryrun", "-user"}, quadletDir)
+			session.WaitWithDefaultTimeout()
+
+			current := session.OutputToStringArray()
+			expected := []string{
+				"---mysleep.service---",
+				"---mysleep_1.service---",
+				"---mysleep_2.service---",
+			}
+
+			Expect(current).To(ContainElements(expected))
+		})
+
 		It("Should parse a kube file and print it to stdout", func() {
 			fileName := "basic.kube"
 			testcase := loadQuadletTestcase(filepath.Join("quadlet", fileName))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Solves #18032 

```release-note
Recursively scans directories for unit files
----------------------
debian@debian:~/Projects/podman$ bin/quadlet -dryrun
quadlet-generator[2453]: No files to parse from [/etc/containers/systemd /usr/share/containers/systemd]

----------------------
debian@debian:~/Projects/podman$ bin/quadlet -dryrun -user
quadlet-generator[2475]: Loading source unit file /home/debian/.config/containers/systemd/test_subdir/sample.container
quadlet-generator[2475]: Loading source unit file /home/debian/.config/containers/systemd/test_subdir/sub_one/sample_two.container
quadlet-generator[2475]: Loading source unit file /home/debian/.config/containers/systemd/test_subdir/sub_two/sample_one.container
---sample.service---
[Unit]
Description=The sleep container
After=local-fs.target
SourcePath=/home/debian/.config/containers/systemd/test_subdir/sample.container
RequiresMountsFor=%t/containers

[X-Container]
Image=registry.access.redhat.com/ubi9-minimal:latest
Exec=sleep 1000

[Install]
# Start by default on boot
WantedBy=multi-user.target default.target

[Service]
Environment=PODMAN_SYSTEMD_UNIT=%n
KillMode=mixed
ExecStop=/usr/local/bin/podman rm -f -i --cidfile=%t/%N.cid
ExecStopPost=-/usr/local/bin/podman rm -f -i --cidfile=%t/%N.cid
Delegate=yes
Type=notify
NotifyAccess=all
SyslogIdentifier=%N
ExecStart=/usr/local/bin/podman run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon -d registry.access.redhat.com/ubi9-minimal:latest sleep 1000

---sample_two.service---
[Unit]
Description=The sleep container
After=local-fs.target
SourcePath=/home/debian/.config/containers/systemd/test_subdir/sub_one/sample_two.container
RequiresMountsFor=%t/containers

[X-Container]
Image=registry.access.redhat.com/ubi9-minimal:latest
Exec=sleep 1000

[Install]
# Start by default on boot
WantedBy=multi-user.target default.target

[Service]
Environment=PODMAN_SYSTEMD_UNIT=%n
KillMode=mixed
ExecStop=/usr/local/bin/podman rm -f -i --cidfile=%t/%N.cid
ExecStopPost=-/usr/local/bin/podman rm -f -i --cidfile=%t/%N.cid
Delegate=yes
Type=notify
NotifyAccess=all
SyslogIdentifier=%N
ExecStart=/usr/local/bin/podman run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon -d registry.access.redhat.com/ubi9-minimal:latest sleep 1000

---sample_one.service---
[Unit]
Description=The sleep container
After=local-fs.target
SourcePath=/home/debian/.config/containers/systemd/test_subdir/sub_two/sample_one.container
RequiresMountsFor=%t/containers

[X-Container]
Image=registry.access.redhat.com/ubi9-minimal:latest
Exec=sleep 1000

[Install]
# Start by default on boot
WantedBy=multi-user.target default.target

[Service]
Environment=PODMAN_SYSTEMD_UNIT=%n
KillMode=mixed
ExecStop=/usr/local/bin/podman rm -f -i --cidfile=%t/%N.cid
ExecStopPost=-/usr/local/bin/podman rm -f -i --cidfile=%t/%N.cid
Delegate=yes
Type=notify
NotifyAccess=all
SyslogIdentifier=%N
ExecStart=/usr/local/bin/podman run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon -d registry.access.redhat.com/ubi9-minimal:latest sleep 1000
```
