### PR TITLE
StopContainer: display signal num when name unknown

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -473,8 +473,12 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 		}
 
 		if err := waitContainerStop(ctr, time.Duration(util.ConvertTimeout(int(timeout)))*time.Second); err != nil {
-			logrus.Debugf("Timed out stopping container %s with %s, resorting to SIGKILL: %v", ctr.ID(), unix.SignalName(syscall.Signal(stopSignal)), err)
-			logrus.Warnf("StopSignal %s failed to stop container %s in %d seconds, resorting to SIGKILL", unix.SignalName(syscall.Signal(stopSignal)), ctr.Name(), timeout)
+			sigName := unix.SignalName(syscall.Signal(stopSignal))
+			if sigName == "" {
+				sigName = fmt.Sprintf("(%d)", stopSignal)
+			}
+			logrus.Debugf("Timed out stopping container %s with %s, resorting to SIGKILL: %v", ctr.ID(), sigName, err)
+			logrus.Warnf("StopSignal %s failed to stop container %s in %d seconds, resorting to SIGKILL", sigName, ctr.Name(), timeout)
 		} else {
 			// No error, the container is dead
 			return nil

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1058,11 +1058,10 @@ $IMAGE--c_ok" \
            "ls /dev/tty[0-9] with --systemd=always: should have no ttyN devices"
 
     # Make sure run_podman stop supports -1 option
-    # FIXME: why is there no signal name here? Should be 'StopSignal XYZ'
     # FIXME: do we really really mean to say FFFFFFFFFFFFFFFF here???
     run_podman 0+w stop -t -1 $cid
     if ! is_remote; then
-        assert "$output" =~ "StopSignal  failed to stop container .* in 18446744073709551615 seconds, resorting to SIGKILL" "stop -t -1 (negative one) issues warning"
+        assert "$output" =~ "StopSignal \(37\) failed to stop container .* in 18446744073709551615 seconds, resorting to SIGKILL" "stop -t -1 (negative one) issues warning"
     fi
     run_podman rm -t -1 -f $cid
 }

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -359,7 +359,7 @@ failed    | exited     | 17
 
 
 @test "stop and rm" {
-    run_podman stop myrunningcontainer
+    run_podman 0+w stop myrunningcontainer
     run_podman rm   myrunningcontainer
 }
 


### PR DESCRIPTION
Under some circumstances podman tries to kill a container
using signal 37, for which unix.SignalName() returns "".
Not helpful. So, when that happens, show "(signal number)".

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```