### PR TITLE
[CI:BUILD] RPM: define gobuild macro for rhel/centos stream

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -12,7 +12,7 @@
 # until that's fixed.
 # c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
 # c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331
-%if %{defined rhel}
+%if %{defined rhel} && !%{defined eln}
 %define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
 # python3 dep conditional for rhel8
 %if %{?rhel} == 8

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -7,11 +7,17 @@
 %global debug_package %{nil}
 %endif
 
-# RHEL 8's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
-# set it separately here and do not depend on RHEL 8's go-srpm-macros package.
-%if %{defined rhel} && 0%{?rhel} == 8
+# RHEL's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
+# set it separately here and do not depend on RHEL's go-[s]rpm-macros package
+# until that's fixed.
+# c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
+# c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331
+%if %{defined rhel}
 %define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
+# python3 dep conditional for rhel8
+%if %{?rhel} == 8
 %define rhel8py3 1
+%endif
 %endif
 
 %global gomodulesmode GO111MODULE=on


### PR DESCRIPTION
The current gobuild macro doesn't account for build tags on both c9s and c8s. This is currently causing copr build failures for c9s.

Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/6220412/

This commit will define gobuild for all those envs until gobuild is fixed by default.

Refs:
c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
