### PR TITLE
Makefile: don't rely on the non-standard -r flag for ln

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -830,7 +830,7 @@ install.remote:
 install.bin:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(DESTDIR)$(BINDIR)/podman
-	ln -sfr $(DESTDIR)$(BINDIR)/podman $(DESTDIR)$(BINDIR)/podmansh
+	ln -sf podman $(DESTDIR)$(BINDIR)/podmansh
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(LIBEXECPODMAN)
 ifneq ($(shell uname -s),FreeBSD)


### PR DESCRIPTION
This flag is not supported on BSD-derived systems including FreeBSD and macos. We can get exactly the same symlink by passing the desired relative path as source argument to 'ln -sf'.

This fixes a build break on FreeBSD and if possible, I would like this to be merged to the v4.6 branch to simplify packaging v4.6.x releases in future.

#### Does this PR introduce a user-facing change?

```release-note
None
```
