### PR TITLE
hyperv: use StopWithForce with remove

### DIFF
--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -212,11 +212,8 @@ func (v HyperVVirtualization) RemoveAndCleanMachines() error {
 			prevErr = handlePrevError(err, prevErr)
 		}
 
-		// If the VM is not stopped, we need to stop it
-		// TODO stop might not be enough if the state is dorked. we may need
-		// something like forceoff hard switch
 		if vm.State() != hypervctl.Disabled {
-			if err := vm.Stop(); err != nil {
+			if err := vm.StopWithForce(); err != nil {
 				prevErr = handlePrevError(err, prevErr)
 			}
 		}

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -359,7 +359,8 @@ func (m *HyperVMachine) Remove(_ string, opts machine.RemoveOptions) (string, fu
 		if !opts.Force {
 			return "", nil, &machine.ErrVMRunningCannotDestroyed{Name: m.Name}
 		}
-		if err := vm.Stop(); err != nil {
+		// force stop bc we are destroying
+		if err := vm.StopWithForce(); err != nil {
 			return "", nil, err
 		}
 	}


### PR DESCRIPTION
When doing a machine rm -f (force removal of a machine) or a machine reset (force removal of all machines), there is no need to use a "polite/soft" stop.

this will also speed up pkg/machine/e2e tests.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
