### PR TITLE
Fix: cgroup is not set: internal libpod error after os reboot

### DIFF
--- a/libpod/pod_internal_linux.go
+++ b/libpod/pod_internal_linux.go
@@ -21,7 +21,7 @@ func (p *Pod) platformRefresh() error {
 			}
 			p.state.CgroupPath = cgroupPath
 		case config.CgroupfsCgroupsManager:
-			if rootless.IsRootless() && isRootlessCgroupSet(p.config.CgroupParent) {
+			if !rootless.IsRootless() || isRootlessCgroupSet(p.config.CgroupParent) {
 				p.state.CgroupPath = filepath.Join(p.config.CgroupParent, p.ID())
 
 				logrus.Debugf("setting pod cgroup to %s", p.state.CgroupPath)


### PR DESCRIPTION
[NO NEW TESTS NEEDED]
Closes #19175

This PR fix the bug 'cgroup is not set: internal libpod error after os reboot' on system without systemd.

#### Does this PR introduce a user-facing change?
None
