### PR TITLE
[CI:DOCS] Mention no comment lines in Containerfile.in podman-build man page

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -23,8 +23,10 @@ directory, Podman uses the Containerfile's parent directory as its build context
 
 Containerfiles ending with a ".in" suffix are preprocessed via CPP(1).  This
 can be useful to decompose Containerfiles into several reusable parts that can
-be used via CPP's **#include** directive.  Notice, a Containerfile.in file can
-still be used by other tools when manually preprocessing them via `cpp -E`.
+be used via CPP's **#include** directive. Containerfiles ending in .in, are
+restricted to no comment lines unless they are CPP commands.
+Note, a Containerfile.in file can still be used by other tools when manually
+preprocessing them via `cpp -E`.
 
 When the URL is an archive, the contents of the URL is downloaded to a temporary
 location and extracted before execution.


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/13070

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
