### PR TITLE
Change default QEMU CPU level to `qemu64` on Windows amd64

### DIFF
--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -5,11 +5,9 @@ var (
 )
 
 func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
-	// "max" level is used, because "host" is not supported with "whpx" acceleration
-	// "vmx=off" disabled nested virtualization (not needed for podman)
-	// QEMU issue to track nested virtualization: https://gitlab.com/qemu-project/qemu/-/issues/628
-	// "monitor=off" needed to support hosts, which have mwait calls disabled in BIOS/UEFI
-	opts := []string{"-machine", "q35,accel=whpx:tcg", "-cpu", "max,vmx=off,monitor=off"}
+	// "qemu64" level is used, because "host" is not supported with "whpx" acceleration.
+	// It is a stable choice for running on bare metal and inside Hyper-V machine with nested virtualization.
+	opts := []string{"-machine", "q35,accel=whpx:tcg", "-cpu", "qemu64"}
 	return opts
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Originally `max` level with exceptions was used, because netavark could not work with `qemu64`, because there were needed SIMD instructions blocked. Now it works w/o any issues. What could have changed in between:
* qemu64 could have been adjusted to expose more features for this basic CPU;
* Rust compiler could have been improved to generate multiple versions of binary paths to choose the suitable most performant one available at runtime;
* Optimization flags might have changed for netavark;
* Some or all of the above.

This has been verified to work on:
* Windows 10, Intel Core i7 6700K
* Windows 11, Intel Core i7 11375H
* Windows 11 Insiders Preview, Hyper-V machine with nested virtualization on Windows 11 Intel Core i7 11375 host https://github.com/containers/podman/issues/13006#issuecomment-1666003577

SW versions:
* QEMU 8.1.0-rc2 (this is a safe choice, because the QEMU support on Windows is yet to be released)
* Podman 4.7.0-dev

All test were run with SMP 1 and SMP 4. `max` level in Hyper-V was always getting stuck during boot sequence (in different stages for SMP 1 and SMP 4 (SMP 1 was completing slightly more actions, but never fully booted the VM)).

I don't have any AMD machines for testing, but I expect `qemu64` to be more stable for AMD as well as it should hide almost all of the specifics of the CPU in question.

No release note, as there were no releases for Windows QEMU yet.

No tests as this is only the default settings changed and no logic changes.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

[NO NEW TESTS NEEDED]