### PR TITLE
pass --syslog to the cleanup process

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -77,7 +77,6 @@ var (
 	dockerConfig    = ""
 	debug           bool
 
-	useSyslog      bool
 	requireCleanup = true
 
 	// Defaults for capturing/redirecting the command output since (the) cobra is
@@ -576,7 +575,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		pFlags.StringArrayVar(&podmanConfig.RuntimeFlags, runtimeflagFlagName, []string{}, "add global flags for the container runtime")
 		_ = rootCmd.RegisterFlagCompletionFunc(runtimeflagFlagName, completion.AutocompleteNone)
 
-		pFlags.BoolVar(&useSyslog, "syslog", false, "Output logging information to syslog as well as the console (default false)")
+		pFlags.BoolVar(&podmanConfig.Syslog, "syslog", false, "Output logging information to syslog as well as the console (default false)")
 	}
 }
 

--- a/cmd/podman/syslog_common.go
+++ b/cmd/podman/syslog_common.go
@@ -6,12 +6,13 @@ package main
 import (
 	"log/syslog"
 
+	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/sirupsen/logrus"
 	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 func syslogHook() {
-	if !useSyslog {
+	if !registry.PodmanConfig().Syslog {
 		return
 	}
 

--- a/cmd/podman/syslog_unsupported.go
+++ b/cmd/podman/syslog_unsupported.go
@@ -6,13 +6,16 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
+
+	"github.com/containers/podman/v4/cmd/podman/registry"
 )
 
 func syslogHook() {
-	if !useSyslog {
+	if !registry.PodmanConfig().Syslog {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "Logging to Syslog is not supported on Windows")
+	fmt.Fprintf(os.Stderr, "Logging to Syslog is not supported on %s", runtime.GOOS)
 	os.Exit(1)
 }

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1107,7 +1107,7 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		args = append(args, "--no-pivot")
 	}
 
-	exitCommand, err := specgenutil.CreateExitCommandArgs(ctr.runtime.storageConfig, ctr.runtime.config, logrus.IsLevelEnabled(logrus.DebugLevel), ctr.AutoRemove(), false)
+	exitCommand, err := specgenutil.CreateExitCommandArgs(ctr.runtime.storageConfig, ctr.runtime.config, ctr.runtime.syslog || logrus.IsLevelEnabled(logrus.DebugLevel), ctr.AutoRemove(), false)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -47,7 +47,7 @@ type PodmanConfig struct {
 	Remote                   bool           // Connection to Podman API Service will use RESTful API
 	RuntimePath              string         // --runtime flag will set Engine.RuntimePath
 	RuntimeFlags             []string       // global flags for the container runtime
-	Syslog                   bool           // write to StdOut and Syslog, not supported when tunneling
+	Syslog                   bool           // write logging information to syslog as well as the console
 	Trace                    bool           // Hidden: Trace execution
 	URI                      string         // URI to RESTful API Service
 

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -275,8 +275,7 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		options = append(options, libpod.WithDatabaseBackend(cfg.ContainersConf.Engine.DBBackend))
 	}
 
-	// no need to handle the error, it will return false anyway
-	if syslog, _ := fs.GetBool("syslog"); syslog {
+	if cfg.Syslog {
 		options = append(options, libpod.WithSyslog())
 	}
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1259,4 +1259,18 @@ search               | $IMAGE           |
     done < <(parse_table "$tests")
 }
 
+@test "podman --syslog passed to conmon" {
+    skip_if_remote "--syslog is not supported for remote clients"
+    skip_if_journald_unavailable
+
+    run_podman run -d -q --syslog $IMAGE sleep infinity
+    cid="$output"
+
+    run_podman container inspect $cid --format "{{ .State.ConmonPid }}"
+    conmon_pid="$output"
+    is "$(< /proc/$conmon_pid/cmdline)" ".*--exit-command-arg--syslog.*" "conmon's exit-command has --syslog set"
+
+    run_podman rm -f -t0 $cid
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
The --syslog flag has not been passed to the cleanup process (i.e., conmon's exit args) complicating debugging quite a bit.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where the `--syslog` flag was not passed to the cleanup process.
```

Found while debugging https://github.com/containers/podman/issues/19938.  I decided to break this out into a separate PR as https://github.com/containers/podman/issues/19938 is slowly turning into a much bigger adventure than I wished.