### PR TITLE
Don't log EOF error when using podman --remote build with an empty context directory.

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -675,9 +675,10 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						}
 						defer p.Close()
 						_, err = p.Readdir(1)
-						if err != io.EOF {
+						if err == nil {
 							return nil // non empty root dir, need to return
-						} else if err != nil {
+						}
+						if err != io.EOF {
 							logrus.Errorf("While reading directory %v: %v", path, err)
 						}
 					}

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -1097,6 +1097,18 @@ EOF
     run_podman rmi -f build_test
 }
 
+@test "podman build empty context dir" {
+    buildcontextdir=$PODMAN_TMPDIR/emptydir
+    mkdir -p $buildcontextdir
+    containerfile=$PODMAN_TMPDIR/Containerfile
+    echo FROM scratch >$containerfile
+
+    run_podman build -t build_test -f $containerfile $buildcontextdir
+    assert "$output" !~ "EOF" "output should not contain EOF error"
+
+    run_podman rmi -f build_test
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
Closes #15921.

I am not sure if you want to add a new test for this.

#### Does this PR introduce a user-facing change?


```release-note
`None`
```
