### PR TITLE
Quadlet container mount - support non key=val options

### DIFF
--- a/pkg/specgenutilexternal/mount.go
+++ b/pkg/specgenutilexternal/mount.go
@@ -1,0 +1,40 @@
+package specgenutilexternal
+
+import (
+	"encoding/csv"
+	"errors"
+	"strings"
+)
+
+var (
+	errInvalidSyntax = errors.New("incorrect mount format: should be --mount type=<bind|glob|tmpfs|volume>,[src=<host-dir|volume-name>,]target=<ctr-dir>[,options]")
+)
+
+// FindMountType parses the input and extracts the type of the mount type and
+// the remaining non-type tokens.
+func FindMountType(input string) (mountType string, tokens []string, err error) {
+	// Split by comma, iterate over the slice and look for
+	// "type=$mountType". Everything else is appended to tokens.
+	found := false
+	csvReader := csv.NewReader(strings.NewReader(input))
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return "", nil, err
+	}
+	if len(records) != 1 {
+		return "", nil, errInvalidSyntax
+	}
+	for _, s := range records[0] {
+		kv := strings.Split(s, "=")
+		if found || !(len(kv) == 2 && kv[0] == "type") {
+			tokens = append(tokens, s)
+			continue
+		}
+		mountType = kv[1]
+		found = true
+	}
+	if !found {
+		err = errInvalidSyntax
+	}
+	return
+}

--- a/test/e2e/quadlet/mount.container
+++ b/test/e2e/quadlet/mount.container
@@ -2,9 +2,9 @@
 Image=localhost/imagename
 ## assert-podman-args-key-val "--mount" "," "type=bind,source=/path/on/host,destination=/path/in/container"
 Mount=type=bind,source=/path/on/host,destination=/path/in/container
-## assert-podman-args-key-val "--mount" "," "type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared"
+## assert-podman-args-key-val "--mount" "," "type=bind,source=/path/on/host,dst=/path/in/container,relabel=shared"
 Mount=type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
-## assert-podman-args-key-val "--mount" "," "type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true"
+## assert-podman-args-key-val "--mount" "," "type=bind,source=/path/on/host,dst=/path/in/container,relabel=shared,U=true"
 Mount=type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
 ## assert-podman-args-key-val "--mount" "," "type=volume,source=vol1,destination=/path/in/container,ro=true"
 Mount=type=volume,source=vol1,destination=/path/in/container,ro=true
@@ -20,3 +20,7 @@ Mount=type=image,source=fedora,destination=/fedora-image,rw=true
 Mount=type=devpts,destination=/dev/pts
 ## assert-podman-args-key-val-regex "--mount" "," "type=bind,source=.*/podman_test.*/quadlet/path/on/host,destination=/path/in/container"
 Mount=type=bind,source=./path/on/host,destination=/path/in/container
+## assert-podman-args-key-val "--mount" "," "type=volume,source=vol1,destination=/path/in/container,ro"
+Mount=type=volume,source=vol1,destination=/path/in/container,ro
+## assert-podman-args-key-val "--mount" "," "type=bind,source=/tmp,\"dst=/path,1\""
+Mount=type=bind,src=/tmp,\"dst=/path,1\"


### PR DESCRIPTION
Some keys, e.g. ro do not have values.
The current implementation crashed looking for the = sign

Externalize findMountType in a new package
Parse mount command using FindMountType    
Add test case and adjust the test framework

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet container mount - support non key=val options
```

Resolves: #20104
