### PR TITLE
Verify authfile exists if user specifies it

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -68,6 +68,9 @@ func autoUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
 
+	if err := auth.CheckAuthFile(autoUpdateOptions.Authfile); err != nil {
+		return err
+	}
 	if cmd.Flags().Changed("tls-verify") {
 		autoUpdateOptions.InsecureSkipTLSVerify = types.NewOptionalBool(!autoUpdateOptions.tlsVerify)
 	}

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/buildah/pkg/cli"
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/config"
 	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -154,6 +155,11 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 		imageName = name
 	}
+
+	if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
+		return err
+	}
+
 	s := specgen.NewSpecGenerator(imageName, cliVals.RootFS)
 	if err := specgenutil.FillOutSpecGen(s, &cliVals, args); err != nil {
 		return err

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
@@ -114,10 +115,8 @@ func run(cmd *cobra.Command, args []string) error {
 		logrus.Warnf("The input device is not a TTY. The --tty and --interactive flags might not work properly")
 	}
 
-	if af := cliVals.Authfile; len(af) > 0 {
-		if _, err := os.Stat(af); err != nil {
-			return err
-		}
+	if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
+		return err
 	}
 
 	runOpts.CIDFile = cliVals.CIDFile

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -2,7 +2,6 @@ package containers
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/auth"
@@ -91,10 +90,8 @@ func runlabel(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("tls-verify") {
 		runlabelOptions.SkipTLSVerify = types.NewOptionalBool(!runlabelOptions.TLSVerifyCLI)
 	}
-	if runlabelOptions.Authfile != "" {
-		if _, err := os.Stat(runlabelOptions.Authfile); err != nil {
-			return err
-		}
+	if err := auth.CheckAuthFile(runlabelOptions.Authfile); err != nil {
+		return err
 	}
 	return registry.ContainerEngine().ContainerRunlabel(context.Background(), strings.TrimPrefix(args[0], "/"), args[1], args[2:], runlabelOptions.ContainerRunlabelOptions)
 }

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -363,6 +363,10 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		}
 	}
 
+	if err := auth.CheckAuthFile(flags.Authfile); err != nil {
+		return nil, err
+	}
+
 	commonOpts, err := parse.CommonBuildOptions(c)
 	if err != nil {
 		return nil, err
@@ -396,12 +400,6 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 
 	if flags.PullNever || strings.EqualFold(strings.TrimSpace(flags.Pull), "never") {
 		pullPolicy = buildahDefine.PullNever
-	}
-
-	if c.Flag("authfile").Changed {
-		if err := auth.CheckAuthFile(flags.Authfile); err != nil {
-			return nil, err
-		}
 	}
 
 	var cleanTmpFile bool

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -136,10 +136,8 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("tls-verify") {
 		pullOptions.SkipTLSVerify = types.NewOptionalBool(!pullOptions.TLSVerifyCLI)
 	}
-	if pullOptions.Authfile != "" {
-		if _, err := os.Stat(pullOptions.Authfile); err != nil {
-			return err
-		}
+	if err := auth.CheckAuthFile(pullOptions.Authfile); err != nil {
+		return err
 	}
 	platform, err := cmd.Flags().GetString("platform")
 	if err != nil {

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -173,10 +173,8 @@ func imagePush(cmd *cobra.Command, args []string) error {
 		pushOptions.SkipTLSVerify = types.NewOptionalBool(!pushOptions.TLSVerifyCLI)
 	}
 
-	if pushOptions.Authfile != "" {
-		if _, err := os.Stat(pushOptions.Authfile); err != nil {
-			return err
-		}
+	if err := auth.CheckAuthFile(pushOptions.Authfile); err != nil {
+		return err
 	}
 
 	if pushOptions.CredentialsCLI != "" {

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -138,10 +138,8 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 		searchOptions.SkipTLSVerify = types.NewOptionalBool(!searchOptions.TLSVerifyCLI)
 	}
 
-	if searchOptions.Authfile != "" {
-		if _, err := os.Stat(searchOptions.Authfile); err != nil {
-			return err
-		}
+	if err := auth.CheckAuthFile(searchOptions.Authfile); err != nil {
+		return err
 	}
 
 	if searchOptions.CredentialsCLI != "" {

--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -56,6 +56,9 @@ func init() {
 }
 
 func sign(cmd *cobra.Command, args []string) error {
+	if err := auth.CheckAuthFile(signOptions.Authfile); err != nil {
+		return err
+	}
 	if signOptions.SignBy == "" {
 		return errors.New("please provide an identity")
 	}

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -217,10 +217,8 @@ func play(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("build") {
 		playOptions.Build = types.NewOptionalBool(playOptions.BuildCLI)
 	}
-	if playOptions.Authfile != "" {
-		if _, err := os.Stat(playOptions.Authfile); err != nil {
-			return err
-		}
+	if err := auth.CheckAuthFile(playOptions.Authfile); err != nil {
+		return err
 	}
 	if playOptions.ContextDir != "" && playOptions.Build != types.OptionalBoolTrue {
 		return errors.New("--build must be specified when using --context-dir option")

--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -44,6 +44,9 @@ func init() {
 }
 
 func inspect(cmd *cobra.Command, args []string) error {
+	if err := auth.CheckAuthFile(inspectOptions.Authfile); err != nil {
+		return err
+	}
 	if cmd.Flags().Changed("tls-verify") {
 		inspectOptions.SkipTLSVerify = types.NewOptionalBool(!tlsVerifyCLI)
 	} else if cmd.Flags().Changed("insecure") {

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -311,10 +311,11 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create --authfile with nonexistent authfile", func() {
-		// FIXME (#18938): this test should fail but does not!
-		session := podmanTest.Podman([]string{"create", "--authfile", "/tmp/nonexistent", "--name=foo", ALPINE})
+		bogus := filepath.Join(podmanTest.TempDir, "bogus.conf")
+		session := podmanTest.Podman([]string{"create", "--authfile", bogus, "--name=foo", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).To(ExitWithError())
+		Expect(session.ErrorToString()).To(ContainSubstring("no such file or directory"))
 	})
 
 	It("podman create --signature-policy", func() {

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Podman login and logout", func() {
 		session = podmanTest.Podman([]string{"push", "--authfile", "/tmp/nonexistent", ALPINE, testImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(Equal("Error: stat /tmp/nonexistent: no such file or directory"))
+		Expect(session.ErrorToString()).To(Equal("Error: checking authfile: stat /tmp/nonexistent: no such file or directory"))
 
 		session = podmanTest.Podman([]string{"push", "--authfile", authFile, ALPINE, testImg})
 		session.WaitWithDefaultTimeout()

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -724,3 +724,13 @@ spec:
 
     run_podman kube down $pod_file
 }
+
+@test "podman kube with --authfile=/tmp/bogus" {
+    TESTDIR=$PODMAN_TMPDIR/testdir
+    mkdir -p $TESTDIR
+    echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
+    bogus=$PODMAN_TMPDIR/bogus-authfile
+
+    run_podman 125 kube play --authfile=$bogus - < $PODMAN_TMPDIR/test.yaml
+    is "$output" "Error: checking authfile: stat $bogus: no such file or directory" "$command should fail with not such file"
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/18938

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If user specifies the authfile path in podman run or create, the command fails if path does not exists.
```
