### PR TITLE
Always show RemoteSocket.Exists in json

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -269,7 +269,7 @@ remove_packaged_podman_files() {
     req_env_vars OS_RELEASE_ID
 
     # If any binaries are resident they could cause unexpected pollution
-    for unit in io.podman.service io.podman.socket
+    for unit in podman.socket podman-auto-update.timer
     do
         for state in enabled active
         do

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -291,6 +291,9 @@ remove_packaged_podman_files() {
         LISTING_CMD="rpm -ql podman"
     fi
 
+    # delete the podman socket in case it has been created previously
+    rm -f $(podman info --format "{{.Host.RemoteSocket.Path}}")
+
     # yum/dnf/dpkg may list system directories, only remove files
     $LISTING_CMD | while read fullpath
     do

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -68,7 +68,7 @@ type HostInfo struct {
 // RemoteSocket describes information about the API socket
 type RemoteSocket struct {
 	Path   string `json:"path,omitempty"`
-	Exists bool   `json:"exists,omitempty"`
+	Exists bool   `json:"exists"`
 }
 
 // SlirpInfo describes the slirp executable that is being used

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -118,6 +118,8 @@ var _ = Describe("Podman Info", func() {
 		Expect(session).Should(Exit(0))
 		if IsRemote() {
 			Expect(session.OutputToString()).To(ContainSubstring("true"))
+		} else {
+			Expect(session.OutputToString()).To(ContainSubstring("false"))
 		}
 
 	})


### PR DESCRIPTION
The `Exists` field of the `RemoteSocket` struct is marshaled to json with the `omitempty` setting. This has the disadvantage that by default `podman info` shows a `remotePath` entry (the remote path is set in `pkg/domain/infra/abi/systems.go`: `(*ContainerEngine).Info`) but not that this path does not exist:
```
❯ podman info --format json | jq .host.remoteSocket
{
  "path": "/run/user/1000/podman/podman.sock"
}
```

By removing the `omitempty`, we ensure that the existence is always shown:
```
❯ bin/podman info --format json | jq .host.remoteSocket
{
  "path": "/run/user/1000/podman/podman.sock",
  "exists": false
}
```

#### Does this PR introduce a user-facing change?


```release-note
- always display the existence of the podman socket in `podman info`
```
