### PR TITLE
debug tail 800 lines flake

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	. "github.com/onsi/gomega/gexec"
 )
 
@@ -116,6 +117,16 @@ var _ = Describe("Podman logs", func() {
 
 		It("tail 800 lines: "+log, func() {
 			skipIfJournaldInContainer()
+
+			// we match 800 line array here, make sure to print all lines when assertion fails.
+			// There is something weird going on (https://github.com/containers/podman/issues/18501)
+			// and only the normal output log does not seem to be enough to figure out why it flakes.
+			oldLength := format.MaxLength
+			// unlimited matcher output
+			format.MaxLength = 0
+			defer func() {
+				format.MaxLength = oldLength
+			}()
 
 			// this uses -d so that we do not have 1000 unnecessary lines printed in every test log
 			logc := podmanTest.Podman([]string{"run", "--log-driver", log, "-d", ALPINE, "sh", "-c", "i=1; while [ \"$i\" -ne 1000 ]; do echo \"line $i\"; i=$((i + 1)); done"})


### PR DESCRIPTION
Sometimes this tests flakes but in the CI log I see all expected lines printed but still for some reason the matcher fails. Right now it will truncate the array so it is not possible to verify what the matcher sees. Change this be removing the truncate limit for this specific test only.

see #18501

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
