### PR TITLE
[CI:BUILD] Makefile: rpm target generates correct version

### DIFF
--- a/rpm/update-spec-version.sh
+++ b/rpm/update-spec-version.sh
@@ -8,13 +8,13 @@ set -eox pipefail
 
 PACKAGE=podman
 SPEC_FILE=$PACKAGE.spec
-GIT_DESCRIBE=$(git describe)
-VERSION=$(echo $GIT_DESCRIBE | sed -e 's/^v//' -e 's/-/~/g')
+VERSION=$(grep '^const RawVersion' ../version/rawversion/version.go | cut -d\" -f2)
+RPM_VERSION=$(echo $VERSION | sed -e 's/^v//' -e 's/-/~/g')
 
 # Update spec file to use local changes
-sed -i "s/^Version:.*/Version: $VERSION/" $SPEC_FILE
-sed -i "s/^Source0:.*/Source0: $PACKAGE-$GIT_DESCRIBE.tar.gz/" $SPEC_FILE
-sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$GIT_DESCRIBE/" $SPEC_FILE
+sed -i "s/^Version:.*/Version: $RPM_VERSION/" $SPEC_FILE
+sed -i "s/^Source0:.*/Source0: $PACKAGE-$VERSION.tar.gz/" $SPEC_FILE
+sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$VERSION/" $SPEC_FILE
 
 # Generate Source0 archive from HEAD
-(cd .. && git archive --format=tar.gz --prefix=$PACKAGE-$GIT_DESCRIBE/ HEAD -o rpm/$PACKAGE-$GIT_DESCRIBE.tar.gz)
+(cd .. && git archive --format=tar.gz --prefix=$PACKAGE-$VERSION/ HEAD -o rpm/$PACKAGE-$VERSION.tar.gz)


### PR DESCRIPTION
`git describe` is lagging on main so this commit updates `rpm/update-sepc-version.sh` to generate the expected version.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

No release note, given release branches won't be affected.