### PR TITLE
[CI:DOCS] Fix broken code block markup in Introduction.rst

### DIFF
--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -7,6 +7,7 @@ Containers_ simplify the production, distribution, discoverability, and usage of
     podman search docker.io/busybox
 
 Output::
+
     NAME                                         DESCRIPTION
     docker.io/library/busybox                    Busybox base image.
     docker.io/rancher/busybox


### PR DESCRIPTION
This PR fixes the following defect in the documentation:

![Screenshot](https://github.com/containers/podman/assets/13408130/17464822-8dee-442e-a90c-a7d4c9d52525)

It is unclear whether this change warrants a release notes entry, so I added one regardless.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a broken code block markup in the Introduction chapter of the documentation
```
