### PR TITLE
/_ping handler: return OSType http header

### DIFF
--- a/pkg/api/handlers/compat/ping.go
+++ b/pkg/api/handlers/compat/ping.go
@@ -3,6 +3,7 @@ package compat
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 
 	"github.com/containers/buildah"
 )
@@ -18,6 +19,7 @@ func Ping(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Builder-Version", "")
 	w.Header().Set("Docker-Experimental", "true")
 	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("OSType", runtime.GOOS)
 	w.Header().Set("Pragma", "no-cache")
 
 	w.Header().Set("Libpod-Buildah-Version", buildah.Version)

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -11,6 +11,7 @@ t GET  /libpod/_ping 200 OK
 t HEAD /libpod/_ping 200
 
 t GET  _ping        200 OK
+like "$(<$WORKDIR/curl.headers.out)" $'.*\nOstype: ' "#19767 - undocumented part of docker API"
 t HEAD _ping        200
 t GET  libpod/_ping 200 OK
 t HEAD libpod/_ping 200


### PR DESCRIPTION
The docker client expects to read the OSType header from the `/_ping` response in order to determine the OS type of the server, for example, when running `docker run --device=/dev/fuse ...`

https://github.com/moby/moby/blob/master/client/ping.go#L57

This addresses https://github.com/containers/podman/issues/19767

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
