### PR TITLE
Dedup and refactor image acquisition

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -34,7 +34,7 @@ type MMHardwareConfig struct {
 
 func VirtualizationProvider() machine.VirtProvider {
 	return &AppleHVVirtualization{
-		machine.NewVirtualization(machine.Metal, machine.Xz, machine.Raw),
+		machine.NewVirtualization(machine.AppleHV, machine.Xz, machine.Raw, vmtype),
 	}
 }
 

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -44,8 +44,11 @@ func TestMachine(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	qemuVP := qemu.VirtualizationProvider()
-	fcd, err := machine.GetFCOSDownload(qemuVP, defaultStream)
+	dd, err := qemu.VirtualizationProvider().NewDownload("")
+	if err != nil {
+		Fail("unable to create new download")
+	}
+	fcd, err := dd.GetFCOSDownload(defaultStream)
 	if err != nil {
 		Fail("unable to get virtual machine image")
 	}

--- a/pkg/machine/fcos_test.go
+++ b/pkg/machine/fcos_test.go
@@ -1,6 +1,8 @@
 package machine
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_compressionFromFile(t *testing.T) {
 	type args struct {
@@ -164,9 +166,9 @@ func TestFCOSStream_String(t *testing.T) {
 			want: "next",
 		},
 		{
-			name: "default is stable",
-			st:   99,
-			want: "stable",
+			name: "default is custom",
+			st:   CustomStream,
+			want: "custom",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -87,12 +87,12 @@ func supportedURL(path string) (url *url2.URL) {
 	}
 }
 
-func (d Download) GetLocalUncompressedFile(dataDir string) string {
-	compressedFilename := d.VMName + "_" + d.ImageName
+func (dl Download) GetLocalUncompressedFile(dataDir string) string {
+	compressedFilename := dl.VMName + "_" + dl.ImageName
 	extension := compressionFromFile(compressedFilename)
 	uncompressedFile := strings.TrimSuffix(compressedFilename, fmt.Sprintf(".%s", extension.String()))
-	d.LocalUncompressedFile = filepath.Join(dataDir, uncompressedFile)
-	return d.LocalUncompressedFile
+	dl.LocalUncompressedFile = filepath.Join(dataDir, uncompressedFile)
+	return dl.LocalUncompressedFile
 }
 
 func (g GenericDownload) Get() *Download {
@@ -388,8 +388,8 @@ func RemoveImageAfterExpire(dir string, expire time.Duration) error {
 
 // AcquireAlternateImage downloads the alternate image the user provided, which
 // can be a file path or URL
-func AcquireAlternateImage(name string, vmtype VMType, opts InitOptions) (*VMFile, error) {
-	g, err := NewGenericDownloader(vmtype, name, opts.ImagePath)
+func (dl Download) AcquireAlternateImage(inputPath string) (*VMFile, error) {
+	g, err := NewGenericDownloader(dl.VMKind, dl.VMName, inputPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -335,7 +335,7 @@ func (p *QEMUVirtualization) VMType() machine.VMType {
 
 func VirtualizationProvider() machine.VirtProvider {
 	return &QEMUVirtualization{
-		machine.NewVirtualization(machine.Qemu, machine.Xz, machine.Qcow),
+		machine.NewVirtualization(machine.Qemu, machine.Xz, machine.Qcow, vmtype),
 	}
 }
 

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -19,7 +19,7 @@ type WSLVirtualization struct {
 
 func VirtualizationProvider() machine.VirtProvider {
 	return &WSLVirtualization{
-		machine.NewVirtualization(machine.None, machine.Xz, machine.Tar),
+		machine.NewVirtualization(machine.None, machine.Xz, machine.Tar, vmtype),
 	}
 }
 


### PR DESCRIPTION
As promised in #19596, this pr deduplicates and refactors image acquisition.  All virt providers that use FCOS as its default now use the same code.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
