### PR TITLE
Don't re-inspect an image

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -68,11 +68,6 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		return nil, err
 	}
 	if inspectData != nil {
-		inspectData, err = newImage.Inspect(ctx, nil)
-		if err != nil {
-			return nil, err
-		}
-
 		if s.HealthConfig == nil {
 			// NOTE: the health check is only set for Docker images
 			// but inspect will take care of it.


### PR DESCRIPTION
`getImageFromSpec` has just make exactly the same Inspect call.

[NO NEW TESTS NEEDED]: This adds no new functionality, and it's hard to test that a duplicate call didn't happen without (intrusive and hard-to-maintain) mocks.

This is a part of #19718 .

#### Does this PR introduce a user-facing change?

```release-note
None
```
