### PR TITLE
Enable machine e2e test for applehv

### DIFF
--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -24,3 +24,16 @@ Note: Add `--focus-file "basic_test.go" ` to only run basic test
 1. `./test/tools/build/ginkgo.exe -vv  --tags "remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp remote" -timeout=90m --trace --no-color  pkg/machine/e2e/. `
 
 Note: Add `--focus-file "basic_test.go" ` to only run basic test
+
+## MacOS
+
+### Apple Hypervisor
+
+1. `make podman-remote`
+1. `make .install.ginkgo`
+1. `export TMPDIR=/Users/<yourname>`
+1. `export CONTAINERS_MACHINE_PROVIDER="applehv"`
+1. `export MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"`
+1. `./test/tools/build/ginkgo -vv  --tags "remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp remote" -timeout=90m --trace --no-color  pkg/machine/e2e/.`
+
+Note: Add `--focus-file "basic_test.go" ` to only run basic test

--- a/pkg/machine/e2e/config_darwin_test.go
+++ b/pkg/machine/e2e/config_darwin_test.go
@@ -1,0 +1,3 @@
+package e2e_test
+
+const podmanBinary = "../../../bin/darwin/podman"

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -1,10 +1,3 @@
 package e2e_test
 
-import "os/exec"
-
 const podmanBinary = "../../../bin/podman-remote"
-
-func pgrep(n string) (string, error) {
-	out, err := exec.Command("pgrep", "gvproxy").Output()
-	return string(out), err
-}

--- a/pkg/machine/e2e/config_unix_test.go
+++ b/pkg/machine/e2e/config_unix_test.go
@@ -3,6 +3,8 @@
 package e2e_test
 
 import (
+	"os/exec"
+
 	"github.com/containers/podman/v4/pkg/machine"
 	. "github.com/onsi/ginkgo/v2"
 )
@@ -19,4 +21,9 @@ func getDownloadLocation(p machine.VirtProvider) string {
 	}
 
 	return fcd.Location
+}
+
+func pgrep(n string) (string, error) {
+	out, err := exec.Command("pgrep", "gvproxy").Output()
+	return string(out), err
 }


### PR DESCRIPTION
This PR allows you to run the pkg/machine/e2e tests for the applehv PROVIDER.  This does not mean they pass, only that they can run.  There also appears to be leftover gvproxy processes at the conclusion of a single test.  This will need to be corrected.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
