### PR TITLE
CI: try to fix more networking flakes

### DIFF
--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--pod", podID, fedoraMinimal, "curl", "-s", "-f", "localhost:80"})
+		session = podmanTest.Podman([]string{"run", "--pod", podID, fedoraMinimal, "curl", "-s", "--retry", "2", "--retry-connrefused", "-f", "localhost:80"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -485,9 +485,10 @@ _EOF
     SERVER=http://127.0.0.1:$HOST_PORT
 
     run_podman run -d --name myyaml -p "$HOST_PORT:80" \
-    -v $PODMAN_TMPDIR/test.yaml:/var/www/testpod.yaml:Z \
-    -w /var/www \
-    $IMAGE /bin/busybox-extras httpd -f -p 80
+               -v $PODMAN_TMPDIR/test.yaml:/var/www/testpod.yaml:Z \
+               -w /var/www \
+               $IMAGE /bin/busybox-extras httpd -f -p 80
+    wait_for_port 127.0.0.1 $HOST_PORT
 
     run_podman kube play $SERVER/testpod.yaml
     run_podman inspect test_pod-test --format "{{.State.Running}}"

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -241,6 +241,13 @@ function port_is_bound() {
         local proto="tcp"
     fi
 
+    # /proc/net/tcp is insufficient: it does not show some rootless ports.
+    # ss does, so check it first.
+    run ss -${proto:0:1}nlH sport = $port
+    if [[ -n "$output" ]]; then
+        return
+    fi
+
     port=$(printf %04X ${port})
     case "${address}" in
     *":"*)


### PR DESCRIPTION
There's a whole slew of networking-related flakes whose common
element seems to be improper use of curl. Fix those by:

  * add --retry --retry-connrefused; and/or
  * add -S ("show errors". Plain -s silences everything!); and/or
  * test exit status from curl; and/or
  * add wait_for_port after "podman run -d", to avoid races
  * log commands, to make debugging easier

Important note: wait_for_port() was not working with network
namespaces. Trivial proof:

  $ podman run -d --name foo -p 8192:80 \
      quay.io/libpod/testimage:20221018 \
      /bin/busybox-extras httpd -f -p 80
  $ grep :2000 /proc/net/tcp
  [no results]

Solution: use ss tool; it seems to handle namespaces just fine.
There may be a better solution.

Oh, also, add -t1 to a podman restart, to shave 18s from test run.

Fixes: #20335 and, I think, a handful of others:

* fedora-38 : sys podman fedora-38 root host sqlite
    * [10-17 17:41](https://api.cirrus-ci.com/v1/artifact/task/5067387708375040/html/sys-podman-fedora-38-root-host-sqlite.log.html#t--00607) in [sys] podman kube play - URL
* fedora-38 : sys remote fedora-38 root host sqlite [remote]
    * [10-19 09:07](https://api.cirrus-ci.com/v1/artifact/task/6648892645703680/html/sys-remote-fedora-38-root-host-sqlite.log.html#t--00610) in [sys] podman kube play - URL
* fedora-39β : int podman fedora-39β root host boltdb
    * [10-23 22:49](https://api.cirrus-ci.com/v1/artifact/task/5032838051921920/html/int-podman-fedora-39β-root-host-boltdb.log.html#t--Podman-pod-create-podman-pod-correctly-sets-up-NetNS--1) in Podman pod create podman pod correctly sets up NetNS
* fedora-39β : int podman fedora-39β rootless host boltdb
    * [10-11 09:30](https://api.cirrus-ci.com/v1/artifact/task/6428347954102272/html/int-podman-fedora-39β-rootless-host-boltdb.log.html#t--Podman-pod-create-podman-pod-correctly-sets-up-NetNS--1) in Podman pod create podman pod correctly sets up NetNS

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```