### PR TITLE
[CI:DOCS] Revert "GHA: Closed issue/PR comment-lock test"

### DIFF
--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -32,7 +32,7 @@ env:
   # Number of days befor a closed issue/PR is be comment-locked.
   # Note: dessant/lock-threads will only process a max. of
   # 50 issues/PRs at a time.
-  CLOSED_DAYS: 1825
+  CLOSED_DAYS: 90
   # Pre-created issue/PR label to add (preferrably a bright color).
   # This is intended to direct a would-be commenter's actions.
   LOCKED_LABEL: 'locked - please file new issue/PR'
@@ -54,10 +54,6 @@ jobs:
           add-pr-labels: '${{env.LOCKED_LABEL}}'
           pr-lock-reason: 'resolved'
           log-output: true
-      # Test the failure-notification step functions on failure
-      - run: |
-          echo "::warning::Initiating job test-failure to prompt a human to verify this is working and some issues/PRs were locked."
-          false
       - if: failure()
         name: Send job failure notification e-mail
         uses: dawidd6/action-send-mail@v3.8.0
@@ -69,7 +65,4 @@ jobs:
           subject: Github workflow error on ${{github.repository}}
           to: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
           from: ${{secrets.ACTION_MAIL_SENDER}}
-          body: |
-            Job test-failed - https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-
-            Please verify some issues/PRs were locked, then revert the commit which added this check.
+          body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
This is intentional, it was needed for testing.  See 
https://github.com/containers/podman/pull/19691

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
