### PR TITLE
Remove `c.ExtraFiles` line in machine

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -543,7 +543,7 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 	defer ioEater.Close()
 
 	// TODO handle returns from startHostNetworking
-	forwardSock, forwardState, err := m.startHostNetworking(ioEater)
+	forwardSock, forwardState, err := m.startHostNetworking()
 	if err != nil {
 		return err
 	}
@@ -816,7 +816,7 @@ func (m *MacMachine) setupStartHostNetworkingCmd() (gvproxy.GvproxyCommand, stri
 	return cmd, forwardSock, state
 }
 
-func (m *MacMachine) startHostNetworking(ioEater *os.File) (string, machine.APIForwardingState, error) {
+func (m *MacMachine) startHostNetworking() (string, machine.APIForwardingState, error) {
 	var (
 		forwardSock string
 		state       machine.APIForwardingState
@@ -858,7 +858,6 @@ func (m *MacMachine) startHostNetworking(ioEater *os.File) (string, machine.APIF
 
 	cmd, forwardSock, state := m.setupStartHostNetworkingCmd()
 	c := cmd.Cmd(gvproxyBinary)
-	c.ExtraFiles = []*os.File{ioEater, ioEater, ioEater}
 	if err := c.Start(); err != nil {
 		return "", 0, fmt.Errorf("unable to execute: %q: %w", cmd.ToCmdline(), err)
 	}

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1317,14 +1317,6 @@ func (v *MachineVM) startHostNetworking() (string, machine.APIForwardingState, e
 		return "", machine.NoForwarding, err
 	}
 
-	dnr, dnw, err := machine.GetDevNullFiles()
-	if err != nil {
-		return "", machine.NoForwarding, err
-	}
-
-	defer dnr.Close()
-	defer dnw.Close()
-
 	cmd := gvproxy.NewGvproxyCommand()
 	cmd.AddQemuSocket(fmt.Sprintf("unix://%s", v.QMPMonitor.Address.GetPath()))
 	cmd.PidFile = v.PidFilePath.GetPath()
@@ -1342,7 +1334,6 @@ func (v *MachineVM) startHostNetworking() (string, machine.APIForwardingState, e
 	}
 
 	c := cmd.Cmd(binary)
-	c.ExtraFiles = []*os.File{dnr, dnw, dnw}
 	if err := c.Start(); err != nil {
 		return "", 0, fmt.Errorf("unable to execute: %q: %w", cmd.ToCmdline(), err)
 	}


### PR DESCRIPTION
Removes the `c.ExtraFiles` line in applehv and qemu `machine.go` file. These are remnants from #19723. This lines was written to add stdin, stdout, stderr as extra files, but that is not how `c.ExtraFiles` works (unlike `os.ProcAttr`).

go source: https://cs.opensource.google/go/go/+/go1.21.1:src/os/exec/exec.go;l=147

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
