### PR TITLE
e2e: use parallel-safe /dev subdirectories

### DIFF
--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -876,15 +876,17 @@ ENTRYPOINT ["sleep","99999"]
 
 	It("podman pod create --device", func() {
 		SkipIfRootless("Cannot create devices in /dev in rootless mode")
-		Expect(os.MkdirAll("/dev/foodevdir", os.ModePerm)).To(Succeed())
-		defer os.RemoveAll("/dev/foodevdir")
+		// path must be unique to this test, not used anywhere else
+		devdir := "/dev/devdirpodcreate"
+		Expect(os.MkdirAll(devdir, os.ModePerm)).To(Succeed())
+		defer os.RemoveAll(devdir)
 
-		mknod := SystemExec("mknod", []string{"/dev/foodevdir/null", "c", "1", "3"})
+		mknod := SystemExec("mknod", []string{devdir + "/null", "c", "1", "3"})
 		mknod.WaitWithDefaultTimeout()
 		Expect(mknod).Should(Exit(0))
 
 		podName := "testPod"
-		session := podmanTest.Podman([]string{"pod", "create", "--device", "/dev/foodevdir:/dev/bar", "--name", podName})
+		session := podmanTest.Podman([]string{"pod", "create", "--device", devdir + ":/dev/bar", "--name", podName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		session = podmanTest.Podman([]string{"run", "-q", "--pod", podName, ALPINE, "stat", "-c%t:%T", "/dev/bar/null"})

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -72,14 +72,16 @@ var _ = Describe("Podman run device", func() {
 
 	It("podman run device host device and container device parameter are directories", func() {
 		SkipIfRootless("Cannot create devices in /dev in rootless mode")
-		Expect(os.MkdirAll("/dev/foodevdir", os.ModePerm)).To(Succeed())
-		defer os.RemoveAll("/dev/foodevdir")
+		// path must be unique to this test, not used anywhere else
+		devdir := "/dev/devdirrundevice"
+		Expect(os.MkdirAll(devdir, os.ModePerm)).To(Succeed())
+		defer os.RemoveAll(devdir)
 
-		mknod := SystemExec("mknod", []string{"/dev/foodevdir/null", "c", "1", "3"})
+		mknod := SystemExec("mknod", []string{devdir + "/null", "c", "1", "3"})
 		mknod.WaitWithDefaultTimeout()
 		Expect(mknod).Should(Exit(0))
 
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/foodevdir:/dev/bar", ALPINE, "stat", "-c%t:%T", "/dev/bar/null"})
+		session := podmanTest.Podman([]string{"run", "-q", "--device", devdir + ":/dev/bar", ALPINE, "stat", "-c%t:%T", "/dev/bar/null"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Equal("1:3"))


### PR DESCRIPTION
Replace /dev/foodevdir with unique paths, to avoid one
test's RemoveAll() from stepping on another test.

Closes: #18958

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```