### PR TITLE
Kube quadlets can support autoupdate as well as containers

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -517,16 +517,27 @@ There is only one required key, `Yaml`, which defines the path to the Kubernetes
 Valid options for `[Kube]` are listed below:
 
 | **[Kube] options**                  | **podman kube play equivalent**             |
-| ----------------------------------- | ------------------------------------------- |
-| ConfigMap=/tmp/config.map           | --config-map /tmp/config.map                |
-| LogDriver=journald                  | --log-driver journald                       |
-| Network=host                        | --net host                                  |
-| PodmanArgs=\-\-annotation=key=value | --annotation=key=value                      |
-| PublishPort=59-60                   | --publish=59-60                             |
-| UserNS=keep-id:uid=200,gid=210      | --userns keep-id:uid=200,gid=210            |
-| Yaml=/tmp/kube.yaml                 | podman kube play /tmp/kube.yaml             |
+| ----------------------------------- | ------------------------------------------------ |
+| AutoUpdate=registry                 | --annotation "io.containers.autoupdate=registry" |
+| ConfigMap=/tmp/config.map           | --config-map /tmp/config.map                     |
+| LogDriver=journald                  | --log-driver journald                            |
+| Network=host                        | --net host                                       |
+| PodmanArgs=\-\-annotation=key=value | --annotation=key=value                           |
+| PublishPort=59-60                   | --publish=59-60                                  |
+| UserNS=keep-id:uid=200,gid=210      | --userns keep-id:uid=200,gid=210                 |
+| Yaml=/tmp/kube.yaml                 | podman kube play /tmp/kube.yaml                  |
 
 Supported keys in the `[Kube]` section are:
+
+### `AutoUpdate=`
+
+Indicates whether containers will be auto-updated ([podman-auto-update(1)](podman-auto-update.1.md)). AutoUpdate can be specified multiple times. The following values are supported:
+
+* `registry`: Requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container. This enforcement is necessary to know which images to actually check and pull. If an image ID was used, Podman does not know which image to check/pull anymore.
+
+* `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the Kubernetes quadlet.
+
+* `name/(local|registry)`: Tells Podman to preform the `local` or `registry` autoupdate on the specified container name.
 
 ### `ConfigMap=`
 

--- a/test/e2e/quadlet/autoupdate.kube
+++ b/test/e2e/quadlet/autoupdate.kube
@@ -1,0 +1,7 @@
+## assert-podman-args "--annotation" "io.containers.autoupdate=registry"
+## assert-podman-args "--annotation" "io.containers.autoupdate/foobarx=local"
+
+[Kube]
+Yaml=deployment.yml
+AutoUpdate=registry
+AutoUpdate=foobar/local


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Kubernetes quadlets now supports auto update.
```
