### PR TITLE
[CI:BUILD] FCOS + podman-next image: pull in wasm

### DIFF
--- a/contrib/podman-next/fcos-podmanimage/Containerfile
+++ b/contrib/podman-next/fcos-podmanimage/Containerfile
@@ -7,12 +7,14 @@ FROM quay.io/fedora/fedora-coreos:stable
 ADD https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-rawhide/rhcontainerbot-podman-next-fedora-rawhide.repos /etc/yum.repos.d/rhcontainerbot-podman-next-fedora.repo
 ADD https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg /etc/pki/rpm-gpg/rhcontainerbot-podman-next-fedora.gpg
 
-# Replace aardvark-dns, conmon, crun, netavark, podman, containers-common
+# Replace aardvark-dns, containers-common[-extra], crun, netavark, podman
+# Install crun-wasm and wasmedge-rt
 # Remove moby-engine, containerd, runc
 # Note: Currently does not result in a size reduction for the container image
 RUN rpm-ostree override replace --experimental --freeze \
     --from repo="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next" \
-    aardvark-dns crun netavark podman containers-common containers-common-extra && \
+    aardvark-dns containers-common containers-common-extra crun netavark podman && \
+    rpm-ostree install crun-wasm wasmedge-rt && \
     rpm-ostree override remove moby-engine containerd runc && \
     ostree container commit
 


### PR DESCRIPTION
This commit installs `crun-wasm` and `wasmedge-rt` in the FCOS image at https://quay.io/repository/podman/fcos .

- crun-wasm is installed from rhcontainerbot/podman-next
- wasmedge-rt is installed from the official Fedora repos

Packages in Containerfile have also been rearranged in alphabetical order.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
