### PR TITLE
Make podman run --rmi automatically set --rm

### DIFF
--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -347,7 +347,7 @@ the container when it exits. The default is **false**.
 #### **--rmi**
 
 After exit of the container, remove the image unless another
-container is using it. The default is *false*.
+container is using it. Implies --rm=true on the new container. The default is *false*.
 
 @@option rootfs
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -182,12 +182,16 @@ echo $rand        |   0 | $rand
 
     # Now try running with --rmi : it should succeed, but not remove the image
     run_podman run --rmi --rm $NONLOCAL_IMAGE /bin/true
+    is "$output" ".*image is in use by a container" "--rmi should warn that the image was not removed"
     run_podman image exists $NONLOCAL_IMAGE
 
     # Remove the stray container, and run one more time with --rmi.
     run_podman rm /keepme
-    run_podman run --rmi --rm $NONLOCAL_IMAGE /bin/true
+    run_podman run --rmi $NONLOCAL_IMAGE /bin/true
     run_podman 1 image exists $NONLOCAL_IMAGE
+
+    run_podman 125 run --rmi --rm=false $NONLOCAL_IMAGE /bin/true
+    is "$output" "Error: the --rmi option does not work without --rm=true" "--rmi should refuse to remove images when --rm=false set by user"
 }
 
 # 'run --conmon-pidfile --cid-file' makes sure we don't regress on these flags.


### PR DESCRIPTION
Forcing users to set --rm when setting --rmi is just bad UI. If I want the image to be removed, it implies that I want the container removed that I am creating.

Fixes: https://github.com/containers/podman/issues/15640

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman run --rmi now implies --rm option.
```
