### PR TITLE
[CI:BUILD] Cirrus: Prune defunct job + fix noop alias

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -735,10 +735,7 @@ podman_machine_task:
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main
-    always: &machine_logs_benchmarks
-      <<: *int_logs_artifacts
-      benchmark_artifacts:
-          path: ./data/*
+    always: *int_logs_artifacts
 
 
 podman_machine_aarch64_task:
@@ -765,30 +762,7 @@ podman_machine_aarch64_task:
     clone_script: *get_gosrc_aarch64
     setup_script: *setup
     main_script: *main
-    always: *machine_logs_benchmarks
-
-
-bench_stuff_task:
-    name: Record machine benchmarks
-    alias: bench_stuff
-    # Only run on merge and never for cirrus-cron.
-    only_if: $CIRRUS_BRANCH == 'main' && $CIRRUS_CRON == ''
-    depends_on:
-        - podman_machine
-        - podman_machine_aarch64
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        PR: podman run -it --rm -v /tmp/data:/tmp/data:Z -w /tmp/data
-        GACJSON: ENCRYPTED[acd4a8bd843dab6dd135c379a2819546187fd2c7ce43e5839c6db4c798ed652f5b456f5d1716afef662554ee94e098ee]
-    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
-    script:
-        - mkdir /tmp/data
-        # Download benchmark.env and benchmark.csv from podman-machine tasks
-        - $PR quay.io/libpod/ccia $CIRRUS_BUILD_ID benchmark/data
-        - podman secret create --env GACJSON GACJSON
-        # Parse and upload benchmark data to GCE firestore database
-        - $PR --secret GACJSON -e GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/GACJSON quay.io/libpod/bench_stuff ./$CIRRUS_BUILD_ID
+    always: *int_logs_artifacts
 
 
 # Always run subsequent to integration tests.  While parallelism is lost
@@ -1052,7 +1026,7 @@ meta_task:
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]
         GCPNAME: ENCRYPTED[2f9738ef295a706f66a13891b40e8eaa92a89e0e87faf8bed66c41eca72bf76cfd190a6f2d0e8444c631fdf15ed32ef6]
         GCPPROJECT: libpod-218412
-    clone_script: *noop
+    clone_script: &noop mkdir -p "$CIRRUS_WORKING_DIR"
     script: /usr/local/bin/entrypoint.sh
 
 


### PR DESCRIPTION
The mechanism fueling the benchmarks job has long since been removed. Running the job is useless now, remove it.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
