### PR TITLE
libpod: skip DBUS_SESSION_BUS_ADDRESS in conmon

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1316,6 +1316,11 @@ func (r *ConmonOCIRuntime) configureConmonEnv() ([]string, error) {
 			// The NOTIFY_SOCKET must not leak into the environment.
 			continue
 		}
+		if strings.HasPrefix(v, "DBUS_SESSION_BUS_ADDRESS=") && !rootless.IsRootless() {
+			// The DBUS_SESSION_BUS_ADDRESS must not leak into the environment when running as root.
+			// This is because we want to use the system session for root containers, not the user session.
+			continue
+		}
 		res = append(res, v)
 	}
 	runtimeDir, err := util.GetRuntimeDir()

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1301,7 +1301,12 @@ search               | $IMAGE           |
     run_podman container inspect $cid --format "{{ .State.ConmonPid }}"
     conmon_pid="$output"
     is "$(< /proc/$conmon_pid/cmdline)" ".*--exit-command-arg--syslog.*" "conmon's exit-command has --syslog set"
-    assert "$(< /proc/$conmon_pid/environ)" =~ "BATS_TEST_TMPDIR" "entire env is passed down to conmon (incl. BATS variables)"
+    conmon_env="$(< /proc/$conmon_pid/environ)"
+    assert "$conmon_env" =~ "BATS_TEST_TMPDIR" "entire env is passed down to conmon (incl. BATS variables)"
+    assert "$conmon_env" !~ "NOTIFY_SOCKET=" "NOTIFY_SOCKET is not included (incl. BATS variables)"
+    if ! is_rootless; then
+        assert "$conmon_env" !~ "DBUS_SESSION_BUS_ADDRESS=" "DBUS_SESSION_BUS_ADDRESS is not included (incl. BATS variables)"
+    fi
 
     run_podman rm -f -t0 $cid
 }


### PR DESCRIPTION
commit 7ade9721020468438e822b16ed7a65380cc7fbd2 introduced the change that caused an issue in crun since it forces the root user session instead of the system one when DBUS_SESSION_BUS_ADDRESS is set.

I am addressing it in crun, but for the time being, let's also not pass the variable down to conmon since the assumption is that when running as root the containers must be created on the system bus.

[NO NEW TESTS NEEDED]

the crun PR: https://github.com/containers/crun/pull/1328

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
