### PR TITLE
[CI:DOCS] consistentize filter options in man pages

### DIFF
--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -18,10 +18,10 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-| Filter             | Description                                                                 |
-| :----------------: | --------------------------------------------------------------------------- |
-| *label*            | Only remove containers, with (or without, in the case of label!=[...] is used) the specified labels.                  |
-| *until*            | Only remove containers created before given timestamp.           |
+| Filter | Description                                                                                          |
+|:------:|------------------------------------------------------------------------------------------------------|
+| label  | Only remove containers, with (or without, in the case of label!=[...] is used) the specified labels. |
+| until  | Only remove containers created before given timestamp.                                               |
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes containers with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes containers without the specified labels.
 

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -29,10 +29,10 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-| Filter             | Description                                                                 |
-| :----------------: | --------------------------------------------------------------------------- |
-| *label*            | Only remove images, with (or without, in the case of label!=[...] is used) the specified labels.                  |
-| *until*            | Only remove images created before given timestamp.           |
+| Filter | Description                                                                                      |
+|:------:|--------------------------------------------------------------------------------------------------|
+| label  | Only remove images, with (or without, in the case of label!=[...] is used) the specified labels. |
+| until  | Only remove images created before given timestamp.                                               |
 
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes containers with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes containers without the specified labels.

--- a/docs/source/markdown/podman-images.1.md.in
+++ b/docs/source/markdown/podman-images.1.md.in
@@ -31,20 +31,20 @@ The *filters* argument format is of `key=value` or `key!=value`. If there is mor
 
 Supported filters:
 
-| Filter          | Description                                                                                   |
-|:---------------:|-----------------------------------------------------------------------------------------------|
-| *id*            | Filter by image ID.                                                                           |
-| *before*        | Filter by images created before the given IMAGE (name or tag).                                |
-| *containers*    | Filter by images with a running container.                                                    |
-| *dangling*      | Filter by dangling (unused) images.                                                           |
-| *digest*        | Filter by digest.                                                                             |
-| *intermediate*  | Filter by images that are dangling and have no children                                       |
-| *label*         | Filter by images with (or without, in the case of label!=[...] is used) the specified labels. |
-| *manifest*      | Filter by images that are manifest lists.                                                     |
-| *readonly*      | Filter by read-only or read/write images.                                                     |
-| *reference*     | Filter by image name.                                                                         |
-| *after*/*since* | Filter by images created after the given IMAGE (name or tag).                                 |
-| *until*         | Filter by images created until the given duration or time.                                    |
+| Filter       | Description                                                                                   |
+|:------------:|-----------------------------------------------------------------------------------------------|
+| id           | Filter by image ID.                                                                           |
+| before       | Filter by images created before the given IMAGE (name or tag).                                |
+| containers   | Filter by images with a running container.                                                    |
+| dangling     | Filter by dangling (unused) images.                                                           |
+| digest       | Filter by digest.                                                                             |
+| intermediate | Filter by images that are dangling and have no children                                       |
+| label        | Filter by images with (or without, in the case of label!=[...] is used) the specified labels. |
+| manifest     | Filter by images that are manifest lists.                                                     |
+| readonly     | Filter by read-only or read/write images.                                                     |
+| reference    | Filter by image name.                                                                         |
+| after/since  | Filter by images created after the given IMAGE (name or tag).                                 |
+| until        | Filter by images created until the given duration or time.                                    |
 
 The `id` *filter* accepts the image ID string.
 

--- a/docs/source/markdown/podman-network-prune.1.md
+++ b/docs/source/markdown/podman-network-prune.1.md
@@ -21,10 +21,10 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-| Filter             | Description                                                                 |
-| :----------------: | --------------------------------------------------------------------------- |
-| *label*            | Only remove networks, with (or without, in the case of label!=[...] is used) the specified labels. |
-| *until*            | Only remove networks created before given timestamp.           |
+| Filter | Description                                                                                        |
+|:------:|----------------------------------------------------------------------------------------------------|
+| label  | Only remove networks, with (or without, in the case of label!=[...] is used) the specified labels. |
+| until  | Only remove networks created before given timestamp.                                               |
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes networks with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes networks without the specified labels.
 

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -48,18 +48,18 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-| Filter       | Description                                                                                      |
-|--------------|--------------------------------------------------------------------------------------------------|
-| *ctr-ids*    | Filter by container ID within the pod. (CID prefix match by default; accepts regex)              |
-| *ctr-names*  | Filter by container name within the pod.                                                         |
-| *ctr-number* | Filter by number of containers in the pod.                                                       |
-| *ctr-status* | Filter by container status within the pod.                                                       |
-| *id*         | Filter by pod ID. (Prefix match by default; accepts regex)                                       |
-| *label*      | Filter by container with (or without, in the case of label!=[...] is used) the specified labels. |
-| *name*       | Filter by pod name.                                                                              |
-| *network*    | Filter by network name or full ID of network.                                                    |
-| *status*     | Filter by pod status.                                                                            |
-| *until*      | Filter by pods created before given timestamp.                                                   |
+| Filter     | Description                                                                                      |
+|------------|--------------------------------------------------------------------------------------------------|
+| ctr-ids    | Filter by container ID within the pod. (CID prefix match by default; accepts regex)              |
+| ctr-names  | Filter by container name within the pod.                                                         |
+| ctr-number | Filter by number of containers in the pod.                                                       |
+| ctr-status | Filter by container status within the pod.                                                       |
+| id         | Filter by pod ID. (Prefix match by default; accepts regex)                                       |
+| label      | Filter by container with (or without, in the case of label!=[...] is used) the specified labels. |
+| name       | Filter by pod name.                                                                              |
+| network    | Filter by network name or full ID of network.                                                    |
+| status     | Filter by pod status.                                                                            |
+| until      | Filter by pods created before given timestamp.                                                   |
 
 The `ctr-ids`, `ctr-names`, `id`, `name` filters accept `regex` format.
 

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -34,10 +34,10 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-| Filter             | Description                                                                 |
-| :----------------: | --------------------------------------------------------------------------- |
-| *label*            | Only remove containers and images, with (or without, in the case of label!=[...] is used) the specified labels.                  |
-| *until*            | Only remove containers and images created before given timestamp.           |
+| Filter | Description                                                                                                     |
+|:------:|-----------------------------------------------------------------------------------------------------------------|
+| label  | Only remove containers and images, with (or without, in the case of label!=[...] is used) the specified labels. |
+| until  | Only remove containers and images created before given timestamp.                                               |
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes containers and images with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes containers and images without the specified labels.
 

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -23,16 +23,16 @@ The *filters* argument format is of `key=value`. If there is more than one *filt
 
 Supported filters:
 
-| Filter        | Description                                                                                                |
-|:-------------:|------------------------------------------------------------------------------------------------------------|
-| *dangling*    | [Bool] Only remove volumes not referenced by any containers                                                |
-| *driver*      | [String] Only remove volumes with the given driver                                                         |
-| *label*       | [String] Only remove volumes, with (or without, in the case of label!=[...] is used) the specified labels. |
-| *name*        | [String] Only remove volume with the given name                                                            |
-| *opt*         | [String] Only remove volumes created with the given options                                                |
-| *scope*       | [String] Only remove volumes with the given scope                                                          |
-| *until*       | [DateTime] Only remove volumes created before given timestamp.                                             |
-| *after/since* | [Volume] Filter by volumes created after the given VOLUME (name or tag)                                    |
+| Filter      | Description                                                                                                |
+|:-----------:|------------------------------------------------------------------------------------------------------------|
+| dangling    | [Bool] Only remove volumes not referenced by any containers                                                |
+| driver      | [String] Only remove volumes with the given driver                                                         |
+| label       | [String] Only remove volumes, with (or without, in the case of label!=[...] is used) the specified labels. |
+| name        | [String] Only remove volume with the given name                                                            |
+| opt         | [String] Only remove volumes created with the given options                                                |
+| scope       | [String] Only remove volumes with the given scope                                                          |
+| until       | [DateTime] Only remove volumes created before given timestamp.                                             |
+| after/since | [Volume] Filter by volumes created after the given VOLUME (name or tag)                                    |
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes volumes with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes volumes without the specified labels.
 

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -670,17 +670,13 @@ sub podman_man {
                 if ($line =~ /^\|\s+(\S+)\s+\|/) {
                     my $filter = $1;
 
-                    # Special-case transformation: some man pages use
-                    # asterisks, "*foo*", some don't. Ignore asterisks.
-                    $filter =~ tr/\*//d;
-
                     # (Garbage: these are just table column titles & dividers)
-                    next LINE if $filter eq 'Filter';
+                    next LINE if $filter =~ /^\**Filter\**$/;
                     next LINE if $filter =~ /---+/;
 
-                    # Another special case: treat slash-separated options
-                    # ("after/since") as identical, and require that each
-                    # be documented.
+                    # Special case: treat slash-separated options
+                    # ("after/since") as identical, and require that
+                    # each be documented.
                     for my $f (split '/', $filter) {
                         # Special case for negated options ("label!="): allow,
                         # but only immediately after the positive case.


### PR DESCRIPTION
Some --filter descriptions listed the filters with asterisks,
i.e. markdown italics. There were 60+ of those, 250+ without
asterisks, so I choose to de-asterisk them all. Update the
xref script to remove the allow-asterisk exception. (Except
for the column title, which is sometimes written with two
asterisks--boldface--and sometimes plain).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```