### PR TITLE
Ignore spurious container-removal errors

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -916,12 +916,16 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, opts ctrRmO
 			}
 			ctrs, pods, err := r.removeContainer(ctx, dep, recursiveOpts)
 			for rmCtr, err := range ctrs {
-				removedCtrs[rmCtr] = err
+				if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved) {
+					removedCtrs[rmCtr] = nil
+				} else {
+					removedCtrs[rmCtr] = err
+				}
 			}
 			for rmPod, err := range pods {
 				removedPods[rmPod] = err
 			}
-			if err != nil {
+			if err != nil && !errors.Is(err, define.ErrNoSuchCtr) && !errors.Is(err, define.ErrCtrRemoved) {
 				retErr = err
 				return
 			}


### PR DESCRIPTION
When removing a container's dependency, getting an error that the container has already been removed (ErrNoSuchCtr and ErrCtrRemoved) should not be fatal. We wanted the container gone, it's gone, no need to error out.

[NO NEW TESTS NEEDED] This is a race and thus hard to test for.

Fixes #18874

```release-note
Fixed a bug where `podman rm -af` could fail to remove containers under some circumstances ([#18874](https://github.com/containers/podman/issues/18874)).
```
