### PR TITLE
e2e: ExitCleanly(): the final step

### DIFF
--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman export", func() {
@@ -19,7 +18,7 @@ var _ = Describe("Podman export", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
 		result := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		_, err := os.Stat(outfile)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -34,7 +33,7 @@ var _ = Describe("Podman export", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
 		result := podmanTest.Podman([]string{"container", "export", "-o", outfile, cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		_, err := os.Stat(outfile)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/podman/v4/pkg/systemd/parser"
+	. "github.com/containers/podman/v4/test/utils"
 	"github.com/containers/podman/v4/version"
 	"github.com/mattn/go-shellwords"
 
@@ -434,7 +435,7 @@ var _ = Describe("quadlet system generator", func() {
 		It("Should print correct version", func() {
 			session := podmanTest.Quadlet([]string{"-version"}, "/something")
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToString()).To(Equal(version.Version.String()))
 		})
 	})

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -513,6 +513,7 @@ BOGUS=foo
 			session := podmanTest.Quadlet([]string{"-dryrun"}, quadletDir)
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
+			Expect(session.ErrorToString()).To(ContainSubstring("Loading source unit file "))
 
 			current := session.OutputToStringArray()
 			expected := []string{

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -134,6 +134,12 @@ var _ = Describe("Podman restart", func() {
 		timeSince := time.Since(startTime)
 		Expect(timeSince).To(BeNumerically("<", 10*time.Second))
 		Expect(timeSince).To(BeNumerically(">", 2*time.Second))
+		stderr := session.ErrorToString()
+		if IsRemote() {
+			Expect(stderr).To(BeEmpty())
+		} else {
+			Expect(stderr).To(ContainSubstring("StopSignal SIGTERM failed to stop container test1 in 2 seconds, resorting to SIGKILL"))
+		}
 	})
 
 	It("podman restart --all", func() {

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.Podman([]string{"restart", "test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
@@ -35,18 +35,18 @@ var _ = Describe("Podman restart", func() {
 	It("podman restart stopped container by ID", func() {
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToString()
 		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", cid})
 		startTime.WaitWithDefaultTimeout()
 
 		startSession := podmanTest.Podman([]string{"start", "--attach", cid})
 		startSession.WaitWithDefaultTimeout()
-		Expect(startSession).Should(Exit(0))
+		Expect(startSession).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"restart", cid})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2).Should(Exit(0))
+		Expect(session2).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", cid})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
@@ -61,7 +61,7 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.Podman([]string{"restart", "test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
@@ -76,7 +76,7 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.Podman([]string{"container", "restart", "test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"container", "inspect", "--format='{{.State.StartedAt}}'", "test1"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
@@ -93,7 +93,7 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.Podman([]string{"restart", "test1", "test2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToStringArray()[0]).To(Not(Equal(startTime.OutputToStringArray()[0])))
@@ -116,7 +116,7 @@ var _ = Describe("Podman restart", func() {
 		}
 		session := podmanTest.Podman([]string{"restart", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToStringArray()[0]).To(Equal(startTime.OutputToStringArray()[0]))
@@ -126,7 +126,7 @@ var _ = Describe("Podman restart", func() {
 	It("podman restart non-stop container with short timeout", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", "--env", "STOPSIGNAL=SIGKILL", ALPINE, "sleep", "999"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		startTime := time.Now()
 		session = podmanTest.Podman([]string{"restart", "-t", "2", "test1"})
 		session.WaitWithDefaultTimeout()
@@ -142,14 +142,14 @@ var _ = Describe("Podman restart", func() {
 
 		test2 := podmanTest.RunTopContainer("test2")
 		test2.WaitWithDefaultTimeout()
-		Expect(test2).Should(Exit(0))
+		Expect(test2).Should(ExitCleanly())
 
 		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		startTime.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"restart", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToStringArray()[0]).To(Not(Equal(startTime.OutputToStringArray()[0])))
@@ -162,14 +162,14 @@ var _ = Describe("Podman restart", func() {
 
 		test2 := podmanTest.RunTopContainer("test2")
 		test2.WaitWithDefaultTimeout()
-		Expect(test2).Should(Exit(0))
+		Expect(test2).Should(ExitCleanly())
 
 		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		startTime.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"restart", "-a", "--running"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToStringArray()[0]).To(Equal(startTime.OutputToStringArray()[0]))
@@ -184,22 +184,22 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.RunTopContainerInPod("host-restart-test", "foobar99")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		testCmd := []string{"exec", "host-restart-test", "sh", "-c", "wc -l < /etc/hosts"}
 
 		// before restart
 		beforeRestart := podmanTest.Podman(testCmd)
 		beforeRestart.WaitWithDefaultTimeout()
-		Expect(beforeRestart).Should(Exit(0))
+		Expect(beforeRestart).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"restart", "host-restart-test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		afterRestart := podmanTest.Podman(testCmd)
 		afterRestart.WaitWithDefaultTimeout()
-		Expect(afterRestart).Should(Exit(0))
+		Expect(afterRestart).Should(ExitCleanly())
 
 		// line count should be equal
 		Expect(beforeRestart.OutputToString()).To(Equal(afterRestart.OutputToString()))
@@ -208,22 +208,22 @@ var _ = Describe("Podman restart", func() {
 	It("podman restart all stopped containers with --all", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		session = podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 
 		session = podmanTest.Podman([]string{"stop", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"restart", "--all"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 	})
 
@@ -233,16 +233,16 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.Podman([]string{"create", "--cidfile", tmpFile, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid := session.OutputToStringArray()[0]
 
 		session = podmanTest.Podman([]string{"start", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"restart", "--cidfile", tmpFile})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		output := result.OutputToString()
 		Expect(output).To(ContainSubstring(cid))
 	})
@@ -254,19 +254,19 @@ var _ = Describe("Podman restart", func() {
 
 		session := podmanTest.Podman([]string{"run", "--cidfile", tmpFile1, "-d", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid1 := session.OutputToStringArray()[0]
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
 		session = podmanTest.Podman([]string{"run", "--cidfile", tmpFile2, "-d", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		cid2 := session.OutputToStringArray()[0]
 		Expect(podmanTest.NumberOfContainers()).To(Equal(2))
 
 		result := podmanTest.Podman([]string{"restart", "--cidfile", tmpFile1, "--cidfile", tmpFile2})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		output := result.OutputToString()
 		Expect(output).To(ContainSubstring(cid1))
 		Expect(output).To(ContainSubstring(cid2))
@@ -296,17 +296,17 @@ var _ = Describe("Podman restart", func() {
 	It("podman restart --filter", func() {
 		session1 := podmanTest.RunTopContainer("")
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		cid1 := session1.OutputToString()
 
 		session1 = podmanTest.RunTopContainer("")
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		cid2 := session1.OutputToString()
 
 		session1 = podmanTest.RunTopContainerWithArgs("", []string{"--label", "test=with,comma"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		cid3 := session1.OutputToString()
 		shortCid3 := cid3[0:5]
 
@@ -316,22 +316,22 @@ var _ = Describe("Podman restart", func() {
 
 		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", fmt.Sprintf("id=%swrongid", shortCid3)})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		Expect(session1.OutputToString()).To(BeEmpty())
 
 		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", fmt.Sprintf("id=%s", shortCid3)})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
 
 		session1 = podmanTest.Podman([]string{"restart", "-a", "--filter", "label=test=with,comma"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid3))
 
 		session1 = podmanTest.Podman([]string{"restart", "-f", fmt.Sprintf("id=%s", cid2)})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(0))
+		Expect(session1).Should(ExitCleanly())
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid2))
 	})
 })

--- a/test/e2e/run_security_labels_test.go
+++ b/test/e2e/run_security_labels_test.go
@@ -47,6 +47,12 @@ var _ = Describe("Podman generate kube", func() {
 		test1 := podmanTest.Podman([]string{"create", "--label", "io.containers.capabilities=sys_admin", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
 		Expect(test1).Should(Exit(0))
+		stderr := test1.ErrorToString()
+		if IsRemote() {
+			Expect(stderr).To(BeEmpty())
+		} else {
+			Expect(stderr).To(ContainSubstring("Capabilities requested by user or image are not allowed by default: \\\"CAP_SYS_ADMIN\\\""))
+		}
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
@@ -75,6 +81,12 @@ var _ = Describe("Podman generate kube", func() {
 		test1 := podmanTest.Podman([]string{"create", "--cap-drop", "all", "--label", "io.containers.capabilities=sys_admin", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
 		Expect(test1).Should(Exit(0))
+		stderr := test1.ErrorToString()
+		if IsRemote() {
+			Expect(stderr).To(BeEmpty())
+		} else {
+			Expect(stderr).To(ContainSubstring("Capabilities requested by user or image are not allowed by default: \\\"CAP_SYS_ADMIN\\\""))
+		}
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
@@ -90,9 +102,9 @@ var _ = Describe("Podman generate kube", func() {
 		test1.WaitWithDefaultTimeout()
 		Expect(test1).Should(ExitCleanly())
 
-		commit := podmanTest.Podman([]string{"commit", "-c", "label=io.containers.capabilities=setgid,setuid", "test1", "image1"})
+		commit := podmanTest.Podman([]string{"commit", "-q", "-c", "label=io.containers.capabilities=setgid,setuid", "test1", "image1"})
 		commit.WaitWithDefaultTimeout()
-		Expect(commit).Should(Exit(0))
+		Expect(commit).Should(ExitCleanly())
 
 		image1 := podmanTest.Podman([]string{"create", "--name", "test2", "image1", "echo", "test1"})
 		image1.WaitWithDefaultTimeout()

--- a/test/e2e/run_security_labels_test.go
+++ b/test/e2e/run_security_labels_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -14,11 +15,11 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman empty security labels", func() {
 		test1 := podmanTest.Podman([]string{"create", "--label", "io.containers.capabilities=", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
-		Expect(test1).Should(Exit(0))
+		Expect(test1).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		Expect(ctr[0].EffectiveCaps).To(BeNil())
@@ -31,11 +32,11 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman security labels", func() {
 		test1 := podmanTest.Podman([]string{"create", "--label", "io.containers.capabilities=setuid,setgid", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
-		Expect(test1).Should(Exit(0))
+		Expect(test1).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")
@@ -49,7 +50,7 @@ var _ = Describe("Podman generate kube", func() {
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")
@@ -59,11 +60,11 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman --cap-add sys_admin security labels", func() {
 		test1 := podmanTest.Podman([]string{"create", "--cap-add", "SYS_ADMIN", "--label", "io.containers.capabilities=sys_admin", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
-		Expect(test1).Should(Exit(0))
+		Expect(test1).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")
@@ -77,7 +78,7 @@ var _ = Describe("Podman generate kube", func() {
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")
@@ -87,7 +88,7 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman security labels from image", func() {
 		test1 := podmanTest.Podman([]string{"create", "--name", "test1", "alpine", "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
-		Expect(test1).Should(Exit(0))
+		Expect(test1).Should(ExitCleanly())
 
 		commit := podmanTest.Podman([]string{"commit", "-c", "label=io.containers.capabilities=setgid,setuid", "test1", "image1"})
 		commit.WaitWithDefaultTimeout()
@@ -95,11 +96,11 @@ var _ = Describe("Podman generate kube", func() {
 
 		image1 := podmanTest.Podman([]string{"create", "--name", "test2", "image1", "echo", "test1"})
 		image1.WaitWithDefaultTimeout()
-		Expect(image1).Should(Exit(0))
+		Expect(image1).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "test2"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")
@@ -110,11 +111,11 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman --privileged security labels", func() {
 		pull := podmanTest.Podman([]string{"create", "--privileged", "--label", "io.containers.capabilities=setuid,setgid", "--name", "test1", "alpine", "echo", "test"})
 		pull.WaitWithDefaultTimeout()
-		Expect(pull).Should(Exit(0))
+		Expect(pull).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")
@@ -132,11 +133,11 @@ LABEL io.containers.capabilities=chown,kill`, ALPINE)
 
 		test1 := podmanTest.Podman([]string{"create", "--name", "test1", image, "echo", "test1"})
 		test1.WaitWithDefaultTimeout()
-		Expect(test1).Should(Exit(0))
+		Expect(test1).Should(ExitCleanly())
 
 		inspect := podmanTest.Podman([]string{"inspect", "test1"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(Exit(0))
+		Expect(inspect).Should(ExitCleanly())
 
 		ctr := inspect.InspectContainerToJSON()
 		caps := strings.Join(ctr[0].EffectiveCaps, ",")

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -199,7 +199,6 @@ registries = []`
 		// and the exit code will be 0
 		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).Should(BeEmpty())
-		Expect(search.ErrorToString()).Should(BeEmpty())
 	})
 
 	It("podman search in local registry", func() {
@@ -220,9 +219,9 @@ registries = []`
 		err = podmanTest.RestoreArtifact(ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		image := fmt.Sprintf("%s/my-alpine", ep.Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
-		Expect(push).Should(Exit(0))
+		Expect(push).Should(ExitCleanly())
 		search := podmanTest.Podman([]string{"search", image, "--tls-verify=false"})
 		search.WaitWithDefaultTimeout()
 
@@ -256,9 +255,9 @@ registries = []`
 		err = podmanTest.RestoreArtifact(ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		image := fmt.Sprintf("%s/my-alpine", ep.Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
-		Expect(push).Should(Exit(0))
+		Expect(push).Should(ExitCleanly())
 
 		// registries.conf set up
 		var buffer bytes.Buffer
@@ -277,7 +276,6 @@ registries = []`
 
 		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).To(ContainSubstring("my-alpine"))
-		Expect(search.ErrorToString()).Should(BeEmpty())
 
 		// cleanup
 		resetRegistriesConfigEnv()
@@ -301,9 +299,9 @@ registries = []`
 		err = podmanTest.RestoreArtifact(ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		image := fmt.Sprintf("%s/my-alpine", ep.Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
-		Expect(push).Should(Exit(0))
+		Expect(push).Should(ExitCleanly())
 
 		var buffer bytes.Buffer
 		err = registryFileTmpl.Execute(&buffer, ep)
@@ -341,9 +339,9 @@ registries = []`
 		err = podmanTest.RestoreArtifact(ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		image := fmt.Sprintf("%s/my-alpine", ep.Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
-		Expect(push).Should(Exit(0))
+		Expect(push).Should(ExitCleanly())
 
 		var buffer bytes.Buffer
 		err = registryFileBadTmpl.Execute(&buffer, ep)

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -45,7 +45,7 @@ registries = []`
 	It("podman search", func() {
 		search := podmanTest.Podman([]string{"search", "alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))
 		Expect(search.OutputToString()).To(ContainSubstring("alpine"))
 	})
@@ -53,14 +53,14 @@ registries = []`
 	It("podman search single registry flag", func() {
 		search := podmanTest.Podman([]string{"search", "quay.io/skopeo/stable:latest"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).To(ContainSubstring("quay.io/skopeo/stable"))
 	})
 
 	It("podman search image with description", func() {
 		search := podmanTest.Podman([]string{"search", "quay.io/libpod/whalesay"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		output := string(search.Out.Contents())
 		Expect(output).To(MatchRegexp(`(?m)NAME\s+DESCRIPTION$`))
 		Expect(output).To(MatchRegexp(`(?m)quay.io/libpod/whalesay\s+Static image used for automated testing.+$`))
@@ -69,7 +69,7 @@ registries = []`
 	It("podman search image with --compatible", func() {
 		search := podmanTest.Podman([]string{"search", "--compatible", "quay.io/libpod/whalesay"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		output := string(search.Out.Contents())
 		Expect(output).To(MatchRegexp(`(?m)NAME\s+DESCRIPTION\s+STARS\s+OFFICIAL\s+AUTOMATED$`))
 	})
@@ -77,7 +77,7 @@ registries = []`
 	It("podman search format flag", func() {
 		search := podmanTest.Podman([]string{"search", "--format", "table {{.Index}} {{.Name}}", "alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))
 		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
 	})
@@ -85,7 +85,7 @@ registries = []`
 	It("podman search format json", func() {
 		search := podmanTest.Podman([]string{"search", "--format", "json", "busybox"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).To(BeValidJSON())
 		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/busybox"))
 
@@ -102,7 +102,7 @@ registries = []`
 	It("podman search format json list tags", func() {
 		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).To(BeValidJSON())
 		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
 		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
@@ -113,7 +113,7 @@ registries = []`
 	It("podman search no-trunc=false flag", func() {
 		search := podmanTest.Podman([]string{"search", "--no-trunc=false", "alpine", "--format={{.Description}}"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 
 		for _, line := range search.OutputToStringArray() {
 			if len(line) > 44 {
@@ -125,24 +125,24 @@ registries = []`
 	It("podman search limit flag", func() {
 		search := podmanTest.Podman([]string{"search", "docker.io/alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 10))
 
 		search = podmanTest.Podman([]string{"search", "--limit", "3", "docker.io/alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToStringArray()).To(HaveLen(4))
 
 		search = podmanTest.Podman([]string{"search", "--limit", "30", "docker.io/alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToStringArray()).To(HaveLen(31))
 	})
 
 	It("podman search with filter stars", func() {
 		search := podmanTest.Podman([]string{"search", "--filter", "stars=10", "--format", "{{.Stars}}", "alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		output := search.OutputToStringArray()
 		for i := 0; i < len(output); i++ {
 			Expect(strconv.Atoi(output[i])).To(BeNumerically(">=", 10))
@@ -152,7 +152,7 @@ registries = []`
 	It("podman search with filter is-official", func() {
 		search := podmanTest.Podman([]string{"search", "--filter", "is-official", "--format", "{{.Official}}", "alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		output := search.OutputToStringArray()
 		for i := 0; i < len(output); i++ {
 			Expect(output[i]).To(Equal("[OK]"))
@@ -162,7 +162,7 @@ registries = []`
 	It("podman search with filter is-automated", func() {
 		search := podmanTest.Podman([]string{"search", "--filter", "is-automated=false", "--format", "{{.Automated}}", "alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		output := search.OutputToStringArray()
 		for i := 0; i < len(output); i++ {
 			Expect(output[i]).To(Equal(""))
@@ -172,7 +172,7 @@ registries = []`
 	It("podman search format list tags with custom", func() {
 		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "{{.Name}}", "--limit", "1", ALPINE})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).To(Equal("quay.io/libpod/alpine"))
 	})
 
@@ -185,7 +185,7 @@ registries = []`
 			"-p", fmt.Sprintf("%d:5000", port),
 			REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		fakereg.WaitWithDefaultTimeout()
-		Expect(fakereg).Should(Exit(0))
+		Expect(fakereg).Should(ExitCleanly())
 
 		if !WaitContainerReady(podmanTest, "registry", "listening on", 20, 1) {
 			Fail("Cannot start docker registry on port %s", port)
@@ -197,7 +197,7 @@ registries = []`
 
 		// if this test succeeded, there will be no output (there is no entry named fake/image:andtag in an empty registry)
 		// and the exit code will be 0
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).Should(BeEmpty())
 		Expect(search.ErrorToString()).Should(BeEmpty())
 	})
@@ -211,7 +211,7 @@ registries = []`
 			"-p", fmt.Sprintf("%d:5000", port), REGISTRY_IMAGE,
 			"/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		registry.WaitWithDefaultTimeout()
-		Expect(registry).Should(Exit(0))
+		Expect(registry).Should(ExitCleanly())
 
 		if !WaitContainerReady(podmanTest, "registry3", "listening on", 20, 1) {
 			Fail("Cannot start docker registry on port %s", port)
@@ -226,13 +226,13 @@ registries = []`
 		search := podmanTest.Podman([]string{"search", image, "--tls-verify=false"})
 		search.WaitWithDefaultTimeout()
 
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).ShouldNot(BeEmpty())
 
 		// podman search v2 registry with empty query
 		searchEmpty := podmanTest.Podman([]string{"search", fmt.Sprintf("%s/", ep.Address()), "--tls-verify=false"})
 		searchEmpty.WaitWithDefaultTimeout()
-		Expect(searchEmpty).Should(Exit(0))
+		Expect(searchEmpty).Should(ExitCleanly())
 		Expect(searchEmpty.OutputToStringArray()).ToNot(BeEmpty())
 		Expect(search.OutputToString()).To(ContainSubstring("my-alpine"))
 	})
@@ -247,7 +247,7 @@ registries = []`
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port),
 			"--name", "registry4", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		registry.WaitWithDefaultTimeout()
-		Expect(registry).Should(Exit(0))
+		Expect(registry).Should(ExitCleanly())
 
 		if !WaitContainerReady(podmanTest, "registry4", "listening on", 20, 1) {
 			Fail("unable to start registry on port %s", port)
@@ -275,7 +275,7 @@ registries = []`
 		search := podmanTest.Podman([]string{"search", image})
 		search.WaitWithDefaultTimeout()
 
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToString()).To(ContainSubstring("my-alpine"))
 		Expect(search.ErrorToString()).Should(BeEmpty())
 
@@ -292,7 +292,7 @@ registries = []`
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port),
 			"--name", "registry5", REGISTRY_IMAGE})
 		registry.WaitWithDefaultTimeout()
-		Expect(registry).Should(Exit(0))
+		Expect(registry).Should(ExitCleanly())
 
 		if !WaitContainerReady(podmanTest, "registry5", "listening on", 20, 1) {
 			Fail("Cannot start docker registry on port %s", port)
@@ -332,7 +332,7 @@ registries = []`
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port),
 			"--name", "registry6", REGISTRY_IMAGE})
 		registry.WaitWithDefaultTimeout()
-		Expect(registry).Should(Exit(0))
+		Expect(registry).Should(ExitCleanly())
 
 		if !WaitContainerReady(podmanTest, "registry6", "listening on", 20, 1) {
 			Fail("Cannot start docker registry on port %s", port)
@@ -379,19 +379,19 @@ registries = []`
 	It("podman search with wildcards", FlakeAttempts(3), func() {
 		search := podmanTest.Podman([]string{"search", "registry.access.redhat.com/*openshift*"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))
 	})
 
 	It("podman search repository tags", func() {
 		search := podmanTest.Podman([]string{"search", "--list-tags", "--limit", "30", "docker.io/library/alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(search.OutputToStringArray()).To(HaveLen(31))
 
 		search = podmanTest.Podman([]string{"search", "--list-tags", "docker.io/library/alpine"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 2))
 
 		search = podmanTest.Podman([]string{"search", "--filter=is-official", "--list-tags", "docker.io/library/alpine"})
@@ -406,7 +406,7 @@ registries = []`
 	It("podman search with limit over 100", func() {
 		search := podmanTest.Podman([]string{"search", "--limit", "100", "quay.io/podman"})
 		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
+		Expect(search).Should(ExitCleanly())
 		Expect(len(search.OutputToStringArray())).To(BeNumerically("<=", 101))
 	})
 })

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -39,7 +39,7 @@ var _ = Describe("podman system connection", func() {
 			}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			cfg, err := config.ReadCustomConfig()
@@ -57,7 +57,7 @@ var _ = Describe("podman system connection", func() {
 			}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 
 			Expect(config.ReadCustomConfig()).Should(HaveActiveService("QE"))
 		})
@@ -103,7 +103,7 @@ var _ = Describe("podman system connection", func() {
 			}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			Expect(config.ReadCustomConfig()).Should(VerifyService(
@@ -127,7 +127,7 @@ var _ = Describe("podman system connection", func() {
 			}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			cfg, err = config.ReadCustomConfig()
@@ -146,7 +146,7 @@ var _ = Describe("podman system connection", func() {
 			cmd := []string{"farm", "create", "empty-farm"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(ContainSubstring("Farm \"empty-farm\" created"))
 
 			cfg, err := config.ReadCustomConfig()
@@ -162,7 +162,7 @@ var _ = Describe("podman system connection", func() {
 			}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			cfg, err = config.ReadCustomConfig()
@@ -190,7 +190,7 @@ var _ = Describe("podman system connection", func() {
 			}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			cfg, err = config.ReadCustomConfig()
@@ -206,7 +206,7 @@ var _ = Describe("podman system connection", func() {
 			// Remove the QA connection
 			session = podmanTest.Podman([]string{"system", "connection", "remove", "QA"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			cfg, err = config.ReadCustomConfig()
@@ -224,13 +224,13 @@ var _ = Describe("podman system connection", func() {
 				"ssh://root@podman.test:2222/run/podman/podman.sock",
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 
 			// two passes to test that removing non-existent connection is not an error
 			for i := 0; i < 2; i++ {
 				session = podmanTest.Podman([]string{"system", "connection", "remove", "QA"})
 				session.WaitWithDefaultTimeout()
-				Expect(session).Should(Exit(0))
+				Expect(session).Should(ExitCleanly())
 				Expect(session.Out.Contents()).Should(BeEmpty())
 
 				cfg, err := config.ReadCustomConfig()
@@ -248,17 +248,17 @@ var _ = Describe("podman system connection", func() {
 				"ssh://root@podman.test:2222/run/podman/podman.sock",
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 
 			session = podmanTest.Podman([]string{"system", "connection", "remove", "--all"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 			Expect(session.Err.Contents()).Should(BeEmpty())
 
 			session = podmanTest.Podman([]string{"system", "connection", "list"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 		})
 
 		It("default", func() {
@@ -271,13 +271,13 @@ var _ = Describe("podman system connection", func() {
 				}
 				session := podmanTest.Podman(cmd)
 				session.WaitWithDefaultTimeout()
-				Expect(session).Should(Exit(0))
+				Expect(session).Should(ExitCleanly())
 			}
 
 			cmd := []string{"system", "connection", "default", "devl"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out.Contents()).Should(BeEmpty())
 
 			Expect(config.ReadCustomConfig()).Should(HaveActiveService("devl"))
@@ -285,13 +285,13 @@ var _ = Describe("podman system connection", func() {
 			cmd = []string{"system", "connection", "list"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.Out).Should(Say("Name *URI *Identity *Default"))
 
 			cmd = []string{"system", "connection", "list", "--format", "{{.Name}}"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToString()).Should(Equal("devl qe"))
 		})
 
@@ -299,7 +299,7 @@ var _ = Describe("podman system connection", func() {
 			cmd := []string{"system", "connection", "default", "devl"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).ShouldNot(Exit(0))
+			Expect(session).ShouldNot(ExitCleanly())
 			Expect(session.Err).Should(Say("destination is not defined"))
 		})
 
@@ -307,7 +307,7 @@ var _ = Describe("podman system connection", func() {
 			cmd := []string{"system", "connection", "rename", "devl", "QE"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).ShouldNot(Exit(0))
+			Expect(session).ShouldNot(ExitCleanly())
 			Expect(session.Err).Should(Say("destination is not defined"))
 		})
 
@@ -315,7 +315,7 @@ var _ = Describe("podman system connection", func() {
 			cmd := []string{"system", "connection", "list"}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToStringArray()).Should(HaveLen(1))
 			Expect(session.Err.Contents()).Should(BeEmpty())
 		})

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -71,6 +71,8 @@ var _ = Describe("podman system connection", func() {
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 			Expect(session.Out.Contents()).Should(BeEmpty())
+			// stderr will probably warn (ENOENT or EACCESS) about socket
+			// but it's too unreliable to test for.
 
 			Expect(config.ReadCustomConfig()).Should(VerifyService(
 				"QA-UDS",

--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -85,14 +85,14 @@ var _ = Describe("Systemd activate", func() {
 			"create", "--tty", "--name", containerName, "--entrypoint", "top",
 			ALPINE,
 		)
-		Expect(apiSession).Should(Exit(0))
+		Expect(apiSession).Should(testUtils.ExitCleanly())
 		defer podman("rm", "-f", containerName)
 
 		apiSession = podmanRemote("start", containerName)
-		Expect(apiSession).Should(Exit(0))
+		Expect(apiSession).Should(testUtils.ExitCleanly())
 
 		apiSession = podmanRemote("inspect", "--format={{.State.Running}}", containerName)
-		Expect(apiSession).Should(Exit(0))
+		Expect(apiSession).Should(testUtils.ExitCleanly())
 		Expect(apiSession.OutputToString()).To(Equal("true"))
 
 		// Emulate 'systemd stop podman.service'
@@ -101,7 +101,7 @@ var _ = Describe("Systemd activate", func() {
 		Eventually(activateSession).Should(Exit(0))
 
 		abiSession := podman("inspect", "--format={{.State.Running}}", containerName)
-		Expect(abiSession).To(Exit(0))
+		Expect(abiSession).To(testUtils.ExitCleanly())
 		Expect(abiSession.OutputToString()).To(Equal("true"))
 	})
 

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -51,21 +51,21 @@ WantedBy=default.target
 			stop := SystemExec("systemctl", []string{dashWhat, "stop", serviceName})
 			os.Remove(sysFilePath)
 			SystemExec("systemctl", []string{dashWhat, "daemon-reload"})
-			Expect(stop).Should(Exit(0))
+			Expect(stop).Should(ExitCleanly())
 		}()
 
 		create := podmanTest.Podman([]string{"create", "--name", "redis", REDIS_IMAGE})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(Exit(0))
+		Expect(create).Should(ExitCleanly())
 
 		enable := SystemExec("systemctl", []string{dashWhat, "daemon-reload"})
-		Expect(enable).Should(Exit(0))
+		Expect(enable).Should(ExitCleanly())
 
 		start := SystemExec("systemctl", []string{dashWhat, "start", serviceName})
-		Expect(start).Should(Exit(0))
+		Expect(start).Should(ExitCleanly())
 
 		logs := SystemExec("journalctl", []string{dashWhat, "-n", "20", "-u", serviceName})
-		Expect(logs).Should(Exit(0))
+		Expect(logs).Should(ExitCleanly())
 
 		status := SystemExec("systemctl", []string{dashWhat, "status", serviceName})
 		Expect(status.OutputToString()).To(ContainSubstring("active (running)"))
@@ -79,7 +79,7 @@ WantedBy=default.target
 
 		logs := podmanTest.Podman([]string{"logs", ctrName})
 		logs.WaitWithDefaultTimeout()
-		Expect(logs).Should(Exit(0))
+		Expect(logs).Should(ExitCleanly())
 
 		// Give container 10 seconds to start
 		started := podmanTest.WaitContainerReady(ctrName, "Reached target multi-user.target - Multi-User System.", 30, 1)
@@ -87,12 +87,12 @@ WantedBy=default.target
 
 		systemctl := podmanTest.Podman([]string{"exec", ctrName, "systemctl", "status", "--no-pager"})
 		systemctl.WaitWithDefaultTimeout()
-		Expect(systemctl).Should(Exit(0))
+		Expect(systemctl).Should(ExitCleanly())
 		Expect(systemctl.OutputToString()).To(ContainSubstring("State:"))
 
 		result := podmanTest.Podman([]string{"inspect", ctrName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		conData := result.InspectContainerToJSON()
 		Expect(conData).To(HaveLen(1))
 		Expect(conData[0].Config).To(HaveField("SystemdMode", true))
@@ -103,11 +103,11 @@ WantedBy=default.target
 		}
 		stats := podmanTest.Podman([]string{"stats", "--no-stream", ctrName})
 		stats.WaitWithDefaultTimeout()
-		Expect(stats).Should(Exit(0))
+		Expect(stats).Should(ExitCleanly())
 
 		cgroupPath := podmanTest.Podman([]string{"inspect", "--format='{{.State.CgroupPath}}'", ctrName})
 		cgroupPath.WaitWithDefaultTimeout()
-		Expect(cgroupPath).Should(Exit(0))
+		Expect(cgroupPath).Should(ExitCleanly())
 		Expect(cgroupPath.OutputToString()).To(Not(ContainSubstring("init.scope")))
 	})
 
@@ -115,11 +115,11 @@ WantedBy=default.target
 		ctrName := "testCtr"
 		run := podmanTest.Podman([]string{"create", "--name", ctrName, "--entrypoint", "/sbin/init", SYSTEMD_IMAGE})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"inspect", ctrName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		conData := result.InspectContainerToJSON()
 		Expect(conData).To(HaveLen(1))
 		Expect(conData[0].Config).To(HaveField("SystemdMode", true))
@@ -135,16 +135,16 @@ CMD /usr/lib/systemd/systemd`, ALPINE)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "-t", "systemd", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		ctrName := "testCtr"
 		run := podmanTest.Podman([]string{"create", "--name", ctrName, "systemd"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"inspect", ctrName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		conData := result.InspectContainerToJSON()
 		Expect(conData).To(HaveLen(1))
 		Expect(conData[0].Config).To(HaveField("SystemdMode", true))
@@ -154,11 +154,11 @@ CMD /usr/lib/systemd/systemd`, ALPINE)
 		ctrName := "testCtrUidMap"
 		run := podmanTest.Podman([]string{"run", "-d", "--uidmap=0:1:1000", "--name", ctrName, ALPINE, "top"})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"inspect", "--format", "{{.ConmonPidFile}}", ctrName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		pidFile := strings.TrimSuffix(session.OutputToString(), "\n")
 		_, err := os.ReadFile(pidFile)
@@ -169,11 +169,11 @@ CMD /usr/lib/systemd/systemd`, ALPINE)
 		ctrName := "testCtr"
 		run := podmanTest.Podman([]string{"create", "--name", ctrName, "--systemd", "always", ALPINE})
 		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
+		Expect(run).Should(ExitCleanly())
 
 		result := podmanTest.Podman([]string{"inspect", ctrName})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
+		Expect(result).Should(ExitCleanly())
 		conData := result.InspectContainerToJSON()
 		Expect(conData).To(HaveLen(1))
 		Expect(conData[0].Config).To(HaveField("SystemdMode", true))
@@ -182,7 +182,7 @@ CMD /usr/lib/systemd/systemd`, ALPINE)
 	It("podman run --systemd container should NOT mount /run noexec", func() {
 		session := podmanTest.Podman([]string{"run", "--systemd", "always", ALPINE, "sh", "-c", "mount  | grep \"/run \""})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))
 	})
@@ -190,17 +190,17 @@ CMD /usr/lib/systemd/systemd`, ALPINE)
 	It("podman run --systemd arg is case insensitive", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--systemd", "Always", ALPINE, "echo", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("test"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--systemd", "True", ALPINE, "echo", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("test"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--systemd", "False", ALPINE, "echo", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).Should(Equal("test"))
 	})
 })

--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session := podmanTest.Podman([]string{"run", "--dns", "none", ALPINE, "sh", "-c",
 			"rm -f /etc/resolv.conf; touch -d '1970-01-01 00:02:03' /etc/resolv.conf; stat -c %s:%Y /etc/resolv.conf"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("0:123"))
 	})
 
@@ -55,7 +55,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session := podmanTest.Podman([]string{"run", "--no-hosts", ALPINE, "sh", "-c",
 			"rm -f /etc/hosts; touch -d '1970-01-01 00:02:03' /etc/hosts; stat -c %s:%Y /etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("0:123"))
 	})
 
@@ -75,16 +75,16 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--ulimit", "host", ALPINE,
 			"sleep", "1000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test", "sh", "-c",
 			"ulimit -H -n"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		containerHardLimit, err = strconv.Atoi(strings.Trim(session.OutputToString(), "\n"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(containerHardLimit).To(BeNumerically(">=", rlimit.Max))
@@ -116,16 +116,16 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--ipc=host", "--pid=host", ALPINE,
 			"sleep", "1000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"exec", "test",
 			"df", "/dev/shm"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		lines = session.OutputToStringArray()
 		fields = strings.Fields(lines[len(lines)-1])
 		containerShmSize, err = strconv.Atoi(fields[1])
@@ -142,7 +142,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "--user", "root:root", ALPINE,
 			"id"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("uid=0(root) gid=0(root)"))
 	})
 
@@ -160,12 +160,12 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--userns=keep-id", ALPINE,
 			"sleep", "1000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(err).ToNot(HaveOccurred())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		expectedOutput := fmt.Sprintf("uid=%s(%s) gid=%s(%s)",
 			currentUser.Uid, currentUser.Username,
@@ -174,7 +174,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"exec", "test",
 			"id"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(expectedOutput))
 	})
 
@@ -194,11 +194,11 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"create", "--log-driver", "k8s-file", "--name", "test", "--userns=keep-id", "--user", "root:root", fedoraToolbox, "sh", "-c",
 			fmt.Sprintf("%s; %s; echo READY; sleep 1000", useradd, passwd)})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		Expect(WaitContainerReady(podmanTest, "test", "READY", 5, 1)).To(BeTrue())
 
@@ -207,7 +207,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 
 		session = podmanTest.Podman([]string{"exec", "test", "cat", "/etc/passwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(expectedOutput))
 
 		expectedOutput = "passwd: Note: deleting a password also unlocks the password."
@@ -230,22 +230,22 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"create", "--log-driver", "k8s-file", "--name", "test", "--userns=keep-id", "--user", "root:root", fedoraToolbox, "sh", "-c",
 			fmt.Sprintf("%s; echo READY; sleep 1000", groupadd)})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		Expect(WaitContainerReady(podmanTest, "test", "READY", 5, 1)).To(BeTrue())
 
 		session = podmanTest.Podman([]string{"exec", "test", "cat", "/etc/group"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(groupName))
 
 		session = podmanTest.Podman([]string{"logs", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("READY"))
 	})
 
@@ -275,11 +275,11 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"create", "--log-driver", "k8s-file", "--name", "test", "--userns=keep-id", "--user", "root:root", fedoraToolbox, "sh", "-c",
 			fmt.Sprintf("%s; %s; %s; echo READY; sleep 1000", useradd, groupadd, usermod)})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		Expect(WaitContainerReady(podmanTest, "test", "READY", 5, 1)).To(BeTrue())
 
@@ -288,12 +288,12 @@ var _ = Describe("Toolbox-specific testing", func() {
 
 		session = podmanTest.Podman([]string{"exec", "test", "cat", "/etc/passwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(expectedUser))
 
 		session = podmanTest.Podman([]string{"logs", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("READY"))
 	})
 
@@ -304,12 +304,12 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"run", "--privileged", "--userns=keep-id", "--user", "root:root", ALPINE,
 			"mount", "-t", define.TypeTmpfs, define.TypeTmpfs, "/tmp"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "--privileged", "--userns=keep-id", "--user", "root:root", ALPINE,
 			"mount", "--rbind", "/tmp", "/var/tmp"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman create + start - with all needed switches for create - sleep as entry-point", func() {
@@ -335,17 +335,17 @@ var _ = Describe("Toolbox-specific testing", func() {
 			"--user", "root:root",
 			fedoraToolbox, "sh", "-c", "echo READY; sleep 1000"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"start", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 
 		Expect(WaitContainerReady(podmanTest, "test", "READY", 5, 1)).To(BeTrue())
 
 		session = podmanTest.Podman([]string{"logs", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("READY"))
 	})
 
@@ -357,7 +357,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 
 		session = podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:%s", currentUser.HomeDir, currentUser.HomeDir), "--userns=keep-id", fedoraToolbox, "sh", "-c", "echo $HOME"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(currentUser.HomeDir))
 
 		if isRootless() {
@@ -368,7 +368,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 				"--volume", volumeArg,
 				fedoraToolbox, "sh", "-c", "echo $HOME"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(0))
+			Expect(session).Should(ExitCleanly())
 			Expect(session.OutputToString()).To(ContainSubstring(currentUser.HomeDir))
 		}
 	})


### PR DESCRIPTION
Final step in RUN-1907. This is the last set of `*_test.go` files to be migrated to using `ExitCleanly()`.

As always, the first commit is long & uninteresting, the second commit is the important one.

```release-note
None
```