### PR TITLE
[CI:DOCS] Mention TimeoutStartSec in quadlet man page

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -48,6 +48,16 @@ session gets started. For unit files placed in subdirectories within
 /etc/containers/systemd/user/${UID}/ and the other user unit search paths,
 Quadlet will recursively search and run the unit files present in these subdirectories.
 
+Note: When a Quadlet is starting, Podman often pulls one more container images which may take a considerable amount of time.
+Systemd defaults service start time to 90 seconds, or fails the service. Pre-pulling the image or extending
+the systemd timeout time for the service using the *TimeoutStartSec* Service option can fix the problem.
+
+Adding the following snippet to a Quadlet file extends the systemd timeout to 15 minutes.
+
+```
+[Service]
+TimeoutStartSec=900
+```
 
 ### Enabling unit files
 
@@ -895,6 +905,8 @@ Exec=sleep 60
 [Service]
 # Restart service when sleep finishes
 Restart=always
+# Extend Timeout to allow time to pull the image
+TimeoutStartSec=900
 
 [Install]
 # Start by default on boot


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Docs for TimeoutStartSec added to Quadlet man page.
```
