### PR TITLE
[CI:DOCS] Fix gidmap command in example

### DIFF
--- a/docs/source/markdown/options/uidmap.container.md
+++ b/docs/source/markdown/options/uidmap.container.md
@@ -183,7 +183,7 @@ process in the container will belong to group `100000`, and files belonging
 to group `2000` in the host will appear as being owned by group `100000`
 inside the container.
 
-    podman run --group-add=keep-groups --gidmap="+100000:@2000" ...
+    podman run --group-add=keep-groups --gidmap="+g100000:@2000" ...
 
   `No subordinate UIDs`
 


### PR DESCRIPTION
Since we do not want the mapping to be applied to uids, we should use the `g` flag in the mapping in the example as well. The main text (line 179) already includes the `g` flag, but I forgot to add it to the example.

Follow up of #18173

@giuseppe @TomSweeneyRedHat would you please mind a quick review?

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
