### PR TITLE
[CI:DOCS] podman-push: rm confusion on supported transports

### DIFF
--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -64,37 +64,7 @@ Sign the pushed images with a sigstore signature using a private key at the spec
 
 ## DESTINATION
 
- The DESTINATION is a location to store container images
- The Image "DESTINATION" uses a "transport":"details" format.
- If a transport is not given, `podman push` attempts to push
- to a registry.
-
- Multiple transports are supported:
-
-  **dir:**_path_
-  An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
-
-    $ podman manifest push mylist:v1.11 dir:/tmp/mylist
-
-  **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
-
-    $ podman manifest push mylist:v1.11 docker://registry.example.org/mylist:v1.11
-
-  **docker-archive:**_path_[**:**_docker-reference_]
-  An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
-
-    $ podman manifest push mylist:v1.11 docker-archive:/tmp/mylist
-
-  **docker-daemon:**_docker-reference_
-  An image in _docker-reference_ format stored in the docker daemon internal storage. _docker-reference_ must contain a tag.
-
-    $ podman manifest push mylist:v1.11 docker-daemon:registry.example.org/mylist:v1.11
-
-  **oci-archive:**_path_**:**_tag_
-  An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
-
-    $ podman manifest push mylist:v1.11 oci-archive:/tmp/mylist
+ DESTINATION is the location the container image is pushed to. It supports all transports from `containers-transports(5)`. If no transport is specified, the `docker` (i.e., container registry) transport is used.  For remote clients, including Mac and Windows (excluding WSL2) machines, `docker` is the only supported transport.
 
 ## EXAMPLE
 
@@ -103,4 +73,4 @@ podman manifest push mylist:v1.11 docker://registry.example.org/mylist:v1.11
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-manifest(1)](podman-manifest.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-manifest(1)](podman-manifest.1.md)**, **[containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md)**

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -10,10 +10,7 @@ podman\-push - Push an image, manifest list or image index from local storage to
 
 ## DESCRIPTION
 Pushes an image, manifest list or image index from local storage to a specified
-destination. Push is mainly used to push images to registries, however
-**podman push** can be used to save images to tarballs and directories using the
-following transports:
-**dir:**, **docker-archive:**, **docker-daemon:** and **oci-archive:**.
+destination.
 
 ## Image storage
 Images are pushed from those stored in local image storage.


### PR DESCRIPTION
Remote clients only support the docker transport which is mentioned in the destination table below.  So drop the redundant text on supported transports from the main description to avoid confusion.

Closes: #18357

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
