### PR TITLE
Kube - support List documents

### DIFF
--- a/pkg/domain/infra/abi/play_test.go
+++ b/pkg/domain/infra/abi/play_test.go
@@ -246,6 +246,23 @@ kind: Pod
 			"multi doc yaml could not be split",
 			0,
 		},
+		{
+			"DocWithList",
+			`
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+- apiVersion: v1
+  kind: Pod
+- apiVersion: v1
+  kind: Pod
+`,
+			false,
+			"",
+			3,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/pkg/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -929,6 +929,18 @@ const (
 	CauseTypeResourceVersionTooLarge CauseType = "ResourceVersionTooLarge"
 )
 
+// List holds a list of objects, which may not be known by the server.
+type List struct {
+	TypeMeta `json:",inline"`
+	// Standard list metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +optional
+	ListMeta `json:"metadata,omitempty"`
+
+	// List of objects
+	Items []interface{} `json:"items"`
+}
+
 // APIVersions lists the versions that are available, to allow clients to
 // discover the API at /api, which is the root path of the legacy v1 API.
 //

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1190,6 +1190,34 @@ spec:
     - "sysctl kernel.msgmax"
 `
 
+var listPodAndConfigMap = `
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: test-list-configmap
+  data:
+    foo: bar
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test-list-pod
+  spec:
+    containers:
+    - name: container
+      image: quay.io/libpod/alpine:latest
+      command: [ "/bin/sh", "-c", "env" ]
+      env:
+      - name: FOO
+        valueFrom:
+          configMapKeyRef:
+            name: test-list-configmap
+            key: foo
+    restartPolicy: Never
+`
+
 var (
 	defaultCtrName        = "testCtr"
 	defaultCtrCmd         = []string{"top"}
@@ -5954,5 +5982,20 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		ps.WaitWithDefaultTimeout()
 		Expect(ps).Should(Exit(0))
 		Expect(ps.OutputToString()).To(ContainSubstring(podID[:12] + "-infra"))
+	})
+
+	It("podman play kube support List kind", func() {
+		listYamlPathname := filepath.Join(podmanTest.TempDir, "list.yaml")
+		err = writeYaml(listPodAndConfigMap, listYamlPathname)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"play", "kube", listYamlPathname})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "test-list-pod-container", "--format", "'{{ .Config.Env }}'"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).To(ContainSubstring(`FOO=bar`))
 	})
 })


### PR DESCRIPTION
Flatten List into documents
Add List type to meta/v1
Add unittest


#### Does this PR introduce a user-facing change?
Yes

```release-note
Kube - add support for List kind
```

Resolves: #19052
