### PR TITLE
pkg/api: top return error to client

### DIFF
--- a/pkg/api/server/handler_api.go
+++ b/pkg/api/server/handler_api.go
@@ -56,7 +56,9 @@ func (s *APIServer) apiWrapper(h http.HandlerFunc, w http.ResponseWriter, r *htt
 	}
 
 	if buffer {
-		w = newBufferedResponseWriter(w)
+		bw := newBufferedResponseWriter(w)
+		defer bw.b.Flush()
+		w = bw
 	}
 
 	h(w, r)

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -132,6 +132,15 @@ if root; then
     podman rm -f $CTRNAME
 fi
 
+CTRNAME=test123
+podman run --name $CTRNAME -d $IMAGE top
+t GET libpod/containers/$CTRNAME/top?ps_args=--invalid 500 \
+  .cause~".*unrecognized option.*"
+t GET containers/$CTRNAME/top?ps_args=--invalid 500 \
+  .cause~".*unrecognized option.*"
+
+podman rm -f $CTRNAME
+
 # Issue #15765: make sure the memory limit is capped
 if root; then
     CTRNAME=ctr-with-limit


### PR DESCRIPTION
Wait before sending status code 200 for the first top call and if that
fails return a proper error code.

This was leading to some confusion in [1] because podman just reported
200 but did not wirte anything back.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2215572

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The top API endpoint will now correctly report errors.
```
