### PR TITLE
[CI:DOCS] network: document ports and macvlan interaction

### DIFF
--- a/docs/source/markdown/options/publish.md
+++ b/docs/source/markdown/options/publish.md
@@ -21,3 +21,6 @@ Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
 If it is not, the container port is randomly assigned a port on the host.
 
 Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
+
+Note that the network drivers `macvlan` and `ipvlan` do not support port forwarding,
+it will have no effect on these networks.

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -43,6 +43,9 @@ under the `[network]` section.
 The name of the plugin can then be used as driver to create a network for your plugin.
 The list of all supported drivers and plugins can be seen with `podman info --format {{.Plugins.Network}}`.
 
+Note that the `macvlan` and `ipvlan` drivers do not support port forwarding. Support for port forwarding
+with a plugin depends on the implementation of the plugin.
+
 #### **--gateway**=*ip*
 
 Define a gateway for the subnet. To provide a gateway address, a


### PR DESCRIPTION
The network backend will ignore ports for macvlan and ipvlan networks so they do not do anything. No warning or error is shown because containers may be later connected to a bridge network in which case they would be useful.

Fixes #17927

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
