### PR TITLE
start(): don't defer event

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1241,7 +1241,7 @@ func (c *Container) start(ctx context.Context) error {
 		}
 	}
 
-	defer c.newContainerEvent(events.Start)
+	c.newContainerEvent(events.Start)
 
 	if err := c.save(); err != nil {
 		return err


### PR DESCRIPTION
We'd otherwise emit the start event much after the actual start of the container when --sdnotify=healthy.  I missed adding the change to commit 0cfd12786fd1.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
