### PR TITLE
machine: ssh: add stdout and stderr to error message

### DIFF
--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -1,8 +1,8 @@
 package machine
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 
@@ -27,9 +27,15 @@ func CommonSSH(username, identityPath, name string, sshPort int, inputArgs []str
 	cmd := exec.Command("ssh", args...)
 	logrus.Debugf("Executing: ssh %v\n", args)
 
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	return cmd.Run()
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("SSH failed: %w (stdout: %q, stderr: %q)", err, stdout.String(), stderr.String())
+	}
+
+	return nil
 }


### PR DESCRIPTION
The error messages when SSHing into the machine have been suppressed and we only received an `exit status 255` which does not aid much in debugging.

Adding stdout and stderr from executing `ssh` should give a better idea of what went wrong, and ideally leave some breadcrumbs for debugging.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
