### PR TITLE
document available secret drivers

### DIFF
--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -20,7 +20,7 @@ var (
 	createCmd = &cobra.Command{
 		Use:   "create [options] NAME FILE|-",
 		Short: "Create a new secret",
-		Long:  "Create a secret. Input can be a path to a file or \"-\" (read from stdin). Default driver is file (unencrypted).",
+		Long:  "Create a secret. Input can be a path to a file or \"-\" (read from stdin). Secret drivers \"file\" (default), \"pass\", and \"shell\" are available.",
 		RunE:  create,
 		Args:  cobra.ExactArgs(2),
 		Example: `podman secret create mysecret /path/to/secret

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -24,7 +24,7 @@ Secrets can also be used to store passwords for `podman login` to authenticate a
 
 #### **--driver**, **-d**=*driver*
 
-Specify the secret driver (default **file**, which is unencrypted).
+Specify the secret driver (default **file**).
 
 #### **--driver-opts**=*key1=val1,key2=val2*
 
@@ -47,6 +47,34 @@ Add label to secret. These labels can be viewed in podman secrete inspect or ls.
 If existing secret with the same name already exists, update the secret.
 The `--replace` option does not change secrets within existing containers, only newly created containers.
  The default is **false**.
+
+## SECRET DRIVERS
+
+#### file
+
+Secret resides in a read-protected file.
+
+#### pass
+
+Secret resides in a GPG-encrypted file.
+
+#### shell
+
+Secret is managed by custom scripts. An environment variable **SECRET_ID**
+is passed to the scripts (except for **list**), and secrets are communicated
+via stdin/stdout (where applicable). Driver options **list**, **lookup**,
+**store**, and **delete** serve to install the scripts:
+
+```
+[secrets]
+driver = "shell"
+
+[secrets.opts]
+list =
+lookup =
+store =
+delete =
+```
 
 ## EXAMPLES
 


### PR DESCRIPTION
Closes #18387

#### Does this PR introduce a user-facing change?

Yes (minor text changes in `./bin/podman secret create --help` and `man podman-secret-create`, so release note may not be required after all)