### PR TITLE
Consolidate `machine.go` duplicate code across hypervisors

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -360,22 +360,6 @@ func (m *MacMachine) collectFilesToDestroy(opts machine.RemoveOptions) []string 
 	return files
 }
 
-// removeFilesAndConnections removes any files and connections associated with
-// the machine during `Remove`
-func (m *MacMachine) removeFilesAndConnections(files []string) {
-	for _, f := range files {
-		if err := os.Remove(f); err != nil && !errors.Is(err, os.ErrNotExist) {
-			logrus.Error(err)
-		}
-	}
-	if err := machine.RemoveConnections(m.Name); err != nil {
-		logrus.Error(err)
-	}
-	if err := machine.RemoveConnections(m.Name + "-root"); err != nil {
-		logrus.Error(err)
-	}
-}
-
 func (m *MacMachine) Remove(name string, opts machine.RemoveOptions) (string, func() error, error) {
 	var (
 		files []string
@@ -404,7 +388,7 @@ func (m *MacMachine) Remove(name string, opts machine.RemoveOptions) (string, fu
 
 	confirmationMessage += "\n"
 	return confirmationMessage, func() error {
-		m.removeFilesAndConnections(files)
+		machine.RemoveFilesAndConnections(files, m.Name, m.Name+"-root")
 		// TODO We will need something like this for applehv too i think
 		/*
 			// Remove the HVSOCK for networking

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -100,18 +100,11 @@ func (m *MacMachine) acquireVMImage(opts machine.InitOptions, dataDir string) er
 		// The user has provided an alternate image which can be a file path
 		// or URL.
 		m.ImageStream = "custom"
-		g, err := machine.NewGenericDownloader(vmtype, m.Name, opts.ImagePath)
-		if err != nil {
-			return err
-		}
-		imagePath, err := machine.NewMachineFile(g.Get().LocalUncompressedFile, nil)
+		imagePath, err := machine.AcquireAlternateImage(m.Name, vmtype, opts)
 		if err != nil {
 			return err
 		}
 		m.ImagePath = *imagePath
-		if err := machine.DownloadImage(g); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/machine/connection.go
+++ b/pkg/machine/connection.go
@@ -6,8 +6,10 @@ package machine
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/containers/common/pkg/config"
+	"github.com/sirupsen/logrus"
 )
 
 const LocalhostIP = "127.0.0.1"
@@ -88,4 +90,16 @@ func RemoveConnections(names ...string) error {
 		}
 	}
 	return cfg.Write()
+}
+
+// removeFilesAndConnections removes any files and connections with the given names
+func RemoveFilesAndConnections(files []string, names ...string) {
+	for _, f := range files {
+		if err := os.Remove(f); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logrus.Error(err)
+		}
+	}
+	if err := RemoveConnections(names...); err != nil {
+		logrus.Error(err)
+	}
 }

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -692,20 +692,8 @@ func (m *HyperVMachine) writeConfig() error {
 }
 
 func (m *HyperVMachine) setRootful(rootful bool) error {
-	changeCon, err := machine.AnyConnectionDefault(m.Name, m.Name+"-root")
-	if err != nil {
+	if err := machine.SetRootful(rootful, m.Name, m.Name+"-root"); err != nil {
 		return err
-	}
-
-	if changeCon {
-		newDefault := m.Name
-		if rootful {
-			newDefault += "-root"
-		}
-		err := machine.ChangeDefault(newDefault)
-		if err != nil {
-			return err
-		}
 	}
 
 	m.HostUser.Modified = true

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -328,19 +328,6 @@ func (m *HyperVMachine) collectFilesToDestroy(opts machine.RemoveOptions, diskPa
 	return files
 }
 
-// removeFilesAndConnections removes any files and connections associated with
-// the machine during `Remove`
-func (m *HyperVMachine) removeFilesAndConnections(files []string) {
-	for _, f := range files {
-		if err := os.Remove(f); err != nil && !errors.Is(err, os.ErrNotExist) {
-			logrus.Error(err)
-		}
-	}
-	if err := machine.RemoveConnections(m.Name, m.Name+"-root"); err != nil {
-		logrus.Error(err)
-	}
-}
-
 // removeNetworkAndReadySocketsFromRegistry removes the Network and Ready sockets
 // from the Windows Registry
 func (m *HyperVMachine) removeNetworkAndReadySocketsFromRegistry() {
@@ -385,7 +372,7 @@ func (m *HyperVMachine) Remove(_ string, opts machine.RemoveOptions) (string, fu
 
 	confirmationMessage += "\n"
 	return confirmationMessage, func() error {
-		m.removeFilesAndConnections(files)
+		machine.RemoveFilesAndConnections(files, m.Name, m.Name+"-root")
 		m.removeNetworkAndReadySocketsFromRegistry()
 		return vm.Remove(diskPath)
 	}, nil

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -616,24 +616,6 @@ func (m *HyperVMachine) loadHyperVMachineFromJSON(fqConfigPath string) error {
 	return json.Unmarshal(b, m)
 }
 
-// getDevNullFiles returns pointers to Read-only and Write-only DevNull files
-func getDevNullFiles() (*os.File, *os.File, error) {
-	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
-	if err != nil {
-		if e := dnr.Close(); e != nil {
-			err = e
-		}
-		return nil, nil, err
-	}
-
-	return dnr, dnw, nil
-}
-
 func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingState, error) {
 	var (
 		forwardSock string
@@ -645,7 +627,7 @@ func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingStat
 	}
 
 	attr := new(os.ProcAttr)
-	dnr, dnw, err := getDevNullFiles()
+	dnr, dnw, err := machine.GetDevNullFiles()
 	if err != nil {
 		return "", machine.NoForwarding, err
 	}

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/podman/v4/utils"
-	"github.com/containers/storage/pkg/ioutils"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
 )
@@ -673,22 +672,7 @@ func (m *HyperVMachine) forwardSocketPath() (*machine.VMFile, error) {
 
 func (m *HyperVMachine) writeConfig() error {
 	// Write the JSON file
-	opts := &ioutils.AtomicFileWriterOptions{ExplicitCommit: true}
-	w, err := ioutils.NewAtomicFileWriterWithOpts(m.ConfigPath.GetPath(), 0644, opts)
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", " ")
-
-	if err := enc.Encode(m); err != nil {
-		return err
-	}
-
-	// Commit the changes to disk if no errors
-	return w.Commit()
+	return machine.WriteConfig(m.ConfigPath.Path, m)
 }
 
 func (m *HyperVMachine) setRootful(rootful bool) error {

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -54,3 +54,71 @@ func AddSSHConnectionsToPodmanSocket(uid, port int, identityPath, name, remoteUs
 	}
 	return nil
 }
+
+// WaitAPIAndPrintInfo prints info about the machine and does a ping test on the
+// API socket
+func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardSock string, noInfo, isIncompatible, rootful bool) {
+	suffix := ""
+	if name != DefaultMachineName {
+		suffix = " " + name
+	}
+
+	if isIncompatible {
+		fmt.Fprintf(os.Stderr, "\n!!! ACTION REQUIRED: INCOMPATIBLE MACHINE !!!\n")
+
+		fmt.Fprintf(os.Stderr, "\nThis machine was created by an older podman release that is incompatible\n")
+		fmt.Fprintf(os.Stderr, "with this release of podman. It has been started in a limited operational\n")
+		fmt.Fprintf(os.Stderr, "mode to allow you to copy any necessary files before recreating it. This\n")
+		fmt.Fprintf(os.Stderr, "can be accomplished with the following commands:\n\n")
+		fmt.Fprintf(os.Stderr, "\t# Login and copy desired files (Optional)\n")
+		fmt.Fprintf(os.Stderr, "\t# podman machine ssh%s tar cvPf - /path/to/files > backup.tar\n\n", suffix)
+		fmt.Fprintf(os.Stderr, "\t# Recreate machine (DESTRUCTIVE!) \n")
+		fmt.Fprintf(os.Stderr, "\tpodman machine stop%s\n", suffix)
+		fmt.Fprintf(os.Stderr, "\tpodman machine rm -f%s\n", suffix)
+		fmt.Fprintf(os.Stderr, "\tpodman machine init --now%s\n\n", suffix)
+		fmt.Fprintf(os.Stderr, "\t# Copy back files (Optional)\n")
+		fmt.Fprintf(os.Stderr, "\t# cat backup.tar | podman machine ssh%s tar xvPf - \n\n", suffix)
+	}
+
+	if forwardState == NoForwarding {
+		return
+	}
+
+	WaitAndPingAPI(forwardSock)
+
+	if !noInfo {
+		if !rootful {
+			fmt.Printf("\nThis machine is currently configured in rootless mode. If your containers\n")
+			fmt.Printf("require root permissions (e.g. ports < 1024), or if you run into compatibility\n")
+			fmt.Printf("issues with non-podman clients, you can switch using the following command: \n")
+			fmt.Printf("\n\tpodman machine set --rootful%s\n\n", suffix)
+		}
+
+		fmt.Printf("API forwarding listening on: %s\n", forwardSock)
+		if forwardState == DockerGlobal {
+			fmt.Printf("Docker API clients default to this address. You do not need to set DOCKER_HOST.\n\n")
+		} else {
+			stillString := "still "
+			switch forwardState {
+			case NotInstalled:
+				fmt.Printf("\nThe system helper service is not installed; the default Docker API socket\n")
+				fmt.Printf("address can't be used by podman. ")
+				if len(helper) > 0 {
+					fmt.Printf("If you would like to install it run the\nfollowing commands:\n")
+					fmt.Printf("\n\tsudo %s install\n", helper)
+					fmt.Printf("\tpodman machine stop%s; podman machine start%s\n\n", suffix, suffix)
+				}
+			case MachineLocal:
+				fmt.Printf("\nAnother process was listening on the default Docker API socket address.\n")
+			case ClaimUnsupported:
+				fallthrough
+			default:
+				stillString = ""
+			}
+
+			fmt.Printf("You can %sconnect Docker API clients by setting DOCKER_HOST using the\n", stillString)
+			fmt.Printf("following command in your terminal session:\n")
+			fmt.Printf("\n\texport DOCKER_HOST='unix://%s'\n\n", forwardSock)
+		}
+	}
+}

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -122,3 +122,24 @@ func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardS
 		}
 	}
 }
+
+// SetRootful modifies the machine's default connection to be either rootful or
+// rootless
+func SetRootful(rootful bool, name, rootfulName string) error {
+	changeCon, err := AnyConnectionDefault(name, rootfulName)
+	if err != nil {
+		return err
+	}
+
+	if changeCon {
+		newDefault := name
+		if rootful {
+			newDefault += "-root"
+		}
+		err := ChangeDefault(newDefault)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -1,0 +1,26 @@
+//go:build amd64 || arm64
+// +build amd64 arm64
+
+package machine
+
+import (
+	"os"
+)
+
+// getDevNullFiles returns pointers to Read-only and Write-only DevNull files
+func GetDevNullFiles() (*os.File, *os.File, error) {
+	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
+	if err != nil {
+		if e := dnr.Close(); e != nil {
+			err = e
+		}
+		return nil, nil, err
+	}
+
+	return dnr, dnw, nil
+}

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -4,7 +4,10 @@
 package machine
 
 import (
+	"fmt"
+	"net/url"
 	"os"
+	"strconv"
 )
 
 // getDevNullFiles returns pointers to Read-only and Write-only DevNull files
@@ -23,4 +26,31 @@ func GetDevNullFiles() (*os.File, *os.File, error) {
 	}
 
 	return dnr, dnw, nil
+}
+
+// AddSSHConnectionsToPodmanSocket adds SSH connections to the podman socket if
+// no ignition path is provided
+func AddSSHConnectionsToPodmanSocket(uid, port int, identityPath, name, remoteUsername string, opts InitOptions) error {
+	if len(opts.IgnitionPath) < 1 {
+		uri := SSHRemoteConnection.MakeSSHURL(LocalhostIP, fmt.Sprintf("/run/user/%d/podman/podman.sock", uid), strconv.Itoa(port), remoteUsername)
+		uriRoot := SSHRemoteConnection.MakeSSHURL(LocalhostIP, "/run/podman/podman.sock", strconv.Itoa(port), "root")
+
+		uris := []url.URL{uri, uriRoot}
+		names := []string{name, name + "-root"}
+
+		// The first connection defined when connections is empty will become the default
+		// regardless of IsDefault, so order according to rootful
+		if opts.Rootful {
+			uris[0], names[0], uris[1], names[1] = uris[1], names[1], uris[0], names[0]
+		}
+
+		for i := 0; i < 2; i++ {
+			if err := AddConnection(&uris[i], names[i], identityPath, opts.IsDefault && i == 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		fmt.Println("An ignition path was provided.  No SSH connection was added to Podman")
+	}
+	return nil
 }

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -385,3 +385,23 @@ func RemoveImageAfterExpire(dir string, expire time.Duration) error {
 	})
 	return err
 }
+
+// AcquireAlternateImage downloads the alternate image the user provided, which
+// can be a file path or URL
+func AcquireAlternateImage(name string, vmtype VMType, opts InitOptions) (*VMFile, error) {
+	g, err := NewGenericDownloader(vmtype, name, opts.ImagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	imagePath, err := NewMachineFile(g.Get().LocalUncompressedFile, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := DownloadImage(g); err != nil {
+		return nil, err
+	}
+
+	return imagePath, nil
+}

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -629,24 +629,6 @@ func (v *MachineVM) connectToPodmanSocket(maxBackoffs int, backoff time.Duration
 	return
 }
 
-// getDevNullFiles returns pointers to Read-only and Write-only DevNull files
-func getDevNullFiles() (*os.File, *os.File, error) {
-	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
-	if err != nil {
-		if e := dnr.Close(); e != nil {
-			err = e
-		}
-		return nil, nil, err
-	}
-
-	return dnr, dnw, nil
-}
-
 // Start executes the qemu command line and forks it
 func (v *MachineVM) Start(name string, opts machine.StartOptions) error {
 	var (
@@ -739,7 +721,7 @@ func (v *MachineVM) Start(name string, opts machine.StartOptions) error {
 	}
 	defer fd.Close()
 
-	dnr, dnw, err := getDevNullFiles()
+	dnr, dnw, err := machine.GetDevNullFiles()
 	if err != nil {
 		return err
 	}
@@ -1336,7 +1318,7 @@ func (v *MachineVM) startHostNetworking() (string, machine.APIForwardingState, e
 	}
 
 	attr := new(os.ProcAttr)
-	dnr, dnw, err := getDevNullFiles()
+	dnr, dnw, err := machine.GetDevNullFiles()
 	if err != nil {
 		return "", machine.NoForwarding, err
 	}

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -225,20 +225,11 @@ func (v *MachineVM) acquireVMImage(opts machine.InitOptions) error {
 		// The user has provided an alternate image which can be a file path
 		// or URL.
 		v.ImageStream = "custom"
-		g, err := machine.NewGenericDownloader(vmtype, v.Name, opts.ImagePath)
+		imagePath, err := machine.AcquireAlternateImage(v.Name, vmtype, opts)
 		if err != nil {
 			return err
 		}
-
-		imagePath, err := machine.NewMachineFile(g.Get().LocalUncompressedFile, nil)
-		if err != nil {
-			return err
-		}
-
 		v.ImagePath = *imagePath
-		if err := machine.DownloadImage(g); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1607,20 +1607,8 @@ func (v *MachineVM) resizeDisk(diskSize uint64, oldSize uint64) error {
 }
 
 func (v *MachineVM) setRootful(rootful bool) error {
-	changeCon, err := machine.AnyConnectionDefault(v.Name, v.Name+"-root")
-	if err != nil {
+	if err := machine.SetRootful(rootful, v.Name, v.Name+"-root"); err != nil {
 		return err
-	}
-
-	if changeCon {
-		newDefault := v.Name
-		if rootful {
-			newDefault += "-root"
-		}
-		err := machine.ChangeDefault(newDefault)
-		if err != nil {
-			return err
-		}
 	}
 
 	v.HostUser.Modified = true

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/sirupsen/logrus"
@@ -1523,22 +1522,7 @@ func (v *MachineVM) writeConfig() error {
 		return err
 	}
 	// Write the JSON file
-	opts := &ioutils.AtomicFileWriterOptions{ExplicitCommit: true}
-	w, err := ioutils.NewAtomicFileWriterWithOpts(v.ConfigPath.GetPath(), 0644, opts)
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", " ")
-
-	if err := enc.Encode(v); err != nil {
-		return err
-	}
-
-	// Commit the changes to disk if no errors
-	return w.Commit()
+	return machine.WriteConfig(v.ConfigPath.Path, v)
 }
 
 // getImageFile wrapper returns the path to the image used

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1127,19 +1127,6 @@ func (v *MachineVM) removeQMPMonitorSocketAndVMPidFile() {
 	}
 }
 
-// removeFilesAndConnections removes any files and connections associated with
-// the machine during `Remove`
-func (v *MachineVM) removeFilesAndConnections(files []string) {
-	for _, f := range files {
-		if err := os.Remove(f); err != nil && !errors.Is(err, os.ErrNotExist) {
-			logrus.Error(err)
-		}
-	}
-	if err := machine.RemoveConnections(v.Name, v.Name+"-root"); err != nil {
-		logrus.Error(err)
-	}
-}
-
 // Remove deletes all the files associated with a machine including ssh keys, the image itself
 func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func() error, error) {
 	var (
@@ -1181,7 +1168,7 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 
 	confirmationMessage += "\n"
 	return confirmationMessage, func() error {
-		v.removeFilesAndConnections(files)
+		machine.RemoveFilesAndConnections(files, v.Name, v.Name+"-root")
 		return nil
 	}, nil
 }

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/wsl/wutil"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/containers/storage/pkg/ioutils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -405,28 +404,7 @@ func downloadDistro(v *MachineVM, opts machine.InitOptions) error {
 }
 
 func (v *MachineVM) writeConfig() error {
-	const format = "could not write machine json config: %w"
-	jsonFile := v.ConfigPath
-
-	opts := &ioutils.AtomicFileWriterOptions{ExplicitCommit: true}
-	w, err := ioutils.NewAtomicFileWriterWithOpts(jsonFile, 0644, opts)
-	if err != nil {
-		return fmt.Errorf(format, err)
-	}
-	defer w.Close()
-
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", " ")
-	if err := enc.Encode(v); err != nil {
-		return fmt.Errorf(format, err)
-	}
-
-	// Commit the changes to disk if no error has occurred
-	if err := w.Commit(); err != nil {
-		return fmt.Errorf(format, err)
-	}
-
-	return nil
+	return machine.WriteConfig(v.ConfigPath, v)
 }
 
 func setupConnections(v *MachineVM, opts machine.InitOptions) error {

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1525,20 +1525,8 @@ func getMem(vm *MachineVM) (uint64, error) {
 }
 
 func (v *MachineVM) setRootful(rootful bool) error {
-	changeCon, err := machine.AnyConnectionDefault(v.Name, v.Name+"-root")
-	if err != nil {
+	if err := machine.SetRootful(rootful, v.Name, v.Name+"-root"); err != nil {
 		return err
-	}
-
-	if changeCon {
-		newDefault := v.Name
-		if rootful {
-			newDefault += "-root"
-		}
-		err := machine.ChangeDefault(newDefault)
-		if err != nil {
-			return err
-		}
 	}
 
 	dist := toDist(v.Name)


### PR DESCRIPTION
Consolidates duplicate code across the various hypervisors' `machine.go` file and places it either in the proper file that already exists or in the new `pkg/machine/machine_common.go` file.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
