### PR TITLE
libpod: don't make a broken symlink for /etc/mtab on FreeBSD

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1638,18 +1638,8 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 	}
 	defer unix.Close(etcInTheContainerFd)
 
-	// If /etc/mtab does not exist in container image, then we need to
-	// create it, so that mount command within the container will work.
-	err = unix.Symlinkat("/proc/mounts", etcInTheContainerFd, "mtab")
-	if err != nil && !os.IsExist(err) {
-		return "", fmt.Errorf("creating /etc/mtab symlink: %w", err)
-	}
-	// If the symlink was created, then also chown it to root in the container
-	if err == nil && (rootUID != 0 || rootGID != 0) {
-		err = unix.Fchownat(etcInTheContainerFd, "mtab", rootUID, rootGID, unix.AT_SYMLINK_NOFOLLOW)
-		if err != nil {
-			return "", fmt.Errorf("chown /etc/mtab: %w", err)
-		}
+	if err := c.makePlatformMtabLink(etcInTheContainerFd, rootUID, rootGID); err != nil {
+		return "", err
 	}
 
 	tz := c.Timezone()

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -336,3 +336,8 @@ func (s *safeMountInfo) Close() {
 func (c *Container) safeMountSubPath(mountPoint, subpath string) (s *safeMountInfo, err error) {
 	return &safeMountInfo{mountPoint: filepath.Join(mountPoint, subpath)}, nil
 }
+
+func (c *Container) makePlatformMtabLink(etcInTheContainerFd, rootUID, rootGID int) error {
+	// /etc/mtab does not exist on FreeBSD
+	return nil
+}


### PR DESCRIPTION
This file has not been present in BSD systems since 2.9.1 BSD and as far as I remember /proc/mounts has never existed on BSD systems.

#### Does this PR introduce a user-facing change?

```release-note
None
```
