### PR TITLE
[CI:DOCS] hack/perf/system-df.sh: add `df` benchmarks

### DIFF
--- a/hack/perf/system-df.sh
+++ b/hack/perf/system-df.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+source ./helpers.bash
+
+setup
+echo_bold "List $NUM_CONTAINERS created containers"
+create_containers
+hyperfine --warmup 10 --runs $RUNS \
+	"$ENGINE_A system df" \
+	"$ENGINE_B system df"
+
+# Clean up
+$ENGINE_A system prune -f >> /dev/null
+$ENGINE_B system prune -f >> /dev/null


### PR DESCRIPTION
The performance issue in #19467 drove me to add a benchmark for system-df to avoid regressing on it in the future.

Comparing current HEAD to v4.6.0 yields

```
/home/vrothberg/containers/podman/bin/podman system df ran
201.47 times faster than /usr/bin/podman system df
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
