### PR TITLE
Re-organize hypervisor implementations

### DIFF
--- a/cmd/podman/machine/platform.go
+++ b/cmd/podman/machine/platform.go
@@ -29,7 +29,7 @@ func GetSystemProvider() (machine.VirtProvider, error) {
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
 	case machine.QemuVirt:
-		return qemu.GetVirtualizationProvider(), nil
+		return qemu.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}

--- a/cmd/podman/machine/platform_darwin.go
+++ b/cmd/podman/machine/platform_darwin.go
@@ -30,9 +30,9 @@ func GetSystemProvider() (machine.VirtProvider, error) {
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
 	case machine.QemuVirt:
-		return qemu.GetVirtualizationProvider(), nil
+		return qemu.VirtualizationProvider(), nil
 	case machine.AppleHvVirt:
-		return applehv.GetVirtualizationProvider(), nil
+		return applehv.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}

--- a/cmd/podman/machine/platform_windows.go
+++ b/cmd/podman/machine/platform_windows.go
@@ -28,9 +28,9 @@ func GetSystemProvider() (machine.VirtProvider, error) {
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
 	case machine.WSLVirt:
-		return wsl.GetWSLProvider(), nil
+		return wsl.VirtualizationProvider(), nil
 	case machine.HyperVVirt:
-		return hyperv.GetVirtualizationProvider(), nil
+		return hyperv.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}

--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -17,10 +17,8 @@ const (
 	defaultVFKitEndpoint = "http://localhost:8081"
 )
 
-type Virtualization struct {
-	artifact    machine.Artifact
-	compression machine.ImageCompression
-	format      machine.ImageFormat
+type AppleHVVirtualization struct {
+	machine.Virtualization
 }
 
 type MMHardwareConfig struct {
@@ -30,11 +28,13 @@ type MMHardwareConfig struct {
 	Memory   int32
 }
 
-func (v Virtualization) Artifact() machine.Artifact {
-	return machine.Metal
+func VirtualizationProvider() machine.VirtProvider {
+	return &AppleHVVirtualization{
+		machine.NewVirtualization(machine.Metal, machine.Xz, machine.Raw),
+	}
 }
 
-func (v Virtualization) CheckExclusiveActiveVM() (bool, string, error) {
+func (v AppleHVVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
 	fsVms, err := getVMInfos()
 	if err != nil {
 		return false, "", err
@@ -48,15 +48,7 @@ func (v Virtualization) CheckExclusiveActiveVM() (bool, string, error) {
 	return false, "", nil
 }
 
-func (v Virtualization) Compression() machine.ImageCompression {
-	return v.compression
-}
-
-func (v Virtualization) Format() machine.ImageFormat {
-	return v.format
-}
-
-func (v Virtualization) IsValidVMName(name string) (bool, error) {
+func (v AppleHVVirtualization) IsValidVMName(name string) (bool, error) {
 	mm := MacMachine{Name: name}
 	configDir, err := machine.GetConfDir(machine.AppleHvVirt)
 	if err != nil {
@@ -68,7 +60,7 @@ func (v Virtualization) IsValidVMName(name string) (bool, error) {
 	return true, nil
 }
 
-func (v Virtualization) List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
+func (v AppleHVVirtualization) List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
 	var (
 		response []*machine.ListResponse
 	)
@@ -108,12 +100,12 @@ func (v Virtualization) List(opts machine.ListOptions) ([]*machine.ListResponse,
 	return response, nil
 }
 
-func (v Virtualization) LoadVMByName(name string) (machine.VM, error) {
+func (v AppleHVVirtualization) LoadVMByName(name string) (machine.VM, error) {
 	m := MacMachine{Name: name}
 	return m.loadFromFile()
 }
 
-func (v Virtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
+func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 	m := MacMachine{Name: opts.Name}
 
 	configDir, err := machine.GetConfDir(machine.AppleHvVirt)
@@ -149,16 +141,16 @@ func (v Virtualization) NewMachine(opts machine.InitOptions) (machine.VM, error)
 	return m.loadFromFile()
 }
 
-func (v Virtualization) RemoveAndCleanMachines() error {
+func (v AppleHVVirtualization) RemoveAndCleanMachines() error {
 	// This can be implemented when host networking is completed.
 	return machine.ErrNotImplemented
 }
 
-func (v Virtualization) VMType() machine.VMType {
+func (v AppleHVVirtualization) VMType() machine.VMType {
 	return vmtype
 }
 
-func (v Virtualization) loadFromLocalJson() ([]*MacMachine, error) {
+func (v AppleHVVirtualization) loadFromLocalJson() ([]*MacMachine, error) {
 	var (
 		jsonFiles []string
 		mms       []*MacMachine

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -27,14 +27,6 @@ var (
 	vmtype = machine.AppleHvVirt
 )
 
-func GetVirtualizationProvider() machine.VirtProvider {
-	return &Virtualization{
-		artifact:    machine.None,
-		compression: machine.Xz,
-		format:      machine.Raw,
-	}
-}
-
 // VfkitHelper describes the use of vfkit: cmdline and endpoint
 type VfkitHelper struct {
 	Bootloader        string

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -48,19 +48,6 @@ const (
 	DefaultMachineName string = "podman-machine-default"
 )
 
-type VirtProvider interface {
-	Artifact() Artifact
-	CheckExclusiveActiveVM() (bool, string, error)
-	Compression() ImageCompression
-	Format() ImageFormat
-	IsValidVMName(name string) (bool, error)
-	List(opts ListOptions) ([]*ListResponse, error)
-	LoadVMByName(name string) (VM, error)
-	NewMachine(opts InitOptions) (VM, error)
-	RemoveAndCleanMachines() error
-	VMType() VMType
-}
-
 type RemoteConnectionType string
 
 var (
@@ -426,5 +413,44 @@ func ParseVMType(input string, emptyFallback VMType) (VMType, error) {
 		return emptyFallback, nil
 	default:
 		return QemuVirt, fmt.Errorf("unknown VMType `%s`", input)
+	}
+}
+
+type VirtProvider interface {
+	Artifact() Artifact
+	CheckExclusiveActiveVM() (bool, string, error)
+	Compression() ImageCompression
+	Format() ImageFormat
+	IsValidVMName(name string) (bool, error)
+	List(opts ListOptions) ([]*ListResponse, error)
+	LoadVMByName(name string) (VM, error)
+	NewMachine(opts InitOptions) (VM, error)
+	RemoveAndCleanMachines() error
+	VMType() VMType
+}
+
+type Virtualization struct {
+	artifact    Artifact
+	compression ImageCompression
+	format      ImageFormat
+}
+
+func (p *Virtualization) Artifact() Artifact {
+	return p.artifact
+}
+
+func (p *Virtualization) Compression() ImageCompression {
+	return p.compression
+}
+
+func (p *Virtualization) Format() ImageFormat {
+	return p.format
+}
+
+func NewVirtualization(artifact Artifact, compression ImageCompression, format ImageFormat) Virtualization {
+	return Virtualization{
+		artifact,
+		compression,
+		format,
 	}
 }

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -44,7 +44,7 @@ func TestMachine(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	qemuVP := qemu.GetVirtualizationProvider()
+	qemuVP := qemu.VirtualizationProvider()
 	fcd, err := machine.GetFCOSDownload(qemuVP, defaultStream)
 	if err != nil {
 		Fail("unable to get virtual machine image")

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -30,14 +30,6 @@ var (
 	vmtype = machine.HyperVVirt
 )
 
-func GetVirtualizationProvider() machine.VirtProvider {
-	return &Virtualization{
-		artifact:    machine.HyperV,
-		compression: machine.Zip,
-		format:      machine.Vhdx,
-	}
-}
-
 const (
 	// Some of this will need to change when we are closer to having
 	// working code.

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -1,15 +1,312 @@
 package qemu
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/utils"
+	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
 )
 
-type Virtualization struct {
-	artifact    machine.Artifact
-	compression machine.ImageCompression
-	format      machine.ImageFormat
+type QEMUVirtualization struct {
+	machine.Virtualization
+}
+
+// NewMachine initializes an instance of a virtual machine based on the qemu
+// virtualization.
+func (p *QEMUVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
+	vmConfigDir, err := machine.GetConfDir(vmtype)
+	if err != nil {
+		return nil, err
+	}
+	vm := new(MachineVM)
+	if len(opts.Name) > 0 {
+		vm.Name = opts.Name
+	}
+	ignitionFile, err := machine.NewMachineFile(filepath.Join(vmConfigDir, vm.Name+".ign"), nil)
+	if err != nil {
+		return nil, err
+	}
+	vm.IgnitionFile = *ignitionFile
+	imagePath, err := machine.NewMachineFile(opts.ImagePath, nil)
+	if err != nil {
+		return nil, err
+	}
+	vm.ImagePath = *imagePath
+	vm.RemoteUsername = opts.Username
+
+	// Add a random port for ssh
+	port, err := utils.GetRandomPort()
+	if err != nil {
+		return nil, err
+	}
+	vm.Port = port
+
+	vm.CPUs = opts.CPUS
+	vm.Memory = opts.Memory
+	vm.DiskSize = opts.DiskSize
+
+	vm.Created = time.Now()
+
+	// Find the qemu executable
+	cfg, err := config.Default()
+	if err != nil {
+		return nil, err
+	}
+	execPath, err := cfg.FindHelperBinary(QemuCommand, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := vm.setPIDSocket(); err != nil {
+		return nil, err
+	}
+	cmd := []string{execPath}
+	// Add memory
+	cmd = append(cmd, []string{"-m", strconv.Itoa(int(vm.Memory))}...)
+	// Add cpus
+	cmd = append(cmd, []string{"-smp", strconv.Itoa(int(vm.CPUs))}...)
+	// Add ignition file
+	cmd = append(cmd, []string{"-fw_cfg", "name=opt/com.coreos/config,file=" + vm.IgnitionFile.GetPath()}...)
+	// Add qmp socket
+	monitor, err := NewQMPMonitor("unix", vm.Name, defaultQMPTimeout)
+	if err != nil {
+		return nil, err
+	}
+	vm.QMPMonitor = monitor
+	cmd = append(cmd, []string{"-qmp", monitor.Network + ":" + monitor.Address.GetPath() + ",server=on,wait=off"}...)
+
+	// Add network
+	// Right now the mac address is hardcoded so that the host networking gives it a specific IP address.  This is
+	// why we can only run one vm at a time right now
+	cmd = append(cmd, []string{"-netdev", "socket,id=vlan,fd=3", "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee"}...)
+	if err := vm.setReadySocket(); err != nil {
+		return nil, err
+	}
+
+	// Add serial port for readiness
+	cmd = append(cmd, []string{
+		"-device", "virtio-serial",
+		// qemu needs to establish the long name; other connections can use the symlink'd
+		// Note both id and chardev start with an extra "a" because qemu requires that it
+		// starts with a letter but users can also use numbers
+		"-chardev", "socket,path=" + vm.ReadySocket.Path + ",server=on,wait=off,id=a" + vm.Name + "_ready",
+		"-device", "virtserialport,chardev=a" + vm.Name + "_ready" + ",name=org.fedoraproject.port.0",
+		"-pidfile", vm.VMPidFilePath.GetPath()}...)
+	vm.CmdLine = cmd
+	return vm, nil
+}
+
+// LoadVMByName reads a json file that describes a known qemu vm
+// and returns a vm instance
+func (p *QEMUVirtualization) LoadVMByName(name string) (machine.VM, error) {
+	vm := &MachineVM{Name: name}
+	vm.HostUser = machine.HostUser{UID: -1} // posix reserves -1, so use it to signify undefined
+	if err := vm.update(); err != nil {
+		return nil, err
+	}
+
+	return vm, nil
+}
+
+// List lists all vm's that use qemu virtualization
+func (p *QEMUVirtualization) List(_ machine.ListOptions) ([]*machine.ListResponse, error) {
+	return getVMInfos()
+}
+
+func getVMInfos() ([]*machine.ListResponse, error) {
+	vmConfigDir, err := machine.GetConfDir(vmtype)
+	if err != nil {
+		return nil, err
+	}
+
+	var listed []*machine.ListResponse
+
+	if err = filepath.WalkDir(vmConfigDir, func(path string, d fs.DirEntry, err error) error {
+		vm := new(MachineVM)
+		if strings.HasSuffix(d.Name(), ".json") {
+			fullPath := filepath.Join(vmConfigDir, d.Name())
+			b, err := os.ReadFile(fullPath)
+			if err != nil {
+				return err
+			}
+			err = json.Unmarshal(b, vm)
+			if err != nil {
+				// Checking if the file did not unmarshal because it is using
+				// the deprecated config file format.
+				migrateErr := migrateVM(fullPath, b, vm)
+				if migrateErr != nil {
+					return migrateErr
+				}
+			}
+			listEntry := new(machine.ListResponse)
+
+			listEntry.Name = vm.Name
+			listEntry.Stream = vm.ImageStream
+			listEntry.VMType = "qemu"
+			listEntry.CPUs = vm.CPUs
+			listEntry.Memory = vm.Memory * units.MiB
+			listEntry.DiskSize = vm.DiskSize * units.GiB
+			listEntry.Port = vm.Port
+			listEntry.RemoteUsername = vm.RemoteUsername
+			listEntry.IdentityPath = vm.IdentityPath
+			listEntry.CreatedAt = vm.Created
+			listEntry.Starting = vm.Starting
+			listEntry.UserModeNetworking = true // always true
+
+			if listEntry.CreatedAt.IsZero() {
+				listEntry.CreatedAt = time.Now()
+				vm.Created = time.Now()
+				if err := vm.writeConfig(); err != nil {
+					return err
+				}
+			}
+
+			state, err := vm.State(false)
+			if err != nil {
+				return err
+			}
+			listEntry.Running = state == machine.Running
+
+			if !vm.LastUp.IsZero() { // this means we have already written a time to the config
+				listEntry.LastUp = vm.LastUp
+			} else { // else we just created the machine AKA last up = created time
+				listEntry.LastUp = vm.Created
+				vm.LastUp = listEntry.LastUp
+				if err := vm.writeConfig(); err != nil {
+					return err
+				}
+			}
+
+			listed = append(listed, listEntry)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return listed, err
+}
+
+func (p *QEMUVirtualization) IsValidVMName(name string) (bool, error) {
+	infos, err := getVMInfos()
+	if err != nil {
+		return false, err
+	}
+	for _, vm := range infos {
+		if vm.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CheckExclusiveActiveVM checks if there is a VM already running
+// that does not allow other VMs to be running
+func (p *QEMUVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
+	vms, err := getVMInfos()
+	if err != nil {
+		return false, "", fmt.Errorf("checking VM active: %w", err)
+	}
+	for _, vm := range vms {
+		if vm.Running || vm.Starting {
+			return true, vm.Name, nil
+		}
+	}
+	return false, "", nil
+}
+
+// RemoveAndCleanMachines removes all machine and cleans up any other files associated with podman machine
+func (p *QEMUVirtualization) RemoveAndCleanMachines() error {
+	var (
+		vm             machine.VM
+		listResponse   []*machine.ListResponse
+		opts           machine.ListOptions
+		destroyOptions machine.RemoveOptions
+	)
+	destroyOptions.Force = true
+	var prevErr error
+
+	listResponse, err := p.List(opts)
+	if err != nil {
+		return err
+	}
+
+	for _, mach := range listResponse {
+		vm, err = p.LoadVMByName(mach.Name)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+		_, remove, err := vm.Remove(mach.Name, destroyOptions)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		} else {
+			if err := remove(); err != nil {
+				if prevErr != nil {
+					logrus.Error(prevErr)
+				}
+				prevErr = err
+			}
+		}
+	}
+
+	// Clean leftover files in data dir
+	dataDir, err := machine.DataDirPrefix()
+	if err != nil {
+		if prevErr != nil {
+			logrus.Error(prevErr)
+		}
+		prevErr = err
+	} else {
+		err := machine.GuardedRemoveAll(dataDir)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+	}
+
+	// Clean leftover files in conf dir
+	confDir, err := machine.ConfDirPrefix()
+	if err != nil {
+		if prevErr != nil {
+			logrus.Error(prevErr)
+		}
+		prevErr = err
+	} else {
+		err := machine.GuardedRemoveAll(confDir)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+	}
+	return prevErr
+}
+
+func (p *QEMUVirtualization) VMType() machine.VMType {
+	return vmtype
+}
+
+func VirtualizationProvider() machine.VirtProvider {
+	return &QEMUVirtualization{
+		machine.NewVirtualization(machine.Qemu, machine.Xz, machine.Qcow),
+	}
 }
 
 // Deprecated: MachineVMV1 is being deprecated in favor a more flexible and informative
@@ -47,51 +344,9 @@ type MachineVMV1 struct {
 	UID int
 }
 
-type MachineVM struct {
-	// ConfigPath is the path to the configuration file
-	ConfigPath machine.VMFile
-	// The command line representation of the qemu command
-	CmdLine []string
-	// HostUser contains info about host user
-	machine.HostUser
-	// ImageConfig describes the bootable image
-	machine.ImageConfig
-	// Mounts is the list of remote filesystems to mount
-	Mounts []machine.Mount
-	// Name of VM
-	Name string
-	// PidFilePath is the where the Proxy PID file lives
-	PidFilePath machine.VMFile
-	// VMPidFilePath is the where the VM PID file lives
-	VMPidFilePath machine.VMFile
-	// QMPMonitor is the qemu monitor object for sending commands
-	QMPMonitor Monitor
-	// ReadySocket tells host when vm is booted
-	ReadySocket machine.VMFile
-	// ResourceConfig is physical attrs of the VM
-	machine.ResourceConfig
-	// SSHConfig for accessing the remote vm
-	machine.SSHConfig
-	// Starting tells us whether the machine is running or if we have just dialed it to start it
-	Starting bool
-	// Created contains the original created time instead of querying the file mod time
-	Created time.Time
-	// LastUp contains the last recorded uptime
-	LastUp time.Time
-}
-
 type Monitorv1 struct {
 	//	Address portion of the qmp monitor (/tmp/tmp.sock)
 	Address string
-	// Network portion of the qmp monitor (unix)
-	Network string
-	// Timeout in seconds for qmp monitor transactions
-	Timeout time.Duration
-}
-
-type Monitor struct {
-	//	Address portion of the qmp monitor (/tmp/tmp.sock)
-	Address machine.VMFile
 	// Network portion of the qmp monitor (unix)
 	Network string
 	// Timeout in seconds for qmp monitor transactions

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -1,0 +1,213 @@
+//go:build windows
+// +build windows
+
+package wsl
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type WSLVirtualization struct {
+	machine.Virtualization
+}
+
+func VirtualizationProvider() machine.VirtProvider {
+	return &WSLVirtualization{
+		machine.NewVirtualization(machine.None, machine.Xz, machine.Tar),
+	}
+}
+
+// NewMachine initializes an instance of a wsl machine
+func (p *WSLVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
+	vm := new(MachineVM)
+	if len(opts.Name) > 0 {
+		vm.Name = opts.Name
+	}
+	configPath, err := getConfigPath(opts.Name)
+	if err != nil {
+		return vm, err
+	}
+
+	vm.ConfigPath = configPath
+	vm.ImagePath = opts.ImagePath
+	vm.RemoteUsername = opts.Username
+	vm.Created = time.Now()
+	vm.LastUp = vm.Created
+
+	// Default is false
+	if opts.UserModeNetworking != nil {
+		vm.UserModeNetworking = *opts.UserModeNetworking
+	}
+
+	// Add a random port for ssh
+	port, err := utils.GetRandomPort()
+	if err != nil {
+		return nil, err
+	}
+	vm.Port = port
+
+	return vm, nil
+}
+
+// LoadByName reads a json file that describes a known qemu vm
+// and returns a vm instance
+func (p *WSLVirtualization) LoadVMByName(name string) (machine.VM, error) {
+	configPath, err := getConfigPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err := readAndMigrate(configPath, name)
+	return vm, err
+}
+
+// List lists all vm's that use qemu virtualization
+func (p *WSLVirtualization) List(_ machine.ListOptions) ([]*machine.ListResponse, error) {
+	return GetVMInfos()
+}
+
+func GetVMInfos() ([]*machine.ListResponse, error) {
+	vmConfigDir, err := machine.GetConfDir(vmtype)
+	if err != nil {
+		return nil, err
+	}
+
+	var listed []*machine.ListResponse
+
+	if err = filepath.WalkDir(vmConfigDir, func(path string, d fs.DirEntry, err error) error {
+		if strings.HasSuffix(d.Name(), ".json") {
+			path := filepath.Join(vmConfigDir, d.Name())
+			vm, err := readAndMigrate(path, strings.TrimSuffix(d.Name(), ".json"))
+			if err != nil {
+				return err
+			}
+			listEntry := new(machine.ListResponse)
+
+			listEntry.Name = vm.Name
+			listEntry.Stream = vm.ImageStream
+			listEntry.VMType = "wsl"
+			listEntry.CPUs, _ = getCPUs(vm)
+			listEntry.Memory, _ = getMem(vm)
+			listEntry.DiskSize = getDiskSize(vm)
+			listEntry.RemoteUsername = vm.RemoteUsername
+			listEntry.Port = vm.Port
+			listEntry.IdentityPath = vm.IdentityPath
+			listEntry.Starting = false
+			listEntry.UserModeNetworking = vm.UserModeNetworking
+
+			running := vm.isRunning()
+			listEntry.CreatedAt, listEntry.LastUp, _ = vm.updateTimeStamps(running)
+			listEntry.Running = running
+
+			listed = append(listed, listEntry)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return listed, err
+}
+
+func (p *WSLVirtualization) IsValidVMName(name string) (bool, error) {
+	infos, err := GetVMInfos()
+	if err != nil {
+		return false, err
+	}
+	for _, vm := range infos {
+		if vm.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (p *WSLVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
+	return false, "", nil
+}
+
+// RemoveAndCleanMachines removes all machine and cleans up any other files associated with podman machine
+func (p *WSLVirtualization) RemoveAndCleanMachines() error {
+	var (
+		vm             machine.VM
+		listResponse   []*machine.ListResponse
+		opts           machine.ListOptions
+		destroyOptions machine.RemoveOptions
+	)
+	destroyOptions.Force = true
+	var prevErr error
+
+	listResponse, err := p.List(opts)
+	if err != nil {
+		return err
+	}
+
+	for _, mach := range listResponse {
+		vm, err = p.LoadVMByName(mach.Name)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+		_, remove, err := vm.Remove(mach.Name, destroyOptions)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		} else {
+			if err := remove(); err != nil {
+				if prevErr != nil {
+					logrus.Error(prevErr)
+				}
+				prevErr = err
+			}
+		}
+	}
+
+	// Clean leftover files in data dir
+	dataDir, err := machine.DataDirPrefix()
+	if err != nil {
+		if prevErr != nil {
+			logrus.Error(prevErr)
+		}
+		prevErr = err
+	} else {
+		err := machine.GuardedRemoveAll(dataDir)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+	}
+
+	// Clean leftover files in conf dir
+	confDir, err := machine.ConfDirPrefix()
+	if err != nil {
+		if prevErr != nil {
+			logrus.Error(prevErr)
+		}
+		prevErr = err
+	} else {
+		err := machine.GuardedRemoveAll(confDir)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+	}
+	return prevErr
+}
+
+func (p *WSLVirtualization) VMType() machine.VMType {
+	return vmtype
+}


### PR DESCRIPTION
Ensures that for each hypervisor implementation, their `config.go` file deals with implementing the `VirtProvider` interface while the `machine.go` file is for implementing the `VM` interface.

Moves the `Virtualization` type into a common file and created wrappers for the individual hypervisors. Allows for shared functions that are exactly the same while providing the flexibility to create hypervisor-specific implementations of the functions.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
