### PR TITLE
Fix handling of --read-only-tmpfs flag

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -386,7 +386,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.BoolVar(
 			&cf.ReadWriteTmpFS,
 			"read-only-tmpfs", cf.ReadWriteTmpFS,
-			"When running containers in read-only mode mount a read-write tmpfs on /run, /tmp and /var/tmp",
+			"When running --read-only containers mount read-write tmpfs on /dev, /dev/shm, /run, /tmp and /var/tmp",
 		)
 		requiresFlagName := "requires"
 		createFlags.StringSliceVar(

--- a/docs/source/markdown/options/read-only-tmpfs.md
+++ b/docs/source/markdown/options/read-only-tmpfs.md
@@ -4,4 +4,23 @@
 ####> are applicable to all of those.
 #### **--read-only-tmpfs**
 
-If container is running in **--read-only** mode, then mount a read-write tmpfs on _/dev_, _/dev/shm_, _/run_, _/tmp_, and _/var/tmp_. The default is **true**.
+When running --read-only containers, mount a read-write tmpfs on _/dev_, _/dev/shm_, _/run_, _/tmp_, and _/var/tmp_. The default is **true**.
+
+| --read-only | --read-only-tmpfs |  /   | /run, /tmp, /var/tmp|
+| ----------- | ----------------- | ---- | ----------------------------------- |
+| true        |  true             | r/o  | r/w                                 |
+| true        |  false            | r/o  | r/o                                 |
+| false       |  false            | r/w  | r/w                                 |
+| false       |  true             | r/w  | r/w                                 |
+
+When **--read-only=true** and **--read-only-tmpfs=true** additional tmpfs are mounted on
+the /tmp, /run, and /var/tmp directories.
+
+When **--read-only=true** and **--read-only-tmpfs=false** /dev and /dev/shm are marked
+Read/Only and no tmpfs are mounted on /tmp, /run and /var/tmp. The directories
+are exposed from the underlying image, meaning they are read-only by default.
+This makes the container totally read-only. No writable directories exist within
+the container. In this mode writable directories need to be added via external
+volumes or mounts.
+
+By default, when **--read-only=false**, the /dev and /dev/shm are read/write, and the /tmp, /run, and /var/tmp are read/write directories from the container image.

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1120,10 +1120,13 @@ EOF
     CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm --read-only=false $IMAGE touch /testrw
     CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm $IMAGE touch /tmp/testrw
     for dir in /tmp /var/tmp /dev /dev/shm /run; do
+        CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm $IMAGE touch $dir/testro
+        CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm --read-only=false $IMAGE touch $dir/testro
+        CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm --read-only=false --read-only-tmpfs=true $IMAGE touch $dir/testro
+        CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm --read-only-tmpfs=true $IMAGE touch $dir/testro
+
         CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman 1 run --rm --read-only-tmpfs=false $IMAGE touch $dir/testro
         assert "$output" =~ "touch: $dir/testro: Read-only file system"
-        CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm --read-only-tmpfs=true $IMAGE touch $dir/testro
-        CONTAINERS_CONF_OVERRIDE="$containersconf" run_podman run --rm --read-only=false $IMAGE touch $dir/testro
     done
 }
 


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/20225

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman run --read-only-tmpfs=true|false handled correctly when run with --read-only flag
```
