### PR TITLE
Fix setting timezone on HyperV

### DIFF
--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -130,12 +130,11 @@ var _ = Describe("podman machine init", func() {
 		Expect(foundMemory).To(BeNumerically(">", 3800000))
 		Expect(foundMemory).To(BeNumerically("<", 4200000))
 
-		// TODO timezone setting is broken in FCOS rn.  It is either ignition or a change in fedora.
-		// sshTimezone := sshMachine{}
-		// timezoneSession, err := mb.setName(name).setCmd(sshTimezone.withSSHCommand([]string{"date"})).run()
-		// Expect(err).ToNot(HaveOccurred())
-		// Expect(timezoneSession).To(Exit(0))
-		// Expect(timezoneSession.outputToString()).To(ContainSubstring("HST"))
+		sshTimezone := sshMachine{}
+		timezoneSession, err := mb.setName(name).setCmd(sshTimezone.withSSHCommand([]string{"date"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(timezoneSession).To(Exit(0))
+		Expect(timezoneSession.outputToString()).To(ContainSubstring("HST"))
 	})
 
 	It("machine init with volume", func() {

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -127,8 +127,11 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 				User:      GetNodeUsr("root"),
 			},
 			LinkEmbedded1: LinkEmbedded1{
-				Hard:   BoolToPtr(false),
-				Target: filepath.Join("/usr/share/zoneinfo", tz),
+				Hard: BoolToPtr(false),
+				// We always want this value in unix form (/path/to/something) because this is being
+				// set in the machine OS (always Linux).  However, filepath.join on windows will use a "\\"
+				// separator; therefore we use ToSlash to convert the path to unix style
+				Target: filepath.ToSlash(filepath.Join("/usr/share/zoneinfo", tz)),
 			},
 		}
 		ignStorage.Links = append(ignStorage.Links, tzLink)


### PR DESCRIPTION
the timezone was being set with the wrong path separator for hyperv because it was being generated on Windows.

Fixes: coreos/fedora-coreos-tracker#1580

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
