### PR TITLE
podman exec should set umask to match container

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -477,11 +477,10 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	}
 
 	if c.config.Umask != "" {
-		decVal, err := strconv.ParseUint(c.config.Umask, 8, 32)
+		umask, err := c.umask()
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid Umask Value: %w", err)
+			return nil, nil, err
 		}
-		umask := uint32(decVal)
 		g.Config.Process.User.Umask = &umask
 	}
 
@@ -2930,4 +2929,12 @@ func (c *Container) ChangeHostPathOwnership(src string, recurse bool, uid, gid i
 		}
 	}
 	return chown.ChangeHostPathOwnership(src, recurse, uid, gid)
+}
+
+func (c *Container) umask() (uint32, error) {
+	decVal, err := strconv.ParseUint(c.config.Umask, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid Umask Value: %w", err)
+	}
+	return uint32(decVal), nil
 }

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -743,6 +743,14 @@ func (c *Container) prepareProcessExec(options *ExecOptions, env []string, sessi
 		pspec.User = processUser
 	}
 
+	if c.config.Umask != "" {
+		umask, err := c.umask()
+		if err != nil {
+			return nil, err
+		}
+		pspec.User.Umask = &umask
+	}
+
 	if err := c.setProcessCapabilitiesExec(options, user, execUser, pspec); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/19713

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman exec has the same umask as the container it is execing into.
```
