### PR TITLE
test/e2e: default to netavark

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -214,11 +214,9 @@ use_cni() {
         die "Testing debian w/ CNI networking currently not supported"
     fi
 
-    msg "Unsetting NETWORK_BACKEND for all subsequent environments."
-    echo "export -n NETWORK_BACKEND" >> /etc/ci_environment
-    echo "unset NETWORK_BACKEND" >> /etc/ci_environment
-    export -n NETWORK_BACKEND
-    unset NETWORK_BACKEND
+    msg "Forcing NETWORK_BACKEND=cni for all subsequent environments."
+    echo "NETWORK_BACKEND=cni" >> /etc/ci_environment
+    export NETWORK_BACKEND=cni
     # While it's possible a user may want both installed, for CNI CI testing
     # purposes we only care about backward-compatibility, not forward.
     # If both CNI & netavark are present, in some situations where --root
@@ -250,9 +248,11 @@ use_cni() {
 use_netavark() {
     req_env_vars OS_RELEASE_ID PRIOR_FEDORA_NAME DISTRO_NV
     local magickind repokind
-    msg "Forcing NETWORK_BACKEND=netavark for all subsequent environments."
-    echo "NETWORK_BACKEND=netavark" >> /etc/ci_environment
-    export NETWORK_BACKEND=netavark  # needed for install_test_configs()
+    msg "Unsetting NETWORK_BACKEND for all subsequent environments."
+    echo "export -n NETWORK_BACKEND" >> /etc/ci_environment
+    echo "unset NETWORK_BACKEND" >> /etc/ci_environment
+    export -n NETWORK_BACKEND
+    unset NETWORK_BACKEND
     msg "Removing any/all CNI configuration"
     showrun rm -rvf /etc/cni/net.d/*
     # N/B: The CNI packages are still installed and available. This is

--- a/test/README.md
+++ b/test/README.md
@@ -87,7 +87,7 @@ The following environment variables are supported by the test setup:
  - `QUADLET_BINARY`: path to the quadlet binary, defaults to `bin/quadlet` in the repository root.
  - `CONMON_BINARY`: path to th conmon binary, defaults to `/usr/libexec/podman/conmon`.
  - `OCI_RUNTIME`: which oci runtime to use, defaults to `crun`.
- - `NETWORK_BACKEND`: the network backend, either `cni` (default) or `netavark`.
+ - `NETWORK_BACKEND`: the network backend, either `netavark` (default) or `cni`.
  - `PODMAN_DB`: the database backend `boltdb` (default) or `sqlite`.
  - `PODMAN_TEST_IMAGE_CACHE_DIR`: path were the container images should be cached, defaults to `/tmp`.
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -291,17 +291,17 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		dbBackend = "sqlite"
 	}
 
-	networkBackend := CNI
-	networkConfigDir := "/etc/cni/net.d"
+	networkBackend := Netavark
+	networkConfigDir := "/etc/containers/networks"
 	if isRootless() {
-		networkConfigDir = filepath.Join(os.Getenv("HOME"), ".config/cni/net.d")
+		networkConfigDir = filepath.Join(root, "etc", "networks")
 	}
 
-	if strings.ToLower(os.Getenv("NETWORK_BACKEND")) == "netavark" {
-		networkBackend = Netavark
-		networkConfigDir = "/etc/containers/networks"
+	if strings.ToLower(os.Getenv("NETWORK_BACKEND")) == "cni" {
+		networkBackend = CNI
+		networkConfigDir = "/etc/cni/net.d"
 		if isRootless() {
-			networkConfigDir = filepath.Join(root, "etc", "networks")
+			networkConfigDir = filepath.Join(os.Getenv("HOME"), ".config/cni/net.d")
 		}
 	}
 


### PR DESCRIPTION
When you run e2e tests locally they use CNI unless the NETWORK_BACKEND
env was set to netavark. Because our main focus is on netavark we should
test it by default.

For local tests this should help to prevent CNI/netavark conflicts as I
assume most systems where people run tests on are on netavark by now.
 
For  CI testing we hardcode NETWORK_BACKEND there to test both netavark
(on current fedora) and CNI (prior fedora). MAke sure to switch the
logic in the CI setup to reflect that.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
