### PR TITLE
Break up applehv config code where re-usable

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -109,6 +109,18 @@ func (v AppleHVVirtualization) LoadVMByName(name string) (machine.VM, error) {
 	return m.loadFromFile()
 }
 
+// setVMFile creates a new machine file pointing to the given path and assigns
+// it to the destination
+func setVMFile(dest *machine.VMFile, path string) error {
+	filePath, err := machine.NewMachineFile(path, nil)
+	if err != nil {
+		return err
+	}
+
+	*dest = *filePath
+	return nil
+}
+
 func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 	m := MacMachine{Name: opts.Name}
 
@@ -117,22 +129,18 @@ func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM,
 		return nil, err
 	}
 
-	configPath, err := machine.NewMachineFile(getVMConfigPath(configDir, opts.Name), nil)
-	if err != nil {
+	if err := setVMFile(&m.ConfigPath, getVMConfigPath(configDir, opts.Name)); err != nil {
 		return nil, err
 	}
-	m.ConfigPath = *configPath
 
 	dataDir, err := machine.GetDataDir(machine.AppleHvVirt)
 	if err != nil {
 		return nil, err
 	}
 
-	ignitionPath, err := machine.NewMachineFile(filepath.Join(configDir, m.Name)+".ign", nil)
-	if err != nil {
+	if err := setVMFile(&m.IgnitionFile, filepath.Join(configDir, m.Name)+".ign"); err != nil {
 		return nil, err
 	}
-	m.IgnitionFile = *ignitionPath
 
 	// Set creation time
 	m.Created = time.Now()


### PR DESCRIPTION
Breaks up the `NewMachine` function very slightly to re-use some code. This is in line with work done in other PRs (#19385)

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
