### PR TITLE
[v4.4.1 rhel] Support podman --remote when Containerfile is not in context directory

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -220,9 +220,11 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			var m = []string{}
 			if err := json.Unmarshal([]byte(query.Dockerfile), &m); err != nil {
 				// it's not json, assume just a string
-				m = []string{filepath.Join(contextDirectory, query.Dockerfile)}
+				m = []string{query.Dockerfile}
 			}
-			containerFiles = m
+			for _, containerfile := range m {
+				containerFiles = append(containerFiles, filepath.Join(contextDirectory, filepath.Clean(filepath.FromSlash(containerfile))))
+			}
 			dockerFileSet = true
 		}
 	}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -637,14 +637,14 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 		defer gw.Close()
 		defer tw.Close()
 		seen := make(map[devino]string)
-		for _, src := range sources {
-			s, err := filepath.Abs(src)
+		for i, src := range sources {
+			source, err := filepath.Abs(src)
 			if err != nil {
 				logrus.Errorf("Cannot stat one of source context: %v", err)
 				merr = multierror.Append(merr, err)
 				return
 			}
-			err = filepath.WalkDir(s, func(path string, d fs.DirEntry, err error) error {
+			err = filepath.WalkDir(source, func(path string, dentry fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
@@ -652,9 +652,9 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 				separator := string(filepath.Separator)
 				// check if what we are given is an empty dir, if so then continue w/ it. Else return.
 				// if we are given a file or a symlink, we do not want to exclude it.
-				if s == path {
+				if source == path {
 					separator = ""
-					if d.IsDir() {
+					if dentry.IsDir() {
 						var p *os.File
 						p, err = os.Open(path)
 						if err != nil {
@@ -669,8 +669,15 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						}
 					}
 				}
-				name := filepath.ToSlash(strings.TrimPrefix(path, s+separator))
-
+				var name string
+				if i == 0 {
+					name = filepath.ToSlash(strings.TrimPrefix(path, source+separator))
+				} else {
+					if !dentry.Type().IsRegular() {
+						return fmt.Errorf("path %s must be a regular file", path)
+					}
+					name = filepath.ToSlash(path)
+				}
 				excluded, err := pm.Matches(name) //nolint:staticcheck
 				if err != nil {
 					return fmt.Errorf("checking if %q is excluded: %w", name, err)
@@ -682,8 +689,8 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					return nil
 				}
 				switch {
-				case d.Type().IsRegular(): // add file item
-					info, err := d.Info()
+				case dentry.Type().IsRegular(): // add file item
+					info, err := dentry.Info()
 					if err != nil {
 						return err
 					}
@@ -722,8 +729,8 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						seen[di] = name
 					}
 					return err
-				case d.IsDir(): // add folders
-					info, err := d.Info()
+				case dentry.IsDir(): // add folders
+					info, err := dentry.Info()
 					if err != nil {
 						return err
 					}
@@ -736,12 +743,12 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					if lerr := tw.WriteHeader(hdr); lerr != nil {
 						return lerr
 					}
-				case d.Type()&os.ModeSymlink != 0: // add symlinks as it, not content
+				case dentry.Type()&os.ModeSymlink != 0: // add symlinks as it, not content
 					link, err := os.Readlink(path)
 					if err != nil {
 						return err
 					}
-					info, err := d.Info()
+					info, err := dentry.Info()
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Hi,

This is simply a cherry-pick of #18577 fixing #18239 on RHEL (we use RHEL 9.2, which is using podman 4.4.1). I have just opened the Red Hat case https://access.redhat.com/support/cases/#/case/03574665 to ask officially on Red Hat side for this backport, I have no RH Bugzilla ticket since I can't create them myself.

Note: I didn't cherry-pick the changes in `pkg/util/utils.go` is this function doesn't exist in podman 4.4. I guess with podman 4.4 the handling of .dockerignore might still be a bit fishy when it's a symlink outside of the build tree and we use the remote podman, but it's not something we suffer from, so I have left this part of the diff away.

I checked that this works fine inside containers, using commands similar to the one I wrote in the Red Hat case.

Cheers,
Romain