### PR TITLE
network create --ip-range allow for custom range

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -245,6 +245,23 @@ func parseRoute(routeStr string) (*types.Route, error) {
 }
 
 func parseRange(iprange string) (*types.LeaseRange, error) {
+	split := strings.SplitN(iprange, "-", 2)
+	if len(split) > 1 {
+		// range contains dash so assume form is start-end
+		start := net.ParseIP(split[0])
+		if start == nil {
+			return nil, fmt.Errorf("range start ip %q is not a ip address", split[0])
+		}
+		end := net.ParseIP(split[1])
+		if end == nil {
+			return nil, fmt.Errorf("range end ip %q is not a ip address", split[1])
+		}
+		return &types.LeaseRange{
+			StartIP: start,
+			EndIP:   end,
+		}, nil
+	}
+	// no dash, so assume CIDR is given
 	_, subnet, err := net.ParseCIDR(iprange)
 	if err != nil {
 		return nil, err

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -66,8 +66,9 @@ Restrict external access of this network. Note when using this option, the dnsna
 
 #### **--ip-range**=*range*
 
-Allocate container IP from a range.  The range must be a complete subnet and in CIDR notation.  The *ip-range* option
-must be used with a *subnet* option. Can be specified multiple times.
+Allocate container IP from a range. The range must be a either a complete subnet in CIDR notation or be in
+the `<startIP>-<endIP>` syntax which allows for a more flexible range compared to the CIDR subnet.
+The *ip-range* option must be used with a *subnet* option. Can be specified multiple times.
 The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
 
 #### **--ipam-driver**=*driver*

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -680,7 +680,9 @@ This is equivalent to the Podman `--ipam-driver` option
 
 ### `IPRange=`
 
-Allocate  container  IP  from a range. The range must be a complete subnet and in CIDR notation. The ip-range option must be used with a subnet option.
+Allocate  container  IP  from a range. The range must be a either a complete subnet in CIDR notation or be
+in the `<startIP>-<endIP>` syntax which allows for a more flexible range compared to the CIDR subnet.
+The ip-range option must be used with a subnet option.
 
 This is equivalent to the Podman `--ip-range` option
 


### PR DESCRIPTION
The backend allows for any start/end ip in the subnet. There is no reason to limit the cli to only CIDR subnets. This allows for much more flexibility.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman network create --ip-range` now accepts a new `<startIP>-<endIP>` syntax which allows more flexibility when limiting the ip range that Podman assigns.
```
