### PR TITLE
[CI:DOCS] Some distros do not default to docker.io for shortname searches

### DIFF
--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -4,14 +4,15 @@ Introduction
 ==================================
 Containers_ simplify the production, distribution, discoverability, and usage of applications with all of their dependencies and default configuration files. Users test drive or deploy a new application with one or two commands instead of following pages of installation instructions. Here's how to find your first `Container Image`_::
 
-    podman search busybox
+    podman search docker.io/busybox
 
 Output::
-
-    INDEX       NAME                                DESCRIPTION                                       STARS   OFFICIAL   AUTOMATED
-    docker.io   docker.io/library/busybox           Busybox base image.                               1882    [OK]
-    docker.io   docker.io/radial/busyboxplus        Full-chain, Internet enabled, busybox made f...   30                 [OK]
-    docker.io   docker.io/yauritux/busybox-curl     Busybox with CURL                                 8
+    NAME                                         DESCRIPTION
+    docker.io/library/busybox                    Busybox base image.
+    docker.io/rancher/busybox
+    docker.io/openebs/busybox-client
+    docker.io/antrea/busybox
+    docker.io/hugegraph/busybox                  test image
     ...
 
 The previous command returned a list of publicly available container images on DockerHub. These container images are easy to consume, but of differing levels of quality and maintenance. Let’s use the first one listed because it seems to be well maintained.


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/18910

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
