### PR TITLE
pkg/specgen: Don't crash for device spec with empty destination path

### DIFF
--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -193,7 +193,7 @@ func ParseDevice(device string) (string, string, string, error) {
 		if IsValidDeviceMode(arr[1]) {
 			permissions = arr[1]
 		} else {
-			if arr[1][0] != '/' {
+			if len(arr[1]) > 0 && arr[1][0] != '/' {
 				return "", "", "", fmt.Errorf("invalid device mode: %s", arr[1])
 			}
 			dst = arr[1]

--- a/pkg/specgen/generate/config_linux_test.go
+++ b/pkg/specgen/generate/config_linux_test.go
@@ -26,3 +26,25 @@ func TestShouldMask(t *testing.T) {
 		assert.Equal(t, val, test.shouldMask)
 	}
 }
+
+func TestParseDevice(t *testing.T) {
+	tests := []struct {
+		device string
+		src    string
+		dst    string
+		perm   string
+	}{
+		{"/dev/foo", "/dev/foo", "/dev/foo", "rwm"},
+		{"/dev/foo:/dev/bar", "/dev/foo", "/dev/bar", "rwm"},
+		{"/dev/foo:/dev/bar:rw", "/dev/foo", "/dev/bar", "rw"},
+		{"/dev/foo:rw", "/dev/foo", "/dev/foo", "rw"},
+		{"/dev/foo::rw", "/dev/foo", "/dev/foo", "rw"},
+	}
+	for _, test := range tests {
+		src, dst, perm, err := ParseDevice(test.device)
+		assert.NoError(t, err)
+		assert.Equal(t, src, test.src)
+		assert.Equal(t, dst, test.dst)
+		assert.Equal(t, perm, test.perm)
+	}
+}


### PR DESCRIPTION
This fixes a server-side crash for command lines like:
```
# podman run -ti --rm --device /dev/mem::rw alpine sh
```
Fixes #19335.

#### Does this PR introduce a user-facing change?

```release-note
Fix a crash validating --device argument for create and run (#19335)
```
