### PR TITLE
libpod: pass entire environment to conmon

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1288,7 +1288,7 @@ search               | $IMAGE           |
     done < <(parse_table "$tests")
 }
 
-@test "podman --syslog passed to conmon" {
+@test "podman --syslog and environment passed to conmon" {
     skip_if_remote "--syslog is not supported for remote clients"
     skip_if_journald_unavailable
 
@@ -1298,6 +1298,7 @@ search               | $IMAGE           |
     run_podman container inspect $cid --format "{{ .State.ConmonPid }}"
     conmon_pid="$output"
     is "$(< /proc/$conmon_pid/cmdline)" ".*--exit-command-arg--syslog.*" "conmon's exit-command has --syslog set"
+    assert "$(< /proc/$conmon_pid/environ)" =~ "BATS_TEST_TMPDIR" "entire env is passed down to conmon (incl. BATS variables)"
 
     run_podman rm -f -t0 $cid
 }


### PR DESCRIPTION
Pass the _entire_ environment to conmon instead of selectively enabling only specific variables.  The main reasoning is to make sure that conmon and the podman-cleanup callback process operate in the exact same environment than the initial podman process.  Some configuration files may be passed via environment variables.  Podman not passing those down to conmon has led to subtle and hard to debug issues in the past, so passing all down will avoid such kinds of issues in the future.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
