### PR TITLE
Display secret to user in inspect

### DIFF
--- a/cmd/podman/secrets/inspect.go
+++ b/cmd/podman/secrets/inspect.go
@@ -43,6 +43,8 @@ Created at:        {{.CreatedAt}}
 Updated at:        {{.UpdatedAt}}`
 )
 
+var inspectOpts = entities.SecretInspectOptions{}
+
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: inspectCmd,
@@ -53,12 +55,14 @@ func init() {
 	flags.StringVarP(&format, formatFlagName, "f", "", "Format inspect output using Go template")
 	_ = inspectCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.SecretInfoReport{}))
 
+	flags.BoolVar(&inspectOpts.ShowSecret, "showsecret", false, "Display the secret")
+
 	prettyFlagName := "pretty"
 	flags.BoolVar(&pretty, prettyFlagName, false, "Print inspect output in human-readable format")
 }
 
 func inspect(cmd *cobra.Command, args []string) error {
-	inspected, errs, _ := registry.ContainerEngine().SecretInspect(context.Background(), args)
+	inspected, errs, _ := registry.ContainerEngine().SecretInspect(context.Background(), args, inspectOpts)
 
 	// always print valid list
 	if len(inspected) == 0 {

--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -23,6 +23,7 @@ Format secret output using Go template.
 |--------------------------|-------------------------------------------------------------------|
 | .CreatedAt               | When secret was created (relative timestamp, human-readable)      |
 | .ID                      | ID of secret                                                      |
+| .SecretData              | Secret Data (Displayed only with --showsecret option)		       |
 | .Spec ...                | Details of secret                                                 |
 | .Spec.Driver             | Driver info                                                       |
 | .Spec.Driver.Name        | Driver name (string)                                              |
@@ -39,12 +40,16 @@ Print usage statement.
 
 Print inspect output in human-readable format
 
+#### **--showsecret**
+
+Display secret data
 
 ## EXAMPLES
 
 ```
 $ podman secret inspect mysecret
 $ podman secret inspect --format "{{.Name} {{.Scope}}" mysecret
+$ podman secret inspect --showsecret --format "{{.Name} {{.SecretData}}" mysecret
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-secret-ls.1.md.in
+++ b/docs/source/markdown/podman-secret-ls.1.md.in
@@ -34,6 +34,7 @@ Valid placeholders for the Go template are listed below:
 | ------------------------ | ----------------------------------------------------------------- |
 | .CreatedAt               | When secret was created (relative timestamp, human-readable)      |
 | .ID                      | ID of secret                                                      |
+| .SecretData              | Secret Data (Displayed only with --showsecret option)		       |
 | .Spec ...                | Details of secret                                                 |
 | .Spec.Driver             | Driver info                                                       |
 | .Spec.Driver.Name        | Driver name (string)                                              |

--- a/pkg/api/server/register_secrets.go
+++ b/pkg/api/server/register_secrets.go
@@ -79,6 +79,11 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: the name or ID of the secret
+	//  - in: query
+	//    name: showsecret
+	//    type: boolean
+	//    description: Display Secret
+	//    default: false
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/secrets/secrets.go
+++ b/pkg/bindings/secrets/secrets.go
@@ -33,6 +33,9 @@ func List(ctx context.Context, options *ListOptions) ([]*entities.SecretInfoRepo
 
 // Inspect returns low-level information about a secret.
 func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*entities.SecretInfoReport, error) {
+	if options == nil {
+		options = new(InspectOptions)
+	}
 	var (
 		inspect *entities.SecretInfoReport
 	)
@@ -40,12 +43,15 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/secrets/%s/json", nil, nil, nameOrID)
+	params, err := options.ToParams()
+	if err != nil {
+		return nil, err
+	}
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/secrets/%s/json", params, nil, nameOrID)
 	if err != nil {
 		return inspect, err
 	}
 	defer response.Body.Close()
-
 	return inspect, response.Process(&inspect)
 }
 

--- a/pkg/bindings/secrets/types.go
+++ b/pkg/bindings/secrets/types.go
@@ -11,6 +11,7 @@ type ListOptions struct {
 //
 //go:generate go run ../generator/generator.go InspectOptions
 type InspectOptions struct {
+	ShowSecret *bool
 }
 
 // RemoveOptions are optional options for removing secrets

--- a/pkg/bindings/secrets/types_inspect_options.go
+++ b/pkg/bindings/secrets/types_inspect_options.go
@@ -16,3 +16,18 @@ func (o *InspectOptions) Changed(fieldName string) bool {
 func (o *InspectOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
+
+// WithShowSecret set field ShowSecret to given value
+func (o *InspectOptions) WithShowSecret(value bool) *InspectOptions {
+	o.ShowSecret = &value
+	return o
+}
+
+// GetShowSecret returns value of field ShowSecret
+func (o *InspectOptions) GetShowSecret() bool {
+	if o.ShowSecret == nil {
+		var z bool
+		return z
+	}
+	return *o.ShowSecret
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -93,7 +93,7 @@ type ContainerEngine interface { //nolint:interfacebloat
 	PodUnpause(ctx context.Context, namesOrIds []string, options PodunpauseOptions) ([]*PodUnpauseReport, error)
 	SetupRootless(ctx context.Context, noMoveProcess bool) error
 	SecretCreate(ctx context.Context, name string, reader io.Reader, options SecretCreateOptions) (*SecretCreateReport, error)
-	SecretInspect(ctx context.Context, nameOrIDs []string) ([]*SecretInfoReport, []error, error)
+	SecretInspect(ctx context.Context, nameOrIDs []string, options SecretInspectOptions) ([]*SecretInfoReport, []error, error)
 	SecretList(ctx context.Context, opts SecretListRequest) ([]*SecretInfoReport, error)
 	SecretRm(ctx context.Context, nameOrID []string, opts SecretRmOptions) ([]*SecretRmReport, error)
 	SecretExists(ctx context.Context, nameOrID string) (*BoolReport, error)

--- a/pkg/domain/entities/secrets.go
+++ b/pkg/domain/entities/secrets.go
@@ -16,6 +16,10 @@ type SecretCreateOptions struct {
 	Labels     map[string]string
 }
 
+type SecretInspectOptions struct {
+	ShowSecret bool
+}
+
 type SecretListRequest struct {
 	Filters map[string][]string
 }
@@ -38,10 +42,11 @@ type SecretRmReport struct {
 }
 
 type SecretInfoReport struct {
-	ID        string
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	Spec      SecretSpec
+	ID         string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	Spec       SecretSpec
+	SecretData string `json:"SecretData,omitempty"`
 }
 
 type SecretInfoReportCompat struct {

--- a/pkg/domain/infra/tunnel/secrets.go
+++ b/pkg/domain/infra/tunnel/secrets.go
@@ -23,11 +23,14 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 	return created, nil
 }
 
-func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string) ([]*entities.SecretInfoReport, []error, error) {
+func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string, options entities.SecretInspectOptions) ([]*entities.SecretInfoReport, []error, error) {
 	allInspect := make([]*entities.SecretInfoReport, 0, len(nameOrIDs))
 	errs := make([]error, 0, len(nameOrIDs))
+	opts := new(secrets.InspectOptions).
+		WithShowSecret(options.ShowSecret)
+
 	for _, name := range nameOrIDs {
-		inspected, err := secrets.Inspect(ic.ClientCtx, name, nil)
+		inspected, err := secrets.Inspect(ic.ClientCtx, name, opts)
 		if err != nil {
 			errModel, ok := err.(*errorhandling.ErrorModel)
 			if !ok {


### PR DESCRIPTION
It is pretty complicated to display the secret on the host, but is not really secured. This patch makes it easier to examine the secret.

Partial fix for https://github.com/containers/podman/issues/18667

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman secret inspect has a new options --showsecret which will output the actual secret.
```
