### PR TITLE
Podmansh: use podmansh_timeout

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	_ "github.com/containers/podman/v4/cmd/podman/completion"
@@ -43,9 +44,7 @@ func main() {
 		(len(os.Args[0]) > 0 && filepath.Base(os.Args[0][1:]) == registry.PodmanSh) {
 		shell := strings.TrimPrefix(os.Args[0], "-")
 
-		// The wait timeout will soon be made configurable via the
-		// upcoming `podmansh_timeout` option in containers.conf
-		args := []string{shell, "exec", "-i", "--wait", "30"}
+		args := []string{shell, "exec", "-i", "--wait", strconv.FormatUint(uint64(registry.PodmanConfig().ContainersConfDefaultsRO.Engine.PodmanshTimeout), 10)}
 		if term.IsTerminal(0) || term.IsTerminal(1) || term.IsTerminal(2) {
 			args = append(args, "-t")
 		}

--- a/docs/source/markdown/podmansh.1.md
+++ b/docs/source/markdown/podmansh.1.md
@@ -20,6 +20,8 @@ Systemd will automatically create the container when the user session is started
 
 Administrators can use volumes to expose specific host data from the host system to the user, without the user being exposed to other parts of the system.
 
+Timeout for podmansh can be set using the `podmansh_timeout` option in containers.conf.
+
 ## Setup
 Create user login session using useradd while running as root.
 
@@ -126,7 +128,7 @@ _EOF
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, **quadlet(5)**
+**[containers.conf(5)](containers.conf.5.md)**, **[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, **quadlet(5)**
 
 ## HISTORY
 May 2023, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
podmansh_timeout is now a configurable option in containers.conf.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podmansh timeout is now configurable using the `podmansh_timeout` option in containers.conf
```
