### PR TITLE
libpod: write /etc/{hosts,resolv.conf} once

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1819,17 +1819,17 @@ func (c *Container) makeBindMounts() error {
 		// will recreate. Only do this if we aren't sharing them with
 		// another container.
 		if c.config.NetNsCtr == "" {
-			if resolvePath, ok := c.state.BindMounts["/etc/resolv.conf"]; ok {
+			if resolvePath, ok := c.state.BindMounts[resolvconf.DefaultResolvConf]; ok {
 				if err := os.Remove(resolvePath); err != nil && !os.IsNotExist(err) {
 					return fmt.Errorf("container %s: %w", c.ID(), err)
 				}
-				delete(c.state.BindMounts, "/etc/resolv.conf")
+				delete(c.state.BindMounts, resolvconf.DefaultResolvConf)
 			}
-			if hostsPath, ok := c.state.BindMounts["/etc/hosts"]; ok {
+			if hostsPath, ok := c.state.BindMounts[config.DefaultHostsFile]; ok {
 				if err := os.Remove(hostsPath); err != nil && !os.IsNotExist(err) {
 					return fmt.Errorf("container %s: %w", c.ID(), err)
 				}
-				delete(c.state.BindMounts, "/etc/hosts")
+				delete(c.state.BindMounts, config.DefaultHostsFile)
 			}
 		}
 
@@ -1851,9 +1851,9 @@ func (c *Container) makeBindMounts() error {
 
 			// The other container may not have a resolv.conf or /etc/hosts
 			// If it doesn't, don't copy them
-			resolvPath, exists := bindMounts["/etc/resolv.conf"]
+			resolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]
 			if !c.config.UseImageResolvConf && exists {
-				err := c.mountIntoRootDirs("/etc/resolv.conf", resolvPath)
+				err := c.mountIntoRootDirs(resolvconf.DefaultResolvConf, resolvPath)
 
 				if err != nil {
 					return fmt.Errorf("assigning mounts to container %s: %w", c.ID(), err)
@@ -1896,31 +1896,31 @@ func (c *Container) makeBindMounts() error {
 			}
 		} else {
 			if !c.config.UseImageResolvConf {
-				if err := c.generateResolvConf(); err != nil {
+				if err := c.createResolvConf(); err != nil {
 					return fmt.Errorf("creating resolv.conf for container %s: %w", c.ID(), err)
 				}
 			}
 
 			if !c.config.UseImageHosts {
-				if err := c.createHosts(); err != nil {
+				if err := c.createHostsFile(); err != nil {
 					return fmt.Errorf("creating hosts file for container %s: %w", c.ID(), err)
 				}
 			}
 		}
 
-		if c.state.BindMounts["/etc/hosts"] != "" {
-			if err := c.relabel(c.state.BindMounts["/etc/hosts"], c.config.MountLabel, true); err != nil {
+		if c.state.BindMounts[config.DefaultHostsFile] != "" {
+			if err := c.relabel(c.state.BindMounts[config.DefaultHostsFile], c.config.MountLabel, true); err != nil {
 				return err
 			}
 		}
 
-		if c.state.BindMounts["/etc/resolv.conf"] != "" {
-			if err := c.relabel(c.state.BindMounts["/etc/resolv.conf"], c.config.MountLabel, true); err != nil {
+		if c.state.BindMounts[resolvconf.DefaultResolvConf] != "" {
+			if err := c.relabel(c.state.BindMounts[resolvconf.DefaultResolvConf], c.config.MountLabel, true); err != nil {
 				return err
 			}
 		}
-	} else if !c.config.UseImageHosts && c.state.BindMounts["/etc/hosts"] == "" {
-		if err := c.createHosts(); err != nil {
+	} else if !c.config.UseImageHosts && c.state.BindMounts[config.DefaultHostsFile] == "" {
+		if err := c.createHostsFile(); err != nil {
 			return fmt.Errorf("creating hosts file for container %s: %w", c.ID(), err)
 		}
 	}
@@ -2028,8 +2028,25 @@ rootless=%d
 	return c.makePlatformBindMounts()
 }
 
-// generateResolvConf generates a containers resolv.conf
-func (c *Container) generateResolvConf() error {
+// createResolvConf create the resolv.conf file and bind mount it
+func (c *Container) createResolvConf() error {
+	destPath := filepath.Join(c.state.RunDir, "resolv.conf")
+	f, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	f.Close()
+	return c.bindMountRootFile(destPath, resolvconf.DefaultResolvConf)
+}
+
+// addResolvConf add resolv.conf entries
+func (c *Container) addResolvConf() error {
+	destPath, ok := c.state.BindMounts[resolvconf.DefaultResolvConf]
+	if !ok {
+		// no resolv.conf mount, do nothing
+		return nil
+	}
+
 	var (
 		networkNameServers   []string
 		networkSearchDomains []string
@@ -2082,11 +2099,7 @@ func (c *Container) generateResolvConf() error {
 		nameservers = networkNameServers
 
 		// slirp4netns has a built in DNS forwarder.
-		// If in userns the network is not setup here, instead we need to do that in
-		// c.completeNetworkSetup() which knows the actual slirp dns ip only at that point
-		if !c.config.PostConfigureNetNS {
-			nameservers = c.addSlirp4netnsDNS(nameservers)
-		}
+		nameservers = c.addSlirp4netnsDNS(nameservers)
 	}
 
 	// Set DNS search domains
@@ -2102,8 +2115,6 @@ func (c *Container) generateResolvConf() error {
 	options := make([]string, 0, len(c.config.DNSOption)+len(c.runtime.config.Containers.DNSOptions))
 	options = append(options, c.runtime.config.Containers.DNSOptions...)
 	options = append(options, c.config.DNSOption...)
-
-	destPath := filepath.Join(c.state.RunDir, "resolv.conf")
 
 	var namespaces []spec.LinuxNamespace
 	if c.config.Spec.Linux != nil {
@@ -2122,7 +2133,7 @@ func (c *Container) generateResolvConf() error {
 		return fmt.Errorf("building resolv.conf for container %s: %w", c.ID(), err)
 	}
 
-	return c.bindMountRootFile(destPath, resolvconf.DefaultResolvConf)
+	return nil
 }
 
 // Check if a container uses IPv6.
@@ -2209,36 +2220,38 @@ func (c *Container) getHostsEntries() (etchosts.HostEntries, error) {
 	return entries, nil
 }
 
-func (c *Container) createHosts() error {
-	var containerIPsEntries etchosts.HostEntries
-	var err error
-	// if we configure the netns after the container create we should not add
-	// the hosts here since we have no information about the actual ips
-	// instead we will add them in c.completeNetworkSetup()
-	if !c.config.PostConfigureNetNS {
-		containerIPsEntries, err = c.getHostsEntries()
-		if err != nil {
-			return fmt.Errorf("failed to get container ip host entries: %w", err)
-		}
+func (c *Container) createHostsFile() error {
+	targetFile := filepath.Join(c.state.RunDir, "hosts")
+	f, err := os.Create(targetFile)
+	if err != nil {
+		return err
+	}
+	f.Close()
+	return c.bindMountRootFile(targetFile, config.DefaultHostsFile)
+}
+
+func (c *Container) addHosts() error {
+	targetFile, ok := c.state.BindMounts[config.DefaultHostsFile]
+	if !ok {
+		// no host file nothing to do
+		return nil
+	}
+	containerIPsEntries, err := c.getHostsEntries()
+	if err != nil {
+		return fmt.Errorf("failed to get container ip host entries: %w", err)
 	}
 	baseHostFile, err := etchosts.GetBaseHostFile(c.runtime.config.Containers.BaseHostsFile, c.state.Mountpoint)
 	if err != nil {
 		return err
 	}
 
-	targetFile := filepath.Join(c.state.RunDir, "hosts")
-	err = etchosts.New(&etchosts.Params{
+	return etchosts.New(&etchosts.Params{
 		BaseFile:                 baseHostFile,
 		ExtraHosts:               c.config.HostAdd,
 		ContainerIPs:             containerIPsEntries,
 		HostContainersInternalIP: etchosts.GetHostContainersInternalIP(c.runtime.config, c.state.NetworkStatus, c.runtime.network),
 		TargetFile:               targetFile,
 	})
-	if err != nil {
-		return err
-	}
-
-	return c.bindMountRootFile(targetFile, config.DefaultHostsFile)
 }
 
 // bindMountRootFile will chown and relabel the source file to make it usable in the container.


### PR DESCRIPTION
My PR[1] to remove PostConfigureNetNS is blocked on other things I want to split this change out. It reduces the complexity when generating /etc/hosts and /etc/resolv.conf as now we always write this file after we setup the network. this means we can get the actual ip from the netns which is important.

[NO NEW TESTS NEEDED] This is just a rework.

[1] https://github.com/containers/podman/pull/18468

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
