### PR TITLE
Cirrus: change FreeBSD CI build to run in a VM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -383,8 +383,6 @@ alt_build_task:
             ALT_NAME: 'Build Without CGO'
       - env:
             ALT_NAME: 'Alt Arch. Cross'
-      - env:
-            ALT_NAME: 'FreeBSD Cross'
     # This task cannot make use of the shared repo.tbz artifact.
     clone_script: *full_clone
     setup_script: *setup
@@ -446,6 +444,37 @@ osx_alt_build_task:
     repo_prep_script: *repo_prep
     repo_artifacts: *repo_artifacts
     always: *runner_stats
+
+
+# Build freebsd release natively on a FreeBSD VM.
+freebsd_alt_build_task:
+    name: "FreeBSD Cross"
+    alias: freebsd_alt_build
+    # Docs: ./contrib/cirrus/CIModes.md
+    only_if: |
+      $CIRRUS_CRON != 'multiarch' &&
+      ($CIRRUS_BRANCH == 'main' || $CIRRUS_BASE_BRANCH == 'main')
+    depends_on:
+        - build
+    env:
+        <<: *stdenvars
+        # Functional FreeBSD builds must be built natively since they depend on CGO
+        DISTRO_NV: freebsd-13
+        VM_IMAGE_NAME: notyet
+        CTR_FQIN: notyet
+        CIRRUS_SHELL: "/bin/sh"
+        TEST_FLAVOR: "altbuild"
+        ALT_NAME: 'FreeBSD Cross'
+    freebsd_instance:
+        image_family: freebsd-13-2
+    setup_script:
+        - pkg install -y gpgme bash go-md2man gmake gsed gnugrep go pkgconf
+    build_amd64_script:
+        - gmake podman-release
+    # This task cannot make use of the shared repo.tbz artifact and must
+    # produce a new repo.tbz artifact for consumption by 'artifacts' task.
+    repo_prep_script: *repo_prep
+    repo_artifacts: *repo_artifacts
 
 
 # Verify podman is compatible with the docker python-module.
@@ -1041,6 +1070,7 @@ success_task:
         - swagger
         - alt_build
         - osx_alt_build
+        - freebsd_alt_build
         - win_installer
         - windows_smoke_test
         - docker-py_test

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ PROJECT := github.com/containers/podman
 GIT_BASE_BRANCH ?= origin/main
 LIBPOD_INSTANCE := libpod_dev
 PREFIX ?= /usr/local
+RELEASE_PREFIX = /usr
 BINDIR ?= ${PREFIX}/bin
 LIBEXECDIR ?= ${PREFIX}/libexec
 LIBEXECPODMAN ?= ${LIBEXECDIR}/podman
@@ -180,6 +181,10 @@ else ifeq ($(GOOS),darwin)
 BINSFX :=
 SRCBINDIR := bin/darwin
 CGO_ENABLED := 0
+else ifeq ($(GOOS),freebsd)
+BINSFX := -remote
+SRCBINDIR := bin
+RELEASE_PREFIX = /usr/local
 else
 BINSFX := -remote
 SRCBINDIR := bin
@@ -711,7 +716,7 @@ podman-release: podman-release-$(GOARCH).tar.gz  # Build all Linux binaries for 
 podman-release-%.tar.gz: test/version/version
 	$(eval TMPDIR := $(shell mktemp -d podman_tmp_XXXX))
 	$(eval SUBDIR := podman-v$(call err_if_empty,RELEASE_NUMBER))
-	$(eval _DSTARGS := "DESTDIR=$(TMPDIR)/$(SUBDIR)" "PREFIX=/usr")
+	$(eval _DSTARGS := "DESTDIR=$(TMPDIR)/$(SUBDIR)" "PREFIX=$(RELEASE_PREFIX)")
 	$(eval GOARCH := $*)
 	mkdir -p "$(call err_if_empty,TMPDIR)/$(SUBDIR)"
 	$(MAKE) GOOS=$(GOOS) GOARCH=$(NATIVE_GOARCH) \
@@ -730,7 +735,7 @@ podman-release-%.tar.gz: test/version/version
 podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$GOOS_$GOARCH, and docs. into an installation zip.
 	$(eval TMPDIR := $(shell mktemp -d podman_tmp_XXXX))
 	$(eval SUBDIR := podman-$(call err_if_empty,RELEASE_NUMBER))
-	$(eval _DSTARGS := "DESTDIR=$(TMPDIR)/$(SUBDIR)" "PREFIX=/usr")
+	$(eval _DSTARGS := "DESTDIR=$(TMPDIR)/$(SUBDIR)" "PREFIX=$(RELEASE_PREFIX)")
 	$(eval GOOS := $(firstword $(subst _, ,$*)))
 	$(eval GOARCH := $(lastword $(subst _, ,$*)))
 	$(eval _GOPLAT := GOOS=$(call err_if_empty,GOOS) GOARCH=$(call err_if_empty,GOARCH))

--- a/contrib/cirrus/CIModes.md
+++ b/contrib/cirrus/CIModes.md
@@ -49,6 +49,7 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + swagger
 + *alt_build*
 + osx_alt_build
++ freebsd_alt_build
 + docker-py_test
 + *unit_test*
 + apiv2_test
@@ -84,6 +85,7 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + validate
 + *alt_build*
 + osx_alt_build
++ freebsd_alt_build
 + test_image_build
 + meta
 + success
@@ -111,6 +113,7 @@ pressing the re-run button **is not** good enough).
 + swagger
 + *alt_build*
 + osx_alt_build
++ freebsd_alt_build
 + *local_system_test*
 + *remote_system_test*
 + *rootless_remote_system_test*
@@ -129,6 +132,7 @@ pressing the re-run button **is not** good enough).
 + swagger
 + *alt_build*
 + osx_alt_build
++ freebsd_alt_build
 + meta
 + success
 + artifacts

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -282,9 +282,6 @@ function _run_altbuild() {
         *RPM*)
             make package
             ;;
-        FreeBSD*Cross)
-            make bin/podman.cross.freebsd.amd64
-            ;;
         Alt*Cross)
             arches=(\
                 amd64

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -23,7 +23,7 @@ fi
 
 function usage() {
     echo >&2 "$0 PLATFORM TARGET SOURCES..."
-    echo >&2 "PLATFORM: Is either linux, darwin or windows."
+    echo >&2 "PLATFORM: Is either linux, darwin, windows or freebsd."
     echo >&2 "TARGET: Is the directory where files will be staged. eg, docs/build/remote/linux"
     echo >&2 "SOURCES: Are the directories of source files. eg, docs/source/markdown"
 }
@@ -34,7 +34,7 @@ function fail() {
 }
 
 case $PLATFORM in
-darwin|linux)
+darwin|linux|freebsd)
     PUBLISHER=man_fn
     ext=1
     ;;


### PR DESCRIPTION
This enables 'make podman-release' for FreeBSD and changes the Cirrus CI config to run that build in a FreeBSD VM so that the build can use CGO.

I attempted to add FreeBSD binaries to the artifacts task but this failed, apparently because the extra 50Mb of space exceeded a 1Gb limit in Cirrus.

#### Does this PR introduce a user-facing change?

```release-note
None
```
