### PR TITLE
compat API container create: handle platform parameter

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -624,3 +624,14 @@ fi
 rm -rf $TMPD
 
 podman container rm -fa
+
+# 18951: Make sure container create supports the platform parameter.  Force an
+# initial architecture to make sure the test runs on all platforms.
+podman pull --platform=linux/amd64 $IMAGE
+t POST containers/create?platform=linux/amd64 \
+  Image=$IMAGE \
+  201
+t POST containers/create?platform=linux/aarch64 \
+  Image=$IMAGE \
+  404
+podman rmi -f $IMAGE


### PR DESCRIPTION
The platform parameter has been ignored such that images have been looked up by name only.

Fixes: #18951

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support the `platform` parameter in the compat API for container creation.
```