### PR TITLE
[CI:DOCS] Use code blocks for commands in podman-completion

### DIFF
--- a/docs/source/markdown/podman-completion.1.md
+++ b/docs/source/markdown/podman-completion.1.md
@@ -40,12 +40,12 @@ podman completion -f /etc/bash_completion.d/podman bash
 
 
 ### ZSH
-Shell completion needs to be already enabled in the environment. The following can be executed:\
+Shell completion needs to be already enabled in the environment. The following can be executed:
 ```
 echo "autoload -U compinit; compinit" >> ~/.zshrc
 ```
 
-To make it available for all zsh sessions run:\
+To make it available for all zsh sessions run:
 ```
 podman completion -f "${fpath[1]}/_podman" zsh
 ```

--- a/docs/source/markdown/podman-completion.1.md
+++ b/docs/source/markdown/podman-completion.1.md
@@ -28,33 +28,47 @@ The default is **false**.
 ### BASH
 `bash-completion` has to be installed on the system.
 
-To load the completion script into the current session run:\
-**source <(podman completion bash)**
+To load the completion script into the current session run:
+```
+source <(podman completion bash)
+```
 
-To make it available for all bash sessions run:\
-**podman completion -f /etc/bash_completion.d/podman bash**.
+To make it available for all bash sessions run:
+```
+podman completion -f /etc/bash_completion.d/podman bash
+```
 
 
 ### ZSH
 Shell completion needs to be already enabled in the environment. The following can be executed:\
-**echo "autoload -U compinit; compinit" >> ~/.zshrc**
+```
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
 
 To make it available for all zsh sessions run:\
-**podman completion -f "${fpath[1]}/_podman" zsh**
+```
+podman completion -f "${fpath[1]}/_podman" zsh
+```
 
 Once the shell is reloaded the auto-completion works.
 
 
 ### FISH
 To load the completion script into the current session run:
-**podman completion fish | source**
+```
+podman completion fish | source
+```
 
 To make it available for all fish sessions run:
-**podman completion -f ~/.config/fish/completions/podman.fish fish**
+```
+podman completion -f ~/.config/fish/completions/podman.fish fish
+```
 
 ### POWERSHELL
 To load the completion script into the current session run:
-**podman.exe completion powershell | Out-String | Invoke-Expression**
+```
+podman.exe completion powershell | Out-String | Invoke-Expression
+```
 
 To make it available in all powershell sessions that a user has, write the
 completion output to a file and source that to the user's powershell profile.


### PR DESCRIPTION
Currently, due to sphinx smart quote features being enabled, fancy quotes are used in the commands. This means the docs are harder to use as the commands cannot be copy/pasted into a terminal.

Wrapping the code in code blocks fixes this. An alternative would be to disable smart quotes entirely, but this seems over-the-top (especially considering wrapping commands in code blocks harmonises this page with most of the other documentation)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
