### PR TITLE
hyperV: Update lastUp time

### DIFF
--- a/pkg/machine/e2e/stop_test.go
+++ b/pkg/machine/e2e/stop_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,6 +33,7 @@ var _ = Describe("podman machine stop", func() {
 	It("Stop running machine", func() {
 		name := randomString()
 		i := new(initMachine)
+		starttime := time.Now()
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
@@ -46,5 +48,14 @@ var _ = Describe("podman machine stop", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stopAgain).To(Exit((0)))
 		Expect(stopAgain.outputToString()).To(ContainSubstring(fmt.Sprintf("Machine \"%s\" stopped successfully", name)))
+
+		// Stopping a machine should update the last up time
+		inspect := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspect.withFormat("{{.LastUp.Format \"2006-01-02T15:04:05Z07:00\"}}")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		lastupTime, err := time.Parse(time.RFC3339, inspectSession.outputToString())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lastupTime).To(BeTemporally(">", starttime))
 	})
 })

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -605,8 +605,13 @@ func (m *HyperVMachine) Stop(name string, opts machine.StopOptions) error {
 		logrus.Error(err)
 	}
 
-	return vm.Stop()
+	if err := vm.Stop(); err != nil {
+		return err
+	}
 
+	// keep track of last up
+	m.LastUp = time.Now()
+	return m.writeConfig()
 }
 
 func (m *HyperVMachine) jsonConfigPath() (string, error) {
@@ -660,7 +665,6 @@ func (m *HyperVMachine) loadFromFile() (*HyperVMachine, error) {
 	if cfg.Hardware.Memory > 0 {
 		mm.Memory = uint64(cfg.Hardware.Memory)
 	}
-	mm.LastUp = cfg.Status.LastUp
 
 	return &mm, nil
 }


### PR DESCRIPTION
LastUp now correctly reports the lastUp time for podman machine on hyperv, for both inspect and list.

Closes: #18522

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the podman machine list and podman machine inspect commands  would not show the correct Last Up time on hyperV
```
