### PR TITLE
Use /proc/self/gid_map as intended, not uid_map

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -195,7 +195,7 @@ func GetKeepIDMapping(opts *namespaces.KeepIDUserNsOptions) (*stypes.IDMappingOp
 		if err != nil {
 			return nil, 0, 0, err
 		}
-		gids, err := rootless.ReadMappingsProc("/proc/self/uid_map")
+		gids, err := rootless.ReadMappingsProc("/proc/self/gid_map")
 		if err != nil {
 			return nil, 0, 0, err
 		}


### PR DESCRIPTION
GetKeepIDMapping never read the gid (as it intended) but reused the uid. Most likely a typo that never bothered anybody as uid and gid usually match.

I stumbled across this by accident and figured I can just fix it along the way, even though I was not hit by that bug :)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]