### PR TITLE
update vfkit vendored code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/containers/storage v1.50.2
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/coreos/stream-metadata-go v0.4.3
-	github.com/crc-org/vfkit v0.1.1
+	github.com/crc-org/vfkit v0.1.2-0.20230829083117-09e62065eb6e
 	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/digitalocean/go-qemu v0.0.0-20230711162256-2e3d0186973e
 	github.com/docker/distribution v2.8.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/coreos/stream-metadata-go v0.4.3/go.mod h1:fMObQqQm8Ku91G04btKzEH3Asd
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/crc-org/vfkit v0.1.1 h1:F0QXj9ik1mhVq2R8FmWFhQH8SuFGYP5Xu2KF7cTvALs=
-github.com/crc-org/vfkit v0.1.1/go.mod h1:vjZiHDacUi0iLosvwyLvqJvJXQhByzlLQbMkdIfCQWk=
+github.com/crc-org/vfkit v0.1.2-0.20230829083117-09e62065eb6e h1:UlIzed038y+BSh8GTg3yuL1i8309mrs3Gth9s26AdT8=
+github.com/crc-org/vfkit v0.1.2-0.20230829083117-09e62065eb6e/go.mod h1:RJbirUrdvb3qyOxjySBeOfuc9wgbJrZxJP2eNcxDWGs=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=

--- a/pkg/machine/applehv/vfkit.go
+++ b/pkg/machine/applehv/vfkit.go
@@ -56,7 +56,9 @@ func getIgnitionVsockDevice(path string) (vfConfig.VirtioDevice, error) {
 
 func VirtIOFsToVFKitVirtIODevice(fs machine.VirtIoFs) vfConfig.VirtioFs {
 	return vfConfig.VirtioFs{
+		DirectorySharingConfig: vfConfig.DirectorySharingConfig{
+			MountTag: fs.Tag,
+		},
 		SharedDir: fs.Source,
-		MountTag:  fs.Tag,
 	}
 }

--- a/vendor/github.com/crc-org/vfkit/pkg/config/json.go
+++ b/vendor/github.com/crc-org/vfkit/pkg/config/json.go
@@ -25,6 +25,7 @@ const (
 	vfGpu          vmComponentKind = "virtiogpu"
 	vfInput        vmComponentKind = "virtioinput"
 	usbMassStorage vmComponentKind = "usbmassstorage"
+	rosetta        vmComponentKind = "rosetta"
 )
 
 type jsonKind struct {
@@ -110,6 +111,10 @@ func unmarshalDevice(rawMsg json.RawMessage) (VirtioDevice, error) {
 		dev = &newDevice
 	case vfFs:
 		var newDevice VirtioFs
+		err = json.Unmarshal(rawMsg, &newDevice)
+		dev = &newDevice
+	case rosetta:
+		var newDevice RosettaShare
 		err = json.Unmarshal(rawMsg, &newDevice)
 		dev = &newDevice
 	case vfRng:
@@ -250,6 +255,17 @@ func (dev *VirtioFs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(devWithKind{
 		jsonKind: kind(vfFs),
 		VirtioFs: *dev,
+	})
+}
+
+func (dev *RosettaShare) MarshalJSON() ([]byte, error) {
+	type devWithKind struct {
+		jsonKind
+		RosettaShare
+	}
+	return json.Marshal(devWithKind{
+		jsonKind:     kind(rosetta),
+		RosettaShare: *dev,
 	})
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -409,7 +409,7 @@ github.com/coreos/stream-metadata-go/release
 github.com/coreos/stream-metadata-go/release/rhcos
 github.com/coreos/stream-metadata-go/stream
 github.com/coreos/stream-metadata-go/stream/rhcos
-# github.com/crc-org/vfkit v0.1.1
+# github.com/crc-org/vfkit v0.1.2-0.20230829083117-09e62065eb6e
 ## explicit; go 1.18
 github.com/crc-org/vfkit/pkg/cmdline
 github.com/crc-org/vfkit/pkg/config


### PR DESCRIPTION
upstream reversed width and height and now we get an unusable gui

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
