### PR TITLE
Update c/common to remove a dependency on libimage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.31.1-0.20230722114901-5ece066f82c6
-	github.com/containers/common v0.55.1-0.20230828100250-07e4cdeb1499
+	github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa
 	github.com/containers/libhvee v0.4.1-0.20230816135538-b81ee3f10e1e

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.31.1-0.20230722114901-5ece066f82c6 h1:K/S8SFQsnnNTF0Ws58SrBD9L0EuClzAG8Zp08d7+6AA=
 github.com/containers/buildah v1.31.1-0.20230722114901-5ece066f82c6/go.mod h1:0sptTFBBtSznLqoTh80DfvMOCNbdRsNRgVOKhBhrupA=
-github.com/containers/common v0.55.1-0.20230828100250-07e4cdeb1499 h1:YxSpAmFtHY/sbLtX29KXOZuoHgIL1ZOu06DQzGYND/o=
-github.com/containers/common v0.55.1-0.20230828100250-07e4cdeb1499/go.mod h1:Xcw3UosoUax8jn+MZoxL7LbEbfxKqhUNMZyhdd5s/vk=
+github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43 h1:Or7mn/haMXOsLC3FiwTCaHRCdez5TkqEJE+U+rSwTIo=
+github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43/go.mod h1:Xcw3UosoUax8jn+MZoxL7LbEbfxKqhUNMZyhdd5s/vk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa h1:wDfVQtc6ik2MvsUmu/YRSyBAE5YUxdjcEDtuT1q2KDo=

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/libimage"
+	"github.com/containers/common/libimage/define"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/libpod"
@@ -173,7 +173,7 @@ func ManifestInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var schema2List libimage.ManifestListData
+	var schema2List define.ManifestListData
 	if err := json.Unmarshal(rawManifest, &schema2List); err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)
 		return

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/libimage"
+	"github.com/containers/common/libimage/define"
 	"github.com/containers/image/v5/manifest"
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/pkg/auth"
@@ -110,7 +110,7 @@ func Inspect(ctx context.Context, name string, options *InspectOptions) (*manife
 // InspectListData returns a manifest list for a given name.
 // Contains exclusive field like `annotations` which is only
 // present in OCI spec and not in docker image spec.
-func InspectListData(ctx context.Context, name string, options *InspectOptions) (*libimage.ManifestListData, error) {
+func InspectListData(ctx context.Context, name string, options *InspectOptions) (*define.ManifestListData, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func InspectListData(ctx context.Context, name string, options *InspectOptions) 
 	}
 	defer response.Body.Close()
 
-	var list libimage.ManifestListData
+	var list define.ManifestListData
 	return &list, response.Process(&list)
 }
 

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/common/libimage"
+	"github.com/containers/common/libimage/define"
 	podmanRegistry "github.com/containers/podman/v4/hack/podman-registry-go"
 	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/archive"
@@ -288,7 +288,7 @@ var _ = Describe("Podman manifest", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		var inspect libimage.ManifestListData
+		var inspect define.ManifestListData
 		err := json.Unmarshal(session.Out.Contents(), &inspect)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(inspect.Manifests[0].Annotations).To(Equal(map[string]string{"hoge": "fuga"}))

--- a/vendor/github.com/containers/common/libimage/define/manifests.go
+++ b/vendor/github.com/containers/common/libimage/define/manifests.go
@@ -1,0 +1,27 @@
+package define
+
+import (
+	"github.com/containers/image/v5/manifest"
+)
+
+// ManifestListDescriptor references a platform-specific manifest.
+// Contains exclusive field like `annotations` which is only present in
+// OCI spec and not in docker image spec.
+type ManifestListDescriptor struct {
+	manifest.Schema2Descriptor
+	Platform manifest.Schema2PlatformSpec `json:"platform"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// ManifestListData is a list of platform-specific manifests, specifically used to
+// generate output struct for `podman manifest inspect`. Reason for maintaining and
+// having this type is to ensure we can have a common type which contains exclusive
+// fields from both Docker manifest format and OCI manifest format.
+type ManifestListData struct {
+	SchemaVersion int                      `json:"schemaVersion"`
+	MediaType     string                   `json:"mediaType"`
+	Manifests     []ManifestListDescriptor `json:"manifests"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/containers/common/libimage/image.go
+++ b/vendor/github.com/containers/common/libimage/image.go
@@ -91,13 +91,14 @@ func (i *Image) isCorrupted(name string) error {
 		return err
 	}
 
-	if _, err := ref.NewImage(context.Background(), nil); err != nil {
+	img, err := ref.NewImage(context.Background(), nil)
+	if err != nil {
 		if name == "" {
 			name = i.ID()[:12]
 		}
 		return fmt.Errorf("Image %s exists in local storage but may be corrupted (remove the image to resolve the issue): %v", name, err)
 	}
-	return nil
+	return img.Close()
 }
 
 // Names returns associated names with the image which may be a mix of tags and
@@ -872,6 +873,7 @@ func (i *Image) hasDifferentDigestWithSystemContext(ctx context.Context, remoteR
 	if err != nil {
 		return false, err
 	}
+	defer remoteImg.Close()
 
 	rawManifest, rawManifestMIMEType, err := remoteImg.Manifest(ctx)
 	if err != nil {

--- a/vendor/github.com/containers/common/libimage/manifest_list.go
+++ b/vendor/github.com/containers/common/libimage/manifest_list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containers/common/libimage/define"
 	"github.com/containers/common/libimage/manifests"
 	imageCopy "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
@@ -38,28 +39,6 @@ type ManifestList struct {
 
 	// The underlying manifest list.
 	list manifests.List
-}
-
-// ManifestListDescriptor references a platform-specific manifest.
-// Contains exclusive field like `annotations` which is only present in
-// OCI spec and not in docker image spec.
-type ManifestListDescriptor struct {
-	manifest.Schema2Descriptor
-	Platform manifest.Schema2PlatformSpec `json:"platform"`
-	// Annotations contains arbitrary metadata for the image index.
-	Annotations map[string]string `json:"annotations,omitempty"`
-}
-
-// ManifestListData is a list of platform-specific manifests, specifically used to
-// generate output struct for `podman manifest inspect`. Reason for maintaining and
-// having this type is to ensure we can have a common type which contains exclusive
-// fields from both Docker manifest format and OCI manifest format.
-type ManifestListData struct {
-	SchemaVersion int                      `json:"schemaVersion"`
-	MediaType     string                   `json:"mediaType"`
-	Manifests     []ManifestListDescriptor `json:"manifests"`
-	// Annotations contains arbitrary metadata for the image index.
-	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // ID returns the ID of the manifest list.
@@ -238,8 +217,8 @@ func (i *Image) IsManifestList(ctx context.Context) (bool, error) {
 }
 
 // Inspect returns a dockerized version of the manifest list.
-func (m *ManifestList) Inspect() (*ManifestListData, error) {
-	inspectList := ManifestListData{}
+func (m *ManifestList) Inspect() (*define.ManifestListData, error) {
+	inspectList := define.ManifestListData{}
 	dockerFormat := m.list.Docker()
 	err := structcopier.Copy(&inspectList, &dockerFormat)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.55.1-0.20230828100250-07e4cdeb1499
+# github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
`libimage.ManifestList{Descriptor,Data}` are (for better or worse) a part of Podman's API, so `podman-remote` needs to include the subpackage that defines them - which is all of `libimage` (and `c/image/v5/copy`) right now.

Instead, https://github.com/containers/common/pull/1629 moves them to libimage/define; this is an update + test for that change.

Alternatively, maybe Podman's API should not directly depend on (unstable) c/common types?! This PR just makes a mechanical change without considering that design question.

[NO NEW TESTS NEEDED]: Only moves unchanged code, should not change behavior.

This is a part of #19718 .

#### Does this PR introduce a user-facing change?

```release-note
None
```
