### PR TITLE
Add missing reserved annotation support to play 

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -507,6 +507,9 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 		if ctrSpec.Annotations[define.InspectAnnotationInit] == define.InspectResponseTrue {
 			hostConfig.Init = true
 		}
+		if ctrSpec.Annotations[define.InspectAnnotationPublishAll] == define.InspectResponseTrue {
+			hostConfig.PublishAllPorts = true
+		}
 	}
 
 	if err := c.platformInspectContainerHostConfig(ctrSpec, hostConfig); err != nil {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -417,7 +417,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(image[0].Config.ExposedPorts).To(HaveKey("2004-2005/tcp"))
 
 		containerName := "testcontainer"
-		session := podmanTest.Podman([]string{"create", "--name", containerName, imageName, "true"})
+		session := podmanTest.Podman([]string{"create", "--publish-all", "--name", containerName, imageName, "true"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(containerName)
 		Expect(inspectOut).To(HaveLen(1))
@@ -430,6 +430,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveKey("2003/tcp"))
 		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveKey("2004/tcp"))
 		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveKey("2005/tcp"))
+		Expect(inspectOut[0].HostConfig.PublishAllPorts).To(BeTrue())
 	})
 
 	It("podman run -p 127.0.0.1::8980/udp", func() {


### PR DESCRIPTION
Adds any required "wiring" to ensure the reserved annotations are supported by `podman kube play`.

Addtionally fixes a bug where, when inspected, containers created using the `--publish-all` flag had a field `.HostConfig.PublishAllPorts` whose value was only evaluated as `false`.

Associated with: #19102
Adding reserved annotations with `kube generate`:  #19211

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds support to `podman kube play` for the use of reserved annotations in the generated YAML. Fixes a bug where `.HostConfig.PublishAllPorts` always evaluates to `false` when inspecting a container created with `--publish-all`
```
