### PR TITLE
[CI:BUILD] rpm: depend on man-db

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -114,6 +114,7 @@ BuildRequires: libselinux-devel
 BuildRequires: shadow-utils-subid-devel
 BuildRequires: pkgconfig
 BuildRequires: make
+BuildRequires: man-db
 BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel


### PR DESCRIPTION
Include dependencies in rpm/podman.spec to make it easy for end users to build podman from source. This way users can install all build dependencies by running `dnf -y builddep rpm/podman.spec`.

This is not usually noticeable except on container environments where man-db often isn't installed by default.

Refs:
https://github.com/containers/podman.io/issues/157
https://github.com/containers/podman.io/pull/174

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
