### PR TITLE
Set default Umask for `podman kube play`

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -178,6 +178,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		return nil, err
 	}
 
+	if s.Umask == "" {
+		s.Umask = rtc.Umask()
+	}
+
 	if s.CgroupsMode == "" {
 		s.CgroupsMode = rtc.Cgroups()
 	}


### PR DESCRIPTION
Fixes a bug where `podman kube play` fails to set a container's Umask to the default 0022, and sets it to 0000 instead.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a bug where `podman kube play` fails to set a container's Umask to the default 0022
```
