### PR TITLE
CI: systests: remove pasta ICMP tests

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -758,37 +758,6 @@ function teardown() {
     pasta_test_do
 }
 
-### ICMP, ICMPv6 ###############################################################
-
-@test "podman networking with pasta(1) - ICMP echo request" {
-    skip_if_no_ipv4 "IPv6 not routable on the host"
-
-    local minuid=$(cut -f1 /proc/sys/net/ipv4/ping_group_range)
-    local maxuid=$(cut -f2 /proc/sys/net/ipv4/ping_group_range)
-
-    if [ $(id -u) -lt ${minuid} ] || [ $(id -u) -gt ${maxuid} ]; then
-        skip "ICMP echo sockets not available for this UID"
-    fi
-
-    run_podman run --net=pasta $IMAGE \
-        sh -c 'ping -c3 -W1 $(sed -nr "s/^nameserver[ ]{1,}([^.]*).(.*)/\1.\2/p" /etc/resolv.conf | head -1)'
-}
-
-@test "podman networking with pasta(1) - ICMPv6 echo request" {
-    skip "Unsupported test, see the 'Local forwarder, IPv6' case for details"
-    skip_if_no_ipv6 "IPv6 not routable on the host"
-
-    local minuid=$(cut -f1 /proc/sys/net/ipv4/ping_group_range)
-    local maxuid=$(cut -f2 /proc/sys/net/ipv4/ping_group_range)
-
-    if [ $(id -u) -lt ${minuid} ] || [ $(id -u) -gt ${maxuid} ]; then
-        skip "ICMPv6 echo sockets not available for this UID"
-    fi
-
-    run_podman run --net=pasta $IMAGE \
-        sh -c 'ping -c3 -W1 $(sed -nr "s/^nameserver[ ]{1,}([^:]*):(.*)/\1:\2/p" /etc/resolv.conf | head -1)'
-}
-
 ### Lifecycle ##################################################################
 
 @test "podman networking with pasta(1) - pasta(1) quits when the namespace is gone" {


### PR DESCRIPTION
IPv6 test has been hard-skipped for six months.

IPv4 test is flaking in Cirrus and hard-failing in Gating.

Absent a reliable way to test in CI and gating, and absent
a strong reason to test ICMP in pasta anyway, the solution
is simple.

Closes: #19612

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```