### PR TITLE
system test: skip some quadlet tests when use journald log driver

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -628,6 +628,11 @@ EOF
 @test "quadlet - rootfs" {
     skip_if_no_selinux
     skip_if_rootless
+    run_podman info --format {{.Host.LogDriver}}
+    if [ "$output" != "journald" ]; then
+        skip "This test can only be run when the log driver is journald."
+    fi
+
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
     cat > $quadlet_file <<EOF
 [Container]
@@ -646,6 +651,11 @@ EOF
 
 @test "quadlet - selinux disable" {
     skip_if_no_selinux
+    run_podman info --format {{.Host.LogDriver}}
+    if [ "$output" != "journald" ]; then
+        skip "This test can only be run when the log driver is journald."
+    fi
+
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
     cat > $quadlet_file <<EOF
 [Container]
@@ -669,6 +679,11 @@ EOF
 
 @test "quadlet - selinux labels" {
     skip_if_no_selinux
+    run_podman info --format {{.Host.LogDriver}}
+    if [ "$output" != "journald" ]; then
+        skip "This test can only be run when the log driver is journald."
+    fi
+
     NAME=$(random_string)
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
     cat > $quadlet_file <<EOF
@@ -698,6 +713,11 @@ EOF
 }
 
 @test "quadlet - secret as environment variable" {
+    run_podman info --format {{.Host.LogDriver}}
+    if [ "$output" != "journald" ]; then
+        skip "This test can only be run when the log driver is journald."
+    fi
+
     create_secret
 
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
@@ -725,6 +745,11 @@ EOF
 }
 
 @test "quadlet - secret as a file" {
+    run_podman info --format {{.Host.LogDriver}}
+    if [ "$output" != "journald" ]; then
+        skip "This test can only be run when the log driver is journald."
+    fi
+
     create_secret
 
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container


### PR DESCRIPTION
Some quadlet tests can only be run when the log driver is set to journald in containers.conf.
Therefore, those tests will be skipped if the log driver is not set to journald.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
