### PR TITLE
fix(ssh): machine failed to start with exit status 255

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -573,6 +573,7 @@ func AppleHVSSH(username, identityPath, name string, sshPort int, inputArgs []st
 	port := strconv.Itoa(sshPort)
 
 	args := []string{"-i", identityPath, "-p", port, sshDestination,
+		"-o", "IdentitiesOnly=yes",
 		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
 	if len(inputArgs) > 0 {
 		args = append(args, inputArgs...)

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -16,6 +16,7 @@ func CommonSSH(username, identityPath, name string, sshPort int, inputArgs []str
 	port := strconv.Itoa(sshPort)
 
 	args := []string{"-i", identityPath, "-p", port, sshDestination,
+		"-o", "IdentitiesOnly=yes",
 		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
 	if len(inputArgs) > 0 {
 		args = append(args, inputArgs...)

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1492,7 +1492,10 @@ func (v *MachineVM) SSH(name string, opts machine.SSHOptions) error {
 	sshDestination := username + "@localhost"
 	port := strconv.Itoa(v.Port)
 
-	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination, "-o", "UserKnownHostsFile /dev/null", "-o", "StrictHostKeyChecking no"}
+	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination,
+		"-o", "IdentitiesOnly yes",
+		"-o", "UserKnownHostsFile /dev/null",
+		"-o", "StrictHostKeyChecking no"}
 	if len(opts.Args) > 0 {
 		args = append(args, opts.Args...)
 	} else {


### PR DESCRIPTION
Fix: https://github.com/containers/podman/issues/17403

#### Does this PR introduce a user-facing change?

```release-note
fix machine failed to start with exit status 255
```

Thanks, @chevdor reply: https://github.com/containers/podman/issues/17403#issuecomment-1511363735

I know this solution is not perfect as it does not really solve the problem in a true sense. However, it is the only quick solution for podman in the short term. Additionally, in the current scenario, adding the `IdentitiesOnly=yes` parameter makes logical sense because podman indeed does not need to read configurations from the `~/.ssh/config` file.


/cc @ashley-cui @baude 

[NO NEW TESTS NEEDED]