### PR TITLE
podman stop --cidfile missing --ignore

### DIFF
--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -110,6 +111,9 @@ func stop(cmd *cobra.Command, args []string) error {
 	for _, cidFile := range stopCidFiles {
 		content, err := os.ReadFile(cidFile)
 		if err != nil {
+			if stopOptions.Ignore && errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}
 		id := strings.Split(string(content), "\n")[0]

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -20,6 +20,8 @@ Remove all containers.  Can be used in conjunction with **-f** as well.
 
 @@option cidfile.read
 
+Command does not fail when *file* is missing and user specified --ignore.
+
 #### **--depend**
 
 Remove selected container and recursively remove all containers that depend on it.

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -23,6 +23,8 @@ Stop all running containers.  This does not include paused containers.
 
 @@option cidfile.read
 
+Command does not fail when *file* is missing and user specified --ignore.
+
 #### **--filter**, **-f**=*filter*
 
 Filter what containers are going to be stopped.

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -85,6 +85,13 @@ load helpers
 
     run_podman stop --ignore $name
     is "$output" "" "podman stop nonexistent container, with --ignore"
+
+    nosuchfile=$PODMAN_TMPDIR/no-such-file
+    run_podman 125 stop --cidfile=$nosuchfile
+    is "$output" "Error: reading CIDFile: open $nosuchfile: no such file or directory" "podman stop with missing cidfile, without --ignore"
+
+    run_podman stop --cidfile=$nosuchfile --ignore
+    is "$output" "" "podman stop with missing cidfile, with --ignore"
 }
 
 


### PR DESCRIPTION
Podman should ignore failures to find a cidfile when stoping the container if the user specified --ignore

Fixes: https://github.com/containers/podman/issues/19546

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman stop will ignore cidfile not existing when user specifies --ignore flag.
```
