### PR TITLE
Add riscv64 support for cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ CROSS_BUILD_TARGETS := \
 	bin/podman.cross.linux.mipsle \
 	bin/podman.cross.linux.mips64 \
 	bin/podman.cross.linux.mips64le \
+	bin/podman.cross.linux.riscv64 \
 	bin/podman.cross.freebsd.amd64 \
 	bin/podman.cross.freebsd.arm64
 

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -192,6 +192,8 @@ func GetFcosArch() string {
 	switch runtime.GOARCH {
 	case "arm64":
 		arch = "aarch64"
+	case "riscv64":
+		arch = "riscv64"
 	default:
 		arch = "x86_64"
 	}


### PR DESCRIPTION
~~- add riscv64 linux static release build~~
~~- update the release-artifacts with riscv64~~
~~- bump containers/ocicrypt to v1.1.8~~
- adding a cross-compilation option for riscv64
- extending GetFcosArch with the riscv64 architecture parameter

[NO NEW TESTS NEEDED]