### PR TITLE
Machine: Teardown on init failure

### DIFF
--- a/pkg/machine/cleanup.go
+++ b/pkg/machine/cleanup.go
@@ -1,0 +1,68 @@
+package machine
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+type CleanupCallback struct {
+	Funcs []func() error
+	mu    sync.Mutex
+}
+
+func (c *CleanupCallback) CleanIfErr(err *error) {
+	// Do not remove created files if the init is successful
+	if *err == nil {
+		return
+	}
+	c.clean()
+}
+
+func (c *CleanupCallback) CleanOnSignal() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+
+	_, ok := <-ch
+	if !ok {
+		return
+	}
+
+	c.clean()
+	os.Exit(1)
+}
+
+func (c *CleanupCallback) clean() {
+	c.mu.Lock()
+	// Claim exclusive usage by copy and resetting to nil
+	funcs := c.Funcs
+	c.Funcs = nil
+	c.mu.Unlock()
+
+	// Already claimed or none set
+	if funcs == nil {
+		return
+	}
+
+	// Cleanup functions can now exclusively be run
+	for _, cleanfunc := range funcs {
+		if err := cleanfunc(); err != nil {
+			logrus.Error(err)
+		}
+	}
+}
+
+func InitCleanup() CleanupCallback {
+	return CleanupCallback{
+		Funcs: []func() error{},
+	}
+}
+
+func (c *CleanupCallback) Add(anotherfunc func() error) {
+	c.mu.Lock()
+	c.Funcs = append(c.Funcs, anotherfunc)
+	c.mu.Unlock()
+}

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -74,7 +74,6 @@ var _ = Describe("podman machine rm", func() {
 	})
 
 	It("machine rm --save-keys, --save-ignition, --save-image", func() {
-
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
@@ -120,6 +119,5 @@ var _ = Describe("podman machine rm", func() {
 		}
 		_, err = os.Stat(img)
 		Expect(err).ToNot(HaveOccurred())
-
 	})
 })

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -200,11 +200,25 @@ func (m *HyperVMachine) readAndSplitIgnition() error {
 func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 	var (
 		key string
+		err error
 	)
 
-	if err := m.addNetworkAndReadySocketsToRegistry(); err != nil {
+	// cleanup half-baked files if init fails at any point
+	callbackFuncs := machine.InitCleanup()
+	defer callbackFuncs.CleanIfErr(&err)
+	go callbackFuncs.CleanOnSignal()
+
+	callbackFuncs.Add(m.ImagePath.Delete)
+	callbackFuncs.Add(m.ConfigPath.Delete)
+	callbackFuncs.Add(m.unregisterMachine)
+
+	if err = m.addNetworkAndReadySocketsToRegistry(); err != nil {
 		return false, err
 	}
+	callbackFuncs.Add(func() error {
+		m.removeNetworkAndReadySocketsFromRegistry()
+		return nil
+	})
 
 	m.IdentityPath = util.GetIdentityPath(m.Name)
 
@@ -230,13 +244,14 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	callbackFuncs.Add(m.removeSystemConnections)
 
 	if len(opts.IgnitionPath) < 1 {
-		var err error
 		key, err = machine.CreateSSHKeys(m.IdentityPath)
 		if err != nil {
 			return false, err
 		}
+		callbackFuncs.Add(m.removeSSHKeys)
 	}
 
 	m.ResourceConfig = machine.ResourceConfig{
@@ -255,6 +270,7 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 		}
 		return false, os.WriteFile(m.IgnitionFile.GetPath(), inputIgnition, 0644)
 	}
+	callbackFuncs.Add(m.IgnitionFile.Delete)
 
 	if err := m.writeConfig(); err != nil {
 		return false, err
@@ -265,13 +281,33 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 		return false, err
 	}
 
-	if err := m.resizeDisk(strongunits.GiB(opts.DiskSize)); err != nil {
+	if err = m.resizeDisk(strongunits.GiB(opts.DiskSize)); err != nil {
 		return false, err
 	}
 	// The ignition file has been written. We now need to
 	// read it so that we can put it into key-value pairs
 	err = m.readAndSplitIgnition()
 	return err == nil, err
+}
+
+func (m *HyperVMachine) unregisterMachine() error {
+	vmm := hypervctl.NewVirtualMachineManager()
+	vm, err := vmm.GetMachine(m.Name)
+	if err != nil {
+		logrus.Error(err)
+	}
+	return vm.Remove("")
+}
+
+func (m *HyperVMachine) removeSSHKeys() error {
+	if err := os.Remove(fmt.Sprintf("%s.pub", m.IdentityPath)); err != nil {
+		logrus.Error(err)
+	}
+	return os.Remove(m.IdentityPath)
+}
+
+func (m *HyperVMachine) removeSystemConnections() error {
+	return machine.RemoveConnections(m.Name, fmt.Sprintf("%s-root", m.Name))
 }
 
 func (m *HyperVMachine) Inspect() (*machine.InspectInfo, error) {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -272,7 +272,14 @@ RequiredBy=default.target
 func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	var (
 		key string
+		err error
 	)
+
+	// cleanup half-baked files if init fails at any point
+	callbackFuncs := machine.InitCleanup()
+	defer callbackFuncs.CleanIfErr(&err)
+	go callbackFuncs.CleanOnSignal()
+
 	v.IdentityPath = util.GetIdentityPath(v.Name)
 	v.Rootful = opts.Rootful
 
@@ -285,12 +292,13 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	callbackFuncs.Add(imagePath.Delete)
 
 	// Assign values about the download
 	v.ImagePath = *imagePath
 	v.ImageStream = strm.String()
 
-	if err := v.addMountsToVM(opts); err != nil {
+	if err = v.addMountsToVM(opts); err != nil {
 		return false, err
 	}
 
@@ -299,7 +307,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	// Add location of bootable image
 	v.CmdLine.SetBootableImage(v.getImageFile())
 
-	if err := machine.AddSSHConnectionsToPodmanSocket(
+	if err = machine.AddSSHConnectionsToPodmanSocket(
 		v.UID,
 		v.Port,
 		v.IdentityPath,
@@ -309,23 +317,25 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	); err != nil {
 		return false, err
 	}
+	callbackFuncs.Add(v.removeSystemConnections)
 
 	// Write the JSON file
-	if err := v.writeConfig(); err != nil {
+	if err = v.writeConfig(); err != nil {
 		return false, fmt.Errorf("writing JSON file: %w", err)
 	}
+	callbackFuncs.Add(v.ConfigPath.Delete)
 
 	// User has provided ignition file so keygen
 	// will be skipped.
 	if len(opts.IgnitionPath) < 1 {
-		var err error
 		key, err = machine.CreateSSHKeys(v.IdentityPath)
 		if err != nil {
 			return false, err
 		}
+		callbackFuncs.Add(v.removeSSHKeys)
 	}
 	// Run arch specific things that need to be done
-	if err := v.prepare(); err != nil {
+	if err = v.prepare(); err != nil {
 		return false, err
 	}
 	originalDiskSize, err := getDiskSize(v.getImageFile())
@@ -333,7 +343,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		return false, err
 	}
 
-	if err := v.resizeDisk(opts.DiskSize, originalDiskSize>>(10*3)); err != nil {
+	if err = v.resizeDisk(opts.DiskSize, originalDiskSize>>(10*3)); err != nil {
 		return false, err
 	}
 
@@ -352,7 +362,20 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	}
 
 	err = v.writeIgnitionConfigFile(opts, key)
+	callbackFuncs.Add(v.IgnitionFile.Delete)
+
 	return err == nil, err
+}
+
+func (v *MachineVM) removeSSHKeys() error {
+	if err := os.Remove(fmt.Sprintf("%s.pub", v.IdentityPath)); err != nil {
+		logrus.Error(err)
+	}
+	return os.Remove(v.IdentityPath)
+}
+
+func (v *MachineVM) removeSystemConnections() error {
+	return machine.RemoveConnections(v.Name, fmt.Sprintf("%s-root", v.Name))
 }
 
 func (v *MachineVM) Set(_ string, opts machine.SetOptions) ([]error, error) {


### PR DESCRIPTION
If init fails, podman machine should remove all files and configs created during the init. This includes config jsons, image files, ssh id's, and system connections. On windows, the VM instances are also removed. On Mac/Linux, the cleanup is also extended for SIGTERM.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman machine init` command now cleans up half-baked files on failure.
```
