### PR TITLE
[CI:DOCS] GHA: Use stable go for Mac/Win builds

### DIFF
--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
       uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: stable
     - name: Create Keychain
       if: steps.check.outputs.buildamd == 'true' || steps.check.outputs.buildarm == 'true'
       run: |

--- a/.github/workflows/upload-win-installer.yml
+++ b/.github/workflows/upload-win-installer.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/setup-go@v4
       if: steps.check.outputs.already-exists != 'true'
       with:
-        go-version: 1.18
+        go-version: stable
     - name: Setup Signature Tooling
       if: steps.Check.outputs.already-exists != 'true'
       run: |


### PR DESCRIPTION
Having hard-coded versions burried under a hidden directory is ripe for maintenance headaches.  Use the latest 'stable' version, since this will be "close enough" to what we test in CI.

Ref: https://github.com/containers/podman/discussions/19404

***Note***: There's no simple way to test these changes, they're only effective after being merged into `main`.  However, I [double-checked the `actions/setup-go` docs](https://github.com/actions/setup-go) and am confident this change will work okay.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
