### PR TITLE
Add podman secret rm --ignore option

### DIFF
--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -23,8 +23,9 @@ var (
 		Long:  "Create a secret. Input can be a path to a file or \"-\" (read from stdin). Default driver is file (unencrypted).",
 		RunE:  create,
 		Args:  cobra.ExactArgs(2),
-		Example: `podman secret create mysecret /path/to/secret
-		printf "secretdata" | podman secret create mysecret -`,
+		Example: `
+podman secret create mysecret /path/to/secret
+printf "secretdata" | podman secret create mysecret -`,
 		ValidArgsFunction: common.AutocompleteSecretCreate,
 	}
 )

--- a/cmd/podman/secrets/rm.go
+++ b/cmd/podman/secrets/rm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
@@ -29,6 +30,7 @@ func init() {
 	})
 	flags := rmCmd.Flags()
 	flags.BoolVarP(&rmOptions.All, "all", "a", false, "Remove all secrets")
+	flags.BoolVarP(&rmOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified secret is missing")
 }
 
 var (
@@ -50,6 +52,9 @@ func rm(cmd *cobra.Command, args []string) error {
 		if r.Err == nil {
 			fmt.Println(r.ID)
 		} else {
+			if rmOptions.Ignore && strings.Contains(r.Err.Error(), "no such secret") {
+				continue
+			}
 			errs = append(errs, r.Err)
 		}
 	}

--- a/docs/source/markdown/podman-secret-rm.1.md
+++ b/docs/source/markdown/podman-secret-rm.1.md
@@ -22,6 +22,10 @@ the old secret value still remains.
 
 Remove all existing secrets.
 
+#### **--ignore**, **-i**
+
+Ignore errors when specified secrets do not exist.
+
 #### **--help**
 
 Print usage statement.

--- a/pkg/domain/entities/secrets.go
+++ b/pkg/domain/entities/secrets.go
@@ -34,7 +34,8 @@ type SecretListReport struct {
 }
 
 type SecretRmOptions struct {
-	All bool
+	All    bool
+	Ignore bool
 }
 
 type SecretRmReport struct {

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -356,6 +356,15 @@ var _ = Describe("Podman secret", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
 		Expect(inspect.OutputToString()).To(Equal(secrID))
+
+		session = podmanTest.Podman([]string{"secret", "rm", secrID})
+		session.WaitWitthDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(secrID))
+
+		session = podmanTest.Podman([]string{"secret", "rm", "--ignore", secrID})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
 	})
 
 	It("podman secret with labels", func() {


### PR DESCRIPTION
Partial fix for https://github.com/containers/podman/issues/18591

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add --ignore option to podman secret rm --ignore
```
