### PR TITLE
Define better error message for container name conflicts with external storage

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/parallel"
 	"github.com/containers/podman/v4/version"
+	"github.com/containers/storage"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -626,7 +627,8 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 
 func formatError(err error) string {
 	var message string
-	if errors.Is(err, define.ErrOCIRuntime) {
+	switch {
+	case errors.Is(err, define.ErrOCIRuntime):
 		// OCIRuntimeErrors include the reason for the failure in the
 		// second to last message in the error chain.
 		message = fmt.Sprintf(
@@ -634,7 +636,9 @@ func formatError(err error) string {
 			define.ErrOCIRuntime.Error(),
 			strings.TrimSuffix(err.Error(), ": "+define.ErrOCIRuntime.Error()),
 		)
-	} else {
+	case errors.Is(err, storage.ErrDuplicateName):
+		message = fmt.Sprintf("Error: %s, or use --replace to instruct Podman to do so.", err.Error())
+	default:
 		if logrus.IsLevelEnabled(logrus.TraceLevel) {
 			message = fmt.Sprintf("Error: %+v", err)
 		} else {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -496,6 +496,11 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		}
 	}
 	if containerInfoErr != nil {
+		if errors.Is(containerInfoErr, storage.ErrDuplicateName) {
+			if _, err := c.runtime.LookupContainer(c.config.Name); errors.Is(err, define.ErrNoSuchCtr) {
+				return fmt.Errorf("creating container storage: %w by an external entity", containerInfoErr)
+			}
+		}
 		return fmt.Errorf("creating container storage: %w", containerInfoErr)
 	}
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1303,4 +1303,29 @@ search               | $IMAGE           |
     run_podman rm -f -t0 $cid
 }
 
+@test "podman create container with conflicting name" {
+    local cname="$(random_string 10 | tr A-Z a-z)"
+    local output_msg_ext="^Error: .*: the container name \"$cname\" is already in use by .* You have to remove that container to be able to reuse that name: that name is already in use by an external entity, or use --replace to instruct Podman to do so."
+    local output_msg="^Error: .*: the container name \"$cname\" is already in use by .* You have to remove that container to be able to reuse that name: that name is already in use, or use --replace to instruct Podman to do so."
+    if is_remote; then
+        output_msg_ext="^Error: .*: the container name \"$cname\" is already in use by .* You have to remove that container to be able to reuse that name: that name is already in use by an external entity"
+        output_msg="^Error: .*: the container name \"$cname\" is already in use by .* You have to remove that container to be able to reuse that name: that name is already in use"
+    fi
+
+    # external container
+    buildah from --name $cname scratch
+
+    run_podman 125 create --name $cname $IMAGE
+    assert "$output" =~ "$output_msg_ext" "Trying to create two containers with same name"
+
+    run_podman container rm $cname
+
+    run_podman --noout create --name $cname $IMAGE
+
+    run_podman 125 create --name $cname $IMAGE
+    assert "$output" =~ "$output_msg" "Trying to create two containers with same name"
+
+    run_podman container rm $cname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Updated the error message to suggest user to use --replace option to instruct Podman to replace the existsing external container with a newly created one.

closes #16759

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
User will be suggested to use --external option to override if a name conflict with external container is detected.
```
