### PR TITLE
[CI:DOCS] restart.md: migrate to container unit

### DIFF
--- a/docs/source/markdown/options/restart.md
+++ b/docs/source/markdown/options/restart.md
@@ -17,4 +17,6 @@ Valid _policy_ values are:
 
 Podman provides a systemd unit file, podman-restart.service, which restarts containers after a system reboot.
 
-If container runs as a system service, generate a systemd unit file to manage it. See **podman generate systemd**.
+When running containers in systemd services, use the restart functionality provided by systemd.
+In other words, do not use this option in a container unit, instead set the `Restart=` systemd directive in the `[Service]` section.
+See **podman-systemd.unit**(5) and **systemd.service**(5).


### PR DESCRIPTION
The command `podman generate systemd` is deprecated since this PR:

* https://github.com/containers/podman/pull/19414

Rewrite _restart.md_ to refer to container units instead.

Fixes: https://github.com/containers/podman/issues/19968





<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
