### PR TITLE
[CI:DOCS] socket_activation.md: increase socat timeout

### DIFF
--- a/docs/tutorials/socket_activation.md
+++ b/docs/tutorials/socket_activation.md
@@ -193,19 +193,22 @@ $ systemctl --user start echo.socket
 Test the echo server with the program __socat__
 
 ```
-$ echo hello | socat - tcp4:127.0.0.1:3000
+$ echo hello | socat -t 30 - tcp4:127.0.0.1:3000
 hello
-$ echo hello | socat - tcp6:[::1]:3000
+$ echo hello | socat -t 30 - tcp6:[::1]:3000
 hello
-$ echo hello | socat - udp4:127.0.0.1:3000
+$ echo hello | socat -t 30 - udp4:127.0.0.1:3000
 hello
-$ echo hello | socat - udp6:[::1]:3000
+$ echo hello | socat -t 30 - udp6:[::1]:3000
 hello
-$ echo hello | socat - unix:$HOME/echo_stream_sock
+$ echo hello | socat -t 30 - unix:$HOME/echo_stream_sock
 hello
-$ echo hello | socat - VSOCK-CONNECT:1:3000
+$ echo hello | socat -t 30 - VSOCK-CONNECT:1:3000
 hello
 ```
+
+The option `-t 30` configures socat to use a timeout of 30 seconds when socat reads from the socket awaiting to get an EOF (End-Of-File).
+As the container image has already been pulled, such a long timeout is not really needed.
 
 The echo server works as expected. It replies _"hello"_ after receiving the text _"hello"_.
 


### PR DESCRIPTION
The default socat timeout is 0.5 seconds.
Make the socket-activate-echo example in [socket_activation.md](https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md) more robust by increasing the socat timeout.

Regarding the text: I'm not sure this is good understandable English:
```
The option `-t 30` configures socat to use a timeout of 30 seconds when socat reads from the socket awaiting to get an EOF (End-Of-File).
```


Fixes: https://github.com/containers/podman/issues/19373

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
