### PR TITLE
Makefile: work around the lack of 'man -l' on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,11 @@ PRE_COMMIT = $(shell command -v bin/venv/bin/pre-commit ~/.local/bin/pre-commit 
 ifeq ($(shell uname -s),FreeBSD)
 SED=gsed
 GREP=ggrep
+MAN_L=	mandoc
 else
 SED=sed
 GREP=grep
+MAN_L=	man -l
 endif
 
 # This isn't what we actually build; it's a superset, used for target
@@ -503,7 +505,7 @@ $(MANPAGES): %: %.md .install.md2man docdir
 	@if grep 'included file options/' docs/build/man/*; then \
 		echo "FATAL: man pages must not contain ^^^^"; exit 1; \
 	fi
-	@if man -l $(subst source/markdown,build/man,$@) | grep -Pazoq '│\s+│\n\s+├─+┼─+┤\n\s+│\s+│'; then  \
+	@if $(MAN_L) $(subst source/markdown,build/man,$@) | $(GREP) -Pazoq '│\s+│\n\s+├─+┼─+┤\n\s+│\s+│'; then  \
 		echo "FATAL: $< has a too-long table column; use 'man -l $(subst source/markdown,build/man,$@)' and look for empty table cells."; exit 1; \
 	fi
 


### PR DESCRIPTION
The mandoc(1) utility is used for this on FreeBSD systems. This fixes a confusing (but harmless) series of error messages when building manpages on FreeBSD.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
