### PR TITLE
e2e: more ExitCleanly(): low-hanging fruit

### DIFF
--- a/test/e2e/container_create_volume_test.go
+++ b/test/e2e/container_create_volume_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string) {
@@ -40,7 +40,7 @@ func createContainersConfFile(pTest *PodmanTestIntegration) {
 func checkDataVolumeContainer(pTest *PodmanTestIntegration, image, cont, dest, data string) {
 	create := pTest.Podman([]string{"create", "--name", cont, image})
 	create.WaitWithDefaultTimeout()
-	Expect(create).Should(Exit(0))
+	Expect(create).Should(ExitCleanly())
 
 	inspect := pTest.InspectContainer(cont)
 	Expect(inspect).To(HaveLen(1))
@@ -51,7 +51,7 @@ func checkDataVolumeContainer(pTest *PodmanTestIntegration, image, cont, dest, d
 
 	volList := pTest.Podman([]string{"volume", "list", "--quiet"})
 	volList.WaitWithDefaultTimeout()
-	Expect(volList).Should(Exit(0))
+	Expect(volList).Should(ExitCleanly())
 	Expect(volList.OutputToStringArray()).To(HaveLen(1))
 	Expect(volList.OutputToStringArray()[0]).To(Equal(mntName))
 
@@ -98,6 +98,6 @@ var _ = Describe("Podman create data volume", func() {
 
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "echo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 })

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -3,9 +3,9 @@ package integration
 import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/annotations"
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman container inspect", func() {
@@ -14,7 +14,7 @@ var _ = Describe("Podman container inspect", func() {
 		const testContainer = "container-inspect-test-1"
 		setup := podmanTest.RunTopContainer(testContainer)
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		data := podmanTest.InspectContainer(testContainer)
 		Expect(data[0].Config.Annotations[annotations.ContainerManager]).
@@ -25,7 +25,7 @@ var _ = Describe("Podman container inspect", func() {
 		name := "testcon"
 		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8787/udp", "--name", name, ALPINE, "sleep", "inf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		data := podmanTest.InspectContainer(name)
 
 		Expect(data).To(HaveLen(1))
@@ -37,7 +37,7 @@ var _ = Describe("Podman container inspect", func() {
 		name := "testcon"
 		session := podmanTest.Podman([]string{"run", "-d", "--expose", "8989", "--name", name, NGINX_IMAGE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		data := podmanTest.InspectContainer(name)
 		Expect(data).To(HaveLen(1))

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -31,12 +31,12 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf is set to "nofile=500:500"
 		session := podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "ulimit", "-n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("500"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--ulimit", "nofile=2048:2048", fedoraMinimal, "ulimit", "-n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("2048"))
 
 		// Reset CONTAINERS_CONF to "/dev/null"
@@ -44,7 +44,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		os.Setenv("CONTAINERS_CONF", "/dev/null")
 		session = podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "ulimit", "-n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if IsRemote() {
 			Expect(session.OutputToString()).To(ContainSubstring("500"))
 		} else {
@@ -58,7 +58,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf is set to "oom_score_adj=999"
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "cat", "/proc/self/oom_score_adj"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("999"))
 
 		raw, err := os.ReadFile("/proc/self/oom_score_adj")
@@ -71,7 +71,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		os.Setenv("CONTAINERS_CONF", "/dev/null")
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "cat", "/proc/self/oom_score_adj"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if IsRemote() {
 			Expect(session.OutputToString()).To(Equal("999"))
 		} else {
@@ -104,12 +104,12 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf is set to "pids.max=1234"
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "cat", "/sys/fs/cgroup/pids.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("1234"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--cgroup-conf", "pids.max=400", ALPINE, "cat", "/sys/fs/cgroup/pids.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("400"))
 	})
 
@@ -117,7 +117,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf default env includes foo
 		session := podmanTest.Podman([]string{"run", ALPINE, "printenv"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("foo=bar"))
 	})
 
@@ -125,7 +125,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf devices includes notone
 		session := podmanTest.Podman([]string{"run", "--device", "/dev/null:/dev/bar", ALPINE, "ls", "/dev"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(
 			And(
 				ContainSubstring("bar"),
@@ -137,12 +137,12 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf default sets shm-size=201k, which ends up as 200k
 		session := podmanTest.Podman([]string{"run", ALPINE, "grep", "shm", "/proc/self/mounts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("size=200k"))
 
 		session = podmanTest.Podman([]string{"run", "--shm-size", "1g", ALPINE, "grep", "shm", "/proc/self/mounts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("size=1048576k"))
 	})
 
@@ -150,7 +150,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CGroupsV1")
 		cap := podmanTest.Podman([]string{"run", ALPINE, "grep", "CapEff", "/proc/self/status"})
 		cap.WaitWithDefaultTimeout()
-		Expect(cap).Should(Exit(0))
+		Expect(cap).Should(ExitCleanly())
 
 		os.Setenv("CONTAINERS_CONF", "config/containers-ns.conf")
 		if IsRemote() {
@@ -158,7 +158,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		}
 		session := podmanTest.Podman([]string{"run", BB, "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).ToNot(Equal(cap.OutputToString()))
 	})
 
@@ -167,7 +167,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		setup.WaitWithDefaultTimeout()
 		result := podmanTest.Podman([]string{"top", "test1", "capeff"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(
 			And(
 				ContainSubstring("FOWNER"),
@@ -184,7 +184,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		setup.WaitWithDefaultTimeout()
 		result := podmanTest.Podman([]string{"container", "top", "test1", "capeff"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).ToNot(
 			And(
 				ContainSubstring("SETUID"),
@@ -201,7 +201,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf default ipcns to default to host
 		session := podmanTest.Podman([]string{"run", ALPINE, "ls", "-l", nspath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		fields := strings.Split(session.OutputToString(), " ")
 		ctrNS := strings.TrimSuffix(fields[len(fields)-1], "\n")
 
@@ -214,7 +214,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session = podmanTest.Podman([]string{"run", option, "private", ALPINE, "ls", "-l", nspath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		fields = strings.Split(session.OutputToString(), " ")
 		ctrNS = fields[len(fields)-1]
 		Expect(hostNS).ToNot(Equal(ctrNS))
@@ -248,12 +248,12 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		}
 		logc := podmanTest.Podman([]string{"run", "-d", ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc).Should(Exit(0))
+		Expect(logc).Should(ExitCleanly())
 		cid := logc.OutputToString()
 
 		wait := podmanTest.Podman([]string{"wait", cid})
 		wait.WaitWithDefaultTimeout()
-		Expect(wait).Should(Exit(0))
+		Expect(wait).Should(ExitCleanly())
 
 		// Flake prevention: journalctl makes no timeliness guarantees.
 		time.Sleep(1 * time.Second)
@@ -278,55 +278,55 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		}
 		result := podmanTest.Podman([]string{"run", ALPINE, "ls", volume})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("sysctl test", func() {
 		// containers.conf is set to   "net.ipv4.ping_group_range=0 1000"
 		session := podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "cat", "/proc/sys/net/ipv4/ping_group_range"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("1000"))
 
 		// Ignore containers.conf setting if --net=host
 		session = podmanTest.Podman([]string{"run", "--rm", "--net", "host", fedoraMinimal, "cat", "/proc/sys/net/ipv4/ping_group_range"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).ToNot((ContainSubstring("1000")))
 	})
 
 	It("search domain", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search foobar.com")))
 	})
 
 	It("add dns server", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.2.3.4")))
 	})
 
 	It("add dns option", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
 	})
 
 	It("remove all search domain", func() {
 		session := podmanTest.Podman([]string{"run", "--dns-search=.", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(Not(ContainElement(HavePrefix("search"))))
 	})
 
 	It("add search domain", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search")))
 		Expect(session.OutputToString()).To(
 			And(
@@ -340,13 +340,13 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf timezone set to Pacific/Honolulu
 		session := podmanTest.Podman([]string{"run", "--tz", "", ALPINE, "date", "+'%H %Z'"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("HST"))
 
 		// verify flag still overrides
 		session = podmanTest.Podman([]string{"run", "--tz", "EST", ALPINE, "date", "+'%H %Z'"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("EST"))
 	})
 
@@ -358,14 +358,14 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "sh", "-c", "umask"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("0002"))
 	})
 
 	It("network slirp options to allow host loopback", func() {
 		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns", ALPINE, "ping", "-c1", "10.0.2.2"})
 		session.Wait(30)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman-remote test localcontainers.conf", func() {
@@ -376,13 +376,13 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// env
 		session := podmanTest.Podman([]string{"run", ALPINE, "printenv", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("bar"))
 
 		// dns-search, server, options
 		session = podmanTest.Podman([]string{"run", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search")))
 		Expect(session.OutputToString()).To(
 			And(
@@ -394,26 +394,26 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// sysctls
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "cat", "/proc/sys/net/ipv4/ping_group_range"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("1000"))
 
 		// shm-size
 		session = podmanTest.Podman([]string{"run", ALPINE, "grep", "shm", "/proc/self/mounts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("size=200k"))
 
 		// ulimits
 		session = podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "ulimit", "-n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("500"))
 
 		// Configuration that comes from remote client
 		// Timezone
 		session = podmanTest.Podman([]string{"run", ALPINE, "date", "+'%H %Z'"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(
 			Or(
 				ContainSubstring("EST"),
@@ -423,7 +423,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// Umask
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "sh", "-c", "umask"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("0022"))
 	})
 
@@ -431,7 +431,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// containers.conf is set to "run.oci.keep_original_groups=1"
 		session := podmanTest.Podman([]string{"create", "--rm", "--name", "test", fedoraMinimal})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{ .Config.Annotations }}", "test"})
 		inspect.WaitWithDefaultTimeout()
@@ -446,18 +446,18 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session = podmanTest.Podman([]string{"run", "-dt", "--add-host", "test1:127.0.0.1", "--no-hosts=false", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("no-hosts=true /etc/hosts does not include hostname", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--name", "test", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).ToNot(ContainSubstring("test"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--name", "test", "--no-hosts=false", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("test"))
 	})
 
@@ -476,7 +476,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.Security.SECCOMPProfilePath}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(profile))
 	})
 
@@ -494,7 +494,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/var/tmp"))
 
 		storagePath := filepath.Join(podmanTest.TempDir, "storage")
@@ -511,7 +511,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session = podmanTest.Podman([]string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/foobar"))
 
 		containersConf = []byte(fmt.Sprintf("[engine]\nimage_copy_tmp_dir=%q", storagePath))
@@ -523,7 +523,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		session = podmanTest.Podman([]string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(storagePath))
 
 		containersConf = []byte("[engine]\nimage_copy_tmp_dir=\"storage1\"")
@@ -539,7 +539,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 			os.Setenv("TMPDIR", "/hoge")
 			session = podmanTest.Podman([]string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToString()).To(Equal("/hoge"))
 			os.Unsetenv("TMPDIR")
 		}
@@ -551,7 +551,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		result := podmanTest.Podman([]string{"system", "service", "--help"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("(default 1234)"))
 	})
 
@@ -624,7 +624,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		result := podmanTest.Podman([]string{"create", ALPINE, "true"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{ .HostConfig.Cgroups }}", result.OutputToString()})
 		inspect.WaitWithDefaultTimeout()
@@ -636,7 +636,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		}
 		result = podmanTest.Podman([]string{"create", ALPINE, "true"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		inspect = podmanTest.Podman([]string{"inspect", "--format", "{{ .HostConfig.Cgroups }}", result.OutputToString()})
 		inspect.WaitWithDefaultTimeout()
@@ -645,7 +645,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		// Check we can also create a pod when cgroups=disabled
 		result = podmanTest.Podman([]string{"pod", "create"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman containers.conf runtime", func() {
@@ -657,7 +657,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		os.Setenv("CONTAINERS_CONF", conffile)
 		result := podmanTest.Podman([]string{"--help"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("Path to the OCI-compatible binary used to run containers. (default \"testruntime\")"))
 	})
 
@@ -683,11 +683,11 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 				Expect(podman.ErrorToString()).Should(ContainSubstring("invalid default_rootless_network_cmd option \"invalid\""))
 				continue
 			}
-			Expect(podman).Should(Exit(0))
+			Expect(podman).Should(ExitCleanly())
 
 			inspect := podmanTest.Podman([]string{"inspect", "--format", "{{.HostConfig.NetworkMode}}", mode})
 			inspect.WaitWithDefaultTimeout()
-			Expect(inspect).Should(Exit(0))
+			Expect(inspect).Should(ExitCleanly())
 			Expect(inspect.OutputToString()).Should(Equal(mode))
 		}
 	})

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // NOTE: Only smoke tests.  The system tests (i.e., "./test/system/*") take
@@ -33,7 +32,7 @@ var _ = Describe("Podman cp", func() {
 		// Create a container. NOTE that container mustn't be running for copying.
 		session := podmanTest.Podman([]string{"create", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		name := session.OutputToString()
 
 		// Copy TO the container.
@@ -46,7 +45,7 @@ var _ = Describe("Podman cp", func() {
 		// The file will now be created (and written to).
 		session = podmanTest.Podman([]string{"cp", srcFile.Name(), name + ":foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Copy FROM the container.
 
@@ -57,11 +56,11 @@ var _ = Describe("Podman cp", func() {
 
 		session = podmanTest.Podman([]string{"cp", name + ":foo", destFile.Name()})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", name})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Now make sure the content matches.
 		roundtripContent, err := os.ReadFile(destFile.Name())
@@ -84,17 +83,17 @@ var _ = Describe("Podman cp", func() {
 		// Create a container. NOTE that container mustn't be running for copying.
 		session := podmanTest.Podman([]string{"create", "--pid=host", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		name := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"start", name})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// The file will now be created (and written to).
 		session = podmanTest.Podman([]string{"cp", srcFile.Name(), name + ":foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Copy FROM the container.
 
@@ -105,7 +104,7 @@ var _ = Describe("Podman cp", func() {
 
 		session = podmanTest.Podman([]string{"cp", name + ":foo", destFile.Name()})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Now make sure the content matches.
 		roundtripContent, err := os.ReadFile(destFile.Name())
@@ -128,25 +127,25 @@ var _ = Describe("Podman cp", func() {
 
 		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		name := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"exec", name, "ln", "-s", "/tmp", "/test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"cp", "--pause=false", srcFile.Name(), name + ":/test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", name, "cat", "/tmp/" + filepath.Base(srcFile.Name())})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(string(originalContent)))
 
 		session = podmanTest.Podman([]string{"exec", name, "cat", "/test/" + filepath.Base(srcFile.Name())})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(string(originalContent)))
 	})
 
@@ -166,21 +165,21 @@ var _ = Describe("Podman cp", func() {
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"volume", "create", "data"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", "data:/data", "--name", "container1", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"cp", srcFile.Name(), "container1" + ":/data/file.txt"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Now get the volume's mount point, read the file and make
 		// sure the contents match.
 		session = podmanTest.Podman([]string{"volume", "inspect", "data", "--format", "{{.Mountpoint}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		volumeMountPoint := session.OutputToString()
 		copiedContent, err := os.ReadFile(filepath.Join(volumeMountPoint, "file.txt"))
@@ -199,19 +198,19 @@ var _ = Describe("Podman cp", func() {
 
 		setup := podmanTest.RunTopContainer("testctr")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "testctr", "adduser", "-S", "testuser"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "-u", "testuser", "testctr", "touch", "/tmp/testfile"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"cp", "--pause=false", "testctr:/tmp/testfile", srcFile.Name()})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// owner of the file copied to local machine is not testuser
 		u, err := user.Current()
@@ -223,12 +222,12 @@ var _ = Describe("Podman cp", func() {
 
 		session = podmanTest.Podman([]string{"cp", "--pause=false", srcFile.Name(), "testctr:testfile2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// owner of the file copied to a container is the root user
 		session = podmanTest.Podman([]string{"exec", "testctr", "ls", "-l", "testfile2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("root"))
 	})
 
@@ -237,17 +236,17 @@ var _ = Describe("Podman cp", func() {
 		container := "copyroottohost"
 		session := podmanTest.RunTopContainer(container)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", container, "touch", "/dummy.txt"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		tmpDir := GinkgoT().TempDir()
 
 		session = podmanTest.Podman([]string{"cp", container + ":/", tmpDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cmd := exec.Command("ls", "-la", tmpDir)
 		output, err := cmd.Output()

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 		SkipIfRootless("--ip not supported without network in rootless mode")
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "203.0.113.124", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result = podmanTest.Podman([]string{"start", "test"})
 		result.WaitWithDefaultTimeout()
@@ -36,11 +36,11 @@ var _ = Describe("Podman create with --ip flag", func() {
 		if isRootless() {
 			Expect(result).Should(Exit(125))
 		} else {
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 
 			result = podmanTest.Podman([]string{"start", "-a", "test"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(ContainSubstring(ip + "/16"))
 		}
 	})
@@ -50,20 +50,20 @@ var _ = Describe("Podman create with --ip flag", func() {
 		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"create", "--log-driver", "k8s-file", "--name", "test1", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		result = podmanTest.Podman([]string{"create", "--log-driver", "k8s-file", "--name", "test2", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		result = podmanTest.Podman([]string{"start", "test1"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// race prevention: wait until IP address is assigned and
 		// container is running.
 		for i := 0; i < 5; i++ {
 			result = podmanTest.Podman([]string{"inspect", "--format", "{{.State.Status}} {{.NetworkSettings.IPAddress}}", "test1"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			if result.OutputToString() == "running "+ip {
 				break
 			}

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +16,7 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 		if isRootless() {
 			Expect(result).Should(Exit(125))
 		} else {
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(ContainSubstring("92:d0:c6:0a:29:34"))
 		}
 	})
@@ -25,11 +26,11 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"run", "--network", net, "--mac-address", "92:d0:c6:00:29:34", ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("92:d0:c6:00:29:34"))
 	})
 })


### PR DESCRIPTION
Ongoing steps toward RUN-1907: replace Exit(0) with ExitCleanly()

A handful of test files with trivial command-line replacement,
and no manual muckery (aside from includes).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```