### PR TITLE
pwsh completers ∀x∈ {cmds, aliases}

### DIFF
--- a/completions/powershell/podman.ps1
+++ b/completions/powershell/podman.ps1
@@ -241,7 +241,16 @@ filter __podman_escapeStringWithSpecialChars {
 
     }
 }
+# Enumerate the cmds for podman (set by System.Environment)
+$availablePodmans = Get-Command -Name podman -All -ErrorAction SilentlyContinue
 
-Register-ArgumentCompleter -CommandName 'podman' -ScriptBlock $__podmanCompleterBlock
+# Enumerate set aliases for podman (set by user)
+$podmanAliases = @()
+foreach($podmanCmd in $availablePodmans){
+    $podmanAliases += Get-Alias | Where-Object { $_.Definition -eq ($podmanCmd | Resolve-Path) }
+}
+
+# Register args completer for all cmds and aliases
+Register-ArgumentCompleter -CommandName ([array]$availablePodmans.Name + [array]$podmanAliases.Name) -ScriptBlock $__podmanCompleterBlock
 
 # This file is generated with "podman completion"; see: podman-completion(1)


### PR DESCRIPTION
Provide PowerShell argument completer for all `podman` commands and aliases. This is especially useful for cases where user set `docker` as an alias. 

Also, the PowerShell argument completer will now apply for `podman.exe` if that is an entrypoint to `podman` that is set by `System.Environment`. This is useful for cases (Windows contexts) where the executable has `*.exe` extension. (We don't want to deny argument completion when the user is employing _a canonical name_ for the executable, which it does in the status quo.)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

Yes.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Extend PowerShell argument completer to apply for each `podman` command (including `*.exe`) and aliases (e.g., `docker`).
```
