### PR TITLE
e2e: ExitCleanly(): more low-hanging fruit

### DIFF
--- a/test/e2e/run_aardvark_test.go
+++ b/test/e2e/run_aardvark_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run networking", func() {
@@ -20,16 +20,16 @@ var _ = Describe("Podman run networking", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, NGINX_IMAGE})
 		ctrID.WaitWithDefaultTimeout()
-		Expect(ctrID).Should(Exit(0))
+		Expect(ctrID).Should(ExitCleanly())
 		cid := ctrID.OutputToString()
 
 		ctrIP := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netName), cid})
 		ctrIP.WaitWithDefaultTimeout()
-		Expect(ctrIP).Should(Exit(0))
+		Expect(ctrIP).Should(ExitCleanly())
 		cip := ctrIP.OutputToString()
 		Expect(cip).To(MatchRegexp(IPRegex))
 
@@ -37,7 +37,7 @@ var _ = Describe("Podman run networking", func() {
 
 		reverseLookup := podmanTest.Podman([]string{"exec", cid, "dig", "+short", "-x", cip})
 		reverseLookup.WaitWithDefaultTimeout()
-		Expect(reverseLookup).Should(Exit(0))
+		Expect(reverseLookup).Should(ExitCleanly())
 		revListArray := reverseLookup.OutputToStringArray()
 		Expect(revListArray).Should(HaveLen(2))
 		Expect(strings.TrimRight(revListArray[0], ".")).To(Equal("aone"))
@@ -50,27 +50,27 @@ var _ = Describe("Podman run networking", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctr1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, NGINX_IMAGE})
 		ctr1.WaitWithDefaultTimeout()
-		Expect(ctr1).Should(Exit(0))
+		Expect(ctr1).Should(ExitCleanly())
 		cid1 := ctr1.OutputToString()
 
 		ctrIP1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netName), cid1})
 		ctrIP1.WaitWithDefaultTimeout()
-		Expect(ctrIP1).Should(Exit(0))
+		Expect(ctrIP1).Should(ExitCleanly())
 		cip1 := ctrIP1.OutputToString()
 		Expect(cip1).To(MatchRegexp(IPRegex))
 
 		ctr2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwo", "--network", netName, NGINX_IMAGE})
 		ctr2.WaitWithDefaultTimeout()
-		Expect(ctr2).Should(Exit(0))
+		Expect(ctr2).Should(ExitCleanly())
 		cid2 := ctr2.OutputToString()
 
 		ctrIP2 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netName), cid2})
 		ctrIP2.WaitWithDefaultTimeout()
-		Expect(ctrIP2).Should(Exit(0))
+		Expect(ctrIP2).Should(ExitCleanly())
 		cip2 := ctrIP2.OutputToString()
 		Expect(cip2).To(MatchRegexp(IPRegex))
 
@@ -80,7 +80,7 @@ var _ = Describe("Podman run networking", func() {
 
 		reverseLookup12 := podmanTest.Podman([]string{"exec", cid1, "dig", "+short", "-x", cip2})
 		reverseLookup12.WaitWithDefaultTimeout()
-		Expect(reverseLookup12).Should(Exit(0))
+		Expect(reverseLookup12).Should(ExitCleanly())
 		revListArray12 := reverseLookup12.OutputToStringArray()
 		Expect(revListArray12).Should(HaveLen(2))
 		Expect(strings.TrimRight(revListArray12[0], ".")).To(Equal("atwo"))
@@ -88,7 +88,7 @@ var _ = Describe("Podman run networking", func() {
 
 		reverseLookup21 := podmanTest.Podman([]string{"exec", cid2, "dig", "+short", "-x", cip1})
 		reverseLookup21.WaitWithDefaultTimeout()
-		Expect(reverseLookup21).Should(Exit(0))
+		Expect(reverseLookup21).Should(ExitCleanly())
 		revListArray21 := reverseLookup21.OutputToStringArray()
 		Expect(revListArray21).Should(HaveLen(2))
 		Expect(strings.TrimRight(revListArray21[0], ".")).To(Equal("aone"))
@@ -101,25 +101,25 @@ var _ = Describe("Podman run networking", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctr1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, "--network-alias", "alias_a1,alias_1a", NGINX_IMAGE})
 		ctr1.WaitWithDefaultTimeout()
-		Expect(ctr1).Should(Exit(0))
+		Expect(ctr1).Should(ExitCleanly())
 
 		ctrIP1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netName), "aone"})
 		ctrIP1.WaitWithDefaultTimeout()
-		Expect(ctrIP1).Should(Exit(0))
+		Expect(ctrIP1).Should(ExitCleanly())
 		cip1 := ctrIP1.OutputToString()
 		Expect(cip1).To(MatchRegexp(IPRegex))
 
 		ctr2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwo", "--network", netName, "--network-alias", "alias_a2,alias_2a", NGINX_IMAGE})
 		ctr2.WaitWithDefaultTimeout()
-		Expect(ctr2).Should(Exit(0))
+		Expect(ctr2).Should(ExitCleanly())
 
 		ctrIP2 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netName), "atwo"})
 		ctrIP2.WaitWithDefaultTimeout()
-		Expect(ctrIP2).Should(Exit(0))
+		Expect(ctrIP2).Should(ExitCleanly())
 		cip2 := ctrIP2.OutputToString()
 		Expect(cip2).To(MatchRegexp(IPRegex))
 
@@ -142,13 +142,13 @@ var _ = Describe("Podman run networking", func() {
 		sessionA := podmanTest.Podman([]string{"network", "create", netNameA})
 		sessionA.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameA)
-		Expect(sessionA).Should(Exit(0))
+		Expect(sessionA).Should(ExitCleanly())
 
 		netNameB := createNetworkName("TestB")
 		sessionB := podmanTest.Podman([]string{"network", "create", netNameB})
 		sessionB.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameB)
-		Expect(sessionB).Should(Exit(0))
+		Expect(sessionB).Should(ExitCleanly())
 
 		ctrA1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, NGINX_IMAGE})
 		ctrA1.WaitWithDefaultTimeout()
@@ -160,24 +160,24 @@ var _ = Describe("Podman run networking", func() {
 
 		ctrIPA1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameA), cidA1})
 		ctrIPA1.WaitWithDefaultTimeout()
-		Expect(ctrIPA1).Should(Exit(0))
+		Expect(ctrIPA1).Should(ExitCleanly())
 		cipA1 := ctrIPA1.OutputToString()
 		Expect(cipA1).To(MatchRegexp(IPRegex))
 
 		ctrIPB1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameB), cidB1})
 		ctrIPB1.WaitWithDefaultTimeout()
-		Expect(ctrIPB1).Should(Exit(0))
+		Expect(ctrIPB1).Should(ExitCleanly())
 		cipB1 := ctrIPB1.OutputToString()
 		Expect(cipB1).To(MatchRegexp(IPRegex))
 
 		resA1B1 := podmanTest.Podman([]string{"exec", "aone", "dig", "+short", "bone"})
 		resA1B1.WaitWithDefaultTimeout()
-		Expect(resA1B1).Should(Exit(0))
+		Expect(resA1B1).Should(ExitCleanly())
 		Expect(resA1B1.OutputToString()).To(Equal(""))
 
 		resB1A1 := podmanTest.Podman([]string{"exec", "bone", "dig", "+short", "aone"})
 		resB1A1.WaitWithDefaultTimeout()
-		Expect(resB1A1).Should(Exit(0))
+		Expect(resB1A1).Should(ExitCleanly())
 		Expect(resB1A1.OutputToString()).To(Equal(""))
 	})
 
@@ -186,13 +186,13 @@ var _ = Describe("Podman run networking", func() {
 		sessionA := podmanTest.Podman([]string{"network", "create", netNameA})
 		sessionA.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameA)
-		Expect(sessionA).Should(Exit(0))
+		Expect(sessionA).Should(ExitCleanly())
 
 		netNameB := createNetworkName("TestB")
 		sessionB := podmanTest.Podman([]string{"network", "create", netNameB})
 		sessionB.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameB)
-		Expect(sessionB).Should(Exit(0))
+		Expect(sessionB).Should(ExitCleanly())
 
 		ctrA1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, NGINX_IMAGE})
 		ctrA1.WaitWithDefaultTimeout()
@@ -200,7 +200,7 @@ var _ = Describe("Podman run networking", func() {
 
 		ctrIPA1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameA), cidA1})
 		ctrIPA1.WaitWithDefaultTimeout()
-		Expect(ctrIPA1).Should(Exit(0))
+		Expect(ctrIPA1).Should(ExitCleanly())
 		cipA1 := ctrIPA1.OutputToString()
 		Expect(cipA1).To(MatchRegexp(IPRegex))
 
@@ -210,7 +210,7 @@ var _ = Describe("Podman run networking", func() {
 
 		ctrIPB1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameB), cidB1})
 		ctrIPB1.WaitWithDefaultTimeout()
-		Expect(ctrIPB1).Should(Exit(0))
+		Expect(ctrIPB1).Should(ExitCleanly())
 		cipB1 := ctrIPB1.OutputToString()
 		Expect(cipB1).To(MatchRegexp(IPRegex))
 
@@ -220,13 +220,13 @@ var _ = Describe("Podman run networking", func() {
 
 		ctrIPA2B21 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameA), cidA2B2})
 		ctrIPA2B21.WaitWithDefaultTimeout()
-		Expect(ctrIPA2B21).Should(Exit(0))
+		Expect(ctrIPA2B21).Should(ExitCleanly())
 		cipA2B21 := ctrIPA2B21.OutputToString()
 		Expect(cipA2B21).To(MatchRegexp(IPRegex))
 
 		ctrIPA2B22 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameB), cidA2B2})
 		ctrIPA2B22.WaitWithDefaultTimeout()
-		Expect(ctrIPA2B22).Should(Exit(0))
+		Expect(ctrIPA2B22).Should(ExitCleanly())
 		cipA2B22 := ctrIPA2B22.OutputToString()
 		Expect(cipA2B22).To(MatchRegexp(IPRegex))
 
@@ -244,44 +244,44 @@ var _ = Describe("Podman run networking", func() {
 		sessionA := podmanTest.Podman([]string{"network", "create", netNameA})
 		sessionA.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameA)
-		Expect(sessionA).Should(Exit(0))
+		Expect(sessionA).Should(ExitCleanly())
 
 		netNameB := createNetworkName("TestB")
 		sessionB := podmanTest.Podman([]string{"network", "create", netNameB})
 		sessionB.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameB)
-		Expect(sessionB).Should(Exit(0))
+		Expect(sessionB).Should(ExitCleanly())
 
 		netNameC := createNetworkName("TestC")
 		sessionC := podmanTest.Podman([]string{"network", "create", netNameC})
 		sessionC.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netNameC)
-		Expect(sessionC).Should(Exit(0))
+		Expect(sessionC).Should(ExitCleanly())
 
 		ctrA := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, NGINX_IMAGE})
 		ctrA.WaitWithDefaultTimeout()
-		Expect(ctrA).Should(Exit(0))
+		Expect(ctrA).Should(ExitCleanly())
 
 		ctrC := podmanTest.Podman([]string{"run", "-dt", "--name", "cone", "--network", netNameC, NGINX_IMAGE})
 		ctrC.WaitWithDefaultTimeout()
-		Expect(ctrC).Should(Exit(0))
+		Expect(ctrC).Should(ExitCleanly())
 
 		ctrnetAB1 := podmanTest.Podman([]string{"network", "connect", "--alias", "testB1_nw", netNameB, "aone"})
 		ctrnetAB1.WaitWithDefaultTimeout()
-		Expect(ctrnetAB1).Should(Exit(0))
+		Expect(ctrnetAB1).Should(ExitCleanly())
 
 		ctrIPAB1 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameB), "aone"})
 		ctrIPAB1.WaitWithDefaultTimeout()
-		Expect(ctrIPAB1).Should(Exit(0))
+		Expect(ctrIPAB1).Should(ExitCleanly())
 		cipAB1 := ctrIPAB1.OutputToString()
 
 		ctrnetCB2 := podmanTest.Podman([]string{"network", "connect", "--alias", "testB2_nw", netNameB, "cone"})
 		ctrnetCB2.WaitWithDefaultTimeout()
-		Expect(ctrnetCB2).Should(Exit(0))
+		Expect(ctrnetCB2).Should(ExitCleanly())
 
 		ctrIPCB2 := podmanTest.Podman([]string{"inspect", "--format", fmt.Sprintf(`{{.NetworkSettings.Networks.%s.IPAddress}}`, netNameB), "cone"})
 		ctrIPCB2.WaitWithDefaultTimeout()
-		Expect(ctrIPCB2).Should(Exit(0))
+		Expect(ctrIPCB2).Should(ExitCleanly())
 		cipCB2 := ctrIPCB2.OutputToString()
 
 		digShort("aone", "testB2_nw", cipCB2, podmanTest)

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // wip
@@ -33,7 +32,7 @@ var _ = Describe("Podman run", func() {
 		skipIfAppArmorDisabled()
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set
@@ -45,7 +44,7 @@ var _ = Describe("Podman run", func() {
 		skipIfAppArmorDisabled()
 		session := podmanTest.Podman([]string{"create", "--privileged", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set
@@ -57,7 +56,7 @@ var _ = Describe("Podman run", func() {
 		skipIfAppArmorDisabled()
 		session := podmanTest.Podman([]string{"create", "--security-opt", fmt.Sprintf("apparmor=%s", apparmor.Profile), "--privileged", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set
@@ -84,11 +83,11 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 		aaFile := filepath.Join(os.TempDir(), "aaFile")
 		Expect(os.WriteFile(aaFile, []byte(aaProfile), 0755)).To(Succeed())
 		parse := SystemExec("apparmor_parser", []string{"-Kr", aaFile})
-		Expect(parse).Should(Exit(0))
+		Expect(parse).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=aa-test-profile", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set
@@ -107,7 +106,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 		skipIfAppArmorDisabled()
 		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set
@@ -128,7 +127,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 		// Should succeed if user specifies apparmor on disabled system
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set
@@ -141,7 +140,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		cid := session.OutputToString()
 		// Verify that apparmor.Profile is being set

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 const cgroupRoot = "/sys/fs/cgroup"
@@ -27,7 +26,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		cgroup := "/zzz"
 		run := podmanTest.Podman([]string{"run", "--cgroupns=host", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).To(ContainSubstring(cgroup))
 	})
 
@@ -42,7 +41,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		}
 		run := podmanTest.Podman([]string{"run", "--cgroupns=host", fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).To(ContainSubstring(cgroup))
 	})
 
@@ -57,12 +56,12 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 
 		run := podmanTest.Podman([]string{"run", "-d", "--cgroupns=host", fedoraMinimal, "sleep", "100"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		cid := run.OutputToString()
 
 		exec := podmanTest.Podman([]string{"exec", cid, "cat", "/proc/1/cgroup"})
 		exec.WaitWithDefaultTimeout()
-		Expect(exec).Should(Exit(0))
+		Expect(exec).Should(ExitCleanly())
 
 		containerCgroup := strings.TrimRight(strings.ReplaceAll(exec.OutputToString(), "0::", ""), "\n")
 
@@ -81,7 +80,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 
 		run = podmanTest.Podman([]string{"--cgroup-manager=cgroupfs", "run", "--rm", "--cgroupns=host", fmt.Sprintf("--cgroup-parent=%s", newCgroup), fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		cgroupEffective := strings.TrimRight(strings.ReplaceAll(run.OutputToString(), "0::", ""), "\n")
 
 		Expect(newCgroup).To(Equal(filepath.Dir(cgroupEffective)))
@@ -94,7 +93,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		cgroup := "aaaa.slice"
 		run := podmanTest.Podman([]string{"run", "--cgroupns=host", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/1/cgroup"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).To(ContainSubstring(cgroup))
 	})
 })

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run exit", func() {
@@ -16,33 +15,33 @@ var _ = Describe("Podman run exit", func() {
 		result := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
 		result.WaitWithDefaultTimeout()
 		cid := result.OutputToString()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		mount := SystemExec("mount", nil)
-		Expect(mount).Should(Exit(0))
+		Expect(mount).Should(ExitCleanly())
 		Expect(mount.OutputToString()).To(ContainSubstring(cid))
 
 		pmount := podmanTest.Podman([]string{"mount", "--no-trunc"})
 		pmount.WaitWithDefaultTimeout()
-		Expect(pmount).Should(Exit(0))
+		Expect(pmount).Should(ExitCleanly())
 		Expect(pmount.OutputToString()).To(ContainSubstring(cid))
 
 		stop := podmanTest.Podman([]string{"stop", cid})
 		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(Exit(0))
+		Expect(stop).Should(ExitCleanly())
 
 		// We have to force cleanup so the unmount happens
 		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", cid})
 		podmanCleanupSession.WaitWithDefaultTimeout()
-		Expect(podmanCleanupSession).Should(Exit(0))
+		Expect(podmanCleanupSession).Should(ExitCleanly())
 
 		mount = SystemExec("mount", nil)
-		Expect(mount).Should(Exit(0))
+		Expect(mount).Should(ExitCleanly())
 		Expect(mount.OutputToString()).NotTo(ContainSubstring(cid))
 
 		pmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		pmount.WaitWithDefaultTimeout()
-		Expect(pmount).Should(Exit(0))
+		Expect(pmount).Should(ExitCleanly())
 		Expect(pmount.OutputToString()).NotTo(ContainSubstring(cid))
 	})
 
@@ -53,11 +52,11 @@ var _ = Describe("Podman run exit", func() {
 		result := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
 		result.WaitWithDefaultTimeout()
 		cid := result.OutputToString()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		mount := podmanTest.Podman([]string{"unshare", "mount"})
 		mount.WaitWithDefaultTimeout()
-		Expect(mount).Should(Exit(0))
+		Expect(mount).Should(ExitCleanly())
 		Expect(mount.OutputToString()).To(ContainSubstring(cid))
 
 		// command: podman <options> unshare podman <options> image mount ALPINE
@@ -67,26 +66,26 @@ var _ = Describe("Podman run exit", func() {
 
 		pmount := podmanTest.Podman(args)
 		pmount.WaitWithDefaultTimeout()
-		Expect(pmount).Should(Exit(0))
+		Expect(pmount).Should(ExitCleanly())
 		Expect(pmount.OutputToString()).To(ContainSubstring(cid))
 
 		stop := podmanTest.Podman([]string{"stop", cid})
 		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(Exit(0))
+		Expect(stop).Should(ExitCleanly())
 
 		// We have to force cleanup so the unmount happens
 		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", cid})
 		podmanCleanupSession.WaitWithDefaultTimeout()
-		Expect(podmanCleanupSession).Should(Exit(0))
+		Expect(podmanCleanupSession).Should(ExitCleanly())
 
 		mount = podmanTest.Podman([]string{"unshare", "mount"})
 		mount.WaitWithDefaultTimeout()
-		Expect(mount).Should(Exit(0))
+		Expect(mount).Should(ExitCleanly())
 		Expect(mount.OutputToString()).NotTo(ContainSubstring(cid))
 
 		pmount = podmanTest.Podman(args)
 		pmount.WaitWithDefaultTimeout()
-		Expect(pmount).Should(Exit(0))
+		Expect(pmount).Should(ExitCleanly())
 		Expect(pmount.OutputToString()).NotTo(ContainSubstring(cid))
 	})
 })

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Podman run cpu", func() {
 			result = podmanTest.Podman([]string{"run", "--rm", "--cpu-period=5000", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.cfs_period_us"})
 		}
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("5000"))
 	})
 
@@ -42,7 +42,7 @@ var _ = Describe("Podman run cpu", func() {
 			result = podmanTest.Podman([]string{"run", "--rm", "--cpu-quota=5000", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"})
 		}
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring("5000"))
 	})
 
@@ -50,17 +50,17 @@ var _ = Describe("Podman run cpu", func() {
 		if CGROUPSV2 {
 			result := podmanTest.Podman([]string{"run", "--rm", "--cpu-quota=5000", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/cpu.max"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(Equal("5000 100000"))
 		} else {
 			result := podmanTest.Podman([]string{"run", "--rm", "--cpus=0.5", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.cfs_period_us"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(Equal("100000"))
 
 			result = podmanTest.Podman([]string{"run", "--rm", "--cpus=0.5", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(Equal("50000"))
 		}
 	})
@@ -70,12 +70,12 @@ var _ = Describe("Podman run cpu", func() {
 			// [2-262144] is mapped to [1-10000]
 			result := podmanTest.Podman([]string{"run", "--rm", "--cpu-shares=262144", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/cpu.weight"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(Equal("10000"))
 		} else {
 			result := podmanTest.Podman([]string{"run", "--rm", "-c", "2", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.shares"})
 			result.WaitWithDefaultTimeout()
-			Expect(result).Should(Exit(0))
+			Expect(result).Should(ExitCleanly())
 			Expect(result.OutputToString()).To(Equal("2"))
 		}
 	})
@@ -89,7 +89,7 @@ var _ = Describe("Podman run cpu", func() {
 			result = podmanTest.Podman([]string{"run", "--rm", "--cpuset-cpus=0", ALPINE, "cat", "/sys/fs/cgroup/cpuset/cpuset.cpus"})
 		}
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("0"))
 	})
 
@@ -102,7 +102,7 @@ var _ = Describe("Podman run cpu", func() {
 			result = podmanTest.Podman([]string{"run", "--rm", "--cpuset-mems=0", ALPINE, "cat", "/sys/fs/cgroup/cpuset/cpuset.mems"})
 		}
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(Equal("0"))
 	})
 
@@ -122,7 +122,7 @@ var _ = Describe("Podman run cpu", func() {
 		SkipIfCgroupV1("testing options that only work in cgroup v2")
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-rt-period=5000", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.ErrorToString()).To(ContainSubstring("Realtime period not supported on cgroups V2 systems"))
 	})
 
@@ -130,7 +130,7 @@ var _ = Describe("Podman run cpu", func() {
 		SkipIfCgroupV1("testing options that only work in cgroup v2")
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-rt-runtime=5000", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.ErrorToString()).To(ContainSubstring("Realtime runtime not supported on cgroups V2 systems"))
 	})
 })

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Podman run cpu", func() {
 		SkipIfCgroupV1("testing options that only work in cgroup v2")
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-rt-period=5000", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(ExitCleanly())
+		Expect(result).Should(Exit(0))
 		Expect(result.ErrorToString()).To(ContainSubstring("Realtime period not supported on cgroups V2 systems"))
 	})
 
@@ -130,7 +130,7 @@ var _ = Describe("Podman run cpu", func() {
 		SkipIfCgroupV1("testing options that only work in cgroup v2")
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-rt-runtime=5000", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(ExitCleanly())
+		Expect(result).Should(Exit(0))
 		Expect(result.ErrorToString()).To(ContainSubstring("Realtime runtime not supported on cgroups V2 systems"))
 	})
 })

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -36,11 +36,11 @@ var _ = Describe("Podman run device", func() {
 	It("podman run device test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", ALPINE, "test", "-c", "/dev/kmsg"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		if !isRootless() {
 			session = podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", "--cap-add", "SYS_ADMIN", ALPINE, "head", "-n", "1", "/dev/kmsg"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 		}
 	})
 
@@ -48,21 +48,21 @@ var _ = Describe("Podman run device", func() {
 		// TODO: Confirm absence of /dev/kmsg in container
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1", ALPINE, "test", "-c", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run device permission test", func() {
 		// TODO: Confirm write-permission failure
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:r", ALPINE, "test", "-r", "/dev/kmsg"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run device rename and permission test", func() {
 		// TODO: Confirm write-permission failure
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:r", ALPINE, "test", "-r", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 	It("podman run device rename and bad permission test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "true"})
@@ -79,18 +79,18 @@ var _ = Describe("Podman run device", func() {
 
 		mknod := SystemExec("mknod", []string{devdir + "/null", "c", "1", "3"})
 		mknod.WaitWithDefaultTimeout()
-		Expect(mknod).Should(Exit(0))
+		Expect(mknod).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"run", "-q", "--device", devdir + ":/dev/bar", ALPINE, "stat", "-c%t:%T", "/dev/bar/null"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("1:3"))
 	})
 
 	It("podman run device host device with --privileged", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", ALPINE, "test", "-c", "/dev/kmsg"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// verify --privileged is required
 		session2 := podmanTest.Podman([]string{"run", ALPINE, "test", "-c", "/dev/kmsg"})
 		session2.WaitWithDefaultTimeout()
@@ -111,24 +111,24 @@ var _ = Describe("Podman run device", func() {
 
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "vendor.com/device=myKmsg", ALPINE, "test", "-c", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		createContainersConfFileWithDevices(podmanTest, "\"vendor.com/device=myKmsg\"")
 		session = podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", ALPINE, "test", "-c", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run --gpus noop", func() {
 		session := podmanTest.Podman([]string{"run", "--gpus", "all", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run cannot access non default devices", func() {
 		session := podmanTest.Podman([]string{"run", "-v /dev:/dev-host", ALPINE, "head", "-1", "/dev-host/kmsg"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Not(Exit(0)))
+		Expect(session).Should(Not(ExitCleanly()))
 	})
 
 })

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run dns", func() {
@@ -12,14 +11,14 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add search domain", func() {
 		session := podmanTest.Podman([]string{"run", "--dns-search=foobar.com", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search foobar.com")))
 	})
 
 	It("podman run remove all search domain", func() {
 		session := podmanTest.Podman([]string{"run", "--dns-search=.", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(Not(ContainElement(HavePrefix("search"))))
 	})
 
@@ -32,7 +31,7 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add dns server", func() {
 		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.2.3.4")))
 
 	})
@@ -40,7 +39,7 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add dns option", func() {
 		session := podmanTest.Podman([]string{"run", "--dns-opt=debug", ALPINE, "cat", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
 	})
 
@@ -53,26 +52,26 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add host", func() {
 		session := podmanTest.Podman([]string{"run", "--add-host=foobar:1.1.1.1", "--add-host=foobaz:2001:db8::68", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElements(HavePrefix("1.1.1.1\tfoobar"), HavePrefix("2001:db8::68\tfoobaz")))
 	})
 
 	It("podman run add hostname", func() {
 		session := podmanTest.Podman([]string{"run", "--hostname=foobar", ALPINE, "cat", "/etc/hostname"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("foobar"))
 
 		session = podmanTest.Podman([]string{"run", "--hostname=foobar", ALPINE, "hostname"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("foobar"))
 	})
 
 	It("podman run add hostname sets /etc/hosts", func() {
 		session := podmanTest.Podman([]string{"run", "--hostname=foobar", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("foobar"))
 	})
 
@@ -91,6 +90,6 @@ var _ = Describe("Podman run dns", func() {
 
 		session = podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 })

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -27,7 +28,7 @@ CMD []
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest", "echo", "hello"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("hello"))
 	})
 
@@ -38,7 +39,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
@@ -50,7 +51,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 	})
 
@@ -62,7 +63,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest", "-i"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(5))
 	})
 
@@ -73,7 +74,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest", "-i"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(5))
 	})
 
@@ -85,12 +86,12 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "--entrypoint=uname", "foobar.com/entrypoint:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("Linux")))
 
 		session = podmanTest.Podman([]string{"run", "--entrypoint", "", "foobar.com/entrypoint:latest", "uname"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("Linux")))
 	})
 
@@ -102,7 +103,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "--entrypoint=uname", "foobar.com/entrypoint:latest", "-r"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(Not(ContainElement(HavePrefix("Linux"))))
 	})
 })

--- a/test/e2e/run_env_test.go
+++ b/test/e2e/run_env_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -13,40 +14,40 @@ var _ = Describe("Podman run", func() {
 	It("podman run environment test", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "HOME"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/root"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "2", ALPINE, "printenv", "HOME"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/sbin"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "HOME=/foo", ALPINE, "printenv", "HOME"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/foo"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR,BAZ", ALPINE, "printenv", "FOO"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("BAR,BAZ"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "PATH=/bin", ALPINE, "printenv", "PATH"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/bin"))
 
 		// Verify environ keys with spaces do not blow up podman command
 		os.Setenv("FOO BAR", "BAZ")
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		os.Unsetenv("FOO BAR")
 
 		os.Setenv("FOO", "BAR")
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("BAR"))
 		os.Unsetenv("FOO")
 
@@ -57,13 +58,13 @@ var _ = Describe("Podman run", func() {
 
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// This currently does not work
 		// Re-enable when hostname is an env variable
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "sh", "-c", "printenv"})
 		session.Wait(10)
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("HOSTNAME"))
 	})
 
@@ -74,12 +75,12 @@ ENV hello=world
 		podmanTest.BuildImage(dockerfile, "test", "false")
 		session := podmanTest.Podman([]string{"run", "--rm", "--env-merge", "hello=${hello}-earth", "test", "env"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("world-earth"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--env-merge", "foo=${bar}-earth", "test", "printenv", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("-earth"))
 	})
 
@@ -93,12 +94,12 @@ ENV hello=world
 			Expect(session.ErrorToString()).To(ContainSubstring("unknown flag: --env-host"))
 			return
 		}
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("BAR"))
 
 		session = podmanTest.PodmanAsUser([]string{"run", "--rm", "--env", "FOO=BAR1", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("BAR1"))
 		os.Unsetenv("FOO")
 	})
@@ -119,7 +120,7 @@ ENV hello=world
 		}
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "http_proxy"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("1.2.3.4"))
 
 		session = podmanTest.Podman([]string{"run", "--http-proxy=false", ALPINE, "printenv", "http_proxy"})
@@ -129,12 +130,12 @@ ENV hello=world
 
 		session = podmanTest.Podman([]string{"run", "--env", "http_proxy=5.6.7.8", ALPINE, "printenv", "http_proxy"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("5.6.7.8"))
 
 		session = podmanTest.Podman([]string{"run", "--http-proxy=false", "--env", "http_proxy=5.6.7.8", ALPINE, "printenv", "http_proxy"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("5.6.7.8"))
 	})
 })

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/containers/podman/v4/libpod/define"
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -32,7 +33,7 @@ var _ = Describe("Podman run exit", func() {
 	It("podman run exit 0", func() {
 		result := podmanTest.Podman([]string{"run", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 	})
 
 	It("podman run exit 50", func() {

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -3,9 +3,9 @@ package integration
 import (
 	"fmt"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run memory", func() {
@@ -23,7 +23,7 @@ var _ = Describe("Podman run memory", func() {
 			session = podmanTest.Podman([]string{"run", "--memory=40m", ALPINE, "cat", "/sys/fs/cgroup/memory/memory.limit_in_bytes"})
 		}
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("41943040"))
 	})
 
@@ -37,7 +37,7 @@ var _ = Describe("Podman run memory", func() {
 		}
 
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("41943040"))
 	})
 
@@ -55,7 +55,7 @@ var _ = Describe("Podman run memory", func() {
 			expect = "31457280"
 		}
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(expect))
 	})
 
@@ -66,7 +66,7 @@ var _ = Describe("Podman run memory", func() {
 			SkipIfCgroupV2("memory-swappiness not supported on cgroupV2")
 			session := podmanTest.Podman([]string{"run", fmt.Sprintf("--memory-swappiness=%s", limit), ALPINE, "cat", "/sys/fs/cgroup/memory/memory.swappiness"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToString()).To(Equal(limit))
 		})
 	}

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run ns", func() {
@@ -16,12 +15,12 @@ var _ = Describe("Podman run ns", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		session := podmanTest.Podman([]string{"run", fedoraMinimal, "bash", "-c", "echo $$"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("1"))
 
 		session = podmanTest.Podman([]string{"run", "--pid=host", fedoraMinimal, "bash", "-c", "echo $$"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(Equal("1")))
 
 		session = podmanTest.Podman([]string{"run", "--pid=badpid", fedoraMinimal, "bash", "-c", "echo $$"})
@@ -32,7 +31,7 @@ var _ = Describe("Podman run ns", func() {
 	It("podman run --cgroup private test", func() {
 		session := podmanTest.Podman([]string{"run", "--cgroupns=private", fedoraMinimal, "cat", "/proc/self/cgroup"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		output := session.OutputToString()
 		Expect(output).ToNot(ContainSubstring("slice"))
@@ -40,41 +39,41 @@ var _ = Describe("Podman run ns", func() {
 
 	It("podman run ipcns test", func() {
 		setup := SystemExec("ls", []string{"--inode", "-d", "/dev/shm"})
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 		hostShm := setup.OutputToString()
 
 		session := podmanTest.Podman([]string{"run", "--ipc=host", fedoraMinimal, "ls", "--inode", "-d", "/dev/shm"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(hostShm))
 	})
 
 	It("podman run ipcns ipcmk host test", func() {
 		setup := SystemExec("ipcmk", []string{"-M", "1024"})
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 		output := strings.Split(setup.OutputToString(), " ")
 		ipc := output[len(output)-1]
 		session := podmanTest.Podman([]string{"run", "--ipc=host", fedoraMinimal, "ipcs", "-m", "-i", ipc})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		setup = SystemExec("ipcrm", []string{"-m", ipc})
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 	})
 
 	It("podman run ipcns ipcmk container test", func() {
 		setup := podmanTest.Podman([]string{"run", "-d", "--name", "test1", fedoraMinimal, "sleep", "999"})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "ipcmk", "-M", "1024"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output := strings.Split(session.OutputToString(), " ")
 		ipc := output[len(output)-1]
 		session = podmanTest.Podman([]string{"run", "--ipc=container:test1", fedoraMinimal, "ipcs", "-m", "-i", ipc})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run bad ipc pid test", func() {
@@ -86,7 +85,7 @@ var _ = Describe("Podman run ns", func() {
 	It("podman run mounts fresh cgroup", func() {
 		session := podmanTest.Podman([]string{"run", fedoraMinimal, "grep", "cgroup", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output := session.OutputToString()
 		Expect(output).ToNot(ContainSubstring(".."))
 	})
@@ -107,13 +106,13 @@ var _ = Describe("Podman run ns", func() {
 
 		session := podmanTest.Podman([]string{"run", "--ipc=host", "--pid=host", ALPINE, "ls", "-l", "/proc/self/ns/pid"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		fields = strings.Split(session.OutputToString(), " ")
 		ctrPidNS := strings.TrimSuffix(fields[len(fields)-1], "\n")
 
 		session = podmanTest.Podman([]string{"run", "--ipc=host", "--pid=host", ALPINE, "ls", "-l", "/proc/self/ns/ipc"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		fields = strings.Split(session.OutputToString(), " ")
 		ctrIpcNS := strings.TrimSuffix(fields[len(fields)-1], "\n")
 

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run passwd", func() {
@@ -14,27 +13,27 @@ var _ = Describe("Podman run passwd", func() {
 	It("podman run no user specified ", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("passwd")))
 	})
 	It("podman run user specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "bin", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("passwd")))
 	})
 
 	It("podman run UID specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "2:1", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("passwd")))
 	})
 
 	It("podman run UID not specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "20001:1", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("passwd"))
 	})
 
@@ -46,26 +45,26 @@ USER 1000`, ALPINE)
 		podmanTest.BuildImage(dockerfile, imgName, "false")
 		session := podmanTest.Podman([]string{"run", "--passwd=false", "--rm", imgName, "ls", "/etc/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("passwd")))
 
 		// test that the /etc/passwd file is created
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "0:0", imgName, "ls", "/etc/passwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run with no user specified does not change --group specified", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/etc/group")))
 	})
 
 	It("podman run group specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "root:bin", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/etc/group")))
 	})
 
@@ -78,21 +77,21 @@ USER 1000`, ALPINE)
 	It("podman run numeric group specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "root:11", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/etc/group")))
 	})
 
 	It("podman run numeric group not specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "20001:20001", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/etc/group"))
 	})
 
 	It("podman run numeric user not specified in container modifies group", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "20001", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/etc/group"))
 	})
 
@@ -104,19 +103,19 @@ USER 1000`, ALPINE)
 		podmanTest.BuildImage(dockerfile, imgName, "false")
 		session := podmanTest.Podman([]string{"run", "--rm", imgName, "ls", "/etc/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/etc/group")))
 	})
 
 	It("podman run --no-manage-passwd flag", func() {
 		run := podmanTest.Podman([]string{"run", "--user", "1234:1234", ALPINE, "cat", "/etc/passwd"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).To(ContainSubstring("1234:1234"))
 
 		run = podmanTest.Podman([]string{"run", "--passwd=false", "--user", "1234:1234", ALPINE, "cat", "/etc/passwd"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).NotTo((ContainSubstring("1234:1234")))
 	})
 
@@ -124,11 +123,11 @@ USER 1000`, ALPINE)
 		// Test that the line we add doesn't contain anything else than what is specified
 		run := podmanTest.Podman([]string{"run", "--user", "1234:1234", "--passwd-entry=FOO", ALPINE, "grep", "^FOO$", "/etc/passwd"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		run = podmanTest.Podman([]string{"run", "--user", "12345:12346", "-w", "/etc", "--passwd-entry=$UID-$GID-$NAME-$HOME-$USERNAME", ALPINE, "cat", "/etc/passwd"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).To(ContainSubstring("12345-12346-container user-/etc-12345"))
 	})
 
@@ -136,11 +135,11 @@ USER 1000`, ALPINE)
 		// Test that the line we add doesn't contain anything else than what is specified
 		run := podmanTest.Podman([]string{"run", "--user", "1234:1234", "--group-entry=FOO", ALPINE, "grep", "^FOO$", "/etc/group"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		run = podmanTest.Podman([]string{"run", "--user", "12345:12346", "--group-entry=$GID", ALPINE, "tail", "/etc/group"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).To(ContainSubstring("12346"))
 	})
 })

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -40,17 +39,17 @@ var _ = Describe("Podman privileged container tests", func() {
 	It("podman privileged make sure sys is mounted rw", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("sysfs (rw,"))
 	})
 
 	It("podman privileged CapEff", func() {
 		hostCap := SystemExec("awk", []string{"/^CapEff/ { print $2 }", "/proc/self/status"})
-		Expect(hostCap).Should(Exit(0))
+		Expect(hostCap).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"run", "--privileged", BB, "awk", "/^CapEff/ { print $2 }", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		containerCapMatchesHost(session.OutputToString(), hostCap.OutputToString())
 	})
@@ -58,11 +57,11 @@ var _ = Describe("Podman privileged container tests", func() {
 	It("podman cap-add CapEff", func() {
 		// Get caps of current process
 		hostCap := SystemExec("awk", []string{"/^CapEff/ { print $2 }", "/proc/self/status"})
-		Expect(hostCap).Should(Exit(0))
+		Expect(hostCap).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"run", "--cap-add", "all", BB, "awk", "/^CapEff/ { print $2 }", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		containerCapMatchesHost(session.OutputToString(), hostCap.OutputToString())
 	})
@@ -70,11 +69,11 @@ var _ = Describe("Podman privileged container tests", func() {
 	It("podman cap-add CapEff with --user", func() {
 		// Get caps of current process
 		hostCap := SystemExec("awk", []string{"/^CapEff/ { print $2 }", "/proc/self/status"})
-		Expect(hostCap).Should(Exit(0))
+		Expect(hostCap).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"run", "--user=bin", "--cap-add", "all", BB, "awk", "/^CapEff/ { print $2 }", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		containerCapMatchesHost(session.OutputToString(), hostCap.OutputToString())
 	})
@@ -82,31 +81,31 @@ var _ = Describe("Podman privileged container tests", func() {
 	It("podman cap-drop CapEff", func() {
 		session := podmanTest.Podman([]string{"run", "--cap-drop", "all", BB, "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		capEff := strings.Split(session.OutputToString(), " ")
 		Expect("0000000000000000").To(Equal(capEff[1]))
 	})
 
 	It("podman privileged should disable seccomp by default", func() {
 		hostSeccomp := SystemExec("grep", []string{"-Ei", "^Seccomp:\\s+0$", "/proc/self/status"})
-		Expect(hostSeccomp).Should(Exit(0))
+		Expect(hostSeccomp).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"run", "--privileged", ALPINE, "grep", "-Ei", "^Seccomp:\\s+0$", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman non-privileged should have very few devices", func() {
 		session := podmanTest.Podman([]string{"run", "-t", BB, "ls", "-l", "/dev"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(17))
 	})
 
 	It("podman privileged should inherit host devices", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", ALPINE, "ls", "-l", "/dev"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 20))
 	})
 
@@ -120,18 +119,18 @@ var _ = Describe("Podman privileged container tests", func() {
 
 		mknod := SystemExec("mknod", []string{devdir + "/null", "c", "1", "3"})
 		mknod.WaitWithDefaultTimeout()
-		Expect(mknod).Should(Exit(0))
+		Expect(mknod).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"run", "--name=" + containerName, "--privileged", fedoraMinimal, "ls", "/dev"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		deviceFiles := session.OutputToStringArray()
 
 		os.RemoveAll(devdir)
 		session = podmanTest.Podman([]string{"start", "--attach", containerName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		deviceFilesAfterRemoval := session.OutputToStringArray()
 		Expect(deviceFiles).To(Not(Equal(deviceFilesAfterRemoval)))
@@ -152,12 +151,12 @@ var _ = Describe("Podman privileged container tests", func() {
 
 		session := podmanTest.Podman([]string{"run", BB, "grep", "NoNewPrivs", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		privs := strings.Split(session.OutputToString(), ":")
 		session = podmanTest.Podman([]string{"run", "--security-opt", "no-new-privileges", BB, "grep", "NoNewPrivs", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		noprivs := strings.Split(session.OutputToString(), ":")
 		Expect(privs[1]).To(Not(Equal(noprivs[1])))

--- a/test/e2e/run_restart_test.go
+++ b/test/e2e/run_restart_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run restart containers", func() {
@@ -12,15 +11,15 @@ var _ = Describe("Podman run restart containers", func() {
 	It("Podman start after successful run", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "test", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"wait", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"start", "--attach", "test"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 	})
 
 	It("Podman start after signal kill", func() {
@@ -30,10 +29,10 @@ var _ = Describe("Podman run restart containers", func() {
 
 		killSession := podmanTest.Podman([]string{"kill", "-s", "9", "test1"})
 		killSession.WaitWithDefaultTimeout()
-		Expect(killSession).Should(Exit(0))
+		Expect(killSession).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"start", "test1"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 	})
 })

--- a/test/e2e/run_seccomp_test.go
+++ b/test/e2e/run_seccomp_test.go
@@ -10,14 +10,14 @@ import (
 var _ = Describe("Podman run", func() {
 
 	It("podman run --seccomp-policy default", func() {
-		session := podmanTest.Podman([]string{"run", "--seccomp-policy", "default", alpineSeccomp, "ls"})
+		session := podmanTest.Podman([]string{"run", "-q", "--seccomp-policy", "default", alpineSeccomp, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run --seccomp-policy ''", func() {
 		// Empty string is interpreted as "default".
-		session := podmanTest.Podman([]string{"run", "--seccomp-policy", "", alpineSeccomp, "ls"})
+		session := podmanTest.Podman([]string{"run", "-q", "--seccomp-policy", "", alpineSeccomp, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})

--- a/test/e2e/run_seccomp_test.go
+++ b/test/e2e/run_seccomp_test.go
@@ -12,14 +12,14 @@ var _ = Describe("Podman run", func() {
 	It("podman run --seccomp-policy default", func() {
 		session := podmanTest.Podman([]string{"run", "--seccomp-policy", "default", alpineSeccomp, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run --seccomp-policy ''", func() {
 		// Empty string is interpreted as "default".
 		session := podmanTest.Podman([]string{"run", "--seccomp-policy", "", alpineSeccomp, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run --seccomp-policy invalid", func() {

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -20,105 +21,105 @@ var _ = Describe("Podman run", func() {
 	It("podman run selinux", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_t"))
 	})
 
 	It("podman run selinux grep test", func() {
 		session := podmanTest.Podman([]string{"run", "--security-opt", "label=level:s0:c1,c2", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("s0:c1,c2"))
 	})
 
 	It("podman run selinux disable test", func() {
 		session := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("spc_t"))
 	})
 
 	It("podman run selinux type check test", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Or(ContainSubstring("container_t"), ContainSubstring("svirt_lxc_net_t")))
 	})
 
 	It("podman run selinux type setup test", func() {
 		session := podmanTest.Podman([]string{"run", "--security-opt", "label=type:spc_t", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("spc_t"))
 	})
 
 	It("podman privileged selinux", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("spc_t"))
 	})
 
 	It("podman test selinux label resolv.conf", func() {
 		session := podmanTest.Podman([]string{"run", fedoraMinimal, "ls", "-Z", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux label hosts", func() {
 		session := podmanTest.Podman([]string{"run", fedoraMinimal, "ls", "-Z", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux label hostname", func() {
 		session := podmanTest.Podman([]string{"run", fedoraMinimal, "ls", "-Z", "/etc/hostname"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux label /run/secrets", func() {
 		session := podmanTest.Podman([]string{"run", fedoraMinimal, "ls", "-dZ", "/run/secrets"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux --privileged label resolv.conf", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", fedoraMinimal, "ls", "-Z", "/etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux --privileged label hosts", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", fedoraMinimal, "ls", "-Z", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux --privileged label hostname", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", fedoraMinimal, "ls", "-Z", "/etc/hostname"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman test selinux --privileged label /run/secrets", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", fedoraMinimal, "ls", "-dZ", "/run/secrets"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_file_t"))
 	})
 
 	It("podman run selinux file type setup test", func() {
 		session := podmanTest.Podman([]string{"run", "--security-opt", "label=type:spc_t", "--security-opt", "label=filetype:container_var_lib_t", fedoraMinimal, "ls", "-Z", "/dev"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_var_lib_t"))
 
 		session = podmanTest.Podman([]string{"run", "--security-opt", "label=type:spc_t", "--security-opt", "label=filetype:foobar", fedoraMinimal, "ls", "-Z", "/dev"})
@@ -129,7 +130,7 @@ var _ = Describe("Podman run", func() {
 	It("podman exec selinux check", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/1/attr/current"})
 		session.WaitWithDefaultTimeout()
@@ -141,7 +142,7 @@ var _ = Describe("Podman run", func() {
 	It("podman run --privileged and --security-opt SELinux options", func() {
 		session := podmanTest.Podman([]string{"run", "--privileged", "--security-opt", "label=type:spc_t", "--security-opt", "label=level:s0:c1,c2", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("spc_t"))
 		Expect(session.OutputToString()).To(ContainSubstring("s0:c1,c2"))
 	})
@@ -149,90 +150,90 @@ var _ = Describe("Podman run", func() {
 	It("podman pod container share SELinux labels", func() {
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		podID := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--pod", podID, ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		label1 := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--pod", podID, ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(label1))
 
 		session = podmanTest.Podman([]string{"pod", "rm", "-t", "0", podID, "--force"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman pod container --infra=false doesn't share SELinux labels", func() {
 		session := podmanTest.Podman([]string{"pod", "create", "--infra=false"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		podID := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--pod", podID, ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		label1 := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--pod", podID, ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(Equal(label1)))
 
 		session = podmanTest.Podman([]string{"pod", "rm", "-t", "0", podID, "--force"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman shared IPC NS container share SELinux labels", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		label1 := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--ipc", "container:test1", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(label1))
 	})
 
 	It("podman shared PID NS container share SELinux labels", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		label1 := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--pid", "container:test1", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(label1))
 	})
 
 	It("podman shared NET NS container doesn't share SELinux labels", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		label1 := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--net", "container:test1", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(Equal(label1)))
 	})
 
@@ -240,35 +241,35 @@ var _ = Describe("Podman run", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		session := podmanTest.Podman([]string{"run", "--pid=host", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("spc_t"))
 	})
 
 	It("podman test --ipc=host", func() {
 		session := podmanTest.Podman([]string{"run", "--ipc=host", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("spc_t"))
 	})
 
 	It("podman test --ipc=net", func() {
 		session := podmanTest.Podman([]string{"run", "--net=host", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_t"))
 	})
 
 	It("podman test --ipc=net", func() {
 		session := podmanTest.Podman([]string{"run", "--net=host", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_t"))
 	})
 
 	It("podman test --ipc=net", func() {
 		session := podmanTest.Podman([]string{"run", "--net=host", ALPINE, "cat", "/proc/self/attr/current"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("container_t"))
 	})
 
@@ -283,7 +284,7 @@ var _ = Describe("Podman run", func() {
 		}
 		session := podmanTest.Podman([]string{"create", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{ .ProcessLabel }}", cid})
 		session.WaitWithDefaultTimeout()
@@ -299,7 +300,7 @@ var _ = Describe("Podman run", func() {
 	It("podman test init labels", func() {
 		session := podmanTest.Podman([]string{"create", SYSTEMD_IMAGE, "/sbin/init"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{ .ProcessLabel }}", cid})
 		session.WaitWithDefaultTimeout()
@@ -309,7 +310,7 @@ var _ = Describe("Podman run", func() {
 	It("podman relabels named volume with :Z", func() {
 		session := podmanTest.Podman([]string{"run", "-v", "testvol:/test1/test:Z", fedoraMinimal, "ls", "-alZ", "/test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(":s0:"))
 	})
 })

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 	"golang.org/x/sys/unix"
 )
 
@@ -108,7 +107,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		// Kill with -9 to guarantee the container dies
 		killSession := podmanTest.Podman([]string{"kill", "-s", "9", "test2"})
 		killSession.WaitWithDefaultTimeout()
-		Expect(killSession).Should(Exit(0))
+		Expect(killSession).Should(ExitCleanly())
 
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run with --ip flag", func() {
@@ -40,7 +39,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"run", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(ip + "/16"))
 	})
 
@@ -50,11 +49,11 @@ var _ = Describe("Podman run with --ip flag", func() {
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "fd46:db93:aa76:ac37::/64", netName})
 		net.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
-		Expect(net).To(Exit(0))
+		Expect(net).To(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"run", "--network", netName, "--ip6", ipv6, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(ipv6 + "/64"))
 	})
 
@@ -62,7 +61,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"run", "--network", "bridge:ip=" + ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(ip + "/16"))
 	})
 
@@ -72,7 +71,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		intName := "myeth"
 		result := podmanTest.Podman([]string{"run", "--network", "bridge:ip=" + ip + ",mac=" + mac + ",interface_name=" + intName, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		Expect(result.OutputToString()).To(ContainSubstring(ip + "/16"))
 		Expect(result.OutputToString()).To(ContainSubstring(mac))
 		Expect(result.OutputToString()).To(ContainSubstring(intName))
@@ -82,7 +81,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		ip := GetSafeIPAddress()
 		result := podmanTest.Podman([]string{"run", "-d", "--name", "nginx", "--ip", ip, NGINX_IMAGE})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 
 		// This test should not use a proxy
 		client := &http.Client{

--- a/test/e2e/run_transient_test.go
+++ b/test/e2e/run_transient_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run with volumes", func() {
@@ -27,7 +26,7 @@ var _ = Describe("Podman run with volumes", func() {
 	It("podman run with no transient-store", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		_ = SystemExec("ls", []string{"-l", containerStorageDir})
 
@@ -49,7 +48,7 @@ var _ = Describe("Podman run with volumes", func() {
 	It("podman run --rm with no transient-store", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// All files should not be in permanent store, not volatile
 		Expect(filepath.Join(containerStorageDir, "containers.json")).Should(Not(BeAnExistingFile()))
@@ -70,7 +69,7 @@ var _ = Describe("Podman run with volumes", func() {
 		SkipIfRemote("Can't change store options remotely")
 		session := podmanTest.Podman([]string{"run", "--transient-store", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// All files should be in runroot store, volatile
 		Expect(filepath.Join(containerStorageDir, "containers.json")).Should(Not(BeAnExistingFile()))

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run with volumes", func() {
 		containerDir := strings.SplitN(volume, ":", 3)[1]
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", volume, ALPINE, "awk", fmt.Sprintf(`$5 == "%s" { print }`, containerDir), "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(containerDir), "mount point not found in /proc/self/mountinfo")
 		return strings.Fields(session.OutputToString())
 	}
@@ -66,33 +66,33 @@ var _ = Describe("Podman run with volumes", func() {
 
 		session := podmanTest.Podman([]string{"run", "--rm", "--mount", mount, ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " rw"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",ro", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " ro"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",readonly", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " ro"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",consistency=delegated,shared", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("rw"))
 		Expect(session.OutputToString()).To(ContainSubstring("shared"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=" + dest, ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " rw,nosuid,nodev,relatime - tmpfs"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=/etc/ssl,tmpcopyup", ALPINE, "ls", "/etc/ssl"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("certs"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=/etc/ssl,tmpcopyup,notmpcopyup", ALPINE, "ls", "/etc/ssl"})
@@ -102,7 +102,7 @@ var _ = Describe("Podman run with volumes", func() {
 		// test csv escaping
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount=type=tmpfs,tmpfs-size=512M,\"destination=/test,\"", ALPINE, "ls", "/test,"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=bind,src=/tmp,target=/tmp,tmpcopyup", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
@@ -114,7 +114,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=/etc/ssl,notmpcopyup", ALPINE, "ls", "/etc/ssl"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("certs")))
 	})
 
@@ -140,7 +140,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/data:Z", mountPath), REDIS_IMAGE, "ls", "/data/test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run with mount flag and boolean options", func() {
@@ -151,12 +151,12 @@ var _ = Describe("Podman run with volumes", func() {
 
 		session := podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",ro=false", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " rw"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",ro=true", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " ro"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",ro=true,rw=false", ALPINE, "grep", dest, "/proc/self/mountinfo"})
@@ -167,7 +167,7 @@ var _ = Describe("Podman run with volumes", func() {
 	It("podman run with volume flag and multiple named volumes", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", "testvol1:/testvol1", "-v", "testvol2:/testvol2", ALPINE, "grep", "/testvol", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("/testvol1"))
 		Expect(session.OutputToString()).To(ContainSubstring("/testvol2"))
 	})
@@ -180,7 +180,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", mountPath + ":" + dest + ":suid,dev,exec", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output := session.OutputToString()
 		Expect(output).To(Not(ContainSubstring("noexec")))
 		Expect(output).To(Not(ContainSubstring("nodev")))
@@ -188,7 +188,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--tmpfs", dest + ":suid,dev,exec", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		output = session.OutputToString()
 		Expect(output).To(Not(ContainSubstring("noexec")))
 		Expect(output).To(Not(ContainSubstring("nodev")))
@@ -213,7 +213,7 @@ var _ = Describe("Podman run with volumes", func() {
 		// Container should be able to start with custom overlay volume
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", mountPath + ":/data:O", "--workdir=/data", ALPINE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman support overlay on named volume", func() {
@@ -229,17 +229,17 @@ var _ = Describe("Podman run with volumes", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvolume"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// create file on actual volume
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data", ALPINE, "sh", "-c", "echo hello >> " + "/data/test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// create file on overlay volume
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data:O", ALPINE, "sh", "-c", "echo hello >> " + "/data/overlay"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// volume should contain only `test` not `overlay`
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data", ALPINE, "sh", "-c", "ls /data"})
@@ -275,17 +275,17 @@ var _ = Describe("Podman run with volumes", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvolume"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// create file on actual volume
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data", ALPINE, "sh", "-c", "echo hello >> " + "/data/test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// create file on overlay volume
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data:O," + overlayOpts, ALPINE, "sh", "-c", "echo hello >> " + "/data/overlay"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data:O," + overlayOpts, ALPINE, "sh", "-c", "ls /data"})
 		session.WaitWithDefaultTimeout()
@@ -334,7 +334,7 @@ var _ = Describe("Podman run with volumes", func() {
 		// create file on overlay volume
 		session := podmanTest.Podman([]string{"run", "--volume", bindSource + ":/data:O," + overlayOpts, ALPINE, "sh", "-c", "echo hello >> " + "/data/overlay"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--volume", bindSource + ":/data:O," + overlayOpts, ALPINE, "sh", "-c", "ls /data"})
 		session.WaitWithDefaultTimeout()
@@ -360,7 +360,7 @@ var _ = Describe("Podman run with volumes", func() {
 		volName := "testvol"
 		mkVolume := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=nodev", "testvol"})
 		mkVolume.WaitWithDefaultTimeout()
-		Expect(mkVolume).Should(Exit(0))
+		Expect(mkVolume).Should(ExitCleanly())
 
 		// Volume not mounted on create
 		mountCmd1, err := Start(exec.Command("mount"), GinkgoWriter, GinkgoWriter)
@@ -374,7 +374,7 @@ var _ = Describe("Podman run with volumes", func() {
 		ctrName := "testctr"
 		podmanSession := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "-v", fmt.Sprintf("%s:/testvol", volName), ALPINE, "top"})
 		podmanSession.WaitWithDefaultTimeout()
-		Expect(podmanSession).Should(Exit(0))
+		Expect(podmanSession).Should(ExitCleanly())
 
 		// Volume now mounted as container is running
 		mountCmd2, err := Start(exec.Command("mount"), GinkgoWriter, GinkgoWriter)
@@ -388,12 +388,12 @@ var _ = Describe("Podman run with volumes", func() {
 		// Stop the container to unmount
 		podmanStopSession := podmanTest.Podman([]string{"stop", "--time", "0", ctrName})
 		podmanStopSession.WaitWithDefaultTimeout()
-		Expect(podmanStopSession).Should(Exit(0))
+		Expect(podmanStopSession).Should(ExitCleanly())
 
 		// We have to force cleanup so the unmount happens
 		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", ctrName})
 		podmanCleanupSession.WaitWithDefaultTimeout()
-		Expect(podmanCleanupSession).Should(Exit(0))
+		Expect(podmanCleanupSession).Should(ExitCleanly())
 
 		// Ensure volume is unmounted
 		mountCmd3, err := Start(exec.Command("mount"), GinkgoWriter, GinkgoWriter)
@@ -408,26 +408,26 @@ var _ = Describe("Podman run with volumes", func() {
 	It("podman named volume copyup", func() {
 		baselineSession := podmanTest.Podman([]string{"run", "--rm", ALPINE, "ls", "/etc/apk/"})
 		baselineSession.WaitWithDefaultTimeout()
-		Expect(baselineSession).Should(Exit(0))
+		Expect(baselineSession).Should(ExitCleanly())
 		baselineOutput := baselineSession.OutputToString()
 
 		inlineVolumeSession := podmanTest.Podman([]string{"run", "--rm", "-v", "testvol1:/etc/apk", ALPINE, "ls", "/etc/apk/"})
 		inlineVolumeSession.WaitWithDefaultTimeout()
-		Expect(inlineVolumeSession).Should(Exit(0))
+		Expect(inlineVolumeSession).Should(ExitCleanly())
 		Expect(inlineVolumeSession.OutputToString()).To(Equal(baselineOutput))
 
 		makeVolumeSession := podmanTest.Podman([]string{"volume", "create", "testvol2"})
 		makeVolumeSession.WaitWithDefaultTimeout()
-		Expect(makeVolumeSession).Should(Exit(0))
+		Expect(makeVolumeSession).Should(ExitCleanly())
 
 		separateVolumeSession := podmanTest.Podman([]string{"run", "--rm", "-v", "testvol2:/etc/apk", ALPINE, "ls", "/etc/apk/"})
 		separateVolumeSession.WaitWithDefaultTimeout()
-		Expect(separateVolumeSession).Should(Exit(0))
+		Expect(separateVolumeSession).Should(ExitCleanly())
 		Expect(separateVolumeSession.OutputToString()).To(Equal(baselineOutput))
 
 		copySession := podmanTest.Podman([]string{"run", "--rm", "-v", "testvol3:/etc/apk:copy", ALPINE, "stat", "-c", "%h", "/etc/apk/arch"})
 		copySession.WaitWithDefaultTimeout()
-		Expect(copySession).Should(Exit(0))
+		Expect(copySession).Should(ExitCleanly())
 
 		noCopySession := podmanTest.Podman([]string{"run", "--rm", "-v", "testvol4:/etc/apk:nocopy", ALPINE, "stat", "-c", "%h", "/etc/apk/arch"})
 		noCopySession.WaitWithDefaultTimeout()
@@ -443,62 +443,62 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 
 		baselineSession := podmanTest.Podman([]string{"run", "--rm", imgName, "ls", "/etc/apk/"})
 		baselineSession.WaitWithDefaultTimeout()
-		Expect(baselineSession).Should(Exit(0))
+		Expect(baselineSession).Should(ExitCleanly())
 		baselineOutput := baselineSession.OutputToString()
 
 		outputSession := podmanTest.Podman([]string{"run", "-v", "/etc/apk/", imgName, "ls", "/etc/apk/"})
 		outputSession.WaitWithDefaultTimeout()
-		Expect(outputSession).Should(Exit(0))
+		Expect(outputSession).Should(ExitCleanly())
 		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
 	})
 
 	It("podman named volume copyup empty directory", func() {
 		baselineSession := podmanTest.Podman([]string{"run", "--rm", ALPINE, "ls", "/srv"})
 		baselineSession.WaitWithDefaultTimeout()
-		Expect(baselineSession).Should(Exit(0))
+		Expect(baselineSession).Should(ExitCleanly())
 		baselineOutput := baselineSession.OutputToString()
 
 		outputSession := podmanTest.Podman([]string{"run", "-v", "/srv", ALPINE, "ls", "/srv"})
 		outputSession.WaitWithDefaultTimeout()
-		Expect(outputSession).Should(Exit(0))
+		Expect(outputSession).Should(ExitCleanly())
 		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
 	})
 
 	It("podman named volume copyup of /var", func() {
 		baselineSession := podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "ls", "/var"})
 		baselineSession.WaitWithDefaultTimeout()
-		Expect(baselineSession).Should(Exit(0))
+		Expect(baselineSession).Should(ExitCleanly())
 		baselineOutput := baselineSession.OutputToString()
 
 		outputSession := podmanTest.Podman([]string{"run", "-v", "/var", fedoraMinimal, "ls", "/var"})
 		outputSession.WaitWithDefaultTimeout()
-		Expect(outputSession).Should(Exit(0))
+		Expect(outputSession).Should(ExitCleanly())
 		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
 	})
 
 	It("podman read-only tmpfs conflict with volume", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--read-only", "-v", "tmp_volume:" + dest, ALPINE, "touch", dest + "/a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"run", "--rm", "--read-only", "--tmpfs", dest, ALPINE, "touch", dest + "/a"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 	})
 
 	It("podman run with anonymous volume", func() {
 		list1 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list1.WaitWithDefaultTimeout()
-		Expect(list1).Should(Exit(0))
+		Expect(list1).Should(ExitCleanly())
 		Expect(list1.OutputToString()).To(Equal(""))
 
 		session := podmanTest.Podman([]string{"create", "-v", "/test", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		list2 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list2.WaitWithDefaultTimeout()
-		Expect(list2).Should(Exit(0))
+		Expect(list2).Should(ExitCleanly())
 		arr := list2.OutputToStringArray()
 		Expect(arr).To(HaveLen(1))
 		Expect(arr[0]).To(Not(Equal("")))
@@ -507,57 +507,57 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 	It("podman rm -v removes anonymous volume", func() {
 		list1 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list1.WaitWithDefaultTimeout()
-		Expect(list1).Should(Exit(0))
+		Expect(list1).Should(ExitCleanly())
 		Expect(list1.OutputToString()).To(Equal(""))
 
 		ctrName := "testctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, "-v", "/test", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		list2 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list2.WaitWithDefaultTimeout()
-		Expect(list2).Should(Exit(0))
+		Expect(list2).Should(ExitCleanly())
 		arr := list2.OutputToStringArray()
 		Expect(arr).To(HaveLen(1))
 		Expect(arr[0]).To(Not(Equal("")))
 
 		remove := podmanTest.Podman([]string{"rm", "-v", ctrName})
 		remove.WaitWithDefaultTimeout()
-		Expect(remove).Should(Exit(0))
+		Expect(remove).Should(ExitCleanly())
 
 		list3 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list3.WaitWithDefaultTimeout()
-		Expect(list3).Should(Exit(0))
+		Expect(list3).Should(ExitCleanly())
 		Expect(list3.OutputToString()).To(Equal(""))
 	})
 
 	It("podman rm -v retains named volume", func() {
 		list1 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list1.WaitWithDefaultTimeout()
-		Expect(list1).Should(Exit(0))
+		Expect(list1).Should(ExitCleanly())
 		Expect(list1.OutputToString()).To(Equal(""))
 
 		ctrName := "testctr"
 		volName := "testvol"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, "-v", fmt.Sprintf("%s:/test", volName), ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		list2 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list2.WaitWithDefaultTimeout()
-		Expect(list2).Should(Exit(0))
+		Expect(list2).Should(ExitCleanly())
 		arr := list2.OutputToStringArray()
 		Expect(arr).To(HaveLen(1))
 		Expect(arr[0]).To(Equal(volName))
 
 		remove := podmanTest.Podman([]string{"rm", "-v", ctrName})
 		remove.WaitWithDefaultTimeout()
-		Expect(remove).Should(Exit(0))
+		Expect(remove).Should(ExitCleanly())
 
 		list3 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list3.WaitWithDefaultTimeout()
-		Expect(list3).Should(Exit(0))
+		Expect(list3).Should(ExitCleanly())
 		arr2 := list3.OutputToStringArray()
 		Expect(arr2).To(HaveLen(1))
 		Expect(arr2[0]).To(Equal(volName))
@@ -566,7 +566,7 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 	It("podman run image volume is not noexec", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", REDIS_IMAGE, "grep", "/data", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))
 	})
 
@@ -574,7 +574,7 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=invalid", volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		volMount := podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/tmp", volName), ALPINE, "ls"})
 		volMount.WaitWithDefaultTimeout()
@@ -585,11 +585,11 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		volPath := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{.Mountpoint}}", volName})
 		volPath.WaitWithDefaultTimeout()
-		Expect(volPath).Should(Exit(0))
+		Expect(volPath).Should(ExitCleanly())
 		path := volPath.OutputToString()
 
 		fileName := "thisIsATestFile"
@@ -599,7 +599,7 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 
 		runLs := podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%v:/etc/ssl", volName), ALPINE, "ls", "-1", "/etc/ssl"})
 		runLs.WaitWithDefaultTimeout()
-		Expect(runLs).Should(Exit(0))
+		Expect(runLs).Should(ExitCleanly())
 		outputArr := runLs.OutputToStringArray()
 		Expect(outputArr).To(HaveLen(1))
 		Expect(outputArr[0]).To(ContainSubstring(fileName))
@@ -614,7 +614,7 @@ VOLUME /test/`, ALPINE)
 		ctrName := "testCtr"
 		create := podmanTest.Podman([]string{"create", "-v", "/tmp:/test", "--name", ctrName, image, "ls"})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		data := podmanTest.InspectContainer(ctrName)
 		Expect(data).To(HaveLen(1))
@@ -648,39 +648,39 @@ VOLUME /test/`, ALPINE)
 		// Make sure host files show up in the container
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", volumeFlag, ALPINE, "ls", "/run/test/test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", ".:/app:O", ALPINE, "ls", "/app"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(ContainSubstring(filepath.Base(CurrentSpecReport().FileName())))
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// Make sure modifications in container do not show up on host
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", volumeFlag, ALPINE, "touch", "/run/test/container"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		_, err = os.Stat(filepath.Join(mountPath, "container"))
 		Expect(err).To(HaveOccurred())
 
 		// Make sure modifications in container disappear when container is stopped
 		session = podmanTest.Podman([]string{"create", "-v", fmt.Sprintf("%s:/run/test:O", mountPath), ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"start", "-l"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"exec", "-l", "touch", "/run/test/container"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"exec", "-l", "ls", "/run/test/container"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"stop", "-l"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"start", "-l"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"exec", "-l", "ls", "/run/test/container"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
@@ -702,7 +702,7 @@ VOLUME /test/`, ALPINE)
 
 		session := podmanTest.Podman([]string{"volume", "create", volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// overlay and named volume destinations conflict
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:%s:O", mountPath, mountDest), "-v", fmt.Sprintf("%s:%s", volName, mountDest), ALPINE})
@@ -722,7 +722,7 @@ VOLUME /test/`, ALPINE)
 		volName := "testVol1"
 		session := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/test1", volName), "-v", fmt.Sprintf("%s:/test2", volName), "--rm", ALPINE, "sh", "-c", "mount | grep /test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
@@ -760,18 +760,18 @@ VOLUME /test/`, ALPINE)
 
 		session := podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "-v", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("888:888"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--userns", "auto", "-v", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("888:888"))
 
 		vol += ",O"
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--userns", "keep-id", "-v", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("888:888"))
 	})
 
@@ -800,7 +800,7 @@ VOLUME /test/`, ALPINE)
 		vol := "type=bind,src=" + mountPath + ",dst=" + dest + ",U=false"
 		session := podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--mount", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).ShouldNot(Equal("888:888"))
 
 		// invalid bind mount
@@ -813,32 +813,32 @@ VOLUME /test/`, ALPINE)
 		vol = "type=bind,src=" + mountPath + ",dst=" + dest + ",U=true"
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--mount", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("888:888"))
 
 		// tmpfs mount
 		vol = "type=tmpfs," + "dst=" + dest + ",chown"
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--mount", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("888:888"))
 
 		// anonymous volume mount
 		vol = "type=volume," + "dst=" + dest
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--mount", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("888:888"))
 
 		// named volume mount
 		namedVolume := podmanTest.Podman([]string{"volume", "create", "foo"})
 		namedVolume.WaitWithDefaultTimeout()
-		Expect(namedVolume).Should(Exit(0))
+		Expect(namedVolume).Should(ExitCleanly())
 
 		vol = "type=volume,src=foo,dst=" + dest + ",chown=true"
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--mount", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("888:888"))
 	})
 
@@ -847,11 +847,11 @@ VOLUME /test/`, ALPINE)
 		vol := "type=volume,source=test_vol,dst=/test,volume-opt=type=tmpfs,volume-opt=device=tmpfs,volume-opt=o=nodev"
 		session := podmanTest.Podman([]string{"run", "--rm", "--mount", vol, ALPINE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspectVol := podmanTest.Podman([]string{"volume", "inspect", "test_vol"})
 		inspectVol.WaitWithDefaultTimeout()
-		Expect(inspectVol).Should(Exit(0))
+		Expect(inspectVol).Should(ExitCleanly())
 		Expect(inspectVol.OutputToString()).To(ContainSubstring("nodev"))
 	})
 
@@ -866,17 +866,17 @@ USER testuser`, fedoraMinimal)
 
 		test1 := podmanTest.Podman([]string{"run", "-v", "testvol1:/test", imgName, "bash", "-c", "ls -al /test | grep -v root | grep -v total"})
 		test1.WaitWithDefaultTimeout()
-		Expect(test1).Should(Exit(0))
+		Expect(test1).Should(ExitCleanly())
 		Expect(test1.OutputToString()).To(ContainSubstring(testString))
 
 		volName := "testvol2"
 		vol := podmanTest.Podman([]string{"volume", "create", volName})
 		vol.WaitWithDefaultTimeout()
-		Expect(vol).Should(Exit(0))
+		Expect(vol).Should(ExitCleanly())
 
 		test2 := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/test", volName), imgName, "bash", "-c", "ls -al /test | grep -v root | grep -v total"})
 		test2.WaitWithDefaultTimeout()
-		Expect(test2).Should(Exit(0))
+		Expect(test2).Should(ExitCleanly())
 		Expect(test2.OutputToString()).To(ContainSubstring(testString))
 
 	})
@@ -884,12 +884,12 @@ USER testuser`, fedoraMinimal)
 	It("podman run with named volume check if we honor permission of target dir", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "stat", "-c", "%a %Y", "/var/tmp"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		perms := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", "test:/var/tmp", ALPINE, "stat", "-c", "%a %Y", "/var/tmp"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(perms))
 	})
 
@@ -900,7 +900,7 @@ USER testuser`, fedoraMinimal)
 
 		session := podmanTest.Podman([]string{"run", "-v", mountSrc + ":/run", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// the file should not have been created
 		_, err = os.Stat(filepath.Join(mountSrc, ".containerenv"))
@@ -911,31 +911,31 @@ USER testuser`, fedoraMinimal)
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--opt", "o=uid=1000", volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		volMount := podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/test", volName), ALPINE, "stat", "-c", "%u", "/test"})
 		volMount.WaitWithDefaultTimeout()
-		Expect(volMount).Should(Exit(0))
+		Expect(volMount).Should(ExitCleanly())
 		Expect(volMount.OutputToString()).To(Equal("1000"))
 
 		volName = "testVol2"
 		volCreate = podmanTest.Podman([]string{"volume", "create", "--opt", "o=gid=1000", volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		volMount = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/test", volName), ALPINE, "stat", "-c", "%g", "/test"})
 		volMount.WaitWithDefaultTimeout()
-		Expect(volMount).Should(Exit(0))
+		Expect(volMount).Should(ExitCleanly())
 		Expect(volMount.OutputToString()).To(Equal("1000"))
 
 		volName = "testVol3"
 		volCreate = podmanTest.Podman([]string{"volume", "create", "--opt", "o=uid=1000,gid=1000", volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		volMount = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/test", volName), ALPINE, "stat", "-c", "%u:%g", "/test"})
 		volMount.WaitWithDefaultTimeout()
-		Expect(volMount).Should(Exit(0))
+		Expect(volMount).Should(ExitCleanly())
 		Expect(volMount.OutputToString()).To(Equal("1000:1000"))
 	})
 
@@ -963,7 +963,7 @@ USER testuser`, fedoraMinimal)
 
 		run := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "./:" + dest, ALPINE, "ls", dest})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).Should(ContainSubstring(strings.TrimLeft("/vol/", f.Name())))
 	})
 })

--- a/test/e2e/run_working_dir_test.go
+++ b/test/e2e/run_working_dir_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -15,7 +16,7 @@ var _ = Describe("Podman run", func() {
 	It("podman run a container without workdir", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/"))
 	})
 
@@ -32,7 +33,7 @@ var _ = Describe("Podman run", func() {
 
 		session := podmanTest.Podman([]string{"run", "--volume", fmt.Sprintf("%s:/var_ovl/:O", volume), "--workdir", "/var_ovl/log", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman run a container on an image with a workdir", func() {
@@ -43,7 +44,7 @@ WORKDIR  /etc/foobar`, ALPINE)
 
 		session := podmanTest.Podman([]string{"run", "test", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/etc/foobar"))
 
 		session = podmanTest.Podman([]string{"run", "test", "ls", "-ld", "."})
@@ -52,7 +53,7 @@ WORKDIR  /etc/foobar`, ALPINE)
 
 		session = podmanTest.Podman([]string{"run", "--workdir", "/home/foobar", "test", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/home/foobar"))
 	})
 })

--- a/test/e2e/system_dial_stdio_test.go
+++ b/test/e2e/system_dial_stdio_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -11,7 +12,7 @@ var _ = Describe("podman system dial-stdio", func() {
 	It("podman system dial-stdio help", func() {
 		session := podmanTest.Podman([]string{"system", "dial-stdio", "--help"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("Examples: podman system dial-stdio"))
 	})
 

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -1,9 +1,9 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // system reset must run serial: https://github.com/containers/podman/issues/17903
@@ -16,51 +16,51 @@ var _ = Describe("podman system reset", Serial, func() {
 
 		session := podmanTest.Podman([]string{"rmi", "--force", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"images", "-n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		l := len(session.OutputToStringArray())
 
 		podmanTest.AddImageToRWStore(ALPINE)
 		session = podmanTest.Podman([]string{"volume", "create", "data"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", "data:/data", ALPINE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"network", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"system", "reset", "-f"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		Expect(session.ErrorToString()).To(Not(ContainSubstring("Failed to add pause process")))
 		Expect(session.ErrorToString()).To(Not(ContainSubstring("/usr/share/containers/storage.conf")))
 
 		session = podmanTest.Podman([]string{"images", "-n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(l))
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 
 		session = podmanTest.Podman([]string{"container", "ls", "-q"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 
 		session = podmanTest.Podman([]string{"network", "ls", "-q"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		// default network should exists
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 
@@ -70,7 +70,7 @@ var _ = Describe("podman system reset", Serial, func() {
 		if isRootless() {
 			session = podmanTest.Podman([]string{"machine", "list", "-q"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToStringArray()).To(BeEmpty())
 		}
 	})

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // Without Ordered, tests flake with "Getting key identity" (#18358)
@@ -21,7 +20,7 @@ var _ = Describe("Podman trust", Ordered, func() {
 	It("podman image trust show", func() {
 		session := podmanTest.Podman([]string{"image", "trust", "show", "-n", "--registrypath", filepath.Join(INTEGRATION_ROOT, "test"), "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json")})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		outArray := session.OutputToStringArray()
 		Expect(outArray).To(HaveLen(3))
 
@@ -36,7 +35,7 @@ var _ = Describe("Podman trust", Ordered, func() {
 		policyJSON := filepath.Join(podmanTest.TempDir, "trust_set_test.json")
 		session := podmanTest.Podman([]string{"image", "trust", "set", "--policypath", policyJSON, "-t", "accept", "default"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		var teststruct map[string][]map[string]string
 		policyContent, err := os.ReadFile(policyJSON)
 		if err != nil {
@@ -52,7 +51,7 @@ var _ = Describe("Podman trust", Ordered, func() {
 	It("podman image trust show --json", func() {
 		session := podmanTest.Podman([]string{"image", "trust", "show", "--registrypath", filepath.Join(INTEGRATION_ROOT, "test"), "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json"), "--json"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 		var teststruct []map[string]string
 		err = json.Unmarshal(session.Out.Contents(), &teststruct)
@@ -91,7 +90,7 @@ var _ = Describe("Podman trust", Ordered, func() {
 	It("podman image trust show --raw", func() {
 		session := podmanTest.Podman([]string{"image", "trust", "show", "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json"), "--raw"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		contents, err := os.ReadFile(filepath.Join(INTEGRATION_ROOT, "test/policy.json"))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(session.OutputToString()).To(BeValidJSON())

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -13,7 +14,7 @@ import (
 func cleanupRootlessSlirp4netns(p *PodmanTestIntegration) {
 	session := p.Podman([]string{"run", "--network", "bridge", ALPINE, "true"})
 	session.WaitWithDefaultTimeout()
-	Expect(session).Should(Exit(0))
+	Expect(session).Should(ExitCleanly())
 }
 
 var _ = Describe("Podman unshare", func() {
@@ -32,7 +33,7 @@ var _ = Describe("Podman unshare", func() {
 		userNS, _ := os.Readlink("/proc/self/ns/user")
 		session := podmanTest.Podman([]string{"unshare", "readlink", "/proc/self/ns/user"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).ToNot(ContainSubstring(userNS))
 	})
 
@@ -41,7 +42,7 @@ var _ = Describe("Podman unshare", func() {
 		defer cleanupRootlessSlirp4netns(podmanTest)
 		session := podmanTest.Podman([]string{"unshare", "--rootless-netns", "ip", "addr"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("tap0"))
 	})
 

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -2,9 +2,9 @@ package integration
 
 import (
 	"github.com/containers/common/pkg/cgroupv2"
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman update", func() {
@@ -14,7 +14,7 @@ var _ = Describe("Podman update", func() {
 		SkipIfRootless("many of these handlers are not enabled while rootless in CI")
 		session := podmanTest.Podman([]string{"run", "-dt", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID := session.OutputToString()
 
@@ -32,48 +32,48 @@ var _ = Describe("Podman update", func() {
 
 		session = podmanTest.Podman(commonArgs)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// checking cpu quota from --cpus
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("500000"))
 
 		// checking cpuset-cpus
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpuset/cpuset.cpus"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("0"))
 
 		// checking cpuset-mems
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpuset/cpuset.mems"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("0"))
 
 		// checking memory limit
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/memory/memory.limit_in_bytes"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("1073741824"))
 
 		// checking memory-swap
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("2147483648"))
 
 		// checking cpu-shares
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpu/cpu.shares"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 
 		// checking pids-limit
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/pids/pids.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 
 	})
@@ -83,7 +83,7 @@ var _ = Describe("Podman update", func() {
 		SkipIfRootless("many of these handlers are not enabled while rootless in CI")
 		session := podmanTest.Podman([]string{"run", "-dt", "--pids-limit", "-1", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID := session.OutputToString()
 
@@ -94,14 +94,14 @@ var _ = Describe("Podman update", func() {
 
 		session = podmanTest.Podman(commonArgs)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID = session.OutputToString()
 
 		// checking pids-limit was not changed after update when not specified as an option
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/pids.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("max"))
 	})
 
@@ -110,7 +110,7 @@ var _ = Describe("Podman update", func() {
 		SkipIfRootless("many of these handlers are not enabled while rootless in CI")
 		session := podmanTest.Podman([]string{"run", "-dt", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID := session.OutputToString()
 
@@ -133,62 +133,62 @@ var _ = Describe("Podman update", func() {
 
 		session = podmanTest.Podman(commonArgs)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID = session.OutputToString()
 
 		// checking cpu quota and period
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpu.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("500000"))
 
 		// checking blkio weight
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/io.bfq.weight"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 
 		// checking device-read/write-bps/iops
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/io.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("rbps=10485760 wbps=10485760 riops=1000 wiops=1000"))
 
 		// checking cpuset-cpus
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpuset.cpus"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("0"))
 
 		// checking cpuset-mems
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpuset.mems"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("0"))
 
 		// checking memory limit
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/memory.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("1073741824"))
 
 		// checking memory-swap
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/memory.swap.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("1073741824"))
 
 		// checking cpu-shares
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpu.weight"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("5"))
 
 		// checking pids-limit
 		session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/pids.max"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 	})
 
@@ -196,7 +196,7 @@ var _ = Describe("Podman update", func() {
 		SkipIfRootless("many of these handlers are not enabled while rootless in CI")
 		session := podmanTest.Podman([]string{"run", "-dt", "--cpus", "5", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{
 			"update",
@@ -205,7 +205,7 @@ var _ = Describe("Podman update", func() {
 		})
 
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrID := session.OutputToString()
 
@@ -215,7 +215,7 @@ var _ = Describe("Podman update", func() {
 			session = podmanTest.Podman([]string{"exec", ctrID, "cat", "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"})
 		}
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(ContainSubstring("500000"))
 	})
 })

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Podman volume create", func() {
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		check := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		check.WaitWithDefaultTimeout()
@@ -32,7 +32,7 @@ var _ = Describe("Podman volume create", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		check := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		check.WaitWithDefaultTimeout()
@@ -43,7 +43,7 @@ var _ = Describe("Podman volume create", func() {
 	It("podman create volume with existing name fails", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
@@ -54,11 +54,11 @@ var _ = Describe("Podman volume create", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "--ignore", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(volName))
 	})
 
@@ -70,19 +70,19 @@ var _ = Describe("Podman volume create", func() {
 		volName := "my_vol_" + RandomString(10)
 		session := podmanTest.Podman([]string{"volume", "create", volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(volName))
 
 		helloString := "hello-" + RandomString(20)
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data", ALPINE, "sh", "-c", "echo " + helloString + " >> /data/test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// export to tar file...
 		helloTar := filepath.Join(podmanTest.TempDir, "hello.tar")
 		check := podmanTest.Podman([]string{"volume", "export", "-o", helloTar, volName})
 		check.WaitWithDefaultTimeout()
-		Expect(check).Should(Exit(0))
+		Expect(check).Should(ExitCleanly())
 
 		// ...then confirm that tar file has our desired content.
 		// These flags emit filename to stderr (-v), contents to stdout
@@ -101,25 +101,25 @@ var _ = Describe("Podman volume create", func() {
 		volName := "my_vol_" + RandomString(10)
 		session := podmanTest.Podman([]string{"volume", "create", volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(volName))
 
 		session = podmanTest.Podman([]string{"run", "--volume", volName + ":/data", ALPINE, "sh", "-c", "echo hello >> /data/test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		helloTar := filepath.Join(podmanTest.TempDir, "hello.tar")
 		session = podmanTest.Podman([]string{"volume", "export", volName, "--output", helloTar})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "my_vol2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "import", "my_vol2", helloTar})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(""), "output of volume import")
 
 		session = podmanTest.Podman([]string{"run", "--volume", "my_vol2:/data", ALPINE, "cat", "/data/test"})
@@ -159,16 +159,16 @@ var _ = Describe("Podman volume create", func() {
 		gid := "4000"
 		session := podmanTest.Podman([]string{"volume", "create", "--opt", fmt.Sprintf("o=uid=%s,gid=%s", uid, gid), volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspectUID := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .UID }}", volName})
 		inspectUID.WaitWithDefaultTimeout()
-		Expect(inspectUID).Should(Exit(0))
+		Expect(inspectUID).Should(ExitCleanly())
 		Expect(inspectUID.OutputToString()).To(Equal(uid))
 
 		inspectGID := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .GID }}", volName})
 		inspectGID.WaitWithDefaultTimeout()
-		Expect(inspectGID).Should(Exit(0))
+		Expect(inspectGID).Should(ExitCleanly())
 		Expect(inspectGID.OutputToString()).To(Equal(gid))
 
 		// options should contain `uid=3000,gid=4000:3000:4000`
@@ -176,7 +176,7 @@ var _ = Describe("Podman volume create", func() {
 		optionStrFormatExpect := fmt.Sprintf(`uid=%s,gid=%s:%s:%s`, uid, gid, uid, gid)
 		inspectOpts := podmanTest.Podman([]string{"volume", "inspect", "--format", optionFormat, volName})
 		inspectOpts.WaitWithDefaultTimeout()
-		Expect(inspectOpts).Should(Exit(0))
+		Expect(inspectOpts).Should(ExitCleanly())
 		Expect(inspectOpts.OutputToString()).To(Equal(optionStrFormatExpect))
 	})
 
@@ -185,25 +185,25 @@ var _ = Describe("Podman volume create", func() {
 		volName := "testvol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--driver", "image", "--opt", fmt.Sprintf("image=%s", fedoraMinimal), volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		runCmd := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/test", volName), ALPINE, "cat", "/test/etc/redhat-release"})
 		runCmd.WaitWithDefaultTimeout()
-		Expect(runCmd).Should(Exit(0))
+		Expect(runCmd).Should(ExitCleanly())
 		Expect(runCmd.OutputToString()).To(ContainSubstring("Fedora"))
 
 		rmCmd := podmanTest.Podman([]string{"rmi", "--force", fedoraMinimal})
 		rmCmd.WaitWithDefaultTimeout()
-		Expect(rmCmd).Should(Exit(0))
+		Expect(rmCmd).Should(ExitCleanly())
 
 		psCmd := podmanTest.Podman([]string{"ps", "-aq"})
 		psCmd.WaitWithDefaultTimeout()
-		Expect(psCmd).Should(Exit(0))
+		Expect(psCmd).Should(ExitCleanly())
 		Expect(psCmd.OutputToString()).To(BeEmpty())
 
 		volumesCmd := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		volumesCmd.WaitWithDefaultTimeout()
-		Expect(volumesCmd).Should(Exit(0))
+		Expect(volumesCmd).Should(ExitCleanly())
 		Expect(volumesCmd.OutputToString()).To(Not(ContainSubstring(volName)))
 	})
 
@@ -212,25 +212,25 @@ var _ = Describe("Podman volume create", func() {
 		volName := "testvol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--driver", "image", "--opt", fmt.Sprintf("image=%s", fedoraMinimal), volName})
 		volCreate.WaitWithDefaultTimeout()
-		Expect(volCreate).Should(Exit(0))
+		Expect(volCreate).Should(ExitCleanly())
 
 		runCmd := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/test", volName), ALPINE, "cat", "/test/etc/redhat-release"})
 		runCmd.WaitWithDefaultTimeout()
-		Expect(runCmd).Should(Exit(0))
+		Expect(runCmd).Should(ExitCleanly())
 		Expect(runCmd.OutputToString()).To(ContainSubstring("Fedora"))
 
 		rmCmd := podmanTest.Podman([]string{"volume", "rm", "--force", volName})
 		rmCmd.WaitWithDefaultTimeout()
-		Expect(rmCmd).Should(Exit(0))
+		Expect(rmCmd).Should(ExitCleanly())
 
 		psCmd := podmanTest.Podman([]string{"ps", "-aq"})
 		psCmd.WaitWithDefaultTimeout()
-		Expect(psCmd).Should(Exit(0))
+		Expect(psCmd).Should(ExitCleanly())
 		Expect(psCmd.OutputToString()).To(BeEmpty())
 
 		volumesCmd := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		volumesCmd.WaitWithDefaultTimeout()
-		Expect(volumesCmd).Should(Exit(0))
+		Expect(volumesCmd).Should(ExitCleanly())
 		Expect(volumesCmd.OutputToString()).To(Not(ContainSubstring(volName)))
 	})
 })

--- a/test/e2e/volume_exists_test.go
+++ b/test/e2e/volume_exists_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,11 +18,11 @@ var _ = Describe("Podman volume exists", func() {
 		vol := "vol" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"volume", "create", vol})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "exists", vol})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/volume_inspect_test.go
+++ b/test/e2e/volume_inspect_test.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman volume inspect", func() {
@@ -18,11 +17,11 @@ var _ = Describe("Podman volume inspect", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "inspect", volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 	})
 
@@ -30,11 +29,11 @@ var _ = Describe("Podman volume inspect", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
 		volName := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "inspect", "--format", "{{.Name}}", volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal(volName))
 	})
 
@@ -42,16 +41,16 @@ var _ = Describe("Podman volume inspect", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol1"})
 		session.WaitWithDefaultTimeout()
 		volName1 := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "myvol2"})
 		session.WaitWithDefaultTimeout()
 		volName2 := session.OutputToString()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "inspect", "--format", "{{.Name}}", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToStringArray()[0]).To(Equal(volName1))
 		Expect(session.OutputToStringArray()[1]).To(Equal(volName2))
@@ -61,11 +60,11 @@ var _ = Describe("Podman volume inspect", func() {
 		volName := "testvol"
 		session := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", volName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"volume", "inspect", volName})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(ContainSubstring(define.TypeTmpfs))
 	})
 })

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman volume ls", func() {
@@ -18,56 +17,56 @@ var _ = Describe("Podman volume ls", func() {
 	It("podman ls volume", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
 	It("podman ls volume filter with comma label", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "test=with,comma", "myvol3"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=test=with,comma"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
 	It("podman ls volume filter with a key pattern", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "helloworld=world", "myvol2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=hello*"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
 	It("podman ls volume with JSON format", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--format", "json"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
 	})
 
 	It("podman ls volume with Go template", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--format", "table {{.Name}} {{.Driver}} {{.Scope}}"})
 		session.WaitWithDefaultTimeout()
 
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		arr := session.OutputToStringArray()
 		Expect(arr).To(HaveLen(2))
 		Expect(arr[0]).To(ContainSubstring("NAME"))
@@ -78,48 +77,48 @@ var _ = Describe("Podman volume ls", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "foo=bar", "myvol"})
 		volName := session.OutputToString()
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=bar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=baz"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
 	It("podman ls volume with --filter until flag", func() {
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "until=5000000000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "until=50000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -127,25 +126,25 @@ var _ = Describe("Podman volume ls", func() {
 		volName1 := "volume1"
 		session := podmanTest.Podman([]string{"volume", "create", volName1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		volName2 := "volume2"
 		session2 := podmanTest.Podman([]string{"volume", "create", volName2})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 
 		ctr := podmanTest.Podman([]string{"create", "-v", fmt.Sprintf("%s:/test", volName2), ALPINE, "sh"})
 		ctr.WaitWithDefaultTimeout()
-		Expect(ctr).Should(Exit(0))
+		Expect(ctr).Should(ExitCleanly())
 
 		lsNoDangling := podmanTest.Podman([]string{"volume", "ls", "--filter", "dangling=false", "--quiet"})
 		lsNoDangling.WaitWithDefaultTimeout()
-		Expect(lsNoDangling).Should(Exit(0))
+		Expect(lsNoDangling).Should(ExitCleanly())
 		Expect(lsNoDangling.OutputToString()).To(ContainSubstring(volName2))
 
 		lsDangling := podmanTest.Podman([]string{"volume", "ls", "--filter", "dangling=true", "--quiet"})
 		lsDangling.WaitWithDefaultTimeout()
-		Expect(lsDangling).Should(Exit(0))
+		Expect(lsDangling).Should(ExitCleanly())
 		Expect(lsDangling.OutputToString()).To(ContainSubstring(volName1))
 	})
 
@@ -153,28 +152,28 @@ var _ = Describe("Podman volume ls", func() {
 		volName1 := "volume1"
 		session := podmanTest.Podman([]string{"volume", "create", volName1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		volName2 := "volume2"
 		session2 := podmanTest.Podman([]string{"volume", "create", volName2})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "name=volume1*"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(3))
 		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName1))
 		Expect(session.OutputToStringArray()[2]).To(ContainSubstring(volName2))
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "name=volumex"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "name=volume1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName1))
 	})
@@ -182,32 +181,32 @@ var _ = Describe("Podman volume ls", func() {
 	It("podman ls volume with multiple --filter flag", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "a=b", "--label", "b=c", "vol1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		vol1Name := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"volume", "create", "--label", "b=c", "--label", "a=b", "vol2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		vol2Name := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"volume", "create", "--label", "b=c", "--label", "c=d", "vol3"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		vol3Name := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=a=b", "--filter", "label=b=c"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol1Name))
 		Expect(session.OutputToStringArray()[1]).To(Equal(vol2Name))
 
 		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=c=d", "--filter", "label=b=c"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol3Name))
 	})
@@ -219,15 +218,15 @@ var _ = Describe("Podman volume ls", func() {
 
 		session := podmanTest.Podman([]string{"volume", "create", vol1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", vol2})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", vol3})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "since=" + vol1})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman volume plugins", func() {
@@ -49,7 +48,7 @@ var _ = Describe("Podman volume plugins", func() {
 		pluginName := "image"
 		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// Make sure the socket is available (see #17956)
 		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
@@ -58,11 +57,11 @@ var _ = Describe("Podman volume plugins", func() {
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		ls1 := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		ls1.WaitWithDefaultTimeout()
-		Expect(ls1).Should(Exit(0))
+		Expect(ls1).Should(ExitCleanly())
 		arrOutput := ls1.OutputToStringArray()
 		Expect(arrOutput).To(HaveLen(1))
 		Expect(arrOutput[0]).To(ContainSubstring(volName))
@@ -70,16 +69,16 @@ var _ = Describe("Podman volume plugins", func() {
 		// Verify this is not an image volume.
 		inspect := podmanTest.Podman([]string{"volume", "inspect", volName, "--format", "{{.StorageID}}"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(BeEmpty())
 
 		remove := podmanTest.Podman([]string{"volume", "rm", volName})
 		remove.WaitWithDefaultTimeout()
-		Expect(remove).Should(Exit(0))
+		Expect(remove).Should(ExitCleanly())
 
 		ls2 := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		ls2.WaitWithDefaultTimeout()
-		Expect(ls2).Should(Exit(0))
+		Expect(ls2).Should(ExitCleanly())
 		Expect(ls2.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -94,7 +93,7 @@ var _ = Describe("Podman volume plugins", func() {
 		pluginName := "testvol2"
 		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// Make sure the socket is available (see #17956)
 		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
@@ -103,11 +102,11 @@ var _ = Describe("Podman volume plugins", func() {
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		volInspect := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .Driver }}", volName})
 		volInspect.WaitWithDefaultTimeout()
-		Expect(volInspect).Should(Exit(0))
+		Expect(volInspect).Should(ExitCleanly())
 		Expect(volInspect.OutputToString()).To(ContainSubstring(pluginName))
 	})
 
@@ -123,7 +122,7 @@ var _ = Describe("Podman volume plugins", func() {
 		ctrName := "pluginCtr"
 		plugin := podmanTest.Podman([]string{"run", "--name", ctrName, "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// Make sure the socket is available (see #17956)
 		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
@@ -132,18 +131,18 @@ var _ = Describe("Podman volume plugins", func() {
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		ls1 := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		ls1.WaitWithDefaultTimeout()
-		Expect(ls1).Should(Exit(0))
+		Expect(ls1).Should(ExitCleanly())
 		arrOutput := ls1.OutputToStringArray()
 		Expect(arrOutput).To(HaveLen(1))
 		Expect(arrOutput[0]).To(ContainSubstring(volName))
 
 		stop := podmanTest.Podman([]string{"stop", "--timeout", "0", ctrName})
 		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(Exit(0))
+		Expect(stop).Should(ExitCleanly())
 
 		// Remove should exit non-zero because missing plugin
 		remove := podmanTest.Podman([]string{"volume", "rm", volName})
@@ -153,7 +152,7 @@ var _ = Describe("Podman volume plugins", func() {
 		// But the volume should still be gone
 		ls2 := podmanTest.Podman([]string{"volume", "ls", "-q"})
 		ls2.WaitWithDefaultTimeout()
-		Expect(ls2).Should(Exit(0))
+		Expect(ls2).Should(ExitCleanly())
 		Expect(ls2.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -168,7 +167,7 @@ var _ = Describe("Podman volume plugins", func() {
 		pluginName := "testvol4"
 		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// Make sure the socket is available (see #17956)
 		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
@@ -177,17 +176,17 @@ var _ = Describe("Podman volume plugins", func() {
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1 := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "--name", ctr1Name, "-v", fmt.Sprintf("%v:/test", volName), ALPINE, "sh", "-c", "touch /test/testfile && echo helloworld > /test/testfile"})
 		ctr1.WaitWithDefaultTimeout()
-		Expect(ctr1).Should(Exit(0))
+		Expect(ctr1).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2 := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "--name", ctr2Name, "-v", fmt.Sprintf("%v:/test", volName), ALPINE, "cat", "/test/testfile"})
 		ctr2.WaitWithDefaultTimeout()
-		Expect(ctr2).Should(Exit(0))
+		Expect(ctr2).Should(ExitCleanly())
 		Expect(ctr2.OutputToString()).To(ContainSubstring("helloworld"))
 
 		// HACK: `volume rm -f` is timing out trying to remove containers using the volume.
@@ -195,7 +194,7 @@ var _ = Describe("Podman volume plugins", func() {
 		// TODO: fix this when I get back
 		rmAll := podmanTest.Podman([]string{"rm", "-f", ctr2Name, ctr1Name})
 		rmAll.WaitWithDefaultTimeout()
-		Expect(rmAll).Should(Exit(0))
+		Expect(rmAll).Should(ExitCleanly())
 	})
 
 	It("podman volume reload", func() {
@@ -218,7 +217,7 @@ testvol5 = "/run/docker/plugins/testvol5.sock"`), 0o644)
 		plugin := podmanTest.Podman([]string{"run", "--name", ctrName, "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins",
 			"-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// Make sure the socket is available (see #17956)
 		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
@@ -228,33 +227,33 @@ testvol5 = "/run/docker/plugins/testvol5.sock"`), 0o644)
 		// create local volume
 		session := podmanTest.Podman([]string{"volume", "create", localvol})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		vol1 := "vol1-" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, vol1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		// now create volume in plugin without podman
 		vol2 := "vol2-" + stringid.GenerateRandomID()
 		plugin = podmanTest.Podman([]string{"exec", ctrName, "/usr/local/bin/testvol", "--sock-name", pluginName, "create", vol2})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElements(localvol, vol1))
 		Expect(session.ErrorToString()).To(Equal("")) // make sure no errors are shown
 
 		plugin = podmanTest.Podman([]string{"exec", ctrName, "/usr/local/bin/testvol", "--sock-name", pluginName, "remove", vol1})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// now reload volumes from plugins
 		session = podmanTest.Podman([]string{"volume", "reload"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(string(session.Out.Contents())).To(Equal(fmt.Sprintf(`Added:
 %s
 Removed:
@@ -264,7 +263,7 @@ Removed:
 
 		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(ContainElements(localvol, vol2))
 		Expect(session.ErrorToString()).To(Equal("")) // make no errors are shown
 	})
@@ -280,7 +279,7 @@ Removed:
 		pluginName := "testvol6"
 		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
 		plugin.WaitWithDefaultTimeout()
-		Expect(plugin).Should(Exit(0))
+		Expect(plugin).Should(ExitCleanly())
 
 		// Make sure the socket is available (see #17956)
 		err = WaitForFile(fmt.Sprintf("/run/docker/plugins/%s.sock", pluginName))
@@ -289,21 +288,21 @@ Removed:
 		volName := "testVolume1"
 		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		volInspect := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .Timeout }}", volName})
 		volInspect.WaitWithDefaultTimeout()
-		Expect(volInspect).Should(Exit(0))
+		Expect(volInspect).Should(ExitCleanly())
 		Expect(volInspect.OutputToString()).To(ContainSubstring("15"))
 
 		volName2 := "testVolume2"
 		create2 := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, "--opt", "o=timeout=3", volName2})
 		create2.WaitWithDefaultTimeout()
-		Expect(create2).Should(Exit(0))
+		Expect(create2).Should(ExitCleanly())
 
 		volInspect2 := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .Timeout }}", volName2})
 		volInspect2.WaitWithDefaultTimeout()
-		Expect(volInspect2).Should(Exit(0))
+		Expect(volInspect2).Should(ExitCleanly())
 		Expect(volInspect2.OutputToString()).To(ContainSubstring("3"))
 	})
 })

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -1,9 +1,9 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman volume prune", func() {
@@ -15,152 +15,152 @@ var _ = Describe("Podman volume prune", func() {
 	It("podman prune volume", func() {
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
 	It("podman prune volume --filter until", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=50"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=5000000000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
 	It("podman prune volume --filter", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv1", "myvol2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv2", "myvol3"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1", "myvol4"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", "myvol5:/myvol5", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", "myvol6:/myvol6", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(7))
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=label1=value1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(6))
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1=slv1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(5))
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(3))
 
 		session = podmanTest.Podman([]string{"volume", "create", "--label", "testlabel", "myvol7"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label!=testlabel"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman system prune --volume", func() {
 		useCustomNetworkDir(podmanTest, tempdir)
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
 		session = podmanTest.Podman([]string{"system", "prune", "--force", "--volumes"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -171,19 +171,19 @@ var _ = Describe("Podman volume prune", func() {
 
 		session := podmanTest.Podman([]string{"volume", "create", vol1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", vol2})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", vol3})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "prune", "-f", "--filter", "since=" + vol1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(Exit(0))
+		Expect(session).To(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -16,15 +16,15 @@ var _ = Describe("Podman volume rm", func() {
 	It("podman volume rm", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "rm", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -32,7 +32,7 @@ var _ = Describe("Podman volume rm", func() {
 		session := podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
 		cid := session.OutputToString()
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "rm", "myvol"})
 		session.WaitWithDefaultTimeout()
@@ -41,11 +41,11 @@ var _ = Describe("Podman volume rm", func() {
 
 		session = podmanTest.Podman([]string{"volume", "rm", "-t", "0", "-f", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
@@ -58,45 +58,45 @@ var _ = Describe("Podman volume rm", func() {
 	It("podman rm with --all flag", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "rm", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
 	It("podman volume rm by partial name", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "rm", "myv"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
 	It("podman volume rm by nonunique partial name", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "create", "myvol2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"volume", "rm", "myv"})
 		session.WaitWithDefaultTimeout()
@@ -104,7 +104,7 @@ var _ = Describe("Podman volume rm", func() {
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">=", 2))
 	})
 })


### PR DESCRIPTION
More easy ones: test files that either work with ExitCleanly() or require very, very simple tweaks.

Please review only the second commit. (OK to review the first commit for inadvertent slips, but that's almost entirely an automatic string replace).

```release-note
None
```