### PR TITLE
containers.conf: add `privileged` field to containers table

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -348,7 +348,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		_ = cmd.RegisterFlagCompletionFunc(podIDFileFlagName, completion.AutocompleteDefault)
 		createFlags.BoolVar(
 			&cf.Privileged,
-			"privileged", false,
+			"privileged", podmanConfig.ContainersConfDefaultsRO.Containers.Privileged,
 			"Give extended privileges to container",
 		)
 		createFlags.BoolVarP(

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -53,6 +53,7 @@ var (
 )
 
 func execFlags(cmd *cobra.Command) {
+	podmanConfig := registry.PodmanConfig()
 	flags := cmd.Flags()
 
 	flags.SetInterspersed(false)
@@ -71,7 +72,7 @@ func execFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(envFileFlagName, completion.AutocompleteDefault)
 
 	flags.BoolVarP(&execOpts.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
-	flags.BoolVar(&execOpts.Privileged, "privileged", false, "Give the process extended Linux capabilities inside the container.  The default is false")
+	flags.BoolVar(&execOpts.Privileged, "privileged", podmanConfig.ContainersConfDefaultsRO.Containers.Privileged, "Give the process extended Linux capabilities inside the container.  The default is false")
 	flags.BoolVarP(&execOpts.Tty, "tty", "t", false, "Allocate a pseudo-TTY. The default is false")
 
 	userFlagName := "user"

--- a/docs/source/markdown/options/privileged.md
+++ b/docs/source/markdown/options/privileged.md
@@ -16,5 +16,8 @@ mode (**--systemd=always**).
 A privileged container turns off the security features that isolate the
 container from the host. Dropped Capabilities, limited devices, read-only mount
 points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
+Due to the disabled security features, the privileged field should almost never
+be set as containers can easily break out of confinement.
 
-Rootless containers cannot have more privileges than the account that launched them.
+Containers running in a user namespace (e.g., rootless containers) cannot have
+more privileges than the user that launched them.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.32.0
-	github.com/containers/common v0.56.1-0.20231002091908-745eaa498509
+	github.com/containers/common v0.56.1-0.20231005124809-b4ef9cdeab5b
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.1
 	github.com/containers/image/v5 v5.28.0

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.32.0 h1:uz5Rcf7lGeStj7iPTBgO4UdhQYZqMMzyt9suDf16k1k=
 github.com/containers/buildah v1.32.0/go.mod h1:sN3rA3DbnqekNz3bNdkqWduuirYDuMs54LUCOZOomBE=
-github.com/containers/common v0.56.1-0.20231002091908-745eaa498509 h1:og5WEvZ2R4WMaO7L3F+Nfq0vfhtIZBxfG6BOVpG+Vfs=
-github.com/containers/common v0.56.1-0.20231002091908-745eaa498509/go.mod h1:8whK9BaTeJqaSTAM0r2A7OdW+XVS+4X9SVh0D6zxpek=
+github.com/containers/common v0.56.1-0.20231005124809-b4ef9cdeab5b h1:LIHpr2o8WakQ48q2GAQZlMAG+zsVJPOQSLraxP7j9fI=
+github.com/containers/common v0.56.1-0.20231005124809-b4ef9cdeab5b/go.mod h1:8gifkvVxN1oOHJ9Yp/SHWcN6MlxdC0gZCF2+MaWjErc=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.1 h1:+Rc+sOPplrkQb/BUXeN0ug8TxjgyrIqo/9P/eNS2A4c=

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgen/generate"
 	"github.com/containers/podman/v4/pkg/specgenutil"
+	"github.com/sirupsen/logrus"
 )
 
 // CreateContainer takes a specgenerator and makes a container. It returns
@@ -31,7 +32,8 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 			UseImageHosts: conf.Containers.NoHosts,
 		},
 		ContainerSecurityConfig: specgen.ContainerSecurityConfig{
-			Umask: conf.Containers.Umask,
+			Umask:      conf.Containers.Umask,
+			Privileged: conf.Containers.Privileged,
 		},
 	}
 
@@ -39,6 +41,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("decode(): %w", err))
 		return
 	}
+	logrus.Errorf("Privileged: %v", sg.ContainerSecurityConfig.Privileged)
 	if sg.Passwd == nil {
 		t := true
 		sg.Passwd = &t

--- a/vendor/github.com/containers/common/libimage/copier.go
+++ b/vendor/github.com/containers/common/libimage/copier.go
@@ -72,7 +72,7 @@ type CopyOptions struct {
 	// Default 3.
 	MaxRetries *uint
 	// RetryDelay used for the exponential back off of MaxRetries.
-	// Default 1 time.Scond.
+	// Default 1 time.Second.
 	RetryDelay *time.Duration
 	// ManifestMIMEType is the desired media type the image will be
 	// converted to if needed.  Note that it must contain the exact MIME

--- a/vendor/github.com/containers/common/libimage/filters.go
+++ b/vendor/github.com/containers/common/libimage/filters.go
@@ -289,7 +289,7 @@ func filterReferences(r *Runtime, value string) filterFunc {
 			refString := ref.String() // FQN with tag/digest
 			candidates := []string{refString}
 
-			// Split the reference into 3 components (twice if diggested/tagged):
+			// Split the reference into 3 components (twice if digested/tagged):
 			// 1) Fully-qualified reference
 			// 2) Without domain
 			// 3) Without domain and path

--- a/vendor/github.com/containers/common/libnetwork/netavark/network.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/network.go
@@ -53,7 +53,7 @@ type netavarkNetwork struct {
 	// ipamDBPath is the path to the ip allocation bolt db
 	ipamDBPath string
 
-	// syslog describes whenever the netavark debbug output should be log to the syslog as well.
+	// syslog describes whenever the netavark debug output should be log to the syslog as well.
 	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
 	syslog bool
 
@@ -93,7 +93,7 @@ type InitConfig struct {
 	// PluginDirs list of directories were netavark plugins are located
 	PluginDirs []string
 
-	// Syslog describes whenever the netavark debbug output should be log to the syslog as well.
+	// Syslog describes whenever the netavark debug output should be log to the syslog as well.
 	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
 	Syslog bool
 }

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -213,6 +213,18 @@ type ContainersConfig struct {
 	// performance implications.
 	PrepareVolumeOnCreate bool `toml:"prepare_volume_on_create,omitempty"`
 
+	// Give extended privileges to all containers. A privileged container
+	// turns off the security features that isolate the container from the
+	// host. Dropped Capabilities, limited devices, read-only mount points,
+	// Apparmor/SELinux separation, and Seccomp filters are all disabled.
+	// Due to the disabled security features the privileged field should
+	// almost never be set as containers can easily break out of
+	// confinment.
+	//
+	// Containers running in a user namespace (e.g., rootless containers)
+	// cannot have more privileges than the user that launched them.
+	Privileged bool `toml:"privileged,omitempty"`
+
 	// ReadOnly causes engine to run all containers with root file system mounted read-only
 	ReadOnly bool `toml:"read_only,omitempty"`
 
@@ -662,7 +674,7 @@ type MachineConfig struct {
 	Provider string `toml:"provider,omitempty"`
 }
 
-// FarmConfig represents the "farm" TOML config tabls
+// FarmConfig represents the "farm" TOML config tables
 type FarmConfig struct {
 	// Default is the default farm to be used when farming out builds
 	Default string `toml:"default,omitempty"`

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -237,6 +237,18 @@ default_sysctls = [
 #
 #prepare_volume_on_create = false
 
+# Give extended privileges to all containers. A privileged container turns off
+# the security features that isolate the container from the host. Dropped
+# Capabilities, limited devices, read-only mount points, Apparmor/SELinux
+# separation, and Seccomp filters are all disabled. Due to the disabled
+# security features the privileged field should almost never be set as
+# containers can easily break out of confinment.
+#
+# Containers running in a user namespace (e.g., rootless containers) cannot
+# have more privileges than the user that launched them.
+#
+#privileged = false
+
 # Run all containers with root file system mounted read-only
 #
 # read_only = false

--- a/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
@@ -200,6 +200,18 @@ default_sysctls = [
 #
 #prepare_volume_on_create = false
 
+# Give extended privileges to all containers. A privileged container turns off
+# the security features that isolate the container from the host. Dropped
+# Capabilities, limited devices, read-only mount points, Apparmor/SELinux
+# separation, and Seccomp filters are all disabled. Due to the disabled
+# security features the privileged field should almost never be set as
+# containers can easily break out of confinment.
+#
+# Containers running in a user namespace (e.g., rootless containers) cannot
+# have more privileges than the user that launched them.
+#
+#privileged = false
+
 # Set timezone in container. Takes IANA timezones as well as "local",
 # which sets the timezone in the container to match the host machine.
 #

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,7 +164,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.56.1-0.20231002091908-745eaa498509
+# github.com/containers/common v0.56.1-0.20231005124809-b4ef9cdeab5b
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
As requested in containers/podman/issues/20000, add a `privileged` field to the containers table in containers.conf.  I was hesitant to add such a field at first (for security reasons) but I understand that such a field can come in handy when using modules - certain workloads require a privileged container.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new `privileged` field to container.conf which sets the defaults for `--privileged` flag when creating, running or exec'ing into a container.
```
