### PR TITLE
add "healthy" sdnotify policy

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1545,7 +1545,7 @@ func AutocompleteLogLevel(cmd *cobra.Command, args []string, toComplete string) 
 // AutocompleteSDNotify - Autocomplete sdnotify options.
 // -> "container", "conmon", "ignore"
 func AutocompleteSDNotify(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{define.SdNotifyModeContainer, define.SdNotifyModeContainer, define.SdNotifyModeIgnore}
+	types := []string{define.SdNotifyModeConmon, define.SdNotifyModeContainer, define.SdNotifyModeHealthy, define.SdNotifyModeIgnore}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/docs/source/markdown/options/sdnotify.md
+++ b/docs/source/markdown/options/sdnotify.md
@@ -2,7 +2,7 @@
 ####>   podman create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--sdnotify**=**container** | *conmon* | *ignore*
+#### **--sdnotify**=**container** | *conmon* | *healthy* | *ignore*
 
 Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
 
@@ -10,5 +10,7 @@ Default is **container**, which means allow the OCI runtime to proxy the socket 
 container to receive ready notification. Podman sets the MAINPID to conmon's pid.
 The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
 has started. The socket is never passed to the runtime or the container.
+The **healthy** option sets MAINPID to conmon's pid, and sends READY when the container
+has turned healthy; requires a healthcheck to be set. The socket is never passed to the runtime or the container.
 The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
 for the case where some other process above Podman uses NOTIFY_SOCKET and Podman does not use it.

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -113,7 +113,7 @@ func (c *Container) Start(ctx context.Context, recursive bool) (finalErr error) 
 	}
 
 	// Start the container
-	return c.start()
+	return c.start(ctx)
 }
 
 // Update updates the given container.

--- a/libpod/define/sdnotify.go
+++ b/libpod/define/sdnotify.go
@@ -4,17 +4,18 @@ import "fmt"
 
 // Strings used for --sdnotify option to podman
 const (
-	SdNotifyModeContainer = "container"
 	SdNotifyModeConmon    = "conmon"
+	SdNotifyModeContainer = "container"
+	SdNotifyModeHealthy   = "healthy"
 	SdNotifyModeIgnore    = "ignore"
 )
 
 // ValidateSdNotifyMode validates the specified mode.
 func ValidateSdNotifyMode(mode string) error {
 	switch mode {
-	case "", SdNotifyModeContainer, SdNotifyModeConmon, SdNotifyModeIgnore:
+	case "", SdNotifyModeContainer, SdNotifyModeConmon, SdNotifyModeIgnore, SdNotifyModeHealthy:
 		return nil
 	default:
-		return fmt.Errorf("%w: invalid sdnotify value %q: must be %s, %s or %s", ErrInvalidArg, mode, SdNotifyModeContainer, SdNotifyModeConmon, SdNotifyModeIgnore)
+		return fmt.Errorf("%w: invalid sdnotify value %q: must be %s, %s, %s or %s", ErrInvalidArg, mode, SdNotifyModeConmon, SdNotifyModeContainer, SdNotifyModeHealthy, SdNotifyModeIgnore)
 	}
 }

--- a/libpod/oci_conmon_attach_common.go
+++ b/libpod/oci_conmon_attach_common.go
@@ -4,6 +4,7 @@
 package libpod
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -86,7 +87,7 @@ func (r *ConmonOCIRuntime) Attach(c *Container, params *AttachOptions) error {
 	// If starting was requested, start the container and notify when that's
 	// done.
 	if params.Start {
-		if err := c.start(); err != nil {
+		if err := c.start(context.TODO()); err != nil {
 			return err
 		}
 		params.Started <- true

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -14,8 +14,6 @@ var (
 	ErrInvalidSpecConfig = errors.New("invalid configuration")
 	// SystemDValues describes the only values that SystemD can be
 	SystemDValues = []string{"true", "false", "always"}
-	// SdNotifyModeValues describes the only values that SdNotifyMode can be
-	SdNotifyModeValues = []string{define.SdNotifyModeContainer, define.SdNotifyModeConmon, define.SdNotifyModeIgnore}
 	// ImageVolumeModeValues describes the only values that ImageVolumeMode can be
 	ImageVolumeModeValues = []string{"ignore", define.TypeTmpfs, "anonymous"}
 )


### PR DESCRIPTION
Add a new "healthy" sdnotify policy that instructs Podman to send the READY message once the container has turned healthy.

Fixes: #6160

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new --sdnotify=healthy policy where Podman sends the READY message once the container turns healthy.
```

For auto: @ygalblum @rhatdan PTAL