### PR TITLE
Change log level for health_check

### DIFF
--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -27,7 +27,7 @@ func (c *Container) createTimer(interval string, isStartup bool) error {
 		return fmt.Errorf("failed to get path for podman for a health check timer: %w", err)
 	}
 
-	var cmd = []string{}
+	var cmd = []string{"--property", "LogLevelMax=notice"}
 	if rootless.IsRootless() {
 		cmd = append(cmd, "--user")
 	}


### PR DESCRIPTION
Filter health_check and exec events for logging in console

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
Podman server logs are mostly full of healthcheck output, making them hard to navigate. Hence, made healthcheck service to run with `LogLevelMax=notice,` this would remove the normal output, inclusive the started/stopped messages from systemd itself.

Fixes #17856 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman events' logs in systemd will output limited events in following ways:

- Podman healthcheck run would not emit `exec` and `exec_died` events

```
