### PR TITLE
libpod: make conmon always log to syslog

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1387,10 +1387,8 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 	logLevel := logrus.GetLevel()
 	args = append(args, "--log-level", logLevel.String())
 
-	if logLevel == logrus.DebugLevel {
-		logrus.Debugf("%s messages will be logged to syslog", r.conmonPath)
-		args = append(args, "--syslog")
-	}
+	logrus.Debugf("%s messages will be logged to syslog", r.conmonPath)
+	args = append(args, "--syslog")
 
 	size := r.logSizeMax
 	if ctr.config.LogSize > 0 {


### PR DESCRIPTION
Conmon very early dups the std streams with /dev/null, therefore all errors it reports go nowhere. When you run podman with debug level we set --syslog and we can see the error in the journal. This should be the default. We have a lot of weird failures in CI that could be caused by conmon and we have access to the journal in the cirrus tasks so that should make debugging much easier.

Conmon still uses the same logging level as podman so it will not spam the journal and only log warning and errors by default.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
