### PR TITLE
test/e2e: wait for socket

### DIFF
--- a/pkg/api/handlers/compat/version.go
+++ b/pkg/api/handlers/compat/version.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/types"
 	"github.com/containers/podman/v4/version"
-	"github.com/sirupsen/logrus"
 )
 
 func VersionHandler(w http.ResponseWriter, r *http.Request) {
@@ -45,29 +44,19 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 			"MinAPIVersion": version.APIVersion[version.Libpod][version.MinimalAPI].String(),
 			"Os":            goRuntime.GOOS,
 		},
+	}, {
+		Name:    "Conmon",
+		Version: info.Host.Conmon.Version,
+		Details: map[string]string{
+			"Package": info.Host.Conmon.Package,
+		},
+	}, {
+		Name:    fmt.Sprintf("OCI Runtime (%s)", info.Host.OCIRuntime.Name),
+		Version: info.Host.OCIRuntime.Version,
+		Details: map[string]string{
+			"Package": info.Host.OCIRuntime.Package,
+		},
 	}}
-
-	if conmon, oci, err := runtime.DefaultOCIRuntime().RuntimeInfo(); err != nil {
-		logrus.Warnf("Failed to retrieve Conmon and OCI Information: %q", err.Error())
-	} else {
-		additional := []types.ComponentVersion{
-			{
-				Name:    "Conmon",
-				Version: conmon.Version,
-				Details: map[string]string{
-					"Package": conmon.Package,
-				},
-			},
-			{
-				Name:    fmt.Sprintf("OCI Runtime (%s)", oci.Name),
-				Version: oci.Version,
-				Details: map[string]string{
-					"Package": oci.Package,
-				},
-			},
-		}
-		components = append(components, additional...)
-	}
 
 	apiVersion := version.APIVersion[version.Compat][version.CurrentAPI]
 	minVersion := version.APIVersion[version.Compat][version.MinimalAPI]

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -57,7 +57,6 @@ type PodmanTestIntegration struct {
 	CgroupManager       string
 	Host                HostOS
 	TmpDir              string
-	RemoteStartErr      error
 }
 
 var LockTmpDir string


### PR DESCRIPTION


Do not use podman info/version as they are expensive and clutter the log
for no reason. Just checking if we can connect to the socket should be
good enough and much faster.

Also change the interval, why wait 2s for a retry lets take 100ms steps
instead.

Fixes #19010

api: fix slow version endpoint

This endpoint queried the same package versions twice causing it to be
slower than info. Because it already called info we can just reuse the
package versions from there.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
