### PR TITLE
Bump c/image to v5.26.0, c/common 0.54.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.30.1-0.20230627110136-33b7088fec7b
-	github.com/containers/common v0.53.1-0.20230627061926-e6f314e59b81
+	github.com/containers/common v0.54.0
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/image/v5 v5.25.1-0.20230623174242-68798a22ce3e
+	github.com/containers/image/v5 v5.26.0
 	github.com/containers/libhvee v0.0.5
 	github.com/containers/ocicrypt v1.1.7
 	github.com/containers/psgo v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -241,12 +241,12 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.30.1-0.20230627110136-33b7088fec7b h1:cTb0Sxu/tIQ9uPIchFmkYs+uOtylhyO+0h2+i3XzisQ=
 github.com/containers/buildah v1.30.1-0.20230627110136-33b7088fec7b/go.mod h1:O2jiDd5+569W8cwqyLnRKiqAHOPTi/Kj+oDlFNsFg24=
-github.com/containers/common v0.53.1-0.20230627061926-e6f314e59b81 h1:axB9UaqlBcpVX4yA41OfshJd5emqOuQ/GMNxopyAX20=
-github.com/containers/common v0.53.1-0.20230627061926-e6f314e59b81/go.mod h1:BkgcpfdNC54M3fGDtHUjqt7teGNsuj9yGoWUC+YVhi4=
+github.com/containers/common v0.54.0 h1:jJ2QVuliTa/40QxyDe1ZS1U/7BsDea7qdBeZE0VPu3E=
+github.com/containers/common v0.54.0/go.mod h1:xbA3bUfth8p2xmqSg01oxHNDRJA71SAVUCqhyEISKic=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/image/v5 v5.25.1-0.20230623174242-68798a22ce3e h1:4W/7KRo29f7zRGRruc3kSf18wNZB/loR1jTygi0TvRM=
-github.com/containers/image/v5 v5.25.1-0.20230623174242-68798a22ce3e/go.mod h1:3tWjWAL5TC/ZsaaBNkvTxdQqvlNJ463QF51m+oRtZwI=
+github.com/containers/image/v5 v5.26.0 h1:P9H4+N/7fTTClnFthIWgJU+0LBkhGlW2tCWR+UNG0Vs=
+github.com/containers/image/v5 v5.26.0/go.mod h1:QSW67adLL/B4eYsFPG6TjH5Ye4LiLazPAGWk5oQnUdQ=
 github.com/containers/libhvee v0.0.5 h1:5tUiF2eVe8XbVSPD/Os4dIU1gJWoQgtkQHIjQ5X7wpE=
 github.com/containers/libhvee v0.0.5/go.mod h1:AYsyMe44w9ylWWEZNW+IOzA7oZ2i/P9TChNljavhYMI=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/github.com/containers/common/pkg/config/config_darwin.go
+++ b/vendor/github.com/containers/common/pkg/config/config_darwin.go
@@ -30,9 +30,9 @@ func ifRootlessConfigPath() (string, error) {
 
 var defaultHelperBinariesDir = []string{
 	// Homebrew install paths
-	"/usr/local/opt/podman/libexec",
+	"/usr/local/opt/podman/libexec/podman",
+	"/opt/homebrew/opt/podman/libexec/podman",
 	"/opt/homebrew/bin",
-	"/opt/homebrew/opt/podman/libexec",
 	"/usr/local/bin",
 	// default paths
 	"/usr/local/libexec/podman",

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.54.0-dev"
+const Version = "0.54.0"

--- a/vendor/github.com/containers/image/v5/internal/manifest/list.go
+++ b/vendor/github.com/containers/image/v5/internal/manifest/list.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"fmt"
 
+	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -82,17 +83,21 @@ type ListEdit struct {
 	ListOperation ListOp
 
 	// if Op == ListEditUpdate (basically the previous UpdateInstances). All fields must be set.
-	UpdateOldDigest digest.Digest
-	UpdateDigest    digest.Digest
-	UpdateSize      int64
-	UpdateMediaType string
+	UpdateOldDigest             digest.Digest
+	UpdateDigest                digest.Digest
+	UpdateSize                  int64
+	UpdateMediaType             string
+	UpdateAffectAnnotations     bool
+	UpdateAnnotations           map[string]string
+	UpdateCompressionAlgorithms []compression.Algorithm
 
 	// If Op = ListEditAdd. All fields must be set.
-	AddDigest      digest.Digest
-	AddSize        int64
-	AddMediaType   string
-	AddPlatform    *imgspecv1.Platform
-	AddAnnotations map[string]string
+	AddDigest                digest.Digest
+	AddSize                  int64
+	AddMediaType             string
+	AddPlatform              *imgspecv1.Platform
+	AddAnnotations           map[string]string
+	AddCompressionAlgorithms []compression.Algorithm
 }
 
 // ListPublicFromBlob parses a list of manifests.

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 25
+	VersionMinor = 26
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,7 +128,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.53.1-0.20230627061926-e6f314e59b81
+# github.com/containers/common v0.54.0
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define
@@ -186,7 +186,7 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/image/v5 v5.25.1-0.20230623174242-68798a22ce3e
+# github.com/containers/image/v5 v5.26.0
 ## explicit; go 1.18
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
Bumping these two in preparation for Podman v4.6 and eventuall RHEL 8.9/9.3

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
