### PR TITLE
kube: notifyproxy: close once

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -489,6 +489,8 @@ none | false | false | 0
                  podman_exit=0
             fi
             run_podman $podman_exit kube play --service-exit-code-propagation="$exit_code_prop" --service-container $fname
+            # Make sure that there are no error logs (e.g., #19715)
+            assert "$output" !~ "error msg="
             run_podman container inspect --format '{{.KubeExitCodePropagation}}' $service_container
             is "$output" "$exit_code_prop" "service container has the expected policy set in its annotations"
             run_podman wait $service_container


### PR DESCRIPTION
Do not close a notifyproxy more than once.  Also polish the backend a
bit to reflect ealier changes from commit 4fa307f.

Fixes: #19715

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
