### PR TITLE
cirrus setup: special-case perl unicode

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -112,6 +112,9 @@ CG_FS_TYPE="$(stat -f -c %T /sys/fs/cgroup)"
 # Set to 1 in all podman container images
 CONTAINER="${CONTAINER:-0}"
 
+# Without this, perl garbles "f39β" command-line args
+PERL_UNICODE=A
+
 # END Global export of all variables
 set +a
 


### PR DESCRIPTION
Perl is still stuck in the 1980s. Try to override that.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```