### PR TITLE
[CI:DOCS] Fix secrets scanning GHA Workflow

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -162,10 +162,21 @@ jobs:
         # gitleaks entrypoint runs as gitleaks user (UID/GID 1000)
         run: |
           set -exuo pipefail
+          # TODO: Workaround podman < v4.3.0 support for `--userns=keep-id:uid=1000,gid=1000`.
+          declare -a workaround_args
+          workaround_args=(\
+            --user 1000:1000
+            --uidmap 0:1:1000
+            --uidmap 1000:0:1
+            --uidmap 1001:1001:64536
+            --gidmap 0:1:1000
+            --gidmap 1000:0:1
+            --gidmap 1001:1001:64536
+          )
           # Careful: Changes need coordination with contrib/cirrus/prebuild.sh
           podman run --rm \
             --security-opt=label=disable \
-            --userns=keep-id:uid=1000,gid=1000 \
+            "${workaround_args[@]}" \
             -v ${{ github.workspace }}/_default:/default:ro \
             -v ${{ github.workspace }}/_subject:/subject:ro \
             -v ${{ github.workspace }}/_report:/report:rw \

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -77,12 +77,25 @@ if [[ "${DISTRO_NV}" == "$PRIOR_FEDORA_NAME" ]]; then
     # simply here to...
     msg "Checking GitLeaks functions with current CLI args, configuration, and baseline JSON"
 
+    # TODO: Workaround for GHA Environment, duplicate here for consistency.
+    # Replace with `--userns=keep-id:uid=1000,gid=1000` w/ newer podman in GHA environment.
+    declare -a workaround_args
+    workaround_args=(\
+      --user 1000:1000
+      --uidmap 0:1:1000
+      --uidmap 1000:0:1
+      --uidmap 1001:1001:64536
+      --gidmap 0:1:1000
+      --gidmap 1000:0:1
+      --gidmap 1001:1001:64536
+    )
+
     brdepth=$(get_env_key 'brdepth')
     glfqin=$(get_env_key 'glfqin')
     glargs=$(get_env_key 'glargs')
     showrun podman run --rm \
         --security-opt=label=disable \
-        --userns=keep-id:uid=1000,gid=1000 \
+        "${workaround_args[@]}" \
         -v $CIRRUS_WORKING_DIR:/subject:ro \
         -v $CIRRUS_WORKING_DIR:/default:ro \
         --tmpfs /report:rw,size=256k,mode=1777 \


### PR DESCRIPTION
The podman in `ubuntu-latest` environment apparently is too old to support `--userns=keep-id:uid=1000,gid=1000`.  Employ workaround in GHA workflow and in `prebuild.sh` check.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
