### PR TITLE
run --rmi: "cannot remove" is a warning, not an error

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -13,10 +13,10 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgenutil"
+	"github.com/containers/storage/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -226,8 +226,12 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	if runRmi {
 		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{imageName}, entities.ImageRemoveOptions{})
-		if len(rmErrors) > 0 {
-			logrus.Errorf("%s", errorhandling.JoinErrors(rmErrors))
+		for _, err := range rmErrors {
+			// ImageUnknown would be a super-unlikely race
+			if !errors.Is(err, types.ErrImageUnknown) {
+				// Typical case: ErrImageUsedByContainer
+				logrus.Warn(err)
+			}
 		}
 	}
 	if cmd.Flag("gpus").Changed {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -181,7 +181,7 @@ echo $rand        |   0 | $rand
     run_podman image exists $NONLOCAL_IMAGE
 
     # Now try running with --rmi : it should succeed, but not remove the image
-    run_podman 0+e run --rmi --rm $NONLOCAL_IMAGE /bin/true
+    run_podman 0+w run --rmi --rm $NONLOCAL_IMAGE /bin/true
     is "$output" ".*image is in use by a container" "--rmi should warn that the image was not removed"
     run_podman image exists $NONLOCAL_IMAGE
 

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -359,7 +359,7 @@ failed    | exited     | 17
 
 
 @test "stop and rm" {
-    run_podman stop myrunningcontainer
+    run_podman 0+w stop myrunningcontainer
     run_podman rm   myrunningcontainer
 }
 


### PR DESCRIPTION
When the "rmi" part of "run --rmi" fails due to image being in use
by another container (or for any reason, actually), issue a warning
message, not an error.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```