### PR TITLE
vendor containers/common@12405381ff45

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.31.1-0.20230722114901-5ece066f82c6
-	github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43
+	github.com/containers/common v0.55.1-0.20230830075933-12405381ff45
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa
 	github.com/containers/libhvee v0.4.1-0.20230816135538-b81ee3f10e1e

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.31.1-0.20230722114901-5ece066f82c6 h1:K/S8SFQsnnNTF0Ws58SrBD9L0EuClzAG8Zp08d7+6AA=
 github.com/containers/buildah v1.31.1-0.20230722114901-5ece066f82c6/go.mod h1:0sptTFBBtSznLqoTh80DfvMOCNbdRsNRgVOKhBhrupA=
-github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43 h1:Or7mn/haMXOsLC3FiwTCaHRCdez5TkqEJE+U+rSwTIo=
-github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43/go.mod h1:Xcw3UosoUax8jn+MZoxL7LbEbfxKqhUNMZyhdd5s/vk=
+github.com/containers/common v0.55.1-0.20230830075933-12405381ff45 h1:hwUrFFjPuaQLKDjaXTc3hDfZp2X89IWKx4rBQX0bUwc=
+github.com/containers/common v0.55.1-0.20230830075933-12405381ff45/go.mod h1:Xcw3UosoUax8jn+MZoxL7LbEbfxKqhUNMZyhdd5s/vk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa h1:wDfVQtc6ik2MvsUmu/YRSyBAE5YUxdjcEDtuT1q2KDo=

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -249,11 +249,7 @@ var _ = Describe("Podman load", func() {
 		load := podmanTest.Podman([]string{"load", "-i", outfile})
 		load.WaitWithDefaultTimeout()
 		Expect(load).Should(Exit(0))
-
-		result := podmanTest.Podman([]string{"images", "load:latest"})
-		result.WaitWithDefaultTimeout()
-		Expect(result.OutputToString()).To(Not(ContainSubstring("docker")))
-		Expect(result.OutputToString()).To(ContainSubstring("localhost"))
+		Expect(load.OutputToString()).To(ContainSubstring("Loaded image: sha256:"))
 	})
 
 	It("podman load xz compressed image", func() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -418,7 +418,8 @@ var _ = Describe("Podman pull", func() {
 		dirpath := filepath.Join(podmanTest.TempDir, "cirros")
 		err = os.MkdirAll(dirpath, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
-		imgPath := fmt.Sprintf("oci:%s", dirpath)
+		imgName := "localhost/name:tag"
+		imgPath := fmt.Sprintf("oci:%s:%s", dirpath, imgName)
 
 		session := podmanTest.Podman([]string{"push", "cirros", imgPath})
 		session.WaitWithDefaultTimeout()
@@ -429,10 +430,9 @@ var _ = Describe("Podman pull", func() {
 		session = podmanTest.Podman([]string{"pull", imgPath})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		session = podmanTest.Podman([]string{"images"})
+		session = podmanTest.Podman([]string{"image", "exists", imgName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.LineInOutputContainsTag(filepath.Join("localhost", dirpath), "latest")).To(BeTrue())
 	})
 
 	It("podman pull + inspect from unqualified-search registry", func() {
@@ -648,11 +648,12 @@ var _ = Describe("Podman pull", func() {
 			podmanTest.AddImageToRWStore(ALPINE)
 
 			bbdir := filepath.Join(podmanTest.TempDir, "busybox-oci")
-			imgPath := fmt.Sprintf("oci:%s", bbdir)
+			imgName := "localhost/name:tag"
+			imgPath := fmt.Sprintf("oci:%s:%s", bbdir, imgName)
 
 			session := decryptionTestHelper(imgPath)
 
-			Expect(session.LineInOutputContainsTag(filepath.Join("localhost", bbdir), "latest")).To(BeTrue())
+			Expect(session.LineInOutputContainsTag("localhost/name", "tag")).To(BeTrue())
 		})
 
 		It("From local registry", func() {

--- a/vendor/github.com/containers/common/libimage/pull.go
+++ b/vendor/github.com/containers/common/libimage/pull.go
@@ -230,8 +230,18 @@ func (r *Runtime) copyFromDefault(ctx context.Context, ref types.ImageReference,
 
 	case ociTransport.Transport.Name():
 		split := strings.SplitN(ref.StringWithinTransport(), ":", 2)
-		storageName = toLocalImageName(split[0])
-		imageName = storageName
+		if len(split) == 1 || split[1] == "" {
+			// Same trick as for the dir transport: we cannot use
+			// the path to a directory as the name.
+			storageName, err = getImageID(ctx, ref, nil)
+			if err != nil {
+				return nil, err
+			}
+			imageName = "sha256:" + storageName[1:]
+		} else { // If the OCI-reference includes an image reference, use it
+			storageName = split[1]
+			imageName = storageName
+		}
 
 	case ociArchiveTransport.Transport.Name():
 		manifestDescriptor, err := ociArchiveTransport.LoadManifestDescriptorWithContext(r.SystemContext(), ref)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43
+# github.com/containers/common v0.55.1-0.20230830075933-12405381ff45
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
When pulling from an OCI source, make sure to preseve the optional name. 
For instance, a podman pull oci:/tmp/foo:quay.io/foo/bar:latest should   
pull the image and name it quay.io/foo/bar:latest.                       
                                                                         
While at it, also fix a bug when pulling an OCI without the optional     
name. Previously, we used the path to name the image which will error in 
most cases due to invalid characters (e.g., capital ones). Hence, apply  
the same trick as for the dir transport and generate a sha.              

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Pulling from an `oci` transport will use the optional name for naming the image.
```
