### PR TITLE
Backport #18577 to v4.4.1-rhel

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -220,9 +220,11 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			var m = []string{}
 			if err := json.Unmarshal([]byte(query.Dockerfile), &m); err != nil {
 				// it's not json, assume just a string
-				m = []string{filepath.Join(contextDirectory, query.Dockerfile)}
+				m = []string{query.Dockerfile}
 			}
-			containerFiles = m
+			for _, containerfile := range m {
+				containerFiles = append(containerFiles, filepath.Join(contextDirectory, filepath.Clean(filepath.FromSlash(containerfile))))
+			}
 			dockerFileSet = true
 		}
 	}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -637,14 +637,14 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 		defer gw.Close()
 		defer tw.Close()
 		seen := make(map[devino]string)
-		for _, src := range sources {
-			s, err := filepath.Abs(src)
+		for i, src := range sources {
+			source, err := filepath.Abs(src)
 			if err != nil {
 				logrus.Errorf("Cannot stat one of source context: %v", err)
 				merr = multierror.Append(merr, err)
 				return
 			}
-			err = filepath.WalkDir(s, func(path string, d fs.DirEntry, err error) error {
+			err = filepath.WalkDir(source, func(path string, dentry fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
@@ -652,9 +652,9 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 				separator := string(filepath.Separator)
 				// check if what we are given is an empty dir, if so then continue w/ it. Else return.
 				// if we are given a file or a symlink, we do not want to exclude it.
-				if s == path {
+				if source == path {
 					separator = ""
-					if d.IsDir() {
+					if dentry.IsDir() {
 						var p *os.File
 						p, err = os.Open(path)
 						if err != nil {
@@ -669,8 +669,15 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						}
 					}
 				}
-				name := filepath.ToSlash(strings.TrimPrefix(path, s+separator))
-
+				var name string
+				if i == 0 {
+					name = filepath.ToSlash(strings.TrimPrefix(path, source+separator))
+				} else {
+					if !dentry.Type().IsRegular() {
+						return fmt.Errorf("path %s must be a regular file", path)
+					}
+					name = filepath.ToSlash(path)
+				}
 				excluded, err := pm.Matches(name) //nolint:staticcheck
 				if err != nil {
 					return fmt.Errorf("checking if %q is excluded: %w", name, err)
@@ -682,8 +689,8 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					return nil
 				}
 				switch {
-				case d.Type().IsRegular(): // add file item
-					info, err := d.Info()
+				case dentry.Type().IsRegular(): // add file item
+					info, err := dentry.Info()
 					if err != nil {
 						return err
 					}
@@ -722,8 +729,8 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						seen[di] = name
 					}
 					return err
-				case d.IsDir(): // add folders
-					info, err := d.Info()
+				case dentry.IsDir(): // add folders
+					info, err := dentry.Info()
 					if err != nil {
 						return err
 					}
@@ -736,12 +743,12 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					if lerr := tw.WriteHeader(hdr); lerr != nil {
 						return lerr
 					}
-				case d.Type()&os.ModeSymlink != 0: // add symlinks as it, not content
+				case dentry.Type()&os.ModeSymlink != 0: // add symlinks as it, not content
 					link, err := os.Readlink(path)
 					if err != nil {
 						return err
 					}
-					info, err := d.Info()
+					info, err := dentry.Info()
 					if err != nil {
 						return err
 					}

--- a/test/apiv2/python/requirements.txt
+++ b/test/apiv2/python/requirements.txt
@@ -2,4 +2,4 @@ requests-mock~=1.9.3
 requests~=2.20.0
 setuptools~=50.3.2
 python-dateutil~=2.8.1
-PyYAML~=5.4.1
+PyYAML==6.0.1

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -3,4 +3,4 @@ requests-mock~=1.9.3
 requests~=2.20.0
 setuptools~=50.3.2
 python-dateutil~=2.8.1
-PyYAML~=5.4.1
+PyYAML==6.0.1


### PR DESCRIPTION
Backport per RHBZ [2229749](https://bugzilla.redhat.com/show_bug.cgi?id=2229749)

Replaces #19416

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
