### PR TITLE
[CI:BUILD] Help Renovate manage the golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ BUILDTAGS ?= \
 	$(shell hack/libsubid_tag.sh) \
 	exclude_graphdriver_devicemapper \
 	seccomp
+# N/B: This value is managed by Renovate, manual changes are
+# possible, as long as they don't disturb the formatting
+# (i.e. DO NOT ADD A 'v' prefix!)
+GOLANGCI_LINT_VERSION := 1.53.3
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems
@@ -941,7 +945,7 @@ install.tools: .install.golangci-lint ## Install needed tools
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
-	VERSION=1.53.3 ./hack/install_golangci.sh
+	VERSION=$(GOLANGCI_LINT_VERSION) ./hack/install_golangci.sh
 
 .PHONY: .install.swagger
 .install.swagger:


### PR DESCRIPTION
It's a bit cumbersome to manage a tooling version buried deep in a command, let alone one also buried deep in a `Makefile`.  Add a variable to hold the version number so renovate can easily manage it. This happens via a `regex` manager in the shared configuration include `containers/automation//renovate/defaults.json5`.  Also add a helpful note/reminder to humans who may want to manually change the version for some reason.

Depends on: https://github.com/containers/automation/pull/145

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
