### PR TITLE
[skip-ci] Lock closed issues and PRs

### DIFF
--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -32,7 +32,7 @@ env:
   # Number of days befor a closed issue/PR is be comment-locked.
   # Note: dessant/lock-threads will only process a max. of
   # 50 issues/PRs at a time.
-  CLOSED_DAYS: 90
+  CLOSED_DAYS: 1825
   # Pre-created issue/PR label to add (preferrably a bright color).
   # This is intended to direct a would-be commenter's actions.
   LOCKED_LABEL: 'locked - please file new issue/PR'
@@ -54,6 +54,10 @@ jobs:
           add-pr-labels: '${{env.LOCKED_LABEL}}'
           pr-lock-reason: 'resolved'
           log-output: true
+      # Test the failure-notification step functions on failure
+      - run: |
+          echo "::warning::Initiating job test-failure to prompt a human to verify this is working and some issues/PRs were locked."
+          false
       - if: failure()
         name: Send job failure notification e-mail
         uses: dawidd6/action-send-mail@v3.8.0
@@ -65,4 +69,7 @@ jobs:
           subject: Github workflow error on ${{github.repository}}
           to: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
           from: ${{secrets.ACTION_MAIL_SENDER}}
-          body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+          body: |
+            Job test-failed - https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+            Please verify some issues/PRs were locked, then revert the commit which added this check.

--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -1,0 +1,68 @@
+---
+
+# Format ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: "Lock closed Issue/PR discussions"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  # Allow re-use of this workflow by other repositories
+  # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call:
+    secrets:
+      ACTION_MAIL_SERVER:
+        required: true
+      ACTION_MAIL_USERNAME:
+        required: true
+      ACTION_MAIL_PASSWORD:
+        required: true
+      ACTION_MAIL_SENDER:
+        required: true
+  # Debug: Allow triggering job manually in github-actions WebUI
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lock
+
+env:
+  # Number of days befor a closed issue/PR is be comment-locked.
+  # Note: dessant/lock-threads will only process a max. of
+  # 50 issues/PRs at a time.
+  CLOSED_DAYS: 90
+  # Pre-created issue/PR label to add (preferrably a bright color).
+  # This is intended to direct a would-be commenter's actions.
+  LOCKED_LABEL: 'locked - please file new issue/PR'
+
+jobs:
+  closed_issue_discussion_lock:
+    name: "Lock closed Issue/PR discussions"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # Ref: https://github.com/dessant/lock-threads#usage
+      - uses: dessant/lock-threads@v4
+        with:
+          issue-inactive-days: '${{env.CLOSED_DAYS}}'
+          pr-inactive-days: '${{env.CLOSED_DAYS}}'
+          add-issue-labels: '${{env.LOCKED_LABEL}}'
+          add-pr-labels: '${{env.LOCKED_LABEL}}'
+          pr-lock-reason: 'resolved'
+          log-output: true
+      - if: failure()
+        name: Send job failure notification e-mail
+        uses: dawidd6/action-send-mail@v3.8.0
+        with:
+          server_address: ${{secrets.ACTION_MAIL_SERVER}}
+          server_port: 465
+          username: ${{secrets.ACTION_MAIL_USERNAME}}
+          password: ${{secrets.ACTION_MAIL_PASSWORD}}
+          subject: Github workflow error on ${{github.repository}}
+          to: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
+          from: ${{secrets.ACTION_MAIL_SENDER}}
+          body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,9 @@ to see if someone else has already reported it. If so, feel free to add
 your scenario, or additional information, to the discussion. Or simply
 "subscribe" to it to be notified when it is updated.
 
+Note: Older closed issues/PRs are automatically locked, if you have a similar
+problem please open a new issue instead of commenting.
+
 If you find a new issue with the project we'd love to hear about it! The most
 important aspect of a bug report is that it includes enough information for
 us to reproduce it. To make this easier, there are three types of issue


### PR DESCRIPTION
Lock closed issues and PRs after a reasonable amount of time to prevent spamming engineers with irreverent notifications.  Should the workflow fail for some reason, notify the podman-monitor mailing list.

N/B: This PR includes a commit intended to help confirm this workflow functions w/o affecting potentially thousands of issues/PRs.  It's intended to be reverted by a future PR.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
