### PR TITLE
Set StopTimeout for compat API if not set by client

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -435,6 +435,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		Rm:                cc.HostConfig.AutoRemove,
 		SecurityOpt:       cc.HostConfig.SecurityOpt,
 		StopSignal:        cc.Config.StopSignal,
+		StopTimeout:       rtc.Engine.StopTimeout, // podman default
 		StorageOpts:       stringMaptoArray(cc.HostConfig.StorageOpt),
 		Sysctl:            stringMaptoArray(cc.HostConfig.Sysctls),
 		Systemd:           "true", // podman default

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -65,6 +65,10 @@ func (ic *ContainerEngine) createServiceContainer(ctx context.Context, name stri
 		return nil, fmt.Errorf("image for service container: %w", err)
 	}
 
+	rtc, err := ic.Libpod.GetConfigNoCopy()
+	if err != nil {
+		return nil, err
+	}
 	ctrOpts := entities.ContainerCreateOptions{
 		// Inherited from infra containers
 		ImageVolume:      define.TypeBind,
@@ -73,7 +77,8 @@ func (ic *ContainerEngine) createServiceContainer(ctx context.Context, name stri
 		ReadOnly:         true,
 		ReadWriteTmpFS:   false,
 		// No need to spin up slirp etc.
-		Net: &entities.NetOptions{Network: specgen.Namespace{NSMode: specgen.NoNetwork}},
+		Net:         &entities.NetOptions{Network: specgen.Namespace{NSMode: specgen.NoNetwork}},
+		StopTimeout: rtc.Engine.StopTimeout,
 	}
 
 	// Create and fill out the runtime spec.

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -308,7 +308,7 @@ cid_top=$(jq -r '.Id' <<<"$output")
 t GET containers/${cid_top}/json 200 \
   .Config.Entrypoint[0]="top" \
   .Config.Cmd='[]' \
-  .Config.StopTimeput="10" \
+  .Config.StopTimeout="10" \
   .Path="top" \
   .NetworkSettings.Networks.podman.NetworkID=podman
 t POST  containers/${cid_top}/start 204

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -308,6 +308,7 @@ cid_top=$(jq -r '.Id' <<<"$output")
 t GET containers/${cid_top}/json 200 \
   .Config.Entrypoint[0]="top" \
   .Config.Cmd='[]' \
+  .Config.StopTimeput="10" \
   .Path="top" \
   .NetworkSettings.Networks.podman.NetworkID=podman
 t POST  containers/${cid_top}/start 204

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -206,6 +206,9 @@ EOF
     run_podman container inspect $service_container --format "{{.State.Running}}"
     is "$output" "true"
 
+    run_podman container inspect $service_container --format '{{.Config.StopTimeout}}'
+    is "$output" "10" "StopTimeout should be initialized to 10"
+
     # Stop the *main* container and make sure that
     #  1) The pod transitions to Exited
     #  2) The service container is stopped


### PR DESCRIPTION
Currently containers created via DOCKER API without specifying
StopTimeout are defaulting to 0 seconds. This change should
default them to setting in containers.conf normally 10 seconds.

Fixes: https://github.com/containers/podman/issues/19139

Set StopTimeout for service-container started under podman kube play

Fixes: https://github.com/containers/podman/issues/19139

Service containers are defaulting to 0 seconds for Timeout rather then
the settings in containers.conf.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Containers created via compat API default to 10 seconds or containers.conf setting.
```
