### PR TITLE
[CI:BUILD] rpm: hard dependency on gvisor-tap-vsock-gvforwarder

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -37,7 +37,7 @@
 # include it. Official rawhide should be able to fetch the last active build of
 # gvproxy, the min version requirement has been removed to allow it.
 # Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2224434
-%if !%{defined copr_username} && 0%{?fedora} <= 38
+%if !%{defined copr_username} && 0%{?fedora} <= 37
 %define gvproxy_subpackage 1
 %endif
 
@@ -129,6 +129,11 @@ Requires: containers-common-extra
 Recommends: %{name}-gvproxy = %{epoch}:%{version}-%{release}
 %else
 Recommends: %{name}-gvproxy
+%endif
+# gvforwarder subpackage exists only on f38 and higher as part of the
+# gvisor-tap-vsock package.
+%if %{defined fedora} && 0%{?fedora} >= 38
+Requires: gvisor-tap-vsock-gvforwarder
 %endif
 Provides: %{name}-quadlet
 Obsoletes: %{name}-quadlet <= 5:4.4.0-1


### PR DESCRIPTION
With https://github.com/containers/gvisor-tap-vsock/pull/268, gvforwarder is now provided via the subpackage
`gvisor-tap-vsock-gvforwarder`. FCOS needs this gvforwarder, hence the hard dependency.

gvisor-tap-vsock is a separate package for f38, so the subpackage conditional has been adjusted to fit that.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
