### PR TITLE
Show client info even if remote connection fails

### DIFF
--- a/cmd/podman/client.go
+++ b/cmd/podman/client.go
@@ -1,0 +1,25 @@
+package main
+
+import "github.com/containers/podman/v4/libpod/define"
+
+type clientInfo struct {
+	OSArch   string `json:"OS"`
+	Provider string `json:"provider"`
+	Version  string `json:"version"`
+}
+
+func getClientInfo() (*clientInfo, error) {
+	p, err := getProvider()
+	if err != nil {
+		return nil, err
+	}
+	vinfo, err := define.GetVersion()
+	if err != nil {
+		return nil, err
+	}
+	return &clientInfo{
+		OSArch:   vinfo.OsArch,
+		Provider: p,
+		Version:  vinfo.Version,
+	}, nil
+}

--- a/cmd/podman/client_supported.go
+++ b/cmd/podman/client_supported.go
@@ -1,0 +1,16 @@
+//go:build amd64 || arm64
+// +build amd64 arm64
+
+package main
+
+import (
+	"github.com/containers/podman/v4/pkg/machine/provider"
+)
+
+func getProvider() (string, error) {
+	p, err := provider.Get()
+	if err != nil {
+		return "", err
+	}
+	return p.VMType().String(), nil
+}

--- a/cmd/podman/client_unsupported.go
+++ b/cmd/podman/client_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !amd64 && !arm64
+
+package main
+
+func getProvider() (string, error) {
+	return "", nil
+}

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 
 	. "github.com/containers/podman/v4/test/utils"
@@ -239,5 +240,17 @@ var _ = Describe("Podman Info", func() {
 		// We do this by comparing the number of locks after (plus 1), to the number of locks before.
 		// Don't check absolute numbers because there is a decent chance of contamination, containers that were never removed properly, etc.
 		Expect(free1).To(Equal(free2 + 1))
+	})
+
+	It("Podman info: check for client information when no system service", func() {
+		// the output for this information is not really something we can marshall
+		want := runtime.GOOS + "/" + runtime.GOARCH
+		podmanTest.StopRemoteService()
+		SkipIfNotRemote("Specifically testing a failed remote connection")
+		info := podmanTest.Podman([]string{"info"})
+		info.WaitWithDefaultTimeout()
+		Expect(info.OutputToString()).To(ContainSubstring(want))
+		Expect(info).ToNot(ExitCleanly())
+		podmanTest.StartRemoteService() // Start service again so teardown runs clean
 	})
 })

--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -102,7 +102,7 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true" \
     # when invoking podman.
     _run_podman_remote 125 info
     is "$output" \
-       "Cannot connect to Podman. Please verify.*dial tcp.*connection refused" \
+       "OS: .*provider:.*Cannot connect to Podman. Please verify.*dial tcp.*connection refused" \
        "podman info, without active service"
 
     # Start service. Now podman info should work fine. The %%-remote*


### PR DESCRIPTION
When people report issues, we often ask for the result of `podman info`. However, if the problem is the remote connection, it will error out with no information at all.  This PR at least will report client information before disclosing the connection error.  For example on Windows:

> .\bin\windows\podman.exe info
client:
  OS: windows/amd64
  provider: hyperv
  version: 4.8.0-dev
  host: null
...

Satisfies: RUN-1720

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman info now reports client information even if the remote connection is unreachable
```
