### PR TITLE
Implement gvproxy networking using cmdline wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/containers/buildah v1.32.0
 	github.com/containers/common v0.56.1-0.20230919073449-d1d9d38d8282
 	github.com/containers/conmon v2.0.20+incompatible
+	github.com/containers/gvisor-tap-vsock v0.7.1-0.20230907154503-507f56851e8b
 	github.com/containers/image/v5 v5.28.0
 	github.com/containers/libhvee v0.4.1-0.20230905135638-56fb23533417
 	github.com/containers/ocicrypt v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.28.0 h1:H4cWbdI88UA/mDb6SxMo3IxpmS1BSs/Kifvhwt9g048=
 github.com/containers/image/v5 v5.28.0/go.mod h1:9aPnNkwHNHgGl9VlQxXEshvmOJRbdRAc1rNDD6sP2eU=
+github.com/containers/gvisor-tap-vsock v0.7.1-0.20230907154503-507f56851e8b h1:1nH+VNnclNbAXwcsK2MkLT3gFWfbxasQOPBkj1DUmCI=
+github.com/containers/gvisor-tap-vsock v0.7.1-0.20230907154503-507f56851e8b/go.mod h1:n7xPNoTHhif+K4S9zZMUmBNUvt5tcLfkHlQHreTLomM=
 github.com/containers/libhvee v0.4.1-0.20230905135638-56fb23533417 h1:fr+j21PD+IYR6Kvlf2Zrm1x9oAjV12T2Vz3oZIGTusw=
 github.com/containers/libhvee v0.4.1-0.20230905135638-56fb23533417/go.mod h1:HiXu8GZyjzGjU834fROO00Ka/4B1IM8qxy/6q6x1f+4=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/github.com/containers/gvisor-tap-vsock/LICENSE
+++ b/vendor/github.com/containers/gvisor-tap-vsock/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/configuration.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/configuration.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"net"
+	"regexp"
+)
+
+type Configuration struct {
+	// Print packets on stderr
+	Debug bool
+
+	// Record all packets coming in and out in a file that can be read by Wireshark (pcap)
+	CaptureFile string
+
+	// Length of packet
+	// Larger packets means less packets to exchange for the same amount of data (and less protocol overhead)
+	MTU int
+
+	// Network reserved for the virtual network
+	Subnet string
+
+	// IP address of the virtual gateway
+	GatewayIP string
+
+	// MAC address of the virtual gateway
+	GatewayMacAddress string
+
+	// Built-in DNS records that will be served by the DNS server embedded in the gateway
+	DNS []Zone
+
+	// List of search domains that will be added in all DHCP replies
+	DNSSearchDomains []string
+
+	// Port forwarding between the machine running the gateway and the virtual network.
+	Forwards map[string]string
+
+	// Address translation of incoming traffic.
+	// Useful for reaching the host itself (localhost) from the virtual network.
+	NAT map[string]string
+
+	// IPs assigned to the gateway that can answer to ARP requests
+	GatewayVirtualIPs []string
+
+	// DHCP static leases. Allow to assign pre-defined IP to virtual machine based on the MAC address
+	DHCPStaticLeases map[string]string
+
+	// Only for Hyperkit
+	// Allow to assign a pre-defined MAC address to an Hyperkit VM
+	VpnKitUUIDMacAddresses map[string]string
+
+	// Protocol to be used. Only for /connect mux
+	Protocol Protocol
+}
+
+type Protocol string
+
+const (
+	// HyperKitProtocol is handshake, then 16bits little endian size of packet, then the packet.
+	HyperKitProtocol Protocol = "hyperkit"
+	// QemuProtocol is 32bits big endian size of the packet, then the packet.
+	QemuProtocol Protocol = "qemu"
+	// BessProtocol transfers bare L2 packets as SOCK_SEQPACKET.
+	BessProtocol Protocol = "bess"
+	// StdioProtocol is HyperKitProtocol without the handshake
+	StdioProtocol Protocol = "stdio"
+	// VfkitProtocol transfers bare L2 packets as SOCK_DGRAM.
+	VfkitProtocol Protocol = "vfkit"
+)
+
+type Zone struct {
+	Name      string
+	Records   []Record
+	DefaultIP net.IP
+}
+
+type Record struct {
+	Name   string
+	IP     net.IP
+	Regexp *regexp.Regexp
+}

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/gvproxy_command.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/gvproxy_command.go
@@ -1,0 +1,189 @@
+package types
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+type GvproxyCommand struct {
+	// Print packets on stderr
+	Debug bool
+
+	// Length of packet
+	// Larger packets means less packets to exchange for the same amount of data (and less protocol overhead)
+	MTU int
+
+	// Values passed in by forward-xxx flags in commandline (forward-xxx:info)
+	forwardInfo map[string][]string
+
+	// List of endpoints the user wants to listen to
+	endpoints []string
+
+	// Map of different sockets provided by user (socket-type flag:socket)
+	sockets map[string]string
+
+	// File where gvproxy's pid is stored
+	PidFile string
+
+	// SSHPort to access the guest VM
+	SSHPort int
+}
+
+func NewGvproxyCommand() GvproxyCommand {
+	return GvproxyCommand{
+		MTU:         1500,
+		SSHPort:     2222,
+		endpoints:   []string{},
+		forwardInfo: map[string][]string{},
+		sockets:     map[string]string{},
+	}
+}
+
+func (c *GvproxyCommand) checkSocketsInitialized() {
+	if len(c.sockets) < 1 {
+		c.sockets = map[string]string{}
+	}
+}
+
+func (c *GvproxyCommand) checkForwardInfoInitialized() {
+	if len(c.forwardInfo) < 1 {
+		c.forwardInfo = map[string][]string{}
+	}
+}
+
+func (c *GvproxyCommand) AddEndpoint(endpoint string) {
+	if len(c.endpoints) < 1 {
+		c.endpoints = []string{}
+	}
+
+	c.endpoints = append(c.endpoints, endpoint)
+}
+
+func (c *GvproxyCommand) AddVpnkitSocket(socket string) {
+	c.checkSocketsInitialized()
+	c.sockets["listen-vpnkit"] = socket
+}
+
+func (c *GvproxyCommand) AddQemuSocket(socket string) {
+	c.checkSocketsInitialized()
+	c.sockets["listen-qemu"] = socket
+}
+
+func (c *GvproxyCommand) AddBessSocket(socket string) {
+	c.checkSocketsInitialized()
+	c.sockets["listen-bess"] = socket
+}
+
+func (c *GvproxyCommand) AddStdioSocket(socket string) {
+	c.checkSocketsInitialized()
+	c.sockets["listen-stdio"] = socket
+}
+
+func (c *GvproxyCommand) AddVfkitSocket(socket string) {
+	c.checkSocketsInitialized()
+	c.sockets["listen-vfkit"] = socket
+}
+
+func (c *GvproxyCommand) addForwardInfo(flag, value string) {
+	c.forwardInfo[flag] = append(c.forwardInfo[flag], value)
+}
+
+func (c *GvproxyCommand) AddForwardSock(socket string) {
+	c.checkForwardInfoInitialized()
+	c.addForwardInfo("forward-sock", socket)
+}
+
+func (c *GvproxyCommand) AddForwardDest(dest string) {
+	c.checkForwardInfoInitialized()
+	c.addForwardInfo("forward-dest", dest)
+}
+
+func (c *GvproxyCommand) AddForwardUser(user string) {
+	c.checkForwardInfoInitialized()
+	c.addForwardInfo("forward-user", user)
+}
+
+func (c *GvproxyCommand) AddForwardIdentity(identity string) {
+	c.checkForwardInfoInitialized()
+	c.addForwardInfo("forward-identity", identity)
+}
+
+// socketsToCmdline converts Command.sockets to a commandline format
+func (c *GvproxyCommand) socketsToCmdline() []string {
+	args := []string{}
+
+	for socketFlag, socket := range c.sockets {
+		if socket != "" {
+			args = append(args, "-"+socketFlag, socket)
+		}
+	}
+
+	return args
+}
+
+// forwardInfoToCmdline converts Command.forwardInfo to a commandline format
+func (c *GvproxyCommand) forwardInfoToCmdline() []string {
+	args := []string{}
+
+	for forwardInfoFlag, forwardInfo := range c.forwardInfo {
+		for _, i := range forwardInfo {
+			if i != "" {
+				args = append(args, "-"+forwardInfoFlag, i)
+			}
+		}
+	}
+
+	return args
+}
+
+// endpointsToCmdline converts Command.endpoints to a commandline format
+func (c *GvproxyCommand) endpointsToCmdline() []string {
+	args := []string{}
+
+	for _, endpoint := range c.endpoints {
+		if endpoint != "" {
+			args = append(args, "-listen", endpoint)
+		}
+	}
+
+	return args
+}
+
+// ToCmdline converts Command to a properly formatted command for gvproxy based
+// on its fields
+func (c *GvproxyCommand) ToCmdline() []string {
+	args := []string{}
+
+	// listen (endpoints)
+	args = append(args, c.endpointsToCmdline()...)
+
+	// debug
+	if c.Debug {
+		args = append(args, "-debug")
+	}
+
+	// mtu
+	args = append(args, "-mtu", strconv.Itoa(c.MTU))
+
+	// ssh-port
+	args = append(args, "-ssh-port", strconv.Itoa(c.SSHPort))
+
+	// sockets
+	args = append(args, c.socketsToCmdline()...)
+
+	// forward info
+	args = append(args, c.forwardInfoToCmdline()...)
+
+	// pid-file
+	if c.PidFile != "" {
+		args = append(args, "-pid-file", c.PidFile)
+	}
+
+	return args
+}
+
+// Cmd converts Command to a commandline format and returns an exec.Cmd which
+// can be executed by os/exec
+func (c *GvproxyCommand) Cmd(gvproxyPath string) *exec.Cmd {
+	return exec.Command(gvproxyPath, c.ToCmdline()...) // #nosec G204
+}

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/handshake.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/handshake.go
@@ -1,0 +1,21 @@
+package types
+
+type TransportProtocol string
+
+const (
+	UDP   TransportProtocol = "udp"
+	TCP   TransportProtocol = "tcp"
+	UNIX  TransportProtocol = "unix"
+	NPIPE TransportProtocol = "npipe"
+)
+
+type ExposeRequest struct {
+	Local    string            `json:"local"`
+	Remote   string            `json:"remote"`
+	Protocol TransportProtocol `json:"protocol"`
+}
+
+type UnexposeRequest struct {
+	Local    string            `json:"local"`
+	Protocol TransportProtocol `json:"protocol"`
+}

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/paths.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/paths.go
@@ -1,0 +1,3 @@
+package types
+
+const ConnectPath = "/connect"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -223,6 +223,9 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
+# github.com/containers/gvisor-tap-vsock v0.7.1-0.20230907154503-507f56851e8b
+## explicit; go 1.20
+github.com/containers/gvisor-tap-vsock/pkg/types
 # github.com/containers/image/v5 v5.28.0
 ## explicit; go 1.19
 github.com/containers/image/v5/copy


### PR DESCRIPTION
Converts the host networking code in `podman machine` to use the `Command` type introduced in https://github.com/containers/gvisor-tap-vsock/pull/258

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
