### PR TITLE
[v1.6.4-rhel] podman stats: calc CPU percentage correctly

### DIFF
--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -261,10 +261,6 @@ type PodContainerStats struct {
 
 // GetPodStats returns the stats for each of its containers
 func (p *Pod) GetPodStats(previousContainerStats map[string]*ContainerStats) (map[string]*ContainerStats, error) {
-	var (
-		ok       bool
-		prevStat *ContainerStats
-	)
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -277,10 +273,7 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*ContainerStats) (ma
 	}
 	newContainerStats := make(map[string]*ContainerStats)
 	for _, c := range containers {
-		if prevStat, ok = previousContainerStats[c.ID()]; !ok {
-			prevStat = &ContainerStats{}
-		}
-		newStats, err := c.GetContainerStats(prevStat)
+		newStats, err := c.GetContainerStats(previousContainerStats[c.ID()])
 		// If the container wasn't running, don't include it
 		// but also suppress the error
 		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid {

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -12,7 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetContainerStats gets the running stats for a given container
+// GetContainerStats gets the running stats for a given container.
+// The previousStats is used to correctly calculate cpu percentages. You
+// should pass nil if there is no previous stat for this container.
 func (c *Container) GetContainerStats(previousStats *ContainerStats) (*ContainerStats, error) {
 	stats := new(ContainerStats)
 	stats.ContainerID = c.ID()
@@ -32,6 +34,14 @@ func (c *Container) GetContainerStats(previousStats *ContainerStats) (*Container
 
 	if c.state.State != define.ContainerStateRunning {
 		return stats, define.ErrCtrStateInvalid
+	}
+
+	if previousStats == nil {
+		previousStats = &ContainerStats{
+			// if we have no prev stats use the container start time as prev time
+			// otherwise we cannot correctly calculate the CPU percentage
+			SystemNano: uint64(c.state.StartedTime.UnixNano()),
+		}
 	}
 
 	cgroupPath, err := c.CGroupPath()

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -333,7 +333,7 @@ func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) er
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
 	}
-	containerStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
+	containerStats, err := ctr.GetContainerStats(nil)
 	if err != nil {
 		if errors.Cause(err) == define.ErrCtrStateInvalid {
 			return call.ReplyNoContainerRunning()


### PR DESCRIPTION
When you run podman stats, the first interval always shows the wrong cpu usage. To calculate cpu percentage we get the cpu time from the cgroup and compare this against the system time between two stats. Since the first time we do not have a previous stats an empty struct is used instead. Thus we do not use the actual running time of the container but the current unix timestamp (time since Jan 1 1970).

To fix this we make sure that the previous stats time is set to the container start time, when it is empty.

[NO NEW TESTS NEEDED] No idea how I could create a test which would have a predictable cpu usage.

See the linked bugzilla for a reproducer.

This was fixed with a cherry-pick in Podman v3.0.1-rhel with this commit: https://github.com/containers/podman/pull/18710/commits/ca3d490f01b20a0e83b89cb57ff85245913598a7

However, the two files under the /pkg directory from that commit don't exist in 1.6.4-rhel. Instead we need to modify cmd/podman/stats.go to make use of this new behavior. However the issue here is slightly different, the problem of the wronf cpu here was caused by calling stats two times directly after each other without sleep(). This call caused the cpu calculation to be incorrect because we only measured the usage in a few nanoseconds which is to small as the delta until the time.Now() call is simply to big and thus causes significant different cpu percentage. The fix here is to not init the first stats and thus make sure we always have a second of sleep in between the stats calls which is enough for an accurate reading.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2210140

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
