### PR TITLE
[v4.6 backport] If quadlets have same name, only use first

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -133,6 +133,8 @@ func isExtSupported(filename string) bool {
 	return ok
 }
 
+var seen = make(map[string]struct{})
+
 func loadUnitsFromDir(sourcePath string) ([]*parser.UnitFile, error) {
 	var prevError error
 	files, err := os.ReadDir(sourcePath)
@@ -144,7 +146,6 @@ func loadUnitsFromDir(sourcePath string) ([]*parser.UnitFile, error) {
 	}
 
 	var units []*parser.UnitFile
-	var seen = make(map[string]struct{})
 
 	for _, file := range files {
 		name := file.Name()

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -77,8 +77,9 @@ the container that is run as a service. The resulting service file contains a li
 options passed to Podman. However, some options also affect the details of how systemd is set up to run and
 interact with the container.
 
-By default, the Podman container has the same name as the unit, but with a `systemd-` prefix.
-I.e. a `$name.container` file creates a `$name.service` unit and a `systemd-$name` Podman container.
+By default, the Podman container has the same name as the unit, but with a `systemd-` prefix, i.e.
+a `$name.container` file creates a `$name.service` unit and a `systemd-$name` Podman container. The
+`ContainerName` option allows for overriding this default name with a user-provided one.
 
 There is only one required key, `Image`, which defines the container image the service runs.
 
@@ -622,27 +623,30 @@ Network files are named with a `.network` extension and contain a section `[Netw
 named Podman network. The generated service is a one-time command that ensures that the network
 exists on the host, creating it if needed.
 
-For a network file named `$NAME.network`, the generated Podman network is called `systemd-$NAME`,
-and the generated service file `$NAME-network.service`.
+By default, the Podman network has the same name as the unit, but with a `systemd-` prefix, i.e. for
+a network file named `$NAME.network`, the generated Podman network is called `systemd-$NAME`, and
+the generated service file is `$NAME-network.service`. The `NetworkName` option allows for
+overriding this default name with a user-provided one.
 
 Using network units allows containers to depend on networks being automatically pre-created. This is
 particularly interesting when using special options to control network creation, as Podman otherwise creates networks with the default options.
 
 Valid options for `[Network]` are listed below:
 
-| **[Network] options**            | **podman network create equivalent**   |
-| -----------------                | ------------------                     |
-| DisableDNS=true                  | --disable-dns                          |
-| Driver=bridge                    | --driver bridge                        |
-| Gateway=192.168.55.3             | --gateway 192.168.55.3                 |
-| Internal=true                    | --internal                             |
-| IPAMDriver=dhcp                  | --ipam-driver dhcp                     |
-| IPRange=192.168.55.128/25        | --ip-range 192.168.55.128/25           |
-| IPv6=true                        | --ipv6                                 |
-| Label="YXZ"                      | --label "XYZ"                          |
-| Options=isolate                  | --opt isolate                          |
-| PodmanArgs=--dns=192.168.55.1    | --dns=192.168.55.1                     |
-| Subnet=192.5.0.0/16              | --subnet 192.5.0.0/16                  |
+| **[Network] options**         | **podman network create equivalent** |
+|-------------------------------|--------------------------------------|
+| DisableDNS=true               | --disable-dns                        |
+| Driver=bridge                 | --driver bridge                      |
+| Gateway=192.168.55.3          | --gateway 192.168.55.3               |
+| Internal=true                 | --internal                           |
+| IPAMDriver=dhcp               | --ipam-driver dhcp                   |
+| IPRange=192.168.55.128/25     | --ip-range 192.168.55.128/25         |
+| IPv6=true                     | --ipv6                               |
+| Label="YXZ"                   | --label "XYZ"                        |
+| NetworkName=foo               | podman network create foo            |
+| Options=isolate               | --opt isolate                        |
+| PodmanArgs=--dns=192.168.55.1 | --dns=192.168.55.1                   |
+| Subnet=192.5.0.0/16           | --subnet 192.5.0.0/16                |
 
 Supported keys in `[Network]` section are:
 
@@ -701,6 +705,12 @@ Set one or more OCI labels on the network. The format is a list of
 
 This key can be listed multiple times.
 
+### `NetworkName=`
+
+The (optional) name of the Podman network. If this is not specified, the default value of
+`systemd-%N` is used, which is the same as the unit name but with a `systemd-` prefix to avoid
+conflicts with user-managed networks.
+
 ### `Options=`
 
 Set driver specific options.
@@ -734,8 +744,10 @@ Volume files are named with a `.volume` extension and contain a section `[Volume
 named Podman volume. The generated service is a one-time command that ensures that the volume
 exists on the host, creating it if needed.
 
-For a volume file named `$NAME.volume`, the generated Podman volume is called `systemd-$NAME`,
-and the generated service file `$NAME-volume.service`.
+By default, the Podman volume has the same name as the unit, but with a `systemd-` prefix, i.e. for
+a volume file named `$NAME.volume`, the generated Podman volume is called `systemd-$NAME`, and the
+generated service file is `$NAME-volume.service`. The `VolumeName` option allows for overriding this
+default name with a user-provided one.
 
 Using volume units allows containers to depend on volumes being automatically pre-created. This is
 particularly interesting when using special options to control volume creation,
@@ -743,14 +755,15 @@ as Podman otherwise creates volumes with the default options.
 
 Valid options for `[Volume]` are listed below:
 
-| **[Volume] options**             | **podman volume create equivalent**   |
-| -----------------                | ------------------                    |
-| Device=tmpfs                     | --opt device=tmpfs                    |
-| Copy=true                        | --opt copy                            |
-| Group=192                        | --opt group=192                       |
-| Label="foo=bar"                  | --label "foo=bar"                     |
-| Options=XYZ                      | --opt XYZ                             |
-| PodmanArgs=--driver=image        | --driver=image                        |
+| **[Volume] options**      | **podman volume create equivalent** |
+|---------------------------|-------------------------------------|
+| Device=tmpfs              | --opt device=tmpfs                  |
+| Copy=true                 | --opt copy                          |
+| Group=192                 | --opt group=192                     |
+| Label="foo=bar"           | --label "foo=bar"                   |
+| Options=XYZ               | --opt XYZ                           |
+| PodmanArgs=--driver=image | --driver=image                      |
+| VolumeName=foo            | podman volume create foo            |
 
 Supported keys in `[Volume]` section are:
 
@@ -798,6 +811,12 @@ The filesystem type of `Device` as used by the **mount(8)** commands `-t` option
 ### `User=`
 
 The host (numeric) UID, or user name to use as the owner for the volume
+
+### `VolumeName=`
+
+The (optional) name of the Podman volume. If this is not specified, the default value of
+`systemd-%N` is used, which is the same as the unit name but with a `systemd-` prefix to avoid
+conflicts with user-managed volumes.
 
 ## EXAMPLES
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -76,6 +76,7 @@ const (
 	KeyNetworkIPRange        = "IPRange"
 	KeyNetworkIPv6           = "IPv6"
 	KeyNetworkInternal       = "Internal"
+	KeyNetworkName           = "NetworkName"
 	KeyNetworkOptions        = "Options"
 	KeyNetworkSubnet         = "Subnet"
 	KeyNoNewPrivileges       = "NoNewPrivileges"
@@ -107,6 +108,7 @@ const (
 	KeyUserNS                = "UserNS"
 	KeyVolatileTmp           = "VolatileTmp"
 	KeyVolume                = "Volume"
+	KeyVolumeName            = "VolumeName"
 	KeyWorkingDir            = "WorkingDir"
 	KeyYaml                  = "Yaml"
 )
@@ -188,6 +190,7 @@ var (
 		KeyPodmanArgs: true,
 		KeyType:       true,
 		KeyUser:       true,
+		KeyVolumeName: true,
 	}
 
 	// Supported keys in "Network" group
@@ -200,6 +203,7 @@ var (
 		KeyNetworkIPRange:    true,
 		KeyNetworkIPv6:       true,
 		KeyNetworkInternal:   true,
+		KeyNetworkName:       true,
 		KeyNetworkOptions:    true,
 		KeyNetworkSubnet:     true,
 		KeyPodmanArgs:        true,
@@ -295,7 +299,7 @@ func usernsOpts(kind string, opts []string) string {
 // service file (unit file with Service group) based on the options in the
 // Container group.
 // The original Container group is kept around as X-Container.
-func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile, error) {
+func ConvertContainer(container *parser.UnitFile, names map[string]string, isUser bool) (*parser.UnitFile, error) {
 	service := container.Dup()
 	service.Filename = replaceExtension(container.Filename, ".service", "", "")
 
@@ -381,7 +385,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 		podman.addf("--tz=%s", timezone)
 	}
 
-	addNetworks(container, ContainerGroup, service, podman)
+	addNetworks(container, ContainerGroup, service, names, podman)
 
 	// Run with a pid1 init to reap zombies by default (as most apps don't do that)
 	runInit, ok := container.LookupBoolean(ContainerGroup, KeyRunInit)
@@ -550,7 +554,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 
 		if source != "" {
 			var err error
-			source, err = handleStorageSource(container, service, source)
+			source, err = handleStorageSource(container, service, source, names)
 			if err != nil {
 				return nil, err
 			}
@@ -644,9 +648,9 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 			if paramType == "volume" || paramType == "bind" {
 				var err error
 				if paramSource, ok := paramsMap["source"]; ok {
-					paramsMap["source"], err = handleStorageSource(container, service, paramSource)
+					paramsMap["source"], err = handleStorageSource(container, service, paramSource, names)
 				} else if paramSource, ok = paramsMap["src"]; ok {
-					paramsMap["src"], err = handleStorageSource(container, service, paramSource)
+					paramsMap["src"], err = handleStorageSource(container, service, paramSource, names)
 				}
 				if err != nil {
 					return nil, err
@@ -697,18 +701,24 @@ func ConvertContainer(container *parser.UnitFile, isUser bool) (*parser.UnitFile
 // service file (unit file with Service group) based on the options in the
 // Network group.
 // The original Network group is kept around as X-Network.
-func ConvertNetwork(network *parser.UnitFile, name string) (*parser.UnitFile, error) {
+// Also returns the canonical network name, either auto-generated or user-defined via the
+// NetworkName key-value.
+func ConvertNetwork(network *parser.UnitFile, name string) (*parser.UnitFile, string, error) {
 	service := network.Dup()
 	service.Filename = replaceExtension(network.Filename, ".service", "", "-network")
 
 	if err := checkForUnknownKeys(network, NetworkGroup, supportedNetworkKeys); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	/* Rename old Network group to x-Network so that systemd ignores it */
 	service.RenameGroup(NetworkGroup, XNetworkGroup)
 
-	networkName := replaceExtension(name, "", "systemd-", "")
+	// Derive network name from unit name (with added prefix), or use user-provided name.
+	networkName, ok := network.Lookup(NetworkGroup, KeyNetworkName)
+	if !ok || len(networkName) == 0 {
+		networkName = replaceExtension(name, "", "systemd-", "")
+	}
 
 	// Need the containers filesystem mounted to start podman
 	service.Add(UnitGroup, "RequiresMountsFor", "%t/containers")
@@ -729,10 +739,10 @@ func ConvertNetwork(network *parser.UnitFile, name string) (*parser.UnitFile, er
 	ipRanges := network.LookupAll(NetworkGroup, KeyNetworkIPRange)
 	if len(subnets) > 0 {
 		if len(gateways) > len(subnets) {
-			return nil, fmt.Errorf("cannot set more gateways than subnets")
+			return nil, "", fmt.Errorf("cannot set more gateways than subnets")
 		}
 		if len(ipRanges) > len(subnets) {
-			return nil, fmt.Errorf("cannot set more ranges than subnets")
+			return nil, "", fmt.Errorf("cannot set more ranges than subnets")
 		}
 		for i := range subnets {
 			podman.addf("--subnet=%s", subnets[i])
@@ -744,7 +754,7 @@ func ConvertNetwork(network *parser.UnitFile, name string) (*parser.UnitFile, er
 			}
 		}
 	} else if len(ipRanges) > 0 || len(gateways) > 0 {
-		return nil, fmt.Errorf("cannot set gateway or range without subnet")
+		return nil, "", fmt.Errorf("cannot set gateway or range without subnet")
 	}
 
 	if internal := network.LookupBooleanWithDefault(NetworkGroup, KeyNetworkInternal, false); internal {
@@ -781,25 +791,31 @@ func ConvertNetwork(network *parser.UnitFile, name string) (*parser.UnitFile, er
 		// The default syslog identifier is the exec basename (podman) which isn't very useful here
 		"SyslogIdentifier", "%N")
 
-	return service, nil
+	return service, networkName, nil
 }
 
 // Convert a quadlet volume file (unit file with a Volume group) to a systemd
 // service file (unit file with Service group) based on the options in the
 // Volume group.
 // The original Volume group is kept around as X-Volume.
-func ConvertVolume(volume *parser.UnitFile, name string) (*parser.UnitFile, error) {
+// Also returns the canonical volume name, either auto-generated or user-defined via the VolumeName
+// key-value.
+func ConvertVolume(volume *parser.UnitFile, name string) (*parser.UnitFile, string, error) {
 	service := volume.Dup()
 	service.Filename = replaceExtension(volume.Filename, ".service", "", "-volume")
 
 	if err := checkForUnknownKeys(volume, VolumeGroup, supportedVolumeKeys); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	/* Rename old Volume group to x-Volume so that systemd ignores it */
 	service.RenameGroup(VolumeGroup, XVolumeGroup)
 
-	volumeName := replaceExtension(name, "", "systemd-", "")
+	// Derive volume name from unit name (with added prefix), or use user-provided name.
+	volumeName, ok := volume.Lookup(VolumeGroup, KeyVolumeName)
+	if !ok || len(volumeName) == 0 {
+		volumeName = replaceExtension(name, "", "systemd-", "")
+	}
 
 	// Need the containers filesystem mounted to start podman
 	service.Add(UnitGroup, "RequiresMountsFor", "%t/containers")
@@ -849,7 +865,7 @@ func ConvertVolume(volume *parser.UnitFile, name string) (*parser.UnitFile, erro
 		if devValid {
 			podman.add("--opt", fmt.Sprintf("type=%s", devType))
 		} else {
-			return nil, fmt.Errorf("key Type can't be used without Device")
+			return nil, "", fmt.Errorf("key Type can't be used without Device")
 		}
 	}
 
@@ -861,7 +877,7 @@ func ConvertVolume(volume *parser.UnitFile, name string) (*parser.UnitFile, erro
 			}
 			opts.WriteString(mountOpts)
 		} else {
-			return nil, fmt.Errorf("key Options can't be used without Device")
+			return nil, "", fmt.Errorf("key Options can't be used without Device")
 		}
 	}
 
@@ -884,10 +900,10 @@ func ConvertVolume(volume *parser.UnitFile, name string) (*parser.UnitFile, erro
 		// The default syslog identifier is the exec basename (podman) which isn't very useful here
 		"SyslogIdentifier", "%N")
 
-	return service, nil
+	return service, volumeName, nil
 }
 
-func ConvertKube(kube *parser.UnitFile, isUser bool) (*parser.UnitFile, error) {
+func ConvertKube(kube *parser.UnitFile, names map[string]string, isUser bool) (*parser.UnitFile, error) {
 	service := kube.Dup()
 	service.Filename = replaceExtension(kube.Filename, ".service", "", "")
 
@@ -959,7 +975,7 @@ func ConvertKube(kube *parser.UnitFile, isUser bool) (*parser.UnitFile, error) {
 
 	handleUserNS(kube, KubeGroup, execStart)
 
-	addNetworks(kube, KubeGroup, service, execStart)
+	addNetworks(kube, KubeGroup, service, names, execStart)
 
 	configMaps := kube.LookupAllStrv(KubeGroup, KeyConfigMap)
 	for _, configMap := range configMaps {
@@ -1065,14 +1081,17 @@ func handleUserNS(unitFile *parser.UnitFile, groupName string, podman *PodmanCmd
 	}
 }
 
-func addNetworks(quadletUnitFile *parser.UnitFile, groupName string, serviceUnitFile *parser.UnitFile, podman *PodmanCmdline) {
+func addNetworks(quadletUnitFile *parser.UnitFile, groupName string, serviceUnitFile *parser.UnitFile, names map[string]string, podman *PodmanCmdline) {
 	networks := quadletUnitFile.LookupAll(groupName, KeyNetwork)
 	for _, network := range networks {
 		if len(network) > 0 {
 			quadletNetworkName, options, found := strings.Cut(network, ":")
 			if strings.HasSuffix(quadletNetworkName, ".network") {
-				// the podman network name is systemd-$name
-				networkName := replaceExtension(quadletNetworkName, "", "systemd-", "")
+				// the podman network name is systemd-$name if none is specified by the user.
+				networkName := names[quadletNetworkName]
+				if networkName == "" {
+					networkName = replaceExtension(quadletNetworkName, "", "systemd-", "")
+				}
 
 				// the systemd unit name is $name-network.service
 				networkServiceName := replaceExtension(quadletNetworkName, ".service", "", "-network")
@@ -1192,7 +1211,7 @@ func handleLogDriver(unitFile *parser.UnitFile, groupName string, podman *Podman
 	}
 }
 
-func handleStorageSource(quadletUnitFile, serviceUnitFile *parser.UnitFile, source string) (string, error) {
+func handleStorageSource(quadletUnitFile, serviceUnitFile *parser.UnitFile, source string, names map[string]string) (string, error) {
 	if source[0] == '.' {
 		var err error
 		source, err = getAbsolutePath(quadletUnitFile, source)
@@ -1204,8 +1223,11 @@ func handleStorageSource(quadletUnitFile, serviceUnitFile *parser.UnitFile, sour
 		// Absolute path
 		serviceUnitFile.Add(UnitGroup, "RequiresMountsFor", source)
 	} else if strings.HasSuffix(source, ".volume") {
-		// the podman volume name is systemd-$name
-		volumeName := replaceExtension(source, "", "systemd-", "")
+		// the podman volume name is systemd-$name if none has been provided by the user.
+		volumeName := names[source]
+		if volumeName == "" {
+			volumeName = replaceExtension(source, "", "systemd-", "")
+		}
 
 		// the systemd unit name is $name-volume.service
 		volumeServiceName := replaceExtension(source, ".service", "", "-volume")

--- a/test/e2e/quadlet/name.network
+++ b/test/e2e/quadlet/name.network
@@ -1,0 +1,4 @@
+## assert-podman-final-args "test-network"
+
+[Network]
+NetworkName=test-network

--- a/test/e2e/quadlet/name.volume
+++ b/test/e2e/quadlet/name.volume
@@ -1,0 +1,4 @@
+## assert-podman-final-args "test-volume"
+
+[Volume]
+VolumeName=test-volume

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -606,6 +606,7 @@ BOGUS=foo
 		Entry("device-copy.volume", "device-copy.volume", 0, ""),
 		Entry("device.volume", "device.volume", 0, ""),
 		Entry("label.volume", "label.volume", 0, ""),
+		Entry("name.volume", "name.volume", 0, ""),
 		Entry("podmanargs.volume", "podmanargs.volume", 0, ""),
 		Entry("uid.volume", "uid.volume", 0, ""),
 
@@ -635,6 +636,7 @@ BOGUS=foo
 		Entry("Network - Internal network", "internal.network", 0, ""),
 		Entry("Network - Label", "label.network", 0, ""),
 		Entry("Network - Multiple Options", "options.multiple.network", 0, ""),
+		Entry("Network - Name", "name.network", 0, ""),
 		Entry("Network - Options", "options.network", 0, ""),
 		Entry("Network - PodmanArgs", "podmanargs.network", 0, ""),
 		Entry("Network - Range not enough Subnet", "range.less-subnet.network", 1, "converting \"range.less-subnet.network\": cannot set more ranges than subnets"),


### PR DESCRIPTION
If a user puts a quadlet file in his homedirectory with the same name as one in /etc/containers/systemd/user or /etc/containers/systemd/user/$UID, then only use the one in homedir and ignore the others.


(cherry picked from commit d6a32a3da3d4904ba20bd2592b816ccb9545e920)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet will only use a single quadlet for a given name. Order of preference is `$HOME/.config/containers/systemd/`, `/etc/containers/systemd/users/$UID`, `/etc/containers/systemd/users/`.
```
