### PR TITLE
Podmansh: Useful timeout error, increase timeout to 30s

### DIFF
--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -150,7 +150,9 @@ func exec(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if err := execWait(nameOrID, seconds); err != nil {
-			return err
+			if errors.Is(err, define.ErrCanceled) {
+				return fmt.Errorf("timed out waiting for container: %s", nameOrID)
+			}
 		}
 	}
 

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -41,7 +41,10 @@ func main() {
 	if filepath.Base(os.Args[0]) == registry.PodmanSh ||
 		(len(os.Args[0]) > 0 && filepath.Base(os.Args[0][1:]) == registry.PodmanSh) {
 		shell := strings.TrimPrefix(os.Args[0], "-")
-		args := []string{shell, "exec", "-i", "--wait", "10"}
+
+		// The wait timeout will soon be made configurable via the
+		// upcoming `podmansh_timeout` option in containers.conf
+		args := []string{shell, "exec", "-i", "--wait", "30"}
 		if term.IsTerminal(0) || term.IsTerminal(1) || term.IsTerminal(2) {
 			args = append(args, "-t")
 		}

--- a/docs/source/markdown/podmansh.1.md
+++ b/docs/source/markdown/podmansh.1.md
@@ -10,7 +10,7 @@ podmansh - Execute login shell within the Podman `podmansh` container
 
 Execute a user shell within a container when the user logs into the system. The container that the users get added to can be defined via a Podman Quadlet file. This user only has access to volumes and capabilities configured into the Quadlet file.
 
-Administrators can create a Quadlet in /etc/containers/systemd/users, which systemd will start for all users when they log in. The administrator can create a specific Quadlet with the container name `podmansh`, then enable users to use the login shell /usr/bin/podmansh.  These user login shells are automatically executed inside  the `podmansh` container via Podman.	.
+Administrators can create a Quadlet in /etc/containers/systemd/users, which systemd will start for all users when they log in. The administrator can create a specific Quadlet with the container name `podmansh`, then enable users to use the login shell /usr/bin/podmansh.  These user login shells are automatically executed inside  the `podmansh` container via Podman.
 
 Optionally, the administrator can place Quadlet files in the /etc/containers/systemd/users/${UID} directory for a user. Only this UID will execute these Quadlet services when that user logs in.
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -554,7 +554,7 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 		session := podmanTest.Podman([]string{"exec", "--wait", "2", "1234"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(Equal("Error: cancelled by user"))
+		Expect(session.ErrorToString()).To(Equal("Error: timed out waiting for container: 1234"))
 	})
 
 	It("podman exec --wait 5 seconds for started container", func() {

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -137,7 +137,7 @@ load helpers
 
     # wait on bogus container
     run_podman 125 exec --wait 5 "bogus_container" echo hello
-    assert "$output" = "Error: cancelled by user"
+    assert "$output" = "Error: timed out waiting for container: bogus_container"
 
     run_podman create --name "wait_container" $IMAGE top
     run_podman 255 exec --wait 5 "wait_container" echo hello


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podmansh: Display a more useful error for timeouts
Podmansh: Increase timeout to 30s
```