### PR TITLE
Stop gvproxy on hyperv machine stop

### DIFF
--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -1,0 +1,79 @@
+package machine
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const (
+	loops     = 5
+	sleepTime = time.Millisecond * 1
+)
+
+// backoffForProcess checks if the process still exists, for something like
+// sigterm. If the process still exists after loops and sleep time are exhausted,
+// an error is returned
+func backoffForProcess(pid int) error {
+	sleepInterval := sleepTime
+	for i := 0; i < loops; i++ {
+		proxyProc, err := os.FindProcess(pid)
+		if proxyProc == nil && err != nil {
+			// process is killed, gone
+			return nil //nolint: nilerr
+		}
+		time.Sleep(sleepInterval)
+		// double the time
+		sleepInterval += sleepInterval
+	}
+	return fmt.Errorf("process %d has not ended", pid)
+}
+
+// waitOnProcess takes a pid and sends a sigterm to it. it then waits for the
+// process to not exist.  if the sigterm does not end the process after an interval,
+// then sigkill is sent.  it also waits for the process to exit after the sigkill too.
+func waitOnProcess(processID int) error {
+	proxyProc, err := os.FindProcess(processID)
+	if err != nil {
+		return err
+	}
+
+	// Try to kill the pid with sigterm
+	if err := proxyProc.Signal(syscall.SIGTERM); err != nil {
+		return err
+	}
+
+	if err := backoffForProcess(processID); err == nil {
+		return nil
+	}
+
+	// sigterm has not killed it yet, lets send a sigkill
+	proxyProc, err = os.FindProcess(processID)
+	if proxyProc == nil && err != nil {
+		// process is killed, gone
+		return nil //nolint: nilerr
+	}
+	if err := proxyProc.Signal(syscall.SIGKILL); err != nil {
+		// lets assume it is dead in this case
+		return nil //nolint: nilerr
+	}
+	return backoffForProcess(processID)
+}
+
+// CleanupGVProxy reads the --pid-file for gvproxy attempts to stop it
+func CleanupGVProxy(f VMFile) error {
+	gvPid, err := f.Read()
+	if err != nil {
+		return fmt.Errorf("unable to read gvproxy pid file %s: %v", f.GetPath(), err)
+	}
+	proxyPid, err := strconv.Atoi(string(gvPid))
+	if err != nil {
+		return fmt.Errorf("unable to convert pid to integer: %v", err)
+	}
+	if err := waitOnProcess(proxyPid); err == nil {
+		return nil
+	}
+	return f.Delete()
+}

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -115,6 +115,7 @@ func (v HyperVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, 
 	if err != nil {
 		return nil, err
 	}
+
 	m.ConfigPath = *configPath
 
 	ignitionPath, err := machine.NewMachineFile(filepath.Join(configDir, m.Name)+".ign", nil)
@@ -125,6 +126,18 @@ func (v HyperVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, 
 
 	// Set creation time
 	m.Created = time.Now()
+
+	dataDir, err := machine.GetDataDir(machine.HyperVVirt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the proxy pid file
+	gvProxyPid, err := machine.NewMachineFile(filepath.Join(dataDir, "gvproxy.pid"), nil)
+	if err != nil {
+		return nil, err
+	}
+	m.GvProxyPid = *gvProxyPid
 
 	// Acquire the image
 	imagePath, imageStream, err := v.acquireVMImage(opts)


### PR DESCRIPTION
when we stop a machine, we need to also stop the gvproxy process that is running.

JIRA: RUN-1828

also, remove unused applehv function for ssh

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->


```release-note
None
```
