### PR TITLE
fix(specgen): index out of range when unmask=[]

### DIFF
--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -57,7 +57,7 @@ func getCgroupPermissions(unmask []string) string {
 		return ro
 	}
 
-	if unmask != nil && unmask[0] == "ALL" {
+	if unmask != nil && len(unmask) != 0 && unmask[0] == "ALL" {
 		return rw
 	}
 

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -57,7 +57,7 @@ func getCgroupPermissions(unmask []string) string {
 		return ro
 	}
 
-	if unmask != nil && len(unmask) != 0 && unmask[0] == "ALL" {
+	if len(unmask) != 0 && unmask[0] == "ALL" {
 		return rw
 	}
 


### PR DESCRIPTION
Fixes #18848

```release-note
Fixed index out of range error when unmask is set to empty
```