### PR TITLE
Fix WSL systemd detection

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -69,12 +69,6 @@ chown [USER]:[USER] /home/[USER]/.config
 const sudoers = `%wheel        ALL=(ALL)       NOPASSWD: ALL
 `
 
-const bootstrap = `#!/bin/bash
-ps -ef | grep -v grep | grep -q systemd && exit 0
-nohup unshare --kill-child --fork --pid --mount --mount-proc --propagation shared /lib/systemd/systemd >/dev/null 2>&1 &
-sleep 0.1
-`
-
 const wslmotd = `
 You will be automatically entered into a nested process namespace where
 systemd is running. If you need to access the parent namespace, hit ctrl-d
@@ -82,7 +76,13 @@ or type exit. This also means to log out you need to exit twice.
 
 `
 
-const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 ^/lib/systemd/systemd | awk '{print $2}'`"
+const sysdpid = "SYSDPID=`ps --no-headers -C systemd --format exe,pid | grep -m 1 ^/usr/lib/systemd/systemd | awk '{print $2}'`"
+
+const bootstrap = "#!/bin/bash\n" + sysdpid + `
+[ -n "$SYSDPID" ] && exit 0
+nohup unshare --kill-child --fork --pid --mount --mount-proc --propagation shared /usr/lib/systemd/systemd >/dev/null 2>&1 &
+sleep 0.1
+`
 
 const profile = sysdpid + `
 if [ ! -z "$SYSDPID" ] && [ "$SYSDPID" != "1" ]; then


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes the detection of systemd in WSL.
Users who use WSL with systemd must recreate their machine to apply this fix.
```

If WSL is configured to use systemd by setting `boot.systemd=true`in `/etc/wsl.conf`, WSL creates a Symlink from `/sbin/init` to `/usr/lib/systemd/systemd` and starts systemd via `/sbin/init`.  
`podman machine start`, `podman machine ssh` and other commands check if systemd is running via [isSystemdRunning()](https://github.com/containers/podman/blob/8a9f778e233a51b1896db80703957ef8f9a9d1c5/pkg/machine/wsl/machine.go#L1375) and fail if it is not detected.  

Because [isSystemdRunning()](https://github.com/containers/podman/blob/8a9f778e233a51b1896db80703957ef8f9a9d1c5/pkg/machine/wsl/machine.go#L1375) incorrectly checks for the command name "/lib/systemd/systemd" instead of the executable path it does not  detect systemd running as "/sbin/init".
