### PR TITLE
compose: try all possible providers before throwing an error

### DIFF
--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/provider"
 	"github.com/sirupsen/logrus"
@@ -85,20 +86,19 @@ func composeProvider() (string, error) {
 		return "", errors.New("no compose provider specified, please refer to `man podman-compose` for details")
 	}
 
+	lookupErrors := make([]error, 0, len(candidates))
 	for _, candidate := range candidates {
 		path, err := exec.LookPath(os.ExpandEnv(candidate))
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			return "", err
+		if err == nil {
+			// First specified provider "candidate" wins.
+			logrus.Debugf("Found compose provider %q", path)
+			return path, nil
 		}
-		// First specified provider "candidate" wins.
-		logrus.Debugf("Found compose provider %q", path)
-		return path, nil
+		logrus.Debugf("Error looking up compose provider %q: %v", path, err)
+		lookupErrors = append(lookupErrors, err)
 	}
 
-	return "", errors.New("no configured compose provider found on system, please refer to the documentation for details")
+	return "", fmt.Errorf("looking up compose provider failed\n%v", errorhandling.JoinErrors(lookupErrors))
 }
 
 // composeDockerHost returns the value to be set in the DOCKER_HOST environment


### PR DESCRIPTION
There is a number of paths to look for compose providers.  Hence, do not error out immediately if an error is different than `os.ErrNotExist` to make sure subsequent candidates are tried.  Instead, debug-log and collect the errors.  If no provider was found, return them.

[NO NEW TESTS NEEDED]

Fixes: #20502

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in `podman compose` to try all configured providers before throwing an error.
```
