### PR TITLE
Support passing of Ulimits as -1 to mean max

### DIFF
--- a/docs/source/markdown/options/ulimit.md
+++ b/docs/source/markdown/options/ulimit.md
@@ -11,6 +11,9 @@ Ulimit options. Sets the ulimits values inside of the container.
 $ podman run --ulimit nofile=1024:1024 --rm ubi9 ulimit -n
 1024
 
+Set -1 for the soft or hard limit to set the limit to the maximum limit of the current
+process. In rootful mode this is often unlimited.
+
 Use **host** to copy the current configuration from the host.
 
 Don't use nproc with the ulimit flag as Linux uses nproc to set the

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -644,7 +644,8 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		for _, rlimit := range c.config.Spec.Process.Rlimits {
 			if rlimit.Type == "RLIMIT_NOFILE" {
 				nofileSet = true
-			} else if rlimit.Type == "RLIMIT_NPROC" {
+			}
+			if rlimit.Type == "RLIMIT_NPROC" {
 				nprocSet = true
 			}
 		}

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -324,6 +324,5 @@ func GetLimits(resource *spec.LinuxResources) (runcconfig.Resources, error) {
 
 	// Unified state
 	final.Unified = resource.Unified
-
 	return *final, nil
 }

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -18,6 +18,7 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) {
 
 	for _, u := range s.Rlimits {
 		name := "RLIMIT_" + strings.ToUpper(u.Type)
+		u = subNegativeOne(u)
 		g.AddProcessRlimits(name, u.Hard, u.Soft)
 	}
 }

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/specgen"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 )
@@ -171,4 +172,8 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 func WeightDevices(wtDevices map[string]spec.LinuxWeightDevice) ([]spec.LinuxWeightDevice, error) {
 	devs := []spec.LinuxWeightDevice{}
 	return devs, nil
+}
+
+func subNegativeOne(u specs.POSIXRlimit) specs.POSIXRlimit {
+	return u
 }

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -17,8 +17,10 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/specgen"
+	"github.com/docker/go-units"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -356,4 +358,38 @@ func WeightDevices(wtDevices map[string]spec.LinuxWeightDevice) ([]spec.LinuxWei
 		devs = append(devs, *dev)
 	}
 	return devs, nil
+}
+
+// subNegativeOne translates Hard or soft limits of -1 to the current
+// processes Max limit
+func subNegativeOne(u spec.POSIXRlimit) spec.POSIXRlimit {
+	if !rootless.IsRootless() ||
+		(int64(u.Hard) != -1 && int64(u.Soft) != -1) {
+		return u
+	}
+
+	ul, err := units.ParseUlimit(fmt.Sprintf("%s=%d:%d", u.Type, int64(u.Soft), int64(u.Hard)))
+	if err != nil {
+		logrus.Warnf("Failed to check %s ulimit %q", u.Type, err)
+		return u
+	}
+	rl, err := ul.GetRlimit()
+	if err != nil {
+		logrus.Warnf("Failed to check %s ulimit %q", u.Type, err)
+		return u
+	}
+
+	var rlimit unix.Rlimit
+
+	if err := unix.Getrlimit(rl.Type, &rlimit); err != nil {
+		logrus.Warnf("Failed to return RLIMIT_NOFILE ulimit %q", err)
+		return u
+	}
+	if int64(u.Hard) == -1 {
+		u.Hard = rlimit.Max
+	}
+	if int64(u.Soft) == -1 {
+		u.Soft = rlimit.Max
+	}
+	return u
 }

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -465,7 +465,7 @@ var _ = Describe("Podman inspect", func() {
 		Expect(inspect[0].NetworkSettings.Networks).To(HaveLen(1))
 	})
 
-	It("Container inspect with unlimited uilimits should be -1", func() {
+	It("Container inspect with unlimited ulimits should be -1", func() {
 		ctrName := "testctr"
 		session := podmanTest.Podman([]string{"run", "-d", "--ulimit", "core=-1:-1", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Docker allows the passing of -1 to indicate the maximum limit allowed for the current process.

Fixes: https://github.com/containers/podman/issues/19319

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Ulimits set to -1 sets the container processes limits to the current max (Unlimited)
```
