### PR TITLE
[CI:BUILD] Minor: Don't confuse osx-debugging

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -423,12 +423,14 @@ osx_alt_build_task:
     depends_on:
         - build
     env:
-        <<: *stdenvars
+        DISTRO_NV: macos-ventura
+        VM_IMAGE_NAME: ghcr.io/cirruslabs/${DISTRO_NV}-base:latest
+        CTR_FQIN: notused
         # OSX platform variation prevents this being included in alt_build_task
         TEST_FLAVOR: "altbuild"
         ALT_NAME: 'OSX Cross'
     osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
+        image: $VM_IMAGE_NAME
     setup_script:
         - brew install go
         - brew install go-md2man


### PR DESCRIPTION
Many/most env. vars set by the `stdenvars` alias do not apply to the `osx_alt_build` task.  In case anybody debugging a job might be confused by them, use more meaningful values.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
