### PR TITLE
Fix locale issues with WSL version detection

### DIFF
--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -50,20 +50,13 @@ func IsWSLInstalled() bool {
 
 func IsWSLStoreVersionInstalled() bool {
 	cmd := SilentExecCmd("wsl", "--version")
-	out, err := cmd.StdoutPipe()
+	cmd.Stdout = nil
 	cmd.Stderr = nil
-	if err != nil {
-		return false
-	}
-	if err = cmd.Start(); err != nil {
-		return false
-	}
-	hasVersion := matchOutputLine(out, "WSL version:")
-	if err := cmd.Wait(); err != nil {
+	if err := cmd.Run(); err != nil {
 		return false
 	}
 
-	return hasVersion
+	return true
 }
 
 func matchOutputLine(output io.ReadCloser, match string) bool {


### PR DESCRIPTION
Fixes #20209

Since wsl --version triggers help, which triggers an error code, use that instead of text detection.

```release-note
Fix an issue on non-English locales of Windows where machine installs using user-mode networking were rejected due to erroneous version detection
```