### PR TITLE
[CI:BUILD] FCOS image: enable nightly build

### DIFF
--- a/.github/workflows/fcos-podman-next-build.yml
+++ b/.github/workflows/fcos-podman-next-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Run everyday at midnight and pull the latest packages from the copr
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   IMAGE_NAME: fcos
@@ -24,6 +27,8 @@ jobs:
         sudo apt -y install qemu-user-static
 
     - name: Set up wait-for-copr
+      # Do not run on scheduled nightly builds
+      if: ${{ github.event_name }} != 'schedule'
       run: |
         pip3 install git+https://github.com/packit/wait-for-copr.git@main
 
@@ -35,6 +40,8 @@ jobs:
       id: short_sha
 
     - name: Wait for successful podman-next build with the latest commit
+      # Do not run on scheduled nightly builds
+      if: ${{ github.event_name }} != 'schedule'
       run: |
         # TODO: add this in the Containerfile itself or as a --build-arg
         wait-for-copr --owner ${{ env.COPR_OWNER }} --project ${{ env.COPR_PROJECT }} podman ${{ env.SHORT_SHA }}


### PR DESCRIPTION
`wait-for-copr` is still very flaky and has failed more often than not. Ref: https://github.com/fedora-copr/copr/issues/2819

This change to the fcos GHA will allow nightly builds pulling in whatever packages exist on podman-next at that time without depending on wait-for-copr.

The commit id will still be recorded in podman version as well as the image tag, so auditing is not affected with this change.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
