### PR TITLE
podman build --remote URI Dockerfile should not be treated as file

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -224,8 +224,14 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 				// it's not json, assume just a string
 				m = []string{query.Dockerfile}
 			}
+
 			for _, containerfile := range m {
-				containerFiles = append(containerFiles, filepath.Join(contextDirectory, filepath.Clean(filepath.FromSlash(containerfile))))
+				// Add path to containerfile iff it is not URL
+				if !(strings.HasPrefix(containerfile, "http://") || strings.HasPrefix(containerfile, "https://")) {
+					containerfile = filepath.Join(contextDirectory,
+						filepath.Clean(filepath.FromSlash(containerfile)))
+				}
+				containerFiles = append(containerFiles, containerfile)
 			}
 			dockerFileSet = true
 		}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -431,6 +431,11 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 
 	dontexcludes := []string{"!Dockerfile", "!Containerfile", "!.dockerignore", "!.containerignore"}
 	for _, c := range containerFiles {
+		// Don not add path to containerfile if it is a URL
+		if strings.HasPrefix(c, "http://") || strings.HasPrefix(c, "https://") {
+			newContainerFiles = append(newContainerFiles, c)
+			continue
+		}
 		if c == "/dev/stdin" {
 			content, err := io.ReadAll(os.Stdin)
 			if err != nil {

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -1135,6 +1135,12 @@ EOF
     run_podman rmi -f build_test
 }
 
+@test "podman build --file=https" {
+    run_podman build -t build_test --file=https://raw.githubusercontent.com/containers/podman/main/test/build/from-scratch/Dockerfile $PODMAN_TMPDIR
+
+    run_podman rmi -f build_test
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
Podman build --remote is translating https://path as if it was a file path. This change will leave it as a URL so it can be parsed on the server side.

Fixed: https://github.com/containers/podman/issues/20475

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix handling of https paths in podman --remote build
```
