### PR TITLE
Ensure volumes-from mounts override image volumes

### DIFF
--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -37,9 +37,16 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 	// Supersede from --volumes-from.
 	for dest, mount := range volFromMounts {
 		baseMounts[dest] = mount
+
+		// Necessary to ensure that mounts override image volumes
+		// Ref: https://github.com/containers/podman/issues/19529
+		delete(baseVolumes, dest)
 	}
 	for dest, volume := range volFromVolumes {
 		baseVolumes[dest] = volume
+
+		// I don't think this can happen, but best to be safe.
+		delete(baseMounts, dest)
 	}
 
 	// Need to make map forms of specgen mounts/volumes.


### PR DESCRIPTION
We do not allow volumes and mounts to be placed at the same location in the container, with create-time checks to ensure this does not happen. User-added conflicts cannot be resolved (if the user adds two separate mounts to, say, /myapp, we can't resolve that contradiction and error), but for many other volume sources, we can solve the contradiction ourselves via a priority hierarchy. Image volumes come first, and are overridden by the `--volumes-from` flag, which are overridden by user-added mounts, etc, etc. The problem here is that we were not properly handling volumes-from overriding image volumes. An inherited volume from --volumes-from would supercede an image volume, but an inherited mount would not. Solution is fortunately simple - just clear out the map entry for the other type when adding volumes-from volumes.

Makes me wish for Rust sum types - conflict resolution would be a lot simpler if we could use a sum type for volumes and bind mounts and thus have a single map instead of two maps, one for each type.

Fixes #19529

```release-note
Fixed a bug where a container with an image volume and an inherited mount from the `--volumes-from` option that used the same path could not be created ([#19529](https://github.com/containers/podman/issues/19529)).
```
