### PR TITLE
windows: Use prebuilt gvproxy/win-sshproxy binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,11 +204,9 @@ ifdef HOMEBREW_PREFIX
 endif
 endif
 
-# win-sshproxy is checked out manually to keep from pulling in gvisor and it's transitive
-# dependencies. This is only used for the Windows client archives, which must
-# include this lightweight helper binary.
-GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
-GV_SHA=db608827124caa71ba411cec8ea959bb942984fe
+# gvisor-tap-vsock version for gvproxy.exe and win-sshproxy.exe downloads
+# the upstream project ships pre-built binaries since version 0.7.1
+GV_VERSION=v0.7.1
 
 ###
 ### Primary entry-point targets
@@ -774,16 +772,9 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 # Checks out and builds win-sshproxy helper. See comment on GV_GITURL declaration
 .PHONY: win-gvproxy
 win-gvproxy: test/version/version
-	rm -rf tmp-gv; mkdir tmp-gv
-	(cd tmp-gv; \
-         git init; \
-         git remote add origin $(GV_GITURL); \
-         git fetch --depth 1 origin $(GV_SHA); \
-         git checkout FETCH_HEAD; make win-gvproxy win-sshproxy)
 	mkdir -p bin/windows/
-	cp tmp-gv/bin/win-sshproxy.exe bin/windows/
-	cp tmp-gv/bin/gvproxy.exe bin/windows/
-	rm -rf tmp-gv
+	curl -sSL -o bin/windows/gvproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GV_VERSION)/gvproxy-windowsgui.exe
+	curl -sSL -o bin/windows/win-sshproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GV_VERSION)/win-sshproxy.exe
 
 .PHONY: rpm
 rpm:  ## Build rpm packages

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -31,44 +31,15 @@ function Local-Machine {
 # Expect starting directory to be /podman
 function Win-SSHProxy {
     param (
-        [string]$Ref
+        [string]$Version
     );
 
-    # git is not installed by default on windows
-    # fail if git doesn't exist
-    Get-Command git -ErrorAction SilentlyContinue  | out-null
-    if(!$?){
-        Write-Host "Git not installed, cannot build Win-SSHProxy"
-        Exit 1
-    }
-
-    if (Test-Path ./tmp-gv) {
-        Remove-Item ./tmp-gv -Recurse -Force -Confirm:$false
-    }
-
-    $GV_GITURL = "https://github.com/containers/gvisor-tap-vsock.git"
-
-    New-Item  ./tmp-gv -ItemType Directory -ea 0
-    Push-Location ./tmp-gv
-    Run-Command "git init"
-    Run-Command "git remote add origin $GV_GITURL"
-    Run-Command "git fetch --depth 1 origin main"
-    Run-Command "git fetch --depth 1 --tags"
-    Run-Command "git checkout main"
-    if (-Not $Ref) {
-        Write-Host "empty"
-        $Ref = git describe --abbrev=0
-    }
-    Run-Command "git checkout $Ref"
-    Run-Command "go build -ldflags -H=windowsgui -o bin/win-sshproxy.exe ./cmd/win-sshproxy"
-    Run-Command "go build -ldflags -H=windowsgui -o bin/gvproxy.exe ./cmd/gvproxy"
-    Pop-Location
-
-    # Move location to ./bin/windows for packaging script and for Windows binary testing
     New-Item -ItemType Directory -Force -Path "./bin/windows"
-    Copy-Item -Path "tmp-gv/bin/win-sshproxy.exe" -Destination "./bin/windows/"
-    Copy-Item -Path "tmp-gv/bin/gvproxy.exe" -Destination "./bin/windows/"
-    Remove-Item ./tmp-gv -Recurse -Force -Confirm:$false
+    if (-Not $Version) {
+        $Version = "v0.7.1"
+    }
+    curl.exe -sSL -o "./bin/windows/gvproxy.exe" --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windowsgui.exe"
+    curl.exe -sSL -o "./bin/windows/win-sshproxy.exe" --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy.exe"
 }
 
 # Helpers


### PR DESCRIPTION
Since gvisor-tap-vsock 0.7.1, the upstream project ships pre-built
Windows binaries for gvproxy and win-sshproxy. These binaries are built
with -Hwindowsgui as needed by podman.

This makes the same change in winmake.ps1, but I had to hardcode
gvisor-tap-vsock version in one more place.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```