### PR TITLE
[CI:DOCS] The `podman init` command cannot modify containers.

### DIFF
--- a/docs/source/markdown/podman-init.1.md.in
+++ b/docs/source/markdown/podman-init.1.md.in
@@ -13,7 +13,7 @@ Initialize one or more containers.
 You may use container IDs or names as input.
 Initializing a container performs all tasks necessary for starting the container (mounting filesystems, creating an OCI spec, initializing the container network) but does not start the container.
 If a container is not initialized, the `podman start` and `podman run` commands initialize it automatically prior to starting it.
-This command is intended to be used for inspecting or modifying the container's filesystem or OCI spec prior to starting it.
+This command is intended to be used for inspecting a container's filesystem or OCI spec prior to starting it.
 This can be used to inspect the container before it runs, or debug why a container is failing to run.
 
 ## OPTIONS


### PR DESCRIPTION
`podman init` is a debugging command for inspecting a container's OCI spec before it runs, to look for anything suspicious. It is not capable of supporting modifications to that spec, as it starts Conmon and thus the OCI runtime, so the spec has already been loaded by the time `podman init` is run.


```release-note
NONE
```
