### PR TITLE
e2e: more ExitCleanly() on more test files

### DIFF
--- a/cmd/podman/farm/remove.go
+++ b/cmd/podman/farm/remove.go
@@ -67,7 +67,7 @@ func rm(cmd *cobra.Command, args []string) error {
 	deletedFarms := []string{}
 	for _, k := range args {
 		if _, ok := cfg.Farms.List[k]; !ok {
-			logrus.Warnf("farm %q doesn't exists; nothing to remove", k)
+			logrus.Warnf("farm %q doesn't exist; nothing to remove", k)
 			continue
 		}
 		delete(cfg.Farms.List, k)

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -364,8 +364,9 @@ case "$TEST_FLAVOR" in
         pip install --requirement $GOSRC/test/apiv2/python/requirements.txt
         ;&  # continue with next item
     compose)
-        make install.tools
-        dnf install -y podman-docker*
+        showrun make install.tools
+        showrun dnf remove -y gvisor-tap-vsock
+        showrun dnf install -y podman-docker*
         ;&  # continue with next item
     int)
         make .install.ginkgo

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/libpod/events"
+	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman events", func() {
@@ -25,7 +25,7 @@ var _ = Describe("Podman events", func() {
 		Expect(ec).To(Equal(0))
 		result := podmanTest.Podman([]string{"events", "--stream=false"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman events with an event filter", func() {
@@ -33,7 +33,7 @@ var _ = Describe("Podman events", func() {
 		Expect(ec).To(Equal(0))
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=start"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).ToNot(BeEmpty(), "Number of events")
 		date := time.Now().Format("2006-01-02")
 		Expect(result.OutputToStringArray()).To(ContainElement(HavePrefix(date)), "event log has correct timestamp")
@@ -47,13 +47,13 @@ var _ = Describe("Podman events", func() {
 		resultPrefix := podmanTest.Podman([]string{"events", "--stream=false", "--filter", fmt.Sprintf("volume=%s", vname[:5])})
 
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		events := result.OutputToStringArray()
 		Expect(events).To(HaveLen(1), "number of events")
 		Expect(events[0]).To(ContainSubstring(vname), "event log includes volume name")
 
 		resultPrefix.WaitWithDefaultTimeout()
-		Expect(resultPrefix).Should(Exit(0))
+		Expect(resultPrefix).Should(ExitCleanly())
 		events = resultPrefix.OutputToStringArray()
 		Expect(events).To(HaveLen(1), "number of events")
 		Expect(events[0]).To(ContainSubstring(vname), "event log includes volume name")
@@ -67,7 +67,7 @@ var _ = Describe("Podman events", func() {
 		time.Sleep(5 * time.Second)
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=start", "--filter", fmt.Sprintf("container=%s", cid)})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		events := result.OutputToStringArray()
 		Expect(events).To(HaveLen(1), "number of events")
 		Expect(events[0]).To(ContainSubstring(cid), "event log includes CID")
@@ -79,7 +79,7 @@ var _ = Describe("Podman events", func() {
 		Expect(ec).To(Equal(0))
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "type=pod", "--filter", fmt.Sprintf("container=%s", cid)})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -88,11 +88,11 @@ var _ = Describe("Podman events", func() {
 		setup.WaitWithDefaultTimeout()
 		stop := podmanTest.Podman([]string{"pod", "stop", "foobarpod"})
 		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(Exit(0))
-		Expect(setup).Should(Exit(0))
+		Expect(stop).Should(ExitCleanly())
+		Expect(setup).Should(ExitCleanly())
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "type=pod", "--filter", "pod=foobarpod"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		events := result.OutputToStringArray()
 		GinkgoWriter.Println(events)
 		Expect(len(events)).To(BeNumerically(">=", 2), "Number of events")
@@ -106,7 +106,7 @@ var _ = Describe("Podman events", func() {
 		Expect(ec).To(Equal(0))
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--since", "1m"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman events --until", func() {
@@ -114,7 +114,7 @@ var _ = Describe("Podman events", func() {
 		Expect(ec).To(Equal(0))
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--until", "1h"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman events format", func() {
@@ -123,7 +123,7 @@ var _ = Describe("Podman events", func() {
 
 		test := podmanTest.Podman([]string{"events", "--stream=false", "--format", "json"})
 		test.WaitWithDefaultTimeout()
-		Expect(test).To(Exit(0))
+		Expect(test).To(ExitCleanly())
 
 		jsonArr := test.OutputToStringArray()
 		Expect(test.OutputToStringArray()).ShouldNot(BeEmpty())
@@ -134,7 +134,7 @@ var _ = Describe("Podman events", func() {
 
 		test = podmanTest.Podman([]string{"events", "--stream=false", "--format", "{{json.}}"})
 		test.WaitWithDefaultTimeout()
-		Expect(test).To(Exit(0))
+		Expect(test).To(ExitCleanly())
 
 		jsonArr = test.OutputToStringArray()
 		Expect(test.OutputToStringArray()).ShouldNot(BeEmpty())
@@ -145,7 +145,7 @@ var _ = Describe("Podman events", func() {
 
 		test = podmanTest.Podman([]string{"events", "--stream=false", "--filter=type=container", "--format", "ID: {{.ID}}"})
 		test.WaitWithDefaultTimeout()
-		Expect(test).To(Exit(0))
+		Expect(test).To(ExitCleanly())
 		arr := test.OutputToStringArray()
 		Expect(len(arr)).To(BeNumerically(">", 1))
 		Expect(arr[0]).To(MatchRegexp("ID: [a-fA-F0-9]{64}"))
@@ -157,7 +157,7 @@ var _ = Describe("Podman events", func() {
 		name3 := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"create", "--name", name1, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -169,17 +169,17 @@ var _ = Describe("Podman events", func() {
 			time.Sleep(time.Second * 2)
 			session = podmanTest.Podman([]string{"create", "--name", name2, ALPINE})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			session = podmanTest.Podman([]string{"create", "--name", name3, ALPINE})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 		}()
 
 		// unix timestamp in 10 seconds
 		until := time.Now().Add(time.Second * 10).Unix()
 		result := podmanTest.Podman([]string{"events", "--since", "30s", "--until", fmt.Sprint(until)})
 		result.Wait(11)
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(name1))
 		Expect(result.OutputToString()).To(ContainSubstring(name2))
 		Expect(result.OutputToString()).To(ContainSubstring(name3))
@@ -188,7 +188,7 @@ var _ = Describe("Podman events", func() {
 		untilT := time.Now().Add(time.Second * 9)
 		result = podmanTest.Podman([]string{"events", "--since", "30s", "--until", "10s"})
 		result.Wait(11)
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		tEnd := time.Now()
 		outDur := tEnd.Sub(untilT)
 		Expect(outDur.Seconds()).To(BeNumerically(">", 0), "duration")
@@ -202,29 +202,29 @@ var _ = Describe("Podman events", func() {
 	It("podman events pod creation", func() {
 		create := podmanTest.Podman([]string{"pod", "create", "--infra=false", "--name", "foobarpod"})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 		id := create.OutputToString()
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "pod=" + id})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(HaveLen(1))
 		Expect(result.OutputToString()).To(ContainSubstring("create"))
 
 		ctrName := "testCtr"
 		run := podmanTest.Podman([]string{"create", "--pod", id, "--name", ctrName, ALPINE, "top"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		result2 := podmanTest.Podman([]string{"events", "--stream=false", "--filter", fmt.Sprintf("container=%s", ctrName), "--since", "30s"})
 		result2.WaitWithDefaultTimeout()
-		Expect(result2).Should(Exit(0))
+		Expect(result2).Should(ExitCleanly())
 		Expect(result2.OutputToString()).To(ContainSubstring(fmt.Sprintf("pod_id=%s", id)))
 	})
 
 	It("podman events health_status generated", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "test-hc", "-dt", "--health-cmd", "echo working", "busybox"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		for i := 0; i < 5; i++ {
 			hc := podmanTest.Podman([]string{"healthcheck", "run", "test-hc"})
@@ -238,7 +238,7 @@ var _ = Describe("Podman events", func() {
 
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=health_status", "--since", "1m"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).ToNot(BeEmpty(), "Number of health_status events")
 	})
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -312,7 +312,8 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec terminal doesn't hang", FlakeAttempts(3), func() {
 		setup := podmanTest.Podman([]string{"run", "-dti", "--name", "test1", fedoraMinimal, "sleep", "+Inf"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(ExitCleanly())
+		Expect(setup).Should(Exit(0))
+		Expect(setup.ErrorToString()).To(ContainSubstring("The input device is not a TTY. The --tty and --interactive flags might not work properly"))
 
 		for i := 0; i < 5; i++ {
 			session := podmanTest.Podman([]string{"exec", "-ti", "test1", "true"})
@@ -453,7 +454,7 @@ var _ = Describe("Podman exec", func() {
 		Expect(ctr1).Should(ExitCleanly())
 
 		imgName := "img1"
-		commit := podmanTest.Podman([]string{"commit", ctrName1, imgName})
+		commit := podmanTest.Podman([]string{"commit", "-q", ctrName1, imgName})
 		commit.WaitWithDefaultTimeout()
 		Expect(commit).Should(ExitCleanly())
 
@@ -541,7 +542,7 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(secretsString))
 
-		session = podmanTest.Podman([]string{"commit", "secr", "foobar.com/test1-image:latest"})
+		session = podmanTest.Podman([]string{"commit", "-q", "secr", "foobar.com/test1-image:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -29,49 +29,49 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec simple command", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman container exec simple command", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"container", "exec", "test1", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman exec simple command using latest", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 		cid := "-l"
 		if IsRemote() {
 			cid = "test1"
 		}
 		session := podmanTest.Podman([]string{"exec", cid, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman exec environment test", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "--env", "FOO=BAR", "test1", "printenv", "FOO"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("BAR"))
 
 		session = podmanTest.Podman([]string{"exec", "--env", "PATH=/bin", "test1", "printenv", "PATH"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/bin"))
 	})
 
@@ -79,12 +79,12 @@ var _ = Describe("Podman exec", func() {
 		// remote doesn't properly interpret os.Setenv
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		os.Setenv("FOO", "BAR")
 		session := podmanTest.Podman([]string{"exec", "--env", "FOO", "test1", "printenv", "FOO"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("BAR"))
 		os.Unsetenv("FOO")
 	})
@@ -92,7 +92,7 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec exit code", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "sh", "-c", "exit 100"})
 		session.WaitWithDefaultTimeout()
@@ -104,63 +104,63 @@ var _ = Describe("Podman exec", func() {
 		ctrName := "testctr1"
 		testCtr := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--userns=keep-id", ALPINE, "top"})
 		testCtr.WaitWithDefaultTimeout()
-		Expect(testCtr).Should(Exit(0))
+		Expect(testCtr).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", ctrName, "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 	})
 
 	It("podman exec --privileged", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bndPerms := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--privileged", "--rm", ALPINE, "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		effPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainer("test-privileged")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 	})
 
 	It("podman exec --privileged", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", "--user=bin", "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bndPerms := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--privileged", "--user=bin", "--rm", ALPINE, "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		effPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainer("test-privileged")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=bin", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=bin", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 
 	})
@@ -168,52 +168,52 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec --privileged", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bndPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainer("test-privileged")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=bin", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("00000000"))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=bin", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 	})
 
 	It("podman exec --privileged container not running as root", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bndPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainerWithArgs("test-privileged", []string{"--user=bin"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("00000000"))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=bin", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("00000000"))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=root", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "--user=bin", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 	})
 
@@ -221,26 +221,26 @@ var _ = Describe("Podman exec", func() {
 		capAdd := "--cap-add=net_bind_service"
 		session := podmanTest.Podman([]string{"run", "--user=bin", capAdd, "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bndPerms := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--user=bin", capAdd, "--rm", ALPINE, "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		effPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainerWithArgs("test-privileged", []string{"--user=bin", capAdd})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 
 		session = podmanTest.Podman([]string{"exec", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 	})
 
@@ -249,62 +249,62 @@ var _ = Describe("Podman exec", func() {
 		capDrop := "--cap-drop=all"
 		session := podmanTest.Podman([]string{"run", "--user=bin", capDrop, capAdd, "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bndPerms := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--user=bin", capDrop, capAdd, "--rm", ALPINE, "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		effPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainerWithArgs("test-privileged", []string{"--user=bin", capDrop, capAdd})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bndPerms))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "test-privileged", "sh", "-c", "grep ^CapInh /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 
 		session = podmanTest.Podman([]string{"exec", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 
 		session = podmanTest.Podman([]string{"exec", "test-privileged", "sh", "-c", "grep ^CapPrm /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 
 		session = podmanTest.Podman([]string{"exec", "test-privileged", "sh", "-c", "grep ^CapAmb /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(effPerms))
 	})
 
 	It("podman exec --privileged with user", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", "--user=bin", "--rm", ALPINE, "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		bindPerms := session.OutputToString()
 
 		setup := podmanTest.RunTopContainerWithArgs("test-privileged", []string{"--privileged", "--user=bin"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "test-privileged", "sh", "-c", "grep ^CapBnd /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(bindPerms))
 
 		session = podmanTest.Podman([]string{"exec", "--privileged", "test-privileged", "sh", "-c", "grep ^CapEff /proc/self/status | cut -f 2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 	})
 
@@ -312,49 +312,49 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec terminal doesn't hang", FlakeAttempts(3), func() {
 		setup := podmanTest.Podman([]string{"run", "-dti", "--name", "test1", fedoraMinimal, "sleep", "+Inf"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		for i := 0; i < 5; i++ {
 			session := podmanTest.Podman([]string{"exec", "-ti", "test1", "true"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 		}
 	})
 
 	It("podman exec pseudo-terminal sanity check", func() {
 		setup := podmanTest.Podman([]string{"run", "--detach", "--name", "test1", fedoraMinimal, "sleep", "+Inf"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "--interactive", "--tty", "test1", "/usr/bin/stty", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(" onlcr"))
 	})
 
 	It("podman exec simple command with user", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "--user", "root", "test1", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman exec with user only in container", func() {
 		testUser := "test123"
 		setup := podmanTest.Podman([]string{"run", "--name", "test1", "-d", fedoraMinimal, "sleep", "60"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "useradd", testUser})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"exec", "--user", testUser, "test1", "whoami"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 		Expect(session2.OutputToString()).To(Equal(testUser))
 	})
 
@@ -362,41 +362,41 @@ var _ = Describe("Podman exec", func() {
 		testUser := "guest"
 		setup := podmanTest.Podman([]string{"run", "--user", testUser, "-d", ALPINE, "top"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 		ctrID := setup.OutputToString()
 
 		session := podmanTest.Podman([]string{"exec", ctrID, "whoami"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(testUser))
 
 		overrideUser := "root"
 		session = podmanTest.Podman([]string{"exec", "--user", overrideUser, ctrID, "whoami"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(overrideUser))
 	})
 
 	It("podman exec simple working directory test", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "--workdir", "/tmp", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/tmp"))
 
 		session = podmanTest.Podman([]string{"exec", "-w", "/tmp", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/tmp"))
 	})
 
 	It("podman exec missing working directory test", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "--workdir", "/missing", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
@@ -411,7 +411,7 @@ var _ = Describe("Podman exec", func() {
 		SkipIfNotFedora("FIXME: #19552 fails on Debian SID w/ runc 1.1.5")
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "/etc"})
 		session.WaitWithDefaultTimeout()
@@ -421,7 +421,7 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec command not found", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "notthere"})
 		session.WaitWithDefaultTimeout()
@@ -431,7 +431,7 @@ var _ = Describe("Podman exec", func() {
 	It("podman exec preserve fds sanity check", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		devNull, err := os.Open("/dev/null")
 		Expect(err).ToNot(HaveOccurred())
@@ -441,7 +441,7 @@ var _ = Describe("Podman exec", func() {
 		}
 		session := podmanTest.PodmanExtraFiles([]string{"exec", "--preserve-fds", "1", "test1", "ls"}, files)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman exec preserves --group-add groups", func() {
@@ -450,21 +450,21 @@ var _ = Describe("Podman exec", func() {
 		ctrName1 := "ctr1"
 		ctr1 := podmanTest.Podman([]string{"run", "--name", ctrName1, fedoraMinimal, "groupadd", "-g", gid, groupName})
 		ctr1.WaitWithDefaultTimeout()
-		Expect(ctr1).Should(Exit(0))
+		Expect(ctr1).Should(ExitCleanly())
 
 		imgName := "img1"
 		commit := podmanTest.Podman([]string{"commit", ctrName1, imgName})
 		commit.WaitWithDefaultTimeout()
-		Expect(commit).Should(Exit(0))
+		Expect(commit).Should(ExitCleanly())
 
 		ctrName2 := "ctr2"
 		ctr2 := podmanTest.Podman([]string{"run", "-d", "--name", ctrName2, "--group-add", groupName, imgName, "sleep", "300"})
 		ctr2.WaitWithDefaultTimeout()
-		Expect(ctr2).Should(Exit(0))
+		Expect(ctr2).Should(ExitCleanly())
 
 		exec := podmanTest.Podman([]string{"exec", ctrName2, "id"})
 		exec.WaitWithDefaultTimeout()
-		Expect(exec).Should(Exit(0))
+		Expect(exec).Should(ExitCleanly())
 		Expect(exec.OutputToString()).To(ContainSubstring(fmt.Sprintf("%s(%s)", gid, groupName)))
 	})
 
@@ -479,11 +479,11 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 		ctrName := "testctr"
 		ctr := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--user", "auser:first", "--group-add", "second", imgName, "sleep", "300"})
 		ctr.WaitWithDefaultTimeout()
-		Expect(ctr).Should(Exit(0))
+		Expect(ctr).Should(ExitCleanly())
 
 		exec := podmanTest.Podman([]string{"exec", ctrName, "id"})
 		exec.WaitWithDefaultTimeout()
-		Expect(exec).Should(Exit(0))
+		Expect(exec).Should(ExitCleanly())
 		output := exec.OutputToString()
 		Expect(output).To(ContainSubstring("4000(first)"))
 		Expect(output).To(ContainSubstring("4001(second)"))
@@ -492,18 +492,18 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 		// Kill the container just so the test does not take 15 seconds to stop.
 		kill := podmanTest.Podman([]string{"kill", ctrName})
 		kill.WaitWithDefaultTimeout()
-		Expect(kill).Should(Exit(0))
+		Expect(kill).Should(ExitCleanly())
 	})
 
 	It("podman exec --detach", func() {
 		ctrName := "testctr"
 		ctr := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
-		Expect(ctr).Should(Exit(0))
+		Expect(ctr).Should(ExitCleanly())
 
 		exec1 := podmanTest.Podman([]string{"exec", "-d", ctrName, "top"})
 		exec1.WaitWithDefaultTimeout()
-		Expect(ctr).Should(Exit(0))
+		Expect(ctr).Should(ExitCleanly())
 
 		data := podmanTest.InspectContainer(ctrName)
 		Expect(data).To(HaveLen(1))
@@ -512,14 +512,14 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 
 		exec2 := podmanTest.Podman([]string{"exec", ctrName, "ps", "-a"})
 		exec2.WaitWithDefaultTimeout()
-		Expect(ctr).Should(Exit(0))
+		Expect(ctr).Should(ExitCleanly())
 		Expect(strings.Count(exec2.OutputToString(), "top")).To(Equal(2))
 
 		// Ensure that stop with a running detached exec session is
 		// clean.
 		stop := podmanTest.Podman([]string{"stop", ctrName})
 		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(Exit(0))
+		Expect(stop).Should(ExitCleanly())
 	})
 
 	It("podman exec with env var secret", func() {
@@ -530,20 +530,20 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "-d", "--secret", "source=mysecret,type=env", "--name", "secr", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "secr", "printenv", "mysecret"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(secretsString))
 
 		session = podmanTest.Podman([]string{"commit", "secr", "foobar.com/test1-image:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "foobar.com/test1-image:latest", "printenv", "mysecret"})
 		session.WaitWithDefaultTimeout()
@@ -569,8 +569,8 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 
 		session.Wait(6)
 
-		Expect(session2).Should(Exit(0))
-		Expect(session).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("root"))
 	})
 })

--- a/test/e2e/farm_test.go
+++ b/test/e2e/farm_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 func setupContainersConfWithSystemConnections() {
@@ -181,8 +182,9 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "rm", "farm1", "nonexistent-farm"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitCleanly())
+			Expect(session).Should(Exit(0))
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" deleted"))
+			Expect(session.ErrorToString()).Should(ContainSubstring("doesn't exist; nothing to remove"))
 
 			cfg, err = config.ReadCustomConfig()
 			Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e/farm_test.go
+++ b/test/e2e/farm_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 func setupContainersConfWithSystemConnections() {
@@ -56,21 +55,21 @@ var _ = Describe("podman farm", func() {
 			cmd := []string{"farm", "create", "farm1", "QA", "QB"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" created"))
 
 			// create farm with only one system connection
 			cmd = []string{"farm", "create", "farm2", "QA"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm2\" created"))
 
 			// create empty farm
 			cmd = []string{"farm", "create", "farm3"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm3\" created"))
 
 			cfg, err := config.ReadCustomConfig()
@@ -84,7 +83,7 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "create", "farm3"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Not(Exit(0)))
+			Expect(session).Should(Not(ExitCleanly()))
 		})
 
 		It("update existing farms", func() {
@@ -92,21 +91,21 @@ var _ = Describe("podman farm", func() {
 			cmd := []string{"farm", "create", "farm1", "QA", "QB"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" created"))
 
 			// create farm with only one system connection
 			cmd = []string{"farm", "create", "farm2", "QA"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm2\" created"))
 
 			// create empty farm
 			cmd = []string{"farm", "create", "farm3"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm3\" created"))
 
 			cfg, err := config.ReadCustomConfig()
@@ -120,21 +119,21 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "update", "--remove", "QA,QB", "farm1"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" updated"))
 
 			// update farm3 to add QA and QB connections to it
 			cmd = []string{"farm", "update", "--add", "QB", "farm3"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm3\" updated"))
 
 			// update farm2 to be the default farm
 			cmd = []string{"farm", "update", "--default", "farm2"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm2\" updated"))
 
 			cfg, err = config.ReadCustomConfig()
@@ -148,7 +147,7 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "update", "--default=false", "farm2"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm2\" updated"))
 
 			cfg, err = config.ReadCustomConfig()
@@ -161,14 +160,14 @@ var _ = Describe("podman farm", func() {
 			cmd := []string{"farm", "create", "farm1", "QA", "QB"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" created"))
 
 			// create farm with only one system connection
 			cmd = []string{"farm", "create", "farm2", "QA"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm2\" created"))
 
 			cfg, err := config.ReadCustomConfig()
@@ -182,7 +181,7 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "rm", "farm1", "nonexistent-farm"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" deleted"))
 
 			cfg, err = config.ReadCustomConfig()
@@ -195,7 +194,7 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "rm", "foo", "bar"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Not(Exit(0)))
+			Expect(session).Should(Not(ExitCleanly()))
 		})
 
 		It("remove --all farms", func() {
@@ -203,14 +202,14 @@ var _ = Describe("podman farm", func() {
 			cmd := []string{"farm", "create", "farm1", "QA", "QB"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm1\" created"))
 
 			// create farm with only one system connection
 			cmd = []string{"farm", "create", "farm2", "QA"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"farm2\" created"))
 
 			cfg, err := config.ReadCustomConfig()
@@ -223,7 +222,7 @@ var _ = Describe("podman farm", func() {
 			cmd = []string{"farm", "rm", "--all"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("All farms have been deleted"))
 
 			cfg, err = config.ReadCustomConfig()

--- a/test/e2e/generate_spec_test.go
+++ b/test/e2e/generate_spec_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman generate spec", func() {
@@ -25,22 +24,22 @@ var _ = Describe("Podman generate spec", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		session := podmanTest.Podman([]string{"create", "--cpus", "5", "--name", "specgen", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"generate", "spec", "--compact", "specgen"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman generate spec file", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		session := podmanTest.Podman([]string{"create", "--cpus", "5", "--name", "specgen", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"generate", "spec", "--filename", filepath.Join(tempdir, "out.json"), "specgen"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		path := filepath.Join(tempdir, "out.json")
 
@@ -54,10 +53,10 @@ var _ = Describe("Podman generate spec", func() {
 	It("generate spec pod", func() {
 		session := podmanTest.Podman([]string{"pod", "create", "--cpus", "5", "--name", "podspecgen"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"generate", "spec", "--compact", "podspecgen"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 })

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman disable healthcheck with --no-healthcheck on valid container", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
 		Expect(hc).Should(Exit(125))
@@ -33,17 +33,17 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman disable healthcheck with --no-healthcheck must not show starting on status", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.State.Health.Status}}", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 		Expect(hc.OutputToString()).To(Not(ContainSubstring("starting")))
 	})
 
 	It("podman run healthcheck and logs should contain healthcheck output", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "test-logs", "-dt", "--health-interval", "1s", "--health-cmd", "echo working", "busybox", "sleep", "3600"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Buy a little time to get container running
 		for i := 0; i < 5; i++ {
@@ -58,7 +58,7 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.State.Healthcheck.Log}}", "test-logs"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 		Expect(hc.OutputToString()).To(ContainSubstring("working"))
 	})
 
@@ -67,17 +67,17 @@ var _ = Describe("Podman healthcheck run", func() {
 		// the container or the container-config of an image.
 		session := podmanTest.Podman([]string{"create", "--name", "hc", "quay.io/libpod/healthcheck:config-only", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Config.Healthcheck}}", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 		Expect(hc.OutputToString()).To(Equal("{[CMD-SHELL curl -f http://localhost/ || exit 1] 0s 5m0s 3s 0}"))
 	})
 
 	It("podman disable healthcheck with --health-cmd=none on valid container", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "none", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
 		Expect(hc).Should(Exit(125))
@@ -87,7 +87,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		Skip("Extremely consistent flake - re-enable on debugging")
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		exitCode := 999
 
@@ -105,14 +105,14 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		ps := podmanTest.Podman([]string{"ps"})
 		ps.WaitWithDefaultTimeout()
-		Expect(ps).Should(Exit(0))
+		Expect(ps).Should(ExitCleanly())
 		Expect(ps.OutputToString()).To(ContainSubstring("(healthy)"))
 	})
 
 	It("podman healthcheck that should fail", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "quay.io/libpod/badhealthcheck:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -122,7 +122,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck on stopped container", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "hc", HEALTHCHECK_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -132,7 +132,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck on container without healthcheck", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -142,7 +142,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck should be starting", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		inspect := podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
 	})
@@ -150,7 +150,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck failed checks in start-period should not change status", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-start-period", "2m", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -173,7 +173,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck failed checks must reach retries before unhealthy ", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -195,11 +195,11 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck good check results in healthy even in start-period", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-start-period", "2m", "--health-retries", "2", "--health-cmd", "ls || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 
 		inspect := podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckHealthy))
@@ -208,7 +208,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck unhealthy but valid arguments check", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "[\"ls\", \"/foo\"]", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -218,7 +218,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck single healthy result changes failed to healthy", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
@@ -236,11 +236,11 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		foo := podmanTest.Podman([]string{"exec", "hc", "touch", "/foo"})
 		foo.WaitWithDefaultTimeout()
-		Expect(foo).Should(Exit(0))
+		Expect(foo).Should(ExitCleanly())
 
 		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 
 		inspect = podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckHealthy))
@@ -248,7 +248,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		// Test that events generated have correct status (#19237)
 		events := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=health_status", "--since", "1m"})
 		events.WaitWithDefaultTimeout()
-		Expect(events).Should(Exit(0))
+		Expect(events).Should(ExitCleanly())
 		eventsOut := events.OutputToStringArray()
 		Expect(eventsOut).To(HaveLen(3))
 		Expect(eventsOut[0]).To(ContainSubstring("health_status=starting"))
@@ -258,7 +258,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		// Test podman ps --filter health is working (#11687)
 		ps := podmanTest.Podman([]string{"ps", "--filter", "health=healthy"})
 		ps.WaitWithDefaultTimeout()
-		Expect(ps).Should(Exit(0))
+		Expect(ps).Should(ExitCleanly())
 		Expect(ps.OutputToStringArray()).To(HaveLen(2))
 		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})
@@ -266,15 +266,15 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("stopping and then starting a container with healthcheck cmd", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-cmd", "[\"ls\", \"/foo\"]", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		stop := podmanTest.Podman([]string{"stop", "-t0", "hc"})
 		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(Exit(0))
+		Expect(stop).Should(ExitCleanly())
 
 		startAgain := podmanTest.Podman([]string{"start", "hc"})
 		startAgain.WaitWithDefaultTimeout()
-		Expect(startAgain).Should(Exit(0))
+		Expect(startAgain).Should(ExitCleanly())
 		Expect(startAgain.OutputToString()).To(Equal("hc"))
 		Expect(startAgain.ErrorToString()).To(Equal(""))
 	})
@@ -299,17 +299,17 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 
 		session := podmanTest.Podman([]string{"build", "--format", "docker", "-t", "test", "."})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Check if image inspect contains CMD-SHELL generated by healthcheck.
 		session = podmanTest.Podman([]string{"image", "inspect", "--format", "{{.Config.Healthcheck}}", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("CMD-SHELL"))
 
 		run := podmanTest.Podman([]string{"run", "-dt", "--name", "hctest", "test", "ls"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		inspect := podmanTest.InspectContainer("hctest")
 		// Check to make sure a default time value was added
@@ -324,7 +324,7 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		ctrName := "hcCtr"
 		ctrRun := podmanTest.Podman([]string{"run", "-dt", "--name", ctrName, "--health-cmd", "echo regular", "--health-startup-cmd", "cat /test", ALPINE, "top"})
 		ctrRun.WaitWithDefaultTimeout()
-		Expect(ctrRun).Should(Exit(0))
+		Expect(ctrRun).Should(ExitCleanly())
 
 		inspect := podmanTest.InspectContainer(ctrName)
 		Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
@@ -335,18 +335,18 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 
 		exec := podmanTest.Podman([]string{"exec", ctrName, "sh", "-c", "touch /test && echo startup > /test"})
 		exec.WaitWithDefaultTimeout()
-		Expect(exec).Should(Exit(0))
+		Expect(exec).Should(ExitCleanly())
 
 		hc = podmanTest.Podman([]string{"healthcheck", "run", ctrName})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 
 		inspect = podmanTest.InspectContainer(ctrName)
 		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckHealthy))
 
 		hc = podmanTest.Podman([]string{"healthcheck", "run", ctrName})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(0))
+		Expect(hc).Should(ExitCleanly())
 
 		inspect = podmanTest.InspectContainer(ctrName)
 		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckHealthy))
@@ -354,7 +354,7 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		// Test podman ps --filter health is working (#11687)
 		ps := podmanTest.Podman([]string{"ps", "--filter", "health=healthy"})
 		ps.WaitWithDefaultTimeout()
-		Expect(ps).Should(Exit(0))
+		Expect(ps).Should(ExitCleanly())
 		Expect(ps.OutputToStringArray()).To(HaveLen(2))
 		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck from image's config (not container config)", func() {
 		// Regression test for #12226: a health check may be defined in
 		// the container or the container-config of an image.
-		session := podmanTest.Podman([]string{"create", "--name", "hc", "quay.io/libpod/healthcheck:config-only", "ls"})
+		session := podmanTest.Podman([]string{"create", "-q", "--name", "hc", "quay.io/libpod/healthcheck:config-only", "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Config.Healthcheck}}", "hc"})
@@ -110,7 +110,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck that should fail", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "quay.io/libpod/badhealthcheck:latest"})
+		session := podmanTest.Podman([]string{"run", "-q", "-dt", "--name", "hc", "quay.io/libpod/badhealthcheck:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman history", func() {
@@ -12,45 +11,45 @@ var _ = Describe("Podman history", func() {
 	It("podman history output flag", func() {
 		session := podmanTest.Podman([]string{"history", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 	})
 
 	It("podman history with GO template", func() {
 		session := podmanTest.Podman([]string{"history", "--format", "{{.ID}} {{.Created}}", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 
 		session = podmanTest.Podman([]string{"history", "--format", "{{.CreatedAt}};{{.Size}}", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(MatchRegexp("[0-9-]{10}T[0-9:]{8}[Z0-9+:-]+;[0-9.]+[MG]*B( .+)?"))
 	})
 
 	It("podman history with human flag", func() {
 		session := podmanTest.Podman([]string{"history", "--human=false", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 	})
 
 	It("podman history with quiet flag", func() {
 		session := podmanTest.Podman([]string{"history", "-qH", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 	})
 
 	It("podman history with no-trunc flag", func() {
 		session := podmanTest.Podman([]string{"history", "--no-trunc", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).ToNot(BeEmpty())
 
 		session = podmanTest.Podman([]string{"history", "--no-trunc", "--format", "{{.ID}}", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		lines := session.OutputToStringArray()
 		Expect(lines).ToNot(BeEmpty())
 		// the image id must be 64 chars long
@@ -58,7 +57,7 @@ var _ = Describe("Podman history", func() {
 
 		session = podmanTest.Podman([]string{"history", "--no-trunc", "--format", "{{.CreatedBy}}", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		lines = session.OutputToStringArray()
 		Expect(lines).ToNot(BeEmpty())
 		Expect(session.OutputToString()).ToNot(ContainSubstring("..."))
@@ -69,7 +68,7 @@ var _ = Describe("Podman history", func() {
 	It("podman history with json flag", func() {
 		session := podmanTest.Podman([]string{"history", "--format=json", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 	})
 })

--- a/test/e2e/image_scp_test.go
+++ b/test/e2e/image_scp_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman image scp", func() {
@@ -33,7 +32,7 @@ var _ = Describe("podman image scp", func() {
 		}
 		session := podmanTest.Podman(cmd)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cfg, err := config.ReadCustomConfig()
 		Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e/image_sign_test.go
+++ b/test/e2e/image_sign_test.go
@@ -5,9 +5,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // Each of these tests runs with a different GNUPGHOME; gpg-agent blows up
@@ -50,7 +50,7 @@ var _ = Describe("Podman image sign", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"image", "sign", "--directory", sigDir, "--sign-by", "foo@bar.com", "docker://library/alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		_, err = os.Stat(filepath.Join(sigDir, "library"))
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -66,7 +66,7 @@ var _ = Describe("Podman image sign", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"image", "sign", "--all", "--directory", sigDir, "--sign-by", "foo@bar.com", "docker://library/alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		fInfos, err := os.ReadDir(filepath.Join(sigDir, "library"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(fInfos)).To(BeNumerically(">", 1), "len(fInfos)")

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -199,7 +199,7 @@ WORKDIR /test
 		// Prevent regressing on issue #7651: error parsing name that includes a digest
 		// component as if were a name that includes tag component.
 		digestPullAndList := func(noneTag bool) {
-			session := podmanTest.Podman([]string{"pull", ALPINEAMD64DIGEST})
+			session := podmanTest.Podman([]string{"pull", "-q", ALPINEAMD64DIGEST})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
 
@@ -217,7 +217,7 @@ WORKDIR /test
 		// the additional image store we're using.  Pull the same image by another name to
 		// copy an entry for the image into read-write storage so that the name can be
 		// attached to it.
-		session := podmanTest.Podman([]string{"pull", ALPINELISTTAG})
+		session := podmanTest.Podman([]string{"pull", "-q", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		digestPullAndList(false)

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Podman images", func() {
 	It("podman images", func() {
 		session := podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 2))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("quay.io/libpod/alpine")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("quay.io/libpod/busybox")))
@@ -26,7 +26,7 @@ var _ = Describe("Podman images", func() {
 	It("podman image List", func() {
 		session := podmanTest.Podman([]string{"image", "list"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 2))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("quay.io/libpod/alpine")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("quay.io/libpod/busybox")))
@@ -37,15 +37,15 @@ var _ = Describe("Podman images", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 		session := podmanTest.Podman([]string{"tag", ALPINE, "foo:a", "foo:b", "foo:c"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// tag "foo:c" to "bar:{a,b}"
 		session = podmanTest.Podman([]string{"tag", "foo:c", "bar:a", "bar:b"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// check all previous and the newly tagged images
 		session = podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.LineInOutputContainsTag("quay.io/libpod/alpine", "latest")).To(BeTrue())
 		Expect(session.LineInOutputContainsTag("quay.io/libpod/busybox", "latest")).To(BeTrue())
 		Expect(session.LineInOutputContainsTag("localhost/foo", "a")).To(BeTrue())
@@ -55,14 +55,14 @@ var _ = Describe("Podman images", func() {
 		Expect(session.LineInOutputContainsTag("localhost/bar", "b")).To(BeTrue())
 		session = podmanTest.Podman([]string{"images", "-qn"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(len(CACHE_IMAGES)))
 	})
 
 	It("podman images with digests", func() {
 		session := podmanTest.Podman([]string{"images", "--digests"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 2))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("quay.io/libpod/alpine")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("quay.io/libpod/busybox")))
@@ -71,14 +71,14 @@ var _ = Describe("Podman images", func() {
 	It("podman empty images list in JSON format", func() {
 		session := podmanTest.Podman([]string{"images", "--format=json", "not-existing-image"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 	})
 
 	It("podman images in JSON format", func() {
 		session := podmanTest.Podman([]string{"images", "--format=json"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 	})
 
@@ -86,13 +86,13 @@ var _ = Describe("Podman images", func() {
 		formatStr := "{{.ID}}\t{{.Created}}\t{{.CreatedAt}}\t{{.CreatedSince}}\t{{.CreatedTime}}"
 		session := podmanTest.Podman([]string{"images", fmt.Sprintf("--format=%s", formatStr)})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman images with short options", func() {
 		session := podmanTest.Podman([]string{"images", "-qn"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 1))
 	})
 
@@ -102,43 +102,43 @@ var _ = Describe("Podman images", func() {
 
 		session := podmanTest.Podman([]string{"images", "-q", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 
 		session = podmanTest.Podman([]string{"tag", ALPINE, "foo:a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"tag", BB, "foo:b"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"images", "-q", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
 	It("podman images filter reference", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=quay.io/libpod/*"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(HaveLen(8))
 
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=*lpine*"})
 		retalpine.WaitWithDefaultTimeout()
-		Expect(retalpine).Should(Exit(0))
+		Expect(retalpine).Should(ExitCleanly())
 		Expect(retalpine.OutputToStringArray()).To(HaveLen(5))
 		Expect(retalpine.OutputToString()).To(ContainSubstring("alpine"))
 
 		retalpine = podmanTest.Podman([]string{"images", "-f", "reference=alpine"})
 		retalpine.WaitWithDefaultTimeout()
-		Expect(retalpine).Should(Exit(0))
+		Expect(retalpine).Should(ExitCleanly())
 		Expect(retalpine.OutputToStringArray()).To(HaveLen(2))
 		Expect(retalpine.OutputToString()).To(ContainSubstring("alpine"))
 
 		retnone := podmanTest.Podman([]string{"images", "-q", "-f", "reference=bogus"})
 		retnone.WaitWithDefaultTimeout()
-		Expect(retnone).Should(Exit(0))
+		Expect(retnone).Should(ExitCleanly())
 		Expect(retnone.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -149,7 +149,7 @@ RUN echo hello > /hello
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "before=foobar.com/before:latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).ToNot(BeEmpty())
 	})
 
@@ -160,7 +160,7 @@ WORKDIR /test
 		podmanTest.BuildImage(dockerfile, "foobar.com/workdir:latest", "false")
 		result := podmanTest.Podman([]string{"run", "foobar.com/workdir:latest", "pwd"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("/test"))
 	})
 
@@ -174,13 +174,13 @@ WORKDIR /test
 		// `since` filter
 		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "since=foobar.com/one:latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(HaveLen(2))
 
 		// `after` filter
 		result = podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=foobar.com/one:latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).Should(HaveLen(2), "list filter output: %q", result.OutputToString())
 	})
 
@@ -201,11 +201,11 @@ WORKDIR /test
 		digestPullAndList := func(noneTag bool) {
 			session := podmanTest.Podman([]string{"pull", ALPINEAMD64DIGEST})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 
 			result := podmanTest.Podman([]string{"images", "--all", ALPINEAMD64DIGEST})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 
 			if noneTag {
 				Expect(result.OutputToString()).To(ContainSubstring("<none>"))
@@ -219,14 +219,14 @@ WORKDIR /test
 		// attached to it.
 		session := podmanTest.Podman([]string{"pull", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		digestPullAndList(false)
 
 		// Now remove all names from the read-write image record, re-pull by digest and
 		// check for the "<none>" in its listing.
 		session = podmanTest.Podman([]string{"untag", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		digestPullAndList(true)
 	})
@@ -234,25 +234,25 @@ WORKDIR /test
 	It("podman check for image with sha256: prefix", func() {
 		session := podmanTest.Podman([]string{"inspect", "--format=json", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 		imageData := session.InspectImageJSON()
 
 		result := podmanTest.Podman([]string{"images", "sha256:" + imageData[0].ID})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman check for image with sha256: prefix", func() {
 		session := podmanTest.Podman([]string{"image", "inspect", "--format=json", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 		imageData := session.InspectImageJSON()
 
 		result := podmanTest.Podman([]string{"image", "ls", fmt.Sprintf("sha256:%s", imageData[0].ID)})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman images sort by values", func() {
@@ -307,12 +307,12 @@ ENV foo=bar
 		podmanTest.BuildImage(dockerfile, "test", "true")
 		session := podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(len(CACHE_IMAGES) + 2))
 
 		session2 := podmanTest.Podman([]string{"images", "--all"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 		Expect(session2.OutputToStringArray()).To(HaveLen(len(CACHE_IMAGES) + 4))
 	})
 
@@ -324,7 +324,7 @@ LABEL "com.example.vendor"="Example Vendor"
 		podmanTest.BuildImage(dockerfile, "test", "true")
 		session := podmanTest.Podman([]string{"images", "-f", "label=version=1.0"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
@@ -342,52 +342,52 @@ LABEL "com.example.vendor"="Example Vendor"
 
 		session := podmanTest.Podman([]string{"images", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output := session.OutputToString()
 		Expect(output).To(Not(MatchRegexp("<missing>")))
 		Expect(output).To(Not(MatchRegexp("error")))
 
 		session = podmanTest.Podman([]string{"image", "tree", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(MatchRegexp("No Image Layers"))
 
 		session = podmanTest.Podman([]string{"history", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(Not(MatchRegexp("error")))
 
 		session = podmanTest.Podman([]string{"history", "--quiet", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(6))
 
 		session = podmanTest.Podman([]string{"image", "list", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(Not(MatchRegexp("<missing>")))
 		Expect(output).To(Not(MatchRegexp("error")))
 
 		session = podmanTest.Podman([]string{"image", "list"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(Not(MatchRegexp("<missing>")))
 		Expect(output).To(Not(MatchRegexp("error")))
 
 		session = podmanTest.Podman([]string{"inspect", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(Not(MatchRegexp("<missing>")))
 		Expect(output).To(Not(MatchRegexp("error")))
 
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(Equal("[]"))
 	})
@@ -398,7 +398,7 @@ LABEL "com.example.vendor"="Example Vendor"
 		podmanTest.BuildImageWithLabel(dockerfile, "foobar.com/before:latest", "false", "test=with,comma")
 		result := podmanTest.Podman([]string{"images", "--filter", "label=test=with,comma"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(HaveLen(2))
 	})
 
@@ -408,11 +408,11 @@ LABEL "com.example.vendor"="Example Vendor"
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-f", "readonly=true"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		result1 := podmanTest.Podman([]string{"images", "--filter", "readonly=false"})
 		result1.WaitWithDefaultTimeout()
-		Expect(result1).Should(Exit(0))
+		Expect(result1).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(Not(Equal(result1.OutputToStringArray())))
 	})
 
@@ -428,7 +428,7 @@ RUN > file2
 		// --force used to avoid y/n question
 		result := podmanTest.Podman([]string{"image", "prune", "--filter", "label=abc", "--force"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(HaveLen(1))
 
 		// check if really abc is removed
@@ -449,7 +449,7 @@ RUN > file2
 		// --force used to to avoid y/n question
 		result := podmanTest.Podman([]string{"builder", "prune", "--filter", "label=abc", "--force"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToStringArray()).To(HaveLen(1))
 
 		// check if really abc is removed

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman import", func() {
@@ -18,15 +17,15 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", outfile, "foobar.com/imported-image:latest"})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"inspect", "--type", "image", "foobar.com/imported-image:latest"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(0))
+		Expect(results).Should(ExitCleanly())
 	})
 
 	It("podman import with custom os, arch and variant", func() {
@@ -36,15 +35,15 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", "--os", "testos", "--arch", "testarch", outfile, "foobar.com/imported-image:latest"})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"inspect", "--type", "image", "foobar.com/imported-image:latest"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(0))
+		Expect(results).Should(ExitCleanly())
 		Expect(results.OutputToString()).To(ContainSubstring("testos"))
 		Expect(results.OutputToString()).To(ContainSubstring("testarch"))
 	})
@@ -56,16 +55,16 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", outfile})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		// tag the image which proves it is in R/W storage
 		tag := podmanTest.Podman([]string{"tag", importImage.OutputToString(), "foo"})
 		tag.WaitWithDefaultTimeout()
-		Expect(tag).Should(Exit(0))
+		Expect(tag).Should(ExitCleanly())
 	})
 
 	It("podman import with message flag", func() {
@@ -75,15 +74,15 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", "--message", "importing container test message", outfile, "imported-image"})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"history", "imported-image", "--format", "{{.Comment}}"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(0))
+		Expect(results).Should(ExitCleanly())
 		Expect(results.OutputToStringArray()).To(ContainElement(HavePrefix("importing container test message")))
 	})
 
@@ -94,15 +93,15 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", "--change", "CMD=/bin/bash", outfile, "imported-image"})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"inspect", "imported-image"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(0))
+		Expect(results).Should(ExitCleanly())
 		imageData := results.InspectImageJSON()
 		Expect(imageData[0].Config.Cmd[0]).To(Equal("/bin/sh"))
 		Expect(imageData[0].Config.Cmd[1]).To(Equal("-c"))
@@ -116,15 +115,15 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", "--change", "CMD /bin/sh", outfile, "imported-image"})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"inspect", "imported-image"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(0))
+		Expect(results).Should(ExitCleanly())
 		imageData := results.InspectImageJSON()
 		Expect(imageData[0].Config.Cmd[0]).To(Equal("/bin/sh"))
 		Expect(imageData[0].Config.Cmd[1]).To(Equal("-c"))
@@ -138,15 +137,15 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", "--change", "CMD [\"/bin/bash\"]", outfile, "imported-image"})
 		importImage.WaitWithDefaultTimeout()
-		Expect(importImage).Should(Exit(0))
+		Expect(importImage).Should(ExitCleanly())
 
 		results := podmanTest.Podman([]string{"inspect", "imported-image"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(0))
+		Expect(results).Should(ExitCleanly())
 		imageData := results.InspectImageJSON()
 		Expect(imageData[0].Config.Cmd[0]).To(Equal("/bin/bash"))
 	})
@@ -160,7 +159,7 @@ var _ = Describe("Podman import", func() {
 
 		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		export.WaitWithDefaultTimeout()
-		Expect(export).Should(Exit(0))
+		Expect(export).Should(ExitCleanly())
 
 		importImage := podmanTest.Podman([]string{"import", "--signature-policy", "/no/such/file", outfile})
 		importImage.WaitWithDefaultTimeout()
@@ -174,6 +173,6 @@ var _ = Describe("Podman import", func() {
 			result := podmanTest.Podman([]string{"import", outfile})
 			result.WaitWithDefaultTimeout()
 		}
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 })

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -46,20 +47,20 @@ var _ = Describe("Podman Info", func() {
 	It("podman info --format GO template", func() {
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Store.GraphRoot}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman info --format GO template", func() {
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Registries}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("registry"))
 	})
 
 	It("podman info --format GO template plugins", func() {
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Plugins}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("local"))
 		Expect(session.OutputToString()).To(ContainSubstring("journald"))
 		Expect(session.OutputToString()).To(ContainSubstring("bridge"))
@@ -101,12 +102,12 @@ var _ = Describe("Podman Info", func() {
 	It("check RemoteSocket ", func() {
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.RemoteSocket.Path}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(MatchRegexp("/run/.*podman.*sock"))
 
 		session = podmanTest.Podman([]string{"info", "--format", "{{.Host.ServiceIsRemote}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if podmanTest.RemoteTest {
 			Expect(session.OutputToString()).To(Equal("true"))
 		} else {
@@ -115,7 +116,7 @@ var _ = Describe("Podman Info", func() {
 
 		session = podmanTest.Podman([]string{"info", "--format", "{{.Host.RemoteSocket.Exists}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if IsRemote() {
 			Expect(session.OutputToString()).To(ContainSubstring("true"))
 		} else {
@@ -129,7 +130,7 @@ var _ = Describe("Podman Info", func() {
 		SkipIfRootlessCgroupsV1("Disable cgroups not supported on cgroupv1 for rootless users")
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.CgroupControllers}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("memory"))
 		Expect(session.OutputToString()).To(ContainSubstring("pids"))
 	})
@@ -145,7 +146,7 @@ var _ = Describe("Podman Info", func() {
 		}
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.OCIRuntime.Name}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(want))
 	})
 
@@ -160,12 +161,12 @@ var _ = Describe("Podman Info", func() {
 		}
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.NetworkBackend}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(want))
 
 		session = podmanTest.Podman([]string{"info", "--format", "{{.Host.NetworkBackendInfo.Backend}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(want))
 	})
 
@@ -180,7 +181,7 @@ var _ = Describe("Podman Info", func() {
 		}
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.DatabaseBackend}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(want))
 	})
 
@@ -190,17 +191,17 @@ var _ = Describe("Podman Info", func() {
 		// no skips.
 		info1 := podmanTest.Podman([]string{"info", "--format", "{{ .Host.FreeLocks }}"})
 		info1.WaitWithDefaultTimeout()
-		Expect(info1).To(Exit(0))
+		Expect(info1).To(ExitCleanly())
 		free1, err := strconv.Atoi(info1.OutputToString())
 		Expect(err).To(Not(HaveOccurred()))
 
 		ctr := podmanTest.Podman([]string{"create", ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
-		Expect(ctr).To(Exit(0))
+		Expect(ctr).To(ExitCleanly())
 
 		info2 := podmanTest.Podman([]string{"info", "--format", "{{ .Host.FreeLocks }}"})
 		info2.WaitWithDefaultTimeout()
-		Expect(info2).To(Exit(0))
+		Expect(info2).To(ExitCleanly())
 		free2, err := strconv.Atoi(info2.OutputToString())
 		Expect(err).To(Not(HaveOccurred()))
 


### PR DESCRIPTION
Trying a different approach. Instead of one-file-at-a-time, do a bunch of test files, but in two commits: one a simple string substitution of `Expect...Exit(0)` to `...ExitCleanly()`, and the second being manual fixes. The second commit is the important one to review.
```release-note
None
```