### PR TITLE
[CI:BUILD] Packit: downstream task action fix

### DIFF
--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -10,7 +10,8 @@ PACKAGE=podman
 # script is run from git root directory
 SPEC_FILE=rpm/$PACKAGE.spec
 
-GOPATHDIR=~/go/src/github.com/containers/
+export GOPATH=~/go
+GOPATHDIR=$GOPATH/src/github.com/containers/
 mkdir -p $GOPATHDIR
 ln -sf $(pwd) $GOPATHDIR/.
 


### PR DESCRIPTION
The downstream `pre-sync` task action script needs GOPATH to be specified for the golist tool mentioned in the script to work.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Doesn't affect upstream. Only needed for downstream Fedora tasks.

Would be good to have this in before v4.6.0