### PR TITLE
libpod: fix FreeBSD 'podman-remote top' default behaviour

### DIFF
--- a/libpod/container_top_freebsd.go
+++ b/libpod/container_top_freebsd.go
@@ -43,7 +43,7 @@ func (c *Container) Top(descriptors []string) ([]string, error) {
 	}
 
 	// Default to 'ps -ef' compatible descriptors
-	if len(descriptors) == 0 {
+	if len(strings.Join(descriptors, "")) == 0 {
 		descriptors = []string{"user", "pid", "ppid", "pcpu", "etime", "tty", "time", "args"}
 	}
 


### PR DESCRIPTION
use the 'pf -ef' compatible default when the `descriptor` argument of `Top()` is `[]string{""}` or `[]string{}`

#### why:

the call to `Top()` in

[the REST API handler](https://github.com/containers/podman/blob/87f5a15d62506609a6079ff835651409036879d8/pkg/api/handlers/compat/containers_top.go#L62C3-L62C3)

does pass `[]string{""}` as `descriptors` whenever `ps_args` is empty (the default value for libpod request) because of golang `strings.Split()` semantics.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

* output of `podman --url=$MachineWithFreeBSDocijailRuntime container top $MyContainer` will have the same fields as `podman container top $MyContainer`

* podman-tui will no longer panic in containers/podman-tui/pdcs/containers.Top when used
with a FreeBSD ocijail Runtime (the number of descriptor fields is hardcoded there).

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]