### PR TITLE
Allow systemd specifiers in User and Group Quadlet keys

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -615,18 +615,8 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 		podman.add("--read-only-tmpfs=false")
 	}
 
-	hasUser := container.HasKey(ContainerGroup, KeyUser)
-	hasGroup := container.HasKey(ContainerGroup, KeyGroup)
-	if hasUser || hasGroup {
-		uid := container.LookupUint32(ContainerGroup, KeyUser, 0)
-		gid := container.LookupUint32(ContainerGroup, KeyGroup, 0)
-
-		podman.add("--user")
-		if hasGroup {
-			podman.addf("%d:%d", uid, gid)
-		} else {
-			podman.addf("%d", uid)
-		}
+	if err := handleUser(container, ContainerGroup, podman); err != nil {
+		return nil, err
 	}
 
 	if workdir, exists := container.Lookup(ContainerGroup, KeyWorkingDir); exists {
@@ -1223,6 +1213,30 @@ func ConvertImage(image *parser.UnitFile) (*parser.UnitFile, string, error) {
 		"SyslogIdentifier", "%N")
 
 	return service, imageName, nil
+}
+
+func handleUser(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline) error {
+	user, hasUser := unitFile.Lookup(groupName, KeyUser)
+	okUser := hasUser && len(user) > 0
+
+	group, hasGroup := unitFile.Lookup(groupName, KeyGroup)
+	okGroup := hasGroup && len(group) > 0
+
+	if !okUser {
+		if okGroup {
+			return fmt.Errorf("invalid Group set without User")
+		}
+		return nil
+	}
+
+	if !okGroup {
+		podman.add("--user", user)
+		return nil
+	}
+
+	podman.addf("--user=%s:%s", user, group)
+
+	return nil
 }
 
 func handleUserRemap(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline, isUser, supportManual bool) error {

--- a/test/e2e/quadlet/group.container
+++ b/test/e2e/quadlet/group.container
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "Group set without User"
+
+[Container]
+Image=localhost/imagename
+Group=foobar

--- a/test/e2e/quadlet/user1.container
+++ b/test/e2e/quadlet/user1.container
@@ -1,7 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--user=998:999"
+## assert-podman-args "--user=%U:%G"
 
 [Container]
 Image=localhost/imagename
-User=998
-Group=999
+User=%U:%G

--- a/test/e2e/quadlet/user2.container
+++ b/test/e2e/quadlet/user2.container
@@ -1,7 +1,7 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--user=998:999"
+## assert-podman-args "--user=%U:%G"
 
 [Container]
 Image=localhost/imagename
-User=998
-Group=999
+User=%U
+Group=%G


### PR DESCRIPTION
Replaces: https://github.com/containers/podman/pull/18262

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Systemd specifiers now work with Quadlet User and Group keys
```
