### PR TITLE
kube down/play --replace: handle absent objects

### DIFF
--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -30,6 +30,7 @@ type VolumeConfigResponse struct {
 type VolumeRmOptions struct {
 	All     bool
 	Force   bool
+	Ignore  bool
 	Timeout *uint
 }
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1450,6 +1450,9 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 	for _, name := range podNames {
 		pod, err := ic.Libpod.LookupPod(name)
 		if err != nil {
+			if errors.Is(err, define.ErrNoSuchPod) {
+				continue
+			}
 			return nil, err
 		}
 		ctr, err := pod.ServiceContainer()
@@ -1463,23 +1466,23 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 	}
 
 	// Add the reports
-	reports.StopReport, err = ic.PodStop(ctx, podNames, entities.PodStopOptions{})
+	reports.StopReport, err = ic.PodStop(ctx, podNames, entities.PodStopOptions{Ignore: true})
 	if err != nil {
 		return nil, err
 	}
 
-	reports.RmReport, err = ic.PodRm(ctx, podNames, entities.PodRmOptions{})
+	reports.RmReport, err = ic.PodRm(ctx, podNames, entities.PodRmOptions{Ignore: true})
 	if err != nil {
 		return nil, err
 	}
 
-	reports.SecretRmReport, err = ic.SecretRm(ctx, secretNames, entities.SecretRmOptions{})
+	reports.SecretRmReport, err = ic.SecretRm(ctx, secretNames, entities.SecretRmOptions{Ignore: true})
 	if err != nil {
 		return nil, err
 	}
 
 	if options.Force {
-		reports.VolumeRmReport, err = ic.VolumeRm(ctx, volumeNames, entities.VolumeRmOptions{})
+		reports.VolumeRmReport, err = ic.VolumeRm(ctx, volumeNames, entities.VolumeRmOptions{Ignore: true})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -166,17 +166,10 @@ func (ic *ContainerEngine) SecretRm(ctx context.Context, nameOrIDs []string, opt
 	}
 	for _, nameOrID := range toRemove {
 		deletedID, err := manager.Delete(nameOrID)
-		if err == nil || strings.Contains(err.Error(), "no such secret") {
-			if !options.Ignore {
-				reports = append(reports, &entities.SecretRmReport{
-					Err: err,
-					ID:  deletedID,
-				})
-			}
+		if options.Ignore && errors.Is(err, secrets.ErrNoSuchSecret) {
 			continue
-		} else {
-			return nil, err
 		}
+		reports = append(reports, &entities.SecretRmReport{Err: err, ID: deletedID})
 	}
 
 	return reports, nil

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -61,6 +61,9 @@ func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, op
 		for _, id := range namesOrIds {
 			vol, err := ic.Libpod.LookupVolume(id)
 			if err != nil {
+				if opts.Ignore && errors.Is(err, define.ErrNoSuchVolume) {
+					continue
+				}
 				reports = append(reports, &entities.VolumeRmReport{
 					Err: err,
 					Id:  id,


### PR DESCRIPTION
Make sure that `kube down` and `kube play --replace` do not error out when an object does not exist (or has already been removed).  Such kind of teardown should not be treated as an ordinary `rm` but as an `rm --ignore`.  It's purpose it to make sure that all objects in a YAML are removed; even if they existed only partially.

Fixes: #19711

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where `kube down` would error when an object did not exist.
```
