### PR TITLE
[v4.6] If quadlets have same name, only use first

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -132,6 +132,8 @@ func isExtSupported(filename string) bool {
 	return ok
 }
 
+var seen = make(map[string]bool)
+
 func loadUnitsFromDir(sourcePath string, units map[string]*parser.UnitFile) error {
 	var prevError error
 	files, err := os.ReadDir(sourcePath)
@@ -144,6 +146,9 @@ func loadUnitsFromDir(sourcePath string, units map[string]*parser.UnitFile) erro
 
 	for _, file := range files {
 		name := file.Name()
+		if seen[name] {
+			continue
+		}
 		if units[name] == nil && isExtSupported(name) {
 			path := path.Join(sourcePath, name)
 
@@ -156,6 +161,7 @@ func loadUnitsFromDir(sourcePath string, units map[string]*parser.UnitFile) erro
 				}
 			} else {
 				units[name] = f
+				seen[name] = true
 			}
 		}
 	}

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -173,6 +173,32 @@ EOF
     service_cleanup $QUADLET_SERVICE_NAME failed
 }
 
+@test "quadlet conflict names" {
+    # If two directories in the search have files with the same name, quadlet should
+    # only process the first name
+    dir1=$PODMAN_TMPDIR/$(random_string)
+    dir2=$PODMAN_TMPDIR/$(random_string)
+    local quadlet_file=basic_$(random_string).container
+    mkdir -p $dir1 $dir2
+
+    cat > $dir1/$quadlet_file <<EOF
+[Container]
+Image=$IMAGE
+Notify=yes
+EOF
+
+    cat > $dir2/$quadlet_file <<EOF
+[Container]
+Image=$IMAGE
+Notify=no
+EOF
+    QUADLET_UNIT_DIRS="$dir1:$dir2" run \
+                    timeout --foreground -v --kill=10 $PODMAN_TIMEOUT \
+                    $QUADLET --dryrun
+    assert "$output" =~ "Notify=yes" "quadlet should show Notify=yes"
+    assert "$output" !~ "Notify=no" "quadlet should not show Notify=no"
+}
+
 @test "quadlet - envvar" {
     local quadlet_file=$PODMAN_TMPDIR/envvar_$(random_string).container
     cat > $quadlet_file <<EOF


### PR DESCRIPTION
If a user puts a quadlet file in his homedirectory with the same name as one in /etc/containers/systemd/user or /etc/containers/systemd/user/$UID, then only use the one in homedir and ignore the others.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If quadlets have the same name found in different directories, prefer the first one found.
```
