### PR TITLE
Add TERM iff TERM not defined in container when podman exec -t

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -713,6 +713,14 @@ func (c *Container) LinuxResources() *spec.LinuxResources {
 	return nil
 }
 
+// Env returns the default environment variables defined for the container
+func (c *Container) Env() []string {
+	if c.config.Spec != nil && c.config.Spec.Process != nil {
+		return c.config.Spec.Process.Env
+	}
+	return nil
+}
+
 // State Accessors
 // Require locking
 

--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -16,6 +16,7 @@ import (
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/specgenutil"
+	"github.com/containers/podman/v4/pkg/util"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )
@@ -58,6 +59,10 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	libpodConfig.WorkDir = input.WorkingDir
 	libpodConfig.Privileged = input.Privileged
 	libpodConfig.User = input.User
+
+	if input.Tty {
+		util.ExecAddTERM(ctr.Env(), libpodConfig.Environment)
+	}
 
 	// Make our exit command
 	storageConfig := runtime.StorageConfig()

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -867,6 +867,10 @@ func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, o
 	}
 	ctr := containers[0]
 
+	if options.Tty {
+		util.ExecAddTERM(ctr.Env(), options.Envs)
+	}
+
 	execConfig, err := makeExecConfig(options, ic.Libpod)
 	if err != nil {
 		return ec, err

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1219,3 +1219,20 @@ func ConvertTimeout(timeout int) uint {
 	}
 	return uint(timeout)
 }
+
+// ExecAddTERM when container does not have a TERM environment variable and
+// caller wants a tty, then leak the existing TERM environment into
+// the container.
+func ExecAddTERM(existingEnv []string, execEnvs map[string]string) {
+	if _, ok := execEnvs["TERM"]; ok {
+		return
+	}
+
+	for _, val := range existingEnv {
+		if strings.HasPrefix(val, "TERM=") {
+			return
+		}
+	}
+
+	execEnvs["TERM"] = "xterm"
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/20334

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman exec -t will define TERM environment variable even if container is not running with a terminal.
```
