### PR TITLE
Add support for kube TerminationGracePeriodSeconds

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -33,7 +33,7 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | topologySpreadConstraints\.labelSelector            | N/A     |
 | topologySpreadConstraints\.minDomains               | N/A     |
 | restartPolicy                                       | ✅      |
-| terminationGracePeriod                              | no      |
+| terminationGracePeriodSeconds                       | ✅      |
 | activeDeadlineSeconds                               | no      |
 | readinessGates\.conditionType                       | no      |
 | hostname                                            | ✅      |

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -855,6 +855,10 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			Volumes:            volumes,
 		}
 
+		if podYAML.Spec.TerminationGracePeriodSeconds != nil {
+			specgenOpts.TerminationGracePeriodSeconds = podYAML.Spec.TerminationGracePeriodSeconds
+		}
+
 		specGen, err := kube.ToSpecGen(ctx, &specgenOpts)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -168,6 +168,8 @@ type CtrSpecGenOptions struct {
 	InitContainerType string
 	// PodSecurityContext is the security context specified for the pod
 	PodSecurityContext *v1.PodSecurityContext
+	// TerminationGracePeriodSeconds is the grace period given to a container to stop before being forcefully killed
+	TerminationGracePeriodSeconds *int64
 }
 
 func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGenerator, error) {
@@ -582,6 +584,12 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	// stored as a label at container creation.
 	if unit := os.Getenv(systemdDefine.EnvVariable); unit != "" {
 		s.Labels[systemdDefine.EnvVariable] = unit
+	}
+
+	// Set the stopTimeout if terminationGracePeriodSeconds is set in the kube yaml
+	if opts.TerminationGracePeriodSeconds != nil {
+		timeout := uint(*opts.TerminationGracePeriodSeconds)
+		s.StopTimeout = &timeout
 	}
 
 	return s, nil

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5991,4 +5991,27 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(inspect).Should(Exit(0))
 		Expect(inspect.OutputToString()).To(ContainSubstring(`FOO=bar`))
 	})
+
+	It("podman kube play with TerminationGracePeriodSeconds set", func() {
+		ctrName := "ctr"
+		ctrNameInPod := "ctr-pod-ctr"
+		outputFile := filepath.Join(podmanTest.TempDir, "pod.yaml")
+
+		create := podmanTest.Podman([]string{"create", "--restart", "never", "--stop-timeout", "20", "--name", ctrName, ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).Should(Exit(0))
+
+		generate := podmanTest.Podman([]string{"kube", "generate", "-f", outputFile, ctrName})
+		generate.WaitWithDefaultTimeout()
+		Expect(generate).Should(Exit(0))
+
+		play := podmanTest.Podman([]string{"kube", "play", outputFile})
+		play.WaitWithDefaultTimeout()
+		Expect(play).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", ctrNameInPod, "-f", "{{ .Config.StopTimeout }}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).To(Equal("20"))
+	})
 })


### PR DESCRIPTION
Add support to kube play to support the TerminationGracePeriodSeconds fiels by sending the value of that to podman's stopTimeout. Add support to kube generate to generate TerminationGracePeriodSeconds if stopTimeout is set for a container (will ignore podman's default).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2218061
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support to kube gen and play for k8s `TerminationGracePeriodSeconds`.
```
