### PR TITLE
Tests: remove/update obsolete skips

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4884,7 +4884,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 	})
 
 	It("podman play kube with disabled cgroup", func() {
-		SkipIfRunc(podmanTest, "Test not supported with runc, see issue #17436")
+		SkipIfRunc(podmanTest, "Test not supported with runc (issue 17436, wontfix)")
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
 		// Disabled ipcns and cgroupfs in the config file
 		// Since shmsize (Inherit from infra container) cannot be set if ipcns is "host", we should remove the default value.

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1045,7 +1045,7 @@ ENTRYPOINT ["sleep","99999"]
 
 	It("podman pod create --share-parent test", func() {
 		SkipIfRootlessCgroupsV1("rootless cannot use cgroups with cgroupsv1")
-		SkipIfCgroupV1("FIXME: #15013: CgroupMode shows 'host' instead of CID under Cgroups V1.")
+		SkipIfCgroupV1("CgroupMode shows 'host' on CGv1, not CID (issue 15013, wontfix")
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--share-parent=false"})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(Exit(0))

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -28,10 +28,6 @@ var _ = Describe("Podman run memory", func() {
 	})
 
 	It("podman run memory-reservation test", func() {
-		if podmanTest.Host.Distribution == "ubuntu" {
-			Skip("Unable to perform test on Ubuntu distributions due to memory management")
-		}
-
 		var session *PodmanSessionIntegration
 
 		if CGROUPSV2 {

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Podman UserNS support", func() {
 	})
 
 	It("podman uidmapping and gidmapping with an idmapped volume", func() {
-		SkipIfRunc(podmanTest, "Test not supported yet with runc, see issue #17433")
+		SkipIfRunc(podmanTest, "Test not supported yet with runc (issue 17433, wontfix)")
 		SkipOnOSVersion("fedora", "36")
 		session := podmanTest.Podman([]string{"run", "--uidmap=0:1:500", "--gidmap=0:200:5000", "-v", "my-foo-volume:/foo:Z,idmap", "alpine", "stat", "-c", "#%u:%g#", "/foo"})
 		session.WaitWithDefaultTimeout()

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -76,7 +76,7 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run - uidmapping has no /sys/kernel mounts" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "cannot umount as rootless"
     skip_if_remote "TODO Fix this for remote case"
 
@@ -877,7 +877,7 @@ EOF
 
 # rhbz#1902979 : podman run fails to update /etc/hosts when --uidmap is provided
 @test "podman run update /etc/hosts" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     HOST=$(random_string 25)
     run_podman run --uidmap 0:10001:10002 --rm --hostname ${HOST} $IMAGE grep ${HOST} /etc/hosts
     is "${lines[0]}" ".*${HOST}.*"

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -30,11 +30,6 @@ EOF
 }
 
 @test "podman buildx - basic test" {
-    run_podman info --format "{{.Store.GraphDriverName}}"
-    if [[ "$output" == "vfs" ]]; then
-        skip "Test not supported with VFS podman storage driver (#17520)"
-    fi
-
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)
 

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -82,9 +82,6 @@ verify_iid_and_name() {
 
 @test "podman image scp transfer" {
     skip_if_remote "only applicable under local podman"
-    if is_ubuntu; then
-        skip "I don't have time to deal with this"
-    fi
 
     # The testing is the same whether we're root or rootless; all that
     # differs is the destination (not-me) username.

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -30,7 +30,7 @@ function _require_crun() {
 }
 
 @test "podman --group-add without keep-groups while in a userns" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
     run chroot --groups 1234,5678 / ${PODMAN} run --rm --uidmap 0:200000:5000 --group-add 457 $IMAGE id
@@ -38,7 +38,7 @@ function _require_crun() {
 }
 
 @test "rootful pod with custom ID mapping" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "does not work rootless - rootful feature"
     random_pod_name=$(random_string 30)
     run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -76,11 +76,6 @@ function service_cleanup() {
 # These tests can fail in dev. environment because of SELinux.
 # quick fix: chcon -t container_runtime_exec_t ./bin/podman
 @test "podman generate - systemd - basic" {
-    # Flakes with "ActiveState=failed (expected =inactive)"
-    if is_ubuntu; then
-        skip "FIXME: 2022-09-01: requires conmon-2.1.4, ubuntu has 2.1.3"
-    fi
-
     # Warn when a custom restart policy is used without --new (see #15284)
     run_podman create --restart=always $IMAGE
     cid="$output"

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -15,7 +15,7 @@ function start_time() {
 
 function setup() {
     skip_if_remote "quadlet tests are meaningless over remote"
-    skip_if_rootless_cgroupsv1 "Can't use --cgroups=split w/ CGv1 (#17456)"
+    skip_if_rootless_cgroupsv1 "Can't use --cgroups=split w/ CGv1 (issue 17456, wontfix)"
     skip_if_journald_unavailable "quadlet isn't really usable without journal"
 
     test -x "$QUADLET" || die "Cannot run quadlet tests without executable \$QUADLET ($QUADLET)"

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -7,7 +7,7 @@
 load helpers
 
 @test "podman container storage is not accessible by unprivileged users" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "test meaningless without suid"
     skip_if_remote
 

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -119,7 +119,7 @@ function check_label() {
     skip_if_rootless_cgroupsv1
 
     if [[ $(podman_runtime) == "runc" ]]; then
-        skip "some sort of runc bug, not worth fixing (#11784)"
+        skip "some sort of runc bug, not worth fixing (issue 11784, wontfix)"
     fi
 
     run_podman run -d --name myctr $IMAGE top

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -88,7 +88,7 @@ load helpers.network
 
 # Issue #5466 - port-forwarding doesn't work with this option and -d
 @test "podman networking: port with --userns=keep-id for rootless or --uidmap=* for rootful" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     for cidr in "" "$(random_rfc1918_subnet).0/24"; do
         myport=$(random_free_port 52000-52999)
         if [[ -z $cidr ]]; then
@@ -771,7 +771,7 @@ EOF
 }
 
 @test "podman run /etc/* permissions" {
-    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
+    skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     userns="--userns=keep-id"
     if ! is_rootless; then
         userns="--uidmap=0:1111111:65536 --gidmap=0:1111111:65536"

--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -8,14 +8,6 @@ load helpers.network
 
 CHECKED_ROOTLESS=
 function setup() {
-    # FIXME: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1857257
-    # TL;DR they keep fixing it then breaking it again. There's a test we
-    # could run to see if it's fixed, but it's way too complicated. Since
-    # integration tests also skip checkpoint tests on Ubuntu, do the same here.
-    if is_ubuntu; then
-        skip "FIXME: checkpointing broken in Ubuntu 2004, 2104, 2110, 2204, ..."
-    fi
-
     # None of these tests work rootless....
     if is_rootless; then
         # ...however, is that a genuine cast-in-stone limitation, or one

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -452,10 +452,6 @@ function wait_for_file() {
 # BEGIN miscellaneous tools
 
 # Shortcuts for common needs:
-function is_ubuntu() {
-    grep -qiw ubuntu /etc/os-release
-}
-
 function is_rootless() {
     [ "$(id -u)" -ne 0 ]
 }


### PR DESCRIPTION
To silence my find-obsolete-skips script, remove the '#'
from the following issues in skip messages:

  #11784 #15013 #15025 #17433 #17436 #17456

Also update the messages to reflect the fact that the issues
will never be fixed.

Also remove ubuntu skips: we no longer test ubuntu.

Also remove one buildah skip that is no longer applicable:

Fixes: #17520

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```