### PR TITLE
make --syslog errors non fatal

### DIFF
--- a/cmd/podman/syslog_common.go
+++ b/cmd/podman/syslog_common.go
@@ -4,9 +4,7 @@
 package main
 
 import (
-	"fmt"
 	"log/syslog"
-	"os"
 
 	"github.com/sirupsen/logrus"
 	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -19,10 +17,8 @@ func syslogHook() {
 
 	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Failed to initialize syslog hook: "+err.Error())
-		os.Exit(1)
-	}
-	if err == nil {
+		logrus.Debug("Failed to initialize syslog hook: " + err.Error())
+	} else {
 		logrus.AddHook(hook)
 	}
 }


### PR DESCRIPTION
Podman will always pass down --syslog to conmon since 13c2aca21. However there systems without syslog running, likely in container setups. As reported in this was already a problem before when debug level is used. Then conmon will pass down --syslog back to the podman container cleanup command causing it to fail without doing anything. Given that I think it is better to just ignore the error and log it on debug level, we need to make sure cleanup works consistently.

[NO NEW TESTS NEEDED]

Fixes #19075

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman --syslog will no longer return a fatal error when no syslog server is found and ignores the error. 
```
