### PR TITLE
[CI:DOCS] podmansh man page UID=3267 is not allowed

### DIFF
--- a/docs/source/markdown/podmansh.1.md
+++ b/docs/source/markdown/podmansh.1.md
@@ -34,9 +34,9 @@ Create a Podman Quadlet file that looks something like one of the following.
 Fully locked down container, no access to host OS.
 
 ```
-# UID=$(id -u lockedu)
-# mkdir -p /etc/containers/systemd/users/${UID}
-# cat > /etc/containers/systemd/users/${UID}/podmansh.container << _EOF
+# USERID=$(id -u lockedu)
+# mkdir -p /etc/containers/systemd/users/${USERID}
+# cat > /etc/containers/systemd/users/${USERID}/podmansh.container << _EOF
 [Unit]
 Description=The podmansh container
 After=local-fs.target
@@ -62,9 +62,9 @@ Alternatively, while running as root, create a Quadlet where the user is allowed
 # useradd -s /usr/bin/podmansh confinedu
 # grep confinedu /etc/passwd
 confinedu:x:4009:4009::/home/confinedu:/usr/bin/podmansh
-# UID=$(id -u confinedu)
-# mkdir -p /etc/containers/systemd/users/${UID}
-# cat > /etc/containers/systemd/users/${UID}/podmansh.container << _EOF
+# USERID=$(id -u confinedu)
+# mkdir -p /etc/containers/systemd/users/${USERID}
+# cat > /etc/containers/systemd/users/${USERID}/podmansh.container << _EOF
 [Unit]
 Description=The podmansh container
 After=local-fs.target
@@ -93,9 +93,9 @@ Another example, while running as root, create a Quadlet where the users inside 
 # useradd -s /usr/bin/podmansh fullu
 # grep fullu /etc/passwd
 fullu:x:4010:4010::/home/fullu:/usr/bin/podmansh
-# UID=$(id -u fullu)
-# mkdir -p /etc/containers/systemd/users/${UID}
-# cat > /etc/containers/systemd/users/${UID}/podmansh.container << _EOF
+# USERID=$(id -u fullu)
+# mkdir -p /etc/containers/systemd/users/${USERID}
+# cat > /etc/containers/systemd/users/${USERID}/podmansh.container << _EOF
 [Unit]
 Description=The podmansh container
 After=local-fs.target


### PR DESCRIPTION
Switch man page to user USERID instead of UID, since UID environment variable is set at login, and is not allowed to be changed.

UID=foobar
bash: UID: readonly variable

Fixes: https://github.com/containers/podman/issues/19646

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
