### PR TITLE
[CI:DOCS] go-md2man: use vendored-in version, not system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ override undefine GOBIN
 # This must never include the 'hack' directory
 export PATH := $(shell $(GO) env GOPATH)/bin:$(PATH)
 
-GOMD2MAN ?= $(shell command -v go-md2man || echo './test/tools/build/go-md2man')
+GOMD2MAN ?= ./test/tools/build/go-md2man
 
 CROSS_BUILD_TARGETS := \
 	bin/podman.cross.linux.amd64 \
@@ -954,7 +954,7 @@ install.tools: .install.golangci-lint ## Install needed tools
 .PHONY: .install.md2man
 .install.md2man:
 	if [ ! -x "$(GOMD2MAN)" ]; then \
-		$(MAKE) -C test/tools build/go-md2man ; \
+		$(MAKE) -C test/tools build/go-md2man GOOS=$(NATIVE_GOOS) GOARCH=$(NATIVE_GOARCH); \
 	fi
 
 .PHONY: .install.pre-commit

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -74,7 +74,6 @@ Source1: %{git_plugins}/archive/%{commit_plugins}/%{repo_plugins}-%{commit_plugi
 Source2: %{git_gvproxy}/archive/%{commit_gvproxy}/%{repo_gvproxy}-%{commit_gvproxy}.tar.gz
 Provides: %{name}-manpages = %{epoch}:%{version}-%{release}
 BuildRequires: %{_bindir}/envsubst
-BuildRequires: %{_bindir}/go-md2man
 %if %{defined build_with_btrfs}
 BuildRequires: btrfs-progs-devel
 %endif


### PR DESCRIPTION
go-md2man is fragile, especially around tables (#18678, #19278).
Podman man pages are finely tuned to look OK using v2.02, which
is what we vendor in test/tools, so we should really use it
instead of whatever is installed on the system.

This fixes 'make docs' on RHEL8, broken as of #19278.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Fixes broken tables on some RHEL8 man pages
```