### PR TITLE
Add `--no-trunc` flag to maintain original annotation length

### DIFF
--- a/cmd/podman/kube/generate.go
+++ b/cmd/podman/kube/generate.go
@@ -81,6 +81,9 @@ func generateFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 	flags.Int32VarP(&generateOptions.Replicas, replicasFlagName, "r", 1, "Set the replicas number for Deployment kind")
 	_ = cmd.RegisterFlagCompletionFunc(replicasFlagName, completion.AutocompleteNone)
 
+	noTruncAnnotationsFlagName := "no-trunc"
+	flags.BoolVar(&generateOptions.UseLongAnnotations, noTruncAnnotationsFlagName, false, "Don't truncate annotations to Kubernetes length (63 chars)")
+
 	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -165,6 +165,9 @@ func playFlags(cmd *cobra.Command) {
 	flags.StringSliceVar(&playOptions.ConfigMaps, configmapFlagName, []string{}, "`Pathname` of a YAML file containing a kubernetes configmap")
 	_ = cmd.RegisterFlagCompletionFunc(configmapFlagName, completion.AutocompleteDefault)
 
+	noTruncFlagName := "no-trunc"
+	flags.BoolVar(&playOptions.UseLongAnnotations, noTruncFlagName, false, "Use annotations that are not truncated to the Kubernetes maximum length of 63 characters")
+
 	if !registry.IsRemote() {
 		certDirFlagName := "cert-dir"
 		flags.StringVar(&playOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")
@@ -240,7 +243,7 @@ func play(cmd *cobra.Command, args []string) error {
 			playOptions.Annotations = make(map[string]string)
 		}
 		annotation := splitN[1]
-		if len(annotation) > define.MaxKubeAnnotation {
+		if len(annotation) > define.MaxKubeAnnotation && !playOptions.UseLongAnnotations {
 			return fmt.Errorf("annotation exceeds maximum size, %d, of kubernetes annotation: %s", define.MaxKubeAnnotation, annotation)
 		}
 		playOptions.Annotations[splitN[0]] = annotation

--- a/docs/source/markdown/podman-kube-generate.1.md
+++ b/docs/source/markdown/podman-kube-generate.1.md
@@ -34,6 +34,11 @@ Note that the generated Kubernetes YAML file can be used to re-run the deploymen
 
 Output to the given file instead of STDOUT. If the file already exists, `kube generate` refuses to replace it and returns an error.
 
+#### **--no-trunc**
+
+Don't truncate annotations to the Kubernetes maximum length of 63 characters.
+Note: enabling this flag means the generated YAML file is not Kubernetes compatible and can only be used with `podman kube play`
+
 #### **--replicas**, **-r**=*replica count*
 
 The value to set `replicas` to when generating a **Deployment** kind.

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -214,6 +214,10 @@ When no network option is specified and *host* network mode is not configured in
 
 This option conflicts with host added in the Kubernetes YAML.
 
+#### **--no-trunc**
+
+Use annotations that are not truncated to the Kubernetes maximum length of 63 characters
+
 #### **--publish**=*[[ip:][hostPort]:]containerPort[/protocol]*
 
 Define or override a port definition in the YAML file.

--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -93,6 +93,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 		Service  bool     `schema:"service"`
 		Type     string   `schema:"type"`
 		Replicas int32    `schema:"replicas"`
+		NoTrunc  bool     `schema:"noTrunc"`
 	}{
 		// Defaults would go here.
 		Replicas: 1,
@@ -115,7 +116,12 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	}
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
-	options := entities.GenerateKubeOptions{Service: query.Service, Type: generateType, Replicas: query.Replicas}
+	options := entities.GenerateKubeOptions{
+		Service:            query.Service,
+		Type:               generateType,
+		Replicas:           query.Replicas,
+		UseLongAnnotations: query.NoTrunc,
+	}
 	report, err := containerEngine.GenerateKube(r.Context(), query.Names, options)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("generating YAML: %w", err))

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -29,6 +29,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		StaticMACs       []string          `schema:"staticMACs"`
 		NoHosts          bool              `schema:"noHosts"`
 		PublishPorts     []string          `schema:"publishPorts"`
+		NoTrunc          bool              `schema:"noTrunc"`
 		Wait             bool              `schema:"wait"`
 		ServiceContainer bool              `schema:"serviceContainer"`
 	}{
@@ -85,21 +86,22 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := entities.PlayKubeOptions{
-		Annotations:      query.Annotations,
-		Authfile:         authfile,
-		Username:         username,
-		Password:         password,
-		Networks:         query.Network,
-		NoHosts:          query.NoHosts,
-		Quiet:            true,
-		LogDriver:        logDriver,
-		LogOptions:       query.LogOptions,
-		StaticIPs:        staticIPs,
-		StaticMACs:       staticMACs,
-		IsRemote:         true,
-		PublishPorts:     query.PublishPorts,
-		Wait:             query.Wait,
-		ServiceContainer: query.ServiceContainer,
+		Annotations:        query.Annotations,
+		Authfile:           authfile,
+		Username:           username,
+		Password:           password,
+		Networks:           query.Network,
+		NoHosts:            query.NoHosts,
+		Quiet:              true,
+		LogDriver:          logDriver,
+		LogOptions:         query.LogOptions,
+		StaticIPs:          staticIPs,
+		StaticMACs:         staticMACs,
+		IsRemote:           true,
+		PublishPorts:       query.PublishPorts,
+		Wait:               query.Wait,
+		ServiceContainer:   query.ServiceContainer,
+		UseLongAnnotations: query.NoTrunc,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -58,6 +58,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: false
 	//    description: Clean up all objects created when a SIGTERM is received or pods exit.
+	//  - in: query
+	//    name: noTrunc
+	//    type: boolean
+	//    default: false
+	//    description: use annotations that are not truncated to the Kubernetes maximum length of 63 characters
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.
@@ -125,6 +130,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    format: int32
 	//    default: 0
 	//    description: Set the replica number for Deployment kind.
+	//  - in: query
+	//    name: noTrunc
+	//    type: boolean
+	//    default: false
+	//    description: don't truncate annotations to the Kubernetes maximum length of 63 characters
 	// produces:
 	// - text/vnd.yaml
 	// - application/json

--- a/pkg/bindings/generate/types.go
+++ b/pkg/bindings/generate/types.go
@@ -10,6 +10,8 @@ type KubeOptions struct {
 	Type *string
 	// Replicas - the value to set in the replicas field for a Deployment
 	Replicas *int32
+	// NoTrunc - don't truncate annotations to the Kubernetes maximum length of 63 characters
+	NoTrunc *bool
 }
 
 // SystemdOptions are optional options for generating systemd files

--- a/pkg/bindings/generate/types_kube_options.go
+++ b/pkg/bindings/generate/types_kube_options.go
@@ -61,3 +61,18 @@ func (o *KubeOptions) GetReplicas() int32 {
 	}
 	return *o.Replicas
 }
+
+// WithNoTrunc set field NoTrunc to given value
+func (o *KubeOptions) WithNoTrunc(value bool) *KubeOptions {
+	o.NoTrunc = &value
+	return o
+}
+
+// GetNoTrunc returns value of field NoTrunc
+func (o *KubeOptions) GetNoTrunc() bool {
+	if o.NoTrunc == nil {
+		var z bool
+		return z
+	}
+	return *o.NoTrunc
+}

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -44,6 +44,9 @@ type PlayOptions struct {
 	LogOptions *[]string
 	// Start - don't start the pod if false
 	Start *bool
+	// NoTrunc - use annotations that were not truncated to the
+	// Kubernetes maximum of 63 characters
+	NoTrunc *bool
 	// Userns - define the user namespace to use.
 	Userns *string
 	// Force - remove volumes on --down

--- a/pkg/bindings/kube/types_play_options.go
+++ b/pkg/bindings/kube/types_play_options.go
@@ -273,6 +273,21 @@ func (o *PlayOptions) GetStart() bool {
 	return *o.Start
 }
 
+// WithNoTrunc set field NoTrunc to given value
+func (o *PlayOptions) WithNoTrunc(value bool) *PlayOptions {
+	o.NoTrunc = &value
+	return o
+}
+
+// GetNoTrunc returns value of field NoTrunc
+func (o *PlayOptions) GetNoTrunc() bool {
+	if o.NoTrunc == nil {
+		var z bool
+		return z
+	}
+	return *o.NoTrunc
+}
+
 // WithUserns set field Userns to given value
 func (o *PlayOptions) WithUserns(value string) *PlayOptions {
 	o.Userns = &value

--- a/pkg/domain/entities/generate.go
+++ b/pkg/domain/entities/generate.go
@@ -35,6 +35,8 @@ type GenerateKubeOptions struct {
 	Type string
 	// Replicas - the value to set in the replicas field for a Deployment
 	Replicas int32
+	// UseLongAnnotations - don't truncate annotations to the Kubernetes maximum length of 63 characters
+	UseLongAnnotations bool
 }
 
 type KubeGenerateOptions = GenerateKubeOptions

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -59,6 +59,9 @@ type PlayKubeOptions struct {
 	Start types.OptionalBool
 	// ServiceContainer - creates a service container that is started before and is stopped after all pods.
 	ServiceContainer bool
+	// UseLongAnnotations - use annotations that were not truncated to the
+	// Kubernetes maximum length of 63 characters
+	UseLongAnnotations bool
 	// Userns - define the user namespace to use.
 	Userns string
 	// IsRemote - was the request triggered by running podman-remote

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -207,7 +207,7 @@ func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string,
 
 	// Generate the kube pods from containers.
 	if len(ctrs) >= 1 {
-		po, err := libpod.GenerateForKube(ctx, ctrs, options.Service)
+		po, err := libpod.GenerateForKube(ctx, ctrs, options.Service, options.UseLongAnnotations)
 		if err != nil {
 			return nil, err
 		}
@@ -273,7 +273,7 @@ func getKubePods(ctx context.Context, pods []*libpod.Pod, options entities.Gener
 	svcs := [][]byte{}
 
 	for _, p := range pods {
-		po, sp, err := p.GenerateForKube(ctx, options.Service)
+		po, sp, err := p.GenerateForKube(ctx, options.Service, options.UseLongAnnotations)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -229,8 +229,8 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 			podTemplateSpec.ObjectMeta = podYAML.ObjectMeta
 			podTemplateSpec.Spec = podYAML.Spec
 			for name, val := range podYAML.Annotations {
-				if len(val) > define.MaxKubeAnnotation {
-					return nil, fmt.Errorf("invalid annotation %q=%q value length exceeds Kubernetetes max %d", name, val, define.MaxKubeAnnotation)
+				if len(val) > define.MaxKubeAnnotation && !options.UseLongAnnotations {
+					return nil, fmt.Errorf("annotation %q=%q value length exceeds Kubernetes max %d", name, val, define.MaxKubeAnnotation)
 				}
 			}
 			for name, val := range options.Annotations {

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -46,7 +46,7 @@ func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string,
 //
 // Note: Caller is responsible for closing returned Reader
 func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string, opts entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
-	options := new(generate.KubeOptions).WithService(opts.Service).WithType(opts.Type).WithReplicas(opts.Replicas)
+	options := new(generate.KubeOptions).WithService(opts.Service).WithType(opts.Type).WithReplicas(opts.Replicas).WithNoTrunc(opts.UseLongAnnotations)
 	return generate.Kube(ic.ClientCtx, nameOrIDs, options)
 }
 
@@ -73,6 +73,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts en
 		options.WithStart(start == types.OptionalBoolTrue)
 	}
 	options.WithPublishPorts(opts.PublishPorts)
+	options.WithNoTrunc(opts.UseLongAnnotations)
 	return play.KubeWithBody(ic.ClientCtx, body, options)
 }
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5341,4 +5341,44 @@ spec:
 		Expect(kube).Should(Exit(125))
 		Expect(kube.ErrorToString()).To(ContainSubstring("since Network Namespace set to host: invalid argument"))
 	})
+
+	It("podman kube play test with --no-trunc", func() {
+		ctrName := "demo"
+		vol1 := filepath.Join(podmanTest.TempDir, RandomString(99))
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		session := podmanTest.Podman([]string{"run", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		file := filepath.Join(podmanTest.TempDir, ctrName+".yml")
+		session = podmanTest.Podman([]string{"kube", "generate", "--no-trunc", "-f", file, ctrName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"kube", "play", "--no-trunc", file})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
+
+	It("podman kube play test with long annotation", func() {
+		ctrName := "demo"
+		vol1 := filepath.Join(podmanTest.TempDir, RandomString(99))
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		session := podmanTest.Podman([]string{"run", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		file := filepath.Join(podmanTest.TempDir, ctrName+".yml")
+		session = podmanTest.Podman([]string{"kube", "generate", "--no-trunc", "-f", file, ctrName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"kube", "play", file})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(125))
+	})
 })

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -431,12 +431,27 @@ _EOF
     assert "$output" =~ "annotation exceeds maximum size, 63, of kubernetes annotation:" "Expected to fail with Length greater than 63"
 }
 
+@test "podman play --no-trunc --annotation > Max" {
+    TESTDIR=$PODMAN_TMPDIR/testdir
+    RANDOMSTRING=$(random_string 65)
+    mkdir -p $TESTDIR
+    echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
+    run_podman play kube --no-trunc --annotation "name=$RANDOMSTRING" $PODMAN_TMPDIR/test.yaml
+}
+
 @test "podman play Yaml with annotation > Max" {
    RANDOMSTRING=$(random_string 65)
 
    _write_test_yaml "annotations=test: ${RANDOMSTRING}" command=id
-    run_podman 125 play kube - < $PODMAN_TMPDIR/test.yaml
-    assert "$output" =~ "invalid annotation \"test\"=\"$RANDOMSTRING\"" "Expected to fail with annotation length greater than 63"
+   run_podman 125 play kube - < $PODMAN_TMPDIR/test.yaml
+   assert "$output" =~ "annotation \"test\"=\"$RANDOMSTRING\" value length exceeds Kubernetes max 63" "Expected to fail with annotation length greater than 63"
+}
+
+@test "podman play Yaml --no-trunc with annotation > Max" {
+   RANDOMSTRING=$(random_string 65)
+
+   _write_test_yaml "annotations=test: ${RANDOMSTRING}" command=id
+   run_podman play kube --no-trunc - < $PODMAN_TMPDIR/test.yaml
 }
 
 @test "podman kube play - default log driver" {


### PR DESCRIPTION
Adds a `--no-trunc` flag to `podman kube generate` preventing the
annotations from being trimmed at 63 characters. However, due to
the fact the annotations will not be trimmed, any annotation that is
longer than 63 characters means this YAML will no longer be Kubernetes
compatible. However, these YAML files can still be used with `podman
kube play` due to the addition of the new flag below.

Adds a `--no-trunc` flag to `podman kube play` supporting YAML files with
annotations that were not truncated to the Kubernetes maximum length of
63 characters.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds a `--no-trunc` flag to `podman kube generate` that does not truncate > 63 char annotations. Adds a `--no-trunc` flag to `podman kube play` that suppors YAML files with annotations that are longer than 63 characters. Warning: if an annotation is longer than 63 chars, then the generated yaml file is not Kubernetes compatible. 
```
