### PR TITLE
error when --module is specified on the command level

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -80,7 +80,7 @@ func containersConfModules() ([]string, error) {
 func newPodmanConfig() {
 	modules, err := containersConfModules()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		fmt.Fprintf(os.Stderr, "Error parsing containers.conf modules: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -94,7 +94,7 @@ func newPodmanConfig() {
 		Modules:    modules,
 	})
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Failed to obtain podman configuration: "+err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to obtain podman configuration: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -111,7 +111,7 @@ func newPodmanConfig() {
 			mode = entities.TunnelMode
 		}
 	default:
-		fmt.Fprintf(os.Stderr, "%s is not a supported OS", runtime.GOOS)
+		fmt.Fprintf(os.Stderr, "%s is not a supported OS\n", runtime.GOOS)
 		os.Exit(1)
 	}
 

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -456,7 +456,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		// as a flag here to a) make sure that rootflags are aware of
 		// this flag and b) to have shell completions.
 		moduleFlagName := "module"
-		pFlags.StringSlice(moduleFlagName, nil, "Load the containers.conf(5) module")
+		lFlags.StringSlice(moduleFlagName, nil, "Load the containers.conf(5) module")
 		_ = cmd.RegisterFlagCompletionFunc(moduleFlagName, common.AutocompleteContainersConfModules)
 
 		// A *hidden* flag to change the database backend.

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -92,7 +92,8 @@ Log messages at and above specified level: __debug__, __info__, __warn__, __erro
 
 Load the specified `containers.conf(5)` module.  Can be an absolute or relative path.  Please refer to `containers.conf(5)` for details.
 
-This feature is not supported on the remote client, including Mac and Windows (excluding WSL2) machines
+This flag is not supported on the remote client, including Mac and Windows (excluding WSL2) machines.
+Further note that the flag is a root-level flag and must be specified before any Podman sub-command.
 
 #### **--network-cmd-path**=*path*
 Path to the `slirp4netns(1)` command binary to use for setting up a slirp4netns network.

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -93,6 +93,10 @@ EOF
 annotations=['module=$random_data']
 EOF
 
+    run_podman 125 create --module=$conf_tmp -q $IMAGE
+    is "$output" "Error: unknown flag: --module
+See 'podman create --help'" "--module must be specified before the command"
+
     run_podman --module=$conf_tmp create -q $IMAGE
     cid="$output"
     run_podman container inspect $cid --format '{{index .Config.Annotations "module"}}'


### PR DESCRIPTION
The --module can only be parsed on the root level.  It cannot work on the command level, because it must be "manually" parsed on init() to make sure the specified configuration files/modules are loaded prior to parsing the flags via Cobra.

Hence move --module from the "persistent" to the "local" flags which will yield an error instead of doing nothing when being specified on the command level:

```
$ ./bin/podman run --module=foo.conf --rm alpine
Error: unknown flag: --module
See 'podman run --help'
```

Reported in #20000.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Set release not to none as it'll go into 4.7 which ships the --module flag first.