### PR TITLE
Add --replace flag to podman secret create

### DIFF
--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -55,6 +55,8 @@ func init() {
 	envFlagName := "env"
 	flags.BoolVar(&env, envFlagName, false, "Read secret data from environment variable")
 
+	flags.BoolVar(&createOpts.Replace, "replace", false, "If a secret with the same name exists, replace it")
+
 	labelFlagName := "label"
 	flags.StringArrayVarP(&labels, labelFlagName, "l", nil, "Specify labels on the secret")
 	_ = createCmd.RegisterFlagCompletionFunc(labelFlagName, completion.AutocompleteNone)

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -40,6 +40,12 @@ Print usage statement.
 
 Add label to secret. These labels can be viewed in podman secrete inspect or ls.
 
+#### **--replace**=*false*
+
+If existing secret with the same name already exists, update the secret.
+The `--replace` option does not change secrets within existing containers, only newly created containers.
+ The default is **false**.
+
 ## EXAMPLES
 
 ```

--- a/pkg/api/handlers/libpod/secrets.go
+++ b/pkg/api/handlers/libpod/secrets.go
@@ -24,6 +24,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 		Driver     string            `schema:"driver"`
 		DriverOpts map[string]string `schema:"driveropts"`
 		Labels     map[string]string `schema:"labels"`
+		Replace    bool              `schema:"replace"`
 	}{
 		// override any golang type defaults
 	}
@@ -36,6 +37,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	opts.Driver = query.Driver
 	opts.DriverOpts = query.DriverOpts
 	opts.Labels = query.Labels
+	opts.Replace = query.Replace
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.SecretCreate(r.Context(), query.Name, r.Body, opts)

--- a/pkg/bindings/secrets/types.go
+++ b/pkg/bindings/secrets/types.go
@@ -28,4 +28,5 @@ type CreateOptions struct {
 	Driver     *string
 	DriverOpts map[string]string
 	Labels     map[string]string
+	Replace    *bool
 }

--- a/pkg/bindings/secrets/types_create_options.go
+++ b/pkg/bindings/secrets/types_create_options.go
@@ -76,3 +76,18 @@ func (o *CreateOptions) GetLabels() map[string]string {
 	}
 	return o.Labels
 }
+
+// WithReplace set field Replace to given value
+func (o *CreateOptions) WithReplace(value bool) *CreateOptions {
+	o.Replace = &value
+	return o
+}
+
+// GetReplace returns value of field Replace
+func (o *CreateOptions) GetReplace() bool {
+	if o.Replace == nil {
+		var z bool
+		return z
+	}
+	return *o.Replace
+}

--- a/pkg/domain/entities/secrets.go
+++ b/pkg/domain/entities/secrets.go
@@ -14,6 +14,7 @@ type SecretCreateOptions struct {
 	Driver     string
 	DriverOpts map[string]string
 	Labels     map[string]string
+	Replace    bool
 }
 
 type SecretInspectOptions struct {

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -46,6 +46,7 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 	storeOpts := secrets.StoreOptions{
 		DriverOpts: options.DriverOpts,
 		Labels:     options.Labels,
+		Replace:    options.Replace,
 	}
 
 	secretID, err := manager.Store(name, data, options.Driver, storeOpts)
@@ -86,10 +87,13 @@ func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string
 		if secret.Labels == nil {
 			secret.Labels = make(map[string]string)
 		}
+		if secret.UpdatedAt.IsZero() {
+			secret.UpdatedAt = secret.CreatedAt
+		}
 		report := &entities.SecretInfoReport{
 			ID:        secret.ID,
 			CreatedAt: secret.CreatedAt,
-			UpdatedAt: secret.CreatedAt,
+			UpdatedAt: secret.UpdatedAt,
 			Spec: entities.SecretSpec{
 				Name: secret.Name,
 				Driver: entities.SecretDriverSpec{

--- a/pkg/domain/infra/tunnel/secrets.go
+++ b/pkg/domain/infra/tunnel/secrets.go
@@ -15,7 +15,8 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 		WithDriver(options.Driver).
 		WithDriverOpts(options.DriverOpts).
 		WithName(name).
-		WithLabels(options.Labels)
+		WithLabels(options.Labels).
+		WithReplace(options.Replace)
 	created, err := secrets.Create(ic.ClientCtx, reader, opts)
 	if err != nil {
 		return nil, err
@@ -37,7 +38,7 @@ func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string
 				return nil, nil, err
 			}
 			if errModel.ResponseCode == 404 {
-				errs = append(errs, fmt.Errorf("no such secret %q", name))
+				errs = append(errs, fmt.Errorf("no secret with name or id %q: no such secret ", name))
 				continue
 			}
 			return nil, nil, err


### PR DESCRIPTION
Users may want to update the secret used within containers, without destroying the secret and recreating it.

Partial fix for https://github.com/containers/podman/issues/18667

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman secret create now has a --replace option, which allows you to modify secrets without replacing containers.
```
