### PR TITLE
[CI:DOCS] network create: document --internal better

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -62,7 +62,13 @@ For `macvlan` and `ipvlan`, it is the parent device on the host. It is the same 
 
 #### **--internal**
 
-Restrict external access of this network. Note when using this option, the dnsname plugin is automatically disabled.
+Restrict external access of this network when using a `bridge` network. Note when using the CNI backend
+DNS will be automatically disabled, see **--disable-dns**.
+
+When using the `macvlan` or `ipvlan` driver with this option no default route will be added to the container.
+Because it bypasses the host network stack no additional restrictions can be set by podman and if a
+privileged container is run it can set a default route themselves. If this is a concern then the
+container connections should be blocked on your actual network gateway.
 
 #### **--ip-range**=*range*
 


### PR DESCRIPTION
When using --internal for macvlan/ipvlan networks we simply do not add a default gateway/route. Make this clear in the docs.

Fixes #18914

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
