### PR TITLE
machine: QEMU: lock VM on start

### DIFF
--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -215,8 +215,9 @@ func (p *QEMUVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
 	if err != nil {
 		return false, "", fmt.Errorf("checking VM active: %w", err)
 	}
+	// NOTE: Start() takes care of dealing with the "starting" state.
 	for _, vm := range vms {
-		if vm.Running || vm.Starting {
+		if vm.Running {
 			return true, vm.Name, nil
 		}
 	}


### PR DESCRIPTION
Lock the VM on start.  If the machine is in the "starting" state we know that a previous start has failed and guide the user into resolving the issue.

Concurrent starts will busy wait and return the expected "already running" error.

NOTE: this change is only looking at the start issue (#18662).  Other commands such as stop and update should also lock and will be updated in a future change.  I expect the underlying issue to apply to all machine providers, not only QEMU.  It's desirable to aim for extending the machine interface to also allow to `Lock()` and `Unlock()`.  After acquiring the lock, the VM should automatically be reloaded/updated.

[NO NEW TESTS NEEDED]

Fixes: #18662

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a concurrency bug in `podman machine start` using the QEMU provider.
```
@n1hility @rhatdan @ashley-cui 