### PR TITLE
Use url with scheme and path for the unix address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -637,7 +637,7 @@ remotesystem:
 	rc=0;\
 	if timeout -v 1 true; then \
 		SOCK_FILE=$(shell mktemp --dry-run --tmpdir podman_tmp_XXXX);\
-		export PODMAN_SOCKET=unix:$$SOCK_FILE; \
+		export PODMAN_SOCKET=unix://$$SOCK_FILE; \
 		./bin/podman system service --timeout=0 $$PODMAN_SOCKET > $(if $(PODMAN_SERVER_LOG),$(PODMAN_SERVER_LOG),/dev/null) 2>&1 & \
 		retry=5;\
 		while [ $$retry -ge 0 ]; do\

--- a/cmd/podman/registry/registry.go
+++ b/cmd/podman/registry/registry.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DefaultRootAPIAddress is the default address of the REST socket with unix: prefix
-const DefaultRootAPIAddress = "unix:" + DefaultRootAPIPath
+// DefaultRootAPIAddress is the default path of the REST socket with unix:// prefix
+const DefaultRootAPIAddress = "unix://" + DefaultRootAPIPath
 
 type CliCommand struct {
 	Command *cobra.Command
@@ -104,7 +104,7 @@ func DefaultAPIAddress() string {
 			logrus.Warnf("Failed to get rootless runtime dir for DefaultAPIAddress: %s", err)
 			return DefaultRootAPIAddress
 		}
-		return "unix:" + filepath.Join(xdg, "podman", "podman.sock")
+		return "unix://" + filepath.Join(xdg, "podman", "podman.sock")
 	}
 	return DefaultRootAPIAddress
 }

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -140,7 +140,7 @@ func resolveAPIURI(uri []string) (string, error) {
 		if err := os.MkdirAll(filepath.Dir(socketPath), 0700); err != nil {
 			return "", err
 		}
-		return "unix:" + socketPath, nil
+		return "unix://" + socketPath, nil
 	default:
 		if err := os.MkdirAll(filepath.Dir(registry.DefaultRootAPIPath), 0700); err != nil {
 			return "", err

--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -97,7 +97,7 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 				return fmt.Errorf("unable to create socket %v: %w", host, err)
 			}
 		default:
-			return fmt.Errorf("API Service endpoint scheme %q is not supported. Try tcp://%s or unix:/%s", uri.Scheme, opts.URI, opts.URI)
+			return fmt.Errorf("API Service endpoint scheme %q is not supported. Try tcp://%s or unix://%s", uri.Scheme, opts.URI, opts.URI)
 		}
 		libpodRuntime.SetRemoteURI(uri.String())
 	}

--- a/hack/podman-socat
+++ b/hack/podman-socat
@@ -107,16 +107,16 @@ PODMAN_HOST="${TMPDIR}/podman/podman-socat.sock"
 SOCAT_HOST="${TMPDIR}/podman/podman.sock"
 
 cat <<-EOT
-Podman service running at unix:$SOCAT_HOST
+Podman service running at unix://$SOCAT_HOST
 See /tmp/podman-socat.log for API stream capture
 See /tmp/podman-service.log for service logging
 
-usage: sudo bin/podman-remote --url unix:$SOCAT_HOST images
+usage: sudo bin/podman-remote --url unix://$SOCAT_HOST images
 
 ^C to exit
 EOT
 
-$PODMAN system service --timeout=0 "unix:$PODMAN_HOST" >/tmp/podman-service.log 2>&1 &
+$PODMAN system service --timeout=0 "unix://$PODMAN_HOST" >/tmp/podman-service.log 2>&1 &
 REAP_PIDS=$!
 
 socat -v "UNIX-LISTEN:$SOCAT_HOST",fork,reuseaddr,unlink-early "UNIX-CONNECT:$PODMAN_HOST" >/tmp/podman-socat.log 2>&1

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -366,7 +366,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 			if err == nil {
 				lockFile.Close()
 				p.RemoteSocketLock = lockPath
-				p.RemoteSocket = fmt.Sprintf("unix:%s-%s.sock", pathPrefix, uuid)
+				p.RemoteSocket = fmt.Sprintf("unix://%s-%s.sock", pathPrefix, uuid)
 				break
 			}
 			tries++

--- a/test/system/251-system-service.bats
+++ b/test/system/251-system-service.bats
@@ -18,10 +18,10 @@ function teardown() {
 @test "podman system service <bad_scheme_uri> returns error" {
     skip_if_remote "podman system service unavailable over remote"
     run_podman 125 system service localhost:9292
-    is "$output" "Error: API Service endpoint scheme \"localhost\" is not supported. Try tcp://localhost:9292 or unix:/localhost:9292"
+    is "$output" "Error: API Service endpoint scheme \"localhost\" is not supported. Try tcp://localhost:9292 or unix://localhost:9292"
 
     run_podman 125 system service myunix.sock
-    is "$output" "Error: API Service endpoint scheme \"\" is not supported. Try tcp://myunix.sock or unix:/myunix.sock"
+    is "$output" "Error: API Service endpoint scheme \"\" is not supported. Try tcp://myunix.sock or unix://myunix.sock"
 }
 
 @test "podman-system-service containers survive service stop" {

--- a/test/system/251-system-service.bats
+++ b/test/system/251-system-service.bats
@@ -24,6 +24,20 @@ function teardown() {
     is "$output" "Error: API Service endpoint scheme \"\" is not supported. Try tcp://myunix.sock or unix://myunix.sock"
 }
 
+@test "podman system service unix: without two slashes still works" {
+    skip_if_remote "podman system service unavailable over remote"
+    URL=unix:$PODMAN_TMPDIR/myunix.sock
+
+    systemd-run --unit=$SERVICE_NAME $PODMAN system service $URL --time=0
+    wait_for_file $PODMAN_TMPDIR/myunix.sock
+
+    run_podman --host $URL info --format '{{.Host.RemoteSocket.Path}}'
+    is "$output" "$URL" "RemoteSocket.Path using unix:"
+
+    systemctl stop $SERVICE_NAME
+    rm -f $PODMAN_TMPDIR/myunix.sock
+}
+
 @test "podman-system-service containers survive service stop" {
     skip_if_remote "podman system service unavailable over remote"
     local runtime=$(podman_runtime)


### PR DESCRIPTION
Shortcuts like `unix:path` and `unix:/path` do not work everywhere,
so make sure to use `unix://path` when quoting the url (or address)

This avoids errors such as: (when trying to use it as the `DOCKER_HOST`)
`error during connect: Get "http://unix:2375/run/user/1000/podman/podman.sock/v1.24/version": dial tcp: lookup unix: no such host`

#### Does this PR introduce a user-facing change?

```release-note
None
```


Help before:

```
      --url string                URL to access Podman service (CONTAINER_HOST) (default "unix:/run/user/1000/podman/podman.sock")
```

Help after:

```
      --url string                URL to access Podman service (CONTAINER_HOST) (default "unix:///run/user/1000/podman/podman.sock")
```