### PR TITLE
[CI:DOCS] Fix git build example in build page

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -1047,7 +1047,8 @@ use it as the context. The Containerfile at the root of the repository is used
 and it only works if the GitHub repository is a dedicated repository.
 
 ```
-$ podman build https://github.com/scollier/purpletest
+$ podman build -t hello  https://github.com/containers/PodmanHello.git
+$ podman run hello
 ```
 
   Note: Github does not support using `git://` for performing `clone` operation due to recent changes in their security guidance (https://github.blog/2021-09-01-improving-git-protocol-security-github/). Use an `https://` URL if the source repository is hosted on Github.


### PR DESCRIPTION
The git repo that was used for the example of a git build:

  `podman build https://github.com/scollier/purpletest`

no longer exists.  Someone reached out to @rhatdan about this, and he suggested using the Podman Hello World repo.  However, that didn't exist until a little bit ago, so I've updated the man page with a pointer there.  That should be a lot more stable.

[NO NEW TESTS NEEDED]
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
