### PR TITLE
e2e tests: use registry:2.8.2 (was 2.8)

### DIFF
--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -8,7 +8,7 @@ var (
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, LABELS_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
 	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                                                      //nolint:revive,stylecheck
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
-	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8"                                                                                                                             //nolint:revive,stylecheck
+	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
 	LABELS_IMAGE             = "quay.io/libpod/alpine_labels:latest"                                                                                                                     //nolint:revive,stylecheck
 	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20230106"                                                                                                                   //nolint:revive,stylecheck
 	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck

--- a/test/e2e/config_arm64.go
+++ b/test/e2e/config_arm64.go
@@ -8,7 +8,7 @@ var (
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, LABELS_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
 	NGINX_IMAGE              = "quay.io/lsm5/alpine_nginx-aarch64:latest"                                                                                                                //nolint:revive,stylecheck
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
-	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8"                                                                                                                             //nolint:revive,stylecheck
+	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
 	LABELS_IMAGE             = "quay.io/libpod/alpine_labels:latest"                                                                                                                     //nolint:revive,stylecheck
 	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20230106"                                                                                                                   //nolint:revive,stylecheck
 	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck


### PR DESCRIPTION
...in hopes of addressing flake #18355

FWIW, I included this in #17831 and have let CI hammer away. Have not seen that flake. That doesn't mean too much, it could just be dumb luck, but even so I think this is low-risk and a good idea.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```