### PR TITLE
pod: fix duplicate volumes from containers.conf

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -62,6 +62,10 @@ func init() {
 	flags := createCommand.Flags()
 	flags.SetInterspersed(false)
 	common.DefineCreateDefaults(&infraOptions)
+	// these settings are not applicable to pod create since they are per-container
+	// and they will end up being duplicated for each container in the pod.
+	infraOptions.Volume = nil
+	infraOptions.Mount = nil
 	common.DefineCreateFlags(createCommand, &infraOptions, entities.InfraMode)
 	common.DefineNetFlags(createCommand)
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -71,6 +71,24 @@ function teardown() {
 }
 
 
+@test "podman pod create - custom volumes" {
+    skip_if_remote "CONTAINERS_CONF_OVERRIDE only affects server side"
+    image="i.do/not/exist:image"
+    tmpdir=$PODMAN_TMPDIR/pod-test
+    mkdir -p $tmpdir
+    containersconf=$tmpdir/containers.conf
+    cat >$containersconf <<EOF
+[containers]
+volumes = ["/tmp:/foobar"]
+EOF
+
+    CONTAINERS_CONF_OVERRIDE=$containersconf run_podman pod create
+    podid="$output"
+
+    CONTAINERS_CONF_OVERRIDE=$containersconf run_podman create --pod $podid $IMAGE grep foobar /proc/mounts
+}
+
+
 @test "podman pod create - custom infra image" {
     skip_if_remote "CONTAINERS_CONF_OVERRIDE only affects server side"
     image="i.do/not/exist:image"


### PR DESCRIPTION
If some volumes are specified in containers.conf, they are currently added twice to the containers spec causing the container to fail:

$ head -n2 ~/.config/containers/containers.conf
[containers]
volumes = ["/tmp:/tmp"]
$ podman pod create --name foo
7ac7f97f9b74a596332483e4a13e58cb9c8d997e9c5baae46804ae0acc26cbc6 $ podman run --pod=foo alpine true
Error: "/tmp": duplicate mount destination

The fix is to ignore the setting from containers.conf when setting the pod default configuration.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
running a container in a pod doesn't fail if volumes or mounts are specified in the containers.conf file
```
