### PR TITLE
250-systemd.bats: remove outdated comment

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -448,9 +448,6 @@ $name stderr" "logs work with passthrough"
     is "$output" ".*$service_name,.* (test_pod-b),$IMAGE,false,registry.*" "container-specified auto-update policy gets applied"
 
     # Kill the pod and make sure the service is not running.
-    # The restart policy is set to "never" since there is no
-    # design yet for propagating exit codes up to the service
-    # container.
     run_podman pod kill test_pod
     for i in {0..20}; do
         run systemctl is-active $service_name


### PR DESCRIPTION
Remove an outdated comment on the absence of exit-code propagation when running K8s workloads in systemd.  The `podman-kube@` systemd template is using default restart policy of the system.  The exit-code propagation is tested in other tests, so we can keep the logic as is.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
