### PR TITLE
refactor(machine): remove hard code

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/common/pkg/config"
 	"github.com/sirupsen/logrus"
 )
@@ -618,9 +619,8 @@ func GetProxyVariables() map[string]string {
 				continue
 			}
 
-			// TODO: use constants for host.containers.internal
-			v := strings.ReplaceAll(value, "127.0.0.1", "host.containers.internal")
-			v = strings.ReplaceAll(v, "localhost", "host.containers.internal")
+			v := strings.ReplaceAll(value, "127.0.0.1", etchosts.HostContainersInternal)
+			v = strings.ReplaceAll(v, "localhost", etchosts.HostContainersInternal)
 			proxyOpts[variable] = v
 		}
 	}

--- a/pkg/machine/qemu/machine_test.go
+++ b/pkg/machine/qemu/machine_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,11 +56,11 @@ func TestPropagateHostEnv(t *testing.T) {
 		},
 		"http_proxy": {
 			"127.0.0.1:8888",
-			"host.containers.internal:8888",
+			fmt.Sprintf("%s:8888", etchosts.HostContainersInternal),
 		},
 		"https_proxy": {
 			"localhost:8888",
-			"host.containers.internal:8888",
+			fmt.Sprintf("%s:8888", etchosts.HostContainersInternal),
 		},
 		"SSL_CERT_FILE": {
 			"/some/f=oo.cert",


### PR DESCRIPTION
Use exported variables instead of hard-coded strings.

Ref: https://github.com/containers/common/pull/1516

#### Does this PR introduce a user-facing change?

```release-note
None
```

/cc @vrothberg @Luap99 
