### PR TITLE
Remove 'inspecting object' from inspect errors

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -185,16 +185,16 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 		err = rpt.Execute(data)
 	}
 	if err != nil {
-		errs = append(errs, fmt.Errorf("printing inspect output: %w", err))
+		errs = append(errs, err)
 	}
 
 	if len(errs) > 0 {
 		if len(errs) > 1 {
 			for _, err := range errs[1:] {
-				fmt.Fprintf(os.Stderr, "error inspecting object: %v\n", err)
+				fmt.Fprintf(os.Stderr, "%v\n", err)
 			}
 		}
-		return fmt.Errorf("inspecting object: %w", errs[0])
+		return errs[0]
 	}
 	return nil
 }

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -266,7 +266,7 @@ EOF
 
     run_podman kube down $PODMAN_TMPDIR/test.yaml
     run_podman 125 inspect test_pod-test
-    is "$output" ".*Error: inspecting object: no such object: \"test_pod-test\""
+    is "$output" ".*Error: no such object: \"test_pod-test\""
     run_podman pod rm -a
     run_podman rm -a
 }
@@ -454,7 +454,7 @@ _EOF
 
     run_podman kube down $PODMAN_TMPDIR/test.yaml
     run_podman 125 inspect test_pod-test
-    is "$output" ".*Error: inspecting object: no such object: \"test_pod-test\""
+    is "$output" ".*Error: no such object: \"test_pod-test\""
     run_podman pod rm -a
     run_podman rm -a
 }
@@ -477,7 +477,7 @@ _EOF
     is "$output" "true"
     run_podman kube down $SERVER/testpod.yaml
     run_podman 125 inspect test_pod-test
-    is "$output" ".*Error: inspecting object: no such object: \"test_pod-test\""
+    is "$output" ".*Error: no such object: \"test_pod-test\""
 
     run_podman pod rm -a -f
     run_podman rm -a -f -t0


### PR DESCRIPTION
This is just useless noise and gets us closer to what Docker returns.

Inspired by: https://github.com/containers/podman/issues/19027

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
