### PR TITLE
hyperV: Respect rootful option on machine init

### DIFF
--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -174,10 +174,6 @@ var _ = Describe("podman machine init", func() {
 	})
 
 	It("machine init rootless docker.sock check", func() {
-		if testProvider.VMType() == machine.HyperVVirt {
-			//https://github.com/containers/podman/issues/20092
-			Skip("rootless is broken with hyperv")
-		}
 		i := initMachine{}
 		name := randomString()
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -95,6 +95,7 @@ func (m *HyperVMachine) writeIgnitionConfigFile(opts machine.InitOptions, user, 
 		TimeZone:  opts.TimeZone,
 		WritePath: m.IgnitionFile.GetPath(),
 		UID:       m.UID,
+		Rootful:   m.Rootful,
 	}
 
 	if err := ign.GenerateIgnitionConfig(); err != nil {
@@ -243,6 +244,7 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 		DiskSize: opts.DiskSize,
 		Memory:   opts.Memory,
 	}
+	m.Rootful = opts.Rootful
 
 	// If the user provides an ignition file, we need to
 	// copy it into the conf dir


### PR DESCRIPTION
Fixed a bug where the rootful option to the podman machine init command would not be written to to the machine config, and the rootful docker sock would not be set.

Fixes: https://github.com/containers/podman/issues/20092
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
