### PR TITLE
CI: podman farm tests cleanup

### DIFF
--- a/test/farm/001-farm.bats
+++ b/test/farm/001-farm.bats
@@ -5,15 +5,10 @@
 
 load helpers.bash
 
-###############################################################################
-# BEGIN tests
-
-fname="test-farm"
-containerfile="test/farm/Containerfile"
 
 @test "farm - check farm has been created" {
     run_podman farm ls
-    assert "$output" =~ $fname
+    assert "$output" =~ $FARMNAME
     assert "$output" =~ "test-node"
 }
 
@@ -22,56 +17,79 @@ containerfile="test/farm/Containerfile"
     empty_farm="empty-farm"
     # create an empty farm
     run_podman farm create $empty_farm
-    run_podman farm --farm $empty_farm build -f $containerfile -t $iname .
+    run_podman farm --farm $empty_farm build -t $iname $PODMAN_TMPDIR
     assert "$output" =~ "Local builder ready"
+
     # get the system architecture
     run_podman info --format '{{.Host.Arch}}'
     ARCH=$output
     # inspect manifest list built and saved in local containers-storage
+    # FIXME: use --format?
     run_podman manifest inspect $iname
     assert "$output" =~ $ARCH
+
+    run_podman images -a
+
+    # FIXME-someday: why do we need the prune?
+    run_podman manifest rm $iname
+    run_podman image prune -f
 }
 
 @test "farm - build on farm node only with --cleanup" {
     iname="test-image-2"
-    run_podman farm build -f $containerfile --cleanup --local=false -t $iname .
-    assert "$output" =~ "Farm \"$fname\" ready"
+    run_podman farm build --cleanup --local=false -t $iname $PODMAN_TMPDIR
+    assert "$output" =~ "Farm \"$FARMNAME\" ready"
     # get the system architecture
     run_podman info --format '{{.Host.Arch}}'
     ARCH=$output
     # inspect manifest list built and saved in dir
-    manifest=$(cat $iname/manifest.json)
-    assert "$manifest" =~ $ARCH
+    # FIXME FIXME FIXME! #20505: do not write anything under cwd
+    ls -l $iname
+
+    # FIXME FIXME FIXME FIXME! NEVER WRITE INTO PWD!
+    manifestarch=$(jq -r '.manifests[].platform.architecture' <$iname/manifest.json)
+    assert "$manifestarch" = "$ARCH" "arch from $iname/manifest.json"
+
     # see if we can ssh into node to check the image was cleaned up
-    nodeimg=$(ssh $ROOTLESS_USER@localhost podman images --filter dangling=true --noheading 2>&1)
-    assert "$nodeimg" = ""
+    run ssh $ROOTLESS_USER@localhost podman images --filter dangling=true --noheading
+    assert "$output" = "" "podman images on remote host"
+
     # check that no image was built locally
     run_podman images --filter dangling=true --noheading
-    assert "$output" = ""
+    assert "$output" = "" "podman images on local host"
+
+    run_podman image prune -f
 }
 
 @test "farm - build on farm node and local" {
     iname="test-image-3"
-    run_podman farm build -f $containerfile -t $iname .
-    assert "$output" =~ "Farm \"$fname\" ready"
+    run_podman farm build -t $iname $PODMAN_TMPDIR
+    assert "$output" =~ "Farm \"$FARMNAME\" ready"
+
     # get the system architecture
     run_podman info --format '{{.Host.Arch}}'
     ARCH=$output
     # inspect manifest list built and saved in dir
     run_podman manifest inspect $iname
     assert "$output" =~ $ARCH
+
+    run_podman manifest rm $iname
+    run_podman image prune -f
 }
 
 # Test out podman-remote
 
 @test "farm - build on farm node only (podman-remote)" {
     iname="test-image-4"
-    run_podman --remote farm build -f $containerfile -t $iname .
-    assert "$output" =~ "Farm \"$fname\" ready"
+    run_podman --remote farm build -t $iname $PODMAN_TMPDIR
+    assert "$output" =~ "Farm \"$FARMNAME\" ready"
+
     # get the system architecture
     run_podman --remote info --format '{{.Host.Arch}}'
     ARCH=$output
     # inspect manifest list built and saved in dir
-    manifest=$(cat $iname/manifest.json)
-    assert "$manifest" =~ $ARCH
+    manifestarch=$(jq -r '.manifests[].platform.architecture' <$iname/manifest.json)
+    assert "$manifestarch" = "$ARCH" "arch from $iname/manifest.json"
+
+    run_podman image prune -f
 }

--- a/test/farm/Containerfile
+++ b/test/farm/Containerfile
@@ -1,3 +1,0 @@
-FROM alpine
-RUN arch | tee /arch.txt
-RUN date | tee /built.txt

--- a/test/farm/helpers.bash
+++ b/test/farm/helpers.bash
@@ -4,6 +4,13 @@ load ../system/helpers.bash
 
 function setup(){
     basic_setup
+
+    # Always create the same containerfile
+    cat >$PODMAN_TMPDIR/Containerfile <<EOF
+FROM $IMAGE
+RUN arch | tee /arch.txt
+RUN date | tee /built.txt
+EOF
 }
 
 function teardown(){

--- a/test/farm/setup_suite.bash
+++ b/test/farm/setup_suite.bash
@@ -1,14 +1,40 @@
 # -*- bash -*-
 
-load helpers.bash
+bats_require_minimum_version 1.8.0
+
+load helpers
 
 function setup_suite(){
+    if [[ -z "$ROOTLESS_USER" ]]; then
+        if ! is_rootless; then
+            die "Cannot run as root with no \$ROOTLESS_USER defined"
+        fi
+        export ROOTLESS_USER=$(id -un)
+    fi
+
+    sshdir=/home/$ROOTLESS_USER/.ssh
+    sshkey=$sshdir/id_rsa
+    if [[ ! -e $sshkey ]]; then
+        ssh-keygen -t rsa -N "" -f $sshkey
+        cat ${sshkey}.pub >> $sshdir/authorized_keys
+
+        # Confirm that ssh localhost works. Since this is probably
+        # the first time that we ssh, bypass the host key verification.
+        ssh -T -o 'BatchMode yes' -o 'StrictHostKeyChecking no' localhost true
+    fi
+
+    # Sigh..... "system connection add" fails if podman is not in $PATH.
+    # There does not seem to be any way to tell it to use an explicit path.
+    type -P podman || die "No 'podman' in \$PATH"
+
+    export FARMNAME="test-farm-$(random_string 5)"
+
     # only set up the podman farm before the first test
-    run_podman system connection add --identity /home/$ROOTLESS_USER/.ssh/id_rsa test-node $ROOTLESS_USER@localhost
-    run_podman farm create test-farm test-node
+    run_podman system connection add --identity $sshkey test-node $ROOTLESS_USER@localhost
+    run_podman farm create $FARMNAME test-node
 }
 
-function teardown(){
+function teardown_suite(){
     # clear out the farms after the last farm test
-    run podman farm rm --all
+    run_podman farm rm --all
 }


### PR DESCRIPTION
Followup from #20050. Lots of tiny problems in tests, all of
them adding up to significant maintainability problems.

These tests are currently impossible to run in a dev environment,
and super-painful to set up in 1mt, so I've just done a few hours
of cleanup and am giving up for the week.

This is ready for merge, in the sense that it's much better than
what exists now, but it still needs boatloads more work.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```