### PR TITLE
pkg/specgen: add support for 'podman run --init' on FreeBSD

### DIFF
--- a/libpod/define/mount_freebsd.go
+++ b/libpod/define/mount_freebsd.go
@@ -6,3 +6,8 @@ const (
 	// TypeBind is the type for mounting host dir
 	TypeBind = "nullfs"
 )
+
+var (
+	// Mount potions for bind
+	BindOptions = []string{}
+)

--- a/libpod/define/mount_linux.go
+++ b/libpod/define/mount_linux.go
@@ -6,3 +6,8 @@ const (
 	// TypeBind is the type for mounting host dir
 	TypeBind = "bind"
 )
+
+var (
+	// Mount potions for bind
+	BindOptions = []string{"bind"}
+)

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -363,7 +363,7 @@ func addContainerInitBinary(s *specgen.SpecGenerator, path string) (spec.Mount, 
 		Destination: define.ContainerInitPath,
 		Type:        define.TypeBind,
 		Source:      path,
-		Options:     []string{define.TypeBind, "ro"},
+		Options:     append(define.BindOptions, "ro"),
 	}
 
 	if path == "" {


### PR DESCRIPTION
This adds define.BindOptions to declare the mount options for bind-like mounts (nullfs on FreeBSD). Note: this mirrors identical declarations in buildah and it may be preferable to use buildah's copies throughout podman.

[NO NEW TESTS NEEDED]

#### Does this PR introduce a user-facing change?

```release-note
None
```
