### PR TITLE
exec: do not leak session IDs on errors

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -904,6 +904,7 @@ func (ic *ContainerEngine) ContainerExecDetached(ctx context.Context, nameOrID s
 
 	// TODO: we should try and retrieve exit code if this fails.
 	if err := ctr.ExecStart(id); err != nil {
+		_ = ctr.ExecRemove(id, true)
 		return "", err
 	}
 	return id, nil

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -166,4 +166,17 @@ load helpers
     run_podman rm -f -t0 $cid
 }
 
+@test "podman exec - does not leak session IDs on invalid command" {
+    run_podman run -d $IMAGE top
+    cid="$output"
+
+    for i in {1..3}; do
+        run_podman 127 exec $cid blahblah
+        run_podman 125 exec -d $cid blahblah
+    done
+
+    run_podman inspect --format "{{len .ExecIDs}}" $cid
+    assert "$output" = "0" ".ExecIDs must be empty"
+}
+
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -339,11 +339,18 @@ function run_podman() {
     # Remember command args, for possible use in later diagnostic messages
     MOST_RECENT_PODMAN_COMMAND="podman $*"
 
+    # BATS treats 127 as a special case, so we need to silence it when 127 is the
+    # expected rc: https://bats-core.readthedocs.io/en/stable/warnings/BW01.html
+    silence127=""
+    if [ $expected_rc -eq 127 ]; then
+       silence127="-127"
+    fi
+
     # stdout is only emitted upon error; this printf is to help in debugging
     printf "\n%s %s %s %s\n" "$(timestamp)" "$_LOG_PROMPT" "$PODMAN" "$*"
     # BATS hangs if a subprocess remains and keeps FD 3 open; this happens
     # if podman crashes unexpectedly without cleaning up subprocesses.
-    run timeout --foreground -v --kill=10 $PODMAN_TIMEOUT $PODMAN $_PODMAN_TEST_OPTS "$@" 3>/dev/null
+    run $silence127 timeout --foreground -v --kill=10 $PODMAN_TIMEOUT $PODMAN $_PODMAN_TEST_OPTS "$@" 3>/dev/null
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$(timestamp) $output"


### PR DESCRIPTION
always cleanup the exec session when the command specified to the "exec" is not found.
    
Closes: https://github.com/containers/podman/issues/20392

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
exec sessions are not leaked when the specified command does not exist
```
