### PR TITLE
Update common and buildah vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.6.1
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
-	github.com/containers/buildah v1.32.1-0.20231012130144-244170240d85
-	github.com/containers/common v0.56.1-0.20231010150003-09776aa73db7
+	github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485
+	github.com/containers/common v0.56.1-0.20231013064012-9f2f68b89872
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.1
 	github.com/containers/image/v5 v5.28.0

--- a/go.sum
+++ b/go.sum
@@ -249,10 +249,10 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM=
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
-github.com/containers/buildah v1.32.1-0.20231012130144-244170240d85 h1:Jn3o/XIIbyQqpnzwsALj5qnyr03dfxLmviMiDlBKRyU=
-github.com/containers/buildah v1.32.1-0.20231012130144-244170240d85/go.mod h1:4XtQQpvO6e3qFDzYak6E/KLZLc/Erq02Yr0J9K+SIA4=
-github.com/containers/common v0.56.1-0.20231010150003-09776aa73db7 h1:Gx9i5pM2uXoIL3+QDuS3ddko+vGBCoRfisHchQV4K0g=
-github.com/containers/common v0.56.1-0.20231010150003-09776aa73db7/go.mod h1:UoUXLn51o0628B8h4MOdWGKYfS/y0e9mjizyfERMoes=
+github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485 h1:RqgxHW2iP5QJ3aRahT+KGI2aGXVZeZHTeulmeZQV0y0=
+github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485/go.mod h1:gOMfotERP5Gz2pN+AnuM3ephId/YL9DmbOtVck6fWfE=
+github.com/containers/common v0.56.1-0.20231013064012-9f2f68b89872 h1:8dydB0ivba6JVt04WuJmTlznJTGZNyQePU8aHqxLTFI=
+github.com/containers/common v0.56.1-0.20231013064012-9f2f68b89872/go.mod h1:LM6Uyz5lq80P/DRnhs8NxvPIvBk2zmS2L/oednAGI/s=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.1 h1:+Rc+sOPplrkQb/BUXeN0ug8TxjgyrIqo/9P/eNS2A4c=

--- a/vendor/github.com/containers/buildah/internal/util/util.go
+++ b/vendor/github.com/containers/buildah/internal/util/util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/buildah/define"
 	"github.com/containers/common/libimage"
+	lplatform "github.com/containers/common/libimage/platform"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
@@ -41,7 +42,7 @@ func LookupImage(ctx *types.SystemContext, store storage.Store, image string) (*
 // Wrapper around libimage.NormalizePlatform to return and consume
 // v1.Platform instead of independent os, arch and variant.
 func NormalizePlatform(platform v1.Platform) v1.Platform {
-	os, arch, variant := libimage.NormalizePlatform(platform.OS, platform.Architecture, platform.Variant)
+	os, arch, variant := lplatform.Normalize(platform.OS, platform.Architecture, platform.Variant)
 	return v1.Platform{
 		OS:           os,
 		Architecture: arch,

--- a/vendor/github.com/containers/common/libimage/copier.go
+++ b/vendor/github.com/containers/common/libimage/copier.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containers/common/libimage/manifests"
+	"github.com/containers/common/libimage/platform"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/copy"
@@ -239,7 +240,7 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 
 	c.systemContext.DockerArchiveAdditionalTags = options.dockerArchiveAdditionalTags
 
-	c.systemContext.OSChoice, c.systemContext.ArchitectureChoice, c.systemContext.VariantChoice = NormalizePlatform(options.OS, options.Architecture, options.Variant)
+	c.systemContext.OSChoice, c.systemContext.ArchitectureChoice, c.systemContext.VariantChoice = platform.Normalize(options.OS, options.Architecture, options.Variant)
 
 	if options.SignaturePolicyPath != "" {
 		c.systemContext.SignaturePolicyPath = options.SignaturePolicyPath

--- a/vendor/github.com/containers/common/libimage/define/platform.go
+++ b/vendor/github.com/containers/common/libimage/define/platform.go
@@ -1,0 +1,11 @@
+package define
+
+// PlatformPolicy controls the behavior of image-platform matching.
+type PlatformPolicy int
+
+const (
+	// Only debug log if an image does not match the expected platform.
+	PlatformPolicyDefault PlatformPolicy = iota
+	// Warn if an image does not match the expected platform.
+	PlatformPolicyWarn
+)

--- a/vendor/github.com/containers/common/libimage/platform.go
+++ b/vendor/github.com/containers/common/libimage/platform.go
@@ -1,100 +1,26 @@
 package libimage
 
 import (
-	"context"
-	"fmt"
-	"runtime"
-
-	"github.com/containerd/containerd/platforms"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
+	"github.com/containers/common/libimage/define"
+	"github.com/containers/common/libimage/platform"
 )
 
 // PlatformPolicy controls the behavior of image-platform matching.
-type PlatformPolicy int
+// Deprecated: new code should use define.PlatformPolicy directly.
+type PlatformPolicy = define.PlatformPolicy
 
 const (
 	// Only debug log if an image does not match the expected platform.
-	PlatformPolicyDefault PlatformPolicy = iota
+	// Deprecated: new code should reference define.PlatformPolicyDefault directly.
+	PlatformPolicyDefault = define.PlatformPolicyDefault
 	// Warn if an image does not match the expected platform.
-	PlatformPolicyWarn
+	// Deprecated: new code should reference define.PlatformPolicyWarn directly.
+	PlatformPolicyWarn = define.PlatformPolicyWarn
 )
 
 // NormalizePlatform normalizes (according to the OCI spec) the specified os,
-// arch and variant.  If left empty, the individual item will be normalized.
+// arch and variant. If left empty, the individual item will be normalized.
+// Deprecated: new code should call libimage/platform.Normalize() instead.
 func NormalizePlatform(rawOS, rawArch, rawVariant string) (os, arch, variant string) {
-	platformSpec := v1.Platform{
-		OS:           rawOS,
-		Architecture: rawArch,
-		Variant:      rawVariant,
-	}
-	normalizedSpec := platforms.Normalize(platformSpec)
-	if normalizedSpec.Variant == "" && rawVariant != "" {
-		normalizedSpec.Variant = rawVariant
-	}
-	rawPlatform := toPlatformString(normalizedSpec.OS, normalizedSpec.Architecture, normalizedSpec.Variant)
-	normalizedPlatform, err := platforms.Parse(rawPlatform)
-	if err != nil {
-		logrus.Debugf("Error normalizing platform: %v", err)
-		return rawOS, rawArch, rawVariant
-	}
-	logrus.Debugf("Normalized platform %s to %s", rawPlatform, normalizedPlatform)
-	os = rawOS
-	if rawOS != "" {
-		os = normalizedPlatform.OS
-	}
-	arch = rawArch
-	if rawArch != "" {
-		arch = normalizedPlatform.Architecture
-	}
-	variant = rawVariant
-	if rawVariant != "" || (rawVariant == "" && normalizedPlatform.Variant != "") {
-		variant = normalizedPlatform.Variant
-	}
-	return os, arch, variant
-}
-
-func toPlatformString(os, arch, variant string) string {
-	if os == "" {
-		os = runtime.GOOS
-	}
-	if arch == "" {
-		arch = runtime.GOARCH
-	}
-	if variant == "" {
-		return fmt.Sprintf("%s/%s", os, arch)
-	}
-	return fmt.Sprintf("%s/%s/%s", os, arch, variant)
-}
-
-// Checks whether the image matches the specified platform.
-// Returns
-//   - 1) a matching error that can be used for logging (or returning) what does not match
-//   - 2) a bool indicating whether architecture, os or variant were set (some callers need that to decide whether they need to throw an error)
-//   - 3) a fatal error that occurred prior to check for matches (e.g., storage errors etc.)
-func (i *Image) matchesPlatform(ctx context.Context, os, arch, variant string) (error, bool, error) {
-	if err := i.isCorrupted(""); err != nil {
-		return err, false, nil
-	}
-	inspectInfo, err := i.inspectInfo(ctx)
-	if err != nil {
-		return nil, false, fmt.Errorf("inspecting image: %w", err)
-	}
-
-	customPlatform := len(os)+len(arch)+len(variant) != 0
-
-	expected, err := platforms.Parse(toPlatformString(os, arch, variant))
-	if err != nil {
-		return nil, false, fmt.Errorf("parsing host platform: %v", err)
-	}
-	fromImage, err := platforms.Parse(toPlatformString(inspectInfo.Os, inspectInfo.Architecture, inspectInfo.Variant))
-	if err != nil {
-		return nil, false, fmt.Errorf("parsing image platform: %v", err)
-	}
-
-	if platforms.NewMatcher(expected).Match(fromImage) {
-		return nil, customPlatform, nil
-	}
-
-	return fmt.Errorf("image platform (%s) does not match the expected platform (%s)", platforms.Format(fromImage), platforms.Format(expected)), customPlatform, nil
+	return platform.Normalize(rawOS, rawArch, rawVariant)
 }

--- a/vendor/github.com/containers/common/libimage/platform/platform.go
+++ b/vendor/github.com/containers/common/libimage/platform/platform.go
@@ -1,0 +1,57 @@
+package platform
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/containerd/containerd/platforms"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+// Normalize normalizes (according to the OCI spec) the specified os,
+// arch and variant.  If left empty, the individual item will be normalized.
+func Normalize(rawOS, rawArch, rawVariant string) (os, arch, variant string) {
+	platformSpec := v1.Platform{
+		OS:           rawOS,
+		Architecture: rawArch,
+		Variant:      rawVariant,
+	}
+	normalizedSpec := platforms.Normalize(platformSpec)
+	if normalizedSpec.Variant == "" && rawVariant != "" {
+		normalizedSpec.Variant = rawVariant
+	}
+	rawPlatform := ToString(normalizedSpec.OS, normalizedSpec.Architecture, normalizedSpec.Variant)
+	normalizedPlatform, err := platforms.Parse(rawPlatform)
+	if err != nil {
+		logrus.Debugf("Error normalizing platform: %v", err)
+		return rawOS, rawArch, rawVariant
+	}
+	logrus.Debugf("Normalized platform %s to %s", rawPlatform, normalizedPlatform)
+	os = rawOS
+	if rawOS != "" {
+		os = normalizedPlatform.OS
+	}
+	arch = rawArch
+	if rawArch != "" {
+		arch = normalizedPlatform.Architecture
+	}
+	variant = rawVariant
+	if rawVariant != "" || (rawVariant == "" && normalizedPlatform.Variant != "") {
+		variant = normalizedPlatform.Variant
+	}
+	return os, arch, variant
+}
+
+func ToString(os, arch, variant string) string {
+	if os == "" {
+		os = runtime.GOOS
+	}
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+	if variant == "" {
+		return fmt.Sprintf("%s/%s", os, arch)
+	}
+	return fmt.Sprintf("%s/%s/%s", os, arch, variant)
+}

--- a/vendor/github.com/containers/common/libimage/runtime.go
+++ b/vendor/github.com/containers/common/libimage/runtime.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containers/common/libimage/define"
+	"github.com/containers/common/libimage/platform"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/pkg/shortnames"
@@ -184,7 +186,7 @@ type LookupImageOptions struct {
 	Variant string
 
 	// Controls the behavior when checking the platform of an image.
-	PlatformPolicy PlatformPolicy
+	PlatformPolicy define.PlatformPolicy
 
 	// If set, do not look for items/instances in the manifest list that
 	// match the current platform but return the manifest list as is.
@@ -283,7 +285,7 @@ func (r *Runtime) LookupImage(name string, options *LookupImageOptions) (*Image,
 		options.Variant = r.systemContext.VariantChoice
 	}
 	// Normalize platform to be OCI compatible (e.g., "aarch64" -> "arm64").
-	options.OS, options.Architecture, options.Variant = NormalizePlatform(options.OS, options.Architecture, options.Variant)
+	options.OS, options.Architecture, options.Variant = platform.Normalize(options.OS, options.Architecture, options.Variant)
 
 	// Second, try out the candidates as resolved by shortnames. This takes
 	// "localhost/" prefixed images into account as well.
@@ -435,9 +437,9 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, namedCandida
 			return nil, nil
 		}
 		switch options.PlatformPolicy {
-		case PlatformPolicyDefault:
+		case define.PlatformPolicyDefault:
 			logrus.Debugf("%v", matchError)
-		case PlatformPolicyWarn:
+		case define.PlatformPolicyWarn:
 			logrus.Warnf("%v", matchError)
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,7 +139,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.3.0
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.32.1-0.20231012130144-244170240d85
+# github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485
 ## explicit; go 1.18
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -167,12 +167,13 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.56.1-0.20231010150003-09776aa73db7
+# github.com/containers/common v0.56.1-0.20231013064012-9f2f68b89872
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define
 github.com/containers/common/libimage/filter
 github.com/containers/common/libimage/manifests
+github.com/containers/common/libimage/platform
 github.com/containers/common/libnetwork/cni
 github.com/containers/common/libnetwork/etchosts
 github.com/containers/common/libnetwork/internal/util


### PR DESCRIPTION
Bump up the buildah and common vendors to pick up the move of the libimage/platform code.

This is needed for https://github.com/containers/podman/pull/20050

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Bump up common and buildah to pick up libimage/platform code move
```
