### PR TITLE
e2e: use ExitCleanly() in attach & build tests

### DIFF
--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -4,6 +4,7 @@ import (
 	"syscall"
 	"time"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -18,9 +19,9 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to non-running container", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test1", "-i", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "test1", "-i", CITEST_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"attach", "test1"})
 		results.WaitWithDefaultTimeout()
@@ -28,10 +29,10 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman container attach to non-running container", func() {
-		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-i", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-i", CITEST_IMAGE, "ls"})
 
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"container", "attach", "test1"})
 		results.WaitWithDefaultTimeout()
@@ -41,11 +42,11 @@ var _ = Describe("Podman attach", func() {
 	It("podman attach to multiple containers", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.RunTopContainer("test2")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"attach", "test1", "test2"})
 		results.WaitWithDefaultTimeout()
@@ -53,9 +54,9 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to a running container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", ALPINE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"attach", "test"})
 		time.Sleep(2 * time.Second)
@@ -65,13 +66,13 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to the latest container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", ALPINE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "-d", "--name", "test2", ALPINE, "/bin/sh", "-c", "while true; do echo test2; sleep 1; done"})
+		session = podmanTest.Podman([]string{"run", "-d", "--name", "test2", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test2; sleep 1; done"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := "-l"
 		if IsRemote() {
@@ -85,9 +86,9 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to a container with --sig-proxy set to false", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", ALPINE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"attach", "--sig-proxy=false", "test"})
 		time.Sleep(2 * time.Second)

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/containers/buildah"
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -22,7 +23,7 @@ var _ = Describe("Podman build", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 		session := podmanTest.Podman([]string{"build", "--pull-never", "build/basicalpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		iid := session.OutputToStringArray()[len(session.OutputToStringArray())-1]
 
@@ -35,53 +36,53 @@ var _ = Describe("Podman build", func() {
 
 		session = podmanTest.Podman([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build with a secret from file", func() {
 		session := podmanTest.Podman([]string{"build", "-f", "build/Containerfile.with-secret", "-t", "secret-test", "--secret", "id=mysecret,src=build/secret.txt", "build/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
 
 		session = podmanTest.Podman([]string{"rmi", "secret-test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build with multiple secrets from files", func() {
 		session := podmanTest.Podman([]string{"build", "-f", "build/Containerfile.with-multiple-secret", "-t", "multiple-secret-test", "--secret", "id=mysecret,src=build/secret.txt", "--secret", "id=mysecret2,src=build/anothersecret.txt", "build/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
 		Expect(session.OutputToString()).To(ContainSubstring("anothersecret"))
 
 		session = podmanTest.Podman([]string{"rmi", "multiple-secret-test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build with a secret from file and verify if secret file is not leaked into image", func() {
 		session := podmanTest.Podman([]string{"build", "-f", "build/secret-verify-leak/Containerfile.with-secret-verify-leak", "-t", "secret-test-leak", "--secret", "id=mysecret,src=build/secret.txt", "build/secret-verify-leak"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "secret-test-leak", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("podman-build-secret")))
 
 		session = podmanTest.Podman([]string{"rmi", "secret-test-leak"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build with logfile", func() {
 		logfile := filepath.Join(podmanTest.TempDir, "logfile")
 		session := podmanTest.Podman([]string{"build", "--pull=never", "--tag", "test", "--logfile", logfile, "build/basicalpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Verify that OS and Arch are being set
 		inspect := podmanTest.Podman([]string{"inspect", "test"})
@@ -96,7 +97,7 @@ var _ = Describe("Podman build", func() {
 
 		session = podmanTest.Podman([]string{"rmi", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	// If the context directory is pointing at a file and not a directory,
@@ -110,72 +111,72 @@ var _ = Describe("Podman build", func() {
 	// Check that builds with different values for the squash options
 	// create the appropriate number of layers, then clean up after.
 	It("podman build basic alpine with squash", func() {
-		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/squash/Dockerfile.squash-a", "-t", "test-squash-a:latest", "build/squash"})
+		session := podmanTest.Podman([]string{"build", "-q", "--pull-never", "-f", "build/squash/Dockerfile.squash-a", "-t", "test-squash-a:latest", "build/squash"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Check for two layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(2))
 
-		session = podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/squash/Dockerfile.squash-b", "--squash", "-t", "test-squash-b:latest", "build/squash"})
+		session = podmanTest.Podman([]string{"build", "-q", "--pull-never", "-f", "build/squash/Dockerfile.squash-b", "--squash", "-t", "test-squash-b:latest", "build/squash"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-b"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Check for three layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(3))
 
-		session = podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/squash/Dockerfile.squash-c", "--squash", "-t", "test-squash-c:latest", "build/squash"})
+		session = podmanTest.Podman([]string{"build", "-q", "--pull-never", "-f", "build/squash/Dockerfile.squash-c", "--squash", "-t", "test-squash-c:latest", "build/squash"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-c"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Check for two layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(2))
 
-		session = podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/squash/Dockerfile.squash-c", "--squash-all", "-t", "test-squash-d:latest", "build/squash"})
+		session = podmanTest.Podman([]string{"build", "-q", "--pull-never", "-f", "build/squash/Dockerfile.squash-c", "--squash-all", "-t", "test-squash-d:latest", "build/squash"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-d"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Check for one layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(1))
 
 		session = podmanTest.Podman([]string{"rm", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build verify explicit cache use with squash-all and --layers", func() {
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/squash/Dockerfile.squash-c", "--squash-all", "--layers", "-t", "test-squash-d:latest", "build/squash"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-d"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Check for one layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(1))
 
 		// Second build must use last squashed build from cache
 		session = podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/squash/Dockerfile.squash-c", "--squash-all", "--layers", "-t", "test", "build/squash"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Test if entire build is used from cache
 		Expect(session.OutputToString()).To(ContainSubstring("Using cache"))
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-d"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// Check for one layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(1))
 
@@ -190,7 +191,7 @@ var _ = Describe("Podman build", func() {
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
 		fakeFile := filepath.Join(os.TempDir(), "Containerfile")
-		Expect(os.WriteFile(fakeFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(Succeed())
+		Expect(os.WriteFile(fakeFile, []byte(fmt.Sprintf("FROM %s", CITEST_IMAGE)), 0755)).To(Succeed())
 
 		targetFile := filepath.Join(podmanTest.TempDir, "Containerfile")
 		Expect(os.WriteFile(targetFile, []byte("FROM scratch"), 0755)).To(Succeed())
@@ -207,7 +208,7 @@ var _ = Describe("Podman build", func() {
 		session.WaitWithDefaultTimeout()
 
 		// Then
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(strings.Fields(session.OutputToString())).
 			To(ContainElement("scratch"))
 	})
@@ -223,7 +224,7 @@ var _ = Describe("Podman build", func() {
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "build/basicalpine", "--iidfile", targetFile})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		id, _ := os.ReadFile(targetFile)
 
 		// Verify that id is correct
@@ -239,18 +240,18 @@ var _ = Describe("Podman build", func() {
 			"build", "--annotation", "io.podman.annotations.seccomp=foobar", "--pull-never", "-f", "build/basicalpine/Containerfile.path", "-t", "test-path",
 		})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--name", "foobar", "test-path", "printenv", "PATH"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		stdoutLines := session.OutputToStringArray()
 		Expect(stdoutLines[0]).Should(Equal(path))
 
 		// Reserved annotation should not be applied from the image to the container.
 		session = podmanTest.Podman([]string{"inspect", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).NotTo(ContainSubstring("io.podman.annotations.seccomp"))
 	})
 
@@ -259,11 +260,11 @@ var _ = Describe("Podman build", func() {
 			"build", "-f", "build/workdir-symlink/Dockerfile", "-t", "test-symlink",
 		})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--workdir", "/tmp/link", "test-symlink"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("hello"))
 	})
 
@@ -281,9 +282,9 @@ var _ = Describe("Podman build", func() {
 			// the remote client should still use the proxy that was set for the server
 			os.Setenv("http_proxy", "127.0.0.2")
 		}
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 		dockerfile := fmt.Sprintf(`FROM %s
-RUN printenv http_proxy`, ALPINE)
+RUN printenv http_proxy`, CITEST_IMAGE)
 
 		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
 		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
@@ -291,7 +292,7 @@ RUN printenv http_proxy`, ALPINE)
 		// --http-proxy should be true by default so we do not set it
 		session := podmanTest.Podman([]string{"build", "--pull-never", "--file", dockerfilePath, podmanTest.TempDir})
 		session.Wait(120)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("1.2.3.4"))
 
 		// this tries to use the cache so we explicitly disable it
@@ -306,9 +307,9 @@ RUN printenv http_proxy`, ALPINE)
 			podmanTest.StopRemoteService()
 			podmanTest.StartRemoteService()
 		}
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 		dockerfile := fmt.Sprintf(`FROM %s
-RUN exit 5`, ALPINE)
+RUN exit 5`, CITEST_IMAGE)
 
 		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
 		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
@@ -321,7 +322,7 @@ RUN exit 5`, ALPINE)
 	It("podman build and check identity", func() {
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/basicalpine/Containerfile.path", "--no-cache", "-t", "test", "build/basicalpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Verify that OS and Arch are being set
 		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ index .Config.Labels }}", "test"})
@@ -332,9 +333,9 @@ RUN exit 5`, ALPINE)
 
 	It("podman build and check identity with always", func() {
 		// with --pull=always
-		session := podmanTest.Podman([]string{"build", "--pull=always", "-f", "build/basicalpine/Containerfile.path", "--no-cache", "-t", "test1", "build/basicalpine"})
+		session := podmanTest.Podman([]string{"build", "-q", "--pull=always", "-f", "build/basicalpine/Containerfile.path", "--no-cache", "-t", "test1", "build/basicalpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Verify that OS and Arch are being set
 		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ index .Config.Labels }}", "test1"})
@@ -343,9 +344,9 @@ RUN exit 5`, ALPINE)
 		Expect(data).To(ContainSubstring(buildah.Version))
 
 		// with --pull-always
-		session = podmanTest.Podman([]string{"build", "--pull-always", "-f", "build/basicalpine/Containerfile.path", "--no-cache", "-t", "test2", "build/basicalpine"})
+		session = podmanTest.Podman([]string{"build", "-q", "--pull-always", "-f", "build/basicalpine/Containerfile.path", "--no-cache", "-t", "test2", "build/basicalpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Verify that OS and Arch are being set
 		inspect = podmanTest.Podman([]string{"image", "inspect", "--format", "{{ index .Config.Labels }}", "test2"})
@@ -369,7 +370,7 @@ RUN exit 5`, ALPINE)
 		}
 
 		containerfile := fmt.Sprintf(`FROM %s
-COPY /emptydir/* /dir`, ALPINE)
+COPY /emptydir/* /dir`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "ContainerfilePathToCopier")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
@@ -391,8 +392,6 @@ COPY /emptydir/* /dir`, ALPINE)
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 
-		podmanTest.AddImageToRWStore(ALPINE)
-
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
@@ -404,7 +403,7 @@ COPY /emptydir/* /dir`, ALPINE)
 
 		containerfile := fmt.Sprintf(`FROM %s
 ADD . /test
-RUN find /test`, ALPINE)
+RUN find /test`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
@@ -419,7 +418,7 @@ RUN find /test`, ALPINE)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "-f", "Containerfile", targetSubPath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/test/dummy"))
 	})
 
@@ -442,11 +441,11 @@ RUN find /test`, ALPINE)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "build/containerignore-symlink/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--rm", "test", "ls", "/dir"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("hello"))
 	})
 
@@ -462,7 +461,7 @@ RUN find /test`, ALPINE)
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
@@ -470,7 +469,7 @@ RUN find /test`, ALPINE)
 		err = os.Mkdir(targetSubPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
-		containerfile := fmt.Sprintf("FROM %s", ALPINE)
+		containerfile := fmt.Sprintf("FROM %s", CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetSubPath, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
@@ -485,7 +484,7 @@ RUN find /test`, ALPINE)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "-f", "subdir/Containerfile", "."})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman remote test .dockerignore", func() {
@@ -500,7 +499,7 @@ RUN find /test`, ALPINE)
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		// Write target and fake files
 		targetPath := filepath.Join(podmanTest.TempDir, "build")
@@ -509,7 +508,7 @@ RUN find /test`, ALPINE)
 
 		containerfile := fmt.Sprintf(`FROM %s
 ADD . /testfilter/
-RUN find /testfilter/`, ALPINE)
+RUN find /testfilter/`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
@@ -550,7 +549,7 @@ subdir**`
 
 		session := podmanTest.Podman([]string{"build", "-t", "test", "."})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output := session.OutputToString()
 		Expect(output).To(ContainSubstring("/testfilter/dummy2"))
 		Expect(output).NotTo(ContainSubstring("/testfilter/dummy1"))
@@ -566,10 +565,10 @@ subdir**`
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		contents := bytes.Buffer{}
-		contents.WriteString("FROM " + ALPINE + "\n")
+		contents.WriteString("FROM " + CITEST_IMAGE + "\n")
 		contents.WriteString("ADD . /testfilter/\n")
 		contents.WriteString("RUN find /testfilter/ -print\n")
 
@@ -606,7 +605,7 @@ subdir**`
 
 		session := podmanTest.Podman([]string{"build", "-f", containerfile, contextDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		output := session.OutputToString()
 		Expect(output).To(ContainSubstring("/testfilter/expected"))
@@ -621,7 +620,7 @@ subdir**`
 		cwd, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
@@ -641,7 +640,7 @@ subdir**`
 		containerfile := fmt.Sprintf(`FROM %s
 ADD . /test
 RUN find /test
-RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, ALPINE)
+RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetSubPath, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
@@ -656,7 +655,7 @@ RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, ALPINE)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", targetSubPath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/test/dummy"))
 		Expect(session.OutputToString()).To(ContainSubstring("/test/emptyDir"))
 		Expect(session.OutputToString()).To(ContainSubstring("/test/dummy-symlink"))
@@ -679,14 +678,14 @@ RUN grep CapEff /proc/self/status`
 
 		// When
 		session := podmanTest.Podman([]string{
-			"build", "--pull-never", "--cap-drop=all", "--cap-add=net_bind_service", "--add-host", "testhost:1.2.3.4", "--from", ALPINE, targetPath,
+			"build", "--pull-never", "--cap-drop=all", "--cap-add=net_bind_service", "--add-host", "testhost:1.2.3.4", "--from", CITEST_IMAGE, targetPath,
 		})
 		session.WaitWithDefaultTimeout()
 
 		// Then
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(strings.Fields(session.OutputToString())).
-			To(ContainElement(ALPINE))
+			To(ContainElement(CITEST_IMAGE))
 		Expect(strings.Fields(session.OutputToString())).
 			To(ContainElement("testhost"))
 		Expect(strings.Fields(session.OutputToString())).
@@ -696,7 +695,7 @@ RUN grep CapEff /proc/self/status`
 	It("podman build --isolation && --arch", func() {
 		targetPath := podmanTest.TempDir
 		containerFile := filepath.Join(targetPath, "Containerfile")
-		Expect(os.WriteFile(containerFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(Succeed())
+		Expect(os.WriteFile(containerFile, []byte(fmt.Sprintf("FROM %s", CITEST_IMAGE)), 0755)).To(Succeed())
 
 		defer func() {
 			Expect(os.RemoveAll(containerFile)).To(Succeed())
@@ -704,31 +703,31 @@ RUN grep CapEff /proc/self/status`
 
 		// When
 		session := podmanTest.Podman([]string{
-			"build", "--isolation", "oci", "--arch", "arm64", targetPath,
+			"build", "-q", "--isolation", "oci", "--arch", "arm64", targetPath,
 		})
 		session.WaitWithDefaultTimeout()
 		// Then
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// When
 		session = podmanTest.Podman([]string{
-			"build", "--isolation", "chroot", "--arch", "arm64", targetPath,
+			"build", "-q", "--isolation", "chroot", "--arch", "arm64", targetPath,
 		})
 		session.WaitWithDefaultTimeout()
 		// Then
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// When
 		session = podmanTest.Podman([]string{
-			"build", "--pull-never", "--isolation", "rootless", "--arch", "arm64", targetPath,
+			"build", "-q", "--pull-never", "--isolation", "rootless", "--arch", "arm64", targetPath,
 		})
 		session.WaitWithDefaultTimeout()
 		// Then
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// When
 		session = podmanTest.Podman([]string{
-			"build", "--pull-never", "--isolation", "bogus", "--arch", "arm64", targetPath,
+			"build", "-q", "--pull-never", "--isolation", "bogus", "--arch", "arm64", targetPath,
 		})
 		session.WaitWithDefaultTimeout()
 		// Then
@@ -737,14 +736,14 @@ RUN grep CapEff /proc/self/status`
 
 	It("podman build --timestamp flag", func() {
 		containerfile := fmt.Sprintf(`FROM %s
-RUN echo hello`, ALPINE)
+RUN echo hello`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--timestamp", "0", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Created }}", "test"})
 		inspect.WaitWithDefaultTimeout()
@@ -761,7 +760,7 @@ RUN echo hello`, ALPINE)
 
 		session := podmanTest.Podman([]string{"build", "--log-rusage", "--pull-never", targetPath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("(system)"))
 		Expect(session.OutputToString()).To(ContainSubstring("(user)"))
 		Expect(session.OutputToString()).To(ContainSubstring("(elapsed)"))
@@ -774,7 +773,7 @@ RUN echo hello`, ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--arch", "foo", "--os", "bar", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Architecture }}", "test"})
 		inspect.WaitWithDefaultTimeout()
@@ -793,7 +792,7 @@ RUN echo hello`, ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--os", "windows", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Architecture }}", "test"})
 		inspect.WaitWithDefaultTimeout()
@@ -810,7 +809,7 @@ RUN echo hello`, ALPINE)
 			Skip(fmt.Sprintf("test requires stat /dev/fuse to work: %v", err))
 		}
 		containerfile := fmt.Sprintf(`FROM %s
-RUN ls /dev/fuse`, ALPINE)
+RUN ls /dev/fuse`, CITEST_IMAGE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -820,13 +819,13 @@ RUN ls /dev/fuse`, ALPINE)
 
 		session = podmanTest.Podman([]string{"build", "--pull-never", "--device", "/dev/fuse", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build device rename test", func() {
 		SkipIfRootless("rootless builds do not currently support renaming devices")
 		containerfile := fmt.Sprintf(`FROM %s
-RUN ls /dev/test1`, ALPINE)
+RUN ls /dev/test1`, CITEST_IMAGE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -836,11 +835,11 @@ RUN ls /dev/test1`, ALPINE)
 
 		session = podmanTest.Podman([]string{"build", "--pull-never", "--device", "/dev/zero:/dev/test1", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman build use absolute path even if given relative", func() {
-		containerFile := fmt.Sprintf(`FROM %s`, ALPINE)
+		containerFile := fmt.Sprintf(`FROM %s`, CITEST_IMAGE)
 		relativeDir := filepath.Join(podmanTest.TempDir, "relativeDir")
 		containerFilePath := filepath.Join(relativeDir, "Containerfile")
 		buildRoot := filepath.Join(relativeDir, "build-root")
@@ -853,7 +852,7 @@ RUN ls /dev/test1`, ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		build := podmanTest.Podman([]string{"build", "-f", containerFilePath, buildRoot})
 		build.WaitWithDefaultTimeout()
-		Expect(build).To(Exit(0))
+		Expect(build).To(ExitCleanly())
 	})
 
 	// system reset must run serial: https://github.com/containers/podman/issues/17903
@@ -863,11 +862,11 @@ RUN ls /dev/test1`, ALPINE)
 		podmanTest.AddImageToRWStore(ALPINE)
 		session := podmanTest.Podman([]string{"build", "--pull-never", "--file", "build/cache/Dockerfilecachewrite", "build/cache/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"system", "reset", "-f"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"build", "--pull-never", "--file", "build/cache/Dockerfilecacheread", "build/cache/"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Small steps toward RUN-1907: replace Exit(0) with ExitCleanly()
in ginkgo tests in two test files. Also, when practical,
replace ALPINE with CITEST_IMAGE.

There are still many thousands of instances left to fix. I will
be submitting in reviewable chunks.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```