### PR TITLE
If quadlets have same name, only use first

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -194,6 +194,8 @@ func isExtSupported(filename string) bool {
 	return ok
 }
 
+var seen = make(map[string]struct{})
+
 func loadUnitsFromDir(sourcePath string) ([]*parser.UnitFile, error) {
 	var prevError error
 	files, err := os.ReadDir(sourcePath)
@@ -205,7 +207,6 @@ func loadUnitsFromDir(sourcePath string) ([]*parser.UnitFile, error) {
 	}
 
 	var units []*parser.UnitFile
-	var seen = make(map[string]struct{})
 
 	for _, file := range files {
 		name := file.Name()


### PR DESCRIPTION
If a user puts a quadlet file in his homedirectory with the same name as one in /etc/containers/systemd/user or /etc/containers/systemd/user/$UID, then only use the one in homedir and ignore the others.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet will only use a single quadlet for a given name.
```
