### PR TITLE
machine start: qemu: wait for SSH readiness

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -599,27 +599,47 @@ func (v *MachineVM) Start(name string, opts machine.StartOptions) error {
 			_ = v.writeConfig()
 		}
 	}
-	if len(v.Mounts) > 0 {
-		connected := false
-		backoff = 500 * time.Millisecond
-		for i := 0; i < maxBackoffs; i++ {
-			if i > 0 {
-				time.Sleep(backoff)
-				backoff *= 2
-			}
-			state, err := v.State(true)
-			if err != nil {
-				return err
-			}
-			if state == machine.Running && v.isListening() {
-				connected = true
-				break
-			}
+	if len(v.Mounts) == 0 {
+		v.waitAPIAndPrintInfo(forwardState, forwardSock, opts.NoInfo)
+		return nil
+	}
+
+	connected := false
+	backoff = defaultBackoff
+	var sshError error
+	for i := 0; i < maxBackoffs; i++ {
+		if i > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
 		}
-		if !connected {
-			return fmt.Errorf("machine did not transition into running state")
+		state, err := v.State(true)
+		if err != nil {
+			return err
+		}
+		if state == machine.Running && v.isListening() {
+			// Also make sure that SSH is up and running.  The
+			// ready service's dependencies don't fully make sure
+			// that clients can SSH into the machine immediately
+			// after boot.
+			//
+			// CoreOS users have reported the same observation but
+			// the underlying source of the issue remains unknown.
+			if sshError = v.SSH(name, machine.SSHOptions{Args: []string{"true"}}); sshError != nil {
+				logrus.Debugf("SSH readiness check for machine failed: %v", sshError)
+				continue
+			}
+			connected = true
+			break
 		}
 	}
+	if !connected {
+		msg := "machine did not transition into running state"
+		if sshError != nil {
+			return fmt.Errorf("%s: ssh error: %v", msg, sshError)
+		}
+		return errors.New(msg)
+	}
+
 	for _, mount := range v.Mounts {
 		if !opts.Quiet {
 			fmt.Printf("Mounting volume... %s:%s\n", mount.Source, mount.Target)


### PR DESCRIPTION
During the exponential backoff waiting for the machine to be fully up and running, also make sure that SSH is ready.  The systemd dependencies of the ready.service include the sshd.service among others but that is not enough.

Other CoreOS users reported the same issue on IRC, so I feel fairly confident to use the pragmatic approach of making sure SSH works on the client side.  #17403 is quite old and there are other pressing machine issues that need attention.

Fixes: #17403

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug of flaky podman-machine-start using QEMU.
```
