### PR TITLE
bugfix: do not try to parse empty ranges

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -65,6 +65,10 @@ func parseOptionIDs(ctrMappings []idtools.IDMap, option string) ([]idtools.IDMap
 	for i, m := range ranges {
 		var v idtools.IDMap
 
+		if m == "" {
+			return nil, fmt.Errorf("invalid empty range for %q", option)
+		}
+
 		relative := false
 		if m[0] == '@' {
 			relative = true

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -70,6 +70,9 @@ func TestParseOptionIDs(t *testing.T) {
 
 	_, err = parseOptionIDs(idMap, "@10000-20000-2")
 	assert.NotNil(t, err)
+
+	_, err = parseOptionIDs(idMap, "100-200-3###400-500-6")
+	assert.NotNil(t, err)
 }
 
 func TestParseIDMapMountOption(t *testing.T) {


### PR DESCRIPTION
An empty range caused a panic as parseOptionIDs tried to check further down for an @ at index 0 without taking into account that the splitted out string could be empty.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
