### PR TITLE
[WIP] [CI:BUILD] Update CI VM images w/ newer automation-library + enable multi-arch image build debugging

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20230816t191118z-f38f37d13"
+    IMAGE_SUFFIX: "c20230823t185555z-f38f37d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -962,6 +962,7 @@ image_build_task: &image-build
             CTXDIR: contrib/podmanimage/testing
         - env:
             CTXDIR: contrib/podmanimage/stable
+            A_DEBUG: 1
     env:
         DISTRO_NV: "${FEDORA_NAME}"  # Required for repo cache extraction
         PODMAN_USERNAME: ENCRYPTED[b9f0f2550029dd2196e086d9dd6c2d1fec7e328630b15990d9bb610f9fcccb5baab8b64a8c3e72b0c1d0f5917cf65aa1]

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -101,9 +101,6 @@ PASSTHROUGH_ENV_ATSTART='CI|LANG|LC_|TEST'
 # List of envariable patterns which can match ANYWHERE in the name
 PASSTHROUGH_ENV_ANYWHERE='_NAME|_FQIN'
 
-# Combine into one
-PASSTHROUGH_ENV_RE="(^($PASSTHROUGH_ENV_EXACT)\$)|(^($PASSTHROUGH_ENV_ATSTART))|($PASSTHROUGH_ENV_ANYWHERE)"
-
 # Unsafe env. vars for display
 SECRET_ENV_RE='ACCOUNT|GC[EP]..|SSH|PASSWORD|SECRET|TOKEN'
 
@@ -118,20 +115,6 @@ set +a
 
 lilto() { err_retry 8 1000 "" "$@"; }  # just over 4 minutes max
 bigto() { err_retry 7 5670 "" "$@"; }  # 12 minutes max
-
-# Return a list of environment variables that should be passed through
-# to lower levels (tests in containers, or via ssh to rootless).
-# We return the variable names only, not their values. It is up to our
-# caller to reference values.
-passthrough_envars(){
-    local envname
-    warn "Will pass env. vars. matching the following regex:
-    $PASSTHROUGH_ENV_RE"
-    compgen -A variable | \
-        grep -Ev "SETUP_ENVIRONMENT" | \
-        grep -Ev "$SECRET_ENV_RE" | \
-        grep -E  "$PASSTHROUGH_ENV_RE"
-}
 
 setup_rootless() {
     req_env_vars GOPATH GOSRC SECRET_ENV_RE


### PR DESCRIPTION
***DO NOT MERGE: Debugging in progress***

---

The `v4.3.1` version of the library defines a common `passthrough_envars()` so it doesn't need to be duplicated in podman and buildah CI.  It also includes an update to build-push which should make debugging easier...

---

[A jq error has been plaguing all flavors of all multi-arch image builds](https://cirrus-ci.com/task/5720208665477120?logs=main#L2543) on podman, buildah, and skopeo:

```
jq: error (at <stdin>:29): Cannot iterate over null (null)
```

Unfortunately the issue does not reproduce locally nor in test-builds. Several script changes included in the most recent CI VM images are intended to help debug this.  Enable the debug option on one build to provide (hopefully) helpful clues as to what's going wrong.

#### Does this PR introduce a user-facing change?

```release-note
None
```