### PR TITLE
Enabled amd64 arch for podman applehv provider

### DIFF
--- a/pkg/machine/applehv/claim.go
+++ b/pkg/machine/applehv/claim.go
@@ -1,5 +1,5 @@
-//go:build darwin && arm64
-// +build darwin,arm64
+//go:build darwin
+// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -1,5 +1,5 @@
-//go:build arm64 && darwin
-// +build arm64,darwin
+//go:build darwin
+// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/ignition.go
+++ b/pkg/machine/applehv/ignition.go
@@ -1,5 +1,5 @@
-//go:build darwin && arm64
-// +build darwin,arm64
+//go:build darwin
+// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1,5 +1,5 @@
-//go:build darwin && arm64
-// +build darwin,arm64
+//go:build darwin
+// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/rest.go
+++ b/pkg/machine/applehv/rest.go
@@ -1,5 +1,5 @@
-//go:build arm64 && darwin
-// +build arm64,darwin
+//go:build darwin
+// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/rest_config.go
+++ b/pkg/machine/applehv/rest_config.go
@@ -1,5 +1,5 @@
-//go:build arm64 && darwin
-// +build arm64,darwin
+//go:build darwin
+// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/vfkit.go
+++ b/pkg/machine/applehv/vfkit.go
@@ -1,5 +1,5 @@
-//go:build arm64 && darwin
-// +build arm64,darwin
+//go:build darwin
+// +build darwin
 
 package applehv
 


### PR DESCRIPTION
The apple hypervisor code works on Intel Macs with very recent operating system versions.

[NO NEW TESTS NEEDED]


```release-note
none
```
