### PR TITLE
Quadlet - support oneshot .kube files

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -59,6 +59,18 @@ Adding the following snippet to a Quadlet file extends the systemd timeout to 15
 TimeoutStartSec=900
 ```
 
+### Service Type
+
+By default, the `Type` field of the `Service` section of the Quadlet file does not need to be set.
+Quadlet will set it to `notify` for `.container` and `.kube` files and to `oneshot` for `.volume`, `.network` and `.image` files.
+
+However, the value may be explicitly set to `oneshot` for `.container` and `.kube` files when the no containers are expected
+to run once `podman` exits.
+
+Examples for such cases:
+- `.container` file with an image that exit after their entrypoint has finished
+- `.kube` file pointing to a Kubernetes Yaml file that does not define any containers. E.g. PVCs only
+
 ### Enabling unit files
 
 The services created by Podman are considered transient by systemd, which means they don't have the same

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -64,11 +64,12 @@ TimeoutStartSec=900
 By default, the `Type` field of the `Service` section of the Quadlet file does not need to be set.
 Quadlet will set it to `notify` for `.container` and `.kube` files and to `oneshot` for `.volume`, `.network` and `.image` files.
 
-However, the value may be explicitly set to `oneshot` for `.container` and `.kube` files when the no containers are expected
+However, `Type` may be explicitly set to `oneshot` for `.container` and `.kube` files when no containers are expected
 to run once `podman` exits.
 
 Examples for such cases:
-- `.container` file with an image that exit after their entrypoint has finished
+- `.container` file with an image that exits after their entrypoint has finished
+``
 - `.kube` file pointing to a Kubernetes Yaml file that does not define any containers. E.g. PVCs only
 
 ### Enabling unit files

--- a/test/e2e/quadlet/oneshot.kube
+++ b/test/e2e/quadlet/oneshot.kube
@@ -1,0 +1,19 @@
+## assert-podman-args "kube"
+## assert-podman-args "play"
+## assert-podman-final-args-regex .*/podman_test.*/quadlet/deployment.yml
+## assert-podman-args "--replace"
+## assert-podman-args "--service-container=true"
+## assert-podman-stop-post-args "kube"
+## assert-podman-stop-post-args "down"
+## assert-podman-stop-post-final-args-regex .*/podman_test.*/quadlet/deployment.yml
+## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
+## assert-key-is "Service" "KillMode" "mixed"
+## assert-key-is "Service" "Type" "oneshot"
+## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
+## assert-key-is "Service" "SyslogIdentifier" "%N"
+
+[Kube]
+Yaml=deployment.yml
+
+[Service]
+Type=oneshot

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -764,6 +764,7 @@ BOGUS=foo
 		Entry("Kube - Working Directory already in Service", "workingdir-service.kube", 0, ""),
 		Entry("Kube - global args", "globalargs.kube", 0, ""),
 		Entry("Kube - Containers Conf Modules", "containersconfmodule.kube", 0, ""),
+		Entry("Kube - Service Type=oneshot", "oneshot.kube", 0, ""),
 
 		Entry("Network - Basic", "basic.network", 0, ""),
 		Entry("Network - Disable DNS", "disable-dns.network", 0, ""),


### PR DESCRIPTION
Allow users to manually set the Service Type
Add test
Update README

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - allow users to set the service type of a .kube file to oneshot to support yaml files without containers
```
