### PR TITLE
CI: stop using registry.k8s.io

### DIFF
--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -10,7 +10,7 @@ var (
 	ALPINEAMD64ID     = "961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4"
 	ALPINEARM64DIGEST = "quay.io/libpod/alpine@sha256:f270dcd11e64b85919c3bab66886e59d677cf657528ac0e4805d3c71e458e525"
 	ALPINEARM64ID     = "915beeae46751fc564998c79e73a1026542e945ca4f73dc841d09ccc6c2c0672"
-	INFRA_IMAGE       = "registry.k8s.io/pause:3.2" //nolint:revive,stylecheck
+	INFRA_IMAGE       = "quay.io/libpod/k8s-pause:3.5" //nolint:revive,stylecheck
 	BB                = "quay.io/libpod/busybox:latest"
 	HEALTHCHECK_IMAGE = "quay.io/libpod/alpine_healthcheck:latest" //nolint:revive,stylecheck
 	fedoraToolbox     = "registry.fedoraproject.org/fedora-toolbox:36"

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Podman images", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=quay.io/libpod/*"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
-		Expect(result.OutputToStringArray()).To(HaveLen(9))
+		Expect(result.OutputToStringArray()).To(HaveLen(10))
 
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=*lpine*"})
 		retalpine.WaitWithDefaultTimeout()

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2190,7 +2190,7 @@ var _ = Describe("Podman kube play", func() {
 	It("should use customized infra_image", func() {
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
 
-		infraImage := "registry.k8s.io/pause:3.2"
+		infraImage := INFRA_IMAGE
 		err := os.WriteFile(conffile, []byte(fmt.Sprintf("[engine]\ninfra_image=\"%s\"\n", infraImage)), 0644)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -353,7 +353,7 @@ EOF
 
 @test "podman pod create should fail when infra-name is already in use" {
     local infra_name="infra_container_$(random_string 10 | tr A-Z a-z)"
-    local infra_image="registry.k8s.io/pause:3.5"
+    local infra_image="quay.io/libpod/k8s-pause:3.5"
     local pod_name="$(random_string 10 | tr A-Z a-z)"
 
     run_podman --noout pod create --name $pod_name --infra-name "$infra_name" --infra-image "$infra_image"


### PR DESCRIPTION
It's flaky.

* fedora-38 : sys remote fedora-38 root host boltdb [remote]
  * PR #20366
    * [10-17 08:38](https://api.cirrus-ci.com/v1/artifact/task/6194048763953152/html/sys-remote-fedora-38-root-host-boltdb.log.html#t--00331) in [sys] podman pod create should fail when infra-name is already in use
* fedora-38-aarch64 : sys podman fedora-38-aarch64 root host sqlite
  * PR #17831
    * [05-24-2023 17:49](https://api.cirrus-ci.com/v1/artifact/task/5796819322535936/html/sys-podman-fedora-38-aarch64-root-host-sqlite.log.html#t--00308) in [sys] podman pod create should fail when infra-name is already in use
* fedora-39β : int podman fedora-39β root host sqlite
  * PR #20161
    * [10-17 07:52](https://api.cirrus-ci.com/v1/artifact/task/4730598787383296/html/int-podman-fedora-39β-root-host-sqlite.log.html#t---SynchronizedBeforeSuite---1) in [SynchronizedBeforeSuite]
* fedora-39β : sys podman fedora-39β rootless host sqlite
  * PR #20397
    * [10-18 10:05](https://api.cirrus-ci.com/v1/artifact/task/5236228375707648/html/sys-podman-fedora-39β-rootless-host-sqlite.log.html#t--00332) in [sys] podman pod create should fail when infra-name is already in use

Seen in: int+sys podman+remote fedora-38+fedora-38-aarch64+fedora-39β root+rootless host boltdb+sqlite

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```