### PR TITLE
podman build: correct default pull policy

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -65,11 +65,11 @@ func DefineBuildFlags(cmd *cobra.Command, buildOpts *BuildFlagsWrapper) {
 
 	// --pull flag
 	flag := budFlags.Lookup("pull")
-	if err := flag.Value.Set("true"); err != nil {
-		logrus.Errorf("Unable to set --pull to true: %v", err)
+	flag.DefValue = "missing"
+	if err := flag.Value.Set("missing"); err != nil {
+		logrus.Errorf("Unable to set --pull to 'missing': %v", err)
 	}
-	flag.DefValue = "true"
-	flag.Usage = "Always attempt to pull the image (errors are fatal)"
+	flag.Usage = `Pull image policy ("always/true"|"missing"|"never/false"|"newer")`
 	flags.AddFlagSet(&budFlags)
 
 	// Add the completion functions

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -653,7 +653,7 @@ the help of emulation provided by packages like `qemu-user-static`.
 
 #### **--pull**=*policy*
 
-Pull image policy. The default is **always**.
+Pull image policy. The default is **missing**.
 
 - **always**, **true**: Always pull the image and throw an error if the pull fails.
 - **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -24,6 +24,10 @@ EOF
     PODMAN_TIMEOUT=240 run_podman build -t build_test --format=docker $tmpdir
     is "$output" ".*COMMIT" "COMMIT seen in log"
 
+    # $IMAGE is preloaded, so we should never re-pull
+    assert "$output" !~ "Trying to pull" "Default pull policy should be 'missing'"
+    assert "$output" !~ "Writing manifest" "Default pull policy should be 'missing'"
+
     run_podman run --rm build_test cat /$rand_filename
     is "$output"   "$rand_content"   "reading generated file in image"
 


### PR DESCRIPTION
The default pull policy is "missing" not "always".

Fixes: #20125
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the podman-build man pages and correct the default value of --pull to "missing".
```
