### PR TITLE
[CI:DOCS] Update kube play volume support

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -13,7 +13,7 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | imagePullSecrets                                    | no      |
 | enableServiceLinks                                  | no      |
 | os\.name                                            | no      |
-| volumes                                             | no      |
+| volumes                                             | ✅      |
 | nodeSelector                                        | N/A     |
 | nodeName                                            | N/A     |
 | affinity\.nodeAffinity                              | N/A     |


### PR DESCRIPTION
Update the kubernetes_support table to correctly show that "volumes" is supported in the pod spec.
The kube play docs already specifies which types of volumes are curretnly supported, so no further documentation is needed on that.

Fixes https://github.com/containers/podman/issues/19318

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update kubernetes support table to correctly show volumes support.
```
