### PR TITLE
[CI:DOCS] GHA: Support testing build/sign workflows

### DIFF
--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -8,8 +8,18 @@ on:
       version:
         description: 'Release version to build and upload (e.g. "v4.2.1")'
         required: true
+      dryrun:
+        description: 'Perform all the steps except uploading to the release page'
+        required: true
+        default: "true"  # 'choice' type requires string value
+        type: choice
+        options:
+          - "true"  # Must be quoted string, boolean value not supported.
+          - "false"
+
 permissions:
   contents: write
+
 jobs:
   build:
     runs-on: macos-latest
@@ -26,10 +36,24 @@ jobs:
 
       KEYCHAIN_PWD: ${{ secrets.MACOS_CI_KEYCHAIN_PWD }}
     steps:
+    - name: Consolidate dryrun setting to always be true or false
+      id: actual_dryrun
+      run: |
+        # The 'release' trigger will not have a 'dryrun' input set. Handle
+        # this case in a readable/maintainable way.
+        if [[ -z "${{ inputs.dryrun }}" ]]
+        then
+          echo "dryrun=false" >> $GITHUB_OUTPUT
+        else
+          echo "dryrun=${{ inputs.dryrun }}" >> $GITHUB_OUTPUT
+        fi
+    - name: Dry Run Status
+      run: |
+        echo "::notice::This workflow execution will be a dry-run: ${{ steps.actual_dryrun.outputs.dryrun }}"
     - name: Determine Version
       id: getversion
       run: |
-        if [ -z "${{ inputs.version }}" ]
+        if [[ -z "${{ inputs.version }}" ]]
         then
               VERSION=${{ github.event.release.tag_name }}
         else
@@ -48,7 +72,7 @@ jobs:
         if [[ "$status" == "404" ]] ; then
           echo "buildarm=true" >> $GITHUB_OUTPUT
         else
-          echo "ARM installer already exists, skipping"
+          echo "::warning::ARM installer already exists, skipping"
           echo "buildarm=false" >> $GITHUB_OUTPUT
         fi
 
@@ -56,23 +80,31 @@ jobs:
         if [[ "$status" == "404" ]] ; then
           echo "buildamd=true" >> $GITHUB_OUTPUT
         else
-          echo "AMD installer already exists, skipping"
+          echo "::warning::AMD installer already exists, skipping"
           echo "buildamd=false" >> $GITHUB_OUTPUT
         fi
     - name: Checkout Version
-      # If no binaries need to be built, then there's no reason to Checkout
-      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      if: >-
+        steps.check.outputs.buildamd == 'true' ||
+        steps.check.outputs.buildarm == 'true' ||
+        steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{steps.getversion.outputs.version}}
     - name: Set up Go
-      # If no binaries need to be built, then there's no reason to set up Go
-      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      # Conditional duplication sucks - GHA doesn't grok YAML anchors/aliases
+      if: >-
+        steps.check.outputs.buildamd == 'true' ||
+        steps.check.outputs.buildarm == 'true' ||
+        steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/setup-go@v4
       with:
         go-version: '1.18'
     - name: Create Keychain
-      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      if: >-
+        steps.check.outputs.buildamd == 'true' ||
+        steps.check.outputs.buildarm == 'true' ||
+        steps.actual_dryrun.outputs.dryrun == 'true'
       run: |
         echo $APPLICATION_CERTIFICATE | base64 --decode -o appcert.p12
         echo $INSTALLER_CERTIFICATE | base64 --decode -o instcert.p12
@@ -86,26 +118,32 @@ jobs:
 
         xcrun notarytool store-credentials "notarytool-profile" --apple-id "$NOTARIZE_USERNAME" --team-id "$NOTARIZE_TEAM" --password "$NOTARIZE_PASSWORD" &> /dev/null
     - name: Build and Sign ARM
-      if: steps.check.outputs.buildarm == 'true'
+      if: steps.check.outputs.buildarm == 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
       working-directory: contrib/pkginstaller
       run: |
         make ARCH=aarch64 notarize &> /dev/null
         cd out && shasum -a 256 podman-installer-macos-arm64.pkg >> shasums
     - name: Build and Sign AMD
-      if: steps.check.outputs.buildamd == 'true'
+      if: steps.check.outputs.buildamd == 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
       working-directory: contrib/pkginstaller
       run: |
         make ARCH=amd64 notarize &> /dev/null
         cd out && shasum -a 256 podman-installer-macos-amd64.pkg >> shasums
     - name: Artifact
-      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      if: >-
+        steps.check.outputs.buildamd == 'true' ||
+        steps.check.outputs.buildarm == 'true' ||
+        steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: installers
         path: |
           contrib/pkginstaller/out/podman-installer-macos-*.pkg
     - name: Upload to Release
-      if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
+      if: >-
+        steps.actual_dryrun.outputs.dryrun == 'false' &&
+        (steps.check.outputs.buildamd == 'true' ||
+         steps.check.outputs.buildarm == 'true')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/upload-win-installer.yml
+++ b/.github/workflows/upload-win-installer.yml
@@ -8,12 +8,38 @@ on:
       version:
         description: 'Release version to build and upload (e.g. "4.2.1")'
         required: true
+      dryrun:
+        description: 'Perform all the steps except uploading to the release page'
+        required: true
+        default: "true"  # 'choice' type requires string value
+        type: choice
+        options:
+          - "true"  # Must be quoted string, boolean value not supported.
+          - "false"
+
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest
     env:
         FETCH_BASE_URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
+    - name: Consolidate dryrun setting to always be true or false
+      id: actual_dryrun
+      run: |
+        # The 'release' trigger will not have a 'dryrun' input set. Handle
+        # this case in a readable/maintainable way.
+        $inputs_dryrun = "${{ inputs.dryrun }}"
+        if ($inputs_dryrun.Length -lt 1) {
+          Write-Output "dryrun=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        } else {
+          Write-Output "dryrun=${{ inputs.dryrun }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        }
+    - name: Dry Run Status
+      run: |
+        Write-Output "::notice::This workflow execution will be a dry-run: ${{ steps.actual_dryrun.outputs.dryrun }}"
     - name: Determine version
       id: getversion
       run: |
@@ -21,12 +47,14 @@ jobs:
         if ($version.Length -lt 1) {
           $version = "${{ github.event.release.tag_name }}"
           if ($version.Length -lt 1) {
-            Write-Host "Could not determine version!"
+            Write-Host "::error::Could not determine version!"
             Exit 1
           }
         }
-        Write-Output "::set-output name=version::$version"
+        Write-Output "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
     - uses: actions/checkout@v3
+      with:
+        ref: ${{steps.getversion.outputs.version}}
     - name: Check
       id: check
       run: |
@@ -34,20 +62,29 @@ jobs:
         .\check.ps1 ${{steps.getversion.outputs.version}}
         $code = $LASTEXITCODE
         if ($code -eq 2) {
-          Write-Output "::set-output name=already-exists::true"
+          Write-Output "already-exists=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           Pop-Location
           Exit 0
         }
-        Write-Output "UPLOAD_ASSET_NAME=$env:UPLOAD_ASSET_NAME" | Out-File -FilePath $env:GITHUB_ENV -Append
+        Write-Output "upload_asset_name=$env:UPLOAD_ASSET_NAME" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         Pop-Location
         Exit $code
+    # The podman release process requires a cross-compile of the windows binaries be uploaded to
+    # the release page as a hard-coded filename.  If non-existent, this workflow will fail in
+    # non-obvious ways with a non-obvious error message.  Address that here.
+    - name: Confirm upload_asset_name is non-empty
+      if: ${{ steps.check.outputs.upload_asset_name == '' }}
+      run: |
+          Write-Output "::error::check.ps1 script failed to find manually uploaded podman-remote-release-windows_md64.zip github release asset for version ${{steps.getversion.outputs.version}}."
+          Exit 1
     - name: Set up Go
       uses: actions/setup-go@v4
-      if: steps.check.outputs.already-exists != 'true'
+      # N/B: already-exists may be an empty-string or "false", handle both cases.
+      if: steps.check.outputs.already-exists != 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
       with:
         go-version: 1.18
     - name: Setup Signature Tooling
-      if: steps.Check.outputs.already-exists != 'true'
+      if: steps.Check.outputs.already-exists != 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
       run: |
           dotnet tool install --global AzureSignTool --version 3.0.0
           echo "CERT_NAME=${{secrets.AZ_CERT_NAME}}" | Out-File -FilePath $env:GITHUB_ENV -Append
@@ -57,20 +94,29 @@ jobs:
           echo "CLIENT_SECRET=${{secrets.AZ_CLIENT_SECRET}}" | Out-File -FilePath $env:GITHUB_ENV -Append
     - name: Build
       id: build
-      if: steps.check.outputs.already-exists != 'true'
+      if: steps.check.outputs.already-exists != 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
       run: |
         Push-Location contrib\win-installer
         .\build.ps1 ${{steps.getversion.outputs.version}} prod
         $code = $LASTEXITCODE
         if ($code -eq 2) {
-          Write-Output "::set-output name=artifact-missing::true"
+          Write-Output "artifact-missing=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           Pop-Location
           Exit 0
         }
         Pop-Location
         Exit $code
+    - name: Artifact
+      if: steps.check.outputs.already-exists != 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: installer
+        path: ${{ steps.check.outputs.upload_asset_name }}
     - name: Upload
-      if: steps.check.outputs.already-exists != 'true' && steps.build.outputs.artifact-missing != 'true'
+      if: >-
+        steps.actual_dryrun.outputs.dryrun == 'false' &&
+        steps.check.outputs.already-exists != 'true' &&
+        steps.build.outputs.artifact-missing != 'true'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -79,7 +125,7 @@ jobs:
         if ($version[0] -ne "v") {
           $version = "v$version"
         }
-        gh release upload $version $ENV:UPLOAD_ASSET_NAME
+        gh release upload $version ${{ steps.check.outputs.upload_asset_name }}
         if ($LASTEXITCODE -ne 0) {
           .\check.ps1 $version
           if ($LASTEXITCODE -eq 2) {


### PR DESCRIPTION
Neither `release` nor `workflow_dispatch` triggers may be tested inside a PR context.  The workflow steps always run from what's already committed to `main`.  Rather than waiting for a release to discover some unforeseen workflow problem, allow manual runs to optionally skip the release upload step (by default).

TODO:
- [ ] Test these changes on a throwaway `main` branch somewhere.
- [x] See if it's worth calling to a child-workflow to reduce steps duplication.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
