### PR TITLE
[v4.6] fix: pull parma parsing for the /build compat ep

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -581,9 +581,9 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if _, found := r.URL.Query()["pull"]; found {
 			switch strings.ToLower(query.Pull) {
-			case "false":
+			case "0", "f", "false":
 				pullPolicy = buildahDefine.PullIfMissing
-			case "true":
+			case "on", "1", "t", "true":
 				pullPolicy = buildahDefine.PullAlways
 			default:
 				policyFromMap, foundPolicy := buildahDefine.PolicyMap[query.Pull]


### PR DESCRIPTION
# Changes

Fixing Docker client incompatibility where the `/build` endpoint cannot parse "1" as a boolean.

This PR makes the endpoint to accept string representing boolean which are booleanish by Go standard: string that can be parsed by `strconv.ParseBool()`.

The bug reproduction:
```
# Broken compatibility with the docker CLI
docker build . -t alpine-1000 --pull
Sending build context to Docker daemon  2.048kB
Error response from daemon: failed to parse query parameter 'pull': "1": invalid pull policy: "1"
```

```release-note
Correct parsing of the pull query parameter for the compat /build endpoint.
```
