### PR TITLE
Update rootfs.md: Fix formatting and wording of idmap option

### DIFF
--- a/docs/source/markdown/options/rootfs.md
+++ b/docs/source/markdown/options/rootfs.md
@@ -22,7 +22,9 @@ finishes executing, similar to a tmpfs mount point being unmounted.
 Note: On **SELinux** systems, the rootfs needs the correct label, which is by default
 **unconfined_u:object_r:container_file_t:s0**.
 
-    The `idmap` option if specified, creates an idmapped mount to the target user
+  `idmap`
+
+If `idmap` is specified, create an idmapped mount to the target user
 namespace in the container.
 The idmap option supports a custom mapping that can be different than the user
 namespace used by the container.  The mapping can be specified after the idmap


### PR DESCRIPTION
The newly introduced `idmap` section of rootfs lacked a header (comparable to Overlay Rootfs Mounts), had odd formatting, and wording that differed from other instances of idmap, e.g., the one in the --volume section. This commits addresses those issues.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
