### PR TITLE
security: accept empty capabilities list

### DIFF
--- a/pkg/specgen/generate/security_linux.go
+++ b/pkg/specgen/generate/security_linux.go
@@ -125,7 +125,9 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 				capsRequiredRequested = strings.Split(val, ",")
 			}
 		}
-		if !s.Privileged && len(capsRequiredRequested) > 0 {
+		if !s.Privileged && len(capsRequiredRequested) == 1 && capsRequiredRequested[0] == "" {
+			caplist = []string{}
+		} else if !s.Privileged && len(capsRequiredRequested) > 0 {
 			// Pass capRequiredRequested in CapAdd field to normalize capabilities names
 			capsRequired, err := capabilities.MergeCapabilities(nil, capsRequiredRequested, nil)
 			if err != nil {

--- a/test/e2e/run_security_labels_test.go
+++ b/test/e2e/run_security_labels_test.go
@@ -11,6 +11,23 @@ import (
 
 var _ = Describe("Podman generate kube", func() {
 
+	It("podman empty security labels", func() {
+		test1 := podmanTest.Podman([]string{"create", "--label", "io.containers.capabilities=", "--name", "test1", "alpine", "echo", "test1"})
+		test1.WaitWithDefaultTimeout()
+		Expect(test1).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "test1"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+
+		ctr := inspect.InspectContainerToJSON()
+		Expect(ctr[0].EffectiveCaps).To(BeNil())
+
+		test2 := podmanTest.Podman([]string{"run", "--label", "io.containers.capabilities=", "alpine", "grep", "^CapEff", "/proc/self/status"})
+		test2.WaitWithDefaultTimeout()
+		Expect(test2.OutputToString()).To(ContainSubstring("0000000000000000"))
+	})
+
 	It("podman security labels", func() {
 		test1 := podmanTest.Podman([]string{"create", "--label", "io.containers.capabilities=setuid,setgid", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()


### PR DESCRIPTION
allow the image to specify an empty list of capabilities, currently podman chokes when the io.containers.capabilities specified in an image does not contain at least one capability.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now the io.containers.capabilities LABEL in an image can be an empty string
```
