### PR TITLE
[CI:DOCS] sphinx: skip options include dir

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["markdown/options"]
 
 master_doc = "index"
 


### PR DESCRIPTION
Tell sphinx not to process the "options" dir, those files
are not to be published.

Context: websearching for podman volume info, I stumbled upon:

   https://docs.podman.io/en/latest/markdown/options/volume.html

...and panicked because I saw '<<container|pod>>', the options
include-file syntax that should never be seen by users. I thought
the filter script was broken.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```