### PR TITLE
podman: don't restart after kill

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -292,7 +292,7 @@ func (c *Container) Kill(signal uint) error {
 		return c.waitForConmonToExitAndSave()
 	}
 
-	return nil
+	return c.save()
 }
 
 // Attach attaches to a container.

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -140,6 +140,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 			CheckpointPath: runtimeInfo.CheckpointPath,
 			CheckpointLog:  runtimeInfo.CheckpointLog,
 			RestoreLog:     runtimeInfo.RestoreLog,
+			StoppedByUser:  c.state.StoppedByUser,
 		},
 		Image:                   config.RootfsImageID,
 		ImageName:               config.RootfsImageName,

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -228,6 +228,7 @@ type InspectContainerState struct {
 	CheckpointPath string             `json:"CheckpointPath,omitempty"`
 	RestoreLog     string             `json:"RestoreLog,omitempty"`
 	Restored       bool               `json:"Restored,omitempty"`
+	StoppedByUser  bool               `json:"StoppedByUser,omitempty"`
 }
 
 // Healthcheck returns the HealthCheckResults. This is used for old podman compat


### PR DESCRIPTION
Also add a new `StoppedByUser` field to the container-inspect state which can be useful during debugging and is now also used in the regression test.  Note that I moved the `false` check one test above such that we can compare the previous Podman version which should just be stuck in the `wait $ctr` command since it will continue restarting.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not restart containers after a `podman kill`.
```

Discovered while debugging https://github.com/containers/podman/issues/19815.