### PR TITLE
Cleanup CIDFile on podman-remote run --rm command

### DIFF
--- a/docs/source/markdown/options/cidfile.write.md
+++ b/docs/source/markdown/options/cidfile.write.md
@@ -4,4 +4,5 @@
 ####> are applicable to all of those.
 #### **--cidfile**=*file*
 
-Write the container ID to *file*.  The file is removed along with the container.
+Write the container ID to *file*.  The file is removed along with the container, except
+when used with podman --remote run on detached containers.

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -70,6 +70,7 @@ Valid placeholders for the Go template are listed below:
 | **Placeholder**    | **Description**                              |
 |--------------------|----------------------------------------------|
 | .AutoRemove        | If true, containers are removed on exit      |
+| .CIDFile           | Container ID File                            |
 | .Command           | Quoted command used                          |
 | .Created           | Creation time for container, Y-M-D H:M:S     |
 | .CreatedAt         | Creation time for container (same as above)  |

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -20,6 +20,8 @@ type ListContainer struct {
 	Created time.Time
 	// Human-readable container creation time.
 	CreatedAt string
+	// CIDFile specified at creation time.
+	CIDFile string
 	// If container has exited/stopped
 	Exited bool
 	// Time container exited

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -237,10 +237,11 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 
 	ps := entities.ListContainer{
 		AutoRemove: ctr.AutoRemove(),
+		CIDFile:    conConfig.Spec.Annotations[define.InspectAnnotationCIDFile],
 		Command:    conConfig.Command,
 		Created:    conConfig.CreatedTime,
-		Exited:     exited,
 		ExitCode:   exitCode,
+		Exited:     exited,
 		ExitedAt:   exitedTime.Unix(),
 		ID:         conConfig.ID,
 		Image:      conConfig.RootfsImageName,
@@ -253,11 +254,11 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		Pid:        pid,
 		Pod:        conConfig.Pod,
 		Ports:      portMappings,
+		Restarts:   restartCount,
 		Size:       size,
 		StartedAt:  startedTime.Unix(),
 		State:      conState.String(),
 		Status:     healthStatus,
-		Restarts:   restartCount,
 	}
 	if opts.Pod && len(conConfig.Pod) > 0 {
 		podName, err := rt.GetPodName(conConfig.Pod)


### PR DESCRIPTION
Currently the CIDFile is not removed with podman --remote run --rm if the client and server are on different machines.

[NO NEW TESTS NEEDED] i
There is currently a test for this that does not fail because the client and server are on the same machine.

If we run these tests on a MAC or Windows platform, they would start failing.

Fixes: https://github.com/containers/podman/issues/19420

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CID Files on remote clients will now be removed when container is removed
```
