### PR TITLE
pasta: Create /etc/hosts entries for pods using pasta networking

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2203,6 +2203,12 @@ func (c *Container) getHostsEntries() (etchosts.HostEntries, error) {
 	switch {
 	case c.config.NetMode.IsBridge():
 		entries = etchosts.GetNetworkHostEntries(c.state.NetworkStatus, names...)
+	case c.config.NetMode.IsPasta():
+		ip, err := getPastaIP(c.state)
+		if err != nil {
+			return nil, err
+		}
+		entries = etchosts.HostEntries{{IP: ip.String(), Names: names}}
 	case c.config.NetMode.IsSlirp4netns():
 		ip, err := getSlirp4netnsIP(c.slirp4netnsSubnet)
 		if err != nil {

--- a/libpod/networking_freebsd.go
+++ b/libpod/networking_freebsd.go
@@ -271,3 +271,7 @@ func (c *Container) reloadRootlessRLKPortMapping() error {
 func (c *Container) setupRootlessNetwork() error {
 	return nil
 }
+
+func getPastaIP(state *ContainerState) (net.IP, error) {
+	return nil, fmt.Errorf("pasta networking is Linux only")
+}

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/common/libnetwork/resolvconf"
 	"github.com/containers/common/libnetwork/slirp4netns"
 	"github.com/containers/common/libnetwork/types"
+	netUtil "github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/netns"
 	"github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/pkg/rootless"
@@ -756,4 +757,14 @@ func (c *Container) inspectJoinedNetworkNS(networkns string) (q types.StatusBloc
 		return nil
 	})
 	return result, err
+}
+
+func getPastaIP(state *ContainerState) (net.IP, error) {
+	var ip string
+	err := ns.WithNetNSPath(state.NetNS, func(_ ns.NetNS) error {
+		// get the first ip in the netns
+		ip = netUtil.GetLocalIP()
+		return nil
+	})
+	return net.ParseIP(ip), err
 }

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -235,6 +235,21 @@ function teardown() {
            "Container has IPv6 global address with IPv6 disabled"
 }
 
+@test "podman networking with pasta(1) - podman puts pasta IP in /etc/hosts" {
+    skip_if_no_ipv4 "IPv4 not routable on the host"
+
+    pname="p$(random_string 30)"
+    ip="$(default_addr 4)"
+
+    run_podman pod create --net=pasta --name "${pname}"
+    run_podman run --pod="${pname}" "${IMAGE}" getent hosts "${pname}"
+
+    assert "$(echo ${output} | cut -f1 -d' ')" = "${ip}" "Correct /etc/hsots entry missing"
+
+    run_podman pod rm "${pname}"
+    run_podman rmi $(pause_image)
+}
+
 ### Routes #####################################################################
 
 @test "podman networking with pasta(1) - IPv4 default route" {


### PR DESCRIPTION
For pods with bridged and slirp4netns networking we create /etc/hosts entries to make it more convenient for the containers to address each other.  We omitted to do this for pasta networking, however.  Add the necessary code to do this.

Closes: https://github.com/containers/podman/issues/17922

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
