### PR TITLE
fix pod cgroup lifecycle

### DIFF
--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -361,9 +361,6 @@ func (p *Pod) CgroupPath() (string, error) {
 	if err := p.updatePod(); err != nil {
 		return "", err
 	}
-	if p.state.InfraContainerID == "" {
-		return "", fmt.Errorf("pod has no infra container: %w", define.ErrNoSuchCtr)
-	}
 	return p.state.CgroupPath, nil
 }
 

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -209,6 +209,13 @@ func (p *Pod) stopWithTimeout(ctx context.Context, cleanup bool, timeout int) (m
 		return nil, err
 	}
 
+	if err := p.updatePod(); err != nil {
+		return nil, err
+	}
+	if err := p.removePodCgroup(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 

--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -58,8 +58,12 @@ func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, option
 
 	pod.valid = true
 
-	if err := r.platformMakePod(pod, p); err != nil {
+	parentCgroup, err := r.platformMakePod(pod, p.ResourceLimits)
+	if err != nil {
 		return nil, err
+	}
+	if p.InfraContainerSpec != nil {
+		p.InfraContainerSpec.CgroupParent = parentCgroup
 	}
 
 	if !pod.HasInfraContainer() && pod.SharesNamespaces() {

--- a/libpod/runtime_pod_freebsd.go
+++ b/libpod/runtime_pod_freebsd.go
@@ -1,9 +1,9 @@
 package libpod
 
 import (
-	"github.com/containers/podman/v4/pkg/specgen"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (r *Runtime) platformMakePod(pod *Pod, p specgen.PodSpecGenerator) error {
-	return nil
+func (r *Runtime) platformMakePod(pod *Pod, resourceLimits *spec.LinuxResources) (string, error) {
+	return "", nil
 }

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -10,11 +10,12 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/containers/podman/v4/pkg/specgen"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
 
-func (r *Runtime) platformMakePod(pod *Pod, p specgen.PodSpecGenerator) error {
+func (r *Runtime) platformMakePod(pod *Pod, resourceLimits *spec.LinuxResources) (string, error) {
+	cgroupParent := ""
 	// Check Cgroup parent sanity, and set it if it was not set
 	if r.config.Cgroups() != "disabled" {
 		switch r.config.Engine.CgroupManager {
@@ -25,32 +26,30 @@ func (r *Runtime) platformMakePod(pod *Pod, p specgen.PodSpecGenerator) error {
 				if pod.config.CgroupParent == "" {
 					pod.config.CgroupParent = CgroupfsDefaultCgroupParent
 				} else if strings.HasSuffix(path.Base(pod.config.CgroupParent), ".slice") {
-					return fmt.Errorf("systemd slice received as cgroup parent when using cgroupfs: %w", define.ErrInvalidArg)
+					return "", fmt.Errorf("systemd slice received as cgroup parent when using cgroupfs: %w", define.ErrInvalidArg)
 				}
 				// If we are set to use pod cgroups, set the cgroup parent that
 				// all containers in the pod will share
 				if pod.config.UsePodCgroup {
 					pod.state.CgroupPath = filepath.Join(pod.config.CgroupParent, pod.ID())
-					if p.InfraContainerSpec != nil {
-						p.InfraContainerSpec.CgroupParent = pod.state.CgroupPath
-						// cgroupfs + rootless = permission denied when creating the cgroup.
-						if !rootless.IsRootless() {
-							res, err := GetLimits(p.ResourceLimits)
-							if err != nil {
-								return err
-							}
-							// Need to both create and update the cgroup
-							// rather than create a new path in c/common for pod cgroup creation
-							// just create as if it is a ctr and then update figures out that we need to
-							// populate the resource limits on the pod level
-							cgc, err := cgroups.New(pod.state.CgroupPath, &res)
-							if err != nil {
-								return err
-							}
-							err = cgc.Update(&res)
-							if err != nil {
-								return err
-							}
+					cgroupParent = pod.state.CgroupPath
+					// cgroupfs + rootless = permission denied when creating the cgroup.
+					if !rootless.IsRootless() {
+						res, err := GetLimits(resourceLimits)
+						if err != nil {
+							return "", err
+						}
+						// Need to both create and update the cgroup
+						// rather than create a new path in c/common for pod cgroup creation
+						// just create as if it is a ctr and then update figures out that we need to
+						// populate the resource limits on the pod level
+						cgc, err := cgroups.New(pod.state.CgroupPath, &res)
+						if err != nil {
+							return "", err
+						}
+						err = cgc.Update(&res)
+						if err != nil {
+							return "", err
 						}
 					}
 				}
@@ -63,22 +62,20 @@ func (r *Runtime) platformMakePod(pod *Pod, p specgen.PodSpecGenerator) error {
 					pod.config.CgroupParent = SystemdDefaultCgroupParent
 				}
 			} else if len(pod.config.CgroupParent) < 6 || !strings.HasSuffix(path.Base(pod.config.CgroupParent), ".slice") {
-				return fmt.Errorf("did not receive systemd slice as cgroup parent when using systemd to manage cgroups: %w", define.ErrInvalidArg)
+				return "", fmt.Errorf("did not receive systemd slice as cgroup parent when using systemd to manage cgroups: %w", define.ErrInvalidArg)
 			}
 			// If we are set to use pod cgroups, set the cgroup parent that
 			// all containers in the pod will share
 			if pod.config.UsePodCgroup {
-				cgroupPath, err := systemdSliceFromPath(pod.config.CgroupParent, fmt.Sprintf("libpod_pod_%s", pod.ID()), p.ResourceLimits)
+				cgroupPath, err := systemdSliceFromPath(pod.config.CgroupParent, fmt.Sprintf("libpod_pod_%s", pod.ID()), resourceLimits)
 				if err != nil {
-					return fmt.Errorf("unable to create pod cgroup for pod %s: %w", pod.ID(), err)
+					return "", fmt.Errorf("unable to create pod cgroup for pod %s: %w", pod.ID(), err)
 				}
 				pod.state.CgroupPath = cgroupPath
-				if p.InfraContainerSpec != nil {
-					p.InfraContainerSpec.CgroupParent = pod.state.CgroupPath
-				}
+				cgroupParent = pod.state.CgroupPath
 			}
 		default:
-			return fmt.Errorf("unsupported Cgroup manager: %s - cannot validate cgroup parent: %w", r.config.Engine.CgroupManager, define.ErrInvalidArg)
+			return "", fmt.Errorf("unsupported Cgroup manager: %s - cannot validate cgroup parent: %w", r.config.Engine.CgroupManager, define.ErrInvalidArg)
 		}
 	}
 
@@ -86,5 +83,5 @@ func (r *Runtime) platformMakePod(pod *Pod, p specgen.PodSpecGenerator) error {
 		logrus.Debugf("Got pod cgroup as %s", pod.state.CgroupPath)
 	}
 
-	return nil
+	return cgroupParent, nil
 }

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -44,28 +44,18 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (_ *libpod.Pod, finalErr e
 		p.PodSpecGen.InfraContainerSpec.RawImageName = imageName
 	}
 
-	if !p.PodSpecGen.NoInfra && p.PodSpecGen.InfraContainerSpec != nil {
-		var err error
-		p.PodSpecGen.InfraContainerSpec, err = MapSpec(&p.PodSpecGen)
-		if err != nil {
-			return nil, err
-		}
+	spec, err := MapSpec(&p.PodSpecGen)
+	if err != nil {
+		return nil, err
 	}
-
-	if !p.PodSpecGen.NoInfra {
-		err := specgen.FinishThrottleDevices(p.PodSpecGen.InfraContainerSpec)
-		if err != nil {
-			return nil, err
-		}
-		if p.PodSpecGen.InfraContainerSpec.ResourceLimits != nil &&
-			p.PodSpecGen.InfraContainerSpec.ResourceLimits.BlockIO != nil {
-			p.PodSpecGen.ResourceLimits.BlockIO = p.PodSpecGen.InfraContainerSpec.ResourceLimits.BlockIO
-		}
-		err = specgen.WeightDevices(p.PodSpecGen.InfraContainerSpec)
-		if err != nil {
-			return nil, err
-		}
-		p.PodSpecGen.ResourceLimits = p.PodSpecGen.InfraContainerSpec.ResourceLimits
+	if err := specgen.FinishThrottleDevices(spec); err != nil {
+		return nil, err
+	}
+	if err := specgen.WeightDevices(spec); err != nil {
+		return nil, err
+	}
+	if spec.ResourceLimits != nil && spec.ResourceLimits.BlockIO != nil {
+		p.PodSpecGen.ResourceLimits.BlockIO = spec.ResourceLimits.BlockIO
 	}
 
 	options, err := createPodOptions(&p.PodSpecGen)
@@ -177,12 +167,18 @@ func createPodOptions(p *specgen.PodSpecGenerator) ([]libpod.PodCreateOption, er
 // MapSpec modifies the already filled Infra specgenerator,
 // replacing necessary values with those specified in pod creation
 func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
+	var spec *specgen.SpecGenerator
+	if p.InfraContainerSpec != nil {
+		spec = p.InfraContainerSpec
+	} else {
+		spec = &specgen.SpecGenerator{}
+	}
 	if len(p.PortMappings) > 0 {
 		ports, err := ParsePortMapping(p.PortMappings, nil)
 		if err != nil {
 			return nil, err
 		}
-		p.InfraContainerSpec.PortMappings = ports
+		spec.PortMappings = ports
 	}
 	switch p.NetNS.NSMode {
 	case specgen.Default, "":
@@ -191,90 +187,90 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 			break
 		}
 	case specgen.Bridge:
-		p.InfraContainerSpec.NetNS.NSMode = specgen.Bridge
+		spec.NetNS.NSMode = specgen.Bridge
 		logrus.Debugf("Pod using bridge network mode")
 	case specgen.Private:
-		p.InfraContainerSpec.NetNS.NSMode = specgen.Private
+		spec.NetNS.NSMode = specgen.Private
 		logrus.Debugf("Pod will use default network mode")
 	case specgen.Host:
 		logrus.Debugf("Pod will use host networking")
-		if len(p.InfraContainerSpec.PortMappings) > 0 ||
-			len(p.InfraContainerSpec.Networks) > 0 ||
-			p.InfraContainerSpec.NetNS.NSMode == specgen.NoNetwork {
+		if len(spec.PortMappings) > 0 ||
+			len(spec.Networks) > 0 ||
+			spec.NetNS.NSMode == specgen.NoNetwork {
 			return nil, fmt.Errorf("cannot set host network if network-related configuration is specified: %w", define.ErrInvalidArg)
 		}
-		p.InfraContainerSpec.NetNS.NSMode = specgen.Host
+		spec.NetNS.NSMode = specgen.Host
 	case specgen.Slirp:
 		logrus.Debugf("Pod will use slirp4netns")
-		if p.InfraContainerSpec.NetNS.NSMode != specgen.Host {
-			p.InfraContainerSpec.NetworkOptions = p.NetworkOptions
-			p.InfraContainerSpec.NetNS.NSMode = specgen.Slirp
+		if spec.NetNS.NSMode != specgen.Host {
+			spec.NetworkOptions = p.NetworkOptions
+			spec.NetNS.NSMode = specgen.Slirp
 		}
 	case specgen.Pasta:
 		logrus.Debugf("Pod will use pasta")
-		if p.InfraContainerSpec.NetNS.NSMode != specgen.Host {
-			p.InfraContainerSpec.NetworkOptions = p.NetworkOptions
-			p.InfraContainerSpec.NetNS.NSMode = specgen.Pasta
+		if spec.NetNS.NSMode != specgen.Host {
+			spec.NetworkOptions = p.NetworkOptions
+			spec.NetNS.NSMode = specgen.Pasta
 		}
 	case specgen.Path:
 		logrus.Debugf("Pod will use namespace path networking")
-		p.InfraContainerSpec.NetNS.NSMode = specgen.Path
-		p.InfraContainerSpec.NetNS.Value = p.PodNetworkConfig.NetNS.Value
+		spec.NetNS.NSMode = specgen.Path
+		spec.NetNS.Value = p.PodNetworkConfig.NetNS.Value
 	case specgen.NoNetwork:
 		logrus.Debugf("Pod will not use networking")
-		if len(p.InfraContainerSpec.PortMappings) > 0 ||
-			len(p.InfraContainerSpec.Networks) > 0 ||
-			p.InfraContainerSpec.NetNS.NSMode == specgen.Host {
+		if len(spec.PortMappings) > 0 ||
+			len(spec.Networks) > 0 ||
+			spec.NetNS.NSMode == specgen.Host {
 			return nil, fmt.Errorf("cannot disable pod network if network-related configuration is specified: %w", define.ErrInvalidArg)
 		}
-		p.InfraContainerSpec.NetNS.NSMode = specgen.NoNetwork
+		spec.NetNS.NSMode = specgen.NoNetwork
 	default:
 		return nil, fmt.Errorf("pods presently do not support network mode %s", p.NetNS.NSMode)
 	}
 
 	if len(p.InfraCommand) > 0 {
-		p.InfraContainerSpec.Entrypoint = p.InfraCommand
+		spec.Entrypoint = p.InfraCommand
 	}
 
 	if len(p.HostAdd) > 0 {
-		p.InfraContainerSpec.HostAdd = p.HostAdd
+		spec.HostAdd = p.HostAdd
 	}
 	if len(p.DNSServer) > 0 {
 		var dnsServers []net.IP
 		dnsServers = append(dnsServers, p.DNSServer...)
 
-		p.InfraContainerSpec.DNSServers = dnsServers
+		spec.DNSServers = dnsServers
 	}
 	if len(p.DNSOption) > 0 {
-		p.InfraContainerSpec.DNSOptions = p.DNSOption
+		spec.DNSOptions = p.DNSOption
 	}
 	if len(p.DNSSearch) > 0 {
-		p.InfraContainerSpec.DNSSearch = p.DNSSearch
+		spec.DNSSearch = p.DNSSearch
 	}
 	if p.NoManageResolvConf {
-		p.InfraContainerSpec.UseImageResolvConf = true
+		spec.UseImageResolvConf = true
 	}
 	if len(p.Networks) > 0 {
-		p.InfraContainerSpec.Networks = p.Networks
+		spec.Networks = p.Networks
 	}
 	// deprecated cni networks for api users
 	if len(p.CNINetworks) > 0 {
-		p.InfraContainerSpec.CNINetworks = p.CNINetworks
+		spec.CNINetworks = p.CNINetworks
 	}
 	if p.NoManageHosts {
-		p.InfraContainerSpec.UseImageHosts = p.NoManageHosts
+		spec.UseImageHosts = p.NoManageHosts
 	}
 
 	if len(p.InfraConmonPidFile) > 0 {
-		p.InfraContainerSpec.ConmonPidFile = p.InfraConmonPidFile
+		spec.ConmonPidFile = p.InfraConmonPidFile
 	}
 
 	if p.Sysctl != nil && len(p.Sysctl) > 0 {
-		p.InfraContainerSpec.Sysctl = p.Sysctl
+		spec.Sysctl = p.Sysctl
 	}
 
-	p.InfraContainerSpec.Image = p.InfraImage
-	return p.InfraContainerSpec, nil
+	spec.Image = p.InfraImage
+	return spec, nil
 }
 
 func PodConfigToSpec(rt *libpod.Runtime, spec *specgen.PodSpecGenerator, infraOptions *entities.ContainerCreateOptions, id string) (p *libpod.Pod, err error) {

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -123,11 +123,12 @@ func createPodOptions(p *specgen.PodSpecGenerator) ([]libpod.PodCreateOption, er
 	var (
 		options []libpod.PodCreateOption
 	)
+
+	if p.ShareParent == nil || (p.ShareParent != nil && *p.ShareParent) {
+		options = append(options, libpod.WithPodParent())
+	}
 	if !p.NoInfra {
 		options = append(options, libpod.WithInfraContainer())
-		if p.ShareParent == nil || (p.ShareParent != nil && *p.ShareParent) {
-			options = append(options, libpod.WithPodParent())
-		}
 		nsOptions, err := GetNamespaceOptions(p.SharedNamespaces, p.InfraContainerSpec.NetNS.IsHost())
 		if err != nil {
 			return nil, err

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -689,4 +689,54 @@ function thingy_with_unique_id() {
     run_podman rm -f -a
 }
 
+
+@test "podman pod cleans cgroup and keeps limits" {
+    skip_if_remote "we cannot check cgroup settings"
+    skip_if_rootless_cgroupsv1 "rootless cannot use cgroups on v1"
+
+    for infra in true false; do
+        run_podman pod create --infra=$infra --memory=256M
+        podid="$output"
+        run_podman run -d --pod $podid $IMAGE top -d 2
+
+        run_podman pod inspect $podid
+        result=$(jq -r .CgroupPath <<< $output)
+        assert "$result" =~ "/" ".CgroupPath is a valid path"
+
+        if is_cgroupsv2; then
+           cgroup_path=/sys/fs/cgroup/$result
+        else
+           cgroup_path=/sys/fs/cgroup/memory/$result
+        fi
+
+        if test ! -e $cgroup_path; then
+            die "the cgroup $cgroup_path does not exist"
+        fi
+
+        run_podman pod stop -t 0 $podid
+        if test -e $cgroup_path; then
+            die "the cgroup $cgroup_path should not exist after pod stop"
+        fi
+
+        run_podman pod start $podid
+        if test ! -e $cgroup_path; then
+            die "the cgroup $cgroup_path does not exist"
+        fi
+
+        # validate that cgroup limits are in place after a restart
+        # issue #19175
+        if is_cgroupsv2; then
+           memory_limit_file=$cgroup_path/memory.max
+        else
+           memory_limit_file=$cgroup_path/memory.limit_in_bytes
+        fi
+        assert "$(< $memory_limit_file)" = "268435456" "Contents of $memory_limit_file"
+
+        run_podman pod rm -t 0 -f $podid
+        if test -e $cgroup_path; then
+            die "the cgroup $cgroup_path should not exist after pod rm"
+        fi
+    done
+}
+
 # vim: filetype=sh

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -47,7 +47,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 		// On errors check if the cgroup already exists, if it does move the process there
 		if props, err := conn.GetUnitTypePropertiesContext(context.Background(), unitName, "Scope"); err == nil {
 			if cgroup, ok := props["ControlGroup"].(string); ok && cgroup != "" {
-				if err := moveUnderCgroup(cgroup, "", []uint32{uint32(pid)}); err == nil {
+				if err := MoveUnderCgroup(cgroup, "", []uint32{uint32(pid)}); err == nil {
 					return nil
 				}
 				// On errors return the original error message we got from StartTransientUnit.
@@ -107,13 +107,13 @@ func GetCgroupProcess(pid int) (string, error) {
 
 // MoveUnderCgroupSubtree moves the PID under a cgroup subtree.
 func MoveUnderCgroupSubtree(subtree string) error {
-	return moveUnderCgroup("", subtree, nil)
+	return MoveUnderCgroup("", subtree, nil)
 }
 
-// moveUnderCgroup moves a group of processes to a new cgroup.
+// MoveUnderCgroup moves a group of processes to a new cgroup.
 // If cgroup is the empty string, then the current calling process cgroup is used.
 // If processes is empty, then the processes from the current cgroup are moved.
-func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
+func MoveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 	procFile := "/proc/self/cgroup"
 	f, err := os.Open(procFile)
 	if err != nil {


### PR DESCRIPTION
while investigating 19175, I've found a bunch of issues with the way we handle the pod cgroup:

- The pod cgroup was not honoring the cgroup limits after a reboot
- The cgroup once created was leaked, even if the pod is stopped
- --infra=false was not creating any pod cgroup, and all the limits were ignored.

More details in the individual commits.  There is some space for improvements, e.g. not trying to guess the systemd path but we would need to fix it in c/common first, we can do this incrementally later.

Closes: https://github.com/containers/podman/issues/19175

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now pod cgroup limits are honored after a reboot
```
