### PR TITLE
manifest inspect: support authentication

### DIFF
--- a/docs/source/markdown/options/authfile.md
+++ b/docs/source/markdown/options/authfile.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman auto update, build, container runlabel, create, image sign, kube play, login, logout, manifest add, manifest push, pull, push, run, search
+####>   podman auto update, build, container runlabel, create, image sign, kube play, login, logout, manifest add, manifest inspect, manifest push, pull, push, run, search
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--authfile**=*path*

--- a/docs/source/markdown/podman-manifest-inspect.1.md.in
+++ b/docs/source/markdown/podman-manifest-inspect.1.md.in
@@ -15,6 +15,8 @@ A formatted JSON representation of the manifest list or image index.
 
 ## OPTIONS
 
+@@option authfile
+
 @@option tls-verify
 
 ## EXAMPLES

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -153,12 +153,19 @@ func ManifestInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	imageEngine := abi.ImageEngine{Libpod: runtime}
-	opts := entities.ManifestInspectOptions{}
+	_, authfile, err := auth.GetCredentials(r)
+	if err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+	defer auth.RemoveAuthfile(authfile)
+
+	opts := entities.ManifestInspectOptions{Authfile: authfile}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		opts.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
 
+	imageEngine := abi.ImageEngine{Libpod: runtime}
 	rawManifest, err := imageEngine.ManifestInspect(r.Context(), name, opts)
 	if err != nil {
 		utils.Error(w, http.StatusNotFound, err)

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -92,7 +92,12 @@ func Inspect(ctx context.Context, name string, options *InspectOptions) (*manife
 		params.Set("tlsVerify", strconv.FormatBool(!options.GetSkipTLSVerify()))
 	}
 
-	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/manifests/%s/json", params, nil, name)
+	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/manifests/%s/json", params, header, name)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +130,12 @@ func InspectListData(ctx context.Context, name string, options *InspectOptions) 
 		params.Set("tlsVerify", strconv.FormatBool(!options.GetSkipTLSVerify()))
 	}
 
-	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/manifests/%s/json", params, nil, name)
+	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/manifests/%s/json", params, header, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -4,6 +4,10 @@ package manifests
 //
 //go:generate go run ../generator/generator.go InspectOptions
 type InspectOptions struct {
+	// Authfile - path to an authentication file.
+	Authfile *string
+	// SkipTLSVerify - skip https and certificate validation when
+	// contacting container registries.
 	SkipTLSVerify *bool
 }
 

--- a/pkg/bindings/manifests/types_inspect_options.go
+++ b/pkg/bindings/manifests/types_inspect_options.go
@@ -17,6 +17,21 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
 
+// WithAuthfile set field Authfile to given value
+func (o *InspectOptions) WithAuthfile(value string) *InspectOptions {
+	o.Authfile = &value
+	return o
+}
+
+// GetAuthfile returns value of field Authfile
+func (o *InspectOptions) GetAuthfile() string {
+	if o.Authfile == nil {
+		var z string
+		return z
+	}
+	return *o.Authfile
+}
+
 // WithSkipTLSVerify set field SkipTLSVerify to given value
 func (o *InspectOptions) WithSkipTLSVerify(value bool) *InspectOptions {
 	o.SkipTLSVerify = &value

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -14,6 +14,8 @@ type ManifestCreateOptions struct {
 
 // ManifestInspectOptions provides model for inspecting manifest
 type ManifestInspectOptions struct {
+	// Path to an authentication file.
+	Authfile string `json:"-" schema:"-"`
 	// Should TLS registry certificate be verified?
 	SkipTLSVerify types.OptionalBool `json:"-" schema:"-"`
 }

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -106,6 +106,10 @@ func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts en
 func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string, opts entities.ManifestInspectOptions) ([]byte, error) {
 	sys := ir.Libpod.SystemContext()
 
+	if opts.Authfile != "" {
+		sys.AuthFilePath = opts.Authfile
+	}
+
 	sys.DockerInsecureSkipTLSVerify = opts.SkipTLSVerify
 	if opts.SkipTLSVerify == types.OptionalBoolTrue {
 		sys.OCIInsecureSkipTLSVerify = true

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -34,7 +34,7 @@ func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entiti
 
 // ManifestInspect returns contents of manifest list with given name
 func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts entities.ManifestInspectOptions) ([]byte, error) {
-	options := new(manifests.InspectOptions)
+	options := new(manifests.InspectOptions).WithAuthfile(opts.Authfile)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)

--- a/test/system/012-manifest.bats
+++ b/test/system/012-manifest.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load helpers
+load helpers.network
+load helpers.registry
 
 # Regression test for #8931
 @test "podman images - bare manifest list" {
@@ -18,6 +20,40 @@ load helpers
     run_podman images --format '{{.ID}}' --no-trunc
     is "$output" ".*sha256:$iid" "Original image ID still shown in podman-images output"
     run_podman rmi test:1.0
+}
+
+@test "podman manifest --tls-verify and --authfile" {
+    skip_if_remote "running a local registry doesn't work with podman-remote"
+    start_registry
+    authfile=${PODMAN_LOGIN_WORKDIR}/auth-$(random_string 10).json
+    run_podman login --tls-verify=false \
+               --username ${PODMAN_LOGIN_USER} \
+               --password-stdin \
+               --authfile=$authfile \
+               localhost:${PODMAN_LOGIN_REGISTRY_PORT} <<<"${PODMAN_LOGIN_PASS}"
+    is "$output" "Login Succeeded!" "output from podman login"
+
+    manifest1="localhost:${PODMAN_LOGIN_REGISTRY_PORT}/test:1.0"
+    run_podman manifest create $manifest1
+    mid=$output
+    run_podman manifest push --authfile=$authfile \
+        --tls-verify=false $mid \
+        $manifest1
+    run_podman manifest rm $manifest1
+
+    # Default is to require TLS; also test explicit opts
+    for opt in '' '--insecure=false' '--tls-verify=true' "--authfile=$authfile"; do
+        run_podman 125 manifest inspect $opt $manifest1
+        assert "$output" =~ "Error: reading image \"docker://$manifest1\": pinging container registry localhost:${PODMAN_LOGIN_REGISTRY_PORT}:.*x509" \
+               "TLE check: fails (as expected) with ${opt:-default}"
+    done
+
+    run_podman manifest inspect --authfile=$authfile --tls-verify=false $manifest1
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --tls-verify=false --authfile works against an insecure registry"
+    run_podman manifest inspect --authfile=$authfile --insecure $manifest1
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --insecure --authfile works against an insecure registry"
+    REGISTRY_AUTH_FILE=$authfile run_podman manifest inspect --tls-verify=false $manifest1
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --tls-verify=false with REGISTRY_AUTH_FILE works against an insecure registry"
 }
 
 # vim: filetype=sh

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -241,35 +241,6 @@ function _test_skopeo_credential_sharing() {
     rm -f $authfile
 }
 
-@test "podman manifest --tls-verify - basic test" {
-    run_podman login --tls-verify=false \
-               --username ${PODMAN_LOGIN_USER} \
-               --password-stdin \
-               localhost:${PODMAN_LOGIN_REGISTRY_PORT} <<<"${PODMAN_LOGIN_PASS}"
-    is "$output" "Login Succeeded!" "output from podman login"
-
-    manifest1="localhost:${PODMAN_LOGIN_REGISTRY_PORT}/test:1.0"
-    run_podman manifest create $manifest1
-    mid=$output
-    run_podman manifest push --authfile=$authfile \
-        --tls-verify=false $mid \
-        $manifest1
-    run_podman manifest rm $manifest1
-    run_podman manifest inspect --insecure $manifest1
-    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --insecure works against an insecure registry"
-    run_podman 125 manifest inspect --insecure=false $manifest1
-    is "$output" ".*Error: reading image \"docker://$manifest1\": pinging container registry localhost:${PODMAN_LOGIN_REGISTRY_PORT}:" "Verify --insecure=false fails"
-    run_podman manifest inspect --tls-verify=false $manifest1
-    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --tls-verify=false works against an insecure registry"
-    run_podman 125 manifest inspect --tls-verify=true $manifest1
-    is "$output" ".*Error: reading image \"docker://$manifest1\": pinging container registry localhost:${PODMAN_LOGIN_REGISTRY_PORT}:" "Verify --tls-verify=true fails"
-
-    # Now log out
-    run_podman logout localhost:${PODMAN_LOGIN_REGISTRY_PORT}
-    is "$output" "Removed login credentials for localhost:${PODMAN_LOGIN_REGISTRY_PORT}" \
-       "output from podman logout"
-}
-
 # END   cooperation with skopeo
 # END   actual tests
 ###############################################################################


### PR DESCRIPTION
Previous tests have worked by pure chance since the client and server ran on the same host; the server picked up the credentials created by the client login.

Extend the gating tests and add a new integration test which is further capable of exercising the remote code.

Note that fixing authentication support requires adding a new `--authfile` CLi flag to `manifest inspect`.  This will at least allow for passing an authfile to be bindings.  Username and password are not yet supported.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support authentication in `podman manifest inspect`.
```
