### PR TITLE
remote wait: fix "removed" condition

### DIFF
--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -12,7 +12,8 @@ CTR="WaitTestingCtr"
 
 t POST "containers/nonExistent/wait?condition=next-exit" 404
 
-podman create --name "${CTR}" --entrypoint '["true"]' "${IMAGE}"
+# Make sure to test a non-zero exit code (see #18889)
+podman create --name "${CTR}" "${IMAGE}" sh -c "exit 3"
 
 t POST "containers/${CTR}/wait?condition=non-existent-cond" 400
 
@@ -24,7 +25,7 @@ child_pid=$!
 
 # This will block until the background job completes
 t POST "containers/${CTR}/wait?condition=next-exit" 200 \
-  .StatusCode=0 \
+  .StatusCode=3 \
   .Error=null
 wait "${child_pid}"
 
@@ -41,6 +42,10 @@ fi
 child_pid=$!
 
 t POST "containers/${CTR}/wait?condition=removed" 200 \
-  .StatusCode=0 \
+  .StatusCode=3 \
   .Error=null
+# Make sure the container has really been removed after waiting for
+# "condition=removed". This check is racy but should flake in case it doesn't
+# work correctly.
+t POST "containers/${CTR}/wait?condition=next-exit" 404
 wait "${child_pid}"


### PR DESCRIPTION
The "removed" condition mapped to an undefined state which ultimately rendered the wait endpoint to return an incorrect exit code.  Instead, map "removed" to "exited" to make sure Podman returns the expected exit code.

Fixes: #18889

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the wait endpoint of the compat API to correctly handle the "removed" condition.
```
