### PR TITLE
Tweaks and cleanups to prepare hyperv for CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containers/common v0.55.1-0.20230829104013-4a76f1739d43
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa
-	github.com/containers/libhvee v0.4.1-0.20230816135538-b81ee3f10e1e
+	github.com/containers/libhvee v0.4.1-0.20230830164110-3777cdaa7db8
 	github.com/containers/ocicrypt v1.1.8
 	github.com/containers/psgo v1.8.0
 	github.com/containers/storage v1.49.1-0.20230823084450-6902c2df7cca

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa h1:wDfVQtc6ik2MvsUmu/YRSyBAE5YUxdjcEDtuT1q2KDo=
 github.com/containers/image/v5 v5.26.1-0.20230807184415-3fb422379cfa/go.mod h1:apL4qwq31NV0gsSZQJPxYyTH0yzWavmMCjT8vsQaXSk=
-github.com/containers/libhvee v0.4.1-0.20230816135538-b81ee3f10e1e h1:j8QuCCOnTxQNtVwARhgUhe3+QYhXpcuoy9YuIgpLWDE=
-github.com/containers/libhvee v0.4.1-0.20230816135538-b81ee3f10e1e/go.mod h1:I30im5oKCYBJMEa+r0jffZn+Yb5/8CnYeAJy+vb77Mg=
+github.com/containers/libhvee v0.4.1-0.20230830164110-3777cdaa7db8 h1:PTtzc5IcpcdHp9vLjE1cpT19Qo1GpouFTFE+rL0UO5I=
+github.com/containers/libhvee v0.4.1-0.20230830164110-3777cdaa7db8/go.mod h1:I30im5oKCYBJMEa+r0jffZn+Yb5/8CnYeAJy+vb77Mg=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -106,6 +106,8 @@ func (v HyperVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, 
 		return nil, errors.New("must define --image-path for hyperv support")
 	}
 
+	m.RemoteUsername = opts.Username
+
 	configDir, err := machine.GetConfDir(machine.HyperVVirt)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
@@ -240,7 +240,7 @@ func (vm *VirtualMachine) Stop() error {
 	}
 
 	// Wait for vm to actually *be* down
-	for i := 0; i < 25; i++ {
+	for i := 0; i < 200; i++ {
 		refreshVM, err := vm.vmm.GetMachine(vm.ElementName)
 		if err != nil {
 			return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -286,7 +286,7 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
-# github.com/containers/libhvee v0.4.1-0.20230816135538-b81ee3f10e1e
+# github.com/containers/libhvee v0.4.1-0.20230830164110-3777cdaa7db8
 ## explicit; go 1.18
 github.com/containers/libhvee/pkg/hypervctl
 github.com/containers/libhvee/pkg/kvp/ginsu


### PR DESCRIPTION
Small fixes for bugs in the hyperv code that were made obvious when manually preparing to run pkg/machine/e2e with windows and hyperv.

Also includes vendoring a new libhvee and solves bug where json config was not being removed.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
