### PR TITLE
Add support for ramfs as well as tmpfs in volume mounts

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -6,25 +6,28 @@
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **tmpfs** and **volume**. <sup>[[1]](#Footnote1)</sup>
+Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **ramfs**, **tmpfs** and **volume**. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
-
        type=bind,source=/path/on/host,destination=/path/in/container
 
        type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
 
        type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
 
+       type=devpts,destination=/dev/pts
+
        type=glob,src=/usr/lib/libfoo*,destination=/usr/lib,ro=true
-
-       type=volume,source=vol1,destination=/path/in/container,ro=true
-
-       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
 
        type=image,source=fedora,destination=/fedora-image,rw=true
 
-       type=devpts,destination=/dev/pts
+       type=ramfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=tmpfs,destination=/path/in/container,noswap
+
+       type=volume,source=vol1,destination=/path/in/container,ro=true
 
        Common Options:
 
@@ -72,17 +75,17 @@ Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **t
 
 	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
-       Options specific to tmpfs:
+       Options specific to tmpfs and ramfs:
 
 	      · ro, readonly: true or false (default).
 
-	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+	      · tmpfs-size: Size of the tmpfs/ramfs mount in bytes. Unlimited by default in Linux.
 
-	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
+	      · tmpfs-mode: File mode of the tmpfs/ramfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
 
-	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
+	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs/ramfs. Used by default.
 
-	      · notmpcopyup: Disable copying files from the image to the tmpfs.
+	      · notmpcopyup: Disable copying files from the image to the tmpfs/ramfs.
 
 	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 

--- a/libpod/define/mount.go
+++ b/libpod/define/mount.go
@@ -1,10 +1,12 @@
 package define
 
 const (
-	// TypeVolume is the type for named volumes
-	TypeVolume = "volume"
-	// TypeTmpfs is the type for mounting tmpfs
-	TypeTmpfs = "tmpfs"
 	// TypeDevpts is the type for creating a devpts
 	TypeDevpts = "devpts"
+	// TypeTmpfs is the type for mounting tmpfs
+	TypeTmpfs = "tmpfs"
+	// TypeRamfs is the type for mounting ramfs
+	TypeRamfs = "ramfs"
+	// TypeVolume is the type for named volumes
+	TypeVolume = "volume"
 )

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -294,4 +294,18 @@ EOF
     is "$output" "bar1.*bar2.*bar3" "Should match multiple source files on single destination directory"
 }
 
+@test "podman mount noswap memory mounts" {
+    # if volumes source and dest match then pass
+    run_podman run --rm --mount type=ramfs,destination=${PODMAN_TMPDIR} $IMAGE stat -f -c "%T" ${PODMAN_TMPDIR}
+    is "$output" "ramfs" "ramfs mounted"
+
+    if is_rootless; then
+        run_podman 125 run --rm --mount type=tmpfs,destination=${PODMAN_TMPDIR},noswap  $IMAGE stat -f -c "%T" ${PODMAN_TMPDIR}
+        is "$output" "Error: the 'noswap' option is only allowed with rootful tmpfs mounts: must provide an argument for option" "noswap not supported in rootless mode"
+    else
+        run_podman run --rm --mount type=tmpfs,destination=${PODMAN_TMPDIR},noswap  $IMAGE sh -c "mount| grep ${PODMAN_TMPDIR}"
+        is "$output" ".*noswap" "tmpfs noswap mounted"
+    fi
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Users want to mount a tmpfs file system with secrets, and make
sure the secret is never saved into swap. They can do this either
by using a ramfs tmpfs mount or by passing `noswap` option to
a tmpfs mount.

Fixes: https://github.com/containers/podman/issues/19659

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman run and create --mount now support the `ramfs` type.
```
