### PR TITLE
[CI:DOCS] Add documentation for the vrf option on Netavark

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -115,6 +115,7 @@ Additionally the `bridge` driver supports the following options:
 - `isolate`: This option isolates networks by blocking traffic between those that have this option enabled.
 - `com.docker.network.bridge.name`: This option assigns the given name to the created Linux Bridge
 - `com.docker.network.driver.mtu`: Sets the Maximum Transmission Unit (MTU) and takes an integer value.
+- `vrf`: This option assigns a VRF to the bridge interface. It accepts the name of the VRF and defaults to none. Can only be used with the Netavark network backend.
 
 The `macvlan` and `ipvlan` driver support the following options:
 


### PR DESCRIPTION
This pull request adds documentation for using the VRF option on the Netavark backend (https://github.com/containers/netavark/commit/4b6d5ab26316b007779e0a504ab9a90a21b2e2dc) . 
This depends on this pull request https://github.com/containers/common/pull/1673.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new vrf option to `podman network create --opt` for the bridge driver.
```
