### PR TITLE
Add support for host-gateway

### DIFF
--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/storage/pkg/regexp"
 )
 
@@ -28,13 +29,16 @@ var (
 )
 
 // validateExtraHost validates that the specified string is a valid extrahost and returns it.
-// ExtraHost is in the form of name:ip where the ip has to be a valid ip (ipv4 or ipv6).
+// ExtraHost is in the form of name:ip where the ip has to be a valid ip (ipv4 or ipv6) or the special string HostGateway.
 // for add-host flag
 func ValidateExtraHost(val string) (string, error) {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	arr := strings.SplitN(val, ":", 2)
 	if len(arr) != 2 || len(arr[0]) == 0 {
 		return "", fmt.Errorf("bad format for add-host: %q", val)
+	}
+	if arr[1] == etchosts.HostGateway {
+		return val, nil
 	}
 	if _, err := validateIPAddress(arr[1]); err != nil {
 		return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])

--- a/cmd/podman/parse/net_test.go
+++ b/cmd/podman/parse/net_test.go
@@ -3,9 +3,11 @@
 package parse
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +53,7 @@ func TestValidateExtraHost(t *testing.T) {
 		{name: "bad-ipv6", args: args{val: "foobar:0db8:85a3:0000:0000:8a2e:0370:7334.0000.0000.000"}, want: "", wantErr: true},
 		{name: "noname-ipv6", args: args{val: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"}, want: "", wantErr: true},
 		{name: "noname-ipv6", args: args{val: ":2001:0db8:85a3:0000:0000:8a2e:0370:7334"}, want: "", wantErr: true},
+		{name: "host-gateway", args: args{val: "foobar:host-gateway"}, want: fmt.Sprintf("foobar:%s", etchosts.HostGateway), wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR requires the changes of https://github.com/containers/common/pull/1549

```release-note
The `--add-host` option now accepts the special string `host-gateway` instead of an IP Address, which will be mapped to the host IP address. 
```
