### PR TITLE
pod rm: do not log error if anonymous volume is still used

### DIFF
--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -327,7 +327,9 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool,
 			continue
 		}
 		if err := r.removeVolume(ctx, volume, false, timeout, false); err != nil {
-			if errors.Is(err, define.ErrNoSuchVolume) || errors.Is(err, define.ErrVolumeRemoved) {
+			// If the anonymous volume is still being used that means it was likely transferred
+			// to another container via --volumes-from so no need to log this as real error.
+			if errors.Is(err, define.ErrNoSuchVolume) || errors.Is(err, define.ErrVolumeRemoved) || errors.Is(err, define.ErrVolumeBeingUsed) {
 				continue
 			}
 			logrus.Errorf("Removing volume %s: %v", volName, err)

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5704,6 +5704,11 @@ spec:
 		Expect(inspectCtr1).Should(ExitCleanly())
 
 		Expect(inspectCtr2.OutputToString()).To(Equal(inspectCtr1.OutputToString()))
+
+		// see https://github.com/containers/podman/pull/19637, we should not see any warning/errors here
+		podrm := podmanTest.Podman([]string{"kube", "down", outputFile})
+		podrm.WaitWithDefaultTimeout()
+		Expect(podrm).Should(ExitCleanly())
 	})
 
 	It("test with reserved autoremove annotation in yaml", func() {


### PR DESCRIPTION
This is not really an error, if the anonymous volume is still used then this likely means it was transferred to another container with --volumes-from. This is what the user wants and it is not like the user can act on the logged error anyway. Once the last user of the volume is removed it will be removed correctly.

see https://github.com/containers/podman/pull/19637

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
