### PR TITLE
[CI:DOCS] Updated docs to reflect pod spec sysctls support added in v4.6

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -64,8 +64,8 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | securityContext\.seLinuxOptions\.role               | ✅      |
 | securityContext\.seLinuxOptions\.type               | ✅      |
 | securityContext\.seLinuxOptions\.user               | ✅      |
-| securityContext\.sysctls\.name                      | no      |
-| securityContext\.sysctls\.value                     | no      |
+| securityContext\.sysctls\.name                      | ✅      |
+| securityContext\.sysctls\.value                     | ✅      |
 | securityContext\.windowsOptions\.gmsaCredentialSpec | no      |
 | securityContext\.windowsOptions\.hostProcess        | no      |
 | securityContext\.windowsOptions\.runAsUserName      | no      |


### PR DESCRIPTION
Added support for `security.Context.sysctls.name` and `security.Context.sysctls.value` fields in `v4.6`, documentation updated accordingly

See also: #16711, #17464
Commit: f9af496 "[FEAT] Support sysctl configurations from Pod Spec"

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? 

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
