### PR TITLE
Podman inspect completion

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
@@ -28,7 +27,7 @@ func AddInspectFlagSet(cmd *cobra.Command) *entities.InspectOptions {
 
 	formatFlagName := "format"
 	flags.StringVarP(&opts.Format, formatFlagName, "f", "json", "Format the output to a Go template or json")
-	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(nil)) // passing nil as the type selection logic is in AutocompleteFormat function
 
 	typeFlagName := "type"
 	flags.StringVarP(&opts.Type, typeFlagName, "t", common.AllType, "Specify inspect-object type")

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -309,6 +309,25 @@ function _check_no_suggestions() {
     # recurse for any subcommands.
     check_shell_completion
 
+    # check inspect with format flag
+    run_completion inspect -f "{{."
+    assert "$output" =~ ".*^\{\{\.Args\}\}\$.*" "Defaulting to container type is completed"
+
+    run_completion inspect created-$random_container_name -f "{{."
+    assert "$output" =~ ".*^\{\{\.Args\}\}\$.*" "Container type is completed"
+
+    run_completion inspect $random_image_name -f "{{."
+    assert "$output" =~ ".*^\{\{\.Digest\}\}\$.*" "Image type is completed"
+
+    run_completion inspect $random_volume_name -f "{{."
+    assert "$output" =~ ".*^\{\{\.Anonymous\}\}\$.*" "Volume type is completed"
+
+    run_completion inspect created-$random_pod_name -f "{{."
+    assert "$output" =~ ".*^\{\{\.BlkioDeviceReadBps\}\}\$.*" "Pod type is completed"
+
+    run_completion inspect $random_network_name -f "{{."
+    assert "$output" =~ ".*^\{\{\.DNSEnabled\}\}\$.*" "Network type is completed"
+
     # cleanup
     run_podman secret rm $random_secret_name
     rm -f $secret_file

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -25,6 +25,8 @@ history           | $IMAGE
 image history     | $IMAGE
 image inspect     | $IMAGE
 container inspect | mycontainer
+inspect           | mycontainer
+
 
 volume inspect    | -a
 secret inspect    | mysecret

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -82,7 +82,15 @@ the function or perhaps just a substring.
 Requirements
 ============
 
-The `jq` tool is needed for parsing JSON output.
+- bats
+- jq
+- skopeo
+- nmap-ncat
+- httpd-tools
+- openssl
+- socat
+- buildah
+- gnupg
 
 
 Further Details


### PR DESCRIPTION
Add tab-completion feature for podman inspect -f
The command:
```podman inspect <ContainerID> -f "{{."```
was not giving any output in console for bash-completion but the same was working fine for the command:
```podman container inspect <ContainerID> -f "{{."```
So added a flow to handle the former command and additionally handled all types of entities namely container, image, volume, pod and network.
This would ESSENTIALLY make the sub-commands such as follows OBSOLETE:
podman container inspect
podman image inspect
podman volume inspect
podman pod inspect
podman network inspect


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The following command is now enabled with tab-completion:
podman inspect {CONTAINER | IMAGE | VOLUME | POD | NETWORK} -f "{{." <tab>
where CONTAINER can be ContainerID or ContainerName and same for other given entities.
```

Closes #18672 

Signed-off-by: Chetan Giradkar <cgiradka@redhat.com>