### PR TITLE
linux, rootless: clamp oom_score_adj if it is too low

### DIFF
--- a/docs/source/markdown/options/oom-score-adj.md
+++ b/docs/source/markdown/options/oom-score-adj.md
@@ -5,3 +5,7 @@
 #### **--oom-score-adj**=*num*
 
 Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).
+
+When running in rootless mode, the specified value can't be lower than
+the oom_score_adj for the current process. In this case, the
+oom-score-adj is clamped to the current process value.

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -939,6 +939,17 @@ EOF
     is "$output" "$oomscore" "--oom-score-adj should override containers.conf"
 }
 
+# issue 19829
+@test "rootless podman clamps oom-score-adj if it is lower than the current one" {
+    skip_if_not_rootless
+    skip_if_remote
+    if grep -- -1000 /proc/self/oom_score_adj; then
+        skip "the current oom-score-adj is already -1000"
+    fi
+    run_podman run --oom-score-adj=-1000 --rm $IMAGE true
+    is "$output" ".*Requested oom_score_adj=.* is lower than the current one, changing to .*"
+}
+
 # CVE-2022-1227 : podman top joins container mount NS and uses nsenter from image
 @test "podman top does not use nsenter from image" {
     keepid="--userns=keep-id"


### PR DESCRIPTION
when running rootless, if the specified oom_score_adj for the container process is lower than the current value, clamp it to the current value and print a warning.

Closes: https://github.com/containers/podman/issues/19829

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When running rootless, if the oom-score-adj value is too low, then it is clamped to the current value
```
