### PR TITLE
pasta: Remove some leftover code from pasta bats tests

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -55,12 +55,6 @@ function pasta_test_do() {
         skip_if_no_ipv4 "IPv4 not routable on the host"
     elif [ ${ip_ver} -eq 6 ]; then
         skip_if_no_ipv6 "IPv6 not routable on the host"
-        if [ ${iftype} = "loopback" ]; then
-            local ifname="lo"
-            local addr="::1"
-        else
-            local addr="$(ipv6_get_addr_default)"
-        fi
     else
         skip "Unsupported IP version"
     fi


### PR DESCRIPTION
https://github.com/containers/podman/pull/19021 fixed bugs with the pasta networking tests not working on hosts with multiple interfaces.  Alas, the patch left in some stale code that generates spurious error messages for the IPv6 case.  This is sort of harmless - later code overrides what's done here and the tests can pass anyway.  However if a test fails for some other reason it means we get a misleading irrelevant error message.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
