### PR TITLE
fixes for pkg/machine/e2e on hyperv

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -46,7 +46,9 @@ const (
 	// Stopped indicates the vm has stopped.
 	Stopped Status = "stopped"
 	// Starting indicated the vm is in the process of starting
-	Starting           Status = "starting"
+	Starting Status = "starting"
+	// Unknown means the state is not known
+	Unknown            Status = "unknown"
 	DefaultMachineName string = "podman-machine-default"
 	apiUpTimeout              = 20 * time.Second
 )

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -43,9 +43,11 @@ func TestMachine(t *testing.T) {
 	RunSpecs(t, "Podman Machine tests")
 }
 
-var _ = BeforeSuite(func() {
+var testProvider machine.VirtProvider
 
-	testProvider, err := provider.Get()
+var _ = BeforeSuite(func() {
+	var err error
+	testProvider, err = provider.Get()
 	if err != nil {
 		Fail("unable to create testProvider")
 	}

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -6,6 +6,7 @@ package hyperv
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -283,4 +284,16 @@ func handlePrevError(e, prevErr error) error {
 		logrus.Error(e)
 	}
 	return e
+}
+
+func stateConversion(s hypervctl.EnabledState) (machine.Status, error) {
+	switch s {
+	case hypervctl.Enabled:
+		return machine.Running, nil
+	case hypervctl.Disabled:
+		return machine.Stopped, nil
+	case hypervctl.Starting:
+		return machine.Starting, nil
+	}
+	return machine.Unknown, fmt.Errorf("unknown state: %q", s.String())
 }

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -283,6 +283,11 @@ func (m *HyperVMachine) Inspect() (*machine.InspectInfo, error) {
 		return nil, err
 	}
 
+	vmState, err := stateConversion(vm.State())
+	if err != nil {
+		return nil, err
+	}
+
 	return &machine.InspectInfo{
 		ConfigPath:     m.ConfigPath,
 		ConnectionInfo: machine.ConnectionConfig{},
@@ -300,7 +305,7 @@ func (m *HyperVMachine) Inspect() (*machine.InspectInfo, error) {
 			Memory:   cfg.Hardware.Memory,
 		},
 		SSHConfig: m.SSHConfig,
-		State:     vm.State().String(),
+		State:     string(vmState),
 		Rootful:   m.Rootful,
 	}, nil
 }


### PR DESCRIPTION
some problems were found in machine tests on hyperv.

in the case of rootful, it is currently not implemented.  an issue #20092 has been created for that problem.

there also seems to be a timezone issue between ignition and fcos right now.  inquiries are in for that but no issue generated for that.  this problem is not exclusive to hyperv by any means.

both of the above have been skipped or commented out.

otherwise, this fixes machine state reporting for consistency.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
