### PR TITLE
remove selinux tag as not needed anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ BUILDTAGS ?= \
 	$(shell hack/apparmor_tag.sh) \
 	$(shell hack/btrfs_installed_tag.sh) \
 	$(shell hack/btrfs_tag.sh) \
-	$(shell hack/selinux_tag.sh) \
 	$(shell hack/systemd_tag.sh) \
 	$(shell hack/libsubid_tag.sh) \
 	exclude_graphdriver_devicemapper \

--- a/hack/selinux_tag.sh
+++ b/hack/selinux_tag.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-if pkg-config libselinux 2> /dev/null ; then
-	echo selinux
-fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

I'm not sure about `apparmor` tag. Atleast runc isn't using it anymore.
"apparmor (since runc v1.0.0-rc93 the feature is always enabled)" from https://github.com/opencontainers/runc
`containers-common` still seems to check for `apparmor`, so not touching it for now.
