### PR TITLE
Breakup hyperv machine funcs

### DIFF
--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -353,6 +353,18 @@ func (m *HyperVMachine) removeFilesAndConnections(files []string) {
 	}
 }
 
+func (m *HyperVMachine) removeNetworkAndReadySocketsFromRegistry() {
+	// Remove the HVSOCK for networking
+	if err := m.NetworkHVSock.Remove(); err != nil {
+		logrus.Errorf("unable to remove registry entry for %s: %q", m.NetworkHVSock.KeyName, err)
+	}
+
+	// Remove the HVSOCK for events
+	if err := m.ReadyHVSock.Remove(); err != nil {
+		logrus.Errorf("unable to remove registry entry for %s: %q", m.ReadyHVSock.KeyName, err)
+	}
+}
+
 func (m *HyperVMachine) Remove(_ string, opts machine.RemoveOptions) (string, func() error, error) {
 	var (
 		files    []string
@@ -384,16 +396,7 @@ func (m *HyperVMachine) Remove(_ string, opts machine.RemoveOptions) (string, fu
 	confirmationMessage += "\n"
 	return confirmationMessage, func() error {
 		m.removeFilesAndConnections(files)
-
-		// Remove the HVSOCK for networking
-		if err := m.NetworkHVSock.Remove(); err != nil {
-			logrus.Errorf("unable to remove registry entry for %s: %q", m.NetworkHVSock.KeyName, err)
-		}
-
-		// Remove the HVSOCK for events
-		if err := m.ReadyHVSock.Remove(); err != nil {
-			logrus.Errorf("unable to remove registry entry for %s: %q", m.NetworkHVSock.KeyName, err)
-		}
+		m.removeNetworkAndReadySocketsFromRegistry()
 		return vm.Remove(diskPath)
 	}, nil
 }

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -605,6 +605,23 @@ func loadMacMachineFromJSON(fqConfigPath string, macMachine *HyperVMachine) erro
 	return json.Unmarshal(b, macMachine)
 }
 
+func getDevNullFiles() (*os.File, *os.File, error) {
+	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
+	if err != nil {
+		if e := dnr.Close(); e != nil {
+			err = e
+		}
+		return nil, nil, err
+	}
+
+	return dnr, dnw, nil
+}
+
 func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingState, error) {
 	var (
 		forwardSock string
@@ -616,11 +633,7 @@ func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingStat
 	}
 
 	attr := new(os.ProcAttr)
-	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
-	if err != nil {
-		return "", machine.NoForwarding, err
-	}
-	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
+	dnr, dnw, err := getDevNullFiles()
 	if err != nil {
 		return "", machine.NoForwarding, err
 	}


### PR DESCRIPTION
The functions for HyperV's VM interface implementation (machine.go) had quite large functions. Pulls out some code that could be moved to its own function for easier readability.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
