### PR TITLE
remote: fix podman-remote play kube --userns

### DIFF
--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -28,6 +28,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		StaticIPs        []string          `schema:"staticIPs"`
 		StaticMACs       []string          `schema:"staticMACs"`
 		NoHosts          bool              `schema:"noHosts"`
+		Userns           string            `schema:"userns"`
 		PublishPorts     []string          `schema:"publishPorts"`
 		NoTrunc          bool              `schema:"noTrunc"`
 		Wait             bool              `schema:"wait"`
@@ -98,6 +99,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		StaticIPs:          staticIPs,
 		StaticMACs:         staticMACs,
 		IsRemote:           true,
+		Userns:             query.Userns,
 		PublishPorts:       query.PublishPorts,
 		Wait:               query.Wait,
 		ServiceContainer:   query.ServiceContainer,

--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -63,6 +63,10 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: false
 	//    description: use annotations that are not truncated to the Kubernetes maximum length of 63 characters
+	//  - in: query
+	//    name: userns
+	//    type: string
+	//    description: Set the user namespace mode for the pods.
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.


### PR DESCRIPTION
Fix `podman play kube --userns` to work in remote environment.

Related: #17392

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The remote Podman client’s `podman play kube` command now work --userns option.
```
