### PR TITLE
hyperv: machine e2e tests for set command

### DIFF
--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -201,17 +200,4 @@ func (matcher *ValidJSONMatcher) FailureMessage(actual interface{}) (message str
 
 func (matcher *ValidJSONMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "to _not_ be valid JSON")
-}
-
-func checkReason(reason string) {
-	if len(reason) < 5 {
-		panic("Test must specify a reason to skip")
-	}
-}
-
-func SkipIfNotWindows(reason string) {
-	checkReason(reason)
-	if runtime.GOOS != "windows" {
-		Skip("[not windows]: " + reason)
-	}
 }

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v4/pkg/machine"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -139,8 +140,9 @@ var _ = Describe("podman machine set", func() {
 	})
 
 	It("set user mode networking", func() {
-		SkipIfNotWindows("Setting user mode networking is only honored on Windows")
-
+		if testProvider.VMType() != machine.WSLVirt {
+			Skip("Test is only for WSL")
+		}
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()


### PR DESCRIPTION
The usermode networking scenario is only for WSL.  Hyperv cannot run it.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
