### PR TITLE
Use logical AND on chained label! filters

### DIFF
--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -306,7 +306,7 @@ func GeneratePruneContainerFilterFuncs(filter string, filterValues []string, r *
 		}, nil
 	case "label!":
 		return func(c *libpod.Container) bool {
-			return !filters.MatchLabelFilters(filterValues, c.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, c.Labels())
 		}, nil
 	case "until":
 		return prepareUntilFilterFunc(filterValues)

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -42,7 +42,7 @@ func GenerateVolumeFilters(filter string, filterValues []string, runtime *libpod
 		}, nil
 	case "label!":
 		return func(v *libpod.Volume) bool {
-			return !filters.MatchLabelFilters(filterValues, v.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, v.Labels())
 		}, nil
 	case "opt":
 		return func(v *libpod.Volume) bool {
@@ -111,7 +111,7 @@ func GeneratePruneVolumeFilters(filter string, filterValues []string, runtime *l
 		}, nil
 	case "label!":
 		return func(v *libpod.Volume) bool {
-			return !filters.MatchLabelFilters(filterValues, v.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, v.Labels())
 		}, nil
 	case "until":
 		return createUntilFilterVolumeFunction(filterValues)

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -593,4 +593,28 @@ var _ = Describe("Podman prune", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dirents).To(HaveLen(3))
 	})
+
+	It("podman container prune with chained label!", func() {
+		foobar := podmanTest.Podman([]string{"create", "--label", "foobar", "--name", "foobar", ALPINE})
+		foobar.WaitWithDefaultTimeout()
+		Expect(foobar).Should(ExitCleanly())
+
+		foo := podmanTest.Podman([]string{"create", "--label", "foo", "--name", "foo", ALPINE})
+		foo.WaitWithDefaultTimeout()
+		Expect(foo).Should(ExitCleanly())
+
+		bar := podmanTest.Podman([]string{"create", "--label", "bar", "--name", "bar", ALPINE})
+		bar.WaitWithDefaultTimeout()
+		Expect(bar).Should(ExitCleanly())
+
+		Expect(podmanTest.NumberOfContainers()).To(Equal(3))
+
+		prune := podmanTest.Podman([]string{"container", "prune", "--force", "--filter", "label!=foo", "--filter", "label!=foobar"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune).Should(ExitCleanly())
+
+		Expect(podmanTest.NumberOfContainers()).To(Equal(2))
+		Expect(prune.OutputToStringArray()).To(HaveLen(1))
+		Expect(prune.OutputToString()).To(Equal(bar.OutputToString()))
+	})
 })

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -190,4 +190,34 @@ var _ = Describe("Podman volume prune", func() {
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol1))
 	})
+
+	It("podman volume prune with chained label!", func() {
+		foobar := podmanTest.Podman([]string{"volume", "create", "--label", "foobar", "foobar"})
+		foobar.WaitWithDefaultTimeout()
+		Expect(foobar).Should(ExitCleanly())
+
+		foo := podmanTest.Podman([]string{"volume", "create", "--label", "foo", "foo"})
+		foo.WaitWithDefaultTimeout()
+		Expect(foo).Should(ExitCleanly())
+
+		bar := podmanTest.Podman([]string{"volume", "create", "--label", "bar", "bar"})
+		bar.WaitWithDefaultTimeout()
+		Expect(bar).Should(ExitCleanly())
+
+		ls := podmanTest.Podman([]string{"volume", "list", "-q"})
+		ls.WaitWithDefaultTimeout()
+		Expect(ls).Should(ExitCleanly())
+		Expect(ls.OutputToStringArray()).To(HaveLen(3))
+
+		prune := podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label!=foo", "--filter", "label!=foobar"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune).Should(ExitCleanly())
+
+		ls = podmanTest.Podman([]string{"volume", "list", "-q"})
+		ls.WaitWithDefaultTimeout()
+		Expect(ls).Should(ExitCleanly())
+		Expect(ls.OutputToStringArray()).To(HaveLen(2))
+		Expect(prune.OutputToStringArray()).To(HaveLen(1))
+		Expect(prune.OutputToString()).To(Equal("bar"))
+	})
 })


### PR DESCRIPTION
Fixes the filter matching for chained negated labels (label!) on containers and volumes. When pruning with chained label! filters, the filters will be ANDed instead of ORed.

Fixes #17413

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
action required: Uses logical AND on chained label! filters instead of logical OR for containers, networks, and volumes.
```
