### PR TITLE
[CI:DOCS] Fix service_destinations description in podman man page

### DIFF
--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -72,7 +72,7 @@ Details:
 URL value resolution precedence:
  - command line value
  - environment variable `CONTAINER_HOST`
- - `containers.conf` `service_destinations` table
+ - `engine.service_destinations` table in containers.conf, excluding the /usr/share/containers directory
  - `unix://run/podman/podman.sock`
 
 Remote connections use local containers.conf for default.

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -186,7 +186,7 @@ Details:
 URL value resolution precedence:
  - command line value
  - environment variable `CONTAINER_HOST`
- - `containers.conf` `service_destinations` table
+ - `engine.service_destinations` table in containers.conf, excluding the /usr/share/containers directory
  - `unix://run/podman/podman.sock`
 
 Remote connections use local containers.conf for default.


### PR DESCRIPTION
- [service_destinations] should be [engine.service_destinations]
- service_destinations does not read from `/usr/share/containers/containers.conf` because podman uses config.ReadCustomConfig().

Fixes: #15615

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
