### PR TITLE
Add support for ShmSize to quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -132,6 +132,7 @@ Valid options for `[Container]` are listed below:
 | SecurityLabelLevel=s0:c1,c2    | --security-opt label=level:s0:c1,c2                  |
 | SecurityLabelNested=true       | --security-opt label=nested                          |
 | SecurityLabelType=spc_t        | --security-opt label=type:spc_t                      |
+| ShmSize=100m                   | --shm-size=100m                                      |
 | Sysctl=name=value              | --sysctl=name=value                                  |
 | Timezone=local                 | --tz local                                           |
 | Tmpfs=/work                    | --tmpfs /work                                        |
@@ -446,6 +447,12 @@ Set the label process type for the container processes.
 
 Use a Podman secret in the container either as a file or an environment variable.
 This is equivalent to the Podman `--secret` option and generally has the form `secret[,opt=opt ...]`
+
+### `ShmSize=`
+
+Size of /dev/shm.
+
+This is equivalent to the Podman `--shm-size` option and generally has the form `number[unit]`
 
 ### `Sysctl=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -55,6 +55,7 @@ const (
 	KeyEnvironmentFile       = "EnvironmentFile"
 	KeyEnvironmentHost       = "EnvironmentHost"
 	KeyExec                  = "Exec"
+	KeyExitCodePropagation   = "ExitCodePropagation"
 	KeyExposeHostPort        = "ExposeHostPort"
 	KeyGroup                 = "Group"
 	KeyHealthCmd             = "HealthCmd"
@@ -69,10 +70,9 @@ const (
 	KeyHealthStartupTimeout  = "HealthStartupTimeout"
 	KeyHealthTimeout         = "HealthTimeout"
 	KeyHostName              = "HostName"
-	KeyImage                 = "Image"
 	KeyIP                    = "IP"
 	KeyIP6                   = "IP6"
-	KeyExitCodePropagation   = "ExitCodePropagation"
+	KeyImage                 = "Image"
 	KeyLabel                 = "Label"
 	KeyLogDriver             = "LogDriver"
 	KeyMask                  = "Mask"
@@ -102,13 +102,14 @@ const (
 	KeyRootfs                = "Rootfs"
 	KeyRunInit               = "RunInit"
 	KeySeccompProfile        = "SeccompProfile"
+	KeySecret                = "Secret"
 	KeySecurityLabelDisable  = "SecurityLabelDisable"
 	KeySecurityLabelFileType = "SecurityLabelFileType"
 	KeySecurityLabelLevel    = "SecurityLabelLevel"
 	KeySecurityLabelNested   = "SecurityLabelNested"
 	KeySecurityLabelType     = "SecurityLabelType"
-	KeySecret                = "Secret"
 	KeySetWorkingDirectory   = "SetWorkingDirectory"
+	KeyShmSize               = "ShmSize"
 	KeySysctl                = "Sysctl"
 	KeyTimezone              = "Timezone"
 	KeyTmpfs                 = "Tmpfs"
@@ -179,6 +180,7 @@ var (
 		KeySecurityLabelLevel:    true,
 		KeySecurityLabelNested:   true,
 		KeySecurityLabelType:     true,
+		KeyShmSize:               true,
 		KeySysctl:                true,
 		KeyTimezone:              true,
 		KeyTmpfs:                 true,
@@ -491,6 +493,11 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	addCaps := container.LookupAllStrv(ContainerGroup, KeyAddCapability)
 	for _, caps := range addCaps {
 		podman.addf("--cap-add=%s", strings.ToLower(caps))
+	}
+
+	shmSize, hasShmSize := container.Lookup(ContainerGroup, KeyShmSize)
+	if hasShmSize {
+		podman.addf("--shm-size=%s", shmSize)
 	}
 
 	sysctl := container.LookupAllStrv(ContainerGroup, KeySysctl)

--- a/test/e2e/quadlet/shmsize.container
+++ b/test/e2e/quadlet/shmsize.container
@@ -1,0 +1,5 @@
+## assert-podman-args "--shm-size=5g"
+
+[Container]
+Image=localhost/imagename
+ShmSize=5g

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -594,6 +594,7 @@ BOGUS=foo
 		Entry("seccomp.container", "seccomp.container", 0, ""),
 		Entry("secrets.container", "secrets.container", 0, ""),
 		Entry("selinux.container", "selinux.container", 0, ""),
+		Entry("shmsize.container", "shmsize.container", 0, ""),
 		Entry("shortname.container", "shortname.container", 0, "Warning: shortname.container specifies the image \"shortname\" which not a fully qualified image name. This is not ideal for performance and security reasons. See the podman-pull manpage discussion of short-name-aliases.conf for details."),
 		Entry("sysctl.container", "sysctl.container", 0, ""),
 		Entry("timezone.container", "timezone.container", 0, ""),


### PR DESCRIPTION
I am working on running android auto in a quadlet.

[Container]
AddDevice=/dev/dri/renderD128
AddDevice=/dev/kvm
DropCapability=all
Environment=PULSE_SERVER=$XDG_RUNTIME_DIR/pulse/native Environment=WAYLAND_DISPLAY=wayland-0
Environment=XDG_RUNTIME_DIR
Image=quay.io/slopezpa/qemu-aaos
ContainerName=Android
PodmanArgs=--shm-size=5g
SecurityLabelDisable=true
Volume=$XDG_RUNTIME_DIR:$XDG_RUNTIME_DIR

And I need to be able to set the --shm-size option.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman quadlet now supports ShmSize option in unit files.
```
