### PR TITLE
compat API create/pull/push: fix error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/crc-org/vfkit v0.0.5-0.20230602131541-3d57f09010c9
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11
 	github.com/docker/go-plugins-helpers v0.0.0-20211224144127-6eecb7beb651
@@ -90,7 +91,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/digitalocean/go-libvirt v0.0.0-20220804181439-8648fbde413e // indirect
 	github.com/disiqueira/gotree/v3 v3.0.2 // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsouza/go-dockerclient v1.9.7 // indirect

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -72,6 +72,7 @@ t POST "images/create?fromSrc=-&repo=myimage&tag=mytag" - 200
 t GET "images/myimage:mytag/json" 200 \
   .Id~'^sha256:[0-9a-f]\{64\}$' \
   .RepoTags[0]="docker.io/library/myimage:mytag"
+t POST /images/create?fromImage=busybox:invalidtag123 404
 
 # Display the image history
 t GET libpod/images/nonesuch/history 404

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -25,7 +25,7 @@ t GET libpod/images/$IMAGE/json 200 \
   .RepoTags[1]=localhost:$REGISTRY_PORT/myrepo:mytag
 
 # Push to local registry...
-t POST "images/localhost:$REGISTRY_PORT/myrepo/push?tag=mytag" 200 \
+t POST "/v1.40/images/localhost:$REGISTRY_PORT/myrepo/push?tag=mytag" 500 \
   .error~".*x509: certificate signed by unknown authority"
 t POST "images/localhost:$REGISTRY_PORT/myrepo/push?tlsVerify=false&tag=mytag" 200 \
   .error~null

--- a/test/apiv2/70-short-names.at
+++ b/test/apiv2/70-short-names.at
@@ -82,10 +82,9 @@ t DELETE "images/foo"                                200
 
 ########## PUSH
 
-t POST   "images/alpine/push?destination=localhost:9999/do:exist"                    200
-t POST   "images/quay.io/libpod/alpine/push?destination=localhost:9999/do/not:exist" 200 # Error is in the response
+t POST   "images/quay.io/libpod/alpine/push?destination=localhost:9999/do/not:exist" 500
 t POST   "images/quay.io/libpod/alpine/tag?repo=foo"                                 201
-t POST   "images/foo/push?destination=localhost:9999/do/not:exist"                   200 # Error is in the response
+t POST   "images/foo/push?destination=localhost:9999/do/not:exist"                   500
 t DELETE "images/foo"                                                                200
 
 
@@ -125,7 +124,7 @@ t POST   "images/alpine/tag?repo=foo"                                 201
 t GET    "images/localhost/foo:latest/get"                            200
 t DELETE "images/foo"                                                 200
 t GET    "images/alpine/history"                                      200
-t POST   "images/alpine/push?destination=localhost:9999/do/not:exist" 200 # Error is in the response
+t POST   "images/alpine/push?destination=localhost:9999/do/not:exist" 500
 t POST   "containers/create" Image=alpine                             201
 cid=$(jq -r '.Id' <<<"$output")
 t POST   "commit?container=$cid&repo=foo&tag=tag"                     201


### PR DESCRIPTION
Please refer to the individual commits for details.  I am sure there are more such cases scattered across the compat and libpod API.  For now, I focus on reported issues to get the fixes out in time with the upcoming 4.6 release.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix error handling in the Docker-compat API when pulling and pushing images.
```
