### PR TITLE
Share podman sock bindings with other WSL distros

### DIFF
--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -187,6 +187,10 @@ func (v *MachineVM) launchUserModeNetDist(exeFile string) error {
 }
 
 func installUserModeDist(dist string, imagePath string) error {
+	if err := verifyWSLUserModeCompat(); err != nil {
+		return err
+	}
+
 	exists, err := isWSLExist(userModeDist)
 	if err != nil {
 		return err
@@ -315,10 +319,6 @@ func (v *MachineVM) obtainUserModeNetLock() (*fileLock, error) {
 }
 
 func changeDistUserModeNetworking(dist string, user string, image string, enable bool) error {
-	if err := verifyWSLUserModeCompat(); err != nil {
-		return err
-	}
-
 	// Only install if user-mode is being enabled and there was an image path passed
 	if enable && len(image) > 0 {
 		if err := installUserModeDist(dist, image); err != nil {


### PR DESCRIPTION
Resolves #15190

Registers a rootless and rootful socket underneath /mnt/wsl/podman-sockets/[machine name]/ This allows podman remote clients on other Linux distributions to access podman.

This also registers the podman root socket under the wheel group, to allow for rootful linking against /var/run/docker.sock, a use case expected by some clients and APIs. While this is not recommended practice on a Linux host, a WSL guest is user-isolated and already enables escalation trivially.

```release-note
Registers shared socket bindings on Windows, to allow other WSL distributions easy remote access
```
