### PR TITLE
[CI:DOCS] Fix a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For blogs, release announcements and more, please checkout the [podman.io](https
 **[Installation notes](install.md)**
 Information on how to install Podman in your environment.
 
-**[OCI Hooks Support](pkg/hooks/README.md)**
+**[OCI Hooks Support](https://github.com/containers/common/blob/main/pkg/hooks/README.md)**
 Information on how Podman configures [OCI Hooks][spec-hooks] to run when launching a container.
 
 **[Podman API](https://docs.podman.io/en/latest/_static/api.html)**


### PR DESCRIPTION
In README, a link from text "OCI Hooks Support" is broken, since the destination `pkg/hooks/README.md` has been moved to a separate project.
This PR just provides a fix to that issue.

#### Does this PR introduce a user-facing change?

```release-note
None
```
