### PR TITLE
podman machine: disable zincati update service

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -24,7 +24,30 @@ but can be optionally used on Linux.
 SSH keys are automatically generated to access the VM, and system connections to the root account
 and a user account inside the VM are added.
 
-By default, the VM distribution is [Fedora CoreOS](https://getfedora.org/en/coreos?stream=testing).
+By default, the VM distribution is [Fedora CoreOS](https://getfedora.org/en/coreos?stream=testing) except for
+WSL which is based on a custom Fedora image.  While Fedora CoreOS upgrades come out every 14 days, the automatic
+update mechanism Zincata is disabled by Podman machine.
+
+To check if there is an upgrade available for your machine os, you can run the following command:
+
+```
+$ podman machine ssh 'sudo rpm-ostree upgrade --check'
+
+```
+If an update is available, you can rerun the above command and remove the `--check` and your operating system will
+be updated.  After updating, you must stop and start your machine with `podman machine stop && podman machine start` for
+it to take effect.
+
+Note: Updating as described above can result in version mismatches between Podman on the host and Podman in the
+machine.  Executing `podman info` should reveal versions of both.  A configuration where the Podman host and machine
+mismatch are unsupported.
+
+For more information on updates and advanced configuration,
+see the Fedora CoreOS documentation about [auto-updates](https://docs.fedoraproject.org/en-US/fedora-coreos/auto-updates/) and [update strategies](https://coreos.github.io/zincati/usage/updates-strategy/).
+
+
+
+
 Fedora CoreOS upgrades come out every 14 days and are detected and installed automatically. The VM is rebooted during the upgrade.
 For more information on updates and advanced configuration,
 see the Fedora CoreOS documentation about [auto-updates](https://docs.fedoraproject.org/en-US/fedora-coreos/auto-updates/) and [update strategies](https://coreos.github.io/zincati/usage/updates-strategy/).
@@ -77,6 +100,9 @@ API forwarding, if available, follows this setting.
 Set the timezone for the machine and containers.  Valid values are `local` or
 a `timezone` such as `America/Chicago`.  A value of `local`, which is the default,
 means to use the timezone of the machine host.
+
+The timezone setting is not used with WSL.  WSL automatically sets the timezone to the same
+as the host Windows operating system.
 
 @@option user-mode-networking
 

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -203,17 +203,26 @@ func (matcher *ValidJSONMatcher) NegatedFailureMessage(actual interface{}) (mess
 }
 
 func skipIfVmtype(vmType machine.VMType, message string) {
-	if testProvider.VMType() == vmType {
+	if isVmtype(vmType) {
 		Skip(message)
 	}
 }
 
 func skipIfNotVmtype(vmType machine.VMType, message string) {
-	if testProvider.VMType() != vmType {
+	if !isVmtype(vmType) {
 		Skip(message)
 	}
 }
 
 func skipIfWSL(message string) {
 	skipIfVmtype(machine.WSLVirt, message)
+}
+
+func isVmtype(vmType machine.VMType) bool {
+	return testProvider.VMType() == vmType
+}
+
+// isWSL is a simple wrapper to determine if the testprovider is WSL
+func isWSL() bool {
+	return isVmtype(machine.WSLVirt)
 }

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/pkg/machine"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -52,7 +51,7 @@ var _ = Describe("podman machine init", func() {
 
 		testMachine := inspectBefore[0]
 		Expect(testMachine.Name).To(Equal(mb.names[0]))
-		if testProvider.VMType() != machine.WSLVirt { // WSL hardware specs are hardcoded
+		if testProvider.VMType() == machine.WSLVirt { // WSL hardware specs are hardcoded
 			Expect(testMachine.Resources.CPUs).To(Equal(uint64(cpus)))
 			Expect(testMachine.Resources.Memory).To(Equal(uint64(2048)))
 		}
@@ -82,6 +81,16 @@ var _ = Describe("podman machine init", func() {
 		Expect(inspectBefore).ToNot(BeEmpty())
 		Expect(inspectAfter).ToNot(BeEmpty())
 		Expect(inspectAfter[0].State).To(Equal(machine.Running))
+
+		if isWSL() { // WSL does not use FCOS
+			return
+		}
+
+		// check to see that zincati is masked
+		sshDisk := sshMachine{}
+		zincati, err := mb.setCmd(sshDisk.withSSHCommand([]string{"sudo", "systemctl", "is-enabled", "zincati"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(zincati.outputToString()).To(ContainSubstring("disabled"))
 	})
 
 	It("simple init with username", func() {

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -210,6 +210,12 @@ WantedBy=sysinit.target
 				Name:     "remove-moby.service",
 				Contents: &deMoby,
 			},
+			{
+				// Disable auto-updating of fcos images
+				// https://github.com/containers/podman/issues/20122
+				Enabled: BoolToPtr(false),
+				Name:    "zincati.service",
+			},
 		}}
 
 	// Only qemu has the qemu firmware environment setting


### PR DESCRIPTION
As explained in #21022, there are all kinds of downsides to a machine updating itself (via zincati) automatically, like interuption of service, lost mounts, etc.

disabling zincati will at least allow stop these downsides.  we are likely to contemplate if podman will take over the update process externally where interuption of services will not occur etc.

Fixes #20122

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Disable auto-updates in podman machine vms that use FCOS
```
