### PR TITLE
Plumbing to run machine tests with hyperv

### DIFF
--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -16,9 +16,9 @@ import (
 	"text/template"
 
 	"github.com/containers/common/pkg/config"
-	cmdMachine "github.com/containers/podman/v4/cmd/podman/machine"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/provider"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -155,7 +155,7 @@ func composeDockerHost() (string, error) {
 		return strings.TrimSuffix(connection.URI, parsedConnection.Path), nil
 	}
 
-	machineProvider, err := cmdMachine.GetSystemProvider()
+	machineProvider, err := provider.Get()
 	if err != nil {
 		return "", fmt.Errorf("getting machine provider: %w", err)
 	}

--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -28,7 +28,7 @@ var (
 		Use:               "info [options]",
 		Short:             "Display machine host info",
 		Long:              infoDescription,
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              info,
 		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,
@@ -101,10 +101,6 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 	host.Arch = runtime.GOARCH
 	host.OS = runtime.GOOS
 
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return nil, err
-	}
 	var listOpts machine.ListOptions
 	listResponse, err := provider.List(listOpts)
 	if err != nil {

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -19,7 +19,7 @@ var (
 		Use:               "init [options] [NAME]",
 		Short:             "Initialize a virtual machine",
 		Long:              "Initialize a virtual machine",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              initMachine,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine init podman-machine-default`,
@@ -128,10 +128,6 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		vm  machine.VM
 	)
 
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
 	initOpts.Name = defaultMachineName
 	if len(args) > 0 {
 		if len(args[0]) > maxMachineNameSize {

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -19,7 +19,7 @@ var (
 		Use:               "inspect [options] [MACHINE...]",
 		Short:             "Inspect an existing machine",
 		Long:              "Provide details on a managed virtual machine",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              inspect,
 		Example:           `podman machine inspect myvm`,
 		ValidArgsFunction: autocompleteMachine,
@@ -51,10 +51,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 		args = append(args, defaultMachineName)
 	}
 	vms := make([]machine.InspectInfo, 0, len(args))
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
+
 	for _, vmName := range args {
 		vm, err := provider.LoadVMByName(vmName)
 		if err != nil {

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -28,7 +28,7 @@ var (
 		Aliases:           []string{"ls"},
 		Short:             "List machines",
 		Long:              "List managed virtual machines.",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              list,
 		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,
@@ -66,10 +66,6 @@ func list(cmd *cobra.Command, args []string) error {
 		err          error
 	)
 
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
 	listResponse, err = provider.List(opts)
 	if err != nil {
 		return fmt.Errorf("listing vms: %w", err)

--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	machineconfig "github.com/containers/common/pkg/machine"
-	"github.com/containers/podman/v4/cmd/podman/machine"
 	pkgMachine "github.com/containers/podman/v4/pkg/machine"
 	pkgOS "github.com/containers/podman/v4/pkg/machine/os"
+	"github.com/containers/podman/v4/pkg/machine/provider"
 )
 
 type ManagerOpts struct {
@@ -48,11 +48,11 @@ func machineOSManager(opts ManagerOpts) (pkgOS.Manager, error) {
 	if opts.VMName == "" {
 		vmName = pkgMachine.DefaultMachineName
 	}
-	provider, err := machine.GetSystemProvider()
+	p, err := provider.Get()
 	if err != nil {
 		return nil, err
 	}
-	vm, err := provider.LoadVMByName(vmName)
+	vm, err := p.LoadVMByName(vmName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -20,7 +20,7 @@ var (
 		Use:               "rm [options] [MACHINE]",
 		Short:             "Remove an existing machine",
 		Long:              "Remove a managed virtual machine ",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              rm,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine rm podman-machine-default`,
@@ -62,10 +62,6 @@ func rm(_ *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -18,7 +18,7 @@ var (
 		Use:               "set [options] [NAME]",
 		Short:             "Set a virtual machine setting",
 		Long:              "Set an updatable virtual machine setting",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              setMachine,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine set --rootful=false`,
@@ -89,10 +89,7 @@ func setMachine(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
 	}
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
+
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -20,7 +20,7 @@ var (
 		Use:               "ssh [options] [NAME] [COMMAND [ARG ...]]",
 		Short:             "SSH into an existing machine",
 		Long:              "SSH into a managed virtual machine ",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              ssh,
 		Example: `podman machine ssh podman-machine-default
   podman machine ssh myvm echo hello`,
@@ -53,10 +53,6 @@ func ssh(cmd *cobra.Command, args []string) error {
 
 	// Set the VM to default
 	vmName := defaultMachineName
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
 
 	// If len is greater than 0, it means we may have been
 	// provided the VM name.  If so, we check.  The VM name,

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -17,7 +17,7 @@ var (
 		Use:               "start [options] [MACHINE]",
 		Short:             "Start an existing machine",
 		Long:              "Start a managed virtual machine ",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              start,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine start podman-machine-default`,
@@ -51,11 +51,6 @@ func start(_ *cobra.Command, args []string) error {
 	vmName := defaultMachineName
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
-	}
-
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
 	}
 
 	vm, err = provider.LoadVMByName(vmName)

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -17,7 +17,7 @@ var (
 		Use:               "stop [MACHINE]",
 		Short:             "Stop an existing machine",
 		Long:              "Stop a managed virtual machine ",
-		PersistentPreRunE: rootlessOnly,
+		PersistentPreRunE: machinePreRunE,
 		RunE:              stop,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine stop podman-machine-default`,
@@ -42,10 +42,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
 	}
-	provider, err := GetSystemProvider()
-	if err != nil {
-		return err
-	}
+
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -4,11 +4,11 @@
 package system
 
 import (
-	cmdMach "github.com/containers/podman/v4/cmd/podman/machine"
+	p "github.com/containers/podman/v4/pkg/machine/provider"
 )
 
 func resetMachine() error {
-	provider, err := cmdMach.GetSystemProvider()
+	provider, err := p.Get()
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -1,0 +1,19 @@
+# Working README for running the machine tests
+
+
+## Linux
+
+### QEMU
+
+`make localmachine`
+
+## Microsoft Windows
+
+### HyperV
+
+1. Open a powershell as admin
+2. $env:CONTAINERS_MACHINE_PROVIDER="hyperv"
+3. $env:MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/hyperv/fedora-coreos-38.20230830.dev.0-hyperv.x86_64.vhdx.zip"
+4. `./test/tools/build/ginkgo.exe -vv  --tags "remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp remote" -timeout=90m --trace --no-color  pkg/machine/e2e/. `
+
+Note: Add `--focus-file "basic_test.go" ` to only run basic test

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -1,0 +1,3 @@
+package e2e_test
+
+const podmanBinary = "../../../bin/podman-remote"

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -97,7 +97,7 @@ func newMB() (*machineTestBuilder, error) {
 	if err != nil {
 		return nil, err
 	}
-	mb.podmanBinary = filepath.Join(cwd, "../../../bin/podman-remote")
+	mb.podmanBinary = filepath.Join(cwd, podmanBinary)
 	if os.Getenv("PODMAN_BINARY") != "" {
 		mb.podmanBinary = os.Getenv("PODMAN_BINARY")
 	}

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -1,0 +1,3 @@
+package e2e_test
+
+const podmanBinary = "../../../bin/windows/podman.exe"

--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -1,6 +1,6 @@
 //go:build (amd64 && !windows && amd64 && !darwin) || (arm64 && !windows && arm64 && !darwin) || (amd64 && darwin)
 
-package machine
+package provider
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func GetSystemProvider() (machine.VirtProvider, error) {
+func Get() (machine.VirtProvider, error) {
 	cfg, err := config.Default()
 	if err != nil {
 		return nil, err

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -1,4 +1,6 @@
-package machine
+//go:build darwin && arm64
+
+package provider
 
 import (
 	"fmt"
@@ -6,12 +8,12 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/hyperv"
-	"github.com/containers/podman/v4/pkg/machine/wsl"
+	"github.com/containers/podman/v4/pkg/machine/applehv"
+	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/sirupsen/logrus"
 )
 
-func GetSystemProvider() (machine.VirtProvider, error) {
+func Get() (machine.VirtProvider, error) {
 	cfg, err := config.Default()
 	if err != nil {
 		return nil, err
@@ -20,17 +22,17 @@ func GetSystemProvider() (machine.VirtProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := machine.ParseVMType(provider, machine.WSLVirt)
+	resolvedVMType, err := machine.ParseVMType(provider, machine.QemuVirt)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
-	case machine.WSLVirt:
-		return wsl.VirtualizationProvider(), nil
-	case machine.HyperVVirt:
-		return hyperv.VirtualizationProvider(), nil
+	case machine.QemuVirt:
+		return qemu.VirtualizationProvider(), nil
+	case machine.AppleHvVirt:
+		return applehv.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -1,6 +1,4 @@
-//go:build darwin && arm64
-
-package machine
+package provider
 
 import (
 	"fmt"
@@ -8,12 +6,12 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/applehv"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
+	"github.com/containers/podman/v4/pkg/machine/hyperv"
+	"github.com/containers/podman/v4/pkg/machine/wsl"
 	"github.com/sirupsen/logrus"
 )
 
-func GetSystemProvider() (machine.VirtProvider, error) {
+func Get() (machine.VirtProvider, error) {
 	cfg, err := config.Default()
 	if err != nil {
 		return nil, err
@@ -22,17 +20,17 @@ func GetSystemProvider() (machine.VirtProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := machine.ParseVMType(provider, machine.QemuVirt)
+	resolvedVMType, err := machine.ParseVMType(provider, machine.WSLVirt)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
-	case machine.QemuVirt:
-		return qemu.VirtualizationProvider(), nil
-	case machine.AppleHvVirt:
-		return applehv.VirtualizationProvider(), nil
+	case machine.WSLVirt:
+		return wsl.VirtualizationProvider(), nil
+	case machine.HyperVVirt:
+		return hyperv.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}


### PR DESCRIPTION
this pr has the basic plumbing that allows the e2e machine tests to run with the hyperv provider.

it requires a special fcos image right now because gvforwarder was not in the upstream fcos images for hyperv.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
