### PR TITLE
e2e: fix two toolbox flakes

### DIFF
--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -257,9 +257,9 @@ var _ = Describe("Toolbox-specific testing", func() {
 		var username string = "testuser"
 		var homeDir string = "/home/testuser"
 		var shell string = "/bin/bash"
-		var uid string = "2000"
+		var uid string = "1411"
 		var groupName string = "testgroup"
-		var gid string = "2000"
+		var gid string = "1422"
 
 		// The use of bad* in the name of variables does not imply the invocation
 		// of useradd should fail The user is supposed to be created successfully

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -225,13 +225,13 @@ func (p *PodmanTest) WaitContainerReady(id string, expStr string, timeout int, s
 	s.WaitWithDefaultTimeout()
 
 	for {
+		if strings.Contains(s.OutputToString(), expStr) || strings.Contains(s.ErrorToString(), expStr) {
+			return true
+		}
+
 		if time.Since(startTime) >= time.Duration(timeout)*time.Second {
 			GinkgoWriter.Printf("Container %s is not ready in %ds", id, timeout)
 			return false
-		}
-
-		if strings.Contains(s.OutputToString(), expStr) || strings.Contains(s.ErrorToString(), expStr) {
-			return true
 		}
 		time.Sleep(time.Duration(step) * time.Second)
 		s = p.PodmanBase([]string{"logs", id}, false, true)


### PR DESCRIPTION
1. toolbox UID/GID allocation: pick numbers < 1500. Otherwise
   we run the risk of colliding with the Cirrus rootless user.

   [sample failure](https://api.cirrus-ci.com/v1/artifact/task/4682721818050560/html/int-podman-fedora-38-rootless-host-boltdb.log.html#t--Toolbox-specific-testing-podman-create-userns-keep-id-entrypoint-modifying-existing-user-with-usermod-add-to-new-group--change-home-shell-uid--1)

2. WaitContainerReady(): check the results of the last "podman logs"
   before timing out. Otherwise, the user will see "READY" followed
   immediately by "Container is not ready".
   (global bug, not just toolbox, but that's where I discovered it).

   [sample failure](https://api.cirrus-ci.com/v1/artifact/task/6550789993267200/html/int-podman-debian-12-rootless-host-sqlite.log.html#t--Toolbox-specific-testing-podman-create-userns-keep-id-entrypoint-modifying-existing-user-with-usermod-add-to-new-group--change-home-shell-uid--1)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```