### PR TITLE
fix(command): ignore `--format` in `podman search --list-tags`

### DIFF
--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -182,7 +182,11 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 			listTagsEntries := buildListTagsJSON(searchReport)
 			return printArbitraryJSON(listTagsEntries)
 		}
-		rpt, err = rpt.Parse(report.OriginPodman, "{{range .}}{{.Name}}\t{{.Tag}}\n{{end -}}")
+		if cmd.Flags().Changed("format") {
+			rpt, err = rpt.Parse(report.OriginUser, searchOptions.Format)
+		} else {
+			rpt, err = rpt.Parse(report.OriginPodman, "{{range .}}{{.Name}}\t{{.Tag}}\n{{end -}}")
+		}
 	case isJSON:
 		return printArbitraryJSON(searchReport)
 	case cmd.Flags().Changed("format"):

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -177,6 +177,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 		}
 	})
 
+	It("podman search format list tags with custom", func() {
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "{{.Name}}", "--limit", "1", ALPINE})
+		search.WaitWithDefaultTimeout()
+		Expect(search).Should(Exit(0))
+		Expect(search.OutputToString()).To(Equal("quay.io/libpod/alpine"))
+	})
+
 	It("podman search attempts HTTP if tls-verify flag is set false", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")


### PR DESCRIPTION
Fix: https://github.com/containers/podman/issues/19033

#### Does this PR introduce a user-facing change?

```release-note
Fix ignore `--format` in `podman search --list-tags`
```

/cc @vrothberg 