### PR TITLE
CI: e2e: safer GetPort()

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1233,7 +1233,7 @@ func GetPort() int {
 		// Random port within that range
 		port := portMin + rng.Intn((portMax-portMin)/nProcs)*nProcs + myProc
 
-		used, err := net.Listen("tcp", "localhost:"+strconv.Itoa(port))
+		used, err := net.Listen("tcp", "0.0.0.0:"+strconv.Itoa(port))
 		if err == nil {
 			// it's open. Return it.
 			err = used.Close()
@@ -1242,7 +1242,7 @@ func GetPort() int {
 		}
 	}
 
-	Fail(fmt.Sprintf("unable to get free port: %v", err))
+	Fail(fmt.Sprintf("unable to get free port in range %d-%d", portMin, portMax))
 	return 0 // notreached
 }
 


### PR DESCRIPTION
Problem: frequent CI flakes of the form:

   Error: cannot listen on the TCP port: listen tcp4 :5355: bind: address already in use

Always 5355.

Cause: systemd-resolve listens on 5355, but not on 127.0.0.1. So
when GetPort() tries its is-it-in-use check by binding localhost,
it succeeds; but then podman binds * and fails.

Solution: GetPort(): test by binding 0.0.0.0.

Also, improve the failure message.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```