### PR TITLE
URGENT: fix broken CI

### DIFF
--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -359,7 +359,7 @@ failed    | exited     | 17
 
 
 @test "stop and rm" {
-    run_podman stop myrunningcontainer
+    run_podman 0+w stop myrunningcontainer
     run_podman rm   myrunningcontainer
 }
 


### PR DESCRIPTION
PR #19878 (checking for warnings in system tests) broke upgrade tests.

Reason: my long-ago "optimization" in which, if a PR touches only
tests in X, do not run tests in Y. Unfortunately, upgrade tests
rely on code in the system-test directory. I don't know if this
is fixable; nor if it's an acceptable tradeoff. Please discuss.

Sorry, everyone.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```