### PR TITLE
manifest,push: support `add_compression` from `containers.conf`

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -42,6 +42,7 @@ var (
 )
 
 func init() {
+	podmanConfig := registry.PodmanConfig()
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: pushCmd,
 		Parent:  manifestCmd,
@@ -57,7 +58,7 @@ func init() {
 	_ = pushCmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
 	addCompressionFlagName := "add-compression"
-	flags.StringSliceVar(&manifestPushOpts.AddCompression, addCompressionFlagName, nil, "add instances with selected compression while pushing")
+	flags.StringSliceVar(&manifestPushOpts.AddCompression, addCompressionFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.AddCompression, "add instances with selected compression while pushing")
 	_ = pushCmd.RegisterFlagCompletionFunc(addCompressionFlagName, common.AutocompleteCompressionFormat)
 
 	certDirFlagName := "cert-dir"


### PR DESCRIPTION
Use `add_compression` field from `containers.conf` if found instead and `CLI` field `--add-compression` is not set.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
manifest,push: support add_compression from containers.conf
```
