### PR TITLE
Add secret support to podman login

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/containers/common/pkg/auth"
@@ -9,6 +11,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +51,11 @@ func init() {
 	completion.CompleteCommandFlags(loginCommand, auth.GetLoginFlagsCompletions())
 
 	// Podman flags.
-	flags.BoolVarP(&loginOptions.tlsVerify, "tls-verify", "", false, "Require HTTPS and verify certificates when contacting registries")
+	secretFlagName := "secret"
+	flags.BoolVar(&loginOptions.tlsVerify, "tls-verify", false, "Require HTTPS and verify certificates when contacting registries")
+	flags.String(secretFlagName, "", "Retrieve passwd from secret file")
+	_ = loginCommand.RegisterFlagCompletionFunc(secretFlagName, common.AutocompleteSecrets)
+
 	loginOptions.Stdin = os.Stdin
 	loginOptions.Stdout = os.Stdout
 	loginOptions.AcceptUnspecifiedRegistry = true
@@ -61,6 +68,31 @@ func login(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flags().Changed("tls-verify") {
 		skipTLS = types.NewOptionalBool(!loginOptions.tlsVerify)
+	}
+
+	secretName := cmd.Flag("secret").Value.String()
+	if len(secretName) > 0 {
+		if len(loginOptions.Password) > 0 {
+			return errors.New("--secret can not be used with --password options")
+		}
+		if len(loginOptions.Username) == 0 {
+			loginOptions.Username = secretName
+		}
+		var inspectOpts = entities.SecretInspectOptions{
+			ShowSecret: true,
+		}
+		inspected, errs, _ := registry.ContainerEngine().SecretInspect(context.Background(), []string{secretName}, inspectOpts)
+
+		if len(errs) > 0 && errs[0] != nil {
+			return errs[0]
+		}
+		if len(inspected) == 0 {
+			return fmt.Errorf("no secrets found for %q", secretName)
+		}
+		if len(inspected) > 1 {
+			return fmt.Errorf("unexpected error SecretInspect of a single secret should never return more then one secrets %q", secretName)
+		}
+		loginOptions.Password = inspected[0].SecretData
 	}
 
 	sysCtx := &types.SystemContext{

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -53,7 +53,7 @@ func init() {
 	// Podman flags.
 	secretFlagName := "secret"
 	flags.BoolVar(&loginOptions.tlsVerify, "tls-verify", false, "Require HTTPS and verify certificates when contacting registries")
-	flags.String(secretFlagName, "", "Retrieve passwd from secret file")
+	flags.String(secretFlagName, "", "Retrieve password from a podman secret")
 	_ = loginCommand.RegisterFlagCompletionFunc(secretFlagName, common.AutocompleteSecrets)
 
 	loginOptions.Stdin = os.Stdin

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -48,6 +48,11 @@ Password for registry
 
 Take the password from stdin
 
+#### **--secret**=*name*
+
+Read the password for the registry from the podman secret `name`.
+If --username is not specified --username=`name` is used.
+
 @@option tls-verify
 
 #### **--username**, **-u**=*username*
@@ -80,6 +85,13 @@ Login Succeeded!
 ```
 
 ```
+$ echo -n MySecret! | podman secret create secretname -
+a0ad54df3c97cf89d5ca6193c
+$ podman login --secret secretname -u testuser quay.io
+Login Succeeded!
+```
+
+```
 $ podman login --tls-verify=false -u test -p test localhost:5000
 Login Succeeded!
 ```
@@ -108,7 +120,7 @@ Login Succeeded!
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-logout(1)](podman-logout.1.md)**, **[containers-auth.json(5)](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)**
+**[podman(1)](podman.1.md)**, **[podman-logout(1)](podman-logout.1.md)**, **[containers-auth.json(5)](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)**, **[podman-secret(1)](podman-secret.1.md)**, **[podman-secret-create(1)](podman-secret-create.1.md)**
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -18,6 +18,8 @@ TLS certificates and keys, SSH keys or other important generic strings or binary
 
 Secrets are not committed to an image with `podman commit`, and does not get committed in the archive created by a `podman export` command.
 
+Secrets can also be used to store passwords for `podman login` to authenticate against container registries.
+
 ## OPTIONS
 
 #### **--driver**, **-d**=*driver*
@@ -55,7 +57,7 @@ $ printf <secret> | podman secret create my_secret -
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-secret(1)](podman-secret.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-secret(1)](podman-secret.1.md)**, **[podman-login(1)](podman-login.1.md)**
 
 ## HISTORY
 January 2021, Originally compiled by Ashley Cui <acui@redhat.com>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman login can now read the secret for a registry from its secret database created with podman secret create.
```
Fixes: https://github.com/containers/podman/issues/18667
