### PR TITLE
specgen: raise error with --device-cgroup-rule in a userns

### DIFF
--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -258,7 +258,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	if isRootless && len(s.DeviceCgroupRule) > 0 {
 		return nil, fmt.Errorf("device cgroup rules are not supported in rootless mode or in a user namespace")
 	}
-	if !inUserNS && !s.Privileged {
+	if !isRootless && !s.Privileged {
 		for _, dev := range s.DeviceCgroupRule {
 			g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)
 		}

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -255,6 +255,9 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	s.HostDeviceList = userDevices
 
 	// set the devices cgroup when not running in a user namespace
+	if isRootless && len(s.DeviceCgroupRule) > 0 {
+		return nil, fmt.Errorf("device cgroup rules are not supported in rootless mode or in a user namespace")
+	}
 	if !inUserNS && !s.Privileged {
 		for _, dev := range s.DeviceCgroupRule {
 			g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -746,7 +746,11 @@ EOF
 }
 
 @test "podman run --device-cgroup-rule tests" {
-    skip_if_rootless "cannot add devices in rootless mode"
+    if is_rootless; then
+        run_podman 125 run --device-cgroup-rule="b 7:* rmw" --rm $IMAGE
+        is "$output" "Error: device cgroup rules are not supported in rootless mode or in a user namespace"
+        return
+    fi
 
     run_podman run --device-cgroup-rule="b 7:* rmw" --rm $IMAGE
     run_podman run --device-cgroup-rule="c 7:* rmw" --rm $IMAGE


### PR DESCRIPTION
we were silently ignoring --device-cgroup-rule in rootless mode.  Make sure an error is returned if the user tries to use it.

Closes: https://github.com/containers/podman/issues/18698

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now --device-cgroup-rule causes an error when used in a user namespace instead of being silently ignored
```
