### PR TITLE
Create Qemu command wrapper

### DIFF
--- a/pkg/machine/qemu/command.go
+++ b/pkg/machine/qemu/command.go
@@ -1,0 +1,87 @@
+package qemu
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/containers/podman/v4/pkg/machine"
+)
+
+// QemuCmd is an alias around a string slice to prevent the need to migrate the
+// MachineVM struct due to changes
+type QemuCmd []string
+
+// NewQemuBuilder creates a new QemuCmd object that we will build on top of,
+// starting with the qemu binary, architecture specific options, and propogated
+// proxy and SSL settings
+func NewQemuBuilder(binary string, options []string) QemuCmd {
+	q := QemuCmd{binary}
+	return append(q, options...)
+}
+
+// SetMemory adds the specified amount of memory for the machine
+func (q *QemuCmd) SetMemory(m uint64) {
+	*q = append(*q, "-m", strconv.FormatUint(m, 10))
+}
+
+// SetCPUs adds the number of CPUs the machine will have
+func (q *QemuCmd) SetCPUs(c uint64) {
+	*q = append(*q, "-smp", strconv.FormatUint(c, 10))
+}
+
+// SetIgnitionFile specifies the machine's ignition file
+func (q *QemuCmd) SetIgnitionFile(file machine.VMFile) {
+	*q = append(*q, "-fw_cfg", "name=opt/com.coreos/config,file="+file.GetPath())
+}
+
+// SetQmpMonitor specifies the machine's qmp socket
+func (q *QemuCmd) SetQmpMonitor(monitor Monitor) {
+	*q = append(*q, "-qmp", monitor.Network+":"+monitor.Address.GetPath()+",server=on,wait=off")
+}
+
+// SetNetwork adds a network device to the machine
+func (q *QemuCmd) SetNetwork() {
+	// Right now the mac address is hardcoded so that the host networking gives it a specific IP address.  This is
+	// why we can only run one vm at a time right now
+	*q = append(*q, "-netdev", "socket,id=vlan,fd=3", "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee")
+}
+
+// SetSerialPort adds a serial port to the machine for readiness
+func (q *QemuCmd) SetSerialPort(readySocket, vmPidFile machine.VMFile, name string) {
+	*q = append(*q,
+		"-device", "virtio-serial",
+		// qemu needs to establish the long name; other connections can use the symlink'd
+		// Note both id and chardev start with an extra "a" because qemu requires that it
+		// starts with a letter but users can also use numbers
+		"-chardev", "socket,path="+readySocket.GetPath()+",server=on,wait=off,id=a"+name+"_ready",
+		"-device", "virtserialport,chardev=a"+name+"_ready"+",name=org.fedoraproject.port.0",
+		"-pidfile", vmPidFile.GetPath())
+}
+
+// SetVirtfsMount adds a virtfs mount to the machine
+func (q *QemuCmd) SetVirtfsMount(source, tag, securityModel string, readonly bool) {
+	virtfsOptions := fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=%s", source, tag, securityModel)
+	if readonly {
+		virtfsOptions += ",readonly"
+	}
+	*q = append(*q, "-virtfs", virtfsOptions)
+}
+
+// SetBootableImage specifies the image the machine will use to boot
+func (q *QemuCmd) SetBootableImage(image string) {
+	*q = append(*q, "-drive", "if=virtio,file="+image)
+}
+
+// SetDisplay specifies whether the machine will have a display
+func (q *QemuCmd) SetDisplay(display string) {
+	*q = append(*q, "-display", display)
+}
+
+// SetPropagatedHostEnvs adds options that propagate SSL and proxy settings
+func (q *QemuCmd) SetPropagatedHostEnvs() {
+	*q = propagateHostEnv(*q)
+}
+
+func (q *QemuCmd) Build() []string {
+	return *q
+}

--- a/pkg/machine/qemu/machine_test.go
+++ b/pkg/machine/qemu/machine_test.go
@@ -17,12 +17,12 @@ import (
 
 func TestEditCmd(t *testing.T) {
 	vm := new(MachineVM)
-	vm.CmdLine = []string{"command", "-flag", "value"}
+	vm.CmdLine = QemuCmd{"command", "-flag", "value"}
 
 	vm.editCmdLine("-flag", "newvalue")
 	vm.editCmdLine("-anotherflag", "anothervalue")
 
-	require.Equal(t, vm.CmdLine, []string{"command", "-flag", "newvalue", "-anotherflag", "anothervalue"})
+	require.Equal(t, vm.CmdLine.Build(), []string{"command", "-flag", "newvalue", "-anotherflag", "anothervalue"})
 }
 
 func TestPropagateHostEnv(t *testing.T) {

--- a/pkg/machine/qemu/qemu_command_test.go
+++ b/pkg/machine/qemu/qemu_command_test.go
@@ -1,0 +1,67 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
+// +build amd64,!windows arm64,!windows
+
+package qemu
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQemuCmd(t *testing.T) {
+	ignFile, err := machine.NewMachineFile(t.TempDir()+"demo-ignition-file.ign", nil)
+	assert.NoError(t, err)
+
+	machineAddrFile, err := machine.NewMachineFile(t.TempDir()+"tmp.sock", nil)
+	assert.NoError(t, err)
+
+	readySocket, err := machine.NewMachineFile(t.TempDir()+"readySocket.sock", nil)
+	assert.NoError(t, err)
+
+	vmPidFile, err := machine.NewMachineFile(t.TempDir()+"vmpidfile.pid", nil)
+	assert.NoError(t, err)
+
+	monitor := Monitor{
+		Address: *machineAddrFile,
+		Network: "unix",
+		Timeout: 3,
+	}
+	ignPath := ignFile.GetPath()
+	addrFilePath := machineAddrFile.GetPath()
+	readySocketPath := readySocket.GetPath()
+	vmPidFilePath := vmPidFile.GetPath()
+	bootableImagePath := t.TempDir() + "test-machine_fedora-coreos-38.20230918.2.0-qemu.x86_64.qcow2"
+
+	cmd := NewQemuBuilder("/usr/bin/qemu-system-x86_64", []string{})
+	cmd.SetMemory(2048)
+	cmd.SetCPUs(4)
+	cmd.SetIgnitionFile(*ignFile)
+	cmd.SetQmpMonitor(monitor)
+	cmd.SetNetwork()
+	cmd.SetSerialPort(*readySocket, *vmPidFile, "test-machine")
+	cmd.SetVirtfsMount("/tmp/path", "vol10", "none", true)
+	cmd.SetBootableImage(bootableImagePath)
+	cmd.SetDisplay("none")
+
+	expected := []string{
+		"/usr/bin/qemu-system-x86_64",
+		"-m", "2048",
+		"-smp", "4",
+		"-fw_cfg", fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignPath),
+		"-qmp", fmt.Sprintf("unix:%s,server=on,wait=off", addrFilePath),
+		"-netdev", "socket,id=vlan,fd=3",
+		"-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee",
+		"-device", "virtio-serial",
+		"-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=atest-machine_ready", readySocketPath),
+		"-device", "virtserialport,chardev=atest-machine_ready,name=org.fedoraproject.port.0",
+		"-pidfile", vmPidFilePath,
+		"-virtfs", "local,path=/tmp/path,mount_tag=vol10,security_model=none,readonly",
+		"-drive", fmt.Sprintf("if=virtio,file=%s", bootableImagePath),
+		"-display", "none"}
+
+	require.Equal(t, cmd.Build(), expected)
+}


### PR DESCRIPTION
Creates a wrapper around the Qemu command line implementation to prevent the need to hard-code the different command line options in Init and Start.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
