### PR TITLE
fix --authfile auto-update test

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -647,8 +647,10 @@ EOF
         --password ${PODMAN_LOGIN_PASS} \
         $registry
 
-    run_podman tag $IMAGE $image_on_local_registry
-    run_podman push --tls-verify=false --creds "${PODMAN_LOGIN_USER}:${PODMAN_LOGIN_PASS}" $image_on_local_registry
+    # Push the image to the registry and pull it down again to make sure we
+    # have the identical digest in the local storage
+    run_podman push --tls-verify=false --creds "${PODMAN_LOGIN_USER}:${PODMAN_LOGIN_PASS}" $IMAGE $image_on_local_registry
+    run_podman pull --tls-verify=false --creds "${PODMAN_LOGIN_USER}:${PODMAN_LOGIN_PASS}" $image_on_local_registry
 
     # Generate a systemd service with the "registry" auto-update policy running
     # "top" inside the image we just pushed to the local registry.


### PR DESCRIPTION
The test started to fail in gating and on workstations.  It turned out that pushing the test image to the registry recompresses it which in turn may change the digest.  The digest now started to change; computing it depends on the toolchain so the test passed before by pure luck it seems.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
