### PR TITLE
[CI:DOCS] Build and Sign Mac Pkginstaller

### DIFF
--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -1,0 +1,115 @@
+name: Sign and Upload Mac Installer
+
+on:
+  release:
+    types: [created, published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to build and upload (e.g. "v4.2.1")'
+        required: true
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      APPLICATION_CERTIFICATE: ${{ secrets.MACOS_APPLICATION_CERT }}
+      CODESIGN_IDENTITY: ${{ secrets.MACOS_APPLICATION_IDENTITY }}
+      INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERT }}
+      PRODUCTSIGN_IDENTITY: ${{ secrets.MACOS_INSTALLER_IDENTITY }}
+      CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+
+      NOTARIZE_TEAM: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
+      NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
+      NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
+
+      KEYCHAIN_PWD: ${{ secrets.MACOS_CI_KEYCHAIN_PWD }}
+    steps:
+    - name: Determine Version
+      id: getversion
+      run: |
+        if [ -z "${{ inputs.version }}" ]
+        then
+              VERSION=${{ github.event.release.tag_name }}
+        else
+              VERSION=${{ inputs.version }}
+        fi
+        echo
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Check uploads
+      id: check
+      run: |
+        URI="https://github.com/containers/podman/releases/download/${{steps.getversion.outputs.version}}"
+        ARM_FILE="podman-installer-macos-arm64.pkg"
+        AMD_FILE="podman-installer-macos-amd64.pkg"
+
+        status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${ARM_FILE}")
+        if [[ "$status" == "404" ]] ; then
+          echo "buildarm=true" >> $GITHUB_OUTPUT
+        else
+          echo "ARM installer already exists, skipping"
+          echo "buildarm=false" >> $GITHUB_OUTPUT
+        fi
+
+        status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${AMD_FILE}")
+        if [[ "$status" == "404" ]] ; then
+          echo "buildamd=true" >> $GITHUB_OUTPUT
+        else
+          echo "AMD installer already exists, skipping"
+          echo "buildamd=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Checkout Version
+      # If no binaries need to be built, then there's no reason to Checkout
+      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      uses: actions/checkout@v3
+      with:
+        ref: ${{steps.getversion.outputs.version}}
+    - name: Set up Go
+      # If no binaries need to be built, then there's no reason to set up Go
+      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.18'
+    - name: Create Keychain
+      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      run: |
+        echo $APPLICATION_CERTIFICATE | base64 --decode -o appcert.p12
+        echo $INSTALLER_CERTIFICATE | base64 --decode -o instcert.p12
+
+        security create-keychain -p "$KEYCHAIN_PWD" build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p "$KEYCHAIN_PWD" build.keychain
+        security import appcert.p12 -k build.keychain -P "$CERTIFICATE_PWD" -T /usr/bin/codesign
+        security import instcert.p12 -k build.keychain -P "$CERTIFICATE_PWD" -T /usr/bin/productsign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PWD" build.keychain &> /dev/null
+
+        xcrun notarytool store-credentials "notarytool-profile" --apple-id "$NOTARIZE_USERNAME" --team-id "$NOTARIZE_TEAM" --password "$NOTARIZE_PASSWORD" &> /dev/null
+    - name: Build and Sign ARM
+      if: steps.check.outputs.buildarm == 'true'
+      working-directory: contrib/pkginstaller
+      run: |
+        make ARCH=aarch64 notarize &> /dev/null
+        cd out && shasum -a 256 podman-installer-macos-arm64.pkg >> shasums
+    - name: Build and Sign AMD
+      if: steps.check.outputs.buildamd == 'true'
+      working-directory: contrib/pkginstaller
+      run: |
+        make ARCH=amd64 notarize &> /dev/null
+        cd out && shasum -a 256 podman-installer-macos-amd64.pkg >> shasums
+    - name: Artifact
+      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: installers
+        path: |
+          contrib/pkginstaller/out/podman-installer-macos-*.pkg
+    - name: Upload to Release
+      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        (gh release download ${{steps.getversion.outputs.version}} -p "shasums" || exit 0)
+        cat contrib/pkginstaller/out/shasums >> shasums
+        gh release upload ${{steps.getversion.outputs.version}} contrib/pkginstaller/out/podman-installer-macos-*.pkg
+        gh release upload ${{steps.getversion.outputs.version}} --clobber shasums

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -238,32 +238,6 @@ spelled with complete minutiae.
 
    1. In the directory where you downloaded the archives, run
       `sha256sum *.tar.gz *.zip > shasums` to generate SHA sums.
-   1. Build the Mac pkginstaller. Note that this needs to be built
-      on a Mac with the correct DevID signing credentials. The
-      installers will be built to `/contrib/pkginstaller/out`Add the
-      shasums of `podman-installer-macos-amd64.pkg` and
-      `podman-installer-macos-arm64.pkg` to the `shasums` file.
-      ```shell
-      $ git checkout vX.Y.Z
-
-      $ cd contrib/pkginstaller
-
-      $ make ARCH=amd64 \
-      CODESIGN_IDENTITY=$DevAppID  \
-      PRODUCTSIGN_IDENTITY=$DevInsID \
-      NOTARIZE_USERNAME=$AppleAcc \
-      NOTARIZE_PASSWORD=$AppleAccPwd \
-      NOTARIZE_TEAM=$DevTeam \
-      notarize
-
-      $ make ARCH=aarch64 \
-      CODESIGN_IDENTITY=$DevAppID  \
-      PRODUCTSIGN_IDENTITY=$DevInsID \
-      NOTARIZE_USERNAME=$AppleAcc \
-      NOTARIZE_PASSWORD=$AppleAccPwd \
-      NOTARIZE_TEAM=$DevTeam \
-      notarize
-      ```
    1. Go to `https://github.com/containers/podman/releases/tag/vX.Y.Z` and
       press the "Edit Release" button.  Change the name to the form `vX.Y.Z`
    1. If this is a release candidate be certain to click the pre-release
@@ -290,7 +264,7 @@ spelled with complete minutiae.
    1. Click the Publish button to make the release (or pre-release)
       available.
    1. Check the "Actions" tab, after the publish you should see a job
-      automatically launch to build the windows installer (named after
+      automatically launch to build the Windows installer and the Mac Installer (named after
       the release). There may be more than one running due to the multiple
       event states triggered, but this can be ignored, as any duplicates
       will gracefully back-off. The job takes 5-6 minutes to complete.
@@ -314,6 +288,21 @@ spelled with complete minutiae.
       ### *GUI Approach*
       1. Go to the "Actions" tab
       1. On the left pick the "Update Windows Installer" category
+      1. A blue box will appear above the job list with a right side drop
+         -down. Click the drop-down and specify the version number in the
+         dialog that appears
+
+      ## Manually Triggering Mac Installer Build & Upload
+
+      ### *CLI Approach*
+      1. Install the GitHub CLI (e.g. `sudo dnf install gh`)
+      1. Run (replacing below version number to release version)
+         ```
+         gh workflow run "Sign and Upload Mac Installer" -F version="v4.2.0"
+         ```
+      ### *GUI Approach*
+      1. Go to the "Actions" tab
+      1. On the left pick the "Sign and Upload Mac Installer" category
       1. A blue box will appear above the job list with a right side drop
          -down. Click the drop-down and specify the version number in the
          dialog that appears


### PR DESCRIPTION
Create a new GitHub Action that builds and signs the Mac pkginstaller. The action also uploads the installers to the release, and updates the shasums file.

This action is triggered on release creation, but it can also be triggered manually via a workflow dispatch.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
