### PR TITLE
use container restart policy if user specifies one

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -588,7 +588,7 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		retries       uint
 	)
 	// If the container is running in a pod, use the pod's restart policy for all the containers
-	if pod != nil && !s.IsInitContainer() {
+	if pod != nil && !s.IsInitContainer() && s.RestartPolicy == "" {
 		podConfig := pod.ConfigNoCopy()
 		if podConfig.RestartRetries != nil {
 			retries = *podConfig.RestartRetries


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/19671

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If restart policy is specified for container in a pod, then use it rather then the pods restart policy.
```
