### PR TITLE
[SKIP CI] github: add issue type as link to podman github discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Podman Desktop issues
     url: https://github.com/containers/podman-desktop/issues
     about: Please report issues with Podman Desktop here.
+  - name: Ask a question
+    url: https://github.com/containers/podman/discussions/new
+    about: Ask a question about Podman


### PR DESCRIPTION
Some issues reported in the podman github project contains a question instead of a bug report or  a feature request. Make it easier for users to find a place to ask questions.

This PR was inspired by
https://github.com/containers/podman/pull/18853

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
