### PR TITLE
applehv: machine tests for stop and rm

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -681,7 +681,7 @@ func (m *MacMachine) Stop(name string, opts machine.StopOptions) error {
 	}
 
 	if vmState != machine.Running {
-		return machine.ErrWrongState
+		return nil
 	}
 
 	defer func() {

--- a/pkg/machine/applehv/rest.go
+++ b/pkg/machine/applehv/rest.go
@@ -94,9 +94,10 @@ func (vf *VfkitHelper) stop(force, wait bool) error {
 		if err := vf.stateChange(define.HardStop); err != nil {
 			return err
 		}
-	}
-	if err := vf.stateChange(define.Stop); err != nil {
-		return err
+	} else {
+		if err := vf.stateChange(define.Stop); err != nil {
+			return err
+		}
 	}
 	if !wait {
 		return nil


### PR DESCRIPTION
change behaviour of stopped a stopped/exited machine to match qemu in that stopping a stopped machine is NOT an error.

add condition to machine rm where rm is not run twice due to a logic error

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
