### PR TITLE
go mod: no longer use 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ build-all-new-commits:
 
 .PHONY: vendor
 vendor:
-	$(GO) mod tidy -compat=1.18
+	$(GO) mod tidy
 	$(GO) mod vendor
 	$(GO) mod verify
 


### PR DESCRIPTION
1.18 is EOL and we should not have to set this since the current versions should generate compatible go.sum files anyway.

This is an attempt to fix broken renovate PRs which create a different go.sum and thus do not pass CI checks.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
