### PR TITLE
contrib: add firewall reload services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -887,7 +887,9 @@ PODMAN_UNIT_FILES = contrib/systemd/auto-update/podman-auto-update.service \
 		    contrib/systemd/system/podman.service \
 		    contrib/systemd/system/podman-restart.service \
 		    contrib/systemd/system/podman-kube@.service \
-		    contrib/systemd/system/podman-clean-transient.service
+		    contrib/systemd/system/podman-clean-transient.service \
+		    contrib/systemd/system/podman-firewalld-reload.service.in \
+		    contrib/systemd/system/podman-firewalld-restart.service.in
 
 %.service: %.service.in
 	sed -e 's;@@PODMAN@@;$(BINDIR)/podman;g' $< >$@.tmp.$$ \
@@ -902,6 +904,8 @@ install.systemd: $(PODMAN_UNIT_FILES)
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman.service ${DESTDIR}${USERSYSTEMDDIR}/podman.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-restart.service ${DESTDIR}${USERSYSTEMDDIR}/podman-restart.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-kube@.service ${DESTDIR}${USERSYSTEMDDIR}/podman-kube@.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-firewalld-reload.service ${DESTDIR}${USERSYSTEMDDIR}/podman-firewalld-reload.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-firewalld-restart.service ${DESTDIR}${USERSYSTEMDDIR}/podman-firewalld-restart.service
 	# System services
 	install ${SELINUXOPT} -m 644 contrib/systemd/auto-update/podman-auto-update.service ${DESTDIR}${SYSTEMDDIR}/podman-auto-update.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/auto-update/podman-auto-update.timer ${DESTDIR}${SYSTEMDDIR}/podman-auto-update.timer
@@ -910,6 +914,8 @@ install.systemd: $(PODMAN_UNIT_FILES)
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-restart.service ${DESTDIR}${SYSTEMDDIR}/podman-restart.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-kube@.service ${DESTDIR}${SYSTEMDDIR}/podman-kube@.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-clean-transient.service ${DESTDIR}${SYSTEMDDIR}/podman-clean-transient.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-firewalld-reload.service ${DESTDIR}${SYSTEMDDIR}/podman-firewalld-reload.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-firewalld-restart.service ${DESTDIR}${SYSTEMDDIR}/podman-firewalld-restart.service
 	rm -f $(PODMAN_UNIT_FILES)
 else
 install.systemd:

--- a/Makefile
+++ b/Makefile
@@ -888,8 +888,8 @@ PODMAN_UNIT_FILES = contrib/systemd/auto-update/podman-auto-update.service \
 		    contrib/systemd/system/podman-restart.service \
 		    contrib/systemd/system/podman-kube@.service \
 		    contrib/systemd/system/podman-clean-transient.service \
-		    contrib/systemd/system/podman-firewalld-reload.service.in \
-		    contrib/systemd/system/podman-firewalld-restart.service.in
+		    contrib/systemd/system/podman-firewalld-reload.service \
+		    contrib/systemd/system/podman-firewalld-restart.service
 
 %.service: %.service.in
 	sed -e 's;@@PODMAN@@;$(BINDIR)/podman;g' $< >$@.tmp.$$ \

--- a/contrib/systemd/system/podman-firewalld-reload.service.in
+++ b/contrib/systemd/system/podman-firewalld-reload.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=firewalld reload hook - run a hook script on firewalld reload
+Wants=dbus.service
+After=dbus.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/bash -c '/usr/bin/busctl monitor --system --match "interface=org.fedoraproject.FirewallD1,member=Reloaded" --match "interface=org.fedoraproject.FirewallD1,member=PropertiesChanged" | while read -r line ; do @@PODMAN@@ network reload --all ; done'
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/system/podman-firewalld-restart.service.in
+++ b/contrib/systemd/system/podman-firewalld-restart.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Redo podman NAT rules after firewalld starts or reloads
+Wants=dbus.service
+After=dbus.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/bash -c '/usr/bin/dbus-monitor --profile --system "type=signal,sender=org.freedesktop.DBus,path=/org/freedesktop/DBus,interface=org.freedesktop.DBus,member=NameAcquired,arg0=org.fedoraproject.FirewallD1" "type=signal,path=/org/fedoraproject/FirewallD1,interface=org.fedoraproject.FirewallD1,member=Reloaded" | sed -u "/^#/d" | while read -r type timestamp serial sender destination path interface member _junk; do if [[ $type = "#"* ]]; then continue; elif [[ $interface = org.freedesktop.DBus && $member = NameAcquired ]]; then echo "firewalld started"; @@PODMAN@@ network reload --all; elif [[ $interface = org.fedoraproject.FirewallD1 && $member = Reloaded ]]; then echo "firewalld reloaded"; @@PODMAN@@ network reload --all; fi; done'
+Restart=Always
+
+[Install]
+WantedBy=default.target

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -63,3 +63,19 @@ quadlet_to_service_name() {
 
     echo "$filename$suffix.service"
 }
+
+setup_firewalld_services() {
+    unit_names=("podman-firewalld-reload.service" "podman-firewalld-restart.service")
+
+    for unit_name in "${unit_names[@]}"; do
+        unit_file="contrib/systemd/system/${unit_name}"
+
+        if [[ -e $unit_file.in ]]; then
+            echo "# [Building & using $unit_name from source]" >&3
+            # Force regenerating unit file (existing one may have /usr/bin path)
+            rm -f "$unit_file"
+            BINDIR=$(dirname "$PODMAN") make "$unit_file"
+            cp "$unit_file" "$UNIT_DIR/$unit_name"
+        fi
+    done
+}


### PR DESCRIPTION
Should we package this until this is fixed in netavark/aardvark-dns as has been mentioned over on #5431? The unit files have been taken from @githubcek's comment [here](https://github.com/containers/podman/issues/5431#issuecomment-1018338165).

Refers #5431

cc/ @dcermak 