### PR TITLE
libpod: use /var/run instead of /run on FreeBSD

### DIFF
--- a/docs/source/markdown/options/secret.md
+++ b/docs/source/markdown/options/secret.md
@@ -26,7 +26,9 @@ Secret Options
 - `target=target`     : Target of secret.
                         For mounted secrets, this is the path to the secret inside the container.
                         If a fully qualified path is provided, the secret is mounted at that location.
-                        Otherwise, the secret is mounted to `/run/secrets/target`.
+                        Otherwise, the secret is mounted to
+                        `/run/secrets/target` for linux containers or
+                        `/var/run/secrets/target` for freebsd containers.
                         If the target is not set, the secret is mounted to `/run/secrets/secretname` by default.
                         For env secrets, this is the environment variable key. Defaults to `secretname`.
 - `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -28,7 +28,8 @@ These will be based on the host's version of the files, though they can be
 customized with options (for example, **--dns** will override the host's DNS
 servers in the created _resolv.conf_). Additionally, a container environment
 file is created in each container to indicate to programs they are running in a
-container. This file is located at _/run/.containerenv_. When using the
+container. This file is located at _/run/.containerenv_ (or
+_/var/run/.containerenv_ for FreeBSD containers). When using the
 --privileged flag the .containerenv contains name/value pairs indicating the
 container engine version, whether the engine is running in rootless mode, the
 container name and ID, as well as the image name and ID that the container is based on. Note: _/run/.containerenv_ will not be created when a volume is mounted on /run.

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -365,3 +365,23 @@ func (c *Container) makePlatformMtabLink(etcInTheContainerFd, rootUID, rootGID i
 	// /etc/mtab does not exist on FreeBSD
 	return nil
 }
+
+func (c *Container) getPlatformRunPath() (string, error) {
+	// If we have a linux image, use "/run", otherwise use "/var/run" for
+	// consistency with FreeBSD path conventions.
+	runPath := "/var/run"
+	if c.config.RootfsImageID != "" {
+		image, _, err := c.runtime.libimageRuntime.LookupImage(c.config.RootfsImageID, nil)
+		if err != nil {
+			return "", err
+		}
+		inspectData, err := image.Inspect(nil, nil)
+		if err != nil {
+			return "", err
+		}
+		if inspectData.Os == "linux" {
+			runPath = "/run"
+		}
+	}
+	return runPath, nil
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -801,3 +801,7 @@ func (c *Container) makePlatformMtabLink(etcInTheContainerFd, rootUID, rootGID i
 	}
 	return nil
 }
+
+func (c *Container) getPlatformRunPath() (string, error) {
+	return "/run", nil
+}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -424,6 +424,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		g.RemoveMount("/etc/hosts")
 		g.RemoveMount("/run/.containerenv")
 		g.RemoveMount("/run/secrets")
+		g.RemoveMount("/var/run/.containerenv")
+		g.RemoveMount("/var/run/secrets")
 
 		// Regenerate Cgroup paths so they don't point to the old
 		// container ID.

--- a/pkg/specgen/generate/storage_freebsd.go
+++ b/pkg/specgen/generate/storage_freebsd.go
@@ -1,0 +1,22 @@
+package generate
+
+import (
+	"context"
+
+	"github.com/containers/common/libimage"
+)
+
+func imageRunPath(ctx context.Context, img *libimage.Image) (string, error) {
+	if img != nil {
+		inspectData, err := img.Inspect(ctx, nil)
+		if err != nil {
+			return "", err
+		}
+		if inspectData.Os == "freebsd" {
+			return "/var/run", nil
+		}
+		return "/run", nil
+	} else {
+		return "/var/run", nil
+	}
+}

--- a/pkg/specgen/generate/storage_linux.go
+++ b/pkg/specgen/generate/storage_linux.go
@@ -1,0 +1,11 @@
+package generate
+
+import (
+	"context"
+
+	"github.com/containers/common/libimage"
+)
+
+func imageRunPath(ctx context.Context, img *libimage.Image) (string, error) {
+	return "/run", nil
+}


### PR DESCRIPTION
This changes /run to /var/run for .containerenv and secrets in FreeBSD containers for consistency with FreeBSD path conventions. Running Linux containers on FreeBSD hosts continue to use /run for compatibility.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
