### PR TITLE
CI: e2e: reenable containerized checkpoint tests

### DIFF
--- a/test/e2e/checkpoint_image_test.go
+++ b/test/e2e/checkpoint_image_test.go
@@ -16,7 +16,6 @@ import (
 var _ = Describe("Podman checkpoint", func() {
 
 	BeforeEach(func() {
-		SkipIfContainerized("FIXME: #15015. All checkpoint tests hang when containerized.")
 		SkipIfRootless("checkpoint not supported in rootless mode")
 		// Check if the runtime implements checkpointing. Currently only
 		// runc's checkpoint/restore implementation is supported.

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -32,7 +32,6 @@ var _ = Describe("Podman checkpoint", func() {
 
 	BeforeEach(func() {
 		SkipIfRootless("checkpoint not supported in rootless mode")
-		SkipIfContainerized("FIXME: #15015. All checkpoint tests hang when containerized.")
 
 		// Check if the runtime implements checkpointing. Currently only
 		// runc's checkpoint/restore implementation is supported.


### PR DESCRIPTION
And lo, a miracle occurred. Containerized checkpoint tests are
no longer hanging. Reenable them.

(Followup miracle: tests are still passing, after a year of not
running!)

Closes: #15015

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```