### PR TITLE
Mask /sys/devices/virtual/powercap

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -680,6 +680,8 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		}
 	}
 
+	c.addMaskedPaths(&g)
+
 	return g.Config, cleanupFunc, nil
 }
 

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -385,3 +385,7 @@ func (c *Container) getPlatformRunPath() (string, error) {
 	}
 	return runPath, nil
 }
+
+func (c *Container) addMaskedPaths(g *generate.Generator) {
+	// There are currently no FreeBSD-specific masked paths
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -805,3 +805,9 @@ func (c *Container) makePlatformMtabLink(etcInTheContainerFd, rootUID, rootGID i
 func (c *Container) getPlatformRunPath() (string, error) {
 	return "/run", nil
 }
+
+func (c *Container) addMaskedPaths(g *generate.Generator) {
+	if !c.config.Privileged {
+		g.AddLinuxMaskedPaths("/sys/devices/virtual/powercap")
+	}
+}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -414,6 +414,29 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(Not(BeEmpty()))
 	})
 
+	It("podman run powercap is masked", func() {
+		Skip("CI VMs do not have access to powercap")
+
+		testCtr1 := "testctr"
+		run := podmanTest.Podman([]string{"run", "-d", "--name", testCtr1, ALPINE, "top"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(ExitCleanly())
+
+		exec := podmanTest.Podman([]string{"exec", "-ti", testCtr1, "ls", "/sys/devices/virtual/powercap"})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec).To(ExitWithError())
+
+		testCtr2 := "testctr2"
+		run2 := podmanTest.Podman([]string{"run", "-d", "--privileged", "--name", testCtr2, ALPINE, "top"})
+		run2.WaitWithDefaultTimeout()
+		Expect(run2).Should(ExitCleanly())
+
+		exec2 := podmanTest.Podman([]string{"exec", "-ti", testCtr2, "ls", "/sys/devices/virtual/powercap"})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+		Expect(exec2.OutputToString()).Should(Not(BeEmpty()))
+	})
+
 	It("podman run security-opt unmask on /sys/fs/cgroup", func() {
 
 		SkipIfCgroupV1("podman umask on /sys/fs/cgroup will fail with cgroups V1")


### PR DESCRIPTION
I don't really like this solution because it can't be undone by `--security-opt unmask=all` but I don't see another way to make this retroactive. We can potentially change things up to do this the right way with 5.0 (actually have it in the list of masked paths, as opposed to adding at spec finalization as now).


```release-note
NONE
```
