### PR TITLE
hyperv: Fixes for info, inspect tests 

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -298,10 +298,16 @@ func (m *MacMachine) Inspect() (*machine.InspectInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	podmanSocket, err := m.forwardSocketPath()
+	if err != nil {
+		return nil, err
+	}
+
 	ii := machine.InspectInfo{
 		ConfigPath: m.ConfigPath,
 		ConnectionInfo: machine.ConnectionConfig{
-			PodmanSocket: nil,
+			PodmanSocket: podmanSocket,
 			PodmanPipe:   nil,
 		},
 		Created: m.Created,

--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -13,17 +13,20 @@ Note: you must not have any machines defined before running tests
 
 1. Open a powershell as admin
 1. $env:CONTAINERS_MACHINE_PROVIDER="hyperv"
-1. $env:MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/hyperv/fedora-coreos-38.20230830.dev.0-hyperv.x86_64.vhdx.zip"
-1. `./test/tools/build/ginkgo.exe -vv  --tags "remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp remote" -timeout=90m --trace --no-color  pkg/machine/e2e/. `
+1. `./winmake localmachine`
 
-Note: Add `--focus-file "basic_test.go" ` to only run basic test
+Note: To run specfic test files, add the test files to the end of the winmake command:
+
+`./winmake localmachine "basic_test.go start_test.go"`
 
 ### WSL
 1. Open a powershell as a regular user
 1. Build and copy win-sshproxy into bin/
-1. `./test/tools/build/ginkgo.exe -vv  --tags "remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp remote" -timeout=90m --trace --no-color  pkg/machine/e2e/. `
+1. `./winmake localmachine`
 
-Note: Add `--focus-file "basic_test.go" ` to only run basic test
+Note: To run specfic test files, add the test files to the end of the winmake command:
+
+`./winmake localmachine "basic_test.go start_test.go"`
 
 ## MacOS
 

--- a/pkg/machine/e2e/info_test.go
+++ b/pkg/machine/e2e/info_test.go
@@ -1,6 +1,8 @@
 package e2e_test
 
 import (
+	"strconv"
+
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	jsoniter "github.com/json-iterator/go"
 	. "github.com/onsi/ginkgo/v2"
@@ -27,12 +29,13 @@ var _ = Describe("podman machine info", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(infoSession).Should(Exit(0))
 
-		// Verify go template works and check for no running machines
+		// Verify go template works and check for number of machines
 		info = new(infoMachine)
 		infoSession, err = mb.setCmd(info.withFormat("{{.Host.NumberOfMachines}}")).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(infoSession).Should(Exit(0))
-		Expect(infoSession.outputToString()).To(Equal("0"))
+		numMachines, err := strconv.Atoi(infoSession.outputToString())
+		Expect(err).ToNot(HaveOccurred())
 
 		// Create a machine and check if info has been updated
 		i := new(initMachine)
@@ -44,7 +47,7 @@ var _ = Describe("podman machine info", func() {
 		infoSession, err = mb.setCmd(info.withFormat("{{.Host.NumberOfMachines}}")).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(infoSession).Should(Exit(0))
-		Expect(infoSession.outputToString()).To(Equal("1"))
+		Expect(infoSession.outputToString()).To(Equal(strconv.Itoa(numMachines + 1)))
 
 		// Check if json is in correct format
 		infoSession, err = mb.setCmd(info.withFormat("json")).run()

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -290,10 +290,17 @@ func (m *HyperVMachine) Inspect() (*machine.InspectInfo, error) {
 		return nil, err
 	}
 
+	podmanSocket, err := m.forwardSocketPath()
+	if err != nil {
+		return nil, err
+	}
+
 	return &machine.InspectInfo{
-		ConfigPath:     m.ConfigPath,
-		ConnectionInfo: machine.ConnectionConfig{},
-		Created:        m.Created,
+		ConfigPath: m.ConfigPath,
+		ConnectionInfo: machine.ConnectionConfig{
+			PodmanSocket: podmanSocket,
+		},
+		Created: m.Created,
 		Image: machine.ImageConfig{
 			IgnitionFile: m.IgnitionFile,
 			ImageStream:  "",


### PR DESCRIPTION
Add podman socket info to machine inspect
Fix podman machine info test for hyperV 
Update machine tests README 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
