### PR TITLE
fix(machine): throw error `connection refused` after set proxy

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/sirupsen/logrus"
@@ -613,7 +614,14 @@ func GetProxyVariables() map[string]string {
 	proxyOpts := make(map[string]string)
 	for _, variable := range config.ProxyEnv {
 		if value, ok := os.LookupEnv(variable); ok {
-			proxyOpts[variable] = value
+			if value == "" {
+				continue
+			}
+
+			// TODO: use constants for host.containers.internal
+			v := strings.ReplaceAll(value, "127.0.0.1", "host.containers.internal")
+			v = strings.ReplaceAll(v, "localhost", "host.containers.internal")
+			proxyOpts[variable] = v
 		}
 	}
 	return proxyOpts


### PR DESCRIPTION
When the `machine start` command is executed, Podman automatically retrieves the current host's `*_PROXY` environment variable and assigns it directly to the virtual machine in QEMU. However, most `*_PROXY` variables are set with `127.0.0.1` or `localhost`, such as `127.0.0.1:8888`. This causes failures in network-related operations within the virtual machine due to incorrect proxy settings.


#### Does this PR introduce a user-facing change?

```release-note
Fix a bug proxy IP did not get properly translated when executing `machine start`
```

/cc @Luap99 