### PR TITLE
Add ability for machine rm -f for WSL

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1522,7 +1522,12 @@ func (v *MachineVM) Remove(name string, opts machine.RemoveOptions) (string, fun
 	var files []string
 
 	if v.isRunning() {
-		return "", nil, fmt.Errorf("running vm %q cannot be destroyed", v.Name)
+		if !opts.Force {
+			return "", nil, fmt.Errorf("running vm %q cannot be destroyed", v.Name)
+		}
+		if err := v.Stop(v.Name, machine.StopOptions{}); err != nil {
+			return "", nil, err
+		}
 	}
 
 	// Collect all the files that need to be destroyed


### PR DESCRIPTION
When passing the force flag to machine rm, wsl needs to stop the VM if it is running before attempting to remove it.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
