### PR TITLE
unbreak CI: useradd not found

### DIFF
--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -2,7 +2,7 @@ package integration
 
 var (
 	REDIS_IMAGE       = "quay.io/libpod/redis:alpine" //nolint:revive,stylecheck
-	fedoraMinimal     = "registry.fedoraproject.org/fedora-minimal:39"
+	fedoraMinimal     = "registry.fedoraproject.org/fedora-minimal:34"
 	ALPINE            = "quay.io/libpod/alpine:latest"
 	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
 	ALPINELISTDIGEST  = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -345,11 +345,11 @@ var _ = Describe("Podman exec", func() {
 
 	It("podman exec with user only in container", func() {
 		testUser := "test123"
-		setup := podmanTest.Podman([]string{"run", "--name", "test1", "-d", fedoraMinimal, "sleep", "60"})
+		setup := podmanTest.Podman([]string{"run", "--name", "test1", "-d", CITEST_IMAGE, "sleep", "60"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(ExitCleanly())
 
-		session := podmanTest.Podman([]string{"exec", "test1", "useradd", testUser})
+		session := podmanTest.Podman([]string{"exec", "test1", "adduser", "-D", testUser})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -669,6 +669,10 @@ ENTRYPOINT ["sleep","99999"]
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(ExitCleanly())
 
+		// NOTE: we need to use a Fedora image here since the
+		// alpine/busybox versions are not capable of dealing with
+		// --userns=keep-id and will just error out when not running as
+		// "root"
 		ctrName := "ctr-name"
 		session := podmanTest.Podman([]string{"run", "--pod", podName, "-d", "--stop-signal", "9", "--name", ctrName, fedoraMinimal, "sleep", "600"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Podman UserNS support", func() {
 		}
 
 		ctrName := "ctr-name"
-		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "--user", "root:root", "-d", "--stop-signal", "9", "--name", ctrName, fedoraMinimal, "sleep", "600"})
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "--user", "root:root", "-d", "--stop-signal", "9", "--name", ctrName, CITEST_IMAGE, "sleep", "600"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -165,7 +165,7 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(exec1).Should(ExitCleanly())
 		Expect(exec1.OutputToString()).To(ContainSubstring(userName))
 
-		exec2 := podmanTest.Podman([]string{"exec", ctrName, "useradd", "testuser"})
+		exec2 := podmanTest.Podman([]string{"exec", ctrName, "adduser", "-D", "testuser"})
 		exec2.WaitWithDefaultTimeout()
 		Expect(exec2).Should(ExitCleanly())
 	})

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -858,13 +858,13 @@ VOLUME /test/`, ALPINE)
 	It("volume permissions after run", func() {
 		imgName := "testimg"
 		dockerfile := fmt.Sprintf(`FROM %s
-RUN useradd -m testuser -u 1005
-USER testuser`, fedoraMinimal)
+RUN adduser -D -u 1005 testuser
+USER testuser`, CITEST_IMAGE)
 		podmanTest.BuildImage(dockerfile, imgName, "false")
 
 		testString := "testuser testuser"
 
-		test1 := podmanTest.Podman([]string{"run", "-v", "testvol1:/test", imgName, "bash", "-c", "ls -al /test | grep -v root | grep -v total"})
+		test1 := podmanTest.Podman([]string{"run", "-v", "testvol1:/test", imgName, "sh", "-c", "ls -al /test | grep -v root | grep -v total"})
 		test1.WaitWithDefaultTimeout()
 		Expect(test1).Should(ExitCleanly())
 		Expect(test1.OutputToString()).To(ContainSubstring(testString))
@@ -874,7 +874,7 @@ USER testuser`, fedoraMinimal)
 		vol.WaitWithDefaultTimeout()
 		Expect(vol).Should(ExitCleanly())
 
-		test2 := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/test", volName), imgName, "bash", "-c", "ls -al /test | grep -v root | grep -v total"})
+		test2 := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/test", volName), imgName, "sh", "-c", "ls -al /test | grep -v root | grep -v total"})
 		test2.WaitWithDefaultTimeout()
 		Expect(test2).Should(ExitCleanly())
 		Expect(test2.OutputToString()).To(ContainSubstring(testString))


### PR DESCRIPTION
The fedora minimal 39 image has been updated on the fedora registry and removed the `useradd` binary.  Since we were pulling by tag and not by digest, updates to images outside of our control always entail a certain risk - and now it bit us.

To fix it, try to move as many users of `useradd` to _our_ CITEST_IMAGE and migrate the code where necessary to this Alpine-based tooling. However, the Alpine-based `adduser` binary (not useradd!) doesn't work well when being executed as a non-root user and will just error out. Hence, move the fedora minimal image back to version 34 which is still including the `useradd` binary.

Ultimately, all images on public registries should be pulled via digest to make sure we pin them down.  I refrain from doing this now to make sure we can cherry-pick this PR to older branches and get things back into a working state ASAP.

Fixes: #20119

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
