### PR TITLE
Support signed quadlets

### DIFF
--- a/cmd/quadlet/validate.go
+++ b/cmd/quadlet/validate.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+)
+
+var pubkeysForDir = make(map[string][]ed25519.PublicKey)
+
+func loadPublicKeysFromDir(dir string) ([]ed25519.PublicKey, error) {
+	if existing, ok := pubkeysForDir[dir]; ok {
+		return existing, nil
+	}
+
+	keys := make([]ed25519.PublicKey, 0)
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return keys, nil
+		}
+		return nil, err
+	}
+
+	for _, file := range files {
+		name := file.Name()
+		path := path.Join(dir, name)
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+
+		if fileInfo.Mode().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+
+			pub, err := x509.ParsePKIXPublicKey(data)
+			if err != nil {
+				return nil, err
+			}
+
+			if key, ok := pub.(ed25519.PublicKey); ok {
+				keys = append(keys, key)
+			} else {
+				Logf("Warning: Public key %s has the wrong type", path)
+			}
+		}
+	}
+
+	pubkeysForDir[dir] = keys
+
+	return keys, nil
+}
+
+func loadPublicKeysFromDirs(dirs []string) ([]ed25519.PublicKey, error) {
+	keys := make([]ed25519.PublicKey, 0)
+
+	for _, dir := range dirs {
+		dirKeys, err := loadPublicKeysFromDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, dirKeys...)
+	}
+	return keys, nil
+}
+
+func validateSignatureFor(path string, data []byte, keys []ed25519.PublicKey) error {
+	sigPath := path + ".sig"
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("No signature for %s, but signatures are required", path)
+		}
+		return fmt.Errorf("error loading signature %q, %w", sigPath, err)
+	}
+
+	if len(sigData) != ed25519.SignatureSize {
+		return fmt.Errorf("Invalid signature size for %s", sigPath)
+	}
+
+	for _, key := range keys {
+		if ed25519.Verify(key, data, sigData) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("No valid signature for %s", path)
+}

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -152,13 +152,7 @@ func NewUnitFile() *UnitFile {
 	return f
 }
 
-// Load a unit file from disk, remembering the path and filename
-func ParseUnitFile(pathName string) (*UnitFile, error) {
-	data, e := os.ReadFile(pathName)
-	if e != nil {
-		return nil, e
-	}
-
+func ParseUnitFileWithData(pathName string, data []byte) (*UnitFile, error) {
 	f := NewUnitFile()
 	f.Path = pathName
 	f.Filename = path.Base(pathName)
@@ -168,6 +162,16 @@ func ParseUnitFile(pathName string) (*UnitFile, error) {
 	}
 
 	return f, nil
+}
+
+// Load a unit file from disk, remembering the path and filename
+func ParseUnitFile(pathName string) (*UnitFile, error) {
+	data, e := os.ReadFile(pathName)
+	if e != nil {
+		return nil, e
+	}
+
+	return ParseUnitFileWithData(pathName, data)
 }
 
 func (f *UnitFile) ensureGroup(groupName string) *unitGroup {

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -182,7 +182,7 @@ func (f *UnitFile) ensureGroup(groupName string) *unitGroup {
 	return g
 }
 
-func (f *UnitFile) merge(source *UnitFile) {
+func (f *UnitFile) Merge(source *UnitFile) {
 	for _, srcGroup := range source.groups {
 		group := f.ensureGroup(srcGroup.name)
 		group.merge(srcGroup)
@@ -193,7 +193,7 @@ func (f *UnitFile) merge(source *UnitFile) {
 func (f *UnitFile) Dup() *UnitFile {
 	copy := NewUnitFile()
 
-	copy.merge(f)
+	copy.Merge(f)
 	copy.Filename = f.Filename
 	return copy
 }

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -156,9 +156,12 @@ const (
 )
 
 const (
-	ConfigGroupMain = "Quadlet"
+	ConfigGroupMain      = "Quadlet"
+	ConfigGroupDirPrefix = "Dir "
 
-	ConfigKeyDirs = "Dirs"
+	ConfigKeyDirs              = "Dirs"
+	ConfigKeyRequireSignatures = "RequireSignatures"
+	ConfigKeyPublicKeyDirs     = "PublicKeyDirs"
 )
 
 const (
@@ -1652,6 +1655,10 @@ func createBasePodmanCommand(unitFile *parser.UnitFile, groupName string) *Podma
 	}
 
 	return podman
+}
+
+func ConfigGroupForDir(dir string) string {
+	return ConfigGroupDirPrefix + dir
 }
 
 func nonNumericFilter(_path string, isUser bool) bool {


### PR DESCRIPTION
On the automotive side (and also often in edge etc), we are interested in running validated read-only system images. Typically the way such systems work is by having /etc be a transient version of the image (via an overlayfs with tmpfs backing). This way we can do things like create /etc/resolv.conf during runtime, but an attacker cannot persist any changes to the next boot.

However, we would like to extend this to using a read-only system image with the ability to install container from a curated set., sort of like an app store model. We want these apps to be containers, using quadlet to install into the system. To do this, we want to add an extra writable directory like `/var/extra-containers` (example name), which quadlet reads in addition to the current ones (which come from the read-only system image).  To ensure these come from the curated app list we want the quadlets to be signed, and for quadlet to only accept files that are signed by a trusted public key.

This PR adds support for a quadlet config file that lest you configure extra directories, as well as per-directory signature requirements. See the individual commits for details.

```release-note
Adds ability to sign quadlet files and add custom quadlet source directories
```
