### PR TITLE
New machines should show Never as LastUp

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -206,6 +206,8 @@ func toHumanFormat(vms []*machine.ListResponse) ([]*entities.ListReporter, error
 		case vm.Running:
 			response.LastUp = "Currently running"
 			response.Running = true
+		case vm.LastUp.IsZero():
+			response.LastUp = "Never"
 		default:
 			response.LastUp = units.HumanDuration(time.Since(vm.LastUp)) + " ago"
 		}

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -787,16 +787,7 @@ func getVMInfos() ([]*machine.ListResponse, error) {
 				return err
 			}
 			listEntry.Running = vmState == machine.Running
-
-			if !vm.LastUp.IsZero() { // this means we have already written a time to the config
-				listEntry.LastUp = vm.LastUp
-			} else { // else we just created the machine AKA last up = created time
-				listEntry.LastUp = vm.Created
-				vm.LastUp = listEntry.LastUp
-				if err := vm.writeConfig(); err != nil {
-					return err
-				}
-			}
+			listEntry.LastUp = vm.LastUp
 
 			listed = append(listed, listEntry)
 		}

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -84,10 +84,16 @@ var _ = Describe("podman machine list", func() {
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
+
+		l := new(listMachine)
+		listSession, err := mb.setCmd(l.withFormat("{{.LastUp}}")).run()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listSession).To(Exit(0))
+		Expect(listSession.outputToString()).To(Equal("Never"))
+
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).runWithoutWait()
 		Expect(err).ToNot(HaveOccurred())
-		l := new(listMachine)
 		for i := 0; i < 30; i++ {
 			listSession, err := mb.setCmd(l).run()
 			Expect(listSession).To(Exit(0))
@@ -100,7 +106,7 @@ var _ = Describe("podman machine list", func() {
 			time.Sleep(3 * time.Second)
 		}
 		Expect(startSession).To(Exit(0))
-		listSession, err := mb.setCmd(l).run()
+		listSession, err = mb.setCmd(l).run()
 		Expect(listSession).To(Exit(0))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listSession.outputToString()).To(ContainSubstring("Currently running"))

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -204,16 +204,7 @@ func getVMInfos() ([]*machine.ListResponse, error) {
 				return err
 			}
 			listEntry.Running = state == machine.Running
-
-			if !vm.LastUp.IsZero() { // this means we have already written a time to the config
-				listEntry.LastUp = vm.LastUp
-			} else { // else we just created the machine AKA last up = created time
-				listEntry.LastUp = vm.Created
-				vm.LastUp = listEntry.LastUp
-				if err := vm.writeConfig(); err != nil {
-					return err
-				}
-			}
+			listEntry.LastUp = vm.LastUp
 
 			listed = append(listed, listEntry)
 		}

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -46,7 +46,6 @@ func (p *WSLVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, er
 	}
 
 	vm.Created = time.Now()
-	vm.LastUp = vm.Created
 
 	// Default is false
 	if opts.UserModeNetworking != nil {


### PR DESCRIPTION
After creating a podman machine, and before starting it, the LastUp value for podman machine ls should display Never. Previously, the LastUp value was the same as creation time. This also changes the LastUp value for inspect to ZeroTime instead of creation time.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the `podman machine ls` command would show Creation time as LastUp time for machines that have never been booted. Now, new machines show `Never`, with the json value being ZeroTime.
```
