### PR TITLE
Remove any quotes around distribution id

### DIFF
--- a/libpod/info.go
+++ b/libpod/info.go
@@ -287,7 +287,7 @@ func (r *Runtime) GetHostDistributionInfo() define.DistributionInfo {
 	l := bufio.NewScanner(f)
 	for l.Scan() {
 		if strings.HasPrefix(l.Text(), "ID=") {
-			dist.Distribution = strings.TrimPrefix(l.Text(), "ID=")
+			dist.Distribution = strings.Trim(strings.TrimPrefix(l.Text(), "ID="), "\"")
 		}
 		if strings.HasPrefix(l.Text(), "VARIANT_ID=") {
 			dist.Variant = strings.Trim(strings.TrimPrefix(l.Text(), "VARIANT_ID="), "\"")


### PR DESCRIPTION
Some distributions add extra quotes, even to fields like ID that doesn't really need them. Make sure to remove them too.

[NO NEW TESTS NEEDED]

Closes #19340

#### Does this PR introduce a user-facing change?

```release-note
Extra quotes around the distribution name removed from podman info output
```


Tested with ubuntu and fedora coreos, that does not have quotes.

```
NAME="Fedora Linux"
VERSION="38.20230709.2.0 (CoreOS)"
ID=fedora
VERSION_ID=38
```

```yaml
  distribution:
    distribution: fedora
    variant: coreos
    version: "38"
```

And verified against centos stream, which does have extra quotes.

```
NAME="CentOS Stream"
VERSION="9"
ID="centos"
ID_LIKE="rhel fedora"
```

```yaml
  distribution:
    distribution: centos
    version: "9"
```