### PR TITLE
Fixups for stopping gvproxy

### DIFF
--- a/pkg/machine/gvproxy_unix.go
+++ b/pkg/machine/gvproxy_unix.go
@@ -1,0 +1,24 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package machine
+
+import (
+	"os"
+	"syscall"
+)
+
+func findProcess(pid int) (*os.Process, error) {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, err
+	}
+	// On unix, findprocess will always return a process even
+	// if the process is not found.  you must send a 0 signal
+	// to the process to see if it is alive.
+	// https://pkg.go.dev/os#FindProcess
+	if err := p.Signal(syscall.Signal(0)); err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/pkg/machine/gvproxy_windows.go
+++ b/pkg/machine/gvproxy_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package machine
+
+import "os"
+
+func findProcess(pid int) (*os.Process, error) {
+	return os.FindProcess(pid)
+}


### PR DESCRIPTION
Paul found logic errors in my earlier code for finding processes and sending signals.  Some of the logic errors are associated with how methods behave on different operating systems.  Created a darwin and linux approach and a windows approach.

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
