### PR TITLE
e2e: GetSafeIPAddress() replaces GetRandomIPAddress

### DIFF
--- a/test/e2e/checkpoint_image_test.go
+++ b/test/e2e/checkpoint_image_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := []string{
 			"run",
 			"-d",
-			"--ip", GetRandomIPAddress(),
+			"--ip", GetSafeIPAddress(),
 			"--name", containerName,
 			ALPINE,
 			"top",

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -23,7 +23,7 @@ import (
 
 func getRunString(input []string) []string {
 	// CRIU does not work with seccomp correctly on RHEL7 : seccomp=unconfined
-	runString := []string{"run", "--security-opt", "seccomp=unconfined", "-d", "--ip", GetRandomIPAddress()}
+	runString := []string{"run", "--security-opt", "seccomp=unconfined", "-d", "--ip", GetSafeIPAddress()}
 	return append(runString, input...)
 }
 

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create with specified static IP has correct IP", func() {
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		// Rootless static ip assignment without network should error
@@ -47,7 +47,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 
 	It("Podman create two containers with the same IP", func() {
 		SkipIfRootless("--ip not supported without network in rootless mode")
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"create", "--log-driver", "k8s-file", "--name", "test1", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with IP address", func() {
 		name := "test"
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", name})
 		podCreate.WaitWithDefaultTimeout()
 		// Rootless should error without network
@@ -232,7 +232,7 @@ var _ = Describe("Podman pod create", func() {
 		SkipIfRootless("Rootless does not support --ip without network")
 		podName := "test"
 		ctrName := "testCtr"
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", podName})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(Exit(0))
@@ -248,7 +248,7 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with IP address and no infra should fail", func() {
 		name := "test"
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", name, "--infra=false"})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(Exit(125))

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with specified static IP has correct IP", func() {
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"run", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
@@ -59,7 +59,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with --network bridge:ip=", func() {
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"run", "--network", "bridge:ip=" + ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
@@ -67,7 +67,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with --network net:ip=,mac=,interface_name=", func() {
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		mac := "44:33:22:11:00:99"
 		intName := "myeth"
 		result := podmanTest.Podman([]string{"run", "--network", "bridge:ip=" + ip + ",mac=" + mac + ",interface_name=" + intName, ALPINE, "ip", "addr"})
@@ -79,7 +79,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run two containers with the same IP", func() {
-		ip := GetRandomIPAddress()
+		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"run", "-d", "--name", "nginx", "--ip", ip, NGINX_IMAGE})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))


### PR DESCRIPTION
For tests that use '--ip XX', random IP allocation is not
working well. Switch instead to a deterministic algorithm
with CPU affinity and a fudge factor for CNI.

Fixes: #18855 

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```