### PR TITLE
Fix `trust` not using local policy file

### DIFF
--- a/pkg/trust/policy.go
+++ b/pkg/trust/policy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,7 +66,7 @@ func DefaultPolicyPath(sys *types.SystemContext) string {
 	if err == nil {
 		return userPolicyFilePath
 	}
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		logrus.Warnf("Error trying to read local config file: %s", err.Error())
 	}
 

--- a/pkg/trust/policy.go
+++ b/pkg/trust/policy.go
@@ -60,8 +60,7 @@ func DefaultPolicyPath(sys *types.SystemContext) string {
 		return sys.SignaturePolicyPath
 	}
 
-	confDir, _ := homedir.GetConfigHome()
-	userPolicyFilePath := filepath.Join(confDir, filepath.FromSlash("containers/policy.json"))
+	userPolicyFilePath := filepath.Join(homedir.Get(), filepath.FromSlash(".config/containers/policy.json"))
 	_, err := os.Stat(userPolicyFilePath)
 	if err == nil {
 		return userPolicyFilePath


### PR DESCRIPTION
When running the `trust` command, only the global policy.json file was being taken into account.

Fixes #19073

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
'trust' command can now use the local policy.json file
```
