### PR TITLE
buildah-bud: test relative TMPDIR

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -279,12 +279,6 @@ skip_if_rootless_remote "FIXME: not sure if 17788 or some other bug" \
                         "bud with Dockerfile from stdin tar" \
                         "build-with-network-test"
 
-# 2023-06-27 UPDATE: this seems to be fixed? Maybe we can remove this skip?
-# 2023-05-04 fails with:
-#   Error: creating build container: initializing source docker://debian:testing-slim: reading manifest testing-slim in quay.io/libpod/debian: manifest unknown
-#skip_if_remote "FIXME: 2023-05-04: new code, fails in podman-remote" \
-#               "bud-verify-if-we-dont-clean-prexisting-path"
-
 # 2023-06-27 confirmed this is still broken, main @ 3794d067e
 # 2023-06-13 buildah 4746 changed exit code & expected error message
 skip "FIXME: 2023-06-13 buildah PR 4746 broke this test" \

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -219,8 +219,11 @@ FROM $IMAGE
 RUN echo $rand_content > /$rand_filename
 EOF
 
+    # "TMPDIR=relative-path" tests buildah PR #5084. Prior to that, podman failed in RUN:
+    #   error running container: checking permissions on "sub-tmp-dir/buildah2917655141": ENOENT
     cd $PODMAN_TMPDIR
-    run_podman build -t build_test -f ./reldir/Containerfile --format=docker $tmpdir
+    mkdir sub-tmp-dir
+    TMPDIR=sub-tmp-dir run_podman build -t build_test -f ./reldir/Containerfile --format=docker $tmpdir
     is "$output" ".*COMMIT" "COMMIT seen in log"
 
     run_podman run --rm build_test cat /$rand_filename


### PR DESCRIPTION
(buildah PR 5084). Should actually have been added as a bud.bats
test in that PR, but I didn't catch it in time.

Also, remove an obsolete bud-tests skip

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```