### PR TITLE
fix(quadlet): Don't crash on invalid mounts

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -733,6 +733,9 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 		paramsMap := make(map[string]string, len(params))
 		for _, param := range params {
 			kv := strings.Split(param, "=")
+			if len(kv) != 2 {
+				return nil, fmt.Errorf(`invalid quadlet mount format: %q`, mount)
+			}
 			paramsMap[kv[0]] = kv[1]
 		}
 		if paramType, ok := paramsMap["type"]; ok {

--- a/test/e2e/quadlet/invalid-mount.container
+++ b/test/e2e/quadlet/invalid-mount.container
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "invalid quadlet mount format"
+
+[Container]
+Image=localhost/imagename
+Mount=/invalid:/mount:ro

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -591,6 +591,7 @@ BOGUS=foo
 		Entry("health.container", "health.container", 0, ""),
 		Entry("hostname.container", "hostname.container", 0, ""),
 		Entry("image.container", "image.container", 0, ""),
+		Entry("invalid-mount.container", "invalid-mount.container", 1, `converting "invalid-mount.container": invalid quadlet mount format: "/invalid:/mount:ro"`),
 		Entry("install.container", "install.container", 0, ""),
 		Entry("ip.container", "ip.container", 0, ""),
 		Entry("label.container", "label.container", 0, ""),


### PR DESCRIPTION
If `Mount` directives are not in the form `Key=Value`, quadlet crashes due to an index out of range error.

Check this & return an error message instead.

Fixes: #20104

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
