### PR TITLE
Use bytes size consistently instead of human size

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -61,7 +61,7 @@ func init() {
 	flags.Uint64Var(
 		&initOpts.DiskSize,
 		diskSizeFlagName, cfg.ContainersConfDefaultsRO.Machine.DiskSize,
-		"Disk size in GB",
+		"Disk size in GiB",
 	)
 
 	_ = initCmd.RegisterFlagCompletionFunc(diskSizeFlagName, completion.AutocompleteNone)
@@ -70,7 +70,7 @@ func init() {
 	flags.Uint64VarP(
 		&initOpts.Memory,
 		memoryFlagName, "m", cfg.ContainersConfDefaultsRO.Machine.Memory,
-		"Memory in MB",
+		"Memory in MiB",
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
 

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -216,8 +216,8 @@ func toHumanFormat(vms []*machine.ListResponse) ([]*entities.ListReporter, error
 		response.Created = units.HumanDuration(time.Since(vm.CreatedAt)) + " ago"
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
-		response.Memory = units.HumanSize(float64(vm.Memory))
-		response.DiskSize = units.HumanSize(float64(vm.DiskSize))
+		response.Memory = units.BytesSize(float64(vm.Memory))
+		response.DiskSize = units.BytesSize(float64(vm.DiskSize))
 
 		humanResponses = append(humanResponses, response)
 	}

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -61,7 +61,7 @@ func init() {
 	flags.Uint64Var(
 		&setFlags.DiskSize,
 		diskSizeFlagName, 0,
-		"Disk size in GB",
+		"Disk size in GiB",
 	)
 
 	_ = setCmd.RegisterFlagCompletionFunc(diskSizeFlagName, completion.AutocompleteNone)
@@ -70,7 +70,7 @@ func init() {
 	flags.Uint64VarP(
 		&setFlags.Memory,
 		memoryFlagName, "m", 0,
-		"Memory in MB",
+		"Memory in MiB",
 	)
 	_ = setCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
 

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -36,7 +36,7 @@ Number of CPUs.
 
 #### **--disk-size**=*number*
 
-Size of the disk for the guest VM in GB.
+Size of the disk for the guest VM in GiB.
 
 #### **--help**
 
@@ -57,7 +57,7 @@ Defaults to `testing`.
 
 #### **--memory**, **-m**=*number*
 
-Memory (in MB).
+Memory (in MiB). Note: 1024MiB = 1GiB.
 
 #### **--now**
 

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -7,11 +7,11 @@ import (
 type initMachine struct {
 	/*
 	      --cpus uint              Number of CPUs (default 1)
-	      --disk-size uint         Disk size in GB (default 100)
+	      --disk-size uint         Disk size in GiB (default 100)
 	      --ignition-path string   Path to ignition file
 	      --username string        Username of the remote user (default "core" for FCOS, "user" for Fedora)
 	      --image-path string      Path to bootable image (default "testing")
-	  -m, --memory uint            Memory in MB (default 2048)
+	  -m, --memory uint            Memory in MiB (default 2048)
 	      --now                    Start machine now
 	      --rootful                Whether this machine should prefer rootful container execution
 	      --timezone string        Set timezone (default "local")


### PR DESCRIPTION
Previously podman was using "MB" and "GB" (binary) for input but "MB" and "GB" (decimal) for output, which was causing confusion.

#### Does this PR introduce a user-facing change?

```release-note
None
```

Looks better (even numbers) in `podman machine list` now:

```
NAME                    VM TYPE     CREATED        LAST UP        CPUS        MEMORY      DISK SIZE
podman-machine-default  qemu        5 minutes ago  5 minutes ago  1           2GiB        100GiB
```

----

For instance in Podman Desktop you were getting some 5-7% "extra" size, compared to what you ordered.

* https://github.com/containers/podman-desktop/issues/3062#issuecomment-1613589034