### PR TITLE
Validate current generation of WSL2 with user-mode-networking

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -338,6 +338,12 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	v.Rootful = opts.Rootful
 	v.Version = currentMachineVersion
 
+	if v.UserModeNetworking {
+		if err := verifyWSLUserModeCompat(); err != nil {
+			return false, err
+		}
+	}
+
 	if err := downloadDistro(v, opts); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
User-mode networking requires the current generation of WSL 2

Fail with a helpful message when an older version of WSL2 is installed and user-mode-networking is enabled.

```release-note
Detect and error with upgrade guidance when enabling user-mode-networking on an older WSL2 generation
```
