### PR TITLE
e2e: ExitCleanly(): generate_kube_test.go

### DIFF
--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -21,19 +21,19 @@ import (
 
 var _ = Describe("Podman kube generate", func() {
 
-	It("podman kube generate pod on bogus object", func() {
+	It("pod on bogus object", func() {
 		session := podmanTest.Podman([]string{"generate", "kube", "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 	})
 
-	It("podman kube generate service on bogus object", func() {
+	It("service on bogus object", func() {
 		session := podmanTest.Podman([]string{"kube", "generate", "-s", "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 	})
 
-	It("podman kube generate on container", func() {
+	It("on container", func() {
 		session := podmanTest.RunTopContainer("top")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -61,12 +61,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(numContainers).To(Equal(1))
 	})
 
-	It("podman kube generate service on container with --security-opt level", func() {
+	It("service on container with --security-opt level", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=level:s0:c100,c200", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "test"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "test"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -76,12 +76,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(kube.OutputToString()).To(ContainSubstring("level: s0:c100,c200"))
 	})
 
-	It("podman generate service kube on container with --security-opt disable", func() {
+	It("service kube on container with --security-opt disable", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test-disable", "--security-opt", "label=disable", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "test-disable"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "test-disable"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -92,7 +92,7 @@ var _ = Describe("Podman kube generate", func() {
 
 	})
 
-	It("podman generate service kube on container with --security-opt type", func() {
+	It("service kube on container with --security-opt type", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=type:foo_bar_t", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -107,7 +107,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(kube.OutputToString()).To(ContainSubstring("type: foo_bar_t"))
 	})
 
-	It("podman generate service kube on container - targetPort should match port name", func() {
+	It("service kube on container - targetPort should match port name", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -131,7 +131,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("podman generate kube on container with and without service", func() {
+	It("on container with and without service", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -168,7 +168,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.Containers[0].Ports[0].HostPort).To(Equal(int32(3890)))
 	})
 
-	It("podman generate kube on pod", func() {
+	It("on pod", func() {
 		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {"toppod"}})
 		Expect(rc).To(Equal(0))
 
@@ -176,7 +176,7 @@ var _ = Describe("Podman kube generate", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "toppod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "toppod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -193,7 +193,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(numContainers).To(Equal(1))
 	})
 
-	It("podman generate kube multiple pods", func() {
+	It("multiple pods", func() {
 		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
@@ -210,7 +210,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(string(kube.Out.Contents())).To(ContainSubstring(`name: pod2`))
 	})
 
-	It("podman generate kube on pod with init containers", func() {
+	It("on pod with init containers", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:toppod", "--init-ctr", "always", ALPINE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -244,7 +244,7 @@ var _ = Describe("Podman kube generate", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube = podmanTest.Podman([]string{"generate", "kube", "toppod-2"})
+		kube = podmanTest.Podman([]string{"kube", "generate", "toppod-2"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -269,7 +269,7 @@ var _ = Describe("Podman kube generate", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube = podmanTest.Podman([]string{"generate", "kube", "toppod-3"})
+		kube = podmanTest.Podman([]string{"kube", "generate", "toppod-3"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -282,7 +282,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(numContainers).To(Equal(1))
 	})
 
-	It("podman generate kube on pod with user namespace", func() {
+	It("on pod with user namespace", func() {
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
 		name := u.Username
@@ -304,7 +304,7 @@ var _ = Describe("Podman kube generate", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testPod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testPod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -315,7 +315,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec).To(HaveField("HostUsers", &expected))
 	})
 
-	It("podman generate kube on pod with host network", func() {
+	It("on pod with host network", func() {
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", "testHostNetwork", "--network", "host"})
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
@@ -324,7 +324,7 @@ var _ = Describe("Podman kube generate", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testHostNetwork"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testHostNetwork"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -334,12 +334,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec).To(HaveField("HostNetwork", true))
 	})
 
-	It("podman generate kube on container with host network", func() {
+	It("on container with host network", func() {
 		session := podmanTest.RunTopContainerWithArgs("topcontainer", []string{"--network", "host"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "topcontainer"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "topcontainer"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -349,7 +349,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec).To(HaveField("HostNetwork", true))
 	})
 
-	It("podman generate kube on pod with hostAliases", func() {
+	It("on pod with hostAliases", func() {
 		podName := "testHost"
 		testIP := "127.0.0.1"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName,
@@ -369,7 +369,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -381,7 +381,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.HostAliases[1]).To(HaveField("IP", testIP))
 	})
 
-	It("podman generate kube with network sharing", func() {
+	It("with network sharing", func() {
 		// Expect error with default sharing options as Net namespace is shared
 		podName := "testPod"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
@@ -408,7 +408,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -422,7 +422,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.Containers[1].Ports[0].HostPort).To(Equal(int32(6000)))
 	})
 
-	It("podman generate kube with and without hostname", func() {
+	It("with and without hostname", func() {
 		// Expect error with default sharing options as UTS namespace is shared
 		podName := "testPod"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
@@ -473,7 +473,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctr3Session.WaitWithDefaultTimeout()
 		Expect(ctr3Session).Should(ExitCleanly())
 
-		kube = podmanTest.Podman([]string{"generate", "kube", podName})
+		kube = podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -484,12 +484,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.Hostname).To(BeEmpty())
 	})
 
-	It("podman generate service kube on pod", func() {
+	It("service kube on pod", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "4000:4000/udp", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "-s", "test-pod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "-s", "test-pod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -509,7 +509,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("podman generate kube on pod with restartPolicy set for container in a pod", func() {
+	It("on pod with restartPolicy set for container in a pod", func() {
 		//TODO: v5.0 - change/remove test once we block --restart on container when it is in a pod
 		// podName,  set,  expect
 		testSli := [][]string{
@@ -533,7 +533,7 @@ var _ = Describe("Podman kube generate", func() {
 			ctr1Session.WaitWithDefaultTimeout()
 			Expect(ctr1Session).Should(ExitCleanly())
 
-			kube := podmanTest.Podman([]string{"generate", "kube", podName})
+			kube := podmanTest.Podman([]string{"kube", "generate", podName})
 			kube.WaitWithDefaultTimeout()
 			Expect(kube).Should(ExitCleanly())
 
@@ -545,7 +545,7 @@ var _ = Describe("Podman kube generate", func() {
 		}
 	})
 
-	It("podman generate kube on pod with restartPolicy", func() {
+	It("on pod with restartPolicy", func() {
 		// podName,  set,  expect
 		testSli := [][]string{
 			{"testPod1", "", ""},
@@ -566,7 +566,7 @@ var _ = Describe("Podman kube generate", func() {
 			ctr1Session.WaitWithDefaultTimeout()
 			Expect(ctr1Session).Should(ExitCleanly())
 
-			kube := podmanTest.Podman([]string{"generate", "kube", podName})
+			kube := podmanTest.Podman([]string{"kube", "generate", podName})
 			kube.WaitWithDefaultTimeout()
 			Expect(kube).Should(ExitCleanly())
 
@@ -578,7 +578,7 @@ var _ = Describe("Podman kube generate", func() {
 		}
 	})
 
-	It("podman generate kube on ctr with restartPolicy", func() {
+	It("on ctr with restartPolicy", func() {
 		// podName,  set,  expect
 		testSli := [][]string{
 			{"", ""}, // some ctr created from cmdline, set it to "" and let k8s default it to Always
@@ -594,7 +594,7 @@ var _ = Describe("Podman kube generate", func() {
 			ctrSession.WaitWithDefaultTimeout()
 			Expect(ctrSession).Should(ExitCleanly())
 
-			kube := podmanTest.Podman([]string{"generate", "kube", ctrName})
+			kube := podmanTest.Podman([]string{"kube", "generate", ctrName})
 			kube.WaitWithDefaultTimeout()
 			Expect(kube).Should(ExitCleanly())
 
@@ -606,7 +606,7 @@ var _ = Describe("Podman kube generate", func() {
 		}
 	})
 
-	It("podman generate kube on pod with memory limit", func() {
+	It("on pod with memory limit", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		podName := "testMemoryLimit"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
@@ -632,7 +632,7 @@ var _ = Describe("Podman kube generate", func() {
 		}
 	})
 
-	It("podman generate kube on pod with cpu limit", func() {
+	It("on pod with cpu limit", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		podName := "testCpuLimit"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
@@ -651,7 +651,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -665,7 +665,7 @@ var _ = Describe("Podman kube generate", func() {
 		}
 	})
 
-	It("podman generate kube on pod with ports", func() {
+	It("on pod with ports", func() {
 		podName := "test"
 
 		lock4 := GetPortLock("4000")
@@ -721,7 +721,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctrWithUDP.WaitWithDefaultTimeout()
 		Expect(ctrWithUDP).Should(ExitCleanly())
 
-		kube = podmanTest.Podman([]string{"generate", "kube", "test-pod"})
+		kube = podmanTest.Podman([]string{"kube", "generate", "test-pod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -735,7 +735,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(containers[0].Ports[0]).To(HaveField("Protocol", v1.ProtocolUDP))
 	})
 
-	It("podman generate and reimport kube on pod", func() {
+	It("generate and reimport kube on pod", func() {
 		podName := "toppod"
 		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(rc).To(Equal(0))
@@ -749,7 +749,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(session2).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
-		kube := podmanTest.Podman([]string{"generate", "kube", "-f", outputFile, podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "-f", outputFile, podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -757,7 +757,7 @@ var _ = Describe("Podman kube generate", func() {
 		session3.WaitWithDefaultTimeout()
 		Expect(session3).Should(ExitCleanly())
 
-		session4 := podmanTest.Podman([]string{"play", "kube", outputFile})
+		session4 := podmanTest.Podman([]string{"kube", "play", outputFile})
 		session4.WaitWithDefaultTimeout()
 		Expect(session4).Should(ExitCleanly())
 
@@ -774,7 +774,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(psOut).To(ContainSubstring("test2"))
 	})
 
-	It("podman generate with user and reimport kube on pod", func() {
+	It("generate with user and reimport kube on pod", func() {
 		podName := "toppod"
 		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(rc).To(Equal(0))
@@ -798,7 +798,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(session).Should(ExitCleanly())
 
 		podmanTest.AddImageToRWStore(ALPINE)
-		session = podmanTest.Podman([]string{"play", "kube", outputFile})
+		session = podmanTest.Podman([]string{"kube", "play", outputFile})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -809,7 +809,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(inspect1.OutputToString()).To(ContainSubstring(inspect.OutputToString()))
 	})
 
-	It("podman generate kube with volume", func() {
+	It("with volume", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -823,7 +823,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(session1).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
-		kube := podmanTest.Podman([]string{"generate", "kube", "test1", "-f", outputFile})
+		kube := podmanTest.Podman([]string{"kube", "generate", "test1", "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -838,7 +838,7 @@ var _ = Describe("Podman kube generate", func() {
 		rm.WaitWithDefaultTimeout()
 		Expect(rm).Should(ExitCleanly())
 
-		play := podmanTest.Podman([]string{"play", "kube", outputFile})
+		play := podmanTest.Podman([]string{"kube", "play", outputFile})
 		play.WaitWithDefaultTimeout()
 		Expect(play).Should(ExitCleanly())
 
@@ -848,7 +848,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(inspect.OutputToString()).To(ContainSubstring(vol1))
 	})
 
-	It("podman generate kube when bind-mounting '/' and '/root' at the same time ", func() {
+	It("when bind-mounting '/' and '/root' at the same time ", func() {
 		// Fixes https://github.com/containers/podman/issues/9764
 
 		ctrName := "mount-root-ctr"
@@ -859,7 +859,7 @@ var _ = Describe("Podman kube generate", func() {
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "mount-root-conflict"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "mount-root-conflict"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -871,7 +871,7 @@ var _ = Describe("Podman kube generate", func() {
 
 	})
 
-	It("podman generate kube with persistent volume claim", func() {
+	It("with persistent volume claim", func() {
 		vol := "vol-test-persistent-volume-claim"
 
 		// we need a container name because IDs don't persist after rm/play
@@ -883,7 +883,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(session).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
-		kube := podmanTest.Podman([]string{"generate", "kube", "test1", "-f", outputFile})
+		kube := podmanTest.Podman([]string{"kube", "generate", "test1", "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -891,7 +891,7 @@ var _ = Describe("Podman kube generate", func() {
 		rm.WaitWithDefaultTimeout()
 		Expect(rm).Should(ExitCleanly())
 
-		play := podmanTest.Podman([]string{"play", "kube", outputFile})
+		play := podmanTest.Podman([]string{"kube", "play", outputFile})
 		play.WaitWithDefaultTimeout()
 		Expect(play).Should(ExitCleanly())
 
@@ -901,7 +901,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(inspect.OutputToString()).To(ContainSubstring(vol))
 	})
 
-	It("podman generate kube sharing pid namespace", func() {
+	It("sharing pid namespace", func() {
 		podName := "test"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName, "--share", "pid"})
 		podSession.WaitWithDefaultTimeout()
@@ -920,7 +920,7 @@ var _ = Describe("Podman kube generate", func() {
 		rm.WaitWithDefaultTimeout()
 		Expect(rm).Should(ExitCleanly())
 
-		play := podmanTest.Podman([]string{"play", "kube", outputFile})
+		play := podmanTest.Podman([]string{"kube", "play", outputFile})
 		play.WaitWithDefaultTimeout()
 		Expect(play).Should(ExitCleanly())
 
@@ -930,7 +930,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(inspect.OutputToString()).To(ContainSubstring(`"pid"`))
 	})
 
-	It("podman generate kube with pods and containers", func() {
+	It("with pods and containers", func() {
 		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
@@ -939,12 +939,12 @@ var _ = Describe("Podman kube generate", func() {
 		pod2.WaitWithDefaultTimeout()
 		Expect(pod2).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "pod1", "top"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "pod1", "top"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 	})
 
-	It("podman generate kube with containers in a pod should fail", func() {
+	It("with containers in a pod should fail", func() {
 		pod1 := podmanTest.Podman([]string{"pod", "create", "--name", "pod1"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
@@ -953,12 +953,12 @@ var _ = Describe("Podman kube generate", func() {
 		con.WaitWithDefaultTimeout()
 		Expect(con).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "top"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).To(ExitWithError())
 	})
 
-	It("podman generate kube with multiple containers", func() {
+	It("with multiple containers", func() {
 		con1 := podmanTest.Podman([]string{"run", "-dt", "--name", "con1", ALPINE, "top"})
 		con1.WaitWithDefaultTimeout()
 		Expect(con1).Should(ExitCleanly())
@@ -967,12 +967,12 @@ var _ = Describe("Podman kube generate", func() {
 		con2.WaitWithDefaultTimeout()
 		Expect(con2).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "con1", "con2"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "con1", "con2"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 	})
 
-	It("podman generate kube with containers in pods should fail", func() {
+	It("with containers in pods should fail", func() {
 		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", "--name", "top1", ALPINE, "top"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
@@ -986,12 +986,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(kube).To(ExitWithError())
 	})
 
-	It("podman generate kube on a container with dns options", func() {
+	It("on a container with dns options", func() {
 		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-option", "color:blue", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "top"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1007,7 +1007,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.DNSConfig.Options[0]).To(HaveField("Value", &s))
 	})
 
-	It("podman generate kube multiple container dns servers and options are cumulative", func() {
+	It("multiple container dns servers and options are cumulative", func() {
 		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--dns", "8.8.8.8", "--dns-search", "foobar.com", ALPINE, "top"})
 		top1.WaitWithDefaultTimeout()
 		Expect(top1).Should(ExitCleanly())
@@ -1016,7 +1016,7 @@ var _ = Describe("Podman kube generate", func() {
 		top2.WaitWithDefaultTimeout()
 		Expect(top2).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "top1", "top2"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "top1", "top2"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1030,7 +1030,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.DNSConfig.Searches).To(ContainElement("homer.com"))
 	})
 
-	It("podman generate kube on a pod with dns options", func() {
+	It("on a pod with dns options", func() {
 		top := podmanTest.Podman([]string{"run", "--pod", "new:pod1", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-opt", "color:blue", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(ExitCleanly())
@@ -1051,12 +1051,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(pod.Spec.DNSConfig.Options[0]).To(HaveField("Value", &s))
 	})
 
-	It("podman generate kube - set entrypoint as command", func() {
+	It("- set entrypoint as command", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--entrypoint", "/bin/sleep", ALPINE, "10s"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testpod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1073,12 +1073,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(containers[0]).To(HaveField("Args", []string{"10s"}))
 	})
 
-	It("podman generate kube - use command from image unless explicitly set in the podman command", func() {
+	It("- use command from image unless explicitly set in the podman command", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "test"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "test"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1112,7 +1112,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(containers[0]).To(HaveField("Command", cmd))
 	})
 
-	It("podman generate kube - use entrypoint from image unless --entrypoint is set", func() {
+	It("- use entrypoint from image unless --entrypoint is set", func() {
 		// Build an image with an entrypoint.
 		containerfile := `FROM quay.io/libpod/alpine:latest
 ENTRYPOINT ["sleep"]`
@@ -1130,7 +1130,7 @@ ENTRYPOINT ["sleep"]`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testpod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1164,7 +1164,7 @@ ENTRYPOINT ["sleep"]`
 		Expect(containers[0]).To(HaveField("Args", []string{"hello"}))
 	})
 
-	It("podman generate kube - image has positive integer user set", func() {
+	It("- image has positive integer user set", func() {
 		// Build an image with user=1000.
 		containerfile := `FROM quay.io/libpod/alpine:latest
 USER 1000`
@@ -1182,7 +1182,7 @@ USER 1000`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testpod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1197,12 +1197,12 @@ USER 1000`
 		Expect(containers[0]).To(HaveField("SecurityContext.RunAsNonRoot", &trueBool))
 	})
 
-	It("podman generate kube - --privileged container", func() {
+	It("- --privileged container", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--privileged", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testpod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1218,7 +1218,7 @@ USER 1000`
 		// Now make sure we can also `play` it.
 		kubeFile := filepath.Join(podmanTest.TempDir, "kube.yaml")
 
-		kube = podmanTest.Podman([]string{"generate", "kube", "testpod", "-f", kubeFile})
+		kube = podmanTest.Podman([]string{"kube", "generate", "testpod", "-f", kubeFile})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1227,12 +1227,12 @@ USER 1000`
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
-		kube = podmanTest.Podman([]string{"play", "kube", kubeFile})
+		kube = podmanTest.Podman([]string{"kube", "play", kubeFile})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 	})
 
-	It("podman generate kube based on user in container", func() {
+	It("based on user in container", func() {
 		// Build an image with an entrypoint.
 		containerfile := `FROM quay.io/libpod/alpine:latest
 RUN adduser -u 10001 -S test1
@@ -1251,7 +1251,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "testpod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1261,14 +1261,14 @@ USER test1`
 		Expect(pod.Spec.Containers[0].SecurityContext.RunAsUser).To(BeNil())
 	})
 
-	It("podman generate kube on named volume", func() {
+	It("on named volume", func() {
 		vol := "simple-named-volume"
 
 		session := podmanTest.Podman([]string{"volume", "create", vol})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", vol})
+		kube := podmanTest.Podman([]string{"kube", "generate", vol})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1280,7 +1280,7 @@ USER test1`
 		Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("1Gi"))
 	})
 
-	It("podman generate kube on named volume with options", func() {
+	It("on named volume with options", func() {
 		vol := "complex-named-volume"
 		volDevice := define.TypeTmpfs
 		volType := define.TypeTmpfs
@@ -1290,7 +1290,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", vol})
+		kube := podmanTest.Podman([]string{"kube", "generate", vol})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1313,12 +1313,12 @@ USER test1`
 		}
 	})
 
-	It("podman generate kube on container with auto update labels", func() {
+	It("on container with auto update labels", func() {
 		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--label", "io.containers.autoupdate=local", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "top"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1329,7 +1329,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue("io.containers.autoupdate/top", "local"))
 	})
 
-	It("podman generate kube on pod with auto update labels in all containers", func() {
+	It("on pod with auto update labels in all containers", func() {
 		pod1 := podmanTest.Podman([]string{"pod", "create", "--name", "pod1"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
@@ -1342,7 +1342,7 @@ USER test1`
 		top2.WaitWithDefaultTimeout()
 		Expect(top2).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "pod1"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "pod1"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1358,7 +1358,7 @@ USER test1`
 		}
 	})
 
-	It("podman generate kube can export env variables correctly", func() {
+	It("can export env variables correctly", func() {
 		// Fixes https://github.com/containers/podman/issues/12647
 		// PR https://github.com/containers/podman/pull/12648
 
@@ -1372,7 +1372,7 @@ USER test1`
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1383,14 +1383,14 @@ USER test1`
 		Expect(pod.Spec.Containers[0].Env).To(HaveLen(2))
 	})
 
-	It("podman generate kube omit secret if empty", func() {
+	It("omit secret if empty", func() {
 		dir := GinkgoT().TempDir()
 
 		podCreate := podmanTest.Podman([]string{"run", "-d", "--pod", "new:" + "noSecretsPod", "--name", "noSecretsCtr", "--volume", dir + ":/foobar", ALPINE})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "noSecretsPod"})
+		kube := podmanTest.Podman([]string{"kube", "generate", "noSecretsPod"})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1403,7 +1403,7 @@ USER test1`
 		Expect(pod.Spec.Volumes[0].Secret).To(BeNil())
 	})
 
-	It("podman kube generate with default ulimits", func() {
+	It("with default ulimits", func() {
 		ctrName := "ulimit-ctr"
 		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "sleep", "1000"})
 		session.WaitWithDefaultTimeout()
@@ -1422,7 +1422,7 @@ USER test1`
 		Expect(pod.Annotations).To(Not(HaveKey(define.UlimitAnnotation)))
 	})
 
-	It("podman generate & play kube with --ulimit set", func() {
+	It("with --ulimit set", func() {
 		ctrName := "ulimit-ctr"
 		ctrNameInKubePod := ctrName + "-pod-" + ctrName
 		session1 := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--ulimit", "nofile=1231:3123", ALPINE, "sleep", "1000"})
@@ -1458,7 +1458,7 @@ USER test1`
 		Expect(inspect.OutputToString()).To(ContainSubstring("3123"))
 	})
 
-	It("podman generate kube on pod with --type=deployment", func() {
+	It("on pod with --type=deployment", func() {
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
@@ -1471,7 +1471,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "deployment", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "deployment", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1489,13 +1489,13 @@ USER test1`
 		Expect(numContainers).To(Equal(2))
 	})
 
-	It("podman generate kube on ctr with --type=deployment and --replicas=3", func() {
+	It("on ctr with --type=deployment and --replicas=3", func() {
 		ctrName := "test-ctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "deployment", "--replicas", "3", ctrName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "deployment", "--replicas", "3", ctrName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1514,18 +1514,18 @@ USER test1`
 		Expect(numContainers).To(Equal(1))
 	})
 
-	It("podman generate kube on ctr with --type=pod and --replicas=3 should fail", func() {
+	It("on ctr with --type=pod and --replicas=3 should fail", func() {
 		ctrName := "test-ctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "pod", "--replicas", "3", ctrName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "pod", "--replicas", "3", ctrName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(125))
 	})
 
-	It("podman generate kube on pod with --type=deployment and --restart=no should fail", func() {
+	It("on pod with --type=deployment and --restart=no should fail", func() {
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", "--restart", "no", podName})
 		session.WaitWithDefaultTimeout()
@@ -1535,12 +1535,12 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "deployment", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "deployment", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(125))
 	})
 
-	It("podman generate kube on pod with invalid name", func() {
+	It("on pod with invalid name", func() {
 		podName := "test_pod"
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
@@ -1550,7 +1550,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1562,7 +1562,7 @@ USER test1`
 		Expect(pod.Spec.Hostname).To(Equal(""))
 	})
 
-	It("podman kube generate --no-trunc on container with long annotation", func() {
+	It("--no-trunc on container with long annotation", func() {
 		ctrName := "demo"
 		vol1 := filepath.Join(podmanTest.TempDir, RandomString(99))
 		err := os.MkdirAll(vol1, 0755)
@@ -1584,7 +1584,7 @@ USER test1`
 		Expect(pod.Annotations).To(Not(HaveKeyWithValue(define.BindMountPrefix, vol1[:define.MaxKubeAnnotation])))
 	})
 
-	It("podman kube generate on container with long annotation", func() {
+	It("on container with long annotation", func() {
 		ctrName := "demo"
 		vol1 := filepath.Join(podmanTest.TempDir, RandomString(99))
 		err := os.MkdirAll(vol1, 0755)
@@ -1606,7 +1606,7 @@ USER test1`
 		Expect(pod.Annotations).To(Not(HaveKeyWithValue(define.BindMountPrefix, vol1+":Z")))
 	})
 
-	It("podman kube generate --no-trunc on pod with long annotation", func() {
+	It("--no-trunc on pod with long annotation", func() {
 		ctrName := "demoCtr"
 		podName := "demoPod"
 		vol1 := filepath.Join(podmanTest.TempDir, RandomString(99))
@@ -1633,7 +1633,7 @@ USER test1`
 		Expect(pod.Annotations).To(Not(HaveKeyWithValue(define.BindMountPrefix, vol1[:define.MaxKubeAnnotation])))
 	})
 
-	It("podman kube generate on pod with long annotation", func() {
+	It("on pod with long annotation", func() {
 		ctrName := "demoCtr"
 		podName := "demoPod"
 		vol1 := filepath.Join(podmanTest.TempDir, RandomString(99))
@@ -1660,7 +1660,7 @@ USER test1`
 		Expect(pod.Annotations).To(Not(HaveKeyWithValue(define.BindMountPrefix, vol1+":Z")))
 	})
 
-	It("podman kube generate --podman-only on container with --volumes-from", func() {
+	It("--podman-only on container with --volumes-from", func() {
 		ctr1 := "ctr1"
 		ctr2 := "ctr2"
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
@@ -1686,7 +1686,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationVolumesFrom+"/"+ctr2, ctr1))
 	})
 
-	It("podman kube generate --podman-only on container with --rm", func() {
+	It("--podman-only on container with --rm", func() {
 		ctr := "ctr"
 
 		session := podmanTest.Podman([]string{"create", "--rm", "--name", ctr, ALPINE})
@@ -1703,7 +1703,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationAutoremove+"/"+ctr, define.InspectResponseTrue))
 	})
 
-	It("podman kube generate --podman-only on container with --privileged", func() {
+	It("--podman-only on container with --privileged", func() {
 		ctr := "ctr"
 
 		session := podmanTest.Podman([]string{"create", "--privileged", "--name", ctr, ALPINE})
@@ -1720,7 +1720,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationPrivileged+"/"+ctr, define.InspectResponseTrue))
 	})
 
-	It("podman kube generate --podman-only on container with --init", func() {
+	It("--podman-only on container with --init", func() {
 		ctr := "ctr"
 
 		session := podmanTest.Podman([]string{"create", "--init", "--name", ctr, ALPINE})
@@ -1737,7 +1737,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationInit+"/"+ctr, define.InspectResponseTrue))
 	})
 
-	It("podman kube generate --podman-only on container with --cidfile", func() {
+	It("--podman-only on container with --cidfile", func() {
 		ctr := "ctr"
 		cidFile := filepath.Join(podmanTest.TempDir, RandomString(10)+".txt")
 
@@ -1755,7 +1755,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationCIDFile+"/"+ctr, cidFile))
 	})
 
-	It("podman kube generate --podman-only on container with --security-opt seccomp=unconfined", func() {
+	It("--podman-only on container with --security-opt seccomp=unconfined", func() {
 		ctr := "ctr"
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "seccomp=unconfined", "--name", ctr, ALPINE})
@@ -1772,7 +1772,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationSeccomp+"/"+ctr, "unconfined"))
 	})
 
-	It("podman kube generate --podman-only on container with --security-opt apparmor=unconfined", func() {
+	It("--podman-only on container with --security-opt apparmor=unconfined", func() {
 		ctr := "ctr"
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", "--name", ctr, ALPINE})
@@ -1789,7 +1789,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationApparmor+"/"+ctr, "unconfined"))
 	})
 
-	It("podman kube generate --podman-only on container with --security-opt label=level:s0", func() {
+	It("--podman-only on container with --security-opt label=level:s0", func() {
 		ctr := "ctr"
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "label=level:s0", "--name", ctr, ALPINE})
@@ -1806,7 +1806,7 @@ USER test1`
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationLabel+"/"+ctr, "level:s0"))
 	})
 
-	It("podman kube generate --podman-only on container with --publish-all", func() {
+	It("--podman-only on container with --publish-all", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 		dockerfile := fmt.Sprintf(`FROM %s
 EXPOSE 2002
@@ -1840,7 +1840,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationPublishAll+"/"+ctr, define.InspectResponseTrue))
 	})
 
-	It("podman generate kube on pod with --infra-name set", func() {
+	It("on pod with --infra-name set", func() {
 		infraName := "infra-ctr"
 		podName := "test-pod"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--infra-name", infraName, podName})
@@ -1851,7 +1851,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1861,7 +1861,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(pod.Annotations).To(HaveKeyWithValue(define.InfraNameAnnotation, infraName))
 	})
 
-	It("podman generate kube on pod without --infra-name set", func() {
+	It("on pod without --infra-name set", func() {
 		podName := "test-pod"
 		podSession := podmanTest.Podman([]string{"pod", "create", podName})
 		podSession.WaitWithDefaultTimeout()
@@ -1871,7 +1871,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1882,7 +1882,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(pod.Annotations).To(BeEmpty())
 	})
 
-	It("podman generate kube on pod with --stop-timeout set for ctr", func() {
+	It("on pod with --stop-timeout set for ctr", func() {
 		podName := "test-pod"
 		podSession := podmanTest.Podman([]string{"pod", "create", podName})
 		podSession.WaitWithDefaultTimeout()
@@ -1892,7 +1892,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1903,7 +1903,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(int(*pod.Spec.TerminationGracePeriodSeconds)).To(Equal(20))
 	})
 
-	It("podman generate kube on pod with --type=daemonset", func() {
+	It("on pod with --type=daemonset", func() {
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
@@ -1916,7 +1916,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "daemonset", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "daemonset", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
@@ -1929,19 +1929,19 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
 	})
 
-	It("podman generate kube on ctr with --type=daemonset and --replicas=3 should fail", func() {
+	It("on ctr with --type=daemonset and --replicas=3 should fail", func() {
 		ctrName := "test-ctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "daemonset", "--replicas", "3", ctrName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "daemonset", "--replicas", "3", ctrName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(125))
 		Expect(kube.ErrorToString()).To(ContainSubstring("--replicas can only be set when --type is set to deployment"))
 	})
 
-	It("podman generate kube on pod with --type=daemonset and --restart=no should fail", func() {
+	It("on pod with --type=daemonset and --restart=no should fail", func() {
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", "--restart", "no", podName})
 		session.WaitWithDefaultTimeout()
@@ -1951,7 +1951,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "daemonset", podName})
+		kube := podmanTest.Podman([]string{"kube", "generate", "--type", "daemonset", podName})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(125))
 		Expect(kube.ErrorToString()).To(ContainSubstring("k8s DaemonSets can only have restartPolicy set to Always"))

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -36,11 +36,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman kube generate on container", func() {
 		session := podmanTest.RunTopContainer("top")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "top"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -64,11 +64,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman kube generate service on container with --security-opt level", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=level:s0:c100,c200", "alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "test"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -79,11 +79,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate service kube on container with --security-opt disable", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test-disable", "--security-opt", "label=disable", "alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "test-disable"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -95,11 +95,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate service kube on container with --security-opt type", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=type:foo_bar_t", "alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "test"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -110,11 +110,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate service kube on container - targetPort should match port name", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "-s", "test-ctr"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Separate out the Service and Pod yaml
 		arr := strings.Split(string(kube.Out.Contents()), "---")
@@ -134,11 +134,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on container with and without service", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "-s", "test-ctr"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Separate out the Service and Pod yaml
 		arr := strings.Split(string(kube.Out.Contents()), "---")
@@ -159,7 +159,7 @@ var _ = Describe("Podman kube generate", func() {
 		// Now do kube generate without the --service flag
 		kube = podmanTest.Podman([]string{"kube", "generate", "test-ctr"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// The hostPort in the pod yaml should be set to 3890
 		pod = new(v1.Pod)
@@ -174,11 +174,11 @@ var _ = Describe("Podman kube generate", func() {
 
 		session := podmanTest.RunTopContainerInPod("topcontainer", "toppod")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "toppod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -196,15 +196,15 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube multiple pods", func() {
 		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
 		pod1.WaitWithDefaultTimeout()
-		Expect(pod1).Should(Exit(0))
+		Expect(pod1).Should(ExitCleanly())
 
 		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", ALPINE, "top"})
 		pod2.WaitWithDefaultTimeout()
-		Expect(pod2).Should(Exit(0))
+		Expect(pod2).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "pod1", "pod2"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		Expect(string(kube.Out.Contents())).To(ContainSubstring(`name: pod1`))
 		Expect(string(kube.Out.Contents())).To(ContainSubstring(`name: pod2`))
@@ -213,19 +213,19 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on pod with init containers", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:toppod", "--init-ctr", "always", ALPINE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "toppod", "--init-ctr", "always", ALPINE, "echo", "world"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "toppod", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "toppod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -238,15 +238,15 @@ var _ = Describe("Podman kube generate", func() {
 		// Init container should be in the generated kube yaml if created with "once" type and the pod has not been started
 		session = podmanTest.Podman([]string{"create", "--pod", "new:toppod-2", "--init-ctr", "once", ALPINE, "echo", "using once type"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "toppod-2", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"generate", "kube", "toppod-2"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod = new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -259,19 +259,19 @@ var _ = Describe("Podman kube generate", func() {
 		// Init container should not be in the generated kube yaml if created with "once" type and the pod has been started
 		session = podmanTest.Podman([]string{"create", "--pod", "new:toppod-3", "--init-ctr", "once", ALPINE, "echo", "using once type"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "toppod-3", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"pod", "start", "toppod-3"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"generate", "kube", "toppod-3"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod = new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -298,15 +298,15 @@ var _ = Describe("Podman kube generate", func() {
 		}
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", "testPod", "--userns=auto"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--name", "topcontainer", "--pod", "testPod", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testPod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -318,15 +318,15 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on pod with host network", func() {
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", "testHostNetwork", "--network", "host"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--name", "topcontainer", "--pod", "testHostNetwork", "--network", "host", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testHostNetwork"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -337,11 +337,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on container with host network", func() {
 		session := podmanTest.RunTopContainerWithArgs("topcontainer", []string{"--network", "host"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "topcontainer"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -357,21 +357,21 @@ var _ = Describe("Podman kube generate", func() {
 			"--add-host", "test2.podman.io" + ":" + testIP,
 		})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
-		Expect(ctr1Session).Should(Exit(0))
+		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
-		Expect(ctr2Session).Should(Exit(0))
+		Expect(ctr2Session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -386,7 +386,7 @@ var _ = Describe("Podman kube generate", func() {
 		podName := "testPod"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctrSession := podmanTest.Podman([]string{"create", "--name", "testCtr", "--pod", podName, "-p", "9000:8000", ALPINE, "top"})
 		ctrSession.WaitWithDefaultTimeout()
@@ -396,21 +396,21 @@ var _ = Describe("Podman kube generate", func() {
 		podName = "testNet"
 		podSession = podmanTest.Podman([]string{"pod", "create", "--name", podName, "--share", "ipc"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "-p", "9000:8000", ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
-		Expect(ctr1Session).Should(Exit(0))
+		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, "-p", "6000:5000", ALPINE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
-		Expect(ctr2Session).Should(Exit(0))
+		Expect(ctr2Session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -427,7 +427,7 @@ var _ = Describe("Podman kube generate", func() {
 		podName := "testPod"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctrSession := podmanTest.Podman([]string{"create", "--name", "testCtr", "--pod", podName, "--hostname", "test-hostname", ALPINE, "top"})
 		ctrSession.WaitWithDefaultTimeout()
@@ -438,22 +438,22 @@ var _ = Describe("Podman kube generate", func() {
 		podName = "testHostname"
 		podSession = podmanTest.Podman([]string{"pod", "create", "--name", podName, "--share", "ipc"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1HostName := "ctr1-hostname"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "--hostname", ctr1HostName, ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
-		Expect(ctr1Session).Should(Exit(0))
+		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
-		Expect(ctr2Session).Should(Exit(0))
+		Expect(ctr2Session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -466,16 +466,16 @@ var _ = Describe("Podman kube generate", func() {
 		podName = "testNoHostname"
 		podSession = podmanTest.Podman([]string{"pod", "create", "--name", podName, "--share", "ipc"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr3Name := "ctr3"
 		ctr3Session := podmanTest.Podman([]string{"create", "--name", ctr3Name, "--pod", podName, ALPINE, "top"})
 		ctr3Session.WaitWithDefaultTimeout()
-		Expect(ctr3Session).Should(Exit(0))
+		Expect(ctr3Session).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod = new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -487,11 +487,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate service kube on pod", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "4000:4000/udp", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "-s", "test-pod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Separate out the Service and Pod yaml
 		arr := strings.Split(string(kube.Out.Contents()), "---")
@@ -525,17 +525,17 @@ var _ = Describe("Podman kube generate", func() {
 			// Need to set --restart during pod creation as gen kube only picks up the pod's restart policy
 			podSession := podmanTest.Podman([]string{"pod", "create", "--restart", v[1], "--name", podName})
 			podSession.WaitWithDefaultTimeout()
-			Expect(podSession).Should(Exit(0))
+			Expect(podSession).Should(ExitCleanly())
 
 			ctrName := "ctr" + strconv.Itoa(k)
 			ctr1Session := podmanTest.Podman([]string{"create", "--name", ctrName, "--pod", podName,
 				"--restart", v[1], ALPINE, "top"})
 			ctr1Session.WaitWithDefaultTimeout()
-			Expect(ctr1Session).Should(Exit(0))
+			Expect(ctr1Session).Should(ExitCleanly())
 
 			kube := podmanTest.Podman([]string{"generate", "kube", podName})
 			kube.WaitWithDefaultTimeout()
-			Expect(kube).Should(Exit(0))
+			Expect(kube).Should(ExitCleanly())
 
 			pod := new(v1.Pod)
 			err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -559,16 +559,16 @@ var _ = Describe("Podman kube generate", func() {
 			podName := v[0]
 			podSession := podmanTest.Podman([]string{"pod", "create", "--restart", v[1], podName})
 			podSession.WaitWithDefaultTimeout()
-			Expect(podSession).Should(Exit(0))
+			Expect(podSession).Should(ExitCleanly())
 
 			ctrName := "ctr" + strconv.Itoa(k)
 			ctr1Session := podmanTest.Podman([]string{"create", "--name", ctrName, "--pod", podName, ALPINE, "top"})
 			ctr1Session.WaitWithDefaultTimeout()
-			Expect(ctr1Session).Should(Exit(0))
+			Expect(ctr1Session).Should(ExitCleanly())
 
 			kube := podmanTest.Podman([]string{"generate", "kube", podName})
 			kube.WaitWithDefaultTimeout()
-			Expect(kube).Should(Exit(0))
+			Expect(kube).Should(ExitCleanly())
 
 			pod := new(v1.Pod)
 			err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -592,11 +592,11 @@ var _ = Describe("Podman kube generate", func() {
 			ctrName := "ctr" + strconv.Itoa(k)
 			ctrSession := podmanTest.Podman([]string{"create", "--restart", v[0], "--name", ctrName, ALPINE, "top"})
 			ctrSession.WaitWithDefaultTimeout()
-			Expect(ctrSession).Should(Exit(0))
+			Expect(ctrSession).Should(ExitCleanly())
 
 			kube := podmanTest.Podman([]string{"generate", "kube", ctrName})
 			kube.WaitWithDefaultTimeout()
-			Expect(kube).Should(Exit(0))
+			Expect(kube).Should(ExitCleanly())
 
 			pod := new(v1.Pod)
 			err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -611,16 +611,16 @@ var _ = Describe("Podman kube generate", func() {
 		podName := "testMemoryLimit"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "--memory", "10M", ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
-		Expect(ctr1Session).Should(Exit(0))
+		Expect(ctr1Session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -637,23 +637,23 @@ var _ = Describe("Podman kube generate", func() {
 		podName := "testCpuLimit"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName,
 			"--cpus", "0.5", ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
-		Expect(ctr1Session).Should(Exit(0))
+		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName,
 			"--cpu-period", "100000", "--cpu-quota", "50000", ALPINE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
-		Expect(ctr2Session).Should(Exit(0))
+		Expect(ctr2Session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -674,21 +674,21 @@ var _ = Describe("Podman kube generate", func() {
 		defer lock5.Unlock()
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName, "-p", "4000:4000", "-p", "5000:5000"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
-		Expect(ctr1Session).Should(Exit(0))
+		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
-		Expect(ctr2Session).Should(Exit(0))
+		Expect(ctr2Session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -719,11 +719,11 @@ var _ = Describe("Podman kube generate", func() {
 		// Create container with UDP port and check the generated kube yaml
 		ctrWithUDP := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "6666:66/udp", ALPINE, "top"})
 		ctrWithUDP.WaitWithDefaultTimeout()
-		Expect(ctrWithUDP).Should(Exit(0))
+		Expect(ctrWithUDP).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"generate", "kube", "test-pod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod = new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -742,33 +742,33 @@ var _ = Describe("Podman kube generate", func() {
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test2", ALPINE, "top"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"generate", "kube", "-f", outputFile, podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		session3 := podmanTest.Podman([]string{"pod", "rm", "-af"})
 		session3.WaitWithDefaultTimeout()
-		Expect(session3).Should(Exit(0))
+		Expect(session3).Should(ExitCleanly())
 
 		session4 := podmanTest.Podman([]string{"play", "kube", outputFile})
 		session4.WaitWithDefaultTimeout()
-		Expect(session4).Should(Exit(0))
+		Expect(session4).Should(ExitCleanly())
 
 		session5 := podmanTest.Podman([]string{"pod", "ps"})
 		session5.WaitWithDefaultTimeout()
-		Expect(session5).Should(Exit(0))
+		Expect(session5).Should(ExitCleanly())
 		Expect(session5.OutputToString()).To(ContainSubstring(podName))
 
 		session6 := podmanTest.Podman([]string{"ps", "-a"})
 		session6.WaitWithDefaultTimeout()
-		Expect(session6).Should(Exit(0))
+		Expect(session6).Should(ExitCleanly())
 		psOut := session6.OutputToString()
 		Expect(psOut).To(ContainSubstring("test1"))
 		Expect(psOut).To(ContainSubstring("test2"))
@@ -781,31 +781,31 @@ var _ = Describe("Podman kube generate", func() {
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", "--user", "100:200", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{.Config.User}}", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(ContainSubstring("100:200"))
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"kube", "generate", "-f", outputFile, podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"pod", "rm", "-af"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		podmanTest.AddImageToRWStore(ALPINE)
 		session = podmanTest.Podman([]string{"play", "kube", outputFile})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		// container name in pod is <podName>-<ctrName>
 		inspect1 := podmanTest.Podman([]string{"inspect", "--format", "{{.Config.User}}", "toppod-test1"})
 		inspect1.WaitWithDefaultTimeout()
-		Expect(inspect1).Should(Exit(0))
+		Expect(inspect1).Should(ExitCleanly())
 		Expect(inspect1.OutputToString()).To(ContainSubstring(inspect.OutputToString()))
 	})
 
@@ -820,12 +820,12 @@ var _ = Describe("Podman kube generate", func() {
 
 		session1 := podmanTest.Podman([]string{"run", "-d", "--pod", "new:test1", "--name", ctrName, "-v", vol1 + ":/volume/:z", "alpine", "top"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"generate", "kube", "test1", "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		b, err := os.ReadFile(outputFile)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -836,15 +836,15 @@ var _ = Describe("Podman kube generate", func() {
 
 		rm := podmanTest.Podman([]string{"pod", "rm", "-t", "0", "-f", "test1"})
 		rm.WaitWithDefaultTimeout()
-		Expect(rm).Should(Exit(0))
+		Expect(rm).Should(ExitCleanly())
 
 		play := podmanTest.Podman([]string{"play", "kube", outputFile})
 		play.WaitWithDefaultTimeout()
-		Expect(play).Should(Exit(0))
+		Expect(play).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", ctrNameInKubePod})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(ContainSubstring(vol1))
 	})
 
@@ -857,11 +857,11 @@ var _ = Describe("Podman kube generate", func() {
 			"-v", "/root:/volume2/",
 			"alpine", "top"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "mount-root-conflict"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -880,24 +880,24 @@ var _ = Describe("Podman kube generate", func() {
 
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:test1", "--name", ctrName, "-v", vol + ":/volume/:z", "alpine", "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"generate", "kube", "test1", "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		rm := podmanTest.Podman([]string{"pod", "rm", "-t", "0", "-f", "test1"})
 		rm.WaitWithDefaultTimeout()
-		Expect(rm).Should(Exit(0))
+		Expect(rm).Should(ExitCleanly())
 
 		play := podmanTest.Podman([]string{"play", "kube", outputFile})
 		play.WaitWithDefaultTimeout()
-		Expect(play).Should(Exit(0))
+		Expect(play).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", ctrNameInKubePod})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(ContainSubstring(vol))
 	})
 
@@ -905,53 +905,53 @@ var _ = Describe("Podman kube generate", func() {
 		podName := "test"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName, "--share", "pid"})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"kube", "generate", podName, "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		rm := podmanTest.Podman([]string{"pod", "rm", "-t", "0", "-f", podName})
 		rm.WaitWithDefaultTimeout()
-		Expect(rm).Should(Exit(0))
+		Expect(rm).Should(ExitCleanly())
 
 		play := podmanTest.Podman([]string{"play", "kube", outputFile})
 		play.WaitWithDefaultTimeout()
-		Expect(play).Should(Exit(0))
+		Expect(play).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"pod", "inspect", podName})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(ContainSubstring(`"pid"`))
 	})
 
 	It("podman generate kube with pods and containers", func() {
 		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
 		pod1.WaitWithDefaultTimeout()
-		Expect(pod1).Should(Exit(0))
+		Expect(pod1).Should(ExitCleanly())
 
 		pod2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top", ALPINE, "top"})
 		pod2.WaitWithDefaultTimeout()
-		Expect(pod2).Should(Exit(0))
+		Expect(pod2).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "pod1", "top"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 	})
 
 	It("podman generate kube with containers in a pod should fail", func() {
 		pod1 := podmanTest.Podman([]string{"pod", "create", "--name", "pod1"})
 		pod1.WaitWithDefaultTimeout()
-		Expect(pod1).Should(Exit(0))
+		Expect(pod1).Should(ExitCleanly())
 
 		con := podmanTest.Podman([]string{"run", "-dt", "--pod", "pod1", "--name", "top", ALPINE, "top"})
 		con.WaitWithDefaultTimeout()
-		Expect(con).Should(Exit(0))
+		Expect(con).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
 		kube.WaitWithDefaultTimeout()
@@ -961,25 +961,25 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube with multiple containers", func() {
 		con1 := podmanTest.Podman([]string{"run", "-dt", "--name", "con1", ALPINE, "top"})
 		con1.WaitWithDefaultTimeout()
-		Expect(con1).Should(Exit(0))
+		Expect(con1).Should(ExitCleanly())
 
 		con2 := podmanTest.Podman([]string{"run", "-dt", "--name", "con2", ALPINE, "top"})
 		con2.WaitWithDefaultTimeout()
-		Expect(con2).Should(Exit(0))
+		Expect(con2).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "con1", "con2"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 	})
 
 	It("podman generate kube with containers in pods should fail", func() {
 		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", "--name", "top1", ALPINE, "top"})
 		pod1.WaitWithDefaultTimeout()
-		Expect(pod1).Should(Exit(0))
+		Expect(pod1).Should(ExitCleanly())
 
 		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", "--name", "top2", ALPINE, "top"})
 		pod2.WaitWithDefaultTimeout()
-		Expect(pod2).Should(Exit(0))
+		Expect(pod2).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "top1", "top2"})
 		kube.WaitWithDefaultTimeout()
@@ -989,11 +989,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on a container with dns options", func() {
 		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-option", "color:blue", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
-		Expect(top).Should(Exit(0))
+		Expect(top).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1010,15 +1010,15 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube multiple container dns servers and options are cumulative", func() {
 		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--dns", "8.8.8.8", "--dns-search", "foobar.com", ALPINE, "top"})
 		top1.WaitWithDefaultTimeout()
-		Expect(top1).Should(Exit(0))
+		Expect(top1).Should(ExitCleanly())
 
 		top2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top2", "--dns", "8.7.7.7", "--dns-search", "homer.com", ALPINE, "top"})
 		top2.WaitWithDefaultTimeout()
-		Expect(top2).Should(Exit(0))
+		Expect(top2).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "top1", "top2"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1033,11 +1033,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube on a pod with dns options", func() {
 		top := podmanTest.Podman([]string{"run", "--pod", "new:pod1", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-opt", "color:blue", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
-		Expect(top).Should(Exit(0))
+		Expect(top).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "pod1"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1054,11 +1054,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube - set entrypoint as command", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--entrypoint", "/bin/sleep", ALPINE, "10s"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the container's command is set to the
 		// entrypoint and it's arguments to "10s".
@@ -1076,11 +1076,11 @@ var _ = Describe("Podman kube generate", func() {
 	It("podman generate kube - use command from image unless explicitly set in the podman command", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "test"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the container's command in the kube yaml is not set to the
 		// image command.
@@ -1095,11 +1095,11 @@ var _ = Describe("Podman kube generate", func() {
 		cmd := []string{"echo", "hi"}
 		session = podmanTest.Podman(append([]string{"create", "--name", "test1", ALPINE}, cmd...))
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"kube", "generate", "test1"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the container's command in the kube yaml is set to the
 		// command passed via the cli to podman create.
@@ -1124,15 +1124,15 @@ ENTRYPOINT ["sleep"]`
 		image := "generatekube:test"
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", containerfilePath, "-t", image})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "new:testpod", image, "10s"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the container's command in the kube yaml is NOT set to the
 		// entrypoint but the arguments should be set to "10s".
@@ -1146,11 +1146,11 @@ ENTRYPOINT ["sleep"]`
 
 		session = podmanTest.Podman([]string{"create", "--pod", "new:testpod-2", "--entrypoint", "echo", image, "hello"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"kube", "generate", "testpod-2"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the container's command in the kube yaml is set to the
 		// entrypoint defined by the --entrypoint flag and the arguments should be set to "hello".
@@ -1176,15 +1176,15 @@ USER 1000`
 		image := "generatekube:test"
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", containerfilePath, "-t", image})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "new:testpod", image, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the container's securityContext has runAsNonRoot=true
 		pod := new(v1.Pod)
@@ -1200,11 +1200,11 @@ USER 1000`
 	It("podman generate kube - --privileged container", func() {
 		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--privileged", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Now make sure that the capabilities aren't set.
 		pod := new(v1.Pod)
@@ -1220,16 +1220,16 @@ USER 1000`
 
 		kube = podmanTest.Podman([]string{"generate", "kube", "testpod", "-f", kubeFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// Remove the pod so play can recreate it.
 		kube = podmanTest.Podman([]string{"pod", "rm", "-t", "0", "-f", "testpod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		kube = podmanTest.Podman([]string{"play", "kube", kubeFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 	})
 
 	It("podman generate kube based on user in container", func() {
@@ -1245,15 +1245,15 @@ USER test1`
 		image := "generatekube:test"
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", containerfilePath, "-t", image})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", "new:testpod", image, "test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "testpod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1266,11 +1266,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"volume", "create", vol})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", vol})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pvc := new(v1.PersistentVolumeClaim)
 		err := yaml.Unmarshal(kube.Out.Contents(), pvc)
@@ -1288,11 +1288,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"volume", "create", "--opt", "device=" + volDevice, "--opt", "type=" + volType, "--opt", "o=" + volOpts, vol})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", vol})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pvc := new(v1.PersistentVolumeClaim)
 		err := yaml.Unmarshal(kube.Out.Contents(), pvc)
@@ -1316,11 +1316,11 @@ USER test1`
 	It("podman generate kube on container with auto update labels", func() {
 		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--label", "io.containers.autoupdate=local", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
-		Expect(top).Should(Exit(0))
+		Expect(top).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1332,19 +1332,19 @@ USER test1`
 	It("podman generate kube on pod with auto update labels in all containers", func() {
 		pod1 := podmanTest.Podman([]string{"pod", "create", "--name", "pod1"})
 		pod1.WaitWithDefaultTimeout()
-		Expect(pod1).Should(Exit(0))
+		Expect(pod1).Should(ExitCleanly())
 
 		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--pod", "pod1", "--label", "io.containers.autoupdate=registry", "--label", "io.containers.autoupdate.authfile=/some/authfile.json", ALPINE, "top"})
 		top1.WaitWithDefaultTimeout()
-		Expect(top1).Should(Exit(0))
+		Expect(top1).Should(ExitCleanly())
 
 		top2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top2", "--workdir", "/root", "--pod", "pod1", "--label", "io.containers.autoupdate=registry", "--label", "io.containers.autoupdate.authfile=/some/authfile.json", ALPINE, "top"})
 		top2.WaitWithDefaultTimeout()
-		Expect(top2).Should(Exit(0))
+		Expect(top2).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "pod1"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1370,11 +1370,11 @@ USER test1`
 			"-e", "HELLO=WORLD",
 			"alpine", "top"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1388,11 +1388,11 @@ USER test1`
 
 		podCreate := podmanTest.Podman([]string{"run", "-d", "--pod", "new:" + "noSecretsPod", "--name", "noSecretsCtr", "--volume", dir + ":/foobar", ALPINE})
 		podCreate.WaitWithDefaultTimeout()
-		Expect(podCreate).Should(Exit(0))
+		Expect(podCreate).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "noSecretsPod"})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		Expect(kube.OutputToString()).ShouldNot(ContainSubstring("secret"))
 
@@ -1407,12 +1407,12 @@ USER test1`
 		ctrName := "ulimit-ctr"
 		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "sleep", "1000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"kube", "generate", ctrName, "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		b, err := os.ReadFile(outputFile)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -1427,12 +1427,12 @@ USER test1`
 		ctrNameInKubePod := ctrName + "-pod-" + ctrName
 		session1 := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--ulimit", "nofile=1231:3123", ALPINE, "sleep", "1000"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 
 		outputFile := filepath.Join(podmanTest.RunRoot, "pod.yaml")
 		kube := podmanTest.Podman([]string{"kube", "generate", ctrName, "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		b, err := os.ReadFile(outputFile)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -1444,15 +1444,15 @@ USER test1`
 
 		rm := podmanTest.Podman([]string{"pod", "rm", "-t", "0", "-f", ctrName})
 		rm.WaitWithDefaultTimeout()
-		Expect(rm).Should(Exit(0))
+		Expect(rm).Should(ExitCleanly())
 
 		play := podmanTest.Podman([]string{"kube", "play", outputFile})
 		play.WaitWithDefaultTimeout()
-		Expect(play).Should(Exit(0))
+		Expect(play).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", ctrNameInKubePod})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 		Expect(inspect.OutputToString()).To(ContainSubstring("RLIMIT_NOFILE"))
 		Expect(inspect.OutputToString()).To(ContainSubstring("1231"))
 		Expect(inspect.OutputToString()).To(ContainSubstring("3123"))
@@ -1462,18 +1462,18 @@ USER test1`
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "deployment", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		dep := new(v1.Deployment)
 		err := yaml.Unmarshal(kube.Out.Contents(), dep)
@@ -1493,11 +1493,11 @@ USER test1`
 		ctrName := "test-ctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "deployment", "--replicas", "3", ctrName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		dep := new(v1.Deployment)
 		err := yaml.Unmarshal(kube.Out.Contents(), dep)
@@ -1518,7 +1518,7 @@ USER test1`
 		ctrName := "test-ctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "pod", "--replicas", "3", ctrName})
 		kube.WaitWithDefaultTimeout()
@@ -1529,11 +1529,11 @@ USER test1`
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", "--restart", "no", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "deployment", podName})
 		kube.WaitWithDefaultTimeout()
@@ -1544,15 +1544,15 @@ USER test1`
 		podName := "test_pod"
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", podName, "--restart", "no", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1570,11 +1570,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--no-trunc", ctrName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1592,11 +1592,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", ctrName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1615,15 +1615,15 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, "--pod", podName, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--no-trunc", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1642,15 +1642,15 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, "--pod", podName, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1670,15 +1670,15 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--volumes-from", ctr1, "--name", ctr2, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr2})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1691,11 +1691,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--rm", "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1708,11 +1708,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--privileged", "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1725,11 +1725,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--init", "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1743,11 +1743,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--cidfile", cidFile, "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1760,11 +1760,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "seccomp=unconfined", "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1777,11 +1777,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1794,11 +1794,11 @@ USER test1`
 
 		session := podmanTest.Podman([]string{"create", "--security-opt", "label=level:s0", "--name", ctr, ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1828,11 +1828,11 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		ctr := "ctr"
 		session := podmanTest.Podman([]string{"create", "--publish-all", "--name", ctr, imageName, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1845,15 +1845,15 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podName := "test-pod"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--infra-name", infraName, podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1865,15 +1865,15 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podName := "test-pod"
 		podSession := podmanTest.Podman([]string{"pod", "create", podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// There should be no infra name annotation set if the --infra-name flag wasn't set during pod creation
 		pod := new(v1.Pod)
@@ -1886,15 +1886,15 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podName := "test-pod"
 		podSession := podmanTest.Podman([]string{"pod", "create", podName})
 		podSession.WaitWithDefaultTimeout()
-		Expect(podSession).Should(Exit(0))
+		Expect(podSession).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, "--stop-timeout", "20", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		// TerminationGracePeriodSeconds should be set to 20
 		pod := new(v1.Pod)
@@ -1907,18 +1907,18 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "daemonset", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(Exit(0))
+		Expect(kube).Should(ExitCleanly())
 
 		dep := new(v1.DaemonSet)
 		err := yaml.Unmarshal(kube.Out.Contents(), dep)
@@ -1933,7 +1933,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		ctrName := "test-ctr"
 		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "daemonset", "--replicas", "3", ctrName})
 		kube.WaitWithDefaultTimeout()
@@ -1945,11 +1945,11 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podName := "test-pod"
 		session := podmanTest.Podman([]string{"pod", "create", "--restart", "no", podName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"generate", "kube", "--type", "daemonset", podName})
 		kube.WaitWithDefaultTimeout()

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("service on container with --security-opt level", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=level:s0:c100,c200", "alpine"})
+		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=level:s0:c100,c200", CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -77,7 +77,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("service kube on container with --security-opt disable", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test-disable", "--security-opt", "label=disable", "alpine"})
+		session := podmanTest.Podman([]string{"create", "--name", "test-disable", "--security-opt", "label=disable", CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -93,7 +93,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("service kube on container with --security-opt type", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=type:foo_bar_t", "alpine"})
+		session := podmanTest.Podman([]string{"create", "--name", "test", "--security-opt", "label=type:foo_bar_t", CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -108,7 +108,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("service kube on container - targetPort should match port name", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", CITEST_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -132,7 +132,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("on container with and without service", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "test-ctr", "-p", "3890:3890", CITEST_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -194,11 +194,11 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("multiple pods", func() {
-		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
+		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", CITEST_IMAGE, "top"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
 
-		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", ALPINE, "top"})
+		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", CITEST_IMAGE, "top"})
 		pod2.WaitWithDefaultTimeout()
 		Expect(pod2).Should(ExitCleanly())
 
@@ -211,15 +211,15 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("on pod with init containers", func() {
-		session := podmanTest.Podman([]string{"create", "--pod", "new:toppod", "--init-ctr", "always", ALPINE, "echo", "hello"})
+		session := podmanTest.Podman([]string{"create", "--pod", "new:toppod", "--init-ctr", "always", CITEST_IMAGE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", "toppod", "--init-ctr", "always", ALPINE, "echo", "world"})
+		session = podmanTest.Podman([]string{"create", "--pod", "toppod", "--init-ctr", "always", CITEST_IMAGE, "echo", "world"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", "toppod", ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", "toppod", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -236,11 +236,11 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(numContainers).To(Equal(3))
 
 		// Init container should be in the generated kube yaml if created with "once" type and the pod has not been started
-		session = podmanTest.Podman([]string{"create", "--pod", "new:toppod-2", "--init-ctr", "once", ALPINE, "echo", "using once type"})
+		session = podmanTest.Podman([]string{"create", "--pod", "new:toppod-2", "--init-ctr", "once", CITEST_IMAGE, "echo", "using once type"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", "toppod-2", ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", "toppod-2", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -257,11 +257,11 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(numContainers).To(Equal(2))
 
 		// Init container should not be in the generated kube yaml if created with "once" type and the pod has been started
-		session = podmanTest.Podman([]string{"create", "--pod", "new:toppod-3", "--init-ctr", "once", ALPINE, "echo", "using once type"})
+		session = podmanTest.Podman([]string{"create", "--pod", "new:toppod-3", "--init-ctr", "once", CITEST_IMAGE, "echo", "using once type"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", "toppod-3", ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", "toppod-3", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -300,7 +300,7 @@ var _ = Describe("Podman kube generate", func() {
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"create", "--name", "topcontainer", "--pod", "testPod", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--name", "topcontainer", "--pod", "testPod", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -320,7 +320,7 @@ var _ = Describe("Podman kube generate", func() {
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"create", "--name", "topcontainer", "--pod", "testHostNetwork", "--network", "host", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--name", "topcontainer", "--pod", "testHostNetwork", "--network", "host", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -360,12 +360,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
-		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, ALPINE, "top"})
+		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, CITEST_IMAGE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
-		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
+		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, CITEST_IMAGE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
@@ -388,7 +388,7 @@ var _ = Describe("Podman kube generate", func() {
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		ctrSession := podmanTest.Podman([]string{"create", "--name", "testCtr", "--pod", podName, "-p", "9000:8000", ALPINE, "top"})
+		ctrSession := podmanTest.Podman([]string{"create", "--name", "testCtr", "--pod", podName, "-p", "9000:8000", CITEST_IMAGE, "top"})
 		ctrSession.WaitWithDefaultTimeout()
 		Expect(ctrSession).Should(Exit(125))
 
@@ -399,12 +399,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
-		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "-p", "9000:8000", ALPINE, "top"})
+		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "-p", "9000:8000", CITEST_IMAGE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
-		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, "-p", "6000:5000", ALPINE, "top"})
+		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, "-p", "6000:5000", CITEST_IMAGE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
@@ -429,7 +429,7 @@ var _ = Describe("Podman kube generate", func() {
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		ctrSession := podmanTest.Podman([]string{"create", "--name", "testCtr", "--pod", podName, "--hostname", "test-hostname", ALPINE, "top"})
+		ctrSession := podmanTest.Podman([]string{"create", "--name", "testCtr", "--pod", podName, "--hostname", "test-hostname", CITEST_IMAGE, "top"})
 		ctrSession.WaitWithDefaultTimeout()
 		Expect(ctrSession).Should(Exit(125))
 
@@ -442,12 +442,12 @@ var _ = Describe("Podman kube generate", func() {
 
 		ctr1Name := "ctr1"
 		ctr1HostName := "ctr1-hostname"
-		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "--hostname", ctr1HostName, ALPINE, "top"})
+		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "--hostname", ctr1HostName, CITEST_IMAGE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
-		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
+		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, CITEST_IMAGE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
@@ -469,7 +469,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(podSession).Should(ExitCleanly())
 
 		ctr3Name := "ctr3"
-		ctr3Session := podmanTest.Podman([]string{"create", "--name", ctr3Name, "--pod", podName, ALPINE, "top"})
+		ctr3Session := podmanTest.Podman([]string{"create", "--name", ctr3Name, "--pod", podName, CITEST_IMAGE, "top"})
 		ctr3Session.WaitWithDefaultTimeout()
 		Expect(ctr3Session).Should(ExitCleanly())
 
@@ -485,7 +485,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("service kube on pod", func() {
-		session := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "4000:4000/udp", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "4000:4000/udp", CITEST_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -529,7 +529,7 @@ var _ = Describe("Podman kube generate", func() {
 
 			ctrName := "ctr" + strconv.Itoa(k)
 			ctr1Session := podmanTest.Podman([]string{"create", "--name", ctrName, "--pod", podName,
-				"--restart", v[1], ALPINE, "top"})
+				"--restart", v[1], CITEST_IMAGE, "top"})
 			ctr1Session.WaitWithDefaultTimeout()
 			Expect(ctr1Session).Should(ExitCleanly())
 
@@ -562,7 +562,7 @@ var _ = Describe("Podman kube generate", func() {
 			Expect(podSession).Should(ExitCleanly())
 
 			ctrName := "ctr" + strconv.Itoa(k)
-			ctr1Session := podmanTest.Podman([]string{"create", "--name", ctrName, "--pod", podName, ALPINE, "top"})
+			ctr1Session := podmanTest.Podman([]string{"create", "--name", ctrName, "--pod", podName, CITEST_IMAGE, "top"})
 			ctr1Session.WaitWithDefaultTimeout()
 			Expect(ctr1Session).Should(ExitCleanly())
 
@@ -590,7 +590,7 @@ var _ = Describe("Podman kube generate", func() {
 
 		for k, v := range testSli {
 			ctrName := "ctr" + strconv.Itoa(k)
-			ctrSession := podmanTest.Podman([]string{"create", "--restart", v[0], "--name", ctrName, ALPINE, "top"})
+			ctrSession := podmanTest.Podman([]string{"create", "--restart", v[0], "--name", ctrName, CITEST_IMAGE, "top"})
 			ctrSession.WaitWithDefaultTimeout()
 			Expect(ctrSession).Should(ExitCleanly())
 
@@ -614,7 +614,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
-		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "--memory", "10M", ALPINE, "top"})
+		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, "--memory", "10M", CITEST_IMAGE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session).Should(ExitCleanly())
 
@@ -641,13 +641,13 @@ var _ = Describe("Podman kube generate", func() {
 
 		ctr1Name := "ctr1"
 		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName,
-			"--cpus", "0.5", ALPINE, "top"})
+			"--cpus", "0.5", CITEST_IMAGE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
 		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName,
-			"--cpu-period", "100000", "--cpu-quota", "50000", ALPINE, "top"})
+			"--cpu-period", "100000", "--cpu-quota", "50000", CITEST_IMAGE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
@@ -677,12 +677,12 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(podSession).Should(ExitCleanly())
 
 		ctr1Name := "ctr1"
-		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, ALPINE, "top"})
+		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, CITEST_IMAGE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session).Should(ExitCleanly())
 
 		ctr2Name := "ctr2"
-		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
+		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, CITEST_IMAGE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session).Should(ExitCleanly())
 
@@ -717,7 +717,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(foundOtherPort).To(Equal(0))
 
 		// Create container with UDP port and check the generated kube yaml
-		ctrWithUDP := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "6666:66/udp", ALPINE, "top"})
+		ctrWithUDP := podmanTest.Podman([]string{"create", "--pod", "new:test-pod", "-p", "6666:66/udp", CITEST_IMAGE, "top"})
 		ctrWithUDP.WaitWithDefaultTimeout()
 		Expect(ctrWithUDP).Should(ExitCleanly())
 
@@ -740,11 +740,11 @@ var _ = Describe("Podman kube generate", func() {
 		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(rc).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session2 := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test2", ALPINE, "top"})
+		session2 := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test2", CITEST_IMAGE, "top"})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(ExitCleanly())
 
@@ -779,7 +779,7 @@ var _ = Describe("Podman kube generate", func() {
 		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(rc).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", "--user", "100:200", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", "--user", "100:200", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -797,7 +797,7 @@ var _ = Describe("Podman kube generate", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 		session = podmanTest.Podman([]string{"kube", "play", outputFile})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -818,7 +818,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctrName := "test-ctr"
 		ctrNameInKubePod := "test1-test-ctr"
 
-		session1 := podmanTest.Podman([]string{"run", "-d", "--pod", "new:test1", "--name", ctrName, "-v", vol1 + ":/volume/:z", "alpine", "top"})
+		session1 := podmanTest.Podman([]string{"run", "-d", "--pod", "new:test1", "--name", ctrName, "-v", vol1 + ":/volume/:z", CITEST_IMAGE, "top"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())
 
@@ -855,7 +855,7 @@ var _ = Describe("Podman kube generate", func() {
 		session1 := podmanTest.Podman([]string{"run", "-d", "--pod", "new:mount-root-conflict", "--name", ctrName,
 			"-v", "/:/volume1/",
 			"-v", "/root:/volume2/",
-			"alpine", "top"})
+			CITEST_IMAGE, "top"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())
 
@@ -878,7 +878,7 @@ var _ = Describe("Podman kube generate", func() {
 		ctrName := "test-persistent-volume-claim"
 		ctrNameInKubePod := "test1-test-persistent-volume-claim"
 
-		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:test1", "--name", ctrName, "-v", vol + ":/volume/:z", "alpine", "top"})
+		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:test1", "--name", ctrName, "-v", vol + ":/volume/:z", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -907,7 +907,7 @@ var _ = Describe("Podman kube generate", func() {
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -931,11 +931,11 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("with pods and containers", func() {
-		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
+		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", CITEST_IMAGE, "top"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
 
-		pod2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top", ALPINE, "top"})
+		pod2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top", CITEST_IMAGE, "top"})
 		pod2.WaitWithDefaultTimeout()
 		Expect(pod2).Should(ExitCleanly())
 
@@ -949,7 +949,7 @@ var _ = Describe("Podman kube generate", func() {
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
 
-		con := podmanTest.Podman([]string{"run", "-dt", "--pod", "pod1", "--name", "top", ALPINE, "top"})
+		con := podmanTest.Podman([]string{"run", "-dt", "--pod", "pod1", "--name", "top", CITEST_IMAGE, "top"})
 		con.WaitWithDefaultTimeout()
 		Expect(con).Should(ExitCleanly())
 
@@ -959,11 +959,11 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("with multiple containers", func() {
-		con1 := podmanTest.Podman([]string{"run", "-dt", "--name", "con1", ALPINE, "top"})
+		con1 := podmanTest.Podman([]string{"run", "-dt", "--name", "con1", CITEST_IMAGE, "top"})
 		con1.WaitWithDefaultTimeout()
 		Expect(con1).Should(ExitCleanly())
 
-		con2 := podmanTest.Podman([]string{"run", "-dt", "--name", "con2", ALPINE, "top"})
+		con2 := podmanTest.Podman([]string{"run", "-dt", "--name", "con2", CITEST_IMAGE, "top"})
 		con2.WaitWithDefaultTimeout()
 		Expect(con2).Should(ExitCleanly())
 
@@ -973,11 +973,11 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("with containers in pods should fail", func() {
-		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", "--name", "top1", ALPINE, "top"})
+		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", "--name", "top1", CITEST_IMAGE, "top"})
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
 
-		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", "--name", "top2", ALPINE, "top"})
+		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", "--name", "top2", CITEST_IMAGE, "top"})
 		pod2.WaitWithDefaultTimeout()
 		Expect(pod2).Should(ExitCleanly())
 
@@ -987,7 +987,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("on a container with dns options", func() {
-		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-option", "color:blue", ALPINE, "top"})
+		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-option", "color:blue", CITEST_IMAGE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(ExitCleanly())
 
@@ -1008,11 +1008,11 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("multiple container dns servers and options are cumulative", func() {
-		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--dns", "8.8.8.8", "--dns-search", "foobar.com", ALPINE, "top"})
+		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--dns", "8.8.8.8", "--dns-search", "foobar.com", CITEST_IMAGE, "top"})
 		top1.WaitWithDefaultTimeout()
 		Expect(top1).Should(ExitCleanly())
 
-		top2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top2", "--dns", "8.7.7.7", "--dns-search", "homer.com", ALPINE, "top"})
+		top2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top2", "--dns", "8.7.7.7", "--dns-search", "homer.com", CITEST_IMAGE, "top"})
 		top2.WaitWithDefaultTimeout()
 		Expect(top2).Should(ExitCleanly())
 
@@ -1031,7 +1031,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("on a pod with dns options", func() {
-		top := podmanTest.Podman([]string{"run", "--pod", "new:pod1", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-opt", "color:blue", ALPINE, "top"})
+		top := podmanTest.Podman([]string{"run", "--pod", "new:pod1", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-opt", "color:blue", CITEST_IMAGE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(ExitCleanly())
 
@@ -1052,7 +1052,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("- set entrypoint as command", func() {
-		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--entrypoint", "/bin/sleep", ALPINE, "10s"})
+		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--entrypoint", "/bin/sleep", CITEST_IMAGE, "10s"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1074,7 +1074,7 @@ var _ = Describe("Podman kube generate", func() {
 	})
 
 	It("- use command from image unless explicitly set in the podman command", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test", ALPINE})
+		session := podmanTest.Podman([]string{"create", "--name", "test", CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1093,7 +1093,7 @@ var _ = Describe("Podman kube generate", func() {
 		Expect(containers[0].Command).To(BeEmpty())
 
 		cmd := []string{"echo", "hi"}
-		session = podmanTest.Podman(append([]string{"create", "--name", "test1", ALPINE}, cmd...))
+		session = podmanTest.Podman(append([]string{"create", "--name", "test1", CITEST_IMAGE}, cmd...))
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1198,7 +1198,7 @@ USER 1000`
 	})
 
 	It("- --privileged container", func() {
-		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--privileged", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--pod", "new:testpod", "--privileged", CITEST_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1314,7 +1314,7 @@ USER test1`
 	})
 
 	It("on container with auto update labels", func() {
-		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--label", "io.containers.autoupdate=local", ALPINE, "top"})
+		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--label", "io.containers.autoupdate=local", CITEST_IMAGE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(ExitCleanly())
 
@@ -1334,11 +1334,11 @@ USER test1`
 		pod1.WaitWithDefaultTimeout()
 		Expect(pod1).Should(ExitCleanly())
 
-		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--pod", "pod1", "--label", "io.containers.autoupdate=registry", "--label", "io.containers.autoupdate.authfile=/some/authfile.json", ALPINE, "top"})
+		top1 := podmanTest.Podman([]string{"run", "-dt", "--name", "top1", "--pod", "pod1", "--label", "io.containers.autoupdate=registry", "--label", "io.containers.autoupdate.authfile=/some/authfile.json", CITEST_IMAGE, "top"})
 		top1.WaitWithDefaultTimeout()
 		Expect(top1).Should(ExitCleanly())
 
-		top2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top2", "--workdir", "/root", "--pod", "pod1", "--label", "io.containers.autoupdate=registry", "--label", "io.containers.autoupdate.authfile=/some/authfile.json", ALPINE, "top"})
+		top2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top2", "--workdir", "/root", "--pod", "pod1", "--label", "io.containers.autoupdate=registry", "--label", "io.containers.autoupdate.authfile=/some/authfile.json", CITEST_IMAGE, "top"})
 		top2.WaitWithDefaultTimeout()
 		Expect(top2).Should(ExitCleanly())
 
@@ -1368,7 +1368,7 @@ USER test1`
 		session1 := podmanTest.Podman([]string{"run", "-d", "--http-proxy=false", "--pod", "new:" + podName, "--name", ctrName,
 			"-e", "FOO=bar",
 			"-e", "HELLO=WORLD",
-			"alpine", "top"})
+			CITEST_IMAGE, "top"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())
 
@@ -1386,7 +1386,7 @@ USER test1`
 	It("omit secret if empty", func() {
 		dir := GinkgoT().TempDir()
 
-		podCreate := podmanTest.Podman([]string{"run", "-d", "--pod", "new:" + "noSecretsPod", "--name", "noSecretsCtr", "--volume", dir + ":/foobar", ALPINE})
+		podCreate := podmanTest.Podman([]string{"run", "-d", "--pod", "new:" + "noSecretsPod", "--name", "noSecretsCtr", "--volume", dir + ":/foobar", CITEST_IMAGE})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(ExitCleanly())
 
@@ -1405,7 +1405,7 @@ USER test1`
 
 	It("with default ulimits", func() {
 		ctrName := "ulimit-ctr"
-		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "sleep", "1000"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, CITEST_IMAGE, "sleep", "1000"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1425,7 +1425,7 @@ USER test1`
 	It("with --ulimit set", func() {
 		ctrName := "ulimit-ctr"
 		ctrNameInKubePod := ctrName + "-pod-" + ctrName
-		session1 := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--ulimit", "nofile=1231:3123", ALPINE, "sleep", "1000"})
+		session1 := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--ulimit", "nofile=1231:3123", CITEST_IMAGE, "sleep", "1000"})
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())
 
@@ -1464,10 +1464,10 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "sleep", "100"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1491,7 +1491,7 @@ USER test1`
 
 	It("on ctr with --type=deployment and --replicas=3", func() {
 		ctrName := "test-ctr"
-		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--name", ctrName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1516,7 +1516,7 @@ USER test1`
 
 	It("on ctr with --type=pod and --replicas=3 should fail", func() {
 		ctrName := "test-ctr"
-		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--name", ctrName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1531,7 +1531,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1546,7 +1546,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", podName, "--restart", "no", ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, "--restart", "no", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1568,7 +1568,7 @@ USER test1`
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
-		session := podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, ALPINE})
+		session := podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1590,13 +1590,19 @@ USER test1`
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
-		session := podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, ALPINE})
+		session := podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", ctrName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(ExitCleanly())
+		Expect(kube).Should(Exit(0))
+		if IsRemote() {
+			Expect(kube.ErrorToString()).To(BeEmpty())
+		} else {
+			Expect(kube.ErrorToString()).To(ContainSubstring("Truncation Annotation:"))
+			Expect(kube.ErrorToString()).To(ContainSubstring("Kubernetes only allows 63 characters"))
+		}
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1617,7 +1623,7 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, "--pod", podName, ALPINE})
+		session = podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, "--pod", podName, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1644,13 +1650,20 @@ USER test1`
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, "--pod", podName, ALPINE})
+		session = podmanTest.Podman([]string{"create", "-v", vol1 + ":/tmp/foo:Z", "--name", ctrName, "--pod", podName, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
 		kube := podmanTest.Podman([]string{"kube", "generate", podName})
 		kube.WaitWithDefaultTimeout()
-		Expect(kube).Should(ExitCleanly())
+		Expect(kube).Should(Exit(0))
+
+		if IsRemote() {
+			Expect(kube.ErrorToString()).To(BeEmpty())
+		} else {
+			Expect(kube.ErrorToString()).To(ContainSubstring("Truncation Annotation:"))
+			Expect(kube.ErrorToString()).To(ContainSubstring("Kubernetes only allows 63 characters"))
+		}
 
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
@@ -1668,11 +1681,11 @@ USER test1`
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
-		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--volumes-from", ctr1, "--name", ctr2, ALPINE})
+		session = podmanTest.Podman([]string{"create", "--volumes-from", ctr1, "--name", ctr2, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1689,7 +1702,7 @@ USER test1`
 	It("--podman-only on container with --rm", func() {
 		ctr := "ctr"
 
-		session := podmanTest.Podman([]string{"create", "--rm", "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--rm", "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1706,7 +1719,7 @@ USER test1`
 	It("--podman-only on container with --privileged", func() {
 		ctr := "ctr"
 
-		session := podmanTest.Podman([]string{"create", "--privileged", "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--privileged", "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1723,7 +1736,7 @@ USER test1`
 	It("--podman-only on container with --init", func() {
 		ctr := "ctr"
 
-		session := podmanTest.Podman([]string{"create", "--init", "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--init", "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1741,7 +1754,7 @@ USER test1`
 		ctr := "ctr"
 		cidFile := filepath.Join(podmanTest.TempDir, RandomString(10)+".txt")
 
-		session := podmanTest.Podman([]string{"create", "--cidfile", cidFile, "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--cidfile", cidFile, "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1758,7 +1771,7 @@ USER test1`
 	It("--podman-only on container with --security-opt seccomp=unconfined", func() {
 		ctr := "ctr"
 
-		session := podmanTest.Podman([]string{"create", "--security-opt", "seccomp=unconfined", "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--security-opt", "seccomp=unconfined", "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1775,7 +1788,7 @@ USER test1`
 	It("--podman-only on container with --security-opt apparmor=unconfined", func() {
 		ctr := "ctr"
 
-		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1792,7 +1805,7 @@ USER test1`
 	It("--podman-only on container with --security-opt label=level:s0", func() {
 		ctr := "ctr"
 
-		session := podmanTest.Podman([]string{"create", "--security-opt", "label=level:s0", "--name", ctr, ALPINE})
+		session := podmanTest.Podman([]string{"create", "--security-opt", "label=level:s0", "--name", ctr, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1807,11 +1820,11 @@ USER test1`
 	})
 
 	It("--podman-only on container with --publish-all", func() {
-		podmanTest.AddImageToRWStore(ALPINE)
+		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 		dockerfile := fmt.Sprintf(`FROM %s
 EXPOSE 2002
 EXPOSE 2001-2003
-EXPOSE 2004-2005/tcp`, ALPINE)
+EXPOSE 2004-2005/tcp`, CITEST_IMAGE)
 		imageName := "testimg"
 		podmanTest.BuildImage(dockerfile, imageName, "false")
 
@@ -1847,7 +1860,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1867,7 +1880,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1888,7 +1901,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"create", "--pod", podName, "--stop-timeout", "20", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", podName, "--stop-timeout", "20", CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1909,10 +1922,10 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "sleep", "100"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1931,7 +1944,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	It("on ctr with --type=daemonset and --replicas=3 should fail", func() {
 		ctrName := "test-ctr"
-		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--name", ctrName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -1947,7 +1960,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "--pod", podName, CITEST_IMAGE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 


### PR DESCRIPTION
Similar to #20065, but simpler. Three commits, and once again the third is the one worth reviewing.

```release-note
None
```