### PR TITLE
pkg/specgen: properly identify image OS on FreeBSD

### DIFF
--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -18,11 +18,17 @@ import (
 
 // SpecGenToOCI returns the base configuration for the container.
 func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, newImage *libimage.Image, mounts []spec.Mount, pod *libpod.Pod, finalCmd []string, compatibleOptions *libpod.InfraInherit) (*spec.Spec, error) {
-	if s.ImageOS != "freebsd" && s.ImageOS != "linux" {
-		return nil, fmt.Errorf("unsupported image OS: %s", s.ImageOS)
+	inspectData, err := newImage.Inspect(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	imageOs := inspectData.Os
+
+	if imageOs != "freebsd" && imageOs != "linux" {
+		return nil, fmt.Errorf("unsupported image OS: %s", imageOs)
 	}
 
-	g, err := generate.New(s.ImageOS)
+	g, err := generate.New(imageOs)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +61,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	// Linux emulatioon
-	if s.ImageOS == "linux" {
+	if imageOs == "linux" {
 		var mounts []spec.Mount
 		for _, m := range configSpec.Mounts {
 			switch m.Destination {


### PR DESCRIPTION
When working on Linux emulation on FreeBSD, I assumed that SpecGenerator.ImageOS was always populated from the image's OS value but in fact, this value comes from the CLI --os flag if set, otherwise "". This broke running FreeBSD native containers unless --os=freebsd was also set. Fix the problem by falling back to runtime.GOOS if ImageOS is not set.

This is a strong incentive for me to complete a stalled project to enable podman system tests on FreeBSD.

#### Does this PR introduce a user-facing change?

```release-note
None
```
