### PR TITLE
[CI:DOCS] Makefile: add warning about RHEL8 failing man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,13 @@ $(MANPAGES): %: %.md .install.md2man docdir
 	@if grep 'included file options/' docs/build/man/*; then \
 		echo "FATAL: man pages must not contain ^^^^"; exit 1; \
 	fi
+	@#
+	@# *** SUPER-IMPORTANT RHEL8 NOTE! THIS TEST WILL FAIL ON RHEL8! ***
+	@# *** As of 2023-07-24, RHEL-8.9 has go-md2man-2.00 which generates
+	@# *** corrupt tables. The bugs are fixed in 2.02, which will probably
+	@# *** never get into RHEL8, so the least-worst solution is simply
+	@# *** to remove the next few lines when building on RHEL8.
+	@# ***   See https://github.com/containers/podman/pull/18678
 	@if man -l $(subst source/markdown,build/man,$@) | grep -Pazoq '│\s+│\n\s+├─+┼─+┤\n\s+│\s+│'; then  \
 		echo "FATAL: $< has a too-long table column; use 'man -l $(subst source/markdown,build/man,$@)' and look for empty table cells."; exit 1; \
 	fi


### PR DESCRIPTION
The new man-page table check (#19278) fails on RHEL8 because
go-md2man is 2.00 and we require 2.02.

After much deliberation.... just ignore the problem. Add a
bold note to that part of the Makefile, and hope that when
the test fails on the next RHEL branching someone will look
at the Makefile, find the comment, and disable that test.

Got any better ideas?

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```