### PR TITLE
e2e: fix race condition (kube play + logs)

### DIFF
--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -350,16 +350,21 @@ echo GOT-HERE
 		Expect(os.Chdir(yamlDir)).To(Succeed())
 		defer func() { (Expect(os.Chdir(cwd)).To(BeNil())) }()
 
-		session := podmanTest.Podman([]string{"play", "kube", "echo.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "echo.yaml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		logs := podmanTest.Podman([]string{"logs", "echo_pod-foobar"})
+		cid := "echo_pod-foobar"
+		wait := podmanTest.Podman([]string{"wait", cid})
+		wait.WaitWithDefaultTimeout()
+		Expect(wait).To(Exit(0))
+
+		logs := podmanTest.Podman([]string{"logs", cid})
 		logs.WaitWithDefaultTimeout()
 		Expect(logs).Should(Exit(0))
 		Expect(logs.OutputToString()).To(Equal("parenBAR braceBAR dollardollarparenGOT-HERE interpBARolate"))
 
-		inspect := podmanTest.Podman([]string{"container", "inspect", "echo_pod-foobar"})
+		inspect := podmanTest.Podman([]string{"container", "inspect", cid})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
 		inspectData := inspect.InspectContainerToJSON()


### PR DESCRIPTION
The usual bug that we always seem to forget about: "kube play"
needs "podman wait" before we can "podman logs". (And, reminder,
"kube play --wait" is worthless because it destroys containers).

Reference: #18074, the original PR that fixed a bunch of these flakes.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```