### PR TITLE
Fix path for omvf vars on Darwin/arm64

### DIFF
--- a/pkg/machine/qemu/options_darwin_amd64.go
+++ b/pkg/machine/qemu/options_darwin_amd64.go
@@ -4,7 +4,7 @@ var (
 	QemuCommand = "qemu-system-x86_64"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{"-machine", "q35,accel=hvf:tcg", "-cpu", "host"}
 	return opts
 }

--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -12,8 +12,8 @@ var (
 	QemuCommand = "qemu-system-aarch64"
 )
 
-func (v *MachineVM) addArchOptions() []string {
-	ovmfDir := getOvmfDir(v.ImagePath.GetPath(), v.Name)
+func (v *MachineVM) addArchOptions(cmdOpts *setNewMachineCMDOpts) []string {
+	ovmfDir := getOvmfDir(cmdOpts.imageDir, v.Name)
 	opts := []string{
 		"-accel", "hvf",
 		"-accel", "tcg",
@@ -25,18 +25,18 @@ func (v *MachineVM) addArchOptions() []string {
 }
 
 func (v *MachineVM) prepare() error {
-	ovmfDir := getOvmfDir(v.ImagePath.GetPath(), v.Name)
+	ovmfDir := getOvmfDir(filepath.Dir(v.ImagePath.GetPath()), v.Name)
 	cmd := []string{"/bin/dd", "if=/dev/zero", "conv=sync", "bs=1m", "count=64", "of=" + ovmfDir}
 	return exec.Command(cmd[0], cmd[1:]...).Run()
 }
 
 func (v *MachineVM) archRemovalFiles() []string {
-	ovmDir := getOvmfDir(v.ImagePath.GetPath(), v.Name)
+	ovmDir := getOvmfDir(filepath.Dir(v.ImagePath.GetPath()), v.Name)
 	return []string{ovmDir}
 }
 
 func getOvmfDir(imagePath, vmName string) string {
-	return filepath.Join(filepath.Dir(imagePath), vmName+"_ovmf_vars.fd")
+	return filepath.Join(imagePath, vmName+"_ovmf_vars.fd")
 }
 
 /*

--- a/pkg/machine/qemu/options_freebsd_amd64.go
+++ b/pkg/machine/qemu/options_freebsd_amd64.go
@@ -4,7 +4,7 @@ var (
 	QemuCommand = "qemu-system-x86_64"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{"-machine", "q35,accel=hvf:tcg", "-cpu", "host"}
 	return opts
 }

--- a/pkg/machine/qemu/options_freebsd_arm64.go
+++ b/pkg/machine/qemu/options_freebsd_arm64.go
@@ -4,7 +4,7 @@ var (
 	QemuCommand = "qemu-system-aarch64"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{
 		"-machine", "virt",
 		"-accel", "tcg",

--- a/pkg/machine/qemu/options_linux_amd64.go
+++ b/pkg/machine/qemu/options_linux_amd64.go
@@ -4,7 +4,7 @@ var (
 	QemuCommand = "qemu-system-x86_64"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{
 		"-accel", "kvm",
 		"-cpu", "host",

--- a/pkg/machine/qemu/options_linux_arm64.go
+++ b/pkg/machine/qemu/options_linux_arm64.go
@@ -9,7 +9,7 @@ var (
 	QemuCommand = "qemu-system-aarch64"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{
 		"-accel", "kvm",
 		"-cpu", "host",

--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -4,7 +4,7 @@ var (
 	QemuCommand = "qemu-system-x86_64w"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	// "max" level is used, because "host" is not supported with "whpx" acceleration
 	// "vmx=off" disabled nested virtualization (not needed for podman)
 	// QEMU issue to track nested virtualization: https://gitlab.com/qemu-project/qemu/-/issues/628

--- a/pkg/machine/qemu/options_windows_arm64.go
+++ b/pkg/machine/qemu/options_windows_arm64.go
@@ -4,7 +4,7 @@ var (
 	QemuCommand = "qemu-system-aarch64w"
 )
 
-func (v *MachineVM) addArchOptions() []string {
+func (v *MachineVM) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	// stub to fix compilation issues
 	opts := []string{}
 	return opts


### PR DESCRIPTION
On darwin arm64, we need to set the location of the ovmf vars. It should be put into the imageDir (also known as as dataDir).  But because qemu determines the image path late in Init(), the image path is set something like a stream marker.

Fixes #20361

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
