### PR TITLE
Fix regression in CI artifacts script introduced by legacy msi removal

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1151,7 +1151,7 @@ artifacts_task:
         - cd /tmp/win
         - $ARTCURL/Windows%20Cross/repo/repo.tbz
         - tar xjf repo.tbz
-        - mv ./podman-remote*.zip ./*.msi $CIRRUS_WORKING_DIR/
+        - mv ./podman-remote*.zip $CIRRUS_WORKING_DIR/
     osx_binaries_script:
         - mkdir -p /tmp/osx
         - cd /tmp/osx

--- a/DOWNLOADS.md
+++ b/DOWNLOADS.md
@@ -50,8 +50,7 @@ matches corresponding changes in the artifacts task.
   and
   [darwin_arm64](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-darwin_arm64.zip).
   if you try to install them.
-* Windows [podman-remote](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman.msi)
-  for x86_64 only.
+* Windows [podman-remote](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip) for x86_64 only.
 * Other podman-remote release builds (includes configuration files & documentation):
   * [podman-release-386.tar.gz](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-release-386.tar.gz)
   * [podman-release-arm.tar.gz](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-release-arm.tar.gz)


### PR DESCRIPTION
Fixes #19383 (regression introduced by #19349)

[NO NEW TESTS NEEDED]
```release-note
none
```
