### PR TITLE
rootless: use default_rootless_network_cmd config

### DIFF
--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/containers/podman/v4/pkg/rootless"
 )
 
 var (
@@ -150,15 +149,6 @@ func (s *SpecGenerator) Validate() error {
 		return err
 	}
 
-	// Set defaults if network info is not provided
-	// when we are rootless we default to slirp4netns
-	if s.NetNS.IsPrivate() || s.NetNS.IsDefault() {
-		if rootless.IsRootless() {
-			s.NetNS.NSMode = Slirp
-		} else {
-			s.NetNS.NSMode = Bridge
-		}
-	}
 	if err := validateNetNS(&s.NetNS); err != nil {
 		return err
 	}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -11,9 +11,12 @@ import (
 
 	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/containers/common/libimage"
+	"github.com/containers/common/libnetwork/pasta"
+	"github.com/containers/common/libnetwork/slirp4netns"
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/namespaces"
+	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgenutil"
 	"github.com/containers/podman/v4/pkg/util"
@@ -184,6 +187,30 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		// ok, we are incorrectly setting the pod as the hostname, let's undo that before validation
 		s.Hostname = ""
 	}
+
+	// Set defaults if network info is not provided
+	if s.NetNS.IsPrivate() || s.NetNS.IsDefault() {
+		if rootless.IsRootless() {
+			// when we are rootless we default to default_rootless_network_cmd from containers.conf
+			conf, err := rt.GetConfigNoCopy()
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			switch conf.Network.DefaultRootlessNetworkCmd {
+			case slirp4netns.BinaryName, "":
+				s.NetNS.NSMode = specgen.Slirp
+			case pasta.BinaryName:
+				s.NetNS.NSMode = specgen.Pasta
+			default:
+				return nil, nil, nil, fmt.Errorf("invalid default_rootless_network_cmd option %q",
+					conf.Network.DefaultRootlessNetworkCmd)
+			}
+		} else {
+			// as root default to bridge
+			s.NetNS.NSMode = specgen.Bridge
+		}
+	}
+
 	if err := s.Validate(); err != nil {
 		return nil, nil, nil, fmt.Errorf("invalid config provided: %w", err)
 	}

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -294,10 +294,6 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 	}
 
 	postConfigureNetNS := !s.UserNS.IsHost()
-	// when we are rootless we default to slirp4netns
-	if rootless.IsRootless() && (s.NetNS.IsPrivate() || s.NetNS.IsDefault()) {
-		s.NetNS.NSMode = specgen.Slirp
-	}
 
 	switch s.NetNS.NSMode {
 	case specgen.FromPod:


### PR DESCRIPTION
Make sure we use the config field to know if we should use pasta or slirp4netns as default.

While at it fix broken code which sets the default at two different places, also do not set in Validate() as this should not modify the specgen IMO, so set it directly before that.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now reads the default_rootless_network_cmd containers.conf option to get the default rootless network program.
```
