### PR TITLE
fix(API): Catch ErrNetworkConnected for compat

### DIFF
--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -530,7 +530,7 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 
 	if err := c.runtime.state.NetworkConnect(c, netName, netOpts); err != nil {
 		// Docker compat: treat requests to attach already attached networks as a no-op, ignoring opts
-		if errors.Is(err, define.ErrNetworkConnected) && c.ensureState(define.ContainerStateConfigured) {
+		if errors.Is(err, define.ErrNetworkConnected) && !c.ensureState(define.ContainerStateRunning, define.ContainerStateCreated) {
 			return nil
 		}
 

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -448,6 +448,10 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
+		if errors.Is(err, define.ErrNetworkConnected) {
+			utils.Error(w, http.StatusForbidden, err)
+			return
+		}
 		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -218,4 +218,26 @@ t GET networks/$nid 200 .Name="network5" \
 # clean the network
 podman network rm -f network5
 
+#
+# Test connecting container to network when connection already exists
+#
+podman network create netcon
+podman create --network bridge --name c1 $IMAGE top
+
+# connect c1 to the network for the first time.
+t POST networks/netcon/connect Container=c1 200 OK
+# connect c1 to netcon again should not error
+t POST networks/netcon/connect Container=c1 200 OK
+
+# connect c1 to netcon here should error as the container is running and it is already connected
+podman start c1
+t POST networks/netcon/connect Container=c1 403 .cause="network is already connected"
+
+# connect c1 to netcon here should not error as container was stopped
+podman stop c1
+t POST networks/netcon/connect Container=c1 200 OK
+
+# cleanup
+podman network rm -f netcon
+
 # vim: filetype=sh


### PR DESCRIPTION
When trying to connect a container to a network and the connection already exists, an error might be raised. To ensure compatibility with the Docker API, this error is caught and "Ok" is returned.

This problem was discovered when trying to setup Nextcloud AIO which makes extensive use of the Docker Socket. There was an issue previously when trying to create networks that already existed as shown [here](https://github.com/nextcloud/all-in-one/discussions/471)

After this was fixed, I was still facing issues because the Podman Socket responded with 500 Internal Server Error when connecting to a container to a network and the connection already existed.

From what I found in the [Docker API](https://github.com/moby/moby/blob/master/daemon/container_operations.go#L676) it seems like Docker simply updates the network config and does not care if anything actually changed. The same should theoretically happen when using Podman, however it seems like the second part if [this condition](https://github.com/containers/podman/blob/b5fec41f2673f17162d0f031e29d56114c363afc/libpod/networking_common.go#L533) evaluates to false and `ErrNetworkConnected` is returned.

By checking for this error in the API handler again, I was able to get Nextcloud AIO to run. I did not dig into the details why the second part of the condition evaluates to false, maybe someone with more expertise than me could have a look at this as this is the first time I am digging through the Podman codebase :) 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed: When trying to connect a container to a network and the connection already exists, 200 Ok is being returned instead of raising 500 internal server error to restore compatibility with the Docker API
```
