### PR TITLE
top: do not depend on ps(1) in container 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -380,8 +380,6 @@ alt_build_task:
       - env:
             ALT_NAME: 'Windows Cross'
       - env:
-            ALT_NAME: 'Build Without CGO'
-      - env:
             ALT_NAME: 'Alt Arch. Cross'
     # This task cannot make use of the shared repo.tbz artifact.
     clone_script: *full_clone

--- a/Makefile
+++ b/Makefile
@@ -451,13 +451,6 @@ local-cross: $(CROSS_BUILD_TARGETS) ## Cross compile podman binary for multiple 
 .PHONY: cross
 cross: local-cross
 
-.PHONY: build-no-cgo
-build-no-cgo:
-	BUILDTAGS="containers_image_openpgp exclude_graphdriver_btrfs \
-		exclude_graphdriver_devicemapper exclude_disk_quota" \
-	CGO_ENABLED=0 \
-	$(MAKE) all
-
 .PHONY: completions
 completions: podman podman-remote
 	# key = shell, value = completion filename

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -276,9 +276,6 @@ function _run_altbuild() {
             make podman-remote-release-windows_amd64.zip
             make podman.msi
             ;;
-        *Without*)
-            make build-no-cgo
-            ;;
         *RPM*)
             make package
             ;;

--- a/docs/source/markdown/podman-pod-top.1.md.in
+++ b/docs/source/markdown/podman-pod-top.1.md.in
@@ -7,7 +7,9 @@ podman\-pod\-top - Display the running processes of containers in a pod
 **podman pod top** [*options*] *pod* [*format-descriptors*]
 
 ## DESCRIPTION
-Display the running processes of containers in a pod. The *format-descriptors* are ps (1) compatible AIX format descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities of a given process. The descriptors can either be passed as separate arguments or as a single comma-separated argument. Note that if additional options of ps(1) are specified, Podman falls back to executing ps with the specified arguments and options in the container.
+Display the running processes of containers in a pod. The *format-descriptors* are ps (1) compatible AIX format
+descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities
+of a given process. The descriptors can either be passed as separate arguments or as a single comma-separated argument.
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-top.1.md.in
+++ b/docs/source/markdown/podman-top.1.md.in
@@ -9,7 +9,14 @@ podman\-top - Display the running processes of a container
 **podman container top** [*options*] *container* [*format-descriptors*]
 
 ## DESCRIPTION
-Display the running processes of the container. The *format-descriptors* are ps (1) compatible AIX format descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities of a given process. The descriptors can either be passed as separated arguments or as a single comma-separated argument. Note that options and or flags of ps(1) can also be specified; in this case, Podman falls back to executing ps with the specified arguments and flags in the container.  Please use the "h*" descriptors to extract host-related information.  For instance, `podman top $name hpid huser` to display the PID and user of the processes in the host context.
+Display the running processes of the container. The *format-descriptors* are ps (1) compatible AIX format
+descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities
+of a given process. The descriptors can either be passed as separated arguments or as a single comma-separated
+argument. Note that options and or flags of ps(1) can also be specified; in this case, Podman falls back to
+executing ps(1) from the host with the specified arguments and flags in the container namespace. If the container
+has the `CAP_SYS_PTRACE` capability then we will execute ps(1) in the container so it must be installed there.
+Please use the "h*" descriptors to extract host-related information.  For instance, `podman top $name hpid huser`
+to display the PID and user of the processes in the host context.
 
 ## OPTIONS
 
@@ -90,7 +97,7 @@ PID   SECCOMP   COMMAND     %CPU
 8     filter    vi /etc/    0.000
 ```
 
-Podman falls back to executing ps(1) in the container if an unknown descriptor is specified.
+Podman falls back to executing ps(1) from the host in the container namespace if an unknown descriptor is specified.
 
 ```
 $ podman top -l -- aux

--- a/libpod/container_top_linux.c
+++ b/libpod/container_top_linux.c
@@ -1,0 +1,81 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* keep special_exit_code in sync with container_top_linux.go */
+int special_exit_code = 255;
+char **argv = NULL;
+
+void
+create_argv (int len)
+{
+  /* allocate one extra element because we need a final NULL in c */
+  argv = malloc (sizeof (char *) * (len + 1));
+  if (argv == NULL)
+    {
+      fprintf (stderr, "failed to allocate ps argv");
+      exit (special_exit_code);
+    }
+  /* add final NULL */
+  argv[len] = NULL;
+}
+
+void
+set_argv (int pos, char *arg)
+{
+  argv[pos] = arg;
+}
+
+/*
+  We use cgo code here so we can fork then exec separately,
+  this is done so we can mount proc after the fork because the pid namespace is
+  only active after spawning childs.
+*/
+void
+fork_exec_ps ()
+{
+  int r, status = 0;
+  pid_t pid;
+
+  if (argv == NULL)
+    {
+      fprintf (stderr, "argv not initialized");
+      exit (special_exit_code);
+    }
+
+  pid = fork ();
+  if (pid < 0)
+    {
+      fprintf (stderr, "fork: %m");
+      exit (special_exit_code);
+    }
+  if (pid == 0)
+    {
+      r = mount ("proc", "/proc", "proc", 0, NULL);
+      if (r < 0)
+        {
+          fprintf (stderr, "mount proc: %m");
+          exit (special_exit_code);
+        }
+      /* use execve to unset all env vars, we do not want to leak anything into the container */
+      execve (argv[0], argv, NULL);
+      fprintf (stderr, "execve: %m");
+      exit (special_exit_code);
+    }
+
+  r = waitpid (pid, &status, 0);
+  if (r < 0)
+    {
+      fprintf (stderr, "waitpid: %m");
+      exit (special_exit_code);
+    }
+  if (WIFEXITED (status))
+    exit (WEXITSTATUS (status));
+  if (WIFSIGNALED (status))
+    exit (128 + WTERMSIG (status));
+  exit (special_exit_code);
+}

--- a/libpod/container_top_unsupported.go
+++ b/libpod/container_top_unsupported.go
@@ -1,5 +1,6 @@
-//go:build !linux && !freebsd
-// +build !linux,!freebsd
+//go:build !(linux && cgo) && !freebsd
+// +build !linux !cgo
+// +build !freebsd
 
 package libpod
 

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -51,9 +51,9 @@ const (
 // AttachStreams contains streams that will be attached to the container
 type AttachStreams struct {
 	// OutputStream will be attached to container's STDOUT
-	OutputStream io.WriteCloser
+	OutputStream io.Writer
 	// ErrorStream will be attached to container's STDERR
-	ErrorStream io.WriteCloser
+	ErrorStream io.Writer
 	// InputStream will be attached to container's STDIN
 	InputStream *bufio.Reader
 	// AttachOutput is whether to attach to STDOUT

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -362,17 +362,12 @@ func PodTop(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 
-	psArgs := "-ef"
-	if utils.IsLibpodRequest(r) {
-		psArgs = ""
-	}
 	query := struct {
 		Delay  int    `schema:"delay"`
 		PsArgs string `schema:"ps_args"`
 		Stream bool   `schema:"stream"`
 	}{
-		Delay:  5,
-		PsArgs: psArgs,
+		Delay: 5,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -444,7 +444,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    name: ps_args
 	//    type: string
 	//    default: -ef
-	//    description: arguments to pass to ps such as aux. Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.
+	//    description: arguments to pass to ps such as aux.
 	// produces:
 	// - application/json
 	// responses:
@@ -1177,7 +1177,6 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    default:
 	//    description: |
 	//      arguments to pass to ps such as aux.
-	//      Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1174,7 +1174,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: ps_args
 	//    type: string
-	//    default: -ef
+	//    default:
 	//    description: |
 	//      arguments to pass to ps such as aux.
 	//      Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -309,7 +309,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: ps_args
 	//    type: string
-	//    default: -ef
+	//    default:
 	//    description: |
 	//      arguments to pass to ps such as aux.
 	//      Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -312,7 +312,6 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//    default:
 	//    description: |
 	//      arguments to pass to ps such as aux.
-	//      Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.
 	// responses:
 	//   200:
 	//     $ref: "#/responses/podTopResponse"

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -295,9 +295,9 @@ type ResizeExecTTYOptions struct {
 //go:generate go run ../generator/generator.go ExecStartAndAttachOptions
 type ExecStartAndAttachOptions struct {
 	// OutputStream will be attached to container's STDOUT
-	OutputStream *io.WriteCloser
+	OutputStream *io.Writer
 	// ErrorStream will be attached to container's STDERR
-	ErrorStream *io.WriteCloser
+	ErrorStream *io.Writer
 	// InputStream will be attached to container's STDIN
 	InputStream *bufio.Reader
 	// AttachOutput is whether to attach to STDOUT

--- a/pkg/bindings/containers/types_execstartandattach_options.go
+++ b/pkg/bindings/containers/types_execstartandattach_options.go
@@ -20,30 +20,30 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 }
 
 // WithOutputStream set field OutputStream to given value
-func (o *ExecStartAndAttachOptions) WithOutputStream(value io.WriteCloser) *ExecStartAndAttachOptions {
+func (o *ExecStartAndAttachOptions) WithOutputStream(value io.Writer) *ExecStartAndAttachOptions {
 	o.OutputStream = &value
 	return o
 }
 
 // GetOutputStream returns value of field OutputStream
-func (o *ExecStartAndAttachOptions) GetOutputStream() io.WriteCloser {
+func (o *ExecStartAndAttachOptions) GetOutputStream() io.Writer {
 	if o.OutputStream == nil {
-		var z io.WriteCloser
+		var z io.Writer
 		return z
 	}
 	return *o.OutputStream
 }
 
 // WithErrorStream set field ErrorStream to given value
-func (o *ExecStartAndAttachOptions) WithErrorStream(value io.WriteCloser) *ExecStartAndAttachOptions {
+func (o *ExecStartAndAttachOptions) WithErrorStream(value io.Writer) *ExecStartAndAttachOptions {
 	o.ErrorStream = &value
 	return o
 }
 
 // GetErrorStream returns value of field ErrorStream
-func (o *ExecStartAndAttachOptions) GetErrorStream() io.WriteCloser {
+func (o *ExecStartAndAttachOptions) GetErrorStream() io.Writer {
 	if o.ErrorStream == nil {
-		var z io.WriteCloser
+		var z io.Writer
 		return z
 	}
 	return *o.ErrorStream

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -410,7 +410,7 @@ var _ = Describe("Podman containers ", func() {
 
 		// With bogus descriptors
 		_, err = containers.Top(bt.conn, cid, new(containers.TopOptions).WithDescriptors([]string{"Me,Neither"}))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("podman bogus container does not exist in local storage", func() {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -123,10 +123,14 @@ if root; then
 
     t GET containers/$CTRNAME/top?stream=false 200 \
       .Titles='[
+  "UID",
   "PID",
-  "USER",
+  "PPID",
+  "C",
+  "STIME",
+  "TTY",
   "TIME",
-  "COMMAND"
+  "CMD"
 ]'
 
     podman rm -f $CTRNAME
@@ -135,9 +139,9 @@ fi
 CTRNAME=test123
 podman run --name $CTRNAME -d $IMAGE top
 t GET libpod/containers/$CTRNAME/top?ps_args=--invalid 500 \
-  .cause~".*unrecognized option.*"
+  .cause~".*unknown gnu long option.*"
 t GET containers/$CTRNAME/top?ps_args=--invalid 500 \
-  .cause~".*unrecognized option.*"
+  .cause~".*unknown gnu long option.*"
 
 podman rm -f $CTRNAME
 


### PR DESCRIPTION
This ended up more complicated then expected. Lets start first with the
problem to show why I am doing this:

Currently we simply execute ps(1) in the container. This has some
drawbacks. First, obviously you need to have ps(1) in the container
image. That is no always the case especially in small images. Second,
even if you do it will often be only busybox's ps which supports far
less options.

Now we also have psgo which is used by default but that only supports a
small subset of ps(1) options. Implementing all options there is way to
much work.

Docker on the other hand executes ps(1) directly on the host and tries
to filter pids with `-q` an option which is not supported by busybox's
ps and conflicts with other ps(1) arguments. That means they fall back
to full ps(1) on the host and then filter based on the pid in the
output. This is kinda ugly and fails short because users can modify the
ps output and it may not even include the pid in the output which causes
an error.

So every solution has a different drawback, but what if we can combine
them somehow?! This commit tries exactly that.

We use ps(1) from the host and execute that in the container's pid
namespace.
There are some security concerns that must be addressed:
- mount the executable paths for ps and podman itself readonly to
  prevent the container from overwriting it via /proc/self/exe.
- set NO_NEW_PRIVS, SET_DUMPABLE and PDEATHSIG
- close all non std fds to prevent leaking files in that the caller had
  open
- unset all environment variables to not leak any into the contianer

Technically this could be a breaking change if somebody does not
have ps on the host and only in the container but I find that very
unlikely so I have removed the in container fallback.

This updates the docs accordingly, note that podman pod top never falls
back to executing ps in the container as this makes no sense with
multiple containers so I fixed the docs there as well.

Fixes https://github.com/containers/podman/issues/19001
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2215572
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman top no longer depends on ps(1) being present in the container image and now uses the one from the host.
```
