### PR TITLE
Add status messages to podman --remote commit

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -165,7 +165,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 
 	commitImage, err := ctr.Commit(r.Context(), destImage, options)
 	if err != nil && !strings.Contains(err.Error(), "is not running") {
-		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("CommitFailure: %w", err))
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusCreated, entities.IDResponse{ID: commitImage.ID()})

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -1,6 +1,8 @@
 package libpod
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +20,8 @@ import (
 	"github.com/containers/podman/v4/pkg/api/handlers"
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
+	"github.com/containers/podman/v4/pkg/bindings/images"
+	"github.com/containers/podman/v4/pkg/channel"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
@@ -30,7 +34,9 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/gorilla/schema"
+	"github.com/sirupsen/logrus"
 )
 
 // Commit
@@ -442,6 +448,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		Pause     bool     `schema:"pause"`
 		Squash    bool     `schema:"squash"`
 		Repo      string   `schema:"repo"`
+		Stream    bool     `schema:"stream"`
 		Tag       string   `schema:"tag"`
 	}{
 		Format: "oci",
@@ -480,7 +487,6 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		SystemContext:         sc,
 		PreferredManifestType: mimeType,
 	}
-
 	if len(query.Tag) > 0 {
 		tag = query.Tag
 	}
@@ -498,12 +504,80 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	if len(query.Repo) > 0 {
 		destImage = fmt.Sprintf("%s:%s", query.Repo, tag)
 	}
-	commitImage, err := ctr.Commit(r.Context(), destImage, options)
-	if err != nil && !strings.Contains(err.Error(), "is not running") {
-		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("CommitFailure: %w", err))
+
+	if !query.Stream {
+		commitImage, err := ctr.Commit(r.Context(), destImage, options)
+		if err != nil && !strings.Contains(err.Error(), "is not running") {
+			utils.Error(w, http.StatusInternalServerError, err)
+			return
+		}
+		utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: commitImage.ID()})
 		return
 	}
-	utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: commitImage.ID()})
+
+	// Channels all mux'ed in select{} below to follow API commit protocol
+	stdout := channel.NewWriter(make(chan []byte))
+	defer stdout.Close()
+	// Channels all mux'ed in select{} below to follow API commit protocol
+	options.CommitOptions.ReportWriter = stdout
+	var (
+		commitImage *libimage.Image
+		commitErr   error
+	)
+	runCtx, cancel := context.WithCancel(r.Context())
+	go func() {
+		defer cancel()
+		commitImage, commitErr = ctr.Commit(r.Context(), destImage, options)
+	}()
+
+	flush := func() {
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	enc := json.NewEncoder(w)
+
+	statusWritten := false
+	writeStatusCode := func(code int) {
+		if !statusWritten {
+			w.WriteHeader(code)
+			w.Header().Set("Content-Type", "application/json")
+			flush()
+			statusWritten = true
+		}
+	}
+
+	for {
+		m := images.BuildResponse{}
+
+		select {
+		case e := <-stdout.Chan():
+			writeStatusCode(http.StatusOK)
+			m.Stream = string(e)
+			if err := enc.Encode(m); err != nil {
+				logrus.Errorf("%v", err)
+			}
+			flush()
+		case <-runCtx.Done():
+			if commitErr != nil {
+				m.Error = &jsonmessage.JSONError{
+					Message: commitErr.Error(),
+				}
+			} else {
+				m.Stream = commitImage.ID()
+			}
+			if err := enc.Encode(m); err != nil {
+				logrus.Errorf("%v", err)
+			}
+			flush()
+			return
+		case <-r.Context().Done():
+			cancel()
+			logrus.Infof("Client disconnect reported for commit")
+			return
+		}
+	}
 }
 
 func UntagImage(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1281,25 +1281,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: the name or ID of a container
 	//    required: true
 	//  - in: query
-	//    name: repo
-	//    type: string
-	//    description: the repository name for the created image
-	//  - in: query
-	//    name: tag
-	//    type: string
-	//    description: tag name for the created image
-	//  - in: query
-	//    name: comment
-	//    type: string
-	//    description: commit message
-	//  - in: query
 	//    name: author
 	//    type: string
 	//    description: author of the image
-	//  - in: query
-	//    name: pause
-	//    type: boolean
-	//    description: pause the container before committing it
 	//  - in: query
 	//    name: changes
 	//    description: instructions to apply while committing in Dockerfile format (i.e. "CMD=/bin/foo")
@@ -1307,9 +1291,33 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    items:
 	//       type: string
 	//  - in: query
+	//    name: comment
+	//    type: string
+	//    description: commit message
+	//  - in: query
 	//    name: format
 	//    type: string
 	//    description: format of the image manifest and metadata (default "oci")
+	//  - in: query
+	//    name: pause
+	//    type: boolean
+	//    description: pause the container before committing it
+	//  - in: query
+	//    name: squash
+	//    type: boolean
+	//    description: squash the container before committing it
+	//  - in: query
+	//    name: repo
+	//    type: string
+	//    description: the repository name for the created image
+	//  - in: query
+	//    name: stream
+	//    type: boolean
+	//    description: output from commit process
+	//  - in: query
+	//    name: tag
+	//    type: string
+	//    description: tag name for the created image
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/containers/commit.go
+++ b/pkg/bindings/containers/commit.go
@@ -2,11 +2,20 @@ package containers
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/containers/podman/v4/pkg/bindings"
+	"github.com/containers/podman/v4/pkg/bindings/images"
 	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/storage/pkg/regexp"
 )
+
+var iidRegex = regexp.Delayed(`^[0-9a-f]{12}`)
 
 // Commit creates a container image from a container.  The container is defined by nameOrID.  Use
 // the CommitOptions for finer grain control on characteristics of the resulting image.
@@ -30,5 +39,55 @@ func Commit(ctx context.Context, nameOrID string, options *CommitOptions) (entit
 	}
 	defer response.Body.Close()
 
+	if !response.IsSuccess() {
+		return id, response.Process(err)
+	}
+
+	if !options.GetStream() {
+		return id, response.Process(&id)
+	}
+	stderr := os.Stderr
+	body := response.Body.(io.Reader)
+	dec := json.NewDecoder(body)
+	for {
+		var s images.BuildResponse
+		select {
+		// FIXME(vrothberg): it seems we always hit the EOF case below,
+		// even when the server quit but it seems desirable to
+		// distinguish a proper build from a transient EOF.
+		case <-response.Request.Context().Done():
+			return id, nil
+		default:
+			// non-blocking select
+		}
+
+		if err := dec.Decode(&s); err != nil {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				return id, fmt.Errorf("server probably quit: %w", err)
+			}
+			// EOF means the stream is over in which case we need
+			// to have read the id.
+			if errors.Is(err, io.EOF) && id.ID != "" {
+				break
+			}
+			return id, fmt.Errorf("decoding stream: %w", err)
+		}
+
+		switch {
+		case s.Stream != "":
+			raw := []byte(s.Stream)
+			stderr.Write(raw)
+			if iidRegex.Match(raw) {
+				id.ID = strings.TrimSuffix(s.Stream, "\n")
+				return id, nil
+			}
+		case s.Error != nil:
+			// If there's an error, return directly.  The stream
+			// will be closed on return.
+			return id, errors.New(s.Error.Message)
+		default:
+			return id, errors.New("failed to parse build results stream, unexpected input")
+		}
+	}
 	return id, response.Process(&id)
 }

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -32,6 +32,7 @@ type CommitOptions struct {
 	Comment *string
 	Format  *string
 	Pause   *bool
+	Stream  *bool
 	Squash  *bool
 	Repo    *string
 	Tag     *string

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -92,6 +92,21 @@ func (o *CommitOptions) GetPause() bool {
 	return *o.Pause
 }
 
+// WithStream set field Stream to given value
+func (o *CommitOptions) WithStream(value bool) *CommitOptions {
+	o.Stream = &value
+	return o
+}
+
+// GetStream returns value of field Stream
+func (o *CommitOptions) GetStream() bool {
+	if o.Stream == nil {
+		var z bool
+		return z
+	}
+	return *o.Stream
+}
+
 // WithSquash set field Squash to given value
 func (o *CommitOptions) WithSquash(value bool) *CommitOptions {
 	o.Squash = &value

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -346,7 +346,7 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 			return nil, fmt.Errorf("invalid image name %q", opts.ImageName)
 		}
 	}
-	options := new(containers.CommitOptions).WithAuthor(opts.Author).WithChanges(opts.Changes).WithComment(opts.Message).WithSquash(opts.Squash)
+	options := new(containers.CommitOptions).WithAuthor(opts.Author).WithChanges(opts.Changes).WithComment(opts.Message).WithSquash(opts.Squash).WithStream(!opts.Quiet)
 	options.WithFormat(opts.Format).WithPause(opts.Pause).WithRepo(repo).WithTag(tag)
 	response, err := containers.Commit(ic.ClientCtx, nameOrID, options)
 	if err != nil {

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
+
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/19947

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman --remote commit now shows additional information when committing.
```
