### PR TITLE
libpod: do not parse --hostuser in base 8

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -821,12 +821,12 @@ func lookupHostUser(name string) (*runcuser.ExecUser, error) {
 	if err != nil {
 		return &execUser, err
 	}
-	uid, err := strconv.ParseUint(u.Uid, 8, 32)
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
 	if err != nil {
 		return &execUser, err
 	}
 
-	gid, err := strconv.ParseUint(u.Gid, 8, 32)
+	gid, err := strconv.ParseUint(u.Gid, 10, 32)
 	if err != nil {
 		return &execUser, err
 	}


### PR DESCRIPTION
fix the parsing of --hostuser to treat the input in base 10.

Closes: https://github.com/containers/podman/issues/19800

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now --hostuser correctly parse the user id in base 10, not in base 8
```
