### PR TITLE
e2e: diff_test: use ExitCleanly()

### DIFF
--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Podman diff", func() {
 	It("podman diff of image", func() {
 		session := podmanTest.Podman([]string{"diff", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 	})
 
@@ -29,23 +29,23 @@ var _ = Describe("Podman diff", func() {
 	It("podman diff image with json output", func() {
 		session := podmanTest.Podman([]string{"diff", "--format=json", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 	})
 
 	It("podman diff container and committed image", func() {
 		session := podmanTest.Podman([]string{"run", "--name=diff-test", ALPINE, "touch", "/tmp/diff-test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"diff", "diff-test"})
 		session.WaitWithDefaultTimeout()
 		containerDiff := session.OutputToStringArray()
 		sort.Strings(containerDiff)
 		Expect(session.OutputToString()).To(ContainSubstring("C /tmp"))
 		Expect(session.OutputToString()).To(ContainSubstring("A /tmp/diff-test"))
-		session = podmanTest.Podman([]string{"commit", "diff-test", "diff-test-img"})
+		session = podmanTest.Podman([]string{"commit", "-q", "diff-test", "diff-test-img"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"diff", "diff-test-img"})
 		session.WaitWithDefaultTimeout()
 		imageDiff := session.OutputToStringArray()
@@ -56,7 +56,7 @@ var _ = Describe("Podman diff", func() {
 	It("podman diff latest container", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "diff-test", ALPINE, "touch", "/tmp/diff-test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if !IsRemote() {
 			session = podmanTest.Podman([]string{"diff", "-l"})
 		} else {
@@ -67,7 +67,7 @@ var _ = Describe("Podman diff", func() {
 		sort.Strings(containerDiff)
 		Expect(session.OutputToString()).To(ContainSubstring("C /tmp"))
 		Expect(session.OutputToString()).To(ContainSubstring("A /tmp/diff-test"))
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman image diff", func() {
@@ -96,13 +96,13 @@ RUN echo test
 
 		session := podmanTest.Podman([]string{"image", "diff", image})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToString()).To(Equal("A " + file3))
 
 		session = podmanTest.Podman([]string{"image", "diff", image, baseImage})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 		Expect(session.OutputToString()).To(ContainSubstring("A " + file1))
 		Expect(session.OutputToString()).To(ContainSubstring("A " + file2))
@@ -112,7 +112,7 @@ RUN echo test
 	It("podman image diff of single image", func() {
 		session := podmanTest.Podman([]string{"image", "diff", BB})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 	})
 
@@ -125,7 +125,7 @@ RUN echo test
 	It("podman image diff of the same image", func() {
 		session := podmanTest.Podman([]string{"image", "diff", ALPINE, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -143,25 +143,25 @@ RUN touch %s`, ALPINE, imagefile)
 
 		session := podmanTest.Podman([]string{"run", "--name", name, ALPINE, "touch", confile})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// podman diff prefers image over container when they have the same name
 		session = podmanTest.Podman([]string{"diff", name})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
 
 		session = podmanTest.Podman([]string{"image", "diff", name})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
 
 		// container diff has to show the container
 		session = podmanTest.Podman([]string{"container", "diff", name})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToString()).To(ContainSubstring(confile))
 	})


### PR DESCRIPTION
Ongoing steps toward RUN-1907: replace Exit(0) with ExitCleanly()

One manual fix: adding -q to podman commit, to avoid progress messages

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```