### PR TITLE
e2e: new ExitCleanly matcher

### DIFF
--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -5,11 +5,11 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver vfs"                                                                                                                                    //nolint:revive,stylecheck
 	ROOTLESS_STORAGE_FS      = "vfs"                                                                                                                                                     //nolint:revive,stylecheck
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"                                                                                                                                    //nolint:revive,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, LABELS_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
 	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                                                      //nolint:revive,stylecheck
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
 	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
-	LABELS_IMAGE             = "quay.io/libpod/alpine_labels:latest"                                                                                                                     //nolint:revive,stylecheck
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20221018"                                                                                                                       //nolint:revive,stylecheck
 	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20230106"                                                                                                                   //nolint:revive,stylecheck
 	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck
 )

--- a/test/e2e/config_arm64.go
+++ b/test/e2e/config_arm64.go
@@ -5,11 +5,11 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver vfs"                                                                                                                                    //nolint:revive,stylecheck
 	ROOTLESS_STORAGE_FS      = "vfs"                                                                                                                                                     //nolint:revive,stylecheck
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"                                                                                                                                    //nolint:revive,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, LABELS_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
 	NGINX_IMAGE              = "quay.io/lsm5/alpine_nginx-aarch64:latest"                                                                                                                //nolint:revive,stylecheck
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
 	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
-	LABELS_IMAGE             = "quay.io/libpod/alpine_labels:latest"                                                                                                                     //nolint:revive,stylecheck
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20221018"                                                                                                                       //nolint:revive,stylecheck
 	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20230106"                                                                                                                   //nolint:revive,stylecheck
 	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck
 )

--- a/test/e2e/config_ppc64le.go
+++ b/test/e2e/config_ppc64le.go
@@ -5,9 +5,9 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver overlay"
 	ROOTLESS_STORAGE_FS      = "vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, INFRA_IMAGE, LABELS_IMAGE}
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, INFRA_IMAGE, CITEST_IMAGE}
 	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx-ppc64le:latest"
 	BB_GLIBC                 = "docker.io/ppc64le/busybox:glibc"
-	LABELS_IMAGE             = "quay.io/libpod/alpine_labels-ppc64le:latest"
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20221018"
 	REGISTRY_IMAGE           string
 )

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Podman images", func() {
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=*lpine*"})
 		retalpine.WaitWithDefaultTimeout()
 		Expect(retalpine).Should(Exit(0))
-		Expect(retalpine.OutputToStringArray()).To(HaveLen(6))
+		Expect(retalpine.OutputToStringArray()).To(HaveLen(5))
 		Expect(retalpine.OutputToString()).To(ContainSubstring("alpine"))
 
 		retalpine = podmanTest.Podman([]string{"images", "-f", "reference=alpine"})

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman play kube with build", func() {
@@ -51,12 +50,12 @@ status: {}
 `
 
 	var playBuildFile = `
-FROM quay.io/libpod/alpine_nginx:latest
+FROM ` + CITEST_IMAGE + `
 LABEL homer=dad
 COPY copyfile /copyfile
 `
 	var prebuiltImage = `
-FROM quay.io/libpod/alpine_nginx:latest
+FROM ` + CITEST_IMAGE + `
 LABEL marge=mom
 `
 
@@ -84,17 +83,17 @@ LABEL marge=mom
 		Expect(os.Chdir(yamlDir)).To(Succeed())
 		defer func() { (Expect(os.Chdir(cwd)).To(BeNil())) }()
 
-		session := podmanTest.Podman([]string{"play", "kube", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		exists := podmanTest.Podman([]string{"image", "exists", "foobar"})
 		exists.WaitWithDefaultTimeout()
-		Expect(exists).Should(Exit(0))
+		Expect(exists).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "top_pod-foobar"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectData := inspect.InspectContainerToJSON()
 		Expect(inspectData).ToNot(BeEmpty())
 		Expect(inspectData[0].Config.Labels).To(HaveKeyWithValue("homer", "dad"))
@@ -121,17 +120,17 @@ LABEL marge=mom
 		Expect(os.Chdir(yamlDir)).To(Succeed())
 		defer func() { (Expect(os.Chdir(cwd)).To(BeNil())) }()
 
-		session := podmanTest.Podman([]string{"play", "kube", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		exists := podmanTest.Podman([]string{"image", "exists", "foobar"})
 		exists.WaitWithDefaultTimeout()
-		Expect(exists).Should(Exit(0))
+		Expect(exists).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "top_pod-foobar"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectData := inspect.InspectContainerToJSON()
 		Expect(inspectData).ToNot(BeEmpty())
 		Expect(inspectData[0].Config.Labels).To(HaveKeyWithValue("homer", "dad"))
@@ -169,15 +168,15 @@ LABEL marge=mom
 		// Build the image into the local store
 		build := podmanTest.Podman([]string{"build", "-t", "foobar", "-f", "Containerfile"})
 		build.WaitWithDefaultTimeout()
-		Expect(build).Should(Exit(0))
+		Expect(build).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"play", "kube", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "top_pod-foobar"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectData := inspect.InspectContainerToJSON()
 		Expect(inspectData).ToNot(BeEmpty())
 		Expect(inspectData[0].Config.Labels).To(Not(HaveKey("homer")))
@@ -216,15 +215,15 @@ LABEL marge=mom
 		// Build the image into the local store
 		build := podmanTest.Podman([]string{"build", "-t", "foobar", "-f", "Containerfile"})
 		build.WaitWithDefaultTimeout()
-		Expect(build).Should(Exit(0))
+		Expect(build).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"play", "kube", "--build=false", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "--build=false", "top.yaml"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "top_pod-foobar"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectData := inspect.InspectContainerToJSON()
 		Expect(inspectData).ToNot(BeEmpty())
 		Expect(inspectData[0].Config.Labels).To(Not(HaveKey("homer")))
@@ -263,15 +262,15 @@ LABEL marge=mom
 		// Build the image into the local store
 		build := podmanTest.Podman([]string{"build", "-t", "foobar", "-f", "Containerfile"})
 		build.WaitWithDefaultTimeout()
-		Expect(build).Should(Exit(0))
+		Expect(build).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"play", "kube", "--build", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "--build", "top.yaml"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "top_pod-foobar"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectData := inspect.InspectContainerToJSON()
 		Expect(inspectData).ToNot(BeEmpty())
 		Expect(inspectData[0].Config.Labels).To(HaveKeyWithValue("homer", "dad"))
@@ -352,21 +351,21 @@ echo GOT-HERE
 
 		session := podmanTest.Podman([]string{"kube", "play", "echo.yaml"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := "echo_pod-foobar"
 		wait := podmanTest.Podman([]string{"wait", cid})
 		wait.WaitWithDefaultTimeout()
-		Expect(wait).To(Exit(0))
+		Expect(wait).To(ExitCleanly())
 
 		logs := podmanTest.Podman([]string{"logs", cid})
 		logs.WaitWithDefaultTimeout()
-		Expect(logs).Should(Exit(0))
+		Expect(logs).Should(ExitCleanly())
 		Expect(logs.OutputToString()).To(Equal("parenBAR braceBAR dollardollarparenGOT-HERE interpBARolate"))
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", cid})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectData := inspect.InspectContainerToJSON()
 		Expect(inspectData).ToNot(BeEmpty())
 


### PR DESCRIPTION
e2e test logs are full of warning messages that we never see. Let's start looking for them.

This PR introduces a new gomega matcher, `ExitCleanly()`, with the purpose of replacing `Should(Exit(0))`. This matcher checks exit code _and_ that no unexpected messages are emitted on stderr. Checking stdout is still up to the test writer.

As proof of concept, use the new matcher in `play_build_test.go`. This resulted in tests failing, because all those `kube play` commands have been spitting out warnings for lo all these years:

     time=.... level=warning msg="HEALTHCHECK is not supported for OCI image format and will be ignored. Must use `docker` format"

To remove that warning, use our standard system-test `libpod/testimage:YYYYMMDD` image instead of `alpine_nginx`. Image is now fetched and cached as part of standard test prep; I expect to use it much more in the future.

FWIW I tried updating `play_kube_test.go` but discovered and filed #19801, a bug that makes that impossible.

```release-note
None
```