### PR TITLE
[CI:DOCS] Docs on sig-proxy are wrong, we support TTY

### DIFF
--- a/docs/source/markdown/options/sig-proxy.md
+++ b/docs/source/markdown/options/sig-proxy.md
@@ -4,4 +4,4 @@
 ####> are applicable to all of those.
 #### **--sig-proxy**
 
-Proxy received signals to the container process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.
+Proxy received signals to the container process. SIGCHLD, SIGURG, SIGSTOP, and SIGKILL are not proxied.


### PR DESCRIPTION
Also, we don't proxy SIGURG (Golang uses it internally for waking threads, so Go processes get it constantly (see [1] for more details).

[1] https://github.com/golang/go/issues/37942

```release-note
NONE
```
