### PR TITLE
Fix readonly=false failure

### DIFF
--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -84,6 +84,22 @@ load helpers
     is "$output" "" "podman image mount, no args, after umount"
 }
 
+@test "podman run --mount ro=false " {
+    local volpath=/path/in/container
+    local stdopts="type=volume,destination=$volpath"
+
+    # Variations on a theme (not by Paganini). All of these should fail.
+    for varopt in readonly readonly=true ro=true ro rw=false;do
+        run_podman 1 run --rm -q --mount $stdopts,$varopt $IMAGE touch $volpath/a
+        is "$output" "touch: $volpath/a: Read-only file system" "with $varopt"
+    done
+
+    # All of these should pass
+    for varopt in rw rw=true ro=false readonly=false;do
+        run_podman run --rm -q --mount $stdopts,$varopt $IMAGE touch $volpath/a
+    done
+}
+
 @test "podman run --mount image" {
     skip_if_rootless "too hard to test rootless"
 


### PR DESCRIPTION
There was a huge cut and paste of mount options which were not constent in parsing tmpfs, bind and volume mounts.  Consolidated into a single function to guarantee all parse the same.

Fixes: https://github.com/containers/podman/issues/18995

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Parse readonly=false on --mount options correctly.
```
