### PR TITLE
hyperv: set more realistic starting state

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -200,12 +200,12 @@ func toHumanFormat(vms []*machine.ListResponse) ([]*entities.ListReporter, error
 			response.Name = vm.Name
 		}
 		switch {
-		case vm.Running:
-			response.LastUp = "Currently running"
-			response.Running = true
 		case vm.Starting:
 			response.LastUp = "Currently starting"
 			response.Starting = true
+		case vm.Running:
+			response.LastUp = "Currently running"
+			response.Running = true
 		default:
 			response.LastUp = units.HumanDuration(time.Since(vm.LastUp)) + " ago"
 		}

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -84,7 +84,7 @@ func (v HyperVVirtualization) List(opts machine.ListOptions) ([]*machine.ListRes
 			CreatedAt:      mm.Created,
 			LastUp:         mm.LastUp,
 			Running:        vm.State() == hypervctl.Enabled,
-			Starting:       vm.IsStarting(),
+			Starting:       mm.isStarting(),
 			Stream:         mm.ImageStream,
 			VMType:         machine.HyperVVirt.String(),
 			CPUs:           mm.CPUs,


### PR DESCRIPTION
the window for hyperv's "Starting" state is very narrow; so to more mimic qemu, we follow suit.  starting bools are set when the vm boots and when it communicates back on the read socket.

this allows pkg/machine/init_test.go to pass

[NO NEW TESTS ARE NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
