### PR TITLE
API: kill: return 409 on invalid state

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -243,6 +243,11 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(report) > 0 && report[0].Err != nil {
+		if errors.Is(report[0].Err, define.ErrCtrStateInvalid) ||
+			errors.Is(report[0].Err, define.ErrCtrStopped) {
+			utils.Error(w, http.StatusConflict, report[0].Err)
+			return
+		}
 		utils.InternalServerError(w, report[0].Err)
 		return
 	}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -32,7 +32,10 @@ t POST "containers/foo/attach?logs=true&stream=false" 200 \
   $'\001\031'$mytext
 t POST "containers/foo/kill" 204
 
-podman run -v /tmp:/tmp $IMAGE true
+podman run --replace --name=foo -v /tmp:/tmp $IMAGE true
+# cannot kill non-running container
+t POST "containers/foo/kill" 409
+t POST "libpod/containers/foo/kill" 409
 
 t GET libpod/containers/json 200 length=0
 


### PR DESCRIPTION
If the container isn't running, make sure to return 409 as specified in the Docker API [1] and the Podman reference.

[1] https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerKill

Fixes: #19368

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the containers/kill rest API to correctly return 409 when a container is not running.
```
