### PR TITLE
Add missing return after utils.InternalServerError()

### DIFF
--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -547,6 +547,7 @@ func PodStats(w http.ResponseWriter, r *http.Request) {
 	options := entities.PodStatsOptions{All: query.All}
 	if err := entities.ValidatePodStatsOptions(query.NamesOrIDs, &options); err != nil {
 		utils.InternalServerError(w, err)
+		return
 	}
 
 	var flush = func() {}

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -103,6 +103,10 @@ t GET libpod/pods/stats?namesOrIDs=fakename 404 \
   .cause="no such pod" \
   .message="unable to get list of pods: no pod with name or ID fakename found: no such pod"
 
+t GET "libpod/pods/stats?all=true&namesOrIDs=foo" 500 \
+  .cause="--all, --latest and arguments cannot be used together" \
+  .message="--all, --latest and arguments cannot be used together"
+
 t DELETE  libpod/pods/bar?force=true 200
 
 # test the fake name


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]
