### PR TITLE
[CI:DOCS] update kube play delete endpoint docs

### DIFF
--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -86,8 +86,8 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers
 	//  - pods
-	// summary: Remove pods from kube play
-	// description: Tears down pods defined in a YAML file
+	// summary: Remove resources created from kube play
+	// description: Tears down pods, secrets, and volumes defined in a YAML file
 	// parameters:
 	//  - in: query
 	//    name: force


### PR DESCRIPTION
Update the docs for the DELETE libpod/kube/play endpoint to mention the resources removed when ran.

Fixes https://github.com/containers/podman/issues/19945

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update DELETE libpod/kube/play endpoint docs
```
