### PR TITLE
Cirrus: Remove EC2 experimental flag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -187,9 +187,6 @@ build_aarch64_task:
     # Multiarch doesn't depend on buildability in this automation context
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: "$CIRRUS_CRON != 'multiarch'"
-    # Enable labeling of EC2 VMs with cirrus task ID. TODO: This can be
-    # removed when the feature goes mainstream.
-    experimental: true
     ec2_instance: &standard_build_ec2_aarch64
         image: ${VM_IMAGE_NAME}
         type: ${EC2_INST_TYPE}
@@ -275,7 +272,6 @@ validate_aarch64_task:
     only_if: *is_pr
     depends_on:
         - build_aarch64
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64
@@ -599,7 +595,6 @@ windows_smoke_test_task:
         $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
     depends_on:
       - alt_build
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         image: "${WINDOWS_AMI}"
         type: m5zn.metal
@@ -720,7 +715,6 @@ podman_machine_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         image: "${VM_IMAGE_NAME}"
         type: "${EC2_INST_TYPE}"
@@ -749,7 +743,6 @@ podman_machine_aarch64_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance:
         <<: *standard_build_ec2_aarch64
     env:
@@ -793,7 +786,6 @@ local_system_test_aarch64_task: &local_system_test_task_aarch64
     depends_on:
         - build_aarch64
         - unit_test
-    experimental: true  # Enable labeling of EC2 VMs with cirrus task ID
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64


### PR DESCRIPTION
The VM-naming feature is now mainstream.
Ref: https://github.com/cirruslabs/cirrus-ci-docs/ issue 1051

Testing note:  Manually confirmed [the `Build for fedora-38-aarch64` task](https://cirrus-ci.com/task/6388501483094016) created an EC2 VM with the following tags:

Key | Value
-- | --
CIRRUS_REPO_FULL_NAME | containers/podman
CIRRUS_BUILD_ID | 6599283714031616
Name | cirrus-task-6388501483094016



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
