### PR TITLE
Skip proxy test for hyperV

### DIFF
--- a/pkg/machine/e2e/proxy_test.go
+++ b/pkg/machine/e2e/proxy_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"os"
 
+	"github.com/containers/podman/v4/pkg/machine"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -22,6 +23,10 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 	})
 
 	It("ssh to running machine and check proxy settings", func() {
+		// https://github.com/containers/podman/issues/20129
+		if testProvider.VMType() == machine.HyperVVirt {
+			Skip("proxy settings not yet supported")
+		}
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()


### PR DESCRIPTION
Currently proxys are not supported on hyperV, skip the test and document it for now.

Opened https://github.com/containers/podman/issues/20129 to track the issue.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
