### PR TITLE
Add `--podman-only` flag to `podman generate kube`

### DIFF
--- a/cmd/podman/kube/generate.go
+++ b/cmd/podman/kube/generate.go
@@ -84,6 +84,9 @@ func generateFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 	noTruncAnnotationsFlagName := "no-trunc"
 	flags.BoolVar(&generateOptions.UseLongAnnotations, noTruncAnnotationsFlagName, false, "Don't truncate annotations to Kubernetes length (63 chars)")
 
+	podmanOnlyFlagName := "podman-only"
+	flags.BoolVar(&generateOptions.PodmanOnly, podmanOnlyFlagName, false, "Add podman-only reserved annotations to the generated YAML file (Cannot be used by Kubernetes)")
+
 	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 

--- a/docs/source/markdown/podman-kube-generate.1.md
+++ b/docs/source/markdown/podman-kube-generate.1.md
@@ -39,6 +39,10 @@ Output to the given file instead of STDOUT. If the file already exists, `kube ge
 Don't truncate annotations to the Kubernetes maximum length of 63 characters.
 Note: enabling this flag means the generated YAML file is not Kubernetes compatible and can only be used with `podman kube play`
 
+#### **--podman-only**
+
+Add podman-only reserved annotations in generated YAML file (Cannot be used by Kubernetes)
+
 #### **--replicas**, **-r**=*replica count*
 
 The value to set `replicas` to when generating a **Deployment** kind.

--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -89,11 +89,12 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		Names    []string `schema:"names"`
-		Service  bool     `schema:"service"`
-		Type     string   `schema:"type"`
-		Replicas int32    `schema:"replicas"`
-		NoTrunc  bool     `schema:"noTrunc"`
+		PodmanOnly bool     `schema:"podmanOnly"`
+		Names      []string `schema:"names"`
+		Service    bool     `schema:"service"`
+		Type       string   `schema:"type"`
+		Replicas   int32    `schema:"replicas"`
+		NoTrunc    bool     `schema:"noTrunc"`
 	}{
 		// Defaults would go here.
 		Replicas: 1,
@@ -117,6 +118,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := entities.GenerateKubeOptions{
+		PodmanOnly:         query.PodmanOnly,
 		Service:            query.Service,
 		Type:               generateType,
 		Replicas:           query.Replicas,

--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -135,6 +135,11 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: false
 	//    description: don't truncate annotations to the Kubernetes maximum length of 63 characters
+	//  - in: query
+	//    name: podmanOnly
+	//    type: boolean
+	//    default: false
+	//    description: add podman-only reserved annotations in generated YAML file (cannot be used by Kubernetes)
 	// produces:
 	// - text/vnd.yaml
 	// - application/json

--- a/pkg/bindings/generate/types.go
+++ b/pkg/bindings/generate/types.go
@@ -4,6 +4,8 @@ package generate
 //
 //go:generate go run ../generator/generator.go KubeOptions
 type KubeOptions struct {
+	// PodmanOnly - add podman-only reserved annotations to generated YAML file (Cannot be used by Kubernetes)
+	PodmanOnly *bool
 	// Service - generate YAML for a Kubernetes _service_ object.
 	Service *bool
 	// Type - the k8s kind to be generated i.e Pod or Deployment

--- a/pkg/bindings/generate/types_kube_options.go
+++ b/pkg/bindings/generate/types_kube_options.go
@@ -17,6 +17,21 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
 
+// WithPodmanOnly set field PodmanOnly to given value
+func (o *KubeOptions) WithPodmanOnly(value bool) *KubeOptions {
+	o.PodmanOnly = &value
+	return o
+}
+
+// GetPodmanOnly returns value of field PodmanOnly
+func (o *KubeOptions) GetPodmanOnly() bool {
+	if o.PodmanOnly == nil {
+		var z bool
+		return z
+	}
+	return *o.PodmanOnly
+}
+
 // WithService set field Service to given value
 func (o *KubeOptions) WithService(value bool) *KubeOptions {
 	o.Service = &value

--- a/pkg/domain/entities/generate.go
+++ b/pkg/domain/entities/generate.go
@@ -29,6 +29,8 @@ type GenerateSystemdReport struct {
 
 // GenerateKubeOptions control the generation of Kubernetes YAML files.
 type GenerateKubeOptions struct {
+	// PodmanOnly - add podman-only reserved annotations in the generated YAML file (Cannot be used by Kubernetes)
+	PodmanOnly bool
 	// Service - generate YAML for a Kubernetes _service_ object.
 	Service bool
 	// Type - the k8s kind to be generated i.e Pod or Deployment

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -207,7 +207,7 @@ func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string,
 
 	// Generate the kube pods from containers.
 	if len(ctrs) >= 1 {
-		po, err := libpod.GenerateForKube(ctx, ctrs, options.Service, options.UseLongAnnotations)
+		po, err := libpod.GenerateForKube(ctx, ctrs, options.Service, options.UseLongAnnotations, options.PodmanOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -273,7 +273,7 @@ func getKubePods(ctx context.Context, pods []*libpod.Pod, options entities.Gener
 	svcs := [][]byte{}
 
 	for _, p := range pods {
-		po, sp, err := p.GenerateForKube(ctx, options.Service, options.UseLongAnnotations)
+		po, sp, err := p.GenerateForKube(ctx, options.Service, options.UseLongAnnotations, options.PodmanOnly)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -46,7 +46,7 @@ func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string,
 //
 // Note: Caller is responsible for closing returned Reader
 func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string, opts entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
-	options := new(generate.KubeOptions).WithService(opts.Service).WithType(opts.Type).WithReplicas(opts.Replicas).WithNoTrunc(opts.UseLongAnnotations)
+	options := new(generate.KubeOptions).WithService(opts.Service).WithType(opts.Type).WithReplicas(opts.Replicas).WithNoTrunc(opts.UseLongAnnotations).WithPodmanOnly(opts.PodmanOnly)
 	return generate.Kube(ic.ClientCtx, nameOrIDs, options)
 }
 


### PR DESCRIPTION
Adds a `--podman-only` flag to `podman generate kube` to allow for podman-only reserved annotations to be included in the generated YAML file. These annotations cannot be used by Kubernetes.

Associated with: #19102

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds `--podman-only` flag to `podman generate kube` to allow podman-only reserved annotations to be used in the generated YAML file. These annotations cannot be used by Kubernetes
```
