### PR TITLE
libpod: don't generate errors for createTimer etc.

### DIFF
--- a/libpod/healthcheck_unsupported.go
+++ b/libpod/healthcheck_unsupported.go
@@ -5,21 +5,20 @@ package libpod
 
 import (
 	"context"
-	"errors"
 )
 
 // createTimer systemd timers for healthchecks of a container
 func (c *Container) createTimer(interval string, isStartup bool) error {
-	return errors.New("not implemented (*Container) createTimer")
+	return nil
 }
 
 // startTimer starts a systemd timer for the healthchecks
 func (c *Container) startTimer(isStartup bool) error {
-	return errors.New("not implemented (*Container) startTimer")
+	return nil
 }
 
 // removeTransientFiles removes the systemd timer and unit files
 // for the container
 func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool) error {
-	return errors.New("not implemented (*Container) removeTransientFiles")
+	return nil
 }


### PR DESCRIPTION
Caller will just log the error which is confusing for the user. This matches the linux non-systemd behaviour.

It would be nice to have timer support for healthcheck on FreeBSD but the only pre-installed timer option is at which probably isn't a good fit here.

[NO NEW TESTS NEEDED]

#### Does this PR introduce a user-facing change?

```release-note
None
```
