### PR TITLE
Fix regression for hyperv

### DIFF
--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -266,7 +266,7 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 		user = machine.DefaultIgnitionUserName
 	}
 	// Write the ignition file
-	if err := m.writeIgnitionConfigFile(opts, key, user); err != nil {
+	if err := m.writeIgnitionConfigFile(opts, user, key); err != nil {
 		return false, err
 	}
 	// The ignition file has been written. We now need to


### PR DESCRIPTION
the method caller for creating the ignition file was accidently misordered for hyperv.  this regression was caused by aa6827a6.

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
