### PR TITLE
CI VMs: bump to f39 + f38

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,14 +26,14 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-38"
+    FEDORA_NAME: "fedora-39β"
     FEDORA_AARCH64_NAME: "${FEDORA_NAME}-aarch64"
-    PRIOR_FEDORA_NAME: "fedora-37"
+    PRIOR_FEDORA_NAME: "fedora-38"
     RAWHIDE_NAME: "rawhide"
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20230816t191118z-f38f37d13"
+    IMAGE_SUFFIX: "c20230928t004553z-f39f38d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -103,9 +103,6 @@ PASSTHROUGH_ENV_ATSTART='CI|LANG|LC_|TEST'
 # List of envariable patterns which can match ANYWHERE in the name
 PASSTHROUGH_ENV_ANYWHERE='_NAME|_FQIN'
 
-# Combine into one
-PASSTHROUGH_ENV_RE="(^($PASSTHROUGH_ENV_EXACT)\$)|(^($PASSTHROUGH_ENV_ATSTART))|($PASSTHROUGH_ENV_ANYWHERE)"
-
 # Unsafe env. vars for display
 SECRET_ENV_RE='ACCOUNT|GC[EP]..|SSH|PASSWORD|SECRET|TOKEN'
 
@@ -120,20 +117,6 @@ set +a
 
 lilto() { err_retry 8 1000 "" "$@"; }  # just over 4 minutes max
 bigto() { err_retry 7 5670 "" "$@"; }  # 12 minutes max
-
-# Return a list of environment variables that should be passed through
-# to lower levels (tests in containers, or via ssh to rootless).
-# We return the variable names only, not their values. It is up to our
-# caller to reference values.
-passthrough_envars(){
-    local envname
-    warn "Will pass env. vars. matching the following regex:
-    $PASSTHROUGH_ENV_RE"
-    compgen -A variable | \
-        grep -Ev "SETUP_ENVIRONMENT" | \
-        grep -Ev "$SECRET_ENV_RE" | \
-        grep -E  "$PASSTHROUGH_ENV_RE"
-}
 
 setup_rootless() {
     req_env_vars GOPATH GOSRC SECRET_ENV_RE

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -156,11 +156,6 @@ case "$OS_RELEASE_ID" in
         # (Checked on 2023-08-08 and it's still too old: 1.1.5)
         # FIXME: please remove this once runc >= 1.2 makes it into debian.
         showrun modprobe tun
-
-        # TODO: move this into image build process
-        # We need the "en_US.UTF-8" locale for the "podman logs with non ASCII log tag" tests
-        showrun sed -i '/en_US.UTF-8/s/^#//g' /etc/locale.gen
-        showrun locale-gen
         ;;
     fedora)
         showrun echo "conditional setup for fedora"

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -596,12 +596,13 @@ var _ = Describe("Podman logs", func() {
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "--log-opt", "tag=äöüß", ALPINE, "echo", "podman"})
 		logc.WaitWithDefaultTimeout()
 		Expect(logc).To(Exit(126))
+		// FIXME-2023-09-26: conmon <2.1.8 logs to stdout; clean this up once >=2.1.8 is universal
+		errmsg := logc.ErrorToString() + logc.OutputToString()
 		if !IsRemote() {
 			// Error is only seen on local client
-			// Why does conmon log this to stdout? This must be fixed after https://github.com/containers/conmon/pull/447.
-			Expect(logc.OutputToString()).To(Equal("conmon: option parsing failed: Invalid byte sequence in conversion input"))
+			Expect(errmsg).To(ContainSubstring("conmon: option parsing failed: Invalid byte sequence in conversion input"))
 		}
-		Expect(logc.ErrorToString()).To(ContainSubstring("conmon failed: exit status 1"))
+		Expect(errmsg).To(ContainSubstring("conmon failed: exit status 1"))
 	})
 
 	It("podman logs with non ASCII log tag succeeds with proper env", func() {

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	. "github.com/containers/podman/v4/test/utils"
@@ -182,9 +181,6 @@ var _ = Describe("Podman stats", func() {
 
 	// Regression test for #8265
 	It("podman stats with custom memory limits", func() {
-		if strings.Contains(podmanTest.OCIRuntime, "crun") {
-			Skip("Test requires crun > 1.8.4")
-		}
 		// Run three containers. One with a memory limit.  Make sure
 		// that the limits are different and the limited one has a
 		// lower limit.
@@ -235,9 +231,6 @@ var _ = Describe("Podman stats", func() {
 	})
 
 	It("podman stats show cgroup memory limit", func() {
-		if strings.Contains(podmanTest.OCIRuntime, "crun") {
-			Skip("Test requires crun > 1.8.4")
-		}
 		ctrWithLimit := "with-limit"
 
 		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrWithLimit, "--memory", "50m", ALPINE, "top"})

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -697,6 +697,7 @@ function teardown() {
 }
 
 @test "podman networking with pasta(1) - TCP/IPv4 large transfer, tap" {
+    skip "FIXME: #20170 - test hangs"
     pasta_test_do
 }
 


### PR DESCRIPTION
...from f38 + f37.

Requires one minor e2e test change, to handle an error logging
change in conmon 2.1.8.

Also, this is important, requires crun-1.9.1 because of a kernel
symlink change; see https://github.com/containers/crun/pull/1309
The VM images here were carefully built to include that. By the
time the next VM images get built, it should be default.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```