### PR TITLE
Emergency gating-test fixes for RHEL8

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -7,7 +7,9 @@ load helpers.network
     rand=$(random_string 30)
 
     err_no_such_cmd="Error:.*/no/such/command.*[Nn]o such file or directory"
-    err_no_exec_dir="Error:.*exec.*permission denied"
+    # runc: RHEL8 on 2023-07-17: "is a directory".
+    # Everything else (crun; runc on debian): "permission denied"
+    err_no_exec_dir="Error:.*exec.*\\\(permission denied\\\|is a directory\\\)"
 
     tests="
 true              |   0 |

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -22,8 +22,13 @@ load helpers
 
     # Specially defined situations: exec a dir, or no such command.
     # We don't check the full error message because runc & crun differ.
-    run_podman 126 exec $cid /etc
-    is "$output" ".*permission denied"  "podman exec /etc"
+    #
+    # UPDATE 2023-07-17 runc on RHEL8 (but not Debian) now says "is a dir"
+    # and exits 255 instead of 126 as it does everywhere else.
+    run_podman '?' exec $cid /etc
+    is "$output" ".*\(permission denied\|is a directory\)"  \
+       "podman exec /etc"
+    assert "$status" -ne 0 "exit status from 'exec /etc'"
     run_podman 127 exec $cid /no/such/command
     is "$output" ".*such file or dir"   "podman exec /no/such/command"
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -110,6 +110,21 @@ function _prefetch() {
     $cmd
 }
 
+
+# Wrapper for skopeo, because skopeo doesn't work rootless if $XDG is unset
+# (as it is in RHEL gating): it defaults to /run/containers/<uid>, which
+# of course is a root-only dir, hence fails with permission denied.
+# -- https://github.com/containers/skopeo/issues/823
+function skopeo() {
+    local xdg=${XDG_RUNTIME_DIR}
+    if [ -z "$xdg" ]; then
+        if is_rootless; then
+            xdg=/run/user/$(id -u)
+        fi
+    fi
+    XDG_RUNTIME_DIR=${xdg} command skopeo "$@"
+}
+
 # END   tools for fetching & caching test images
 ###############################################################################
 # BEGIN setup/teardown tools


### PR DESCRIPTION
- the "podman {run,exec} /etc" test: runc now spits out
  "is a directory" instead of "permission denied". And,
  on exec, exits 255 instead of 126. Deal with it.

- workaround for https://github.com/containers/skopeo/issues/823
  (skopeo XDG bug): always make sure XDG is defined for skopeo

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```