### PR TITLE
Deprecate podman generate systemd

### DIFF
--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -33,6 +33,13 @@ const (
 )
 
 var (
+	deprecation = `
+DEPRECATED command:
+It is recommended to use Quadlets for running containers and pods under systemd.
+
+Please refer to podman-systemd.unit(5) for details.
+`
+
 	envInput           []string
 	files              bool
 	format             string
@@ -42,11 +49,12 @@ var (
 	stopTimeout        uint
 	systemdOptions     = entities.GenerateSystemdOptions{}
 	systemdDescription = `Generate systemd units for a pod or container.
-  The generated units can later be controlled via systemctl(1).`
+  The generated units can later be controlled via systemctl(1).
+` + deprecation
 
 	systemdCmd = &cobra.Command{
 		Use:               "systemd [options] {CONTAINER|POD}",
-		Short:             "Generate systemd units",
+		Short:             "[DEPRECATED] Generate systemd units",
 		Long:              systemdDescription,
 		RunE:              systemd,
 		Args:              cobra.ExactArgs(1),
@@ -119,6 +127,7 @@ func init() {
 }
 
 func systemd(cmd *cobra.Command, args []string) error {
+	fmt.Fprint(os.Stderr, deprecation)
 	if cmd.Flags().Changed(restartPolicyFlagName) {
 		systemdOptions.RestartPolicy = &systemdRestart
 	}

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -1,12 +1,16 @@
 % podman-generate-systemd 1
 
 ## NAME
-podman\-generate\-systemd - Generate systemd unit file(s) for a container or pod
+podman\-generate\-systemd - [DEPRECATED] Generate systemd unit file(s) for a container or pod
 
 ## SYNOPSIS
 **podman generate systemd** [*options*] *container|pod*
 
 ## DESCRIPTION
+DEPRECATED:
+Note: **podman generate systemd** is deprecated. We recommend using [Quadlet](podman-systemd.unit.5.md)
+files when running Podman containers or pods under systemd.
+
 **podman generate systemd** creates a systemd unit file that can be used to control a container or pod.
 By default, the command prints the content of the unit files to stdout.
 
@@ -306,7 +310,7 @@ CONTAINER ID  IMAGE                            COMMAND  CREATED        STATUS   
 bb310a0780ae  docker.io/library/alpine:latest  /bin/sh  3 minutes ago  Created                  busy_moser
 ```
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**, **systemctl(1)**, **systemd.unit(5)**, **systemd.service(5)**, **[conmon(8)](https://github.com/containers/conmon/blob/main/docs/conmon.8.md)**
+**[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**, **systemctl(1)**, **systemd.unit(5)**, **systemd.service(5)**, **[conmon(8)](https://github.com/containers/conmon/blob/main/docs/conmon.8.md)**, **[podman-systemd.unit(5)](podman-systemd.unit.5.md)**
 
 ## HISTORY
 April 2020, Updated details and added use case to use generated .service files as root and non-root, by Sujil Shah (sushah at redhat dot com)

--- a/docs/source/markdown/podman-generate.1.md
+++ b/docs/source/markdown/podman-generate.1.md
@@ -15,7 +15,7 @@ The generate command creates structured output (like YAML) based on a container,
 |---------|------------------------------------------------------------|-------------------------------------------------------------------------------------|
 | kube    | [podman-kube-generate(1)](podman-kube-generate.1.md)       | Generate Kubernetes YAML based on containers, pods or volumes.                      |
 | spec    | [podman-generate-spec(1)](podman-generate-spec.1.md)       | Generate Specgen JSON based on containers or pods.                                  |
-| systemd | [podman-generate-systemd(1)](podman-generate-systemd.1.md) | Generate systemd unit file(s) for a container or pod.                               |
+| systemd | [podman-generate-systemd(1)](podman-generate-systemd.1.md) | [DEPRECATED] Generate systemd unit file(s) for a container or pod.                  |
 
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -102,7 +102,7 @@ If you would like to debug a limited set of unit files, you can copy them to a s
 QUADLET_UNIT_DIRS=<Directory> /usr/lib/systemd/system-generators/podman-system-generator {--user} --dryrun
 ```
 
-This will instruct quadlet to look for units in this directory instead of the common ones and by
+This will instruct Quadlet to look for units in this directory instead of the common ones and by
 that limit the output to only the units you are debugging.
 
 ## Container units [Container]
@@ -580,7 +580,7 @@ Indicates whether containers will be auto-updated ([podman-auto-update(1)](podma
 
 * `registry`: Requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container. This enforcement is necessary to know which images to actually check and pull. If an image ID was used, Podman does not know which image to check/pull anymore.
 
-* `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the Kubernetes quadlet.
+* `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the Kubernetes Quadlet.
 
 * `name/(local|registry)`: Tells Podman to perform the `local` or `registry` autoupdate on the specified container name.
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -468,4 +468,14 @@ $name stderr" "logs work with passthrough"
     rm -f $UNIT_DIR/$unit_name
 }
 
+@test "podman generate - systemd - DEPRECATED" {
+    run_podman generate systemd --help
+    is "$output" ".*[DEPRECATED] command:"
+    is "$output" ".*\[DEPRECATED\] Generate systemd units.*"
+    run_podman create --name test $IMAGE
+    run_podman generate systemd test >/dev/null
+    is "$output" ".*[DEPRECATED] command:"
+    run_podman generate --help
+    is "$output" ".*\[DEPRECATED\] Generate systemd units"
+}
 # vim: filetype=sh


### PR DESCRIPTION
Now that Quadlets are fully supported, it is time to Depracate podman generate systemd command.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman generate systemd` command is deprecated.  Use Quadlet for running containers and pods under systemd. 
```
