### PR TITLE
Kill gvproxy when machine rm -f

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -397,6 +397,11 @@ func (m *MacMachine) Remove(name string, opts machine.RemoveOptions) (string, fu
 		if err := m.Vfkit.stop(true, true); err != nil {
 			return "", nil, err
 		}
+		defer func() {
+			if err := machine.CleanupGVProxy(m.GvProxyPid); err != nil {
+				logrus.Error(err)
+			}
+		}()
 	}
 
 	files = m.collectFilesToDestroy(opts)


### PR DESCRIPTION
In applehv, we were not killing gvproxy when stopping via podman machine rm with force.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
