### PR TITLE
[CI:BUILD] rpm/copr: gvforwarder recommends for RHEL

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -109,7 +109,11 @@ BuildRequires: python3
 Requires: catatonit
 Requires: conmon >= 2:2.1.7-2
 Requires: containers-common-extra
+%if %{defined rhel} && !%{defined eln}
+Recommends: gvisor-tap-vsock-gvforwarder
+%else
 Requires: gvisor-tap-vsock-gvforwarder
+%endif
 Recommends: gvisor-tap-vsock
 Provides: %{name}-quadlet
 Obsoletes: %{name}-quadlet <= 5:4.4.0-1


### PR DESCRIPTION
We don't have a successful rhel build of gvforwarder so far on the podman-next copr, so any RHEL users of podman-next will have trouble installing podman if it's a gvforwarder is a hard dep.

Switching gvforwarder to a Recommends until that's resolved.

The ELN environment is an exception as it gets dependencies updated a lot quicker.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
