### PR TITLE
Remove redundant nil checks in system connection remove

### DIFF
--- a/cmd/podman/system/connection/remove.go
+++ b/cmd/podman/system/connection/remove.go
@@ -54,18 +54,14 @@ func rm(cmd *cobra.Command, args []string) error {
 	}
 
 	if rmOpts.All {
-		if cfg.Engine.ServiceDestinations != nil {
-			for k := range cfg.Engine.ServiceDestinations {
-				delete(cfg.Engine.ServiceDestinations, k)
-			}
+		for k := range cfg.Engine.ServiceDestinations {
+			delete(cfg.Engine.ServiceDestinations, k)
 		}
 		cfg.Engine.ActiveService = ""
 
 		// Clear all the connections in any existing farms
-		if cfg.Farms.List != nil {
-			for k := range cfg.Farms.List {
-				cfg.Farms.List[k] = []string{}
-			}
+		for k := range cfg.Farms.List {
+			cfg.Farms.List[k] = []string{}
 		}
 		return cfg.Write()
 	}
@@ -83,12 +79,10 @@ func rm(cmd *cobra.Command, args []string) error {
 	}
 
 	// If there are existing farm, remove the deleted connection that might be part of a farm
-	if cfg.Farms.List != nil {
-		for k, v := range cfg.Farms.List {
-			index := util.IndexOfStringInSlice(args[0], v)
-			if index > -1 {
-				cfg.Farms.List[k] = append(v[:index], v[index+1:]...)
-			}
+	for k, v := range cfg.Farms.List {
+		index := util.IndexOfStringInSlice(args[0], v)
+		if index > -1 {
+			cfg.Farms.List[k] = append(v[:index], v[index+1:]...)
 		}
 	}
 


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

From the Go specification:

> "3. If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/xzuA7WNrkF4