### PR TITLE
[CI:BUILD] Packit: add back fedora-eln targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,8 @@ jobs:
     targets:
       - fedora-all-x86_64
       - fedora-all-aarch64
+      - fedora-eln-x86_64
+      - fedora-eln-aarch64
       - centos-stream+epel-next-8-x86_64
       - centos-stream+epel-next-8-aarch64
       - centos-stream+epel-next-9-x86_64


### PR DESCRIPTION
Fedora ELN targets were removed in the switch to ephemeral coprs. Add them back.

Podman rpm doesn't depend on go-md2man package anymore and instead uses vendored go-md2man for building manpages, so that's no longer a reason for build failures on Fedora ELN.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
