### PR TITLE
e2e: use ExitCleanly() in cleanup_test.go

### DIFF
--- a/test/e2e/cleanup_test.go
+++ b/test/e2e/cleanup_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -22,45 +23,45 @@ var _ = Describe("Podman container cleanup", func() {
 	It("podman cleanup container by id", func() {
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		session = podmanTest.Podman([]string{"container", "cleanup", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman cleanup container by short id", func() {
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		shortID := cid[0:10]
 		session = podmanTest.Podman([]string{"container", "cleanup", shortID})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(shortID))
 	})
 
 	It("podman cleanup container by name", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "foo", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"container", "cleanup", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("foo"))
 	})
 
 	It("podman cleanup all containers", func() {
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"container", "cleanup", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
@@ -68,23 +69,23 @@ var _ = Describe("Podman container cleanup", func() {
 		SkipIfRemote("--latest flag n/a")
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"container", "cleanup", "--latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman cleanup running container", func() {
 		session := podmanTest.RunTopContainer("running")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"container", "cleanup", "running"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
@@ -95,10 +96,10 @@ var _ = Describe("Podman container cleanup", func() {
 		SkipIfRootlessCgroupsV1("Pause is not supported in cgroups v1")
 		session := podmanTest.RunTopContainer("paused")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"pause", "paused"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"container", "cleanup", "paused"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
@@ -108,6 +109,6 @@ var _ = Describe("Podman container cleanup", func() {
 		// otherwise it fails with container state improper
 		session = podmanTest.Podman([]string{"unpause", "paused"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 })


### PR DESCRIPTION
Ongoing steps toward RUN-1907: replace Exit(0) with ExitCleanly()

Clean command-line replace.

Also, fix up the Containerized and Debian exceptions in matcher.
I was in a huge rush Thursday night when I added the Debian
exception. This, I hope, makes it slightly easier to understand
the cases where we don't check stderr.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```