### PR TITLE
specgen, rootless: fix mount of cgroup without a netns

### DIFF
--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -125,11 +125,12 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		}
 		g.AddMount(sysMnt)
 		g.RemoveMount("/sys/fs/cgroup")
+
 		sysFsCgroupMnt := spec.Mount{
 			Destination: "/sys/fs/cgroup",
-			Type:        define.TypeBind,
+			Type:        "cgroup",
 			Source:      "/sys/fs/cgroup",
-			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r, "rbind"},
+			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r},
 		}
 		g.AddMount(sysFsCgroupMnt)
 		if !s.Privileged && isRootless {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1167,6 +1167,10 @@ EOF
         # verify that the last /sys/fs/cgroup mount is read-only
         run_podman run --net=host --cgroupns=host --rm $IMAGE sh -c "grep ' / /sys/fs/cgroup ' /proc/self/mountinfo | tail -n 1"
         assert "$output" =~ "/sys/fs/cgroup ro"
+
+        # verify that it works also with a cgroupns
+        run_podman run --net=host --cgroupns=private --rm $IMAGE sh -c "grep ' / /sys/fs/cgroup ' /proc/self/mountinfo | tail -n 1"
+        assert "$output" =~ "/sys/fs/cgroup ro"
     fi
 }
 


### PR DESCRIPTION
commit cf364703fc3f94cd759cc683e3ab9083e8ecc324 changed the way /sys/fs/cgroup is mounted when there is not a netns and it now honors the ro flag.  The mount was created using a bind mount that is a problem when using a cgroup namespace, fix that by mounting a fresh cgroup file system.

Closes: https://github.com/containers/podman/issues/20073

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now a cgroup is correctly mounted when running without a network namespace in rootless mode
```
