### PR TITLE
[4.4.1-rhel] linux, rootless: clamp oom_score_adj if it is too low

### DIFF
--- a/docs/source/markdown/options/oom-score-adj.md
+++ b/docs/source/markdown/options/oom-score-adj.md
@@ -5,3 +5,7 @@
 #### **--oom-score-adj**=*num*
 
 Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).
+
+When running in rootless mode, the specified value can't be lower than
+the oom_score_adj for the current process. In this case, the
+oom-score-adj is clamped to the current process value.

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -580,6 +580,16 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		}
 	}
 
+	if rootless.IsRootless() {
+		if g.Config.Process != nil && g.Config.Process.OOMScoreAdj != nil {
+			var err error
+			*g.Config.Process.OOMScoreAdj, err = maybeClampOOMScoreAdj(*g.Config.Process.OOMScoreAdj)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return g.Config, nil
 }
 
@@ -2806,4 +2816,20 @@ func (c *Container) ChangeHostPathOwnership(src string, recurse bool, uid, gid i
 		}
 	}
 	return chown.ChangeHostPathOwnership(src, recurse, uid, gid)
+}
+
+func maybeClampOOMScoreAdj(oomScoreValue int) (int, error) {
+	v, err := os.ReadFile("/proc/self/oom_score_adj")
+	if err != nil {
+		return oomScoreValue, err
+	}
+	currentValue, err := strconv.Atoi(strings.TrimRight(string(v), "\n"))
+	if err != nil {
+		return oomScoreValue, err
+	}
+	if currentValue > oomScoreValue {
+		logrus.Warnf("Requested oom_score_adj=%d is lower than the current one, changing to %d", oomScoreValue, currentValue)
+		return currentValue, nil
+	}
+	return oomScoreValue, nil
 }

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/containers/common/libimage"
@@ -16,6 +18,7 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -67,6 +70,25 @@ func getCgroupPermissons(unmask []string) string {
 		}
 	}
 	return ro
+}
+
+func maybeClampOOMScoreAdj(oomScoreValue int, isRootless bool) (int, error) {
+	if !isRootless {
+		return oomScoreValue, nil
+	}
+	v, err := os.ReadFile("/proc/self/oom_score_adj")
+	if err != nil {
+		return oomScoreValue, err
+	}
+	currentValue, err := strconv.Atoi(strings.TrimRight(string(v), "\n"))
+	if err != nil {
+		return oomScoreValue, err
+	}
+	if currentValue > oomScoreValue {
+		logrus.Warnf("Requested oom_score_adj=%d is lower than the current one, changing to %d", oomScoreValue, currentValue)
+		return currentValue, nil
+	}
+	return oomScoreValue, nil
 }
 
 // SpecGenToOCI returns the base configuration for the container.
@@ -309,7 +331,11 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if s.OOMScoreAdj != nil {
-		g.SetProcessOOMScoreAdj(*s.OOMScoreAdj)
+		score, err := maybeClampOOMScoreAdj(*s.OOMScoreAdj, isRootless)
+		if err != nil {
+			return nil, err
+		}
+		g.SetProcessOOMScoreAdj(score)
 	}
 	setProcOpts(s, &g)
 

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/containers/common/libimage"
@@ -18,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -70,25 +67,6 @@ func getCgroupPermissons(unmask []string) string {
 		}
 	}
 	return ro
-}
-
-func maybeClampOOMScoreAdj(oomScoreValue int, isRootless bool) (int, error) {
-	if !isRootless {
-		return oomScoreValue, nil
-	}
-	v, err := os.ReadFile("/proc/self/oom_score_adj")
-	if err != nil {
-		return oomScoreValue, err
-	}
-	currentValue, err := strconv.Atoi(strings.TrimRight(string(v), "\n"))
-	if err != nil {
-		return oomScoreValue, err
-	}
-	if currentValue > oomScoreValue {
-		logrus.Warnf("Requested oom_score_adj=%d is lower than the current one, changing to %d", oomScoreValue, currentValue)
-		return currentValue, nil
-	}
-	return oomScoreValue, nil
 }
 
 // SpecGenToOCI returns the base configuration for the container.
@@ -331,12 +309,9 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if s.OOMScoreAdj != nil {
-		score, err := maybeClampOOMScoreAdj(*s.OOMScoreAdj, isRootless)
-		if err != nil {
-			return nil, err
-		}
-		g.SetProcessOOMScoreAdj(score)
+		g.SetProcessOOMScoreAdj(*s.OOMScoreAdj)
 	}
+
 	setProcOpts(s, &g)
 
 	return configSpec, nil

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -638,10 +638,17 @@ USER bin`, BB)
 
 		currentOOMScoreAdj, err := os.ReadFile("/proc/self/oom_score_adj")
 		Expect(err).ToNot(HaveOccurred())
-		session = podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
+		name := "ctr-with-oom-score"
+		session = podmanTest.Podman([]string{"create", "--name", name, fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(Equal(strings.TrimRight(string(currentOOMScoreAdj), "\n")))
+
+		for i := 0; i < 2; i++ {
+			session = podmanTest.Podman([]string{"start", "-a", name})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+			Expect(session.OutputToString()).To(Equal(strings.TrimRight(string(currentOOMScoreAdj), "\n")))
+		}
 	})
 
 	It("podman run limits host test", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -842,6 +842,17 @@ EOF
     is "$output" "$current_oom_score_adj" "different oom_score_adj in the container"
 }
 
+# issue 19829
+@test "rootless podman clamps oom-score-adj if it is lower than the current one" {
+    skip_if_not_rootless
+    skip_if_remote
+    if grep -- -1000 /proc/self/oom_score_adj; then
+        skip "the current oom-score-adj is already -1000"
+    fi
+    run_podman run --oom-score-adj=-1000 --rm $IMAGE true
+    is "$output" ".*Requested oom_score_adj=.* is lower than the current one, changing to .*"
+}
+
 # CVE-2022-1227 : podman top joins container mount NS and uses nsenter from image
 @test "podman top does not use nsenter from image" {
     keepid="--userns=keep-id"


### PR DESCRIPTION
backport of:

- 19bd9b33dd8c8f166327f4e1ab18e0cd5afc9180
- 8b4a79a744ac3fd176ca4dc0e3ae40f75159e090

it solves a problem with docker-compose for rootless since it hard codes the oom-score-adj to 0.
