### PR TITLE
Fix multiple filter options logic for `podman volume ls `

### DIFF
--- a/docs/source/markdown/podman-volume-ls.1.md.in
+++ b/docs/source/markdown/podman-volume-ls.1.md.in
@@ -16,6 +16,11 @@ flag. Use the **--quiet** flag to print only the volume names.
 
 #### **--filter**, **-f**=*filter*
 
+Filter what volumes are shown in the output.
+Multiple filters can be given with multiple uses of the --filter flag.
+Filters with the same key work inclusive, with the only exception being `label`
+which is exclusive. Filters with different keys always work exclusive.
+
 Volumes can be filtered by the following attributes:
 
 | **Filter** | **Description**                                                                       |

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -180,32 +180,35 @@ var _ = Describe("Podman volume ls", func() {
 	})
 
 	It("podman ls volume with multiple --filter flag", func() {
-		session := podmanTest.Podman([]string{"volume", "create", "--label", "foo=bar", "myvol"})
-		volName := session.OutputToString()
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "a=b", "--label", "b=c", "vol1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "create", "--label", "foo2=bar2", "anothervol"})
-		anotherVol := session.OutputToString()
+		vol1Name := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "b=c", "--label", "a=b", "vol2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "create"})
+		vol2Name := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "b=c", "--label", "c=d", "vol3"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo", "--filter", "label=foo2"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		Expect(session.OutputToStringArray()).To(HaveLen(3))
-		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
-		Expect(session.OutputToStringArray()[2]).To(ContainSubstring(anotherVol))
+		vol3Name := session.OutputToString()
 
-		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=bar", "--filter", "label=foo2=bar2"})
+		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=a=b", "--filter", "label=b=c"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToStringArray()).To(HaveLen(3))
-		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
-		Expect(session.OutputToStringArray()[2]).To(ContainSubstring(anotherVol))
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+		Expect(session.OutputToStringArray()[0]).To(Equal(vol1Name))
+		Expect(session.OutputToStringArray()[1]).To(Equal(vol2Name))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=c=d", "--filter", "label=b=c"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToStringArray()[0]).To(Equal(vol3Name))
 	})
 })


### PR DESCRIPTION
Fixes a bug where `podman volume ls` with multiple `label` filters would return volumes that matched *any* of the filters, not *all* of them.

Fixes: #19219

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a bug where `podman volume ls` with multiple `label` filters would return volumes that matched any of the filters, not all of them
```
