### PR TITLE
CI: e2e: add delay before podman logs or journalctl

### DIFF
--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containers/podman/v4/libpod/define"
 	. "github.com/containers/podman/v4/test/utils"
@@ -254,6 +255,8 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).Should(Exit(0))
 
+		// Flake prevention: journalctl makes no timeliness guarantees.
+		time.Sleep(1 * time.Second)
 		cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_TAG", fmt.Sprintf("CONTAINER_ID_FULL=%s", cid))
 		out, err := cmd.CombinedOutput()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2499,6 +2499,8 @@ var _ = Describe("Podman play kube", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).Should(Exit(0))
 
+		// Flake prevention: journalctl makes no timeliness guarantees.
+		time.Sleep(1 * time.Second)
 		logs := podmanTest.Podman([]string{"logs", getCtrNameInPod(p)})
 		logs.WaitWithDefaultTimeout()
 		Expect(logs).Should(Exit(0))


### PR DESCRIPTION
...to reduce flakes.

Reason: journald makes no guarantees. Just because a systemd job
has finished, or podman has written+flushed log entries, doesn't
mean that journald will actually know about them:

   https://github.com/systemd/systemd/issues/28650

Workaround: Sleep(1) before every 'podman logs' or 'journalctl'.
Better ideas welcome.

This addresses, but does not close, #18501. That's a firehose,
with many more failures than I can possibly cross-reference.
I will leave it open, then keep monitoring missing-logs flakes
over time, and pick those off as they occur.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```