### PR TITLE
Ensure that we appropriately warn that TCP is insecure

### DIFF
--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -81,6 +81,12 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 				}
 			}
 		case "tcp":
+			// We want to check if the user is requesting a TCP address.
+			// If so, warn that this is insecure.
+			// Ignore errors here, the actual backend code will handle them
+			// better than we can here.
+			logrus.Warnf("Using the Podman API service with TCP sockets is not recommended, please see `podman system service` manpage for details")
+
 			host := uri.Host
 			if host == "" {
 				// For backward compatibility, support "tcp:<host>:<port>" and "tcp://<host>:<port>"

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -66,9 +66,14 @@ To access the API service inside a container:
 - mount the socket as a volume
 - run the container with `--security-opt label=disable`
 
-Please note that the API grants full access to Podman's capabilities, and allows arbitrary code execution as the user running the API.
-We strongly recommend against making the API socket available via the network.
-The default configuration (a Unix socket with permissions set to only allow the user running Podman) is the most secure way of running the API.
+### Security
+
+Please note that the API grants full access to all Podman functionality, and thus allows arbitrary code execution as the user running the API, with no ability to limit or audit this access.
+The API's security model is built upon access via a Unix socket with access restricted via standard file permissions, ensuring that only the user running the service will be able to access it.
+We *strongly* recommend against making the API socket available via the network (IE, bindings the service to a *tcp* URL).
+Even access via Localhost carries risks - anyone with access to the system will be able to access the API.
+If remote access is required, we instead recommend forwarding the API socket via SSH, and limiting access on the remote machine to the greatest extent possible.
+If a *tcp* URL must be used, using the *--cors* option is recommended to improve security.
 
 ## OPTIONS
 

--- a/test/system/271-tcp-cors-server.bats
+++ b/test/system/271-tcp-cors-server.bats
@@ -16,13 +16,18 @@ SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
 @test "podman system service - tcp CORS" {
     skip_if_remote "system service tests are meaningless over remote"
     PORT=$(random_free_port 63000-64999)
-    $PODMAN system service --cors="*" tcp:$SERVICE_TCP_HOST:$PORT -t 20 &
+    log=${PODMAN_TMPDIR}/system-service.log
+    $PODMAN system service --cors="*" tcp:$SERVICE_TCP_HOST:$PORT -t 20 2> $log &
     podman_pid="$!"
     sleep 5s
     run curl -s --max-time 10 -vvv $SERVICE_TCP_HOST:$PORT/_ping 2>&1
     is "$output" ".*< Access-Control-Allow-Origin: \*.*" "access-control-allow-origin verifies CORS is set"
     kill $podman_pid
     wait $podman_pid || true
+
+    # Running server over TCP is a bad idea. We should see a warning
+    assert "$(< $log)" =~ "Using the Podman API service with TCP sockets" \
+           "podman warns about server on TCP"
 }
 
 @test "podman system service - tcp without CORS" {


### PR DESCRIPTION
`podman system service` + TCP is not a configuration we should be recommending. There was already language about this in the manpages, but it was not sufficient in explaining how bad of an idea this is. Expand the manpage warnings, add a dedicated heading so people notice, and add a warning every time the service starts with a TCP URL that directs people to the manpage to see that explanation.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a warning when `podman system service` binds to a TCP socket. This is not a secure configuration and the Podman team recommends against using it.
```
