### PR TITLE
[v4.6] Remove zstd:chunked reference

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1632,7 +1632,7 @@ func AutocompleteCheckpointCompressType(cmd *cobra.Command, args []string, toCom
 
 // AutocompleteCompressionFormat - Autocomplete compression-format type options.
 func AutocompleteCompressionFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{"gzip", "zstd", "zstd:chunked"}
+	types := []string{"gzip", "zstd"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/docs/source/markdown/options/compression-format.md
+++ b/docs/source/markdown/options/compression-format.md
@@ -2,6 +2,6 @@
 ####>   podman manifest push, push
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
+#### **--compression-format**=**gzip** | *zstd*
 
-Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
+Specifies the compression format to use.  Supported values are: `gzip`, and `zstd`.  The default is `gzip` unless overridden in the containers.conf file.


### PR DESCRIPTION
Remove the references of the zstd:chunked encryption algorithm as this will not be supported in RHEL 8.9/9.3 in Podman v4.6.1.  Support is expected in Podman v4.7 and later.

[NO NEW TESTS NEEDED]
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
