### PR TITLE
Trim whitespace from unit files while parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
         exclude: test/buildah-bud/buildah-tests.diff
       - id: trailing-whitespace
-        exclude: test/buildah-bud/buildah-tests.diff
+        exclude: test/buildah-bud/buildah-tests.diff|test/e2e/quadlet/remap-keep-id2.container
       - id: mixed-line-ending
       - id: check-byte-order-marker
       - id: check-executables-have-shebangs

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ help: ## (Default) Print listing of key targets with their descriptions
 .PHONY: .gitvalidation
 .gitvalidation:
 	@echo "Validating vs commit '$(call err_if_empty,EPOCH_TEST_COMMIT)'"
-	GIT_CHECK_EXCLUDE="./vendor:./test/tools/vendor:docs/make.bat:test/buildah-bud/buildah-tests.diff" ./test/tools/build/git-validation -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..$(HEAD)
+	GIT_CHECK_EXCLUDE="./vendor:./test/tools/vendor:docs/make.bat:test/buildah-bud/buildah-tests.diff:test/e2e/quadlet/remap-keep-id2.container" ./test/tools/build/git-validation -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..$(HEAD)
 
 .PHONY: lint
 lint: golangci-lint

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -373,7 +373,7 @@ func (p *UnitFileParser) flushPendingComments(toComment bool) {
 func nextLine(data string, afterPos int) (string, string) {
 	rest := data[afterPos:]
 	if i := strings.Index(rest, "\n"); i >= 0 {
-		return data[:i+afterPos], data[i+afterPos+1:]
+		return strings.TrimSpace(data[:i+afterPos]), data[i+afterPos+1:]
 	}
 	return data, ""
 }

--- a/test/e2e/quadlet/remap-keep-id2.container
+++ b/test/e2e/quadlet/remap-keep-id2.container
@@ -2,6 +2,7 @@
 
 [Container]
 Image=localhost/imagename
-RemapUsers=keep-id
+# The added three spaces to keep-id are necessary for test of trimwhitespace
+RemapUsers=keep-id   
 RemapUid=200
 RemapGid=210


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/18979

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
