### PR TITLE
test/apiv2/20-containers.at: fix NanoCPUs tests on cgroups v1

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -470,11 +470,29 @@ t POST containers/prune?filters='{"network":["anynetwork"]}' 500 \
     .cause="network is an invalid filter"
 
 # Test CPU limit (NanoCPUs)
-t POST containers/create Image=$IMAGE HostConfig='{"NanoCpus":500000}' 201 \
-  .Id~[0-9a-f]\\{64\\}
+nanoCpu=500000
+if have_cgroupsv2; then
+    t POST containers/create Image=$IMAGE HostConfig='{"NanoCpus":500000}' 201 \
+      .Id~[0-9a-f]\\{64\\}
+else
+    if root; then
+      # cgroupsv1 rootful : NanoCpus needs to set more than 10000000
+      t POST containers/create Image=$IMAGE HostConfig='{"NanoCpus":500000}' 500 \
+        .cause="CPU cfs quota cannot be less than 1ms (i.e. 1000)"
+      t POST containers/create Image=$IMAGE HostConfig='{"NanoCpus":10000000}' 201 \
+        .Id~[0-9a-f]\\{64\\}
+      nanoCpu=10000000
+    else
+      # cgroupsv1 rootless : Resource limits that include NanoCPUs are not supported and ignored
+      t POST containers/create Image=$IMAGE HostConfig='{"NanoCpus":500000}' 201 \
+        .Id~[0-9a-f]\\{64\\}
+      nanoCpu=0
+    fi
+fi
+
 cid=$(jq -r '.Id' <<<"$output")
 t GET containers/$cid/json 200 \
-  .HostConfig.NanoCpus=500000
+  .HostConfig.NanoCpus=$nanoCpu
 
 t DELETE containers/$cid?v=true 204
 


### PR DESCRIPTION
`NanoCpus` needs to set more than 10000000 on cgroups v1.

`NanoCpus` tests are failed on cgroups v1 because of the function `verifyContainerResourcesCgroupV1()`
which verifies the resource limits.

https://github.com/containers/podman/blob/b0a45a905b23054f4f3f5bdb46e015ad39fc28f8/pkg/specgen/generate/validate.go#L111-L113

```
not ok 563 [20-containers] POST containers/create [-d {"Image":"quay.io/libpod/alpine_labels:latest","HostConfig":{"NanoCpus":500000}}] : status
#  expected: 201
#    actual: 500
#  response: {"cause":"CPU cfs quota cannot be less than 1ms (i.e. 1000)","message":"container create: CPU cfs quota cannot be less than 1ms (i.e. 1000)","response":500}
```

Also, I verified that the following script fail on cgroups v1:

```bash
#!/bin/bash
podman rm -f test

read -d '' sdef <<EOF
{
  "Image": "alpine",
  "Cmd": [
      "sleep", "1000"
  ],
  "HostConfig": {
    "NanoCpus": 500000
  }
}
EOF
echo "$sdef" | curl -sSLw "%{http_code}" -X POST -H "Content-Type: application/json" --unix-socket /var/run/podman/podman.sock --data @-  http://localhost/containers/create?name=test
```

- cgroups v1

```console
# ./test.bash
{"cause":"CPU cfs quota cannot be less than 1ms (i.e. 1000)","message":"container create: CPU cfs quota cannot be less than 1ms (i.e. 1000)","response":500}
500
```

- cgroups v2

```console
# ./test.bash
{"Id":"a21734d50da858239315752496e3d9e341e701f909935a2a380f93dd34af37db","Warnings":[]}
201
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
