### PR TITLE
Add support for PidsLimit in quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -157,6 +157,7 @@ Valid options for `[Container]` are listed below:
 | NoNewPrivileges=true           | --security-opt no-new-privileges                     |
 | Rootfs=/var/lib/rootfs         | --rootfs /var/lib/rootfs                             |
 | Notify=true                    | --sdnotify container                                 |
+| PidsLimit=10000                | --pids-limit 10000                                   |
 | PodmanArgs=--add-host foobar   | --add-host foobar                                    |
 | PublishPort=50-59              | --publish 50-59                                      |
 | Pull=never                     | --pull=never                                         |
@@ -409,6 +410,11 @@ starts the child in the container. However, if the container application support
 [sd_notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html), then setting
 `Notify` to true passes the notification details to the container allowing it to notify
 of startup on its own.
+
+### `PidsLimit=`
+
+Tune the container's pids limit.
+This is equivalent to the Podman `--pids-limit` option.
 
 ### `PodmanArgs=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -91,6 +91,7 @@ const (
 	KeyNoNewPrivileges       = "NoNewPrivileges"
 	KeyNotify                = "Notify"
 	KeyOptions               = "Options"
+	KeyPidsLimit             = "PidsLimit"
 	KeyPodmanArgs            = "PodmanArgs"
 	KeyPublishPort           = "PublishPort"
 	KeyPull                  = "Pull"
@@ -163,6 +164,7 @@ var (
 		KeyNetwork:               true,
 		KeyNoNewPrivileges:       true,
 		KeyNotify:                true,
+		KeyPidsLimit:             true,
 		KeyPodmanArgs:            true,
 		KeyPublishPort:           true,
 		KeyPull:                  true,
@@ -449,18 +451,23 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 		podman.add("--security-opt", "label:nested")
 	}
 
-	securityLabelType, _ := container.Lookup(ContainerGroup, KeySecurityLabelType)
-	if len(securityLabelType) > 0 {
+	pidsLimit, ok := container.Lookup(ContainerGroup, KeyPidsLimit)
+	if ok && len(pidsLimit) > 0 {
+		podman.add("--pids-limit", pidsLimit)
+	}
+
+	securityLabelType, ok := container.Lookup(ContainerGroup, KeySecurityLabelType)
+	if ok && len(securityLabelType) > 0 {
 		podman.add("--security-opt", fmt.Sprintf("label=type:%s", securityLabelType))
 	}
 
-	securityLabelFileType, _ := container.Lookup(ContainerGroup, KeySecurityLabelFileType)
-	if len(securityLabelFileType) > 0 {
+	securityLabelFileType, ok := container.Lookup(ContainerGroup, KeySecurityLabelFileType)
+	if ok && len(securityLabelFileType) > 0 {
 		podman.add("--security-opt", fmt.Sprintf("label=filetype:%s", securityLabelFileType))
 	}
 
-	securityLabelLevel, _ := container.Lookup(ContainerGroup, KeySecurityLabelLevel)
-	if len(securityLabelLevel) > 0 {
+	securityLabelLevel, ok := container.Lookup(ContainerGroup, KeySecurityLabelLevel)
+	if ok && len(securityLabelLevel) > 0 {
 		podman.add("--security-opt", fmt.Sprintf("label=level:%s", securityLabelLevel))
 	}
 

--- a/test/e2e/quadlet/pids-limit.container
+++ b/test/e2e/quadlet/pids-limit.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--pids-limit" "8765432"
+
+[Container]
+Image=localhost/imagename
+PidsLimit=8765432


### PR DESCRIPTION
QM needs to be able to specify the maximum number of PIDs within the QM environment to ensure FFI.
Picking a total of 10,000 Pids might be a rasonable constraint on the QM.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet now supports seeing the PidsLimit option in a container.
```
