### PR TITLE
e2e: use safe fedora-minimal image

### DIFF
--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -2,7 +2,7 @@ package integration
 
 var (
 	REDIS_IMAGE       = "quay.io/libpod/redis:alpine" //nolint:revive,stylecheck
-	fedoraMinimal     = "registry.fedoraproject.org/fedora-minimal:34"
+	fedoraMinimal     = "quay.io/libpod/systemd-image:20230531"
 	ALPINE            = "quay.io/libpod/alpine:latest"
 	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
 	ALPINELISTDIGEST  = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Podman images", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=quay.io/libpod/*"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
-		Expect(result.OutputToStringArray()).To(HaveLen(8))
+		Expect(result.OutputToStringArray()).To(HaveLen(9))
 
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=*lpine*"})
 		retalpine.WaitWithDefaultTimeout()

--- a/test/e2e/pod_initcontainers_test.go
+++ b/test/e2e/pod_initcontainers_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Podman init containers", func() {
 		filename := filepath.Join("/dev/shm", RandomString(12))
 
 		// Write the date to a file
-		session := podmanTest.Podman([]string{"create", "--init-ctr", "always", "--pod", "new:foobar", fedoraMinimal, "bin/sh", "-c", "date +%T.%N > " + filename})
+		session := podmanTest.Podman([]string{"create", "--init-ctr", "always", "--pod", "new:foobar", fedoraMinimal, "/bin/sh", "-c", "date +%T.%N > " + filename})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		verify := podmanTest.Podman([]string{"create", "--pod", "foobar", "-t", ALPINE, "top"})


### PR DESCRIPTION
PR #20082 bumped fedora-minimal, from f34 to f39. This worked
fine for a few days, then all of a sudden CI started breaking
because the f39 minimal image got rebuilt and repushed without
adduser. #20127 was an emergency fix; this is a stabler fix.

We keep using not-under-our-control container images, and we
keep getting burned when those get updated in nasty ways. Here
we switch to using a tagged & versioned fedora-minimal image
that is under our control.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```