### PR TITLE
auto update: fix usage of --authfile

### DIFF
--- a/docs/source/markdown/options/tls-verify.md
+++ b/docs/source/markdown/options/tls-verify.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container runlabel, create, kube play, login, manifest add, manifest create, manifest inspect, manifest push, pull, push, run, search
+####>   podman auto update, build, container runlabel, create, kube play, login, manifest add, manifest create, manifest inspect, manifest push, pull, push, run, search
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--tls-verify**

--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -79,6 +79,7 @@ Please note that detecting if a systemd unit has failed is best done by the cont
 
 For a container to send the READY message via SDNOTIFY it must be created with the `--sdnotify=container` option (see podman-run(1)).  The application running inside the container can then execute `systemd-notify --ready` when ready or use the sdnotify bindings of the specific programming language (e.g., sd_notify(3)).
 
+@@option tls-verify
 
 ## EXAMPLES
 Autoupdate with registry policy

--- a/go.mod
+++ b/go.mod
@@ -180,3 +180,5 @@ require (
 )
 
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+
+replace github.com/containers/common => github.com/containers/common v0.55.1-0.20230703090011-0ab70cf5664d

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.31.0 h1:NgVtEyTsR7e/XLTSJElbInnGPjdDGNHqLKADPHzaUGg=
 github.com/containers/buildah v1.31.0/go.mod h1:tcgXcGhqw3kw49RapUS7tskEhxKLG4eVFJKA/QzgwNU=
-github.com/containers/common v0.55.1 h1:sOlcIxEYXoR3OSHufew7CuSeOWr7a2jHGYw3r+xKA1k=
-github.com/containers/common v0.55.1/go.mod h1:ZKPllYOZ2xj2rgWRdnHHVvWg6ru4BT28En8mO8DMMPk=
+github.com/containers/common v0.55.1-0.20230703090011-0ab70cf5664d h1:qtrq0ZsAAd+lI9eYBpq/1Fz9cxE1D95AvoB6g4ES0wg=
+github.com/containers/common v0.55.1-0.20230703090011-0ab70cf5664d/go.mod h1:c+q6NRSLy4pKMYzb7Hsu6NPy0LnIjH2CJnplR5w3Bk8=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.26.1 h1:8y3xq8GO/6y8FR+nAedHPsAFiAtOrab9qHTBpbqaX8g=

--- a/pkg/domain/entities/auto-update.go
+++ b/pkg/domain/entities/auto-update.go
@@ -1,5 +1,7 @@
 package entities
 
+import "github.com/containers/image/v5/types"
+
 // AutoUpdateOptions are the options for running auto-update.
 type AutoUpdateOptions struct {
 	// Authfile to use when contacting registries.
@@ -11,6 +13,9 @@ type AutoUpdateOptions struct {
 	// If restarting the service with the new image failed, restart it
 	// another time with the previous image.
 	Rollback bool
+	// Allow contacting registries over HTTP, or HTTPS with failed TLS
+	// verification. Note that this does not affect other TLS connections.
+	InsecureSkipTLSVerify types.OptionalBool
 }
 
 // AutoUpdateReport contains the results from running auto-update.

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -4,6 +4,8 @@
 #
 
 load helpers
+load helpers.network
+load helpers.registry
 load helpers.systemd
 
 SNAME_FILE=$BATS_TMPDIR/services
@@ -47,6 +49,7 @@ function teardown() {
 #   4. Generate the service file from the container
 #   5. Remove the origin container
 #   6. Start the container from service
+#   7. Use this fully-qualified image instead of 2)
 function generate_service() {
     local target_img_basename=$1
     local autoupdate=$2
@@ -64,6 +67,9 @@ function generate_service() {
     # IMPORTANT: variable 'cname' is passed (out of scope) up to caller!
     cname=c_${autoupdate//\'/}_$(random_string)
     target_img="quay.io/libpod/$target_img_basename:latest"
+    if [[ -n "$7" ]]; then
+        target_img="$7"
+    fi
 
     if [[ -z "$noTag" ]]; then
         run_podman tag $IMAGE $target_img
@@ -621,6 +627,64 @@ EOF
     run_podman rmi $local_image $(pause_image)
     rm -f $podunit $ctrunit
     systemctl daemon-reload
+}
+
+@test "podman-auto-update --authfile"  {
+    # Test the three supported ways of using authfiles with auto updates
+    # 1) Passed via --authfile CLI flag
+    # 2) Passed via the REGISTRY_AUTH_FILE env variable
+    # 3) Via a label at container creation where 1) and 2) will be ignored
+
+    registry=localhost:${PODMAN_LOGIN_REGISTRY_PORT}
+    image_on_local_registry=$registry/name:tag
+    authfile=$PODMAN_TMPDIR/authfile.json
+
+    # First, start the registry and populate the authfile that we can use for the test.
+    start_registry
+    run_podman login --authfile=$authfile \
+        --tls-verify=false \
+        --username ${PODMAN_LOGIN_USER} \
+        --password ${PODMAN_LOGIN_PASS} \
+        $registry
+
+    run_podman tag $IMAGE $image_on_local_registry
+    run_podman push --tls-verify=false --creds "${PODMAN_LOGIN_USER}:${PODMAN_LOGIN_PASS}" $image_on_local_registry
+
+    # Generate a systemd service with the "registry" auto-update policy running
+    # "top" inside the image we just pushed to the local registry.
+    generate_service "" registry top "" "" "" $image_on_local_registry
+    ctr=$cname
+    _wait_service_ready container-$ctr.service
+
+    run_podman 125 auto-update
+    is "$output" \
+       ".*Error: checking image updates for container .*: x509: .*"
+
+    run_podman 125 auto-update --tls-verify=false
+    is "$output" \
+       ".*Error: checking image updates for container .*: authentication required"
+
+    # Test 1)
+    run_podman auto-update --authfile=$authfile --tls-verify=false --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    is "$output" "container-$ctr.service,$image_on_local_registry,false,registry" "auto-update works with authfile"
+
+    # Test 2)
+    REGISTRY_AUTH_FILE=$authfile run_podman auto-update --tls-verify=false --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    is "$output" "container-$ctr.service,$image_on_local_registry,false,registry" "auto-update works with env var"
+    systemctl stop container-$ctr.service
+    run_podman rm -f -t0 --ignore $ctr
+
+    # Create a container with the auth-file label
+    generate_service "" registry top "--label io.containers.autoupdate.authfile=$authfile" "" "" $image_on_local_registry
+    ctr=$cname
+    _wait_service_ready container-$ctr.service
+
+    # Test 3)
+    # Also make sure that the label takes precedence over the CLI flag.
+    run_podman auto-update --authfile=/dev/null --tls-verify=false --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    is "$output" "container-$ctr.service,$image_on_local_registry,false,registry" "auto-update works with authfile container label"
+    run_podman rm -f -t0 --ignore $ctr
+    run_podman rmi $image_on_local_registry
 }
 
 # vim: filetype=sh

--- a/vendor/github.com/containers/common/libimage/image.go
+++ b/vendor/github.com/containers/common/libimage/image.go
@@ -806,6 +806,9 @@ type HasDifferentDigestOptions struct {
 	// containers-auth.json(5) file to use when authenticating against
 	// container registries.
 	AuthFilePath string
+	// Allow contacting registries over HTTP, or HTTPS with failed TLS
+	// verification. Note that this does not affect other TLS connections.
+	InsecureSkipTLSVerify types.OptionalBool
 }
 
 // HasDifferentDigest returns true if the image specified by `remoteRef` has a
@@ -831,8 +834,15 @@ func (i *Image) HasDifferentDigest(ctx context.Context, remoteRef types.ImageRef
 		sys.VariantChoice = inspectInfo.Variant
 	}
 
-	if options != nil && options.AuthFilePath != "" {
-		sys.AuthFilePath = options.AuthFilePath
+	if options != nil {
+		if options.AuthFilePath != "" {
+			sys.AuthFilePath = options.AuthFilePath
+		}
+		if options.InsecureSkipTLSVerify != types.OptionalBoolUndefined {
+			sys.DockerInsecureSkipTLSVerify = options.InsecureSkipTLSVerify
+			sys.OCIInsecureSkipTLSVerify = options.InsecureSkipTLSVerify == types.OptionalBoolTrue
+			sys.DockerDaemonInsecureSkipTLSVerify = options.InsecureSkipTLSVerify == types.OptionalBoolTrue
+		}
 	}
 
 	return i.hasDifferentDigestWithSystemContext(ctx, remoteRef, sys)

--- a/vendor/github.com/containers/common/pkg/secrets/secrets.go
+++ b/vendor/github.com/containers/common/pkg/secrets/secrets.go
@@ -217,9 +217,12 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, opti
 	}
 
 	if options.Replace {
-		err = driver.Delete(secr.ID)
-		if err != nil {
-			return "", fmt.Errorf("replacing secret %s: %w", name, err)
+		if err := driver.Delete(secr.ID); err != nil {
+			return "", fmt.Errorf("deleting secret %s: %w", secr.ID, err)
+		}
+
+		if err := s.delete(secr.ID); err != nil {
+			return "", fmt.Errorf("deleting secret %s: %w", secr.ID, err)
 		}
 	}
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.55.1"
+const Version = "0.56.0-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,7 +128,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.55.1
+# github.com/containers/common v0.55.1 => github.com/containers/common v0.55.1-0.20230703090011-0ab70cf5664d
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define
@@ -1154,3 +1154,4 @@ gopkg.in/yaml.v3
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+# github.com/containers/common => github.com/containers/common v0.55.1-0.20230703090011-0ab70cf5664d


### PR DESCRIPTION
The --authfile flag has been ignored.  Fix that and add a test to make
sure we won't regress another time.  Requires a new --tls-verify flag
to actually test the code.

Also bump c/common since common/pull/1538 is required to correctly check
for updates.  Note that I had to use the go-mod-edit-replace trick on
c/common as c/buildah would otherwise be moved back to 1.30.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2218315
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug podman-auto-update to correctly use authentication files when contacting container registries.
```
