### PR TITLE
Fix: use --all in podman stats to get all containers stats

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -120,6 +120,7 @@ func stats(cmd *cobra.Command, args []string) error {
 		Latest:   statsOptions.Latest,
 		Stream:   !statsOptions.NoStream,
 		Interval: statsOptions.Interval,
+		All:      statsOptions.All,
 	}
 	args = putils.RemoveSlash(args)
 	statsChan, err := registry.ContainerEngine().ContainerStats(registry.Context(), args, opts)

--- a/pkg/api/handlers/libpod/containers_stats.go
+++ b/pkg/api/handlers/libpod/containers_stats.go
@@ -34,9 +34,11 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Containers []string `schema:"containers"`
 		Stream     bool     `schema:"stream"`
 		Interval   int      `schema:"interval"`
+		All        bool     `schema:"all"`
 	}{
 		Stream:   true,
 		Interval: 5,
+		All:      false,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
@@ -50,6 +52,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 	statsOptions := entities.ContainerStatsOptions{
 		Stream:   query.Stream,
 		Interval: query.Interval,
+		All:      query.All,
 	}
 
 	// Stats will stop if the connection is closed.

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -208,6 +208,7 @@ type StartOptions struct {
 //
 //go:generate go run ../generator/generator.go StatsOptions
 type StatsOptions struct {
+	All      *bool
 	Stream   *bool
 	Interval *int
 }

--- a/pkg/bindings/containers/types_stats_options.go
+++ b/pkg/bindings/containers/types_stats_options.go
@@ -17,6 +17,21 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
 
+// WithAll set field All to given value
+func (o *StatsOptions) WithAll(value bool) *StatsOptions {
+	o.All = &value
+	return o
+}
+
+// GetAll returns value of field All
+func (o *StatsOptions) GetAll() bool {
+	if o.All == nil {
+		var z bool
+		return z
+	}
+	return *o.All
+}
+
 // WithStream set field Stream to given value
 func (o *StatsOptions) WithStream(value bool) *StatsOptions {
 	o.Stream = &value

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -472,6 +472,8 @@ type ContainerCpOptions struct {
 // ContainerStatsOptions describes input options for getting
 // stats on containers
 type ContainerStatsOptions struct {
+	// Get all containers stats
+	All bool
 	// Operate on the latest known container.  Only supported for local
 	// clients.
 	Latest bool

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -1049,7 +1049,7 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 	if options.Latest {
 		return nil, errors.New("latest is not supported for the remote client")
 	}
-	return containers.Stats(ic.ClientCtx, namesOrIds, new(containers.StatsOptions).WithStream(options.Stream).WithInterval(options.Interval))
+	return containers.Stats(ic.ClientCtx, namesOrIds, new(containers.StatsOptions).WithStream(options.Stream).WithInterval(options.Interval).WithAll(options.All))
 }
 
 // ShouldRestart reports back whether the container will restart.


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

Yes, by default it shows only running containers, unless `--all` is specified

closes #19252 

@vrothberg it looks odd that we didn't have `All` in `ContainerStatsOptions` and that we set the default to `queryAll`.
Maybe I should remove "--all" from stats? Let me know 