### PR TITLE
compat API: fix image-prune --all

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -56,7 +56,18 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 	}
 
 	if !opts.All {
-		pruneOptions.Filters = append(pruneOptions.Filters, "dangling=true")
+		// Issue #20469: Docker clients handle the --all flag on the
+		// client side by setting the dangling filter directly.
+		alreadySet := false
+		for _, filter := range pruneOptions.Filters {
+			if strings.HasPrefix(filter, "dangling=") {
+				alreadySet = true
+				break
+			}
+		}
+		if !alreadySet {
+			pruneOptions.Filters = append(pruneOptions.Filters, "dangling=true")
+		}
 	}
 	if opts.External {
 		pruneOptions.Filters = append(pruneOptions.Filters, "containers=external")

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -164,6 +164,8 @@ t DELETE libpod/images/test:test 200
 t GET images/json?filters='{"label":["xyz"]}' 200 length=0
 t GET libpod/images/json?filters='{"label":["xyz"]}' 200 length=0
 
+# Must not error out: #20469
+t POST images/prune?filters='{"dangling":["false"]}' 200
 
 # to be used in prune until filter tests
 podman image build -t test1:latest -<<EOF


### PR DESCRIPTION
Docker deals with the --all flag on the client side while Podman does it on the server side.  Hence, make sure to not set the dangling filter with two different values in the backend.

Fixes: #20469

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the image/prune compat REST API when the dangling filter has been set to false by clients.
```
