### PR TITLE
System tests: quadlet: fix race in %T test

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -768,10 +768,11 @@ Description=Get the value of percent T
 ExecStart=/bin/bash -c "echo --==%T==--"
 EOF
     systemctl daemon-reload
-    systemctl start $service
+    systemctl --wait start $service
     echo "$_LOG_PROMPT journalctl -u $service"
     run journalctl -u $service
     echo "$output"
+    assert "$output" =~ " --==.*==--" "get-percent-T unit ran to completion"
     percent_t=$(expr "$output" : ".* --==\(.*\)==--")
     # Clean up. Don't bother to systemctl-reload, service_setup does that below.
     rm -f $unitfile


### PR DESCRIPTION
Use "--wait" flag in "systemd start" for a one-shot container.
Should fix a CI failure I've been seeing sporadically, in which
the --==VALUE==-- string is not seen in journal.

And, should this not fix the bug, at least make the failure easier to understand.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```