### PR TITLE
fix(env): parsing --env incorrect in cli

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -102,7 +102,7 @@ func ParseFile(path string) (_ map[string]string, err error) {
 
 	// replace all \r\n and \r with \n
 	text := strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(string(content))
-	if err := parseEnv(env, text, false); err != nil {
+	if err := parseEnv(env, text); err != nil {
 		return nil, err
 	}
 
@@ -110,19 +110,13 @@ func ParseFile(path string) (_ map[string]string, err error) {
 }
 
 // parseEnv parse the given content into env format
-// @param enforceMatch bool	"it throws an error if there is no match"
 //
-// @example: parseEnv(env, "#comment", true) => error("invalid variable: #comment")
-// @example: parseEnv(env, "#comment", false) => nil
-// @example: parseEnv(env, "", false) => nil
-// @example: parseEnv(env, "KEY=FOO", true) => nil
-// @example: parseEnv(env, "KEY", true) => nil
-func parseEnv(env map[string]string, content string, enforceMatch bool) error {
+// @example: parseEnv(env, "#comment") => nil
+// @example: parseEnv(env, "") => nil
+// @example: parseEnv(env, "KEY=FOO") => nil
+// @example: parseEnv(env, "KEY") => nil
+func parseEnv(env map[string]string, content string) error {
 	m := envMatch(content)
-
-	if len(m) == 0 && enforceMatch {
-		return fmt.Errorf("invalid variable: %q", content)
-	}
 
 	for _, match := range m {
 		key := match[1]
@@ -194,4 +188,48 @@ func envMatch(content string) [][]string {
 	}
 
 	return m
+}
+
+// parseEnvWithSlice parsing a set of Env variables from a slice of strings
+// because the majority of shell interpreters discard double quotes and single quotes,
+// for example: podman run -e K='V', when passed into a program, it will become: K=V.
+// This can lead to unexpected issues, as discussed in this link: https://github.com/containers/podman/pull/19096#issuecomment-1670164724.
+//
+// parseEnv method will discard all comments (#) that are not wrapped in quotation marks,
+// so it cannot be used to parse env variables obtained from the command line.
+//
+// @example: parseEnvWithSlice(env, "KEY=FOO") => KEY: FOO
+// @example: parseEnvWithSlice(env, "KEY") => KEY: ""
+// @example: parseEnvWithSlice(env, "KEY=") => KEY: ""
+// @example: parseEnvWithSlice(env, "KEY=FOO=BAR") => KEY: FOO=BAR
+// @example: parseEnvWithSlice(env, "KEY=FOO#BAR") => KEY: FOO#BAR
+func parseEnvWithSlice(env map[string]string, content string) error {
+	data := strings.SplitN(content, "=", 2)
+
+	// catch invalid variables such as "=" or "=A"
+	if data[0] == "" {
+		return fmt.Errorf("invalid variable: %q", content)
+	}
+	// trim the front of a variable, but nothing else
+	name := strings.TrimLeft(data[0], whiteSpaces)
+	if len(data) > 1 {
+		env[name] = data[1]
+	} else {
+		if strings.HasSuffix(name, "*") {
+			name = strings.TrimSuffix(name, "*")
+			for _, e := range os.Environ() {
+				part := strings.SplitN(e, "=", 2)
+				if len(part) < 2 {
+					continue
+				}
+				if strings.HasPrefix(part[0], name) {
+					env[part[0]] = part[1]
+				}
+			}
+		} else if val, ok := os.LookupEnv(name); ok {
+			// if only a pass-through variable is given, clean it up.
+			env[name] = val
+		}
+	}
+	return nil
 }

--- a/pkg/env/env_unix.go
+++ b/pkg/env/env_unix.go
@@ -8,7 +8,7 @@ package env
 func ParseSlice(s []string) (map[string]string, error) {
 	env := make(map[string]string, len(s))
 	for _, e := range s {
-		if err := parseEnv(env, e, true); err != nil {
+		if err := parseEnvWithSlice(env, e); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/env/env_windows.go
+++ b/pkg/env/env_windows.go
@@ -17,7 +17,7 @@ func ParseSlice(s []string) (map[string]string, error) {
 			continue
 		}
 
-		if err := parseEnv(env, e, true); err != nil {
+		if err := parseEnvWithSlice(env, e); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Fixed: https://github.com/containers/podman/pull/19096#issuecomment-1670164724
Fixed: https://github.com/containers/podman/pull/19096#issuecomment-1670613061

The root cause of this issue lies in the fact that the shell discards the quotes in the parameters, as shown in the following code snippet:

```shell
podman run -e K='a#b' alpine printenv aaa
# To
podman run -e K=a#b alpine printenv aaa
```

This will result in problems with the current `parseEnv` implementation. Unfortunately, there is no way to change the behavior of the shell, so the only option is to fix it within `parseEnv`. In order to reduce code complexity, I have ported the previous `parseEnv` function back and renamed it as `parseEnvWithSlice`. Furthermore, this function will be used exclusively for the `--env` option, which will bring another benefit: it will run faster than `--env-file`.

Now:

```shell
$ podman run --env aaa='aaa\nbbb#ccc\nddd' alpine printenv aaa
aaa\nbbb#ccc\nddd
```

<img width="759" alt="44-09 13 44@2x" src="https://github.com/containers/podman/assets/8198408/b3627ece-c420-4b63-bc69-82818e291392">

#### Does this PR introduce a user-facing change?

```release-note
Fix the issue where the parsing of the `--env` parameter value is incorrect.
```

----

Ref:
1. https://github.com/spf13/cobra/issues/898
2. https://stackoverflow.com/questions/53896081/how-to-keep-quotes-in-os-args
3. https://github.com/golang/go/issues/30952

PTAL @rhatdan @vrothberg @Luap99 
/cc @edsantiago @kajinamit 