### PR TITLE
podman: run --replace prints only the new container id

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -203,7 +203,7 @@ func replaceContainer(name string) error {
 		Force:  true, // force stop & removal
 		Ignore: true, // ignore errors when a container doesn't exit
 	}
-	return removeContainers([]string{name}, rmOptions, false)
+	return removeContainers([]string{name}, rmOptions, false, true)
 }
 
 func createOrUpdateFlags(cmd *cobra.Command, vals *entities.ContainerCreateOptions) error {

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -133,14 +133,14 @@ func rm(cmd *cobra.Command, args []string) error {
 		rmOptions.Depend = true
 	}
 
-	return removeContainers(utils.RemoveSlash(args), rmOptions, true)
+	return removeContainers(utils.RemoveSlash(args), rmOptions, true, false)
 }
 
 // removeContainers will remove the specified containers (names or IDs).
 // Allows for sharing removal logic across commands. If setExit is set,
 // removeContainers will set the exit code according to the `podman-rm` man
 // page.
-func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit bool) error {
+func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit bool, quiet bool) error {
 	var errs utils.OutputErrors
 	responses, err := registry.ContainerEngine().ContainerRm(context.Background(), namesOrIDs, rmOptions)
 	if err != nil {
@@ -166,9 +166,13 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 			}
 			errs = append(errs, r.Err)
 		case r.RawInput != "":
-			fmt.Println(r.RawInput)
+			if !quiet {
+				fmt.Println(r.RawInput)
+			}
 		default:
-			fmt.Println(r.Id)
+			if !quiet {
+				fmt.Println(r.Id)
+			}
 		}
 	}
 	return errs.PrintErrors()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1615,9 +1615,12 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		// Run and replace 5 times in a row the "same" container.
 		ctrName := "testCtr"
 		for i := 0; i < 5; i++ {
-			session := podmanTest.Podman([]string{"run", "--detach", "--replace", "--name", ctrName, ALPINE, "/bin/sh"})
+			session := podmanTest.Podman([]string{"run", "--detach", "--replace", "--name", ctrName, ALPINE, "top"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
+
+			// make sure Podman prints only one ID
+			Expect(session.OutputToString()).To(HaveLen(64))
 		}
 	})
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
run --replace prints only the ID for the new container, instead of the ID if the old one was stopped
```
