### PR TITLE
Add DefaultMode to kube play

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -628,6 +628,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			if err != nil || mountPoint == "" {
 				return nil, nil, fmt.Errorf("unable to get mountpoint of volume %q: %w", vol.Name(), err)
 			}
+			defaultMode := v.DefaultMode
 			// Create files and add data to the volume mountpoint based on the Items in the volume
 			for k, v := range v.Items {
 				dataPath := filepath.Join(mountPoint, k)
@@ -638,6 +639,10 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 				defer f.Close()
 				_, err = f.Write(v)
 				if err != nil {
+					return nil, nil, err
+				}
+				// Set file permissions
+				if err := os.Chmod(f.Name(), os.FileMode(defaultMode)); err != nil {
 					return nil, nil, err
 				}
 			}

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -51,6 +51,9 @@ type KubeVolume struct {
 	// If the volume is optional, we can move on if it is not found
 	// Only used when there are volumes in a yaml that refer to a configmap
 	Optional bool
+	// DefaultMode sets the permissions on files created for the volume
+	// This is optional and defaults to 0644
+	DefaultMode int32
 }
 
 // Create a KubeVolume from an HostPathVolumeSource
@@ -135,9 +138,18 @@ func VolumeFromHostPath(hostPath *v1.HostPathVolumeSource, mountLabel string) (*
 // VolumeFromSecret creates a new kube volume from a kube secret.
 func VolumeFromSecret(secretSource *v1.SecretVolumeSource, secretsManager *secrets.SecretsManager) (*KubeVolume, error) {
 	kv := &KubeVolume{
-		Type:   KubeVolumeTypeSecret,
-		Source: secretSource.SecretName,
-		Items:  map[string][]byte{},
+		Type:        KubeVolumeTypeSecret,
+		Source:      secretSource.SecretName,
+		Items:       map[string][]byte{},
+		DefaultMode: v1.SecretVolumeSourceDefaultMode,
+	}
+	// Set the defaultMode if set in the kube yaml
+	validMode, err := isValidDefaultMode(secretSource.DefaultMode)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DefaultMode for secret %q: %w", secretSource.SecretName, err)
+	}
+	if validMode {
+		kv.DefaultMode = *secretSource.DefaultMode
 	}
 
 	// returns a byte array of a kube secret data, meaning this needs to go into a string map
@@ -191,8 +203,9 @@ func VolumeFromPersistentVolumeClaim(claim *v1.PersistentVolumeClaimVolumeSource
 func VolumeFromConfigMap(configMapVolumeSource *v1.ConfigMapVolumeSource, configMaps []v1.ConfigMap) (*KubeVolume, error) {
 	var configMap *v1.ConfigMap
 	kv := &KubeVolume{
-		Type:  KubeVolumeTypeConfigMap,
-		Items: map[string][]byte{},
+		Type:        KubeVolumeTypeConfigMap,
+		Items:       map[string][]byte{},
+		DefaultMode: v1.ConfigMapVolumeSourceDefaultMode,
 	}
 	for _, cm := range configMaps {
 		if cm.Name == configMapVolumeSource.Name {
@@ -202,6 +215,14 @@ func VolumeFromConfigMap(configMapVolumeSource *v1.ConfigMapVolumeSource, config
 			configMap = &matchedCM
 			break
 		}
+	}
+	// Set the defaultMode if set in the kube yaml
+	validMode, err := isValidDefaultMode(configMapVolumeSource.DefaultMode)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DefaultMode for configMap %q: %w", configMapVolumeSource.Name, err)
+	}
+	if validMode {
+		kv.DefaultMode = *configMapVolumeSource.DefaultMode
 	}
 
 	if configMap == nil {
@@ -278,4 +299,15 @@ func InitializeVolumes(specVolumes []v1.Volume, configMaps []v1.ConfigMap, secre
 	}
 
 	return volumes, nil
+}
+
+// isValidDefaultMode returns true if mode is between 0 and 0777
+func isValidDefaultMode(mode *int32) (bool, error) {
+	if mode == nil {
+		return false, nil
+	}
+	if *mode >= 0 && *mode <= int32(os.ModePerm) {
+		return true, nil
+	}
+	return false, errors.New("must be between 0000 and 0777")
 }


### PR DESCRIPTION
Add support for DefaultMode for configMaps and secrets. This allows users to set the file permissions for files created with their volume mounts. Adheres to k8s defaults.

Fixes https://github.com/containers/podman/issues/19313

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for DefaultMode to kube play volumes
```
