### PR TITLE
Add support for kube  securityContext.procMount

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -121,7 +121,7 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | securityContext\.runAsNonRoot                       | no      |
 | securityContext\.runAsGroup                         | ✅      |
 | securityContext\.readOnlyRootFilesystem             | ✅      |
-| securityContext\.procMount                          | no      |
+| securityContext\.procMount                          | ✅      |
 | securityContext\.privileged                         | ✅      |
 | securityContext\.allowPrivilegeEscalation           | ✅      |
 | securityContext\.capabilities\.add                  | ✅      |

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -312,6 +312,10 @@ func (c *Container) GetSecurityOptions() []string {
 	if apparmor, ok := ctrSpec.Annotations[define.InspectAnnotationApparmor]; ok {
 		SecurityOpt = append(SecurityOpt, fmt.Sprintf("apparmor=%s", apparmor))
 	}
+	if c.config.Spec.Linux.MaskedPaths == nil {
+		SecurityOpt = append(SecurityOpt, "unmask=all")
+	}
+
 	return SecurityOpt
 }
 

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -1220,6 +1220,12 @@ func generateKubeSecurityContext(c *Container) (*v1.SecurityContext, bool, error
 		scHasData = true
 		sc.ReadOnlyRootFilesystem = &ro
 	}
+	if c.config.Spec.Linux.MaskedPaths == nil {
+		scHasData = true
+		unmask := v1.UnmaskedProcMount
+		sc.ProcMount = &unmask
+	}
+
 	if c.User() != "" {
 		if !c.batched {
 			c.lock.Lock()

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -807,6 +807,10 @@ func setupSecurityContext(s *specgen.SpecGenerator, securityContext *v1.Security
 		s.NoNewPrivileges = !*securityContext.AllowPrivilegeEscalation
 	}
 
+	if securityContext.ProcMount != nil && *securityContext.ProcMount == v1.UnmaskedProcMount {
+		s.ContainerSecurityConfig.Unmask = append(s.ContainerSecurityConfig.Unmask, []string{"ALL"}...)
+	}
+
 	seopt := securityContext.SELinuxOptions
 	if seopt == nil {
 		seopt = podSecurityContext.SELinuxOptions


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/19881
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman kube play/generate now support     securityContext:      procMount: Unmasked
```
