### PR TITLE
fix: pull error response docker rest api compatibility

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -96,6 +96,10 @@ for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
     .[0].Comment=
 done
 
+# compat api pull image unauthorized message error
+t POST "/images/create?fromImage=quay.io/idonotexist/idonotexist:dummy" 401 \
+  .message="unauthorized: access to the requested resource is not authorized"
+
 # Export an image on the local
 t GET libpod/images/nonesuch/get 404
 t GET libpod/images/$iid/get?format=foo 500


### PR DESCRIPTION
This is related to the issue #20013

I have not added another e2e test, because in the `pull_test.go` file the test called "podman pull bogus image" is checking that the response contains "unauthorized: access to the requested resource is not authorized"

One thing that I was not sure you agreed with is the modified  `jsonmessage.JSONMessage{}` type. That is used there but belongs to the Docker jsonmessage package inside the vendor folder. Maybe it is better to copy that type into the same package and modify it there.

#### Does this PR introduce a user-facing change?

This changes the error response message to the comment in the issue.