### PR TITLE
machine: increase max number of inotify instances

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -431,6 +431,22 @@ Delegate=memory pids cpu io
 		},
 	})
 
+	// Increase the number of inotify instances.
+	files = append(files, File{
+		Node: Node{
+			Group: GetNodeGrp("root"),
+			Path:  "/etc/sysctl.d/10-inotify-instances.conf",
+			User:  GetNodeUsr("root"),
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: nil,
+			Contents: Resource{
+				Source: EncodeDataURLPtr("fs.inotify.max_user_instances=524288\n"),
+			},
+			Mode: IntToPtr(0644),
+		},
+	})
+
 	// Issue #11489: make sure that we can inject a custom registries.conf
 	// file on the system level to force a single search registry.
 	// The remote client does not yet support prompting for short-name


### PR DESCRIPTION
increase the number of inotify instances to 524288 instead of using the default value of 128.

Closes: https://github.com/containers/podman/issues/19848

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The limit of inotify instances was bumped to 524288 for the podman machine
```
