### PR TITLE
system tests: housekeeping: various small fixes

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1123,7 +1123,7 @@ EOF
     run_podman 125 create --name "$randomname/bad" $IMAGE
     run_podman create --name "/$randomname" $IMAGE
     run_podman ps -a --filter name="^/$randomname$" --format '{{ .Names }}'
-    is $output "$randomname" "Should be able to find container by name"
+    is "$output" "$randomname" "Should be able to find container by name"
     run_podman rm "/$randomname"
     run_podman 125 create --name "$randomname/" $IMAGE
 }

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -25,7 +25,7 @@ load helpers
     run_podman mount --notruncate
     # FIXME: is it worth the effort to validate the CID ($1) ?
     reported_mountpoint=$(echo "$output" | awk '{print $2}')
-    is $reported_mountpoint $mount_path "mountpoint reported by 'podman mount'"
+    is "$reported_mountpoint" "$mount_path" "mountpoint reported by 'podman mount'"
 
     # umount, and make sure files are gone
     run_podman umount $c_name
@@ -237,7 +237,7 @@ EOF
     run_podman mount --notruncate
 
     reported_mountpoint=$(echo "$output" | awk '{print $2}')
-    is $reported_mountpoint $mount_path "mountpoint reported by 'podman mount'"
+    is "$reported_mountpoint" "$mount_path" "mountpoint reported by 'podman mount'"
 
     # umount, and make sure files are gone
     run_podman umount $external_cid

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -111,7 +111,7 @@ EOF
     echo ${secret_content} > ${secret_file}
     run_podman secret create ${test_name} ${secret_file}
     run_podman run --rm --secret=${test_name} --userns=auto:size=1000 $IMAGE cat /run/secrets/${test_name}
-    is ${output} ${secret_content} "Secrets should work with user namespace"
+    is "$output" "$secret_content" "Secrets should work with user namespace"
     run_podman secret rm ${test_name}
 }
 

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -476,7 +476,7 @@ none | false | false | 0
             run_podman container inspect --format '{{.KubeExitCodePropagation}}' $service_container
             is "$output" "$exit_code_prop" "service container has the expected policy set in its annotations"
             run_podman wait $service_container
-            is "$output" "$exit_code" "service container reflects expected exit code $exit_code (policy: $policy, cmd1: $cmd1, cmd2: $cmd2)"
+            is "$output" "$exit_code" "service container exit code (propagation: $exit_code_prop, policy: $service_policy, cmds: $cmd1 + $cmd2)"
             run_podman kube down $fname
         done
     done < <(parse_table "$exit_tests")

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -722,7 +722,7 @@ spec:
     run_podman kube play --configmap=$configmap_file $pod_file
     run_podman wait test_pod-server
     run_podman logs test_pod-server
-    is $output "foo:bar"
+    is "$output" "foo:bar"
 
     run_podman kube down $pod_file
 }


### PR DESCRIPTION
Fix unquoted string vars. Something like this:

   is $output "what we expect"

...will fail with a misleading error message if $output is "".

Also:
 - ~~remove skip for #19407 (tar on rawhide, fixed)~~ EDIT: nope, our CI images still have broken tar
 - fix typos in a diagnostic, which was causing unhelpful message
   on failure

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```