### PR TITLE
Make sure users changes --authfile before checking

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -68,8 +68,10 @@ func autoUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
 
-	if err := auth.CheckAuthFile(autoUpdateOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(autoUpdateOptions.Authfile); err != nil {
+			return err
+		}
 	}
 	if cmd.Flags().Changed("tls-verify") {
 		autoUpdateOptions.InsecureSkipTLSVerify = types.NewOptionalBool(!autoUpdateOptions.tlsVerify)

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -156,8 +156,10 @@ func create(cmd *cobra.Command, args []string) error {
 		imageName = name
 	}
 
-	if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
+			return err
+		}
 	}
 
 	s := specgen.NewSpecGenerator(imageName, cliVals.RootFS)

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -115,8 +115,10 @@ func run(cmd *cobra.Command, args []string) error {
 		logrus.Warnf("The input device is not a TTY. The --tty and --interactive flags might not work properly")
 	}
 
-	if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
+			return err
+		}
 	}
 
 	runOpts.CIDFile = cliVals.CIDFile

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -90,8 +90,10 @@ func runlabel(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("tls-verify") {
 		runlabelOptions.SkipTLSVerify = types.NewOptionalBool(!runlabelOptions.TLSVerifyCLI)
 	}
-	if err := auth.CheckAuthFile(runlabelOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(runlabelOptions.Authfile); err != nil {
+			return err
+		}
 	}
 	return registry.ContainerEngine().ContainerRunlabel(context.Background(), strings.TrimPrefix(args[0], "/"), args[1], args[2:], runlabelOptions.ContainerRunlabelOptions)
 }

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -363,8 +363,10 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		}
 	}
 
-	if err := auth.CheckAuthFile(flags.Authfile); err != nil {
-		return nil, err
+	if c.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(flags.Authfile); err != nil {
+			return nil, err
+		}
 	}
 
 	commonOpts, err := parse.CommonBuildOptions(c)

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -136,8 +136,10 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("tls-verify") {
 		pullOptions.SkipTLSVerify = types.NewOptionalBool(!pullOptions.TLSVerifyCLI)
 	}
-	if err := auth.CheckAuthFile(pullOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(pullOptions.Authfile); err != nil {
+			return err
+		}
 	}
 	platform, err := cmd.Flags().GetString("platform")
 	if err != nil {

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -173,8 +173,10 @@ func imagePush(cmd *cobra.Command, args []string) error {
 		pushOptions.SkipTLSVerify = types.NewOptionalBool(!pushOptions.TLSVerifyCLI)
 	}
 
-	if err := auth.CheckAuthFile(pushOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(pushOptions.Authfile); err != nil {
+			return err
+		}
 	}
 
 	if pushOptions.CredentialsCLI != "" {

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -138,8 +138,10 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 		searchOptions.SkipTLSVerify = types.NewOptionalBool(!searchOptions.TLSVerifyCLI)
 	}
 
-	if err := auth.CheckAuthFile(searchOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(searchOptions.Authfile); err != nil {
+			return err
+		}
 	}
 
 	if searchOptions.CredentialsCLI != "" {

--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -56,8 +56,10 @@ func init() {
 }
 
 func sign(cmd *cobra.Command, args []string) error {
-	if err := auth.CheckAuthFile(signOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(signOptions.Authfile); err != nil {
+			return err
+		}
 	}
 	if signOptions.SignBy == "" {
 		return errors.New("no identity provided")

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -217,8 +217,10 @@ func play(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("build") {
 		playOptions.Build = types.NewOptionalBool(playOptions.BuildCLI)
 	}
-	if err := auth.CheckAuthFile(playOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(playOptions.Authfile); err != nil {
+			return err
+		}
 	}
 	if playOptions.ContextDir != "" && playOptions.Build != types.OptionalBoolTrue {
 		return errors.New("--build must be specified when using --context-dir option")

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -93,8 +93,10 @@ func init() {
 }
 
 func add(cmd *cobra.Command, args []string) error {
-	if err := auth.CheckAuthFile(manifestAddOpts.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(manifestAddOpts.Authfile); err != nil {
+			return err
+		}
 	}
 
 	if manifestAddOpts.CredentialsCLI != "" {

--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -44,8 +44,10 @@ func init() {
 }
 
 func inspect(cmd *cobra.Command, args []string) error {
-	if err := auth.CheckAuthFile(inspectOptions.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(inspectOptions.Authfile); err != nil {
+			return err
+		}
 	}
 	if cmd.Flags().Changed("tls-verify") {
 		inspectOptions.SkipTLSVerify = types.NewOptionalBool(!tlsVerifyCLI)

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -114,8 +114,10 @@ func init() {
 }
 
 func push(cmd *cobra.Command, args []string) error {
-	if err := auth.CheckAuthFile(manifestPushOpts.Authfile); err != nil {
-		return err
+	if cmd.Flags().Changed("authfile") {
+		if err := auth.CheckAuthFile(manifestPushOpts.Authfile); err != nil {
+			return err
+		}
 	}
 	listImageSpec := args[0]
 	destSpec := args[len(args)-1]


### PR DESCRIPTION
In certain cases REGISTRY_AUTH_FILE is set but the auth file does not exists yet, do not throw error unless user specified a file directly using --authfile.

Fixes: https://github.com/containers/podman/issues/18405

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
