### PR TITLE
Add support for setting autoupdate in quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -89,6 +89,7 @@ Valid options for `[Container]` are listed below:
 | AddCapability=CAP              | --cap-add CAP                                        |
 | AddDevice=/dev/foo             | --device /dev/foo                                    |
 | Annotation="YXZ"               | --annotation "XYZ"                                   |
+| AutoUpdate=registry            | --label "io.containers.autoupdate=registry"          |
 | ContainerName=name             | --name name                                          |
 | DropCapability=CAP             | --cap-drop=CAP                                       |
 | Environment=foo=bar            | --env foo=bar                                        |
@@ -170,6 +171,14 @@ similar to `Environment`.
 
 This key can be listed multiple times.
 
+### `AutoUpdate=`
+
+Indicates whether the container will be auto-updated ([podman-auto-update(1)](podman-auto-update.1.md)). The following values are supported:
+
+* `registry`: Requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container. This enforcement is necessary to know which image to actually check and pull. If an image ID was used, Podman does not know which image to check/pull anymore.
+
+* `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the container.
+
 ### `ContainerName=`
 
 The (optional) name of the Podman container. If this is not specified, the default value
@@ -199,7 +208,7 @@ Use a line-delimited file to set environment variables in the container.
 The path may be absolute or relative to the location of the unit file.
 This key may be used multiple times, and the order persists when passed to `podman run`.
 
-### `EnvironmentHost=` (defaults to `no`)
+### `EnvironmentHost=`
 
 Use the host environment inside of the container.
 
@@ -838,4 +847,5 @@ Label=org.test.Key=value
 **[systemd.unit(5)](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)**,
 **[systemd.service(5)](https://www.freedesktop.org/software/systemd/man/systemd.service.html)**,
 **[podman-run(1)](podman-run.1.md)**,
-**[podman-network-create(1)](podman-network-create.1.md)**
+**[podman-network-create(1)](podman-network-create.1.md)**,
+**[podman-auto-update(1)](podman-auto-update.1.md)**

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -36,6 +36,7 @@ const (
 	KeyAddCapability         = "AddCapability"
 	KeyAddDevice             = "AddDevice"
 	KeyAnnotation            = "Annotation"
+	KeyAutoUpdate            = "AutoUpdate"
 	KeyConfigMap             = "ConfigMap"
 	KeyContainerName         = "ContainerName"
 	KeyCopy                  = "Copy"
@@ -116,6 +117,7 @@ var (
 		KeyAddCapability:         true,
 		KeyAddDevice:             true,
 		KeyAnnotation:            true,
+		KeyAutoUpdate:            true,
 		KeyContainerName:         true,
 		KeyDropCapability:        true,
 		KeyEnvironment:           true,
@@ -556,6 +558,13 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 		} else {
 			podman.addf("%s:%s%s", source, dest, options)
 		}
+	}
+
+	update, ok := container.Lookup(ContainerGroup, KeyAutoUpdate)
+	if ok && len(update) > 0 {
+		podman.addLabels(map[string]string{
+			"io.containers.autoupdate": update,
+		})
 	}
 
 	exposedPorts := container.LookupAll(ContainerGroup, KeyExposeHostPort)

--- a/test/e2e/quadlet/autoupdate.container
+++ b/test/e2e/quadlet/autoupdate.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--label" "io.containers.autoupdate=registry"
+
+[Container]
+Image=localhost/imagename
+AutoUpdate=registry

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -533,6 +533,7 @@ var _ = Describe("quadlet system generator", func() {
 		},
 		Entry("Basic container", "basic.container"),
 		Entry("annotation.container", "annotation.container"),
+		Entry("autoupdate.container", "autoupdate.container"),
 		Entry("basepodman.container", "basepodman.container"),
 		Entry("capabilities.container", "capabilities.container"),
 		Entry("capabilities2.container", "capabilities2.container"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet .container format now supports AutoUpdate option.
```
