### PR TITLE
--env-host: use default from containers.conf

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -140,7 +140,9 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		if !registry.IsRemote() {
 			createFlags.BoolVar(
 				&cf.EnvHost,
-				"env-host", false, "Use all current host environment variables in container",
+				"env-host",
+				podmanConfig.ContainersConfDefaultsRO.Containers.EnvHost,
+				"Use all current host environment variables in container",
 			)
 		}
 

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -177,4 +177,19 @@ EOF
     assert "${lines[1]}" = "$m2" "completion finds module 2"
 }
 
+@test "podman --module - supported fields" {
+    skip_if_remote "--module is not supported for remote clients"
+
+    conf_tmp="$PODMAN_TMPDIR/test.conf"
+    cat > $conf_tmp <<EOF
+[containers]
+env_host=true
+EOF
+
+    # Make sure env_host variable is read
+    random_env_var="expected_env_var_$(random_string 15)"
+    FOO="$random_env_var" run_podman --module=$conf_tmp run --rm $IMAGE /bin/printenv FOO
+    is "$output" "$random_env_var" "--module should yield injecting host env vars into the container"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
As found while working on #20000, the `--env-host` flag should use the default from containers.conf.  Add a new "supported fields" test to the system tests to make sure we have a goto test for catching such regressions.  I suspect more flags to not use the defaults from containers.conf.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The default value of --env-host can now be configured via containers.conf.
```
