### PR TITLE
Use node hostname in kube play when hostNetwork=true

### DIFF
--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -146,6 +146,7 @@ type PodCreateOptions struct {
 	VolumesFrom        []string          `json:"volumes_from,omitempty"`
 	SecurityOpt        []string          `json:"security_opt,omitempty"`
 	Sysctl             []string          `json:"sysctl,omitempty"`
+	Uts                string            `json:"uts,omitempty"`
 }
 
 // PodLogsOptions describes the options to extract pod logs.
@@ -362,6 +363,12 @@ func ToPodSpecGen(s specgen.PodSpecGenerator, p *PodCreateOptions) (*specgen.Pod
 		return nil, err
 	}
 	s.Ipc = out
+
+	out, err = specgen.ParseNamespace(p.Uts)
+	if err != nil {
+		return nil, err
+	}
+	s.UtsNs = out
 	s.Hostname = p.Hostname
 	s.ExitPolicy = p.ExitPolicy
 	s.Labels = p.Labels

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -789,6 +789,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			SecretsManager:     secretsManager,
 			UserNSIsHost:       p.Userns.IsHost(),
 			Volumes:            volumes,
+			UtsNSIsHost:        p.UtsNs.IsHost(),
 		}
 		specGen, err := kube.ToSpecGen(ctx, &specgenOpts)
 		if err != nil {
@@ -858,6 +859,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			SecretsManager:     secretsManager,
 			UserNSIsHost:       p.Userns.IsHost(),
 			Volumes:            volumes,
+			UtsNSIsHost:        p.UtsNs.IsHost(),
 		}
 
 		if podYAML.Spec.TerminationGracePeriodSeconds != nil {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -69,6 +69,12 @@ func ToPodOpt(ctx context.Context, podName string, p entities.PodCreateOptions, 
 	}
 	if podYAML.Spec.HostNetwork {
 		p.Net.Network = specgen.Namespace{NSMode: "host"}
+		nodeHostName, err := os.Hostname()
+		if err != nil {
+			return p, err
+		}
+		p.Hostname = nodeHostName
+		p.Uts = "host"
 	}
 	if podYAML.Spec.HostAliases != nil {
 		if p.Net.NoHosts {
@@ -156,6 +162,8 @@ type CtrSpecGenOptions struct {
 	UserNSIsHost bool
 	// PidNSIsHost tells the container to use the host pidns
 	PidNSIsHost bool
+	// UtsNSIsHost tells the container to use the host utsns
+	UtsNSIsHost bool
 	// SecretManager to access the secrets
 	SecretsManager *secrets.SecretsManager
 	// LogDriver which should be used for the container
@@ -562,6 +570,9 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	}
 	if opts.IpcNSIsHost {
 		s.IpcNS.NSMode = specgen.Host
+	}
+	if opts.UtsNSIsHost {
+		s.UtsNS.NSMode = specgen.Host
 	}
 
 	// Add labels that come from kube


### PR DESCRIPTION
When the hostNetwork option is set to true in the k8s yaml, set the pod's hostname to the name of the machine/node as is done in k8s.

Fixes https://github.com/containers/podman/issues/19321

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set pod hostname to node/machine name with kube play when hostNetwork=true in k8s yaml
```
