### PR TITLE
add compose v2 command to docker alias script

### DIFF
--- a/docker.in
+++ b/docker.in
@@ -1,4 +1,15 @@
 #!/bin/sh
 [ -e ${ETCDIR}/containers/nodocker ] || \
 echo "Emulate Docker CLI using podman. Create ${ETCDIR}/containers/nodocker to quiet msg." >&2
-exec ${BINDIR}/podman "$@"
+
+EXECUTABLE=${BINDIR}/podman
+if [ "$1" = "compose" ]; then
+        shift
+        EXECUTABLE="$(command -v docker-compose || command -v podman-compose)"
+        if ! [ -x "$EXECUTABLE" ]; then
+                echo 'Error: docker-compose or podman-compose is not installed.' >&2
+                exit 1
+        fi
+fi
+
+exec ${EXECUTABLE} "$@"


### PR DESCRIPTION
`docker compose` is a new recommended command line syntax according to [[docker-compose vs docker compose](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose)](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose) 
To be compatible with the new syntax it introduce the executable switch.

#### Does this PR introduce a user-facing change?

```release-note
Added compose alias command to docker-compose or podman-compose in the docker script
```
