### PR TITLE
libpod: use new libcontainer BlockIO constructors

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -267,49 +267,25 @@ func GetLimits(resource *spec.LinuxResources) (runcconfig.Resources, error) {
 	if resource.BlockIO != nil {
 		if len(resource.BlockIO.ThrottleReadBpsDevice) > 0 {
 			for _, entry := range resource.BlockIO.ThrottleReadBpsDevice {
-				throttle := &runcconfig.ThrottleDevice{}
-				dev := &runcconfig.BlockIODevice{
-					Major: entry.Major,
-					Minor: entry.Minor,
-				}
-				throttle.BlockIODevice = *dev
-				throttle.Rate = entry.Rate
+				throttle := runcconfig.NewThrottleDevice(entry.Major, entry.Minor, entry.Rate)
 				final.BlkioThrottleReadBpsDevice = append(final.BlkioThrottleReadBpsDevice, throttle)
 			}
 		}
 		if len(resource.BlockIO.ThrottleWriteBpsDevice) > 0 {
 			for _, entry := range resource.BlockIO.ThrottleWriteBpsDevice {
-				throttle := &runcconfig.ThrottleDevice{}
-				dev := &runcconfig.BlockIODevice{
-					Major: entry.Major,
-					Minor: entry.Minor,
-				}
-				throttle.BlockIODevice = *dev
-				throttle.Rate = entry.Rate
+				throttle := runcconfig.NewThrottleDevice(entry.Major, entry.Minor, entry.Rate)
 				final.BlkioThrottleWriteBpsDevice = append(final.BlkioThrottleWriteBpsDevice, throttle)
 			}
 		}
 		if len(resource.BlockIO.ThrottleReadIOPSDevice) > 0 {
 			for _, entry := range resource.BlockIO.ThrottleReadIOPSDevice {
-				throttle := &runcconfig.ThrottleDevice{}
-				dev := &runcconfig.BlockIODevice{
-					Major: entry.Major,
-					Minor: entry.Minor,
-				}
-				throttle.BlockIODevice = *dev
-				throttle.Rate = entry.Rate
+				throttle := runcconfig.NewThrottleDevice(entry.Major, entry.Minor, entry.Rate)
 				final.BlkioThrottleReadIOPSDevice = append(final.BlkioThrottleReadIOPSDevice, throttle)
 			}
 		}
 		if len(resource.BlockIO.ThrottleWriteIOPSDevice) > 0 {
 			for _, entry := range resource.BlockIO.ThrottleWriteIOPSDevice {
-				throttle := &runcconfig.ThrottleDevice{}
-				dev := &runcconfig.BlockIODevice{
-					Major: entry.Major,
-					Minor: entry.Minor,
-				}
-				throttle.BlockIODevice = *dev
-				throttle.Rate = entry.Rate
+				throttle := runcconfig.NewThrottleDevice(entry.Major, entry.Minor, entry.Rate)
 				final.BlkioThrottleWriteIOPSDevice = append(final.BlkioThrottleWriteIOPSDevice, throttle)
 			}
 		}
@@ -321,18 +297,14 @@ func GetLimits(resource *spec.LinuxResources) (runcconfig.Resources, error) {
 		}
 		if len(resource.BlockIO.WeightDevice) > 0 {
 			for _, entry := range resource.BlockIO.WeightDevice {
-				weight := &runcconfig.WeightDevice{}
-				dev := &runcconfig.BlockIODevice{
-					Major: entry.Major,
-					Minor: entry.Minor,
-				}
+				var w, lw uint16
 				if entry.Weight != nil {
-					weight.Weight = *entry.Weight
+					w = *entry.Weight
 				}
 				if entry.LeafWeight != nil {
-					weight.LeafWeight = *entry.LeafWeight
+					lw = *entry.LeafWeight
 				}
-				weight.BlockIODevice = *dev
+				weight := runcconfig.NewWeightDevice(entry.Major, entry.Minor, w, lw)
 				final.BlkioWeightDevice = append(final.BlkioWeightDevice, weight)
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

libpod as it currently is is not compatible with newer tagged version of runc, as on that release branch the BlockIO fields are private. However, newer libpod need to use a newer version of runc (which happens to have the blockIO bits exported) to reduce the binary size of podman.

a compromise is libpod can use the constructors where applicable, so podman can build its own smaller binary (with a newer runc) as well as be compatible with the runc 1.1.z branch

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```

EDIT (@lsm5)
[NO NEW TESTS NEEDED]