### PR TITLE
[CI:BUILD] Packit: Adjustments for Cockpit reverse-dependency check

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,7 +37,8 @@ jobs:
     identifier: cockpit-revdeps
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-latest-stable
+      - fedora-development
     tf_extra_params:
       environments:
         - artifacts:

--- a/plans/cockpit-podman.fmf
+++ b/plans/cockpit-podman.fmf
@@ -15,6 +15,11 @@ discover:
 execute:
     how: tmt
 
+# not relevant for testing podman
+environment:
+    TEST_AUDIT_NO_SELINUX: 1
+    TEST_ALLOW_JOURNAL_MESSAGES: ".*"
+
 # This has to duplicate cockpit-podman's plan structure; see https://github.com/teemtee/tmt/issues/1770
 /podman-system:
     summary: Run cockpit-podman system tests


### PR DESCRIPTION
Please see the two individual commit messages for details. This will robustify the test against [unrelated non-fatal unexpected message checks](https://artifacts.dev.testing-farm.io/faf29d9a-0219-47fb-bef4-6d2a151de209/), seen in https://github.com/containers/podman/pull/19741.

#### Does this PR introduce a user-facing change?

```release-note
None
```
