### PR TITLE
Add glob support to podman run/create --mount

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -6,7 +6,7 @@
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
+Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **tmpfs** and **volume**. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
 
@@ -15,6 +15,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
        type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
 
        type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
+
+       type=glob,src=/usr/lib/libfoo*,destination=/usr/lib,ro=true
 
        type=volume,source=vol1,destination=/path/in/container,ro=true
 
@@ -26,9 +28,11 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
        Common Options:
 
-	      · src, source: mount source spec for bind and volume. Mandatory for bind.
+	      · src, source: mount source spec for bind, glob, and volume. Mandatory for bind and glob.
 
 	      · dst, destination, target: mount destination spec.
+
+	      Paths matching globs, are mounted on the destination directory with the identical name inside the container.
 
        Options specific to volume:
 
@@ -47,7 +51,7 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · rw, readwrite: true or false (default).
 
-       Options specific to bind:
+       Options specific to bind and glob:
 
 	      · ro, readonly: true or false (default).
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -443,6 +443,12 @@ $ podman create --name container3 --requires container1,container2 -t -i fedora 
 $ podman start --attach container3
 ```
 
+### Exposing shared libraries inside of container as read-only using a glob
+
+```
+$ podman create --mount type=glob,src=/usr/lib64/libnvidia\*,ro -i -t fedora /bin/bash
+```
+
 ### Configure keep supplemental groups for access to volume
 
 ```

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -468,6 +468,12 @@ $ podman run --read-only -i -t fedora /bin/bash
 $ podman run --read-only --read-only-tmpfs=false --tmpfs /run -i -t fedora /bin/bash
 ```
 
+### Exposing shared libraries inside of container as read-only using a glob
+
+```
+$ podman run --mount type=glob,src=/usr/lib64/libnvidia\*,ro=true -i -t fedora /bin/bash
+```
+
 ### Exposing log messages from the container to the host's log
 
 Bind mount the _/dev/log_ directory to have messages that are logged in the container  show up in the host's

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -664,7 +664,7 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 			paramsMap[kv[0]] = kv[1]
 		}
 		if paramType, ok := paramsMap["type"]; ok {
-			if paramType == "volume" || paramType == "bind" {
+			if paramType == "volume" || paramType == "bind" || paramType == "glob" {
 				var err error
 				if paramSource, ok := paramsMap["source"]; ok {
 					paramsMap["source"], err = handleStorageSource(container, service, paramSource, names)


### PR DESCRIPTION
HPC Community asked for this support specifically for using GPUs
within containers. Nvidia requires the correct shared library to
to be present in the directory that matches the device mounted
into the container. These libraries have random suffixes based
on versions of the installed libraries on the host.

podman run --mount type=glob:src=/usr/lib64/nvidia\*:ro=true. This helps
quadlets be more portable for this use case.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman --mount option supports bind mounts passed as globs.
```
