### PR TITLE
[CI:DOCS] Fix bug report issue template README link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        **NOTE** A large number of issues reported against Podman are often found to already be fixed in more current versions of the project.  Before reporting an issue, please verify the version you are running with `podman version` and compare it to the latest release documented on the top of Podman's [README.md](../README.md). If they differ, please update your version of Podman to the latest possible and retry your command before creating an issue.
+        **NOTE** A large number of issues reported against Podman are often found to already be fixed in more current versions of the project.  Before reporting an issue, please verify the version you are running with `podman version` and compare it to the latest release documented on the top of Podman's [README.md](https://github.com/containers/podman#readme). If they differ, please update your version of Podman to the latest possible and retry your command before creating an issue.
 
         Also, there is a running list of known issues in the [Podman Troubleshooting Guide](https://github.com/containers/podman/blob/main/troubleshooting.md), please reference that page before opening a new issue.
 


### PR DESCRIPTION
The relative link seems flakey: depending where you're creating the issue this may not take you to the right place.

For example, from https://github.com/containers/podman/issues/new?assignees=&labels=kind%2Fbug%2Ctriage-needed&projects=&template=bug_report.yaml it takes you to https://github.com/containers/podman/README.md, which does not exist.

To fix this, I've replaced it with an absolute link to the README for people to find the version easily. Other places in the same issue template use absolute paths to places in the repo e.g. the wiki, so I think this is acceptable.

#### Does this PR introduce a user-facing change?

```release-note
None
```