### PR TITLE
[CI:BUILD] Packit: fix pre-sync action for downstream tasks

### DIFF
--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -4,14 +4,25 @@
 # packaging, via the `propose-downstream` packit action.
 # The goimports don't need to be present upstream.
 
-set -eo pipefail
+set -eox pipefail
 
 PACKAGE=podman
 # script is run from git root directory
 SPEC_FILE=rpm/$PACKAGE.spec
 
+GOPATHDIR=~/go/src/github.com/containers/
+mkdir -p $GOPATHDIR
+ln -sf $(pwd) $GOPATHDIR/.
+
+# Packit sandbox doesn't allow root
+# Install golist by downloading and extracting rpm
+# We could handle this in packit `sandcastle` upstream itself
+# but that depends on golist existing in epel
+# https://github.com/packit/sandcastle/pull/186
+dnf download golist
+rpm2cpio golist-*.rpm | cpio -idmv
+
 sed -i '/Provides: bundled(golang.*/d' $SPEC_FILE
 
-GO_IMPORTS=$(golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs -I{} echo "Provides: bundled(golang({}))")
-
+GO_IMPORTS=$(./usr/bin/golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs -I{} echo "Provides: bundled(golang({}))")
 awk -v r="$GO_IMPORTS" '/^# vendored libraries/ {print; print r; next} 1' $SPEC_FILE > temp && mv temp $SPEC_FILE


### PR DESCRIPTION
One of the reasons the last propose-downstream task failed for Fedora was the `golist` tool wasn't available in the Packit environment.

This commit adds golist to the environment by downloading and extracting the golist rpm.

This dependency could've been added in packit's upstream config but there were a few blockers, so it's easiest to add them in our action script.

Ref: https://github.com/containers/podman/issues/19094

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
