### PR TITLE
[CI:DOCS] (API): Fix compat network (dis-)connect

### DIFF
--- a/pkg/api/handlers/swagger/errors.go
+++ b/pkg/api/handlers/swagger/errors.go
@@ -28,6 +28,13 @@ type networkNotFound struct {
 	Body errorhandling.ErrorModel
 }
 
+// Network is already connected and container is running or transitioning to the running state ('initialized')
+// swagger:response
+type networkConnectedError struct {
+	// in:body
+	Body errorhandling.ErrorModel
+}
+
 // No such exec instance
 // swagger:response
 type execSessionNotFound struct {

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -125,7 +125,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Connect container to network
-	// description: Connect a container to a network.  This endpoint is current a no-op
+	// description: Connect a container to a network
 	// produces:
 	// - application/json
 	// parameters:
@@ -144,6 +144,8 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     description: OK
 	//   400:
 	//     $ref: "#/responses/badParamError"
+	//   403:
+	//     $ref: "#/responses/networkConnectedError"
 	//   500:
 	//     $ref: "#/responses/internalError"
 	r.HandleFunc(VersionedPath("/networks/{name}/connect"), s.APIHandler(compat.Connect)).Methods(http.MethodPost)
@@ -153,7 +155,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Disconnect container from network
-	// description: Disconnect a container from a network.  This endpoint is current a no-op
+	// description: Disconnect a container from a network
 	// produces:
 	// - application/json
 	// parameters:


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

The endpoints to (dis-)connect networks from/to a container are no longer no-ops. Furthermore, the 403 error handled since #20365 has been documented

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
