### PR TITLE
Add infra-name annotations to kube gen/play

### DIFF
--- a/docs/source/markdown/podman-kube-generate.1.md
+++ b/docs/source/markdown/podman-kube-generate.1.md
@@ -28,6 +28,8 @@ Once completed, the correct permissions are in place to access the volume when t
 
 Note that the generated Kubernetes YAML file can be used to re-run the deployment via podman-play-kube(1).
 
+Note that if the pod being generated was created with the **--infra-name** flag set, then the generated kube yaml will have the **io.podman.annotations.infra.name** set where the value is the name of the infra container set by the user.
+
 ## OPTIONS
 
 #### **--filename**, **-f**=*filename*

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -45,6 +45,8 @@ Note: The command `podman play kube` is an alias of `podman kube play`, and perf
 Note: The command `podman kube down` can be used to stop and remove pods or containers based on the same Kubernetes YAML used
 by `podman kube play` to create them.
 
+Note: To customize the name of the infra container created during `podman kube play`, use the **io.podman.annotations.infra.name** annotation in the pod definition. This annotation is automatically set when generating a kube yaml from a pod that was created with the `--infra-name` flag set.
+
 `Kubernetes PersistentVolumeClaims`
 
 A Kubernetes PersistentVolumeClaim represents a Podman named volume. Only the PersistentVolumeClaim name is required by Podman to create a volume. Kubernetes annotations can be used to make use of the available options for Podman volumes.

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -145,6 +145,10 @@ const (
 	// of the init container.
 	InitContainerType = "io.podman.annotations.init.container.type"
 
+	// InfraNameAnnotation is used by generate and play kube when the infra container is set by the user during
+	// pod creation
+	InfraNameAnnotation = "io.podman.annotations.infra.name"
+
 	// UlimitAnnotation is used by kube play when playing a kube yaml to specify the ulimits
 	// of the container
 	UlimitAnnotation = "io.podman.annotations.ulimit"

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -53,7 +53,7 @@ type PlayOptions struct {
 	Force *bool
 	// PublishPorts - configure how to expose ports configured inside the K8S YAML file
 	PublishPorts []string
-	// // Wait - indicates whether to return after having created the pods
+	// Wait - indicates whether to return after having created the pods
 	Wait             *bool
 	ServiceContainer *bool
 }

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -664,6 +664,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		podSpec.PodSpecGen.InfraContainerSpec = specgen.NewSpecGenerator(infraImage, false)
 		podSpec.PodSpecGen.InfraContainerSpec.NetworkOptions = p.NetworkOptions
 		podSpec.PodSpecGen.InfraContainerSpec.SdNotifyMode = define.SdNotifyModeIgnore
+		// If the infraNameAnnotation is set in the yaml, use that as the infra container name
+		// If not, fall back to the default infra container name
+		if v, ok := podYAML.Annotations[define.InfraNameAnnotation]; ok {
+			podSpec.PodSpecGen.InfraContainerSpec.Name = v
+		}
 
 		err = specgenutil.FillOutSpecGen(podSpec.PodSpecGen.InfraContainerSpec, &infraOptions, []string{})
 		if err != nil {


### PR DESCRIPTION
Add io.podman.annotations.infra.name annotation to kube play so
users can set the name of the infra container created.
When a pod is created with --infra-name set, the generated
kube yaml will have an infraName annotation set that will
be used when playing the generated yaml with podman.

Fixes https://github.com/containers/podman/issues/18312
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set an infra name annotation in the generated yaml when the `pod create` command has --infra-name set.
This annotation can also be used with `kube play` when wanting to customize the infra container name.
```
