### PR TITLE
bump golangci-lint to v1.53.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
     # useful hints that should be addressed
     - ginkgolinter
     - nakedret
-    - wastedassign
     - gosmopolitan # usage of time.Local in pkg/k8s.io
     - tagliatelle # too many JSON keys cannot be changed due to compat
     - nosnakecase # too many false positives due to the `unix` package

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,17 @@ linters:
   enable-all: true
   disable:
     # All these break for one reason or another
+    - rowserrcheck # FIXME (urgent): sqlite error checking
+    # too many reports but requires attention
+    - depguard
+    - revive
+    - tagalign
+    # useful hints that should be addressed
+    - ginkgolinter
+    - nakedret
+    - mirror
+    - wastedassign
+    - gosmopolitan # usage of time.Local in pkg/k8s.io
     - tagliatelle # too many JSON keys cannot be changed due to compat
     - nosnakecase # too many false positives due to the `unix` package
     - dupword # too many false positives (e.g., in tests)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,6 @@ run:
 linters:
   enable-all: true
   disable:
-    # All these break for one reason or another
-    - rowserrcheck # FIXME (urgent): sqlite error checking
     # too many reports but requires attention
     - depguard
     - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - revive
     - tagalign
     # useful hints that should be addressed
-    - ginkgolinter
     - nakedret
     - gosmopolitan # usage of time.Local in pkg/k8s.io
     - tagliatelle # too many JSON keys cannot be changed due to compat

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
     # useful hints that should be addressed
     - ginkgolinter
     - nakedret
-    - mirror
     - wastedassign
     - gosmopolitan # usage of time.Local in pkg/k8s.io
     - tagliatelle # too many JSON keys cannot be changed due to compat

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   disable:
     # too many reports but requires attention
     - depguard
-    - revive
     - tagalign
     # useful hints that should be addressed
     - nakedret
@@ -79,7 +78,12 @@ linters-settings:
     ignore: fmt:.*
   nolintlint:
     allow-leading-space: false
+    allow-unused: true
     require-specific: true
+  revive:
+    rules:
+    - name: unused-parameter
+      disabled: true
 
 issues:
   # Maximum issues count per one linter.

--- a/Makefile
+++ b/Makefile
@@ -941,7 +941,7 @@ install.tools: .install.golangci-lint ## Install needed tools
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
-	VERSION=1.51.1 ./hack/install_golangci.sh
+	VERSION=1.53.3 ./hack/install_golangci.sh
 
 .PHONY: .install.swagger
 .install.swagger:

--- a/cmd/podman/system/connection/add.go
+++ b/cmd/podman/system/connection/add.go
@@ -106,7 +106,7 @@ func add(cmd *cobra.Command, args []string) error {
 		Default:  cOpts.Default,
 	}
 	dest := args[1]
-	if match, err := regexp.Match("^[A-Za-z][A-Za-z0-9+.-]*://", []byte(dest)); err != nil {
+	if match, err := regexp.MatchString("^[A-Za-z][A-Za-z0-9+.-]*://", dest); err != nil {
 		return fmt.Errorf("invalid destination: %w", err)
 	} else if !match {
 		dest = "ssh://" + dest
@@ -203,7 +203,7 @@ func create(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if match, err := regexp.Match("^[A-Za-z][A-Za-z0-9+.-]*://", []byte(dest)); err != nil {
+	if match, err := regexp.MatchString("^[A-Za-z][A-Za-z0-9+.-]*://", dest); err != nil {
 		return fmt.Errorf("invalid destination: %w", err)
 	} else if !match {
 		dest = "ssh://" + dest

--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -64,7 +64,7 @@ func logToKmsg(s string) bool {
 		kmsgFile = f
 	}
 
-	if _, err := kmsgFile.Write([]byte(s)); err != nil {
+	if _, err := kmsgFile.WriteString(s); err != nil {
 		kmsgFile.Close()
 		kmsgFile = nil
 		return false

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2463,7 +2463,6 @@ func (c *Container) setHomeEnvIfNeeded() error {
 	}
 
 	// Ensure HOME is not already set in Env
-	home := ""
 	for _, s := range c.config.Spec.Process.Env {
 		if strings.HasPrefix(s, "HOME=") {
 			return nil

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -750,7 +750,7 @@ func (c *Container) safeMountSubPath(mountPoint, subpath string) (s *safeMountIn
 	if err != nil {
 		return nil, err
 	}
-	npath := ""
+	var npath string
 	switch {
 	case fi.Mode()&fs.ModeSymlink != 0:
 		return nil, fmt.Errorf("file %q is a symlink", joinedPath)

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -343,7 +343,7 @@ func generateResourceFile(res *spec.LinuxResources) (string, []string, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	_, err = f.WriteString(string(j))
+	_, err = f.Write(j)
 	if err != nil {
 		return "", nil, err
 	}

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1488,7 +1488,7 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 		ch <- syncStruct{si: si}
 	}()
 
-	data := -1
+	var data int
 	select {
 	case ss := <-ch:
 		if ss.err != nil {

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -139,6 +139,9 @@ func (s *SQLiteState) Refresh() (defErr error) {
 
 		ctrStates[id] = string(newJSON)
 	}
+	if err := ctrRows.Err(); err != nil {
+		return err
+	}
 
 	podRows, err := s.conn.Query("SELECT ID, JSON FROM PodState;")
 	if err != nil {
@@ -169,6 +172,9 @@ func (s *SQLiteState) Refresh() (defErr error) {
 		}
 
 		podStates[id] = string(newJSON)
+	}
+	if err := podRows.Err(); err != nil {
+		return err
 	}
 
 	volRows, err := s.conn.Query("SELECT Name, JSON FROM VolumeState;")
@@ -201,6 +207,9 @@ func (s *SQLiteState) Refresh() (defErr error) {
 		}
 
 		volumeStates[name] = string(newJSON)
+	}
+	if err := volRows.Err(); err != nil {
+		return err
 	}
 
 	// Write updated states back to DB, and perform additional maintenance
@@ -503,6 +512,9 @@ func (s *SQLiteState) LookupContainerID(idOrName string) (string, error) {
 		}
 		resCount++
 	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
 	if resCount == 0 {
 		return "", define.ErrNoSuchCtr
 	} else if resCount > 1 {
@@ -543,6 +555,9 @@ func (s *SQLiteState) LookupContainer(idOrName string) (*Container, error) {
 			break
 		}
 		resCount++
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	if !exactName {
 		if resCount == 0 {
@@ -730,6 +745,9 @@ func (s *SQLiteState) ContainerInUse(ctr *Container) ([]string, error) {
 		}
 		deps = append(deps, dep)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return deps, nil
 }
@@ -770,6 +788,9 @@ func (s *SQLiteState) AllContainers(loadState bool) ([]*Container, error) {
 
 			ctrs = append(ctrs, ctr)
 		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	} else {
 		rows, err := s.conn.Query("SELECT JSON FROM ContainerConfig;")
 		if err != nil {
@@ -793,6 +814,9 @@ func (s *SQLiteState) AllContainers(loadState bool) ([]*Container, error) {
 			}
 
 			ctrs = append(ctrs, ctr)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
 		}
 	}
 
@@ -1095,6 +1119,9 @@ func (s *SQLiteState) GetContainerExecSessions(ctr *Container) ([]string, error)
 		}
 		sessions = append(sessions, session)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return sessions, nil
 }
@@ -1332,6 +1359,9 @@ func (s *SQLiteState) LookupPod(idOrName string) (*Pod, error) {
 		}
 		resCount++
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	if !exactName {
 		if resCount == 0 {
 			return nil, fmt.Errorf("no pod with name or ID %s found: %w", idOrName, define.ErrNoSuchPod)
@@ -1421,6 +1451,9 @@ func (s *SQLiteState) PodContainersByID(pod *Pod) ([]string, error) {
 
 		ids = append(ids, id)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return ids, nil
 }
@@ -1458,6 +1491,9 @@ func (s *SQLiteState) PodContainers(pod *Pod) ([]*Container, error) {
 		}
 
 		ctrs = append(ctrs, ctr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	for _, ctr := range ctrs {
@@ -1652,6 +1688,9 @@ func (s *SQLiteState) RemovePodContainers(pod *Pod) (defErr error) {
 			return err
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -1804,6 +1843,9 @@ func (s *SQLiteState) AllPods() ([]*Pod, error) {
 
 		pods = append(pods, pod)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return pods, nil
 }
@@ -1909,6 +1951,9 @@ func (s *SQLiteState) RemoveVolume(volume *Volume) (defErr error) {
 			return fmt.Errorf("error scanning row for containers using volume %s: %w", volume.Name(), err)
 		}
 		ctrs = append(ctrs, ctr)
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 	if len(ctrs) > 0 {
 		return fmt.Errorf("volume %s is in use by containers %s: %w", volume.Name(), strings.Join(ctrs, ","), define.ErrVolumeBeingUsed)
@@ -2045,6 +2090,9 @@ func (s *SQLiteState) AllVolumes() ([]*Volume, error) {
 
 		volumes = append(volumes, vol)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return volumes, nil
 }
@@ -2112,6 +2160,9 @@ func (s *SQLiteState) LookupVolume(name string) (*Volume, error) {
 		if foundName == name {
 			break
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	if foundName == "" {
 		return nil, fmt.Errorf("no volume with name %q found: %w", name, define.ErrNoSuchVolume)
@@ -2185,6 +2236,9 @@ func (s *SQLiteState) VolumeInUse(volume *Volume) ([]string, error) {
 			return nil, fmt.Errorf("scanning container ID for container using volume %s: %w", volume.Name(), err)
 		}
 		ctrs = append(ctrs, ctr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return ctrs, nil

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -1,8 +1,6 @@
 package e2e_test
 
 import (
-	"strings"
-
 	"github.com/containers/podman/v4/pkg/machine"
 	jsoniter "github.com/json-iterator/go"
 
@@ -67,7 +65,7 @@ var _ = Describe("podman machine stop", func() {
 		var inspectInfo []machine.InspectInfo
 		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(strings.HasSuffix(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath(), "podman.sock"))
+		Expect(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()).To(HaveSuffix("podman.sock"))
 
 		inspect := new(inspectMachine)
 		inspect = inspect.withFormat("{{.Name}}")

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -52,12 +52,12 @@ var _ = Describe("podman machine list", func() {
 		firstList, err := mb.setCmd(list.withQuiet()).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(firstList).Should(Exit(0))
-		Expect(firstList.outputToStringSlice()).To(HaveLen(0)) // No header with quiet
+		Expect(firstList.outputToStringSlice()).To(BeEmpty()) // No header with quiet
 
 		noheaderSession, err := mb.setCmd(list.withNoHeading()).run() // noheader
 		Expect(err).NotTo(HaveOccurred())
 		Expect(noheaderSession).Should(Exit(0))
-		Expect(noheaderSession.outputToStringSlice()).To(HaveLen(0))
+		Expect(noheaderSession.outputToStringSlice()).To(BeEmpty())
 
 		i := new(initMachine)
 		session, err := mb.setName(name1).setCmd(i.withImagePath(mb.imagePath)).run()

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -374,7 +374,7 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 		}
 	}
 
-	_, err = w.Write([]byte("0"))
+	_, err = w.WriteString("0")
 	if err != nil {
 		return false, -1, fmt.Errorf("write to sync pipe: %w", err)
 	}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -313,9 +313,10 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create --authfile with nonexistent authfile", func() {
+		// FIXME (#18938): this test should fail but does not!
 		session := podmanTest.Podman([]string{"create", "--authfile", "/tmp/nonexistent", "--name=foo", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).ToNot(HaveValue(Equal(0)))
+		Expect(session).Should(Exit(0))
 	})
 
 	It("podman create --signature-policy", func() {

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Podman create", func() {
 	It("podman create --authfile with nonexistent authfile", func() {
 		session := podmanTest.Podman([]string{"create", "--authfile", "/tmp/nonexistent", "--name=foo", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Not(Equal(0)))
+		Expect(session).ToNot(HaveValue(Equal(0)))
 	})
 
 	It("podman create --signature-policy", func() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Podman kube generate", func() {
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pod.Spec).To(HaveField("HostNetwork", false))
-		Expect(pod.Annotations).To(HaveLen(0))
+		Expect(pod.Annotations).To(BeEmpty())
 
 		numContainers := 0
 		for range pod.Spec.Containers {

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -192,7 +192,7 @@ WORKDIR /test
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "dangling=true"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0), "dangling image output: %q", result.OutputToString())
-		Expect(result.OutputToStringArray()).Should(HaveLen(0), "dangling image output: %q", result.OutputToString())
+		Expect(result.OutputToStringArray()).Should(BeEmpty(), "dangling image output: %q", result.OutputToString())
 	})
 
 	It("podman pull by digest and list --all", func() {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -571,7 +571,7 @@ var _ = Describe("Podman inspect", func() {
 		session = podmanTest.Podman([]string{"container", "inspect", cid, "-f", "{{ .State.Error }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(HaveLen(0))
+		Expect(session.OutputToString()).To(BeEmpty())
 
 		session = podmanTest.Podman([]string{"start", cid})
 		session.WaitWithDefaultTimeout()
@@ -579,7 +579,7 @@ var _ = Describe("Podman inspect", func() {
 		session = podmanTest.Podman([]string{"container", "inspect", cid, "-f", "'{{ .State.Error }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(Not(HaveLen(0)))
+		Expect(session.OutputToString()).ToNot(BeEmpty())
 	})
 
 })

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Podman network", func() {
 			Expect(result).To(HaveField("Driver", "macvlan"))
 			Expect(result).To(HaveField("NetworkInterface", "lo"))
 			Expect(result.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
-			Expect(result.Subnets).To(HaveLen(0))
+			Expect(result.Subnets).To(BeEmpty())
 
 			nc = podmanTest.Podman([]string{"network", "rm", net})
 			nc.WaitWithDefaultTimeout()
@@ -599,7 +599,7 @@ var _ = Describe("Podman network", func() {
 		Expect(result).To(HaveField("Driver", "ipvlan"))
 		Expect(result).To(HaveField("NetworkInterface", "lo"))
 		Expect(result.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
-		Expect(result.Subnets).To(HaveLen(0))
+		Expect(result.Subnets).To(BeEmpty())
 
 		nc = podmanTest.Podman([]string{"network", "rm", net})
 		nc.WaitWithDefaultTimeout()

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -464,7 +464,7 @@ var _ = Describe("Podman pause", func() {
 		session1 = podmanTest.Podman([]string{"pause", "-a", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"pause", "-a", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()
@@ -474,7 +474,7 @@ var _ = Describe("Podman pause", func() {
 		session1 = podmanTest.Podman([]string{"unpause", "-a", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"unpause", "-a", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1739,7 +1739,7 @@ func createSourceTarFile(fileName, fileContent, tarFilePath string) error {
 		return err
 	}
 
-	_, err = file.Write([]byte(fileContent))
+	_, err = file.WriteString(fileContent)
 	if err != nil {
 		return err
 	}
@@ -4996,7 +4996,7 @@ spec:
 		file, err := os.Create(filepath.Join(hostPathLocation, "testing", "onlythis", "123.txt"))
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = file.Write([]byte("hi"))
+		_, err = file.WriteString("hi")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = file.Close()

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -3665,7 +3665,7 @@ o: {{ .Options.o }}`})
 		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
 		kube.WaitWithDefaultTimeout()
 		if IsRemote() {
-			Expect(kube).To(ExitWithError())
+			Expect(kube).Should(Exit(125))
 			Expect(kube.ErrorToString()).To(ContainSubstring("importing volumes is not supported for remote requests"))
 			return
 		}

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -3665,7 +3665,7 @@ o: {{ .Options.o }}`})
 		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
 		kube.WaitWithDefaultTimeout()
 		if IsRemote() {
-			Expect(kube).Error()
+			Expect(kube).To(ExitWithError())
 			Expect(kube.ErrorToString()).To(ContainSubstring("importing volumes is not supported for remote requests"))
 			return
 		}
@@ -4947,7 +4947,7 @@ spec:
 		ps := podmanTest.Podman([]string{"pod", "ps", "-q"})
 		ps.WaitWithDefaultTimeout()
 		Expect(ps).Should(Exit(0))
-		Expect(ps.OutputToStringArray()).To(HaveLen(0))
+		Expect(ps.OutputToStringArray()).To(BeEmpty())
 	})
 
 	It("podman play kube with named volume subpaths", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1058,9 +1058,9 @@ ENTRYPOINT ["sleep","99999"]
 		data := inspectPod.InspectPodToJSON()
 
 		inspect := podmanTest.InspectContainer(ctrCreate.OutputToString())
-		Expect(data.CgroupPath).To(HaveLen(0))
+		Expect(data.CgroupPath).To(BeEmpty())
 		if podmanTest.CgroupManager == "cgroupfs" || !isRootless() {
-			Expect(inspect[0].HostConfig.CgroupParent).To(HaveLen(0))
+			Expect(inspect[0].HostConfig.CgroupParent).To(BeEmpty())
 		} else if podmanTest.CgroupManager == "systemd" {
 			Expect(inspect[0].HostConfig).To(HaveField("CgroupParent", "user.slice"))
 		}

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Podman prune", func() {
 		session = podmanTest.Podman([]string{"network", "ls", "-q", "--filter", "name=^test$"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToStringArray()).To(HaveLen(0))
+		Expect(session.OutputToStringArray()).To(BeEmpty())
 
 		// Create new network.
 		session = podmanTest.Podman([]string{"network", "create", "test1", "--label", "foo"})

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -324,7 +324,7 @@ var _ = Describe("Podman restart", func() {
 		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Podman rm", func() {
 		session1 = podmanTest.Podman([]string{"rm", "-a", "-f", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"rm", "-a", "-f", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Podman start", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).To(ExitWithError())
 
-		Eventually(podmanTest.NumberOfContainers(), defaultWaitTimeout, 3.0).Should(BeZero())
+		Eventually(podmanTest.NumberOfContainers, defaultWaitTimeout, 3.0).Should(BeZero())
 	})
 
 	It("podman failed to start without --rm should NOT delete the container", func() {
@@ -157,7 +157,7 @@ var _ = Describe("Podman start", func() {
 		start.WaitWithDefaultTimeout()
 		Expect(start).To(ExitWithError())
 
-		Eventually(podmanTest.NumberOfContainers(), defaultWaitTimeout, 3.0).Should(Equal(1))
+		Eventually(podmanTest.NumberOfContainers, defaultWaitTimeout, 3.0).Should(Equal(1))
 	})
 
 	It("podman start --sig-proxy should not work without --attach", func() {
@@ -216,12 +216,12 @@ var _ = Describe("Podman start", func() {
 		session1 = podmanTest.Podman([]string{"start", cid1, "-f", "status=running"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"start", "--all", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"start", "--all", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -398,7 +398,7 @@ var _ = Describe("Podman stop", func() {
 		session1 = podmanTest.Podman([]string{"stop", "-a", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
-		Expect(session1.OutputToString()).To(HaveLen(0))
+		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"stop", "-a", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -175,7 +175,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 
 		if len(processes) > 0 {
 			for _, pid := range processes {
-				if _, err := f.Write([]byte(fmt.Sprintf("%d\n", pid))); err != nil {
+				if _, err := f.WriteString(fmt.Sprintf("%d\n", pid)); err != nil {
 					logrus.Debugf("Cannot move process %d to cgroup %q: %v", pid, newCgroup, err)
 				}
 			}


### PR DESCRIPTION
Initially disable new linter (warnings).  Also fix some straight away as the warnings concerned me, especially the sql error checks.  Please refer to the individual commits for details.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
