### PR TITLE
Bump bundled gvproxy to 0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ endif
 # include this lightweight helper binary.
 #
 GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
-GV_SHA=407efb5dcdb0f4445935f7360535800b60447544
+GV_SHA=db608827124caa71ba411cec8ea959bb942984fe
 
 ###
 ### Primary entry-point targets


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Bumps gvproxy used in Windows build to latest release. This fixes build incompatibility with golang 1.21, because it is not possible to use different golang versions for Podman and gvproxy.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

[NO NEW TESTS NEEDED]