### PR TITLE
[CI:DOCS] uidmap man pages: fix corrupt tables

### DIFF
--- a/docs/source/markdown/options/uidmap.container.md
+++ b/docs/source/markdown/options/uidmap.container.md
@@ -22,7 +22,7 @@ The _amount_ specifies the number of consecutive UIDs that is mapped.
 If for example _amount_ is **4** the mapping looks like:
 
 |   host UID     |    container UID    |
-| -              | -                   |
+| ----------     | ----------------    |
 | _from_uid_     | _container_uid_     |
 | _from_uid_ + 1 | _container_uid_ + 1 |
 | _from_uid_ + 2 | _container_uid_ + 2 |
@@ -42,13 +42,13 @@ _/etc/subuid_ and the UID of the user calling Podman.
 
 First mapping step:
 
-| host UID                                         | intermediate UID |
-| -                                                |                - |
-| UID for the user starting Podman                 |                0 |
-| 1st subordinate UID for the user starting Podman |                1 |
-| 2nd subordinate UID for the user starting Podman |                2 |
-| 3rd subordinate UID for the user starting Podman |                3 |
-| nth subordinate UID for the user starting Podman |                n |
+| host UID            | intermediate UID |
+| --------            | ---------------- |
+| UID for Podman user |                0 |
+| 1st subordinate UID |                1 |
+| 2nd subordinate UID |                2 |
+| 3rd subordinate UID |                3 |
+| nth subordinate UID |                n |
 
 To be able to use intermediate UIDs greater than zero, the user needs to have
 subordinate UIDs configured in _/etc/subuid_. See **subuid**(5).
@@ -58,7 +58,7 @@ The second mapping step is configured with **--uidmap**.
 If for example _amount_ is **5** the second mapping step looks like:
 
 |   intermediate UID   |    container UID    |
-| -                    | -                   |
+| ------------------   | ----------------    |
 | _from_uid_           | _container_uid_     |
 | _from_uid_ + 1       | _container_uid_ + 1 |
 | _from_uid_ + 2       | _container_uid_ + 2 |
@@ -70,11 +70,11 @@ When running as rootless, Podman uses all the ranges configured in the _/etc/sub
 The current user ID is mapped to UID=0 in the rootless user namespace.
 Every additional range is added sequentially afterward:
 
-|   host                |rootless user namespace | length              |
-| -                     | -                      | -                   |
-| $UID                  | 0                      | 1                   |
-| 1                     | $FIRST_RANGE_ID        | $FIRST_RANGE_LENGTH |
-| 1+$FIRST_RANGE_LENGTH | $SECOND_RANGE_ID       | $SECOND_RANGE_LENGTH|
+|   host                | rootless user namespace | length              |
+| ------                | ----------------------- | ------              |
+| $UID                  | 0                       | 1                   |
+| 1                     | $FIRST_RANGE_ID         | $FIRST_RANGE_LENGTH |
+| 1+$FIRST_RANGE_LENGTH | $SECOND_RANGE_ID        | $SECOND_RANGE_LENGTH|
 
 Even if a user does not have any subordinate UIDs in  _/etc/subuid_,
 **--uidmap** can be used to map the normal UID of the user to a


### PR DESCRIPTION
The markdown-to-manpage sequence needs a long row of dashes, not a single dash. A single dash, as used in this one option, generates unreadable *roff.

Also, some tool somewhere doesn't like too-long columns. Shrtn thm.

Also, verify that there are no more three-or-fewer-dash columns:

    $ ack '\|\s+-{1,3}\s' docs/source/markdown

Fixes: #19086

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
Fixes corrupt uidmap tables in podman-create(1) and -run(1)
```
