### PR TITLE
Change priority for cli flags for remotely operating Podman

### DIFF
--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -36,7 +36,10 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 	case entities.TunnelMode:
 		// TODO: look at me!
 		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode)
-		return &tunnel.ImageEngine{ClientCtx: ctx}, err
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", err, facts.URI)
+		}
+		return &tunnel.ImageEngine{ClientCtx: ctx}, nil
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
 }

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -67,9 +67,9 @@ function setup() {
     run_podman --context=default version
 
     # This one must fail
-    run_podman 125 --context=swarm version
+    PODMAN=${PODMAN%%--url*} run_podman 125 --context=swarm version
     is "$output" \
-       "Error: failed to resolve active destination: \"swarm\" service destination not found" \
+       "Error: read cli flags: connection \"swarm\" not found" \
        "--context=swarm should fail"
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
--connection flag couldn't override the active-destination when CONTAINER_HOST env variable was set. As a remedy, the precedence of --connection flag has been changed.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
For operating Podman remotely, the order of priority is:

1.  cli flags (--connection ,--url ,--context ,--host)
2.  Env variables (CONTAINER_HOST and CONTAINER_CONNECTION)
3.  ActiveService from containers.conf
4.  RemoteURI

```
Closes #15588 

Signed-off-by: Chetan Giradkar <cgiradka@redhat.com>