### PR TITLE
Quadlet - Allow setting Service WorkingDirectory for Kube units

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -517,16 +517,17 @@ There is only one required key, `Yaml`, which defines the path to the Kubernetes
 
 Valid options for `[Kube]` are listed below:
 
-| **[Kube] options**                  | **podman kube play equivalent**             |
-| ----------------------------------- | ------------------------------------------------ |
-| AutoUpdate=registry                 | --annotation "io.containers.autoupdate=registry" |
-| ConfigMap=/tmp/config.map           | --config-map /tmp/config.map                     |
-| LogDriver=journald                  | --log-driver journald                            |
-| Network=host                        | --net host                                       |
-| PodmanArgs=\-\-annotation=key=value | --annotation=key=value                           |
-| PublishPort=59-60                   | --publish=59-60                                  |
-| UserNS=keep-id:uid=200,gid=210      | --userns keep-id:uid=200,gid=210                 |
-| Yaml=/tmp/kube.yaml                 | podman kube play /tmp/kube.yaml                  |
+| **[Kube] options**                  | **podman kube play equivalent**                                  |
+| ----------------------------------- | -----------------------------------------------------------------|
+| AutoUpdate=registry                 | --annotation "io.containers.autoupdate=registry"                 |
+| ConfigMap=/tmp/config.map           | --config-map /tmp/config.map                                     |
+| LogDriver=journald                  | --log-driver journald                                            |
+| Network=host                        | --net host                                                       |
+| PodmanArgs=\-\-annotation=key=value | --annotation=key=value                                           |
+| PublishPort=59-60                   | --publish=59-60                                                  |
+| SetWorkingDirectory=yaml            | Set `WorkingDirectory` of unit file to location of the YAML file |
+| UserNS=keep-id:uid=200,gid=210      | --userns keep-id:uid=200,gid=210                                 |
+| Yaml=/tmp/kube.yaml                 | podman kube play /tmp/kube.yaml                                  |
 
 Supported keys in the `[Kube]` section are:
 
@@ -608,6 +609,16 @@ in the Kubernetes YAML file. If the same container port and protocol is specifie
 entry from the unit file takes precedence
 
 This key can be listed multiple times.
+
+### `SetWorkingDirectory=`
+
+Set the `WorkingDirectory` field of the `Service` group of the Systemd service unit file.
+Used to allow `podman kube play` to correctly resolve relative paths.
+Supported values are `yaml` and `unit` to set the working directory to that of the YAML or Quadlet Unit file respectively.
+
+Alternatively, users can explicitly set the `WorkingDirectory` field of the `Service` group in the `.kube` file.
+Please note that if the `WorkingDirectory` field of the `Service` group is set,
+Quadlet will not set it even if `SetWorkingDirectory` is set
 
 ### `Unmask=`
 

--- a/test/e2e/quadlet/workingdir-service.kube
+++ b/test/e2e/quadlet/workingdir-service.kube
@@ -1,0 +1,8 @@
+## assert-key-is-regex "Service" "WorkingDirectory" "/etc/containers/systemd"
+
+[Service]
+WorkingDirectory=/etc/containers/systemd
+
+[Kube]
+Yaml=deployment.yml
+SetWorkingDirectory=unit

--- a/test/e2e/quadlet/workingdir-unit.kube
+++ b/test/e2e/quadlet/workingdir-unit.kube
@@ -1,0 +1,5 @@
+## assert-key-is-regex "Service" "WorkingDirectory" ".*/podman_test.*/quadlet"
+
+[Kube]
+Yaml=deployment.yml
+SetWorkingDirectory=unit

--- a/test/e2e/quadlet/workingdir-yaml-abs.kube
+++ b/test/e2e/quadlet/workingdir-yaml-abs.kube
@@ -1,0 +1,5 @@
+## assert-key-is "Service" "WorkingDirectory" "/etc/containers/systemd"
+
+[Kube]
+Yaml=/etc/containers/systemd/deployment.yml
+SetWorkingDirectory=yaml

--- a/test/e2e/quadlet/workingdir-yaml-rel.kube
+++ b/test/e2e/quadlet/workingdir-yaml-rel.kube
@@ -1,0 +1,5 @@
+## assert-key-is-regex "Service" "WorkingDirectory" ".*/podman_test.*/quadlet/myservice"
+
+[Kube]
+Yaml=./myservice/deployment.yml
+SetWorkingDirectory=yaml

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -624,6 +624,10 @@ BOGUS=foo
 		Entry("Kube - User Remap Auto", "remap-auto.kube", 0, ""),
 		Entry("Kube - User Remap Manual", "remap-manual.kube", 1, "converting \"remap-manual.kube\": RemapUsers=manual is not supported"),
 		Entry("Syslog Identifier", "syslog.identifier.kube", 0, ""),
+		Entry("Kube - Working Directory YAML Absolute Path", "workingdir-yaml-abs.kube", 0, ""),
+		Entry("Kube - Working Directory YAML Relative Path", "workingdir-yaml-rel.kube", 0, ""),
+		Entry("Kube - Working Directory Unit", "workingdir-unit.kube", 0, ""),
+		Entry("Kube - Working Directory already in Service", "workingdir-service.kube", 0, ""),
 
 		Entry("Network - Basic", "basic.network", 0, ""),
 		Entry("Network - Disable DNS", "disable-dns.network", 0, ""),


### PR DESCRIPTION
Add key for Quadlet to set WorkingDirectory to the directory of the YAML or Unit file Add Doc
Add E2E tests
Add System test

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - Allow the user to instruct Quadlet to set the service working directory relative to the YAML or Unit files
```

Resolves #17177 
