### PR TITLE
[CI:DOCS] machine set: document --rootful better

### DIFF
--- a/docs/source/markdown/podman-machine-set.1.md.in
+++ b/docs/source/markdown/podman-machine-set.1.md.in
@@ -43,11 +43,16 @@ container execution. This option updates the current podman
 remote connection default if it is currently pointing at the specified
 machine name (or `podman-machine-default` if no name is specified).
 
-@@option user-mode-networking
-
 Unlike [**podman system connection default**](podman-system-connection-default.1.md)
 this option makes the API socket, if available, forward to the rootful/rootless
 socket in the VM.
+
+Note that changing this option means that all the existing containers/images/volumes, etc...
+are no longer visible with the default connection/socket. This is because the root and rootless
+users in the VM are completely separated and do not share any storage. The data however is not
+lost and you can always change this option back or use the other connection to access it.
+
+@@option user-mode-networking
 
 ## EXAMPLES
 


### PR DESCRIPTION
If you change this option all the containers disappear from the default connection and socket. Thus it is required to recreate the resources. Sharing between root and rootless is not possible for various reasons.

Fixes #19936

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
