### PR TITLE
podman wait: support healthy/unhealthy

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1474,7 +1474,9 @@ func AutocompleteImageSaveFormat(cmd *cobra.Command, args []string, toComplete s
 // AutocompleteWaitCondition - Autocomplete wait condition options.
 // -> "unknown", "configured", "created", "running", "stopped", "paused", "exited", "removing"
 func AutocompleteWaitCondition(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	states := []string{"unknown", "configured", "created", "running", "stopped", "paused", "exited", "removing"}
+	states := []string{"unknown", "configured", "created", "exited",
+		"healthy", "initialized", "paused", "removing", "running",
+		"stopped", "stopping", "unhealthy"}
 	return states, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -185,15 +185,11 @@ func execWait(ctr string, seconds int32) error {
 	ctx, cancel := context.WithTimeout(registry.Context(), maxDuration)
 	defer cancel()
 
-	cond, err := define.StringToContainerStatus("running")
-	if err != nil {
-		return err
-	}
-	waitOptions.Condition = append(waitOptions.Condition, cond)
+	waitOptions.Conditions = []string{define.ContainerStateRunning.String()}
 
 	startTime := time.Now()
 	for time.Since(startTime) < maxDuration {
-		_, err = registry.ContainerEngine().ContainerWait(ctx, []string{ctr}, waitOptions)
+		_, err := registry.ContainerEngine().ContainerWait(ctx, []string{ctr}, waitOptions)
 		if err == nil {
 			return nil
 		}

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/cmd/podman/validate"
-	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
@@ -41,9 +40,8 @@ var (
 )
 
 var (
-	waitOptions    = entities.WaitOptions{}
-	waitConditions []string
-	waitInterval   string
+	waitOptions  = entities.WaitOptions{}
+	waitInterval string
 )
 
 func waitFlags(cmd *cobra.Command) {
@@ -56,7 +54,7 @@ func waitFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&waitOptions.Ignore, "ignore", "", false, "Ignore if a container does not exist")
 
 	conditionFlagName := "condition"
-	flags.StringSliceVar(&waitConditions, conditionFlagName, []string{}, "Condition to wait on")
+	flags.StringSliceVar(&waitOptions.Conditions, conditionFlagName, []string{}, "Condition to wait on")
 	_ = cmd.RegisterFlagCompletionFunc(conditionFlagName, common.AutocompleteWaitCondition)
 }
 
@@ -93,14 +91,6 @@ func wait(cmd *cobra.Command, args []string) error {
 	}
 	if waitOptions.Latest && len(args) > 0 {
 		return errors.New("--latest and containers cannot be used together")
-	}
-
-	for _, condition := range waitConditions {
-		cond, err := define.StringToContainerStatus(condition)
-		if err != nil {
-			return err
-		}
-		waitOptions.Condition = append(waitOptions.Condition, cond)
 	}
 
 	responses, err := registry.ContainerEngine().ContainerWait(context.Background(), args, waitOptions)

--- a/docs/source/markdown/podman-wait.1.md.in
+++ b/docs/source/markdown/podman-wait.1.md.in
@@ -11,8 +11,10 @@ podman\-wait - Wait on one or more containers to stop and print their exit codes
 ## DESCRIPTION
 Waits on one or more containers to stop.  The container can be referred to by its
 name or ID.  In the case of multiple containers, Podman waits on each consecutively.
-After all specified containers are stopped, the containers' return codes are printed
-separated by newline in the same order as they were given to the command.
+After all conditions are satisfied, the containers' return codes are printed
+separated by newline in the same order as they were given to the command.  An
+exit code of -1 is emitted for all conditions other than "stopped" and
+"exited".
 
 NOTE: there is an inherent race condition when waiting for containers with a
 restart policy of `always` or `on-failure`, such as those created by `podman
@@ -22,7 +24,7 @@ with different exit codes, but `podman wait` can only display and detect one.
 ## OPTIONS
 
 #### **--condition**=*state*
-Condition to wait on (default "stopped")
+Container state or condition to wait for.  Can be specified multiple times where at least one condition must match for the command to return.  Supported values are "created", "exited", "initialized", "paused", "removing", "running", "stopped",  "stopping".  The default condition is "stopped".
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-wait.1.md.in
+++ b/docs/source/markdown/podman-wait.1.md.in
@@ -24,7 +24,7 @@ with different exit codes, but `podman wait` can only display and detect one.
 ## OPTIONS
 
 #### **--condition**=*state*
-Container state or condition to wait for.  Can be specified multiple times where at least one condition must match for the command to return.  Supported values are "created", "exited", "initialized", "paused", "removing", "running", "stopped",  "stopping".  The default condition is "stopped".
+Container state or condition to wait for.  Can be specified multiple times where at least one condition must match for the command to return.  Supported values are "configured", "created", "exited", "healthy", "initialized", "paused", "removing", "running", "stopped",  "stopping", "unhealthy".  The default condition is "stopped".
 
 #### **--help**, **-h**
 

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -683,7 +683,7 @@ type waitResult struct {
 	err  error
 }
 
-func (c *Container) WaitForConditionWithInterval(ctx context.Context, waitTimeout time.Duration, conditions ...define.ContainerStatus) (int32, error) {
+func (c *Container) WaitForConditionWithInterval(ctx context.Context, waitTimeout time.Duration, conditions ...string) (int32, error) {
 	if !c.valid {
 		return -1, define.ErrCtrRemoved
 	}
@@ -699,7 +699,11 @@ func (c *Container) WaitForConditionWithInterval(ctx context.Context, waitTimeou
 	waitForExit := false
 	wantedStates := make(map[define.ContainerStatus]bool, len(conditions))
 
-	for _, condition := range conditions {
+	for _, rawCondition := range conditions {
+		condition, err := define.StringToContainerStatus(rawCondition)
+		if err != nil {
+			return -1, err
+		}
 		switch condition {
 		case define.ContainerStateExited, define.ContainerStateStopped:
 			waitForExit = true

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -256,8 +256,8 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 		}
 		if sig == 0 || sig == syscall.SIGKILL {
 			opts := entities.WaitOptions{
-				Condition: []define.ContainerStatus{define.ContainerStateExited, define.ContainerStateStopped},
-				Interval:  time.Millisecond * 250,
+				Conditions: []string{define.ContainerStateExited.String(), define.ContainerStateStopped.String()},
+				Interval:   time.Millisecond * 250,
 			}
 			if _, err := containerEngine.ContainerWait(r.Context(), []string{name}, opts); err != nil {
 				utils.Error(w, http.StatusInternalServerError, err)

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -140,9 +140,13 @@ func createContainerWaitFn(ctx context.Context, containerName string, interval t
 	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
 
 	return func(conditions ...define.ContainerStatus) (int32, error) {
+		var rawConditions []string
+		for _, con := range conditions {
+			rawConditions = append(rawConditions, con.String())
+		}
 		opts := entities.WaitOptions{
-			Condition: conditions,
-			Interval:  interval,
+			Conditions: rawConditions,
+			Interval:   interval,
 		}
 		ctrWaitReport, err := containerEngine.ContainerWait(ctx, []string{containerName}, opts)
 		if err != nil {

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1229,12 +1229,15 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//      enum:
 	//       - configured
 	//       - created
+	//       - exited
+	//       - healthy
+	//       - initialized
+	//       - paused
+	//       - removing
 	//       - running
 	//       - stopped
-	//       - paused
-	//       - exited
-	//       - removing
 	//       - stopping
+	//       - unhealthy
 	//    description: "Conditions to wait for. If no condition provided the 'exited' condition is assumed."
 	//  - in: query
 	//    name: interval

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -341,6 +341,8 @@ func Unpause(ctx context.Context, nameOrID string, options *UnpauseOptions) erro
 func Wait(ctx context.Context, nameOrID string, options *WaitOptions) (int32, error) {
 	if options == nil {
 		options = new(WaitOptions)
+	} else if len(options.Condition) > 0 && len(options.Conditions) > 0 {
+		return -1, fmt.Errorf("%q field cannot be used with deprecated %q field", "Conditions", "Condition")
 	}
 	var exitCode int32
 	conn, err := bindings.GetClient(ctx)
@@ -351,6 +353,7 @@ func Wait(ctx context.Context, nameOrID string, options *WaitOptions) (int32, er
 	if err != nil {
 		return exitCode, err
 	}
+	delete(params, "conditions") // They're called "condition"
 	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/wait", params, nil, nameOrID)
 	if err != nil {
 		return exitCode, err

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -229,8 +229,14 @@ type UnpauseOptions struct{}
 //
 //go:generate go run ../generator/generator.go WaitOptions
 type WaitOptions struct {
+	// Conditions to wait on.  Includes container statuses such as
+	// "running" or "stopped" and health-related values such "healthy".
+	Conditions []string `schema:"condition"`
+	// Time interval to wait before polling for completion.
+	Interval *string
+	// Container status to wait on.
+	// Deprecated: use Conditions instead.
 	Condition []define.ContainerStatus
-	Interval  *string
 }
 
 // StopOptions are optional options for stopping containers

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -18,19 +18,19 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
 
-// WithCondition set field Condition to given value
-func (o *WaitOptions) WithCondition(value []define.ContainerStatus) *WaitOptions {
-	o.Condition = value
+// WithConditions set field Conditions to given value
+func (o *WaitOptions) WithConditions(value []string) *WaitOptions {
+	o.Conditions = value
 	return o
 }
 
-// GetCondition returns value of field Condition
-func (o *WaitOptions) GetCondition() []define.ContainerStatus {
-	if o.Condition == nil {
-		var z []define.ContainerStatus
+// GetConditions returns value of field Conditions
+func (o *WaitOptions) GetConditions() []string {
+	if o.Conditions == nil {
+		var z []string
 		return z
 	}
-	return o.Condition
+	return o.Conditions
 }
 
 // WithInterval set field Interval to given value
@@ -46,4 +46,19 @@ func (o *WaitOptions) GetInterval() string {
 		return z
 	}
 	return *o.Interval
+}
+
+// WithCondition set field Condition to given value
+func (o *WaitOptions) WithCondition(value []define.ContainerStatus) *WaitOptions {
+	o.Condition = value
+	return o
+}
+
+// GetCondition returns value of field Condition
+func (o *WaitOptions) GetCondition() []define.ContainerStatus {
+	if o.Condition == nil {
+		var z []define.ContainerStatus
+		return z
+	}
+	return o.Condition
 }

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -49,15 +49,25 @@ type ContainerRunlabelOptions struct {
 // ContainerRunlabelReport contains the results from executing container-runlabel.
 type ContainerRunlabelReport struct{}
 
+// WaitOptions are arguments for waiting for a container.
 type WaitOptions struct {
-	Condition []define.ContainerStatus
-	Interval  time.Duration
-	Ignore    bool
-	Latest    bool
+	// Conditions to wait on.  Includes container statuses such as
+	// "running" or "stopped" and health-related values such "healthy".
+	Conditions []string
+	// Time interval to wait before polling for completion.
+	Interval time.Duration
+	// Ignore errors when a specified container is missing and mark its
+	// return code as -1.
+	Ignore bool
+	// Use the latest created container.
+	Latest bool
 }
 
+// WaitReport is the result of waiting a container.
 type WaitReport struct {
-	Error    error
+	// Error while waiting.
+	Error error
+	// ExitCode of the container.
 	ExitCode int32
 }
 

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -185,10 +185,13 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 		}
 
 		response := entities.WaitReport{}
-		if options.Condition == nil {
-			options.Condition = []define.ContainerStatus{define.ContainerStateStopped, define.ContainerStateExited}
+		var conditions []string
+		if len(options.Conditions) == 0 {
+			conditions = []string{define.ContainerStateStopped.String(), define.ContainerStateExited.String()}
+		} else {
+			conditions = options.Conditions
 		}
-		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition...)
+		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, conditions...)
 		if err != nil {
 			response.Error = err
 		} else {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -38,8 +38,17 @@ func (ic *ContainerEngine) ContainerExists(ctx context.Context, nameOrID string,
 }
 
 func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []string, opts entities.WaitOptions) ([]entities.WaitReport, error) {
+	conditions := make([]define.ContainerStatus, 0, len(opts.Conditions))
+	for _, condition := range opts.Conditions {
+		cond, err := define.StringToContainerStatus(condition)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, cond)
+	}
+
 	responses := make([]entities.WaitReport, 0, len(namesOrIds))
-	options := new(containers.WaitOptions).WithCondition(opts.Condition).WithInterval(opts.Interval.String())
+	options := new(containers.WaitOptions).WithCondition(conditions).WithInterval(opts.Interval.String())
 	for _, n := range namesOrIds {
 		response := entities.WaitReport{}
 		exitCode, err := containers.Wait(ic.ClientCtx, n, options)

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -38,17 +38,8 @@ func (ic *ContainerEngine) ContainerExists(ctx context.Context, nameOrID string,
 }
 
 func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []string, opts entities.WaitOptions) ([]entities.WaitReport, error) {
-	conditions := make([]define.ContainerStatus, 0, len(opts.Conditions))
-	for _, condition := range opts.Conditions {
-		cond, err := define.StringToContainerStatus(condition)
-		if err != nil {
-			return nil, err
-		}
-		conditions = append(conditions, cond)
-	}
-
 	responses := make([]entities.WaitReport, 0, len(namesOrIds))
-	options := new(containers.WaitOptions).WithCondition(conditions).WithInterval(opts.Interval.String())
+	options := new(containers.WaitOptions).WithConditions(opts.Conditions).WithInterval(opts.Interval.String())
 	for _, n := range namesOrIds {
 		response := entities.WaitReport{}
 		exitCode, err := containers.Wait(ic.ClientCtx, n, options)


### PR DESCRIPTION
Broken into 3 commits as it required some massaging in the backend.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support `--condition={healthy,unhealthy}` in `podman wait` allowing to wait to wait for successful health checks.
```
