### PR TITLE
Ensure HC events fire after logs are written

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -321,9 +321,7 @@ func (c *Container) execStartAndAttach(sessionID string, streams *define.AttachS
 		return err
 	}
 
-	if isHealthcheck {
-		c.newContainerEvent(events.HealthStatus)
-	} else {
+	if !isHealthcheck {
 		c.newContainerEvent(events.Exec)
 	}
 


### PR DESCRIPTION
HC events were firing as part of the `exec` call, before it had even been decided whether the HC succeeded or failed. As such, the status was not going to be correct any time there was a change (e.g. the first event after a container went healthy to unhealthy would still read healthy). Move the event into the actual Healthcheck function and throw it in a defer to make sure it happens at the very end, after logs are written.

Ignores several conditions that did not log previously (container in question does not have a healthcheck, or an internal failure that should not really happen).

Still not a perfect solution. This relies on the HC log being written, when instead we could just get the status straight from the function writing the event - so if we fail to write the log, we can still report a bad status. But if the log wasn't written, we're in bad shape regardless - `podman ps` would disagree with the event written, for example.

Fixes #19237

```release-note
Fixed a bug where events could report incorrect healthcheck results [#19237](https://github.com/containers/podman/issues/19237).
```
