### PR TITLE
packit: Build PRs into default packit COPRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,27 +2,34 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-# Build targets can be found at:
-# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
-
 specfile_path: rpm/podman.spec
 upstream_tag_template: v{version}
 
-jobs:
-  - &copr
-    job: copr_build
-    trigger: pull_request
-    owner: rhcontainerbot
-    project: packit-builds
-    enable_net: true
-    srpm_build_deps:
-      - make
+srpm_build_deps:
+  - make
 
-  - <<: *copr
-    # Run on commit to main branch
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    enable_net: true
+    # keep in sync with https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next
+    targets:
+      - fedora-all-x86_64
+      - fedora-all-aarch64
+      - centos-stream+epel-next-8-x86_64
+      - centos-stream+epel-next-8-aarch64
+      - centos-stream+epel-next-9-x86_64
+      - centos-stream+epel-next-9-aarch64
+    additional_repos:
+      - "copr://rhcontainerbot/podman-next"
+
+  # Run on commit to main branch
+  - job: copr_build
     trigger: commit
     branch: main
+    owner: rhcontainerbot
     project: podman-next
+    enable_net: true
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Building all PRs of all container projects into the same COPR does not properly isolate PRs from each other: E.g. a podman PR currently runs against whichever crun PR was opened/updated last; in other words, sending a broken crun PR will instantly break tests for all subsequent podman runs.

To avoid that, change the copr_build configuration to use the packit default COPRs, which are specific to the particular PR, and disappear after a few weeks. Projects should only run against what landed in our dependencies' main branches, i.e. the podman-next COPR.

Note that this does not preclude testing a podman PR against a e.g. a crun PR: This can be explicitly requested [1]. But most PRs don't change the API and thus should default to isolation.

[1] https://packit.dev/posts/testing-farm-triggering

[NO NEW TESTS NEEDED]

----

This is exactly the same as https://github.com/containers/crun/pull/1260 ; please see the discussion there, this change needs to be applied to all container projects, and then all land together. Let's keep all the relevant discussions in  the crun PR please.

#### Does this PR introduce a user-facing change?

No.

```release-note
None
```
