### PR TITLE
[skip-ci] GHA Workflow: Faster discussion-locking

### DIFF
--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -6,7 +6,12 @@ name: "Lock closed Issue/PR discussions"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    # TODO: Put this back to once-per-day after the workflow is able
+    # to process through the enormous backlog.  Leaving it once-per-hour
+    # runs the risk of spamming podman-monitor should there be some flake
+    # or hiccup.
+    # - cron: '0 0 * * *'
+    - cron: '0 * * * *'
   # Allow re-use of this workflow by other repositories
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   workflow_call:


### PR DESCRIPTION
The closed issue & PR lock is working fine, but it has a built-in 50-item limit.  The limit is not configurable.  Since there are tens-of-thousands of issues/prs to go through, 50-per-day could take almost a year.  Speed things up 24x by running the job every hour instead of daily.

N/B: There's no easy way to test this change.  It won't be in effect until it exists on main.  

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
