### PR TITLE
[v4.6.1-rhel] fix: pull param parsing for the /build compat ep

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -581,9 +581,9 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if _, found := r.URL.Query()["pull"]; found {
 			switch strings.ToLower(query.Pull) {
-			case "false":
+			case "0", "f", "false":
 				pullPolicy = buildahDefine.PullIfMissing
-			case "true":
+			case "on", "1", "t", "true":
 				pullPolicy = buildahDefine.PullAlways
 			default:
 				policyFromMap, foundPolicy := buildahDefine.PolicyMap[query.Pull]


### PR DESCRIPTION
The standard Docker client passes "1" for pull query parameter. This means our compat endpoint has to work with this. The endpoint was recently modified to accept pull-policy however this is not how Docker actually work. Docker actually treats `pull` as boolean.

For sake of compatibility I decide to preserve pull-policy parsing too. We can consider this podman's extension. I should not affect standard clients.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2232127

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
