### PR TITLE
test/apiv2: adapt apiv2 test on cgroups v1 environment

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -235,12 +235,21 @@ t GET libpod/images/newrepo:v1/json 200 \
 # Commit a new image w/ full parameters
 cparam="repo=newrepo&tag=v2&comment=bar&author=eric"
 cparam="$cparam&format=docker&changes=CMD=/bin/foo"
-t POST "libpod/commit?container=${cid:0:12}&$cparam&pause=true" 200
-t GET libpod/images/newrepo:v2/json 200 \
-  .RepoTags[0]=localhost/newrepo:v2	\
-  .Author=eric \
-  .Comment=bar \
-  .Config.Cmd[-1]="/bin/foo"
+
+if root || have_cgroupsv2; then
+    t POST "libpod/commit?container=${cid:0:12}&$cparam&pause=true" 200
+    t GET libpod/images/newrepo:v2/json 200 \
+      .RepoTags[0]=localhost/newrepo:v2	\
+      .Author=eric \
+      .Comment=bar \
+      .Config.Cmd[-1]="/bin/foo"
+    t DELETE images/localhost/newrepo:v2?force=true 200
+else
+    # cgroupsv1 rootless : pause is not supported in cgroups v1 rootless
+    t POST "libpod/commit?container=${cid:0:12}&$cparam&pause=true" 500 \
+      .cause="this container does not have a cgroup" \
+      .message~".*pause containers on rootless containers with cgroup V1"
+fi
 
 # Create a container for testing the container initializing later
 podman create -t -i --name myctr $IMAGE ls
@@ -281,7 +290,6 @@ t GET containers/myctr/json 200 \
 
 t DELETE images/localhost/newrepo:latest?force=true 200
 t DELETE images/localhost/newrepo:v1?force=true 200
-t DELETE images/localhost/newrepo:v2?force=true 200
 t DELETE libpod/containers/$cid?force=true 200 .[0].Id=$cid
 t DELETE libpod/containers/myctr 200
 t DELETE libpod/containers/bogus 404
@@ -641,11 +649,14 @@ t GET containers/status-test/json 200 .State.Status="created"
 podman start status-test
 t GET containers/status-test/json 200 .State.Status="running"
 
-podman pause status-test
-t GET containers/status-test/json 200 .State.Status="paused"
+# cgroupsv1 rootless : pause and unpause are not supported in cgroups v1 rootless
+if root || have_cgroupsv2; then
+    podman pause status-test
+    t GET containers/status-test/json 200 .State.Status="paused"
 
-podman unpause status-test
-t GET containers/status-test/json 200 .State.Status="running"
+    podman unpause status-test
+    t GET containers/status-test/json 200 .State.Status="running"
+fi
 
 podman stop status-test &
 sleep 1
@@ -676,12 +687,20 @@ if root; then
   echo '{"Memory":{"Limit":500000}, "CPU":{"Shares":123}}' >${TMPD}/update.json
   t POST libpod/containers/updateCtr/update ${TMPD}/update.json 201
 
+  cgroupPath=/sys/fs/cgroup/cpu.weight
+  # 002 is the byte length
+  cpu_weight_expect=$'\001\0025'
+  if ! have_cgroupsv2; then
+    cgroupPath=/sys/fs/cgroup/cpu/cpu.shares
+    # 004 is the byte length
+    cpu_weight_expect=$'\001\004123'
+  fi
+
   # Verify
-  echo '{ "AttachStdout":true,"Cmd":["cat","/sys/fs/cgroup/cpu.weight"]}' >${TMPD}/exec.json
+  echo '{ "AttachStdout":true,"Cmd":["cat", "'$cgroupPath'"]}' >${TMPD}/exec.json
   t POST containers/updateCtr/exec ${TMPD}/exec.json 201 .Id~[0-9a-f]\\{64\\}
   eid=$(jq -r '.Id' <<<"$output")
-  # 002 is the byte length
-  t POST exec/$eid/start 200 $'\001\0025'
+  t POST exec/$eid/start 200 $cpu_weight_expect
 
   podman rm -f updateCtr
 fi

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -16,18 +16,28 @@ t GET libpod/containers/nonesuch/exists 404
 # Check container foo exists
 t GET libpod/containers/foo/exists 204
 
-# Pause the container
-t POST libpod/containers/foo/pause 204
+# Pause and Unpause the container
+if root || have_cgroupsv2; then
+    t POST libpod/containers/foo/pause 204
 
-t GET libpod/containers/foo/json 200 \
-  .Id~[0-9a-f]\\{64\\} \
-  .State.Status=paused \
-  .ImageName=$IMAGE \
-  .Config.Cmd[0]=top \
-  .Name=foo
+    t GET libpod/containers/foo/json 200 \
+      .Id~[0-9a-f]\\{64\\} \
+      .State.Status=paused \
+      .ImageName=$IMAGE \
+      .Config.Cmd[0]=top \
+      .Name=foo
 
-# Unpause the container
-t POST libpod/containers/foo/unpause 204
+    t POST libpod/containers/foo/unpause 204
+else
+    # cgroupsv1 rootless : pause and unpause are not supported in cgroups v1 rootless
+    t POST libpod/containers/foo/pause 500 \
+      .cause="this container does not have a cgroup" \
+      .message~".*pause containers on rootless containers with cgroup V1"
+
+    t POST libpod/containers/foo/unpause 500 \
+      .cause="container state improper" \
+      .message~".*is not paused, can't unpause: container state improper"
+fi
 
 t GET libpod/containers/foo/json 200 \
   .Id~[0-9a-f]\\{64\\} \

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -108,21 +108,28 @@ t POST libpod/pods/bar/stop?t=1 200 \
 
 t POST libpod/pods/bar/start 200
 
-t GET libpod/pods/stats?all=true 200
-is $(jq '. | length' <<<"$output") 3 "stats?all=true: number of records found"
+if root || have_cgroupsv2; then
+    t GET libpod/pods/stats?all=true 200
+    is $(jq '. | length' <<<"$output") 3 "stats?all=true: number of records found"
 
-t GET libpod/pods/stats?namesOrIDs=foo 200
-is $(jq '. | length' <<<"$output") 1 "stats?namesOrIDs=foo: number of records found"
+    t GET libpod/pods/stats?namesOrIDs=foo 200
+    is $(jq '. | length' <<<"$output") 1 "stats?namesOrIDs=foo: number of records found"
 
-t GET libpod/pods/stats?namesOrIDs=fakename 404 \
-  .cause="no such pod" \
-  .message="unable to get list of pods: no pod with name or ID fakename found: no such pod"
+    t GET libpod/pods/stats?namesOrIDs=fakename 404 \
+      .cause="no such pod" \
+      .message="unable to get list of pods: no pod with name or ID fakename found: no such pod"
 
-t GET "libpod/pods/stats?all=true&namesOrIDs=foo" 500 \
-  .cause="--all, --latest and arguments cannot be used together" \
-  .message="--all, --latest and arguments cannot be used together"
+    t GET "libpod/pods/stats?all=true&namesOrIDs=foo" 500 \
+      .cause="--all, --latest and arguments cannot be used together" \
+      .message="--all, --latest and arguments cannot be used together"
 
-t DELETE  libpod/pods/bar?force=true 200
+    t DELETE  libpod/pods/bar?force=true 200
+else
+    # Rootless cgroupsv1 : libpod/pods/stats is unsupported
+    t GET libpod/pods/stats?all=true 500 \
+      .cause="pod stats is not supported in rootless mode without cgroups v2" \
+      .message~"pod stats is not supported in rootless mode without cgroups v2"
+fi
 
 # test the fake name
 t GET libpod/pods/fakename/top 404 \
@@ -154,7 +161,10 @@ t DELETE  libpod/pods/foo 200
 t DELETE "libpod/pods/foo (pod has already been deleted)" 404
 
 # Expect this to time out
-APIV2_TEST_EXPECT_TIMEOUT=5 t GET "libpod/pods/stats?stream=true&delay=1" 999
+if root || have_cgroupsv2; then
+    # Rootless cgroupsv1 : libpod/pods/stats is unsupported
+    APIV2_TEST_EXPECT_TIMEOUT=5 t GET "libpod/pods/stats?stream=true&delay=1" 999
+fi
 
 podman pod create --name=specgen
 


### PR DESCRIPTION
Some apiv2 tests are not support on cgroups v1 environment.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
