### PR TITLE
add hostname to network alias

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -607,8 +607,6 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 		if opts.InterfaceName == "" {
 			return fmt.Errorf("network interface name cannot be an empty string: %w", define.ErrInvalidArg)
 		}
-		// always add the short id as alias for docker compat
-		opts.Aliases = append(opts.Aliases, ctr.config.ID[:12])
 		optBytes, err := json.Marshal(opts)
 		if err != nil {
 			return fmt.Errorf("marshalling network options JSON for container %s: %w", ctr.ID(), err)

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -513,8 +513,7 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 	// get network status before we connect
 	networkStatus := c.getNetworkStatus()
 
-	// always add the short id as alias for docker compat
-	netOpts.Aliases = append(netOpts.Aliases, c.config.ID[:12])
+	netOpts.Aliases = append(netOpts.Aliases, getExtraNetworkAliases(c)...)
 
 	if netOpts.InterfaceName == "" {
 		netOpts.InterfaceName = getFreeInterfaceName(networks)
@@ -637,6 +636,16 @@ func getFreeInterfaceName(networks map[string]types.PerNetworkOptions) string {
 		}
 	}
 	return ""
+}
+
+func getExtraNetworkAliases(c *Container) []string {
+	// always add the short id as alias for docker compat
+	alias := []string{c.config.ID[:12]}
+	// if an explicit hostname was set add it as well
+	if c.config.Spec.Hostname != "" {
+		alias = append(alias, c.config.Spec.Hostname)
+	}
+	return alias
 }
 
 // DisconnectContainerFromNetwork removes a container from its network

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -282,6 +282,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					return nil, errors.New("failed to find free network interface name")
 				}
 			}
+			// always add the short id as alias for docker compat
+			opts.Aliases = append(opts.Aliases, ctr.config.ID[:12])
 
 			normalizeNetworks[netName] = opts
 		}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -282,8 +282,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					return nil, errors.New("failed to find free network interface name")
 				}
 			}
-			// always add the short id as alias for docker compat
-			opts.Aliases = append(opts.Aliases, ctr.config.ID[:12])
+			opts.Aliases = append(opts.Aliases, getExtraNetworkAliases(ctr)...)
 
 			normalizeNetworks[netName] = opts
 		}

--- a/libpod/sqlite_state_internal.go
+++ b/libpod/sqlite_state_internal.go
@@ -385,12 +385,6 @@ func (s *SQLiteState) rewriteContainerConfig(ctr *Container, newCfg *ContainerCo
 }
 
 func (s *SQLiteState) addContainer(ctr *Container) (defErr error) {
-	for net := range ctr.config.Networks {
-		opts := ctr.config.Networks[net]
-		opts.Aliases = append(opts.Aliases, ctr.config.ID[:12])
-		ctr.config.Networks[net] = opts
-	}
-
 	configJSON, err := json.Marshal(ctr.config)
 	if err != nil {
 		return fmt.Errorf("marshalling container config json: %w", err)

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1108,7 +1108,8 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(session).Should(Exit(0))
 
 		pod2 := "testpod2"
-		session = podmanTest.Podman([]string{"pod", "create", "--network", net, "--name", pod2})
+		hostname := "hostn1"
+		session = podmanTest.Podman([]string{"pod", "create", "--network", net, "--name", pod2, "--hostname", hostname})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -1128,59 +1129,13 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session = podmanTest.Podman([]string{"run", "--name", "con4", "--network", net, ALPINE, "nslookup", pod2 + ".dns.podman"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-	})
 
-	It("podman run check dnsname plugin with Netavark", func() {
-		SkipIfCNI(podmanTest)
-		pod := "testpod"
-		session := podmanTest.Podman([]string{"pod", "create", "--name", pod})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		net := createNetworkName("IntTest")
-		session = podmanTest.Podman([]string{"network", "create", net})
-		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeNetwork(net)
-		Expect(session).Should(Exit(0))
-
-		pod2 := "testpod2"
-		session = podmanTest.Podman([]string{"pod", "create", "--network", net, "--name", pod2})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		session = podmanTest.Podman([]string{"run", "--name", "con1", "--network", net, ALPINE, "nslookup", "con1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		session = podmanTest.Podman([]string{"run", "--name", "con2", "--pod", pod, "--network", net, ALPINE, "nslookup", "con2"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		session = podmanTest.Podman([]string{"run", "--name", "con3", "--pod", pod2, ALPINE, "nslookup", "con1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
-		Expect(session.ErrorToString()).To(ContainSubstring("can't resolve 'con1'"))
-
-		session = podmanTest.Podman([]string{"run", "--name", "con4", "--network", net, ALPINE, "nslookup", pod2 + ".dns.podman"})
+		session = podmanTest.Podman([]string{"run", "--network", net, ALPINE, "nslookup", hostname})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
 
 	It("podman network adds dns search domain with dns", func() {
-		net := createNetworkName("dnsname")
-		session := podmanTest.Podman([]string{"network", "create", net})
-		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeNetwork(net)
-		Expect(session).Should(Exit(0))
-
-		session = podmanTest.Podman([]string{"run", "--network", net, ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("search dns.podman"))
-	})
-
-	It("podman run check dnsname adds dns search domain with Netavark", func() {
-		SkipIfCNI(podmanTest)
 		net := createNetworkName("dnsname")
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -471,8 +471,10 @@ load helpers.network
     run_podman run -d --network $netname $IMAGE top
     background_cid=$output
 
+    local hostname=host-$(random_string 10)
     # Run a httpd container on first network with exposed port
     run_podman run -d -p "$HOST_PORT:80" \
+            --hostname $hostname \
             --network $netname \
             -v $INDEX1:/var/www/index.txt:Z \
             -w /var/www \
@@ -490,7 +492,7 @@ load helpers.network
 
     # check network alias for container short id
     run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname\").Aliases}}"
-    is "$output" "[${cid:0:12}]" "short container id in network aliases"
+    is "$output" "[${cid:0:12} $hostname]" "short container id and hostname in network aliases"
 
     # check /etc/hosts for our entry
     run_podman exec $cid cat /etc/hosts
@@ -550,7 +552,7 @@ load helpers.network
 
     # check network2 alias for container short id
     run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname2\").Aliases}}"
-    is "$output" "[${cid:0:12}]" "short container id in network aliases"
+    is "$output" "[${cid:0:12} $hostname]" "short container id and hostname in network2 aliases"
 
     # curl should work
     run curl --max-time 3 -s $SERVER/index.txt


### PR DESCRIPTION
We use the name as alias but using the hostname makes also sense and
this is what docker does. We have to keep the short id as well for
docker compat.

While adding some tests I removed some duplicated tests that were
executed twice for nv for no reason.

Fixes #17370

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add the hostname by default as network alias so containers can resolve other hostnames and not only their names.
```
