### PR TITLE
use FindInitBinary() for init binary

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -248,7 +248,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		initPathFlagName := "init-path"
 		createFlags.StringVar(
 			&cf.InitPath,
-			initPathFlagName, initPath(),
+			initPathFlagName, "",
 			// Do not use  the Value field for setting the default value to determine user input (i.e., non-empty string)
 			"Path to the container-init binary",
 		)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -34,13 +34,6 @@ func Env() []string {
 	return nil
 }
 
-func initPath() string {
-	if !registry.IsRemote() {
-		return podmanConfig.ContainersConfDefaultsRO.InitPath()
-	}
-	return ""
-}
-
 func pidsLimit() int64 {
 	if !registry.IsRemote() {
 		return podmanConfig.ContainersConfDefaultsRO.PidsLimit()

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485
-	github.com/containers/common v0.56.1-0.20231017183641-80fb777f79e5
+	github.com/containers/common v0.56.1-0.20231018130318-493ab454c2af
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.1
 	github.com/containers/image/v5 v5.28.0

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485 h1:RqgxHW2iP5QJ3aRahT+KGI2aGXVZeZHTeulmeZQV0y0=
 github.com/containers/buildah v1.32.1-0.20231016164031-ade05159a485/go.mod h1:gOMfotERP5Gz2pN+AnuM3ephId/YL9DmbOtVck6fWfE=
-github.com/containers/common v0.56.1-0.20231017183641-80fb777f79e5 h1:1y1a9x5eG+7E2yzb/KMGLg44xJQoFQExfSfIHW63EZ0=
-github.com/containers/common v0.56.1-0.20231017183641-80fb777f79e5/go.mod h1:LM6Uyz5lq80P/DRnhs8NxvPIvBk2zmS2L/oednAGI/s=
+github.com/containers/common v0.56.1-0.20231018130318-493ab454c2af h1:wjpdOCVcEtR+gfQXfyVxAftVlPnMdqWBVuJFZH62GkA=
+github.com/containers/common v0.56.1-0.20231018130318-493ab454c2af/go.mod h1:LM6Uyz5lq80P/DRnhs8NxvPIvBk2zmS2L/oednAGI/s=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.1 h1:+Rc+sOPplrkQb/BUXeN0ug8TxjgyrIqo/9P/eNS2A4c=

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/common/libnetwork/pasta"
-	libpod "github.com/containers/common/libnetwork/slirp4netns"
+	"github.com/containers/common/libnetwork/slirp4netns"
 	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/common/pkg/seccomp"
@@ -59,7 +59,7 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 
 	slirp4netnsPath := r.config.Engine.NetworkCmdPath
 	if slirp4netnsPath == "" {
-		slirp4netnsPath, _ = r.config.FindHelperBinary(libpod.BinaryName, true)
+		slirp4netnsPath, _ = r.config.FindHelperBinary(slirp4netns.BinaryName, true)
 	}
 	if slirp4netnsPath != "" {
 		ver, err := version.Program(slirp4netnsPath)

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -227,7 +227,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		options = append(options, libpod.WithHostUsers(s.HostUsers))
 	}
 
-	command, err := makeCommand(s, imageData, rtc)
+	command, err := makeCommand(s, imageData)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/containers/common/libimage"
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -24,7 +23,7 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) {
 }
 
 // Produce the final command for the container.
-func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData, rtc *config.Config) ([]string, error) {
+func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]string, error) {
 	finalCommand := []string{}
 
 	entrypoint := s.Entrypoint
@@ -51,13 +50,7 @@ func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData, rtc *c
 	}
 
 	if s.Init {
-		initPath := s.InitPath
-		if initPath == "" && rtc != nil {
-			initPath = rtc.Engine.InitPath
-		}
-		if initPath == "" {
-			return nil, fmt.Errorf("no path to init binary found but container requested an init")
-		}
+		// bind mount for this binary is added in addContainerInitBinary()
 		finalCommand = append([]string{define.ContainerInitPath, "--"}, finalCommand...)
 	}
 

--- a/pkg/specgen/generate/pause_image.go
+++ b/pkg/specgen/generate/pause_image.go
@@ -55,7 +55,7 @@ func buildPauseImage(rt *libpod.Runtime, rtConfig *config.Config) (string, error
 
 	// Also look into the path as some distributions install catatonit in
 	// /usr/bin.
-	catatonitPath, err := rtConfig.FindHelperBinary("catatonit", true)
+	catatonitPath, err := rtConfig.FindInitBinary()
 	if err != nil {
 		return "", fmt.Errorf("finding pause binary: %w", err)
 	}

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -131,8 +131,11 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 	// If requested, add container init binary
 	if s.Init {
 		initPath := s.InitPath
-		if initPath == "" && rtc != nil {
-			initPath = rtc.Engine.InitPath
+		if initPath == "" {
+			initPath, err = rtc.FindInitBinary()
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("lookup init binary: %w", err)
+			}
 		}
 		initMount, err := addContainerInitBinary(s, initPath)
 		if err != nil {

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -149,6 +149,9 @@ default_sysctls = [
 #init = false
 
 # Container init binary, if init=true, this is the init binary to be used for containers.
+# If this option is not set catatonit is searched in the directories listed under
+# the helper_binaries_dir option. It is recommended to just install catatonit
+# there instead of configuring this option here.
 #
 #init_path = "/usr/libexec/podman/catatonit"
 

--- a/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
@@ -133,6 +133,9 @@ default_sysctls = [
 #init = false
 
 # Container init binary, if init=true, this is the init binary to be used for containers.
+# If this option is not set catatonit is searched in the directories listed under
+# the helper_binaries_dir option. It is recommended to just install catatonit
+# there instead of configuring this option here.
 #
 #init_path = "/usr/local/libexec/podman/catatonit"
 

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -30,6 +30,9 @@ const (
 
 	// _defaultImageVolumeMode is a mode to handle built-in image volumes.
 	_defaultImageVolumeMode = _typeBind
+
+	// defaultInitName is the default name of the init binary
+	defaultInitName = "catatonit"
 )
 
 var (
@@ -432,7 +435,6 @@ func defaultEngineConfig() (*EngineConfig, error) {
 	}
 	c.RuntimeSupportsNoCgroups = []string{"crun", "krun"}
 	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc", "krun"}
-	c.InitPath = DefaultInitPath
 	c.NoPivotRoot = false
 
 	c.InfraImage = DefaultInfraImage
@@ -538,11 +540,6 @@ func (c *Config) DNSOptions() []string {
 // Env returns the default additional environment variables to add to containers.
 func (c *Config) Env() []string {
 	return c.Containers.Env
-}
-
-// InitPath returns location where init program added to containers when users specify the --init flag.
-func (c *Config) InitPath() string {
-	return c.Containers.InitPath
 }
 
 // IPCNS returns the default IPC Namespace configuration to run containers with.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.56.1-0.20231017183641-80fb777f79e5
+# github.com/containers/common v0.56.1-0.20231018130318-493ab454c2af
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
Use the new FindInitBinary() function to lookup the init binary, this
allows the use of helper_binaries_dir in containers.conf[1]

[NO NEW TESTS NEEDED]

[1] https://github.com/containers/common/issues/1110

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now also uses the helper_binaries_dir option in containers.conf to lookup the init binary (catatonit).
```
