### PR TITLE
override HealthChecks fields embeded in container image

### DIFF
--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -34,23 +34,25 @@ func Error(w http.ResponseWriter, code int, err error) {
 }
 
 func VolumeNotFound(w http.ResponseWriter, name string, err error) {
-	if !errors.Is(err, define.ErrNoSuchVolume) {
-		InternalServerError(w, err)
+	if errors.Is(err, define.ErrNoSuchVolume) || errors.Is(err, define.ErrVolumeExists) {
+		Error(w, http.StatusNotFound, err)
+		return
 	}
-	Error(w, http.StatusNotFound, err)
+	InternalServerError(w, err)
 }
 
 func ContainerNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrExists) {
 		Error(w, http.StatusNotFound, err)
-	} else {
-		InternalServerError(w, err)
+		return
 	}
+	InternalServerError(w, err)
 }
 
 func ImageNotFound(w http.ResponseWriter, name string, err error) {
 	if !errors.Is(err, storage.ErrImageUnknown) {
 		InternalServerError(w, err)
+		return
 	}
 	Error(w, http.StatusNotFound, err)
 }
@@ -58,6 +60,7 @@ func ImageNotFound(w http.ResponseWriter, name string, err error) {
 func NetworkNotFound(w http.ResponseWriter, name string, err error) {
 	if !errors.Is(err, define.ErrNoSuchNetwork) {
 		InternalServerError(w, err)
+		return
 	}
 	Error(w, http.StatusNotFound, err)
 }
@@ -65,6 +68,7 @@ func NetworkNotFound(w http.ResponseWriter, name string, err error) {
 func PodNotFound(w http.ResponseWriter, name string, err error) {
 	if !errors.Is(err, define.ErrNoSuchPod) {
 		InternalServerError(w, err)
+		return
 	}
 	Error(w, http.StatusNotFound, err)
 }
@@ -72,6 +76,7 @@ func PodNotFound(w http.ResponseWriter, name string, err error) {
 func SessionNotFound(w http.ResponseWriter, name string, err error) {
 	if !errors.Is(err, define.ErrNoSuchExecSession) {
 		InternalServerError(w, err)
+		return
 	}
 	Error(w, http.StatusNotFound, err)
 }
@@ -79,6 +84,7 @@ func SessionNotFound(w http.ResponseWriter, name string, err error) {
 func SecretNotFound(w http.ResponseWriter, nameOrID string, err error) {
 	if errorhandling.Cause(err).Error() != "no such secret" {
 		InternalServerError(w, err)
+		return
 	}
 	Error(w, http.StatusNotFound, err)
 }

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -105,10 +105,6 @@ var _ = Describe("Podman volume rm", func() {
 			// boltdb issues volume name in quotes
 			expect = `more than one result for volume name "myv": volume already exists`
 		}
-		if IsRemote() {
-			// FIXME: #22616
-			expect = `unmarshalling error into &errorhandling.ErrorModel`
-		}
 		Expect(session).To(ExitWithError(125, expect))
 
 		session = podmanTest.Podman([]string{"volume", "ls"})


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/20212

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Users can now override HealthCheck information provided via container images.
```
