### PR TITLE
Add support for Ulimit in quadlet

### DIFF
--- a/docs/source/markdown/options/ulimit.md
+++ b/docs/source/markdown/options/ulimit.md
@@ -4,4 +4,17 @@
 ####> are applicable to all of those.
 #### **--ulimit**=*option*
 
-Ulimit options. You can use **host** to copy the current configuration from the host.
+Ulimit options. Sets the ulimits values inside of the container.
+
+--ulimit with a soft and hard limit in the format <type>=<soft limit>[:<hard limit>]. For example:
+
+$ podman run --ulimit nofile=1024:1024 --rm ubi9 ulimit -n
+1024
+
+Use **host** to copy the current configuration from the host.
+
+Don't use nproc with the ulimit flag as Linux uses nproc to set the
+maximum number of processes available to a user, not to a container.
+
+Use the --pids-limit option to modify the cgroup control to limit the number
+of processes within a container.

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -176,6 +176,7 @@ Valid options for `[Container]` are listed below:
 | Sysctl=name=value              | --sysctl=name=value                                  |
 | Timezone=local                 | --tz local                                           |
 | Tmpfs=/work                    | --tmpfs /work                                        |
+| Ulimit=nofile:1000:10000       | --ulimit nofile:1000:10000                           |
 | User=bin                       | --user bin                                           |
 | UserNS=keep-id:uid=200,gid=210 | --userns keep-id:uid=200,gid=210                     |
 | VolatileTmp=true               | --tmpfs /tmp                                         |
@@ -538,6 +539,10 @@ This key can be listed multiple times.
 ### `Timezone=` (if unset uses system-configured default)
 
 The timezone to run the container in.
+
+### `Ulimit=`
+
+Ulimit options. Sets the ulimits values inside of the container.
 
 ### `User=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -118,6 +118,7 @@ const (
 	KeyTimezone              = "Timezone"
 	KeyTmpfs                 = "Tmpfs"
 	KeyType                  = "Type"
+	KeyUlimit                = "Ulimit"
 	KeyUnmask                = "Unmask"
 	KeyUser                  = "User"
 	KeyUserNS                = "UserNS"
@@ -192,6 +193,7 @@ var (
 		KeySysctl:                true,
 		KeyTimezone:              true,
 		KeyTmpfs:                 true,
+		KeyUlimit:                true,
 		KeyUnmask:                true,
 		KeyUser:                  true,
 		KeyUserNS:                true,
@@ -476,6 +478,11 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	securityLabelLevel, ok := container.Lookup(ContainerGroup, KeySecurityLabelLevel)
 	if ok && len(securityLabelLevel) > 0 {
 		podman.add("--security-opt", fmt.Sprintf("label=level:%s", securityLabelLevel))
+	}
+
+	ulimit, ok := container.Lookup(ContainerGroup, KeyUlimit)
+	if ok && len(ulimit) > 0 {
+		podman.add("--ulimit", ulimit)
 	}
 
 	// But allow overrides with AddCapability

--- a/test/e2e/quadlet/ulimit.container
+++ b/test/e2e/quadlet/ulimit.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--ulimit nproc:1234:5678"
+
+[Container]
+Image=localhost/imagename
+Ulimit=nproc:1234:5678


### PR DESCRIPTION
QM needs to be able to specify the maximum number of open files within the QM environment to ensure FFI.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman quadlet now supports setting Ulimit values.
```
