### PR TITLE
oci: print stderr only after checking state

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -420,22 +420,6 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 
 	killCtr := func(signal uint) (bool, error) {
 		stderr, err := r.killContainer(ctr, signal, all, true)
-
-		// Before handling error from KillContainer, convert STDERR to a []string
-		// (one string per line of output) and print it, ignoring known OCI runtime
-		// errors that we don't care about
-		stderrLines := strings.Split(stderr.String(), "\n")
-		for _, line := range stderrLines {
-			if line == "" {
-				continue
-			}
-			if strings.Contains(line, "container not running") || strings.Contains(line, "open pidfd: No such process") || strings.Contains(line, "kill container: No such process") {
-				logrus.Debugf("Failure to kill container (already stopped?): logged %s", line)
-				continue
-			}
-			fmt.Fprintf(os.Stderr, "%s\n", line)
-		}
-
 		if err != nil {
 			// There's an inherent race with the cleanup process (see
 			// #16142, #17142). If the container has already been marked as
@@ -461,6 +445,16 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 
 			return false, err
 		}
+
+		// Before handling error from KillContainer, convert STDERR to a []string
+		// (one string per line of output) and print it.
+		stderrLines := strings.Split(stderr.String(), "\n")
+		for _, line := range stderrLines {
+			if line != "" {
+				fmt.Fprintf(os.Stderr, "%s\n", line)
+			}
+		}
+
 		return false, nil
 	}
 


### PR DESCRIPTION
when the "kill" command fails, print the stderr from the OCI runtime only after we check the container state.

It also simplifies the code since we don't have to hard code the error messages we want to ignore.

Closes: https://github.com/containers/podman/issues/18452

[NO NEW TESTS NEEDED] it fixes a flake.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
