### PR TITLE
Split up alt binaries to speed up build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -369,7 +369,15 @@ alt_build_task:
       - env:
             ALT_NAME: 'Windows Cross'
       - env:
-            ALT_NAME: 'Alt Arch. Cross'
+            ALT_NAME: 'Alt Arch. x86 Cross'
+      - env:
+            ALT_NAME: 'Alt Arch. ARM Cross'
+      - env:
+            ALT_NAME: 'Alt Arch. MIPS Cross'
+      - env:
+            ALT_NAME: 'Alt Arch. MIPS64 Cross'
+      - env:
+            ALT_NAME: 'Alt Arch. Other Cross'
     # This task cannot make use of the shared repo.tbz artifact.
     clone_script: *full_clone
     setup_script: *setup
@@ -1067,10 +1075,34 @@ artifacts_task:
         - $ARTCURL/Build%20for%20${FEDORA_NAME}/repo/repo.tbz
         - tar xjf repo.tbz
         - cp ./bin/* $CIRRUS_WORKING_DIR/
-    alt_binaries_script:
+    alt_binaries_intel_script:
         - mkdir -p /tmp/alt
         - cd /tmp/alt
-        - $ARTCURL/Alt%20Arch.%20Cross/repo/repo.tbz
+        - $ARTCURL/Alt%20Arch.%20x86%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_arm_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20ARM%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_mips_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20MIPS%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_mips64_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20MIPS64%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_other_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20Other%20Cross/repo/repo.tbz
         - tar xjf repo.tbz
         - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
     win_binaries_script:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -278,26 +278,46 @@ function _run_altbuild() {
         *RPM*)
             make package
             ;;
-        Alt*Cross)
+        Alt*x86*Cross)
             arches=(\
                 amd64
-                ppc64le
+                386)
+            _build_altbuild_archs "${arches[@]}"
+            ;;
+        Alt*ARM*Cross)
+            arches=(\
                 arm
-                arm64
-                386
-                s390x
+                arm64)
+            _build_altbuild_archs "${arches[@]}"
+            ;;
+        Alt*Other*Cross)
+            arches=(\
+                ppc64le
+                s390x)
+            _build_altbuild_archs "${arches[@]}"
+            ;;
+        Alt*MIPS*Cross)
+            arches=(\
                 mips
-                mipsle
+                mipsle)
+            _build_altbuild_archs "${arches[@]}"
+            ;;
+        Alt*MIPS64*Cross*)
+            arches=(\
                 mips64
                 mips64le)
-            for arch in "${arches[@]}"; do
-                msg "Building release archive for $arch"
-                make podman-release-${arch}.tar.gz GOARCH=$arch
-            done
+            _build_altbuild_archs "${arches[@]}"
             ;;
         *)
             die "Unknown/Unsupported \$$ALT_NAME '$ALT_NAME'"
     esac
+}
+
+function _build_altbuild_archs() {
+    for arch in "$@"; do
+        msg "Building release archive for $arch"
+        make podman-release-${arch}.tar.gz GOARCH=$arch
+    done
 }
 
 function _run_release() {


### PR DESCRIPTION
Split up the alt binaries build to better parallelize CI. Previously this section was taking 35-40 mins. After this change, it's a little under 10 mins. 

[NO NEW TESTS NEEDED]
```release-note
none
```
