### PR TITLE
e2e: use ExitCleanly() in checkpoint tests

### DIFF
--- a/test/e2e/checkpoint_image_test.go
+++ b/test/e2e/checkpoint_image_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman checkpoint", func() {
@@ -55,20 +54,20 @@ var _ = Describe("Podman checkpoint", func() {
 		}
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		containerID := session.OutputToString()
 
 		// Checkpoint image should not exist
 		session = podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeFalse())
 
 		// Check if none of the checkpoint/restore specific information is displayed
 		// for newly started containers.
 		inspect := podmanTest.Podman([]string{"inspect", containerID})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectOut := inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -79,13 +78,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "--keep", containerID})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		inspect = podmanTest.Podman([]string{"inspect", containerID})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeTrue(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.CheckpointPath).To(ContainSubstring("userdata/checkpoint"))
@@ -94,13 +93,13 @@ var _ = Describe("Podman checkpoint", func() {
 		// Check if checkpoint image has been created
 		session = podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeTrue())
 
 		// Check if the checkpoint image contains annotations
 		inspect = podmanTest.Podman([]string{"inspect", checkpointImage})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectImageOut := inspect.InspectImageJSON()
 		Expect(inspectImageOut[0].Annotations["io.podman.annotations.checkpoint.name"]).To(
 			BeEquivalentTo(containerName),
@@ -123,25 +122,25 @@ var _ = Describe("Podman checkpoint", func() {
 		// Remove existing container
 		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerID})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Restore container from checkpoint image
 		result = podmanTest.Podman([]string{"container", "restore", checkpointImage})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		// Clean-up
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"rmi", checkpointImage})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -153,57 +152,57 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := []string{"run", "-d", "--name", containerName, ALPINE, "top"}
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		containerID := session.OutputToString()
 
 		// Checkpoint image should not exist
 		session = podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeFalse())
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "--keep", containerID})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		// Check if checkpoint image has been created
 		session = podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeTrue())
 
 		// Remove existing container
 		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerID})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		for i := 1; i < 5; i++ {
 			// Restore container from checkpoint image
 			name := containerName + strconv.Itoa(i)
 			result = podmanTest.Podman([]string{"container", "restore", "--name", name, checkpointImage})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(i))
 
 			// Check that the container is running
 			status := podmanTest.Podman([]string{"inspect", name, "--format={{.State.Status}}"})
 			status.WaitWithDefaultTimeout()
-			Expect(status).Should(Exit(0))
+			Expect(status).Should(ExitCleanly())
 			Expect(status.OutputToString()).To(Equal("running"))
 		}
 
 		// Clean-up
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"rmi", checkpointImage})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -218,60 +217,60 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := []string{"run", "-d", "--name", containerName1, ALPINE, "top"}
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		containerID1 := session.OutputToString()
 
 		// Create second container
 		localRunString = []string{"run", "-d", "--name", containerName2, ALPINE, "top"}
 		session = podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		containerID2 := session.OutputToString()
 
 		// Checkpoint first container
 		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage1, "--keep", containerID1})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		// Checkpoint second container
 		result = podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage2, "--keep", containerID2})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		// Remove existing containers
 		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerName1, containerName2})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Restore both containers from images
 		result = podmanTest.Podman([]string{"container", "restore", checkpointImage1, checkpointImage2})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 
 		// Check if first container is running
 		status := podmanTest.Podman([]string{"inspect", containerName1, "--format={{.State.Status}}"})
 		status.WaitWithDefaultTimeout()
-		Expect(status).Should(Exit(0))
+		Expect(status).Should(ExitCleanly())
 		Expect(status.OutputToString()).To(Equal("running"))
 
 		// Check if second container is running
 		status = podmanTest.Podman([]string{"inspect", containerName2, "--format={{.State.Status}}"})
 		status.WaitWithDefaultTimeout()
-		Expect(status).Should(Exit(0))
+		Expect(status).Should(ExitCleanly())
 		Expect(status.OutputToString()).To(Equal("running"))
 
 		// Clean-up
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"rmi", checkpointImage1, checkpointImage2})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -284,41 +283,41 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := []string{"run", "-d", "--name", containerName, ALPINE, "top"}
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		containerID1 := session.OutputToString()
 
 		// Checkpoint container, create checkpoint image
 		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "--keep", containerID1})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		// Remove existing container
 		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Restore containers from image using `podman run`
 		result = podmanTest.Podman([]string{"run", checkpointImage})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		// Check if the container is running
 		status := podmanTest.Podman([]string{"inspect", containerName, "--format={{.State.Status}}"})
 		status.WaitWithDefaultTimeout()
-		Expect(status).Should(Exit(0))
+		Expect(status).Should(ExitCleanly())
 		Expect(status.OutputToString()).To(Equal("running"))
 
 		// Clean-up
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"rmi", checkpointImage})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 })

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		session := podmanTest.Podman([]string{"network", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		netname = session.OutputToString()
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("Podman checkpoint", func() {
 		if netname != "" {
 			session := podmanTest.Podman([]string{"network", "rm", "-f", netname})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 		}
 	})
 
@@ -79,14 +79,14 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 
 		// Check if none of the checkpoint/restore specific information is displayed
 		// for newly started containers.
 		inspect := podmanTest.Podman([]string{"inspect", cid})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectOut := inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -102,7 +102,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
@@ -111,7 +111,7 @@ var _ = Describe("Podman checkpoint", func() {
 		// to be populated.
 		inspect = podmanTest.Podman([]string{"inspect", cid})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeTrue(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -127,14 +127,14 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		inspect = podmanTest.Podman([]string{"inspect", cid})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Restored).To(BeTrue(), ".State.Restored")
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
@@ -151,7 +151,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{
@@ -161,14 +161,14 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		// Stopping and starting the container should remove all checkpoint
 		// related information from inspect again.
 		inspect = podmanTest.Podman([]string{"inspect", cid})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -181,12 +181,12 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--name", "test_name", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "test_name"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("test_name"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
@@ -194,7 +194,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "test_name"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("test_name"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -203,19 +203,19 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString = getRunString([]string{"--name", "alpine", "quay.io/libpod/alpine:latest", "top"})
 		session = podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{"container", "checkpoint", "alpine"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		result = podmanTest.Podman([]string{"container", "restore", "alpine"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 	})
@@ -224,13 +224,13 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
@@ -243,7 +243,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		result = podmanTest.Podman([]string{"rm", cid})
@@ -253,7 +253,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 	})
@@ -262,30 +262,30 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--name", "first", ALPINE, "top"})
 		session1 := podmanTest.Podman(localRunString)
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 
 		localRunString = getRunString([]string{"--name", "second", ALPINE, "top"})
 		session2 := podmanTest.Podman(localRunString)
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "second"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("second"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		ps := podmanTest.Podman([]string{"ps", "-q", "--no-trunc"})
 		ps.WaitWithDefaultTimeout()
-		Expect(ps).Should(Exit(0))
+		Expect(ps).Should(ExitCleanly())
 		Expect(ps.OutputToString()).To(ContainSubstring(session1.OutputToString()))
 		Expect(ps.OutputToString()).To(Not(ContainSubstring(session2.OutputToString())))
 
 		result = podmanTest.Podman([]string{"container", "restore", "second"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("second"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -293,7 +293,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -301,33 +301,33 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--name", "first", ALPINE, "top"})
 		session1 := podmanTest.Podman(localRunString)
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		cid1 := session1.OutputToString()
 
 		localRunString = getRunString([]string{"--name", "second", ALPINE, "top"})
 		session2 := podmanTest.Podman(localRunString)
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 		cid2 := session2.OutputToString()
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "-a"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid1))
 		Expect(result.OutputToString()).To(ContainSubstring(cid2))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		ps := podmanTest.Podman([]string{"ps", "-q", "--no-trunc"})
 		ps.WaitWithDefaultTimeout()
-		Expect(ps).Should(Exit(0))
+		Expect(ps).Should(ExitCleanly())
 		Expect(ps.OutputToString()).To(Not(ContainSubstring(session1.OutputToString())))
 		Expect(ps.OutputToString()).To(Not(ContainSubstring(session2.OutputToString())))
 
 		result = podmanTest.Podman([]string{"container", "restore", "-a"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid1))
 		Expect(result.OutputToString()).To(ContainSubstring(cid2))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
@@ -336,7 +336,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -344,7 +344,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{REDIS_IMAGE})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		if !WaitContainerReady(podmanTest, cid, "Ready to accept connections", 20, 1) {
 			Fail("Container failed to get ready")
@@ -353,7 +353,7 @@ var _ = Describe("Podman checkpoint", func() {
 		// clunky format needed because CNI uses dashes in net names
 		IP := podmanTest.Podman([]string{"inspect", cid, fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").IPAddress}}", netname)})
 		IP.WaitWithDefaultTimeout()
-		Expect(IP).Should(Exit(0))
+		Expect(IP).Should(ExitCleanly())
 
 		// Open a network connection to the redis server
 		conn, err := net.DialTimeout("tcp4", IP.OutputToString()+":6379", time.Duration(3)*time.Second)
@@ -371,7 +371,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "--tcp-established"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
@@ -387,13 +387,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", cid, "--tcp-established"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		conn.Close()
@@ -403,14 +403,14 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 
 		// Checkpoint container, but leave it running
 		result := podmanTest.Podman([]string{"container", "checkpoint", "--leave-running", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		// Make sure it is still running
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -419,7 +419,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "stop", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
@@ -427,13 +427,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -441,23 +441,23 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--name", "test_name", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// clunky format needed because CNI uses dashes in net names
 		IPBefore := podmanTest.Podman([]string{"inspect", "test_name", fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").IPAddress}}", netname)})
 		IPBefore.WaitWithDefaultTimeout()
-		Expect(IPBefore).Should(Exit(0))
+		Expect(IPBefore).Should(ExitCleanly())
 		Expect(IPBefore.OutputToString()).To(MatchRegexp("^[0-9]+(\\.[0-9]+){3}$"))
 
 		MACBefore := podmanTest.Podman([]string{"inspect", "test_name", fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").MacAddress}}", netname)})
 		MACBefore.WaitWithDefaultTimeout()
-		Expect(MACBefore).Should(Exit(0))
+		Expect(MACBefore).Should(ExitCleanly())
 		Expect(MACBefore.OutputToString()).To(MatchRegexp("^[0-9a-f]{2}(:[0-9a-f]{2}){5}$"))
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "test_name"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
@@ -466,11 +466,11 @@ var _ = Describe("Podman checkpoint", func() {
 
 		IPAfter := podmanTest.Podman([]string{"inspect", "test_name", fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").IPAddress}}", netname)})
 		IPAfter.WaitWithDefaultTimeout()
-		Expect(IPAfter).Should(Exit(0))
+		Expect(IPAfter).Should(ExitCleanly())
 
 		MACAfter := podmanTest.Podman([]string{"inspect", "test_name", fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").MacAddress}}", netname)})
 		MACAfter.WaitWithDefaultTimeout()
-		Expect(MACAfter).Should(Exit(0))
+		Expect(MACAfter).Should(ExitCleanly())
 
 		// Check that IP address did not change between checkpointing and restoring
 		Expect(IPAfter.OutputToString()).To(Equal(IPBefore.OutputToString()))
@@ -478,13 +478,13 @@ var _ = Describe("Podman checkpoint", func() {
 		// Check that MAC address did not change between checkpointing and restoring
 		Expect(MACAfter.OutputToString()).To(Equal(MACBefore.OutputToString()))
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -494,7 +494,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -504,7 +504,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -519,20 +519,20 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName, "-n", "restore_again", "--ignore-static-ip"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -545,7 +545,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -556,7 +556,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -565,7 +565,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -575,7 +575,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -584,7 +584,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -594,7 +594,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -603,7 +603,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -613,7 +613,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -622,7 +622,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -637,7 +637,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"rm", "--time", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -650,7 +650,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -658,15 +658,15 @@ var _ = Describe("Podman checkpoint", func() {
 		// Change the container's root file-system
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "rm /etc/motd"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{"diff", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("C /etc"))
 		Expect(result.OutputToString()).To(ContainSubstring("A /test.output"))
 		Expect(result.OutputToString()).To(ContainSubstring("D /etc/motd"))
@@ -676,7 +676,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -685,7 +685,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -693,12 +693,12 @@ var _ = Describe("Podman checkpoint", func() {
 		// Verify the changes to the container's root file-system
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("test" + cid + "test"))
 
 		result = podmanTest.Podman([]string{"diff", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("C /etc"))
 		Expect(result.OutputToString()).To(ContainSubstring("A /test.output"))
 		Expect(result.OutputToString()).To(ContainSubstring("D /etc/motd"))
@@ -712,7 +712,7 @@ var _ = Describe("Podman checkpoint", func() {
 		// test that restore works without network namespace (https://github.com/containers/podman/issues/14389)
 		session := podmanTest.Podman([]string{"run", "--network=none", "-d", "--rm", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -720,13 +720,13 @@ var _ = Describe("Podman checkpoint", func() {
 		// Change the container's root file-system
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Checkpoint the container
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -735,7 +735,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "--ignore-rootfs", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -754,7 +754,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -762,13 +762,13 @@ var _ = Describe("Podman checkpoint", func() {
 		// Change the container's root file-system
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Checkpoint the container
 		result = podmanTest.Podman([]string{"container", "checkpoint", "--ignore-rootfs", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -777,7 +777,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -797,7 +797,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -806,7 +806,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -815,7 +815,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -823,11 +823,11 @@ var _ = Describe("Podman checkpoint", func() {
 		// Exec in the container
 		result = podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo " + cid + " > /test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 
 		// Remove exported checkpoint
@@ -856,7 +856,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -864,13 +864,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -883,7 +883,7 @@ var _ = Describe("Podman checkpoint", func() {
 			"build", "-f", "build/basicalpine/Containerfile.volume", "-t", "test-cr-volume",
 		})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Start the container
 		localRunString := getRunString([]string{
@@ -895,7 +895,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		session = podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		cid := session.OutputToString()
@@ -905,28 +905,28 @@ var _ = Describe("Podman checkpoint", func() {
 			"exec", cid, "/bin/sh", "-c", "echo " + cid + " > /volume0/test.output",
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Add file in volume1
 		result = podmanTest.Podman([]string{
 			"exec", cid, "/bin/sh", "-c", "echo " + cid + " > /volume1/test.output",
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// Add file in volume2
 		result = podmanTest.Podman([]string{
 			"exec", cid, "/bin/sh", "-c", "echo " + cid + " > /volume2/test.output",
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		checkpointFileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
 
 		// Checkpoint the container
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "-e", checkpointFileName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -942,12 +942,12 @@ var _ = Describe("Podman checkpoint", func() {
 		// Remove named volume
 		session = podmanTest.Podman([]string{"volume", "rm", "my-test-vol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Restoring container
 		result = podmanTest.Podman([]string{"container", "restore", "-i", checkpointFileName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
@@ -955,19 +955,19 @@ var _ = Describe("Podman checkpoint", func() {
 		// Validate volume0 content
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/volume0/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 
 		// Validate volume1 content
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/volume1/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 
 		// Validate volume2 content
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/volume2/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 
 		// Remove exported checkpoint
@@ -981,27 +981,27 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 
 		result := podmanTest.Podman([]string{"container", "checkpoint", "-P", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"container", "checkpoint", "--with-previous", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		result = podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 	})
@@ -1014,7 +1014,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		preCheckpointFileName := filepath.Join(podmanTest.TempDir, "/pre-checkpoint-"+cid+".tar.gz")
 		checkpointFileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1022,27 +1022,27 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "checkpoint", "-P", "-e", preCheckpointFileName, cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"container", "checkpoint", "--with-previous", "-e", checkpointFileName, cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-f", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"container", "restore", "-i", checkpointFileName, "--import-previous", preCheckpointFileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -1056,7 +1056,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"-p", fmt.Sprintf("%d:6379", randomPort), "--rm", REDIS_IMAGE})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
 
@@ -1076,7 +1076,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
@@ -1087,7 +1087,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-p", fmt.Sprintf("%d:6379", newRandomPort), "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -1104,7 +1104,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -1143,7 +1143,7 @@ var _ = Describe("Podman checkpoint", func() {
 				share,
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).To(Exit(0))
+			Expect(session).To(ExitCleanly())
 			podID := session.OutputToString()
 
 			session = podmanTest.Podman([]string{
@@ -1156,7 +1156,7 @@ var _ = Describe("Podman checkpoint", func() {
 				"top",
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).To(Exit(0))
+			Expect(session).To(ExitCleanly())
 			cid := session.OutputToString()
 
 			fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1173,7 +1173,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 			// As the container has been started with '--rm' it will be completely
 			// cleaned up after checkpointing.
-			Expect(result).To(Exit(0))
+			Expect(result).To(ExitCleanly())
 			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 			Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
@@ -1184,7 +1184,7 @@ var _ = Describe("Podman checkpoint", func() {
 				podID,
 			})
 			result.WaitWithDefaultTimeout()
-			Expect(result).To(Exit(0))
+			Expect(result).To(ExitCleanly())
 
 			// First create a pod with different shared namespaces.
 			// Restore should fail
@@ -1198,7 +1198,7 @@ var _ = Describe("Podman checkpoint", func() {
 				wrongShare,
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).To(Exit(0))
+			Expect(session).To(ExitCleanly())
 			podID = session.OutputToString()
 
 			// Restore container with different port mapping
@@ -1221,7 +1221,7 @@ var _ = Describe("Podman checkpoint", func() {
 				podID,
 			})
 			result.WaitWithDefaultTimeout()
-			Expect(result).To(Exit(0))
+			Expect(result).To(ExitCleanly())
 
 			session = podmanTest.Podman([]string{
 				"pod",
@@ -1230,7 +1230,7 @@ var _ = Describe("Podman checkpoint", func() {
 				share,
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).To(Exit(0))
+			Expect(session).To(ExitCleanly())
 			podID = session.OutputToString()
 
 			// Restore container with different port mapping
@@ -1244,7 +1244,7 @@ var _ = Describe("Podman checkpoint", func() {
 			})
 			result.WaitWithDefaultTimeout()
 
-			Expect(result).To(Exit(0))
+			Expect(result).To(ExitCleanly())
 			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 			Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -1254,7 +1254,7 @@ var _ = Describe("Podman checkpoint", func() {
 				result.OutputToString(),
 			})
 			result.WaitWithDefaultTimeout()
-			Expect(result).To(Exit(0))
+			Expect(result).To(ExitCleanly())
 			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 			Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
@@ -1264,7 +1264,7 @@ var _ = Describe("Podman checkpoint", func() {
 				"-fa",
 			})
 			result.WaitWithDefaultTimeout()
-			Expect(result).To(Exit(0))
+			Expect(result).To(ExitCleanly())
 
 			// Remove exported checkpoint
 			os.Remove(fileName)
@@ -1275,7 +1275,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", "--ipc", "host", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1285,6 +1285,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
+		// Cannot use ExitCleanly() because "skipping [ssh-agent-path] since it is a socket"
 		Expect(result).Should(Exit(0))
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
@@ -1293,13 +1294,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -1315,7 +1316,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1331,7 +1332,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -1349,7 +1350,7 @@ var _ = Describe("Podman checkpoint", func() {
 				destinationDirectory,
 			},
 		)
-		Expect(tarsession).Should(Exit(0))
+		Expect(tarsession).Should(ExitCleanly())
 
 		_, err = os.Stat(filepath.Join(destinationDirectory, stats.StatsDump))
 		Expect(err).ShouldNot(HaveOccurred())
@@ -1358,11 +1359,11 @@ var _ = Describe("Podman checkpoint", func() {
 	It("podman checkpoint and restore containers with --print-stats", func() {
 		session1 := podmanTest.Podman(getRunString([]string{REDIS_IMAGE}))
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman(getRunString([]string{REDIS_IMAGE, "top"}))
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{
 			"container",
@@ -1372,7 +1373,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		type checkpointStatistics struct {
@@ -1400,7 +1401,7 @@ var _ = Describe("Podman checkpoint", func() {
 			"--no-trunc",
 		})
 		ps.WaitWithDefaultTimeout()
-		Expect(ps).Should(Exit(0))
+		Expect(ps).Should(ExitCleanly())
 		Expect(ps.OutputToString()).To(Not(ContainSubstring(session1.OutputToString())))
 		Expect(ps.OutputToString()).To(Not(ContainSubstring(session2.OutputToString())))
 
@@ -1412,7 +1413,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 		Expect(podmanTest.GetContainerStatus()).To(Not(ContainSubstring("Exited")))
@@ -1443,7 +1444,7 @@ var _ = Describe("Podman checkpoint", func() {
 			"-fa",
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -1451,7 +1452,7 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--name", "test_name", ALPINE, "flock", "test.lock", "sleep", "100"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Checkpoint is expected to fail without --file-locks
 		result := podmanTest.Podman([]string{"container", "checkpoint", "test_name"})
@@ -1463,20 +1464,20 @@ var _ = Describe("Podman checkpoint", func() {
 		// Checkpoint is expected to succeed with --file-locks
 		result = podmanTest.Podman([]string{"container", "checkpoint", "--file-locks", "test_name"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		result = podmanTest.Podman([]string{"container", "restore", "--file-locks", "test_name"})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-f", "test_name"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
@@ -1489,7 +1490,7 @@ var _ = Describe("Podman checkpoint", func() {
 		})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 
@@ -1500,7 +1501,7 @@ var _ = Describe("Podman checkpoint", func() {
 			cid,
 		})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		runtime := session.OutputToString()
 
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1515,7 +1516,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -1526,7 +1527,7 @@ var _ = Describe("Podman checkpoint", func() {
 			fileName,
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
@@ -1538,7 +1539,7 @@ var _ = Describe("Podman checkpoint", func() {
 			cid,
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(runtime))
 
 		// Remove exported checkpoint
@@ -1587,7 +1588,7 @@ var _ = Describe("Podman checkpoint", func() {
 		// Detect default runtime
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.OCIRuntime.Name}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if defaultRuntime := session.OutputToString(); defaultRuntime != "crun" {
 			Skip(fmt.Sprintf("Default runtime is %q; this test requires crun to be default", defaultRuntime))
 		}
@@ -1596,13 +1597,13 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--runtime", "runc", "--rm", ALPINE, "top"})
 		session = podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.OCIRuntime}}", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("runc"))
 
 		checkpointExportPath := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1611,21 +1612,21 @@ var _ = Describe("Podman checkpoint", func() {
 		session.WaitWithDefaultTimeout()
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"container", "restore", "-i", checkpointExportPath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		// The restored container should have the same runtime as the original container
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.OCIRuntime}}", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("runc"))
 
 		// Remove exported checkpoint
@@ -1660,7 +1661,7 @@ var _ = Describe("Podman checkpoint", func() {
 		)
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 
@@ -1671,7 +1672,7 @@ var _ = Describe("Podman checkpoint", func() {
 			cid,
 		})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		runtime := session.OutputToString()
 
 		fileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1686,7 +1687,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
@@ -1715,7 +1716,7 @@ var _ = Describe("Podman checkpoint", func() {
 			fileName,
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{
 			"inspect",
@@ -1724,7 +1725,7 @@ var _ = Describe("Podman checkpoint", func() {
 			cid,
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal(runtime))
 
 		result = podmanTest.Podman([]string{
@@ -1734,7 +1735,7 @@ var _ = Describe("Podman checkpoint", func() {
 			"-fa",
 		})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		// Remove exported checkpoint
 		os.Remove(fileName)
@@ -1744,18 +1745,18 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 
 		// Add test file in dev/shm
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /dev/shm/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.OCIRuntime}}", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		runtime := session.OutputToString()
 
 		checkpointFileName := filepath.Join(podmanTest.TempDir, "/checkpoint-"+cid+".tar.gz")
@@ -1764,27 +1765,27 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// As the container has been started with '--rm' it will be completely
 		// cleaned up after checkpointing.
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"container", "restore", "-i", checkpointFileName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		// The restored container should have the same runtime as the original container
 		result = podmanTest.Podman([]string{"inspect", "--format", "{{.OCIRuntime}}", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(runtime))
 
 		// Verify the test file content in dev/shm
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/dev/shm/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("test" + cid + "test"))
 
 		// Remove exported checkpoint
@@ -1795,36 +1796,36 @@ var _ = Describe("Podman checkpoint", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		cid := session.OutputToString()
 
 		// Add test file in dev/shm
 		result := podmanTest.Podman([]string{"exec", cid, "/bin/sh", "-c", "echo test" + cid + "test > /dev/shm/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{"container", "checkpoint", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		result = podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		// Verify the test file content in dev/shm
 		result = podmanTest.Podman([]string{"exec", cid, "cat", "/dev/shm/test.output"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("test" + cid + "test"))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 })

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -201,9 +201,12 @@ func (matcher *exitCleanlyMatcher) Match(actual interface{}) (success bool, err 
 	// FIXME: #19809, "failed to connect to syslog" warnings on f38
 	// FIXME: so, until that is fixed, don't check stderr if containerized
 	if !Containerized() {
-		if stderr != "" {
-			matcher.msg = fmt.Sprintf("Unexpected warnings seen on stderr: %q", stderr)
-			return false, nil
+		info := GetHostDistributionInfo()
+		if info.Distribution == "fedora" {
+			if stderr != "" {
+				matcher.msg = fmt.Sprintf("Unexpected warnings seen on stderr: %q", stderr)
+				return false, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Ongoing steps toward RUN-1907: replace Exit(0) with ExitCleanly()

Clean command-line replace, with one manual reversion (commented)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```