### PR TITLE
Better support for Kubernetes health probes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/vbauerster/mpb/v8 v8.4.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.etcd.io/bbolt v1.3.7
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/net v0.12.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.10.0
@@ -166,7 +167,6 @@ require (
 	go.opentelemetry.io/otel v1.15.0 // indirect
 	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/oauth2 v0.9.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	v1 "github.com/containers/podman/v4/pkg/k8s.io/api/core/v1"
+	"github.com/containers/podman/v4/pkg/k8s.io/apimachinery/pkg/util/intstr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +39,27 @@ func TestParseMountPathRO(t *testing.T) {
 	_, options, err = parseMountPath("/to", false, nil)
 	assert.NoError(t, err)
 	assert.NotContains(t, options, "ro")
+}
+
+func TestGetPortNumber(t *testing.T) {
+	portSpec := intstr.IntOrString{Type: intstr.Int, IntVal: 3000, StrVal: "myport"}
+	cp1 := v1.ContainerPort{Name: "myport", ContainerPort: 4000}
+	cp2 := v1.ContainerPort{Name: "myport2", ContainerPort: 5000}
+	i, e := getPortNumber(portSpec, []v1.ContainerPort{cp1, cp2})
+	assert.NoError(t, e)
+	assert.Equal(t, i, int(portSpec.IntVal))
+
+	portSpec.Type = intstr.String
+	i, e = getPortNumber(portSpec, []v1.ContainerPort{cp1, cp2})
+	assert.NoError(t, e)
+	assert.Equal(t, i, 4000)
+
+	portSpec.StrVal = "not_valid"
+	_, e = getPortNumber(portSpec, []v1.ContainerPort{cp1, cp2})
+	assert.Error(t, e)
+
+	portSpec.StrVal = "6000"
+	i, e = getPortNumber(portSpec, []v1.ContainerPort{cp1, cp2})
+	assert.NoError(t, e)
+	assert.Equal(t, i, 6000)
 }


### PR DESCRIPTION
* Add support for using port names in Kubernetes probes
* Support TCPSocket probes without specifying any host names

Closes #18645

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
From now on, you can also use containerPort names inside Kubernetes liveness probes to refer to the desired ports, which was not previously supported by podman.
```
