### PR TITLE
netavark: macvlan networks keep custom nameservers

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2077,12 +2077,12 @@ func (c *Container) addResolvConf() error {
 
 	// If NetworkBackend is `netavark` do not populate `/etc/resolv.conf`
 	// with custom dns server since after https://github.com/containers/netavark/pull/452
-	// netavark will always set required `nameservers` in statsBlock and libpod
+	// netavark will always set required `nameservers` in StatusBlock and libpod
 	// will correctly populate `networkNameServers`. Also see https://github.com/containers/podman/issues/16172
 
 	// Exception: Populate `/etc/resolv.conf` if container is not connected to any network
-	// ( i.e len(netStatus)==0 ) since in such case netavark is not invoked at all.
-	if networkBackend != string(types.Netavark) || len(netStatus) == 0 {
+	// with dns enabled then we do not get any nameservers back.
+	if networkBackend != string(types.Netavark) || len(networkNameServers) == 0 {
 		nameservers = append(nameservers, c.runtime.config.Containers.DNSServers...)
 		for _, ip := range c.config.DNSServer {
 			nameservers = append(nameservers, ip.String())


### PR DESCRIPTION
The change to use the custom dns server in aardvark-dns caused a regression here because macvlan networks never returned the nameservers in netavark and it also does not make sense to do so.

Instead check here if we got any network nameservers, if not we then use the ones from the config if set otherwise fallback to host servers.

Fixes #19169

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a regression where podman run --dns was ignored for maclvan networks.
```
