### PR TITLE
[CI:DOCS] Add missing verb in machinectl example

### DIFF
--- a/docs/tutorials/performance.md
+++ b/docs/tutorials/performance.md
@@ -22,7 +22,7 @@ Interactively
 
 ```
 sudo useradd testuser
-sudo machinectl testuser@
+sudo machinectl shell testuser@
 podman pull docker.io/library/alpine
 /usr/bin/time -v podman --storage-driver=vfs run --rm docker.io/library/alpine /bin/true
 exit


### PR DESCRIPTION
Without the verb 'shell', the invocation fails with:

    Unknown command verb testuser@

#### Does this PR introduce a user-facing change?

```release-note
None
```
