### PR TITLE
system service: unset listen fds on tcp

### DIFF
--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -96,6 +96,18 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 		libpodRuntime.SetRemoteURI(uri.String())
 	}
 
+	// bugzilla.redhat.com/show_bug.cgi?id=2180483:
+	//
+	// Disable leaking the LISTEN_* into containers which
+	// are observed to be passed by systemd even without
+	// being socket activated as described in
+	// https://access.redhat.com/solutions/6512011.
+	for _, val := range []string{"LISTEN_FDS", "LISTEN_PID", "LISTEN_FDNAMES"} {
+		if err := os.Unsetenv(val); err != nil {
+			return fmt.Errorf("unsetting %s: %v", val, err)
+		}
+	}
+
 	// Set stdin to /dev/null, so shortnames will not prompt
 	devNullfile, err := os.Open(os.DevNull)
 	if err != nil {


### PR DESCRIPTION
Disable leaking the LISTEN_* variables into containers which are
observed to be passed by systemd even without being socket activated as
described in https://access.redhat.com/solutions/6512011.

[NO NEW TESTS NEEDED] - Ultimately, the solution 6512011 should be updated.

Fixes: bugzilla.redhat.com/show_bug.cgi?id=2180483

@Luap99 PTAL.  test/e2e/systemd_activate_test.go does not set LISTEN_FDS, so there's no test I can plug into.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix an issue in `system service` when listing on TCP and LISTEN_FDS are set.
```
