### PR TITLE
Implement SetLock for all virt providers

### DIFF
--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -125,6 +125,12 @@ func (p *QEMUVirtualization) LoadVMByName(name string) (machine.VM, error) {
 		return nil, err
 	}
 
+	lock, err := machine.GetLock(vm.Name, vmtype)
+	if err != nil {
+		return nil, err
+	}
+	vm.lock = lock
+
 	return vm, nil
 }
 

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -71,6 +71,16 @@ func (p *WSLVirtualization) LoadVMByName(name string) (machine.VM, error) {
 	}
 
 	vm, err := readAndMigrate(configPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	lock, err := machine.GetLock(vm.Name, vmtype)
+	if err != nil {
+		return nil, err
+	}
+	vm.lock = lock
+
 	return vm, err
 }
 


### PR DESCRIPTION
Implements a shared `SetLock` function for all virtualization providers. Adds the function to the `VM` interface to require implementation.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
