### PR TITLE
systests: tighter checks for unwanted warnings

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -36,7 +36,7 @@ function setup() {
     is "$output" "podman.*version \+"               "'Version line' in output"
 
     run_podman 0+w --config foobar version
-    is "$output" ".*The --config flag is ignored by Podman. Exists for Docker compatibility\+"		  "verify warning for --config option"
+    require_warning "The --config flag is ignored by Podman. Exists for Docker compatibility"
 }
 
 # bats test_tags=distro-integration

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -387,9 +387,9 @@ EOF
     tries=100
     while [[ ${#lines[*]} -gt 1 ]] && [[ $tries -gt 0 ]]; do
         # Prior to #18980, 'podman images' during rmi could fail with 'image not known'
-        # '0+w' reflects that we may see "Top layer not found" warnings.
-        # FIXME FIXME: find a way to check for any other warnings
+        # '0+w' because we sometimes get warnings.
         run_podman 0+w images --format "{{.ID}} {{.Names}}"
+        allow_warnings "Top layer .* of image .* not found in layer tree"
         tries=$((tries - 1))
     done
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -182,7 +182,8 @@ echo $rand        |   0 | $rand
 
     # Now try running with --rmi : it should succeed, but not remove the image
     run_podman 0+w run --rmi --rm $NONLOCAL_IMAGE /bin/true
-    is "$output" ".*image is in use by a container" "--rmi should warn that the image was not removed"
+    require_warning "image is in use by a container" \
+                    "--rmi should warn that the image was not removed"
     run_podman image exists $NONLOCAL_IMAGE
 
     # Remove the stray container, and run one more time with --rmi.
@@ -947,7 +948,7 @@ EOF
         skip "the current oom-score-adj is already -1000"
     fi
     run_podman 0+w run --oom-score-adj=-1000 --rm $IMAGE true
-    is "$output" ".*Requested oom_score_adj=.* is lower than the current one, changing to .*"
+    require_warning "Requested oom_score_adj=.* is lower than the current one, changing to "
 }
 
 # CVE-2022-1227 : podman top joins container mount NS and uses nsenter from image
@@ -1061,7 +1062,8 @@ $IMAGE--c_ok" \
     # FIXME: do we really really mean to say FFFFFFFFFFFFFFFF here???
     run_podman 0+w stop -t -1 $cid
     if ! is_remote; then
-        assert "$output" =~ "StopSignal \(37\) failed to stop container .* in 18446744073709551615 seconds, resorting to SIGKILL" "stop -t -1 (negative one) issues warning"
+        require_warning "StopSignal \(37\) failed to stop container .* in 18446744073709551615 seconds, resorting to SIGKILL" \
+                        "stop -t -1 (negative 1) issues warning"
     fi
     run_podman rm -t -1 -f $cid
 }

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -29,7 +29,7 @@ load helpers
     run_podman rm $cid_none_implicit $cid_none_explicit $cid_on_failure
     run_podman 0+w stop -t 1 $cid_always
     if ! is_remote; then
-        assert "$output" =~ "StopSignal SIGTERM failed to stop container .*, resorting to SIGKILL"
+        require_warning "StopSignal SIGTERM failed to stop container .*, resorting to SIGKILL"
     fi
     run_podman rm $cid_always
 }

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -80,7 +80,8 @@ function service_cleanup() {
     run_podman create --restart=always $IMAGE
     cid="$output"
     run_podman 0+w generate systemd $cid
-    is "$output" ".*Container $cid has restart policy .*always.* which can lead to issues on shutdown.*" "generate systemd emits warning"
+    require_warning "Container $cid has restart policy .*always.* which can lead to issues on shutdown" \
+                    "generate systemd emits warning"
     run_podman rm -f $cid
 
     cname=$(random_string)

--- a/test/system/330-corrupt-images.bats
+++ b/test/system/330-corrupt-images.bats
@@ -76,10 +76,14 @@ function _corrupt_image_test() {
         run_podman 125 images
         is "$output" "Error: locating item named \".*\" for image with ID \"$id\" (consider removing the image to resolve the issue): file does not exist.*"
 
-        # Run the requested command. Confirm it succeeds, with suitable warnings
+        # Run the requested command. Confirm it succeeds, with suitable warnings.
         run_podman 0+w $*
-        is "$output" ".*Failed to determine parent of image.*ignoring the error" \
-           "$* with missing $what_to_rm"
+        # There are three different variations on the warnings, allow each...
+        allow_warnings "Failed to determine parent of image: .*, ignoring the error" \
+                       "Failed to determine if an image is a parent: .*, ignoring the error" \
+                       "Failed to determine if an image is a manifest list: .*, ignoring the error"
+        # ...but make sure we get at least one
+        require_warning "Failed to determine (parent|if an image is) .*, ignoring the error"
 
         run_podman images -a --noheading
         is "$output" "" "podman images -a, after $*, is empty"

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -82,7 +82,7 @@ function teardown() {
 
 @test "podman run --tty -i failure with no tty" {
     run_podman 0+w run --tty -i --rm $IMAGE echo hello < /dev/null
-    is "$output" ".*The input device is not a TTY.*" "-it _without_ a tty"
+    require_warning "The input device is not a TTY.*" "-it _without_ a tty"
 
     CR=$'\r'
     run_podman run --tty -i --rm $IMAGE echo hello <$PODMAN_TEST_PTY

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -631,7 +631,8 @@ load helpers.network
 
         run_podman 0+w restart $cid
         if ! is_remote; then
-            assert "$output" =~ "StopSignal SIGTERM failed to stop container .* in 10 seconds, resorting to SIGKILL" "podman restart issues warning"
+            require_warning "StopSignal SIGTERM failed to stop container .* in 10 seconds, resorting to SIGKILL" \
+                            "podman restart issues warning"
         fi
 
         # Verify http contents again: curl from localhost

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -913,6 +913,38 @@ function is() {
     false
 }
 
+####################
+#  allow_warnings  #  check cmd output for warning messages other than these
+####################
+#
+# HEADS UP: Operates on '$lines' array, so, must be invoked after run_podman
+#
+function allow_warnings() {
+    for line in "${lines[@]}"; do
+        if [[ "$line" =~ level=[we] ]]; then
+            local ok=
+            for pattern in "$@"; do
+                if [[ "$line" =~ $pattern ]]; then
+                   ok=ok
+                fi
+            done
+            if [[ -z "$ok" ]]; then
+                die "Unexpected warning/error in command results: $line"
+            fi
+        fi
+    done
+}
+
+#####################
+#  require_warning  #  Require the given message, but disallow any others
+#####################
+# Optional 2nd argument is a message to display if warning is missing
+function require_warning() {
+    local expect="$1"
+    local msg="${2:-Did not find expected warning/error message}"
+    assert "$output" =~ "$expect" "$msg"
+    allow_warnings "$expect"
+}
 
 ############
 #  dprint  #  conditional debug message


### PR DESCRIPTION
Part of RUN-1906.

Followup to #19878 (check stderr in system tests): allow_warnings()
and require_warning() functions to make sure no unexpected messages
fall through the cracks.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```