### PR TITLE
inspect with network=none show SandboxKey netns path

### DIFF
--- a/libpod/networking_freebsd.go
+++ b/libpod/networking_freebsd.go
@@ -254,8 +254,8 @@ func getContainerNetIO(ctr *Container) (*LinkStatistics64, error) {
 	return &LinkStatistics64{}, nil
 }
 
-func (c *Container) joinedNetworkNSPath() string {
-	return c.state.NetNS
+func (c *Container) joinedNetworkNSPath() (string, bool) {
+	return c.state.NetNS, false
 }
 
 func (c *Container) inspectJoinedNetworkNS(networkns string) (q types.StatusBlock, retErr error) {

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -694,13 +694,14 @@ func getContainerNetIO(ctr *Container) (*netlink.LinkStatistics, error) {
 	return netStats, err
 }
 
-func (c *Container) joinedNetworkNSPath() string {
+// joinedNetworkNSPath returns netns path and bool if netns was set
+func (c *Container) joinedNetworkNSPath() (string, bool) {
 	for _, namespace := range c.config.Spec.Linux.Namespaces {
 		if namespace.Type == specs.NetworkNamespace {
-			return namespace.Path
+			return namespace.Path, true
 		}
 	}
-	return ""
+	return "", false
 }
 
 func (c *Container) inspectJoinedNetworkNS(networkns string) (q types.StatusBlock, retErr error) {


### PR DESCRIPTION
We do not use any special netns path for the netns=none case, however callers that inspect that may still wish to join the netns path directly without extra work to figure out /proc/$pid/ns/net.

Fixes #16716

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman inspect will now show a `.NetworkSettings.SandboxKey` path for containers created with --net=none. 
```
