### PR TITLE
[v4.6] Skip tests that fail in gating

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -41,11 +41,13 @@ function check_label() {
 
 # FIXME #19376 - container-selinux broken -- bats test_tags=distro-integration
 @test "podman selinux: container with label=disable" {
+    skip "Requires unavailable version of container-selinux"
     check_label "--security-opt label=disable" "spc_t"
 }
 
 # FIXME #19376 - container-selinux broken -- bats test_tags=distro-integration
 @test "podman selinux: privileged container" {
+    skip "Requires unavailable version of container-selinux"
     check_label "--privileged --userns=host" "spc_t"
 }
 
@@ -70,6 +72,7 @@ function check_label() {
 
 # FIXME #19376 - container-selinux broken -- bats test_tags=distro-integration
 @test "podman selinux: pid=host" {
+    skip "Requires unavailable version of container-selinux"
     # FIXME this test fails when run rootless with runc:
     #   Error: container_linux.go:367: starting container process caused: process_linux.go:495: container init caused: readonly path /proc/asound: operation not permitted: OCI permission denied
     if is_rootless; then

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -665,6 +665,7 @@ function teardown() {
 ### ICMP, ICMPv6 ###############################################################
 
 @test "podman networking with pasta(1) - ICMP echo request" {
+    skip "Flaky test"
     skip_if_no_ipv4 "IPv6 not routable on the host"
 
     local minuid=$(cut -f1 /proc/sys/net/ipv4/ping_group_range)


### PR DESCRIPTION
SELinux tests are failing in f37, f38, Rawhide. (Did I miss any?) Assume that the new container-selinux will never be available on any of those, so let's just skip those tests. #19376

Pasta ICMP test fails pretty consistently in Gating, and is even flaking in Cirrus, so let's skip that too. #19612

```release-note
None
```
