### PR TITLE
[CI:DOCS] Tweak podman to Podman in a few farm man pages

### DIFF
--- a/docs/source/markdown/podman-farm-create.1.md
+++ b/docs/source/markdown/podman-farm-create.1.md
@@ -7,7 +7,7 @@ podman\-farm\-create - Create a new farm
 **podman farm create** [*options*] *name* [*connections*]
 
 ## DESCRIPTION
-Create a new farm with connections that podman knows about which were added via the
+Create a new farm with connections that Podman knows about which were added via the
 *podman system connection add* command.
 
 An empty farm can be created without adding any connections to it. Add or remove

--- a/docs/source/markdown/podman-farm.1.md
+++ b/docs/source/markdown/podman-farm.1.md
@@ -7,7 +7,7 @@ podman\-farm - Farm out builds to machines running podman for different architec
 **podman farm** *subcommand*
 
 ## DESCRIPTION
-Farm out builds to machines running podman for different architectures.
+Farm out builds to machines running Podman for different architectures.
 
 Manage farms by creating, updating, and removing them.
 


### PR DESCRIPTION
While doing a review of the farm man pages after they had been submitted, I found a few references to "podman" that should have been "Podman".  I have touched those up in this commit.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
