### PR TITLE
[v4.2.0-rhel] podman-kube@.service.in: Remove Restart=never option wi…

### DIFF
--- a/contrib/systemd/system/podman-kube@.service.in
+++ b/contrib/systemd/system/podman-kube@.service.in
@@ -7,7 +7,6 @@ RequiresMountsFor=%t/containers
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=never
 TimeoutStopSec=70
 ExecStart=@@PODMAN@@ play kube --replace --service-container=true %I
 ExecStop=@@PODMAN@@ play kube --down %I


### PR DESCRIPTION
systemd expects the value of the option to be `no` instead, but this is already the default behavior. This fixes the following warning when running `systemctl status` on the unit:

    Failed to parse service restart specifier, ignoring: never

Addresses: https://issues.redhat.com/browse/OCPBUGS-14284

[NO NEW TESTS NEEDED]

Signed-off-by: Andrew Gunnerson <chillermillerlong@hotmail.com>
Signed-off-by: Tom Sweeney <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
