### PR TITLE
CI: bud: skip test that requires hello

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -290,6 +290,10 @@ skip_if_rootless_remote "FIXME: not sure if 17788 or some other bug" \
 skip "FIXME: 2023-06-13 buildah PR 4746 broke this test" \
      "bud with encrypted FROM image"
 
+# 2023-08-24 "hello" got removed from podman repo, tests were skipped
+skip "FIXME! Needs to be fixed on buildah side" \
+     "bud-github-context-with-branch-subdir-commit"
+
 # END   temporary workarounds that must be reevaluated periodically
 ###############################################################################
 


### PR DESCRIPTION
Emergency PR to get CI working again.

PR #19719 removed the "hello" subdirectory and got merged
without actually running CI. This breaks a buildah test
that relied on that subdirectory.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-notes
None
```