### PR TITLE
[v3.4] system reset: show graphRoot/runRoot before removal

### DIFF
--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package system
@@ -61,6 +62,12 @@ WARNING! This will remove:
         - all pods
         - all images
         - all build cache`)
+        	info, _ := registry.ContainerEngine().Info(registry.Context())
+		// lets not hard fail in case of an error
+		if info != nil {
+			fmt.Printf("        - the graphRoot directory: %q\n", info.Store.GraphRoot)
+			fmt.Printf("        - the runRoot directory: %q\n", info.Store.RunRoot)
+		}
 		if len(listCtn) > 0 {
 			fmt.Println(`WARNING! The following external containers will be purged:`)
 			// print first 12 characters of ID and first configured name alias

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -12,6 +12,8 @@ podman\-system\-reset - Reset storage back to initial state
 This command must be run **before** changing any of the following fields in the
 `containers.conf` or `storage.conf` files: `driver`, `static_dir`, `tmp_dir`
 or `volume_path`.
+It also removes the configured graphRoot and runRoot directories. Make sure
+these are not set to some important directory.
 
 `podman system reset` reads the current configuration and attempts to remove all
 of the relevant configurations. If the administrator modified the configuration files first,


### PR DESCRIPTION
Backport of commit 6aaf6a28435c.

system reset it says it will delete containers, images, networks, etc... However it will also delete the graphRoot and runRoot directories. Normally this is not an issue, however in same cases these directories were set to the users home directory or some other important system directory.

As first step simply show the directories that are configured and thus will be deleted by reset. As future step we could implement some safeguard will will not delete some known important directories however I tried to keep it simple for now.

[NO NEW TESTS NEEDED]

see #18349, #18295, and #19870

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Show the graphRoot and runRoot directories when running podman system reset before we ask for confirmation as these directories will be deleted.
```
