### PR TITLE
inspect: ignore ENOENT during device lookup

### DIFF
--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -48,7 +48,16 @@ func FindDeviceNodes() (map[string]string, error) {
 
 		info, err := d.Info()
 		if err != nil {
-			return err
+			// Info() can return ErrNotExist if the file was deleted between the readdir and stat call.
+			// This race can happen and is no reason to log an ugly error. If this is a container device
+			// that is used the code later will print a proper error in such case.
+			// There also seem to be cases were ErrNotExist is always returned likely due a weird device
+			// state, e.g. removing a device forcefully. This can happen with iSCSI devices.
+			if !errors.Is(err, fs.ErrNotExist) {
+				logrus.Errorf("Failed to get device information for %s: %v", path, err)
+			}
+			// return nil here as we want to continue looking for more device and not stop the WalkDir()
+			return nil
 		}
 		// We are a device node. Get major/minor.
 		sysstat, ok := info.Sys().(*syscall.Stat_t)


### PR DESCRIPTION
When we walk the /dev tree we need to lookup all device paths. Now in order to get the major and minor version we have to actually stat each device. This can again fail of course. There is at least a race between the readdir at stat call so it must ignore ENOENT errors to avoid the race condition as this is not a user problem. Second, we should also not return other errors and just log them instead, returning an error means stopping the walk and returning early which means inspect fails with an error which would be bad.

Also there seems to be cases were ENOENT will be returned all the time, e.g. when a device is forcefully removed. In the reported bug this is triggered with iSCSI devices.

Because the caller does already lookup the device from the created map it reports a warning there if the device is missing on the host so it is not a problem to ignore a error during lookup here.

Fixes https://issues.redhat.com/browse/RHEL-11158

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman inspect would fail when stat'ing a device failed.
```
