### PR TITLE
Fail if ssh key exists

### DIFF
--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -20,6 +20,10 @@ var sshCommand = []string{"ssh-keygen", "-N", "", "-t", "ed25519", "-f"}
 // CreateSSHKeys makes a priv and pub ssh key for interacting
 // the a VM.
 func CreateSSHKeys(writeLocation string) (string, error) {
+	// If the SSH key already exists, hard fail
+	if _, err := os.Stat(writeLocation); err == nil {
+		return "", fmt.Errorf("SSH key already exists: %s", writeLocation)
+	}
 	if err := os.MkdirAll(filepath.Dir(writeLocation), 0700); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
when init'ing a machine, if the ssh key already exists, then we get a somewhat oblique error.  here we make it clear what the problem was and early return.

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
