### PR TITLE
pkg/specgen: fix support for --rootfs on FreeBSD

### DIFF
--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -18,11 +18,16 @@ import (
 
 // SpecGenToOCI returns the base configuration for the container.
 func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, newImage *libimage.Image, mounts []spec.Mount, pod *libpod.Pod, finalCmd []string, compatibleOptions *libpod.InfraInherit) (*spec.Spec, error) {
-	inspectData, err := newImage.Inspect(ctx, nil)
-	if err != nil {
-		return nil, err
+	var imageOs string
+	if newImage != nil {
+		inspectData, err := newImage.Inspect(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		imageOs = inspectData.Os
+	} else {
+		imageOs = "freebsd"
 	}
-	imageOs := inspectData.Os
 
 	if imageOs != "freebsd" && imageOs != "linux" {
 		return nil, fmt.Errorf("unsupported image OS: %s", imageOs)


### PR DESCRIPTION
When using 'podman run --rootfs ...', the image passed to SpecGenToOCI may be nil - in this case, fall back to "freebsd" for the container OS.

[NO NEW TESTS NEEDED]

#### Does this PR introduce a user-facing change?

```release-note
None
```
