### PR TITLE
Fix HyperV loadMachineFromJSON function name

### DIFF
--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -50,7 +50,7 @@ func (v HyperVVirtualization) IsValidVMName(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := loadMacMachineFromJSON(configDir, &mm); err != nil {
+	if err := mm.loadHyperVMachineFromJSON(configDir); err != nil {
 		return false, err
 	}
 	// The name is valid for the local filesystem
@@ -257,7 +257,7 @@ func (v HyperVVirtualization) loadFromLocalJson() ([]*HyperVMachine, error) {
 
 	for _, jsonFile := range jsonFiles {
 		mm := HyperVMachine{}
-		if err := loadMacMachineFromJSON(jsonFile, &mm); err != nil {
+		if err := mm.loadHyperVMachineFromJSON(jsonFile); err != nil {
 			return nil, err
 		}
 		if err != nil {

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -520,7 +520,7 @@ func (m *HyperVMachine) loadFromFile() (*HyperVMachine, error) {
 	}
 	mm := HyperVMachine{}
 
-	if err := loadMacMachineFromJSON(jsonPath, &mm); err != nil {
+	if err := mm.loadHyperVMachineFromJSON(jsonPath); err != nil {
 		return nil, err
 	}
 	vmm := hypervctl.NewVirtualMachineManager()
@@ -555,7 +555,7 @@ func getVMConfigPath(configDir, vmName string) string {
 	return filepath.Join(configDir, fmt.Sprintf("%s.json", vmName))
 }
 
-func loadMacMachineFromJSON(fqConfigPath string, macMachine *HyperVMachine) error {
+func (m *HyperVMachine) loadHyperVMachineFromJSON(fqConfigPath string) error {
 	b, err := os.ReadFile(fqConfigPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -563,7 +563,7 @@ func loadMacMachineFromJSON(fqConfigPath string, macMachine *HyperVMachine) erro
 		}
 		return err
 	}
-	return json.Unmarshal(b, macMachine)
+	return json.Unmarshal(b, m)
 }
 
 func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingState, error) {


### PR DESCRIPTION
Re-names HyperV function that was copied from the applehv implementation and not changed.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
