### PR TITLE
systests: pasta: avoid hangs

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -240,7 +240,8 @@ function pasta_test_do() {
         local connect="${proto_upper}${ip_ver}:[${addr}]:${one_port}"
         [ "${proto}" = "udp" ] && connect="${connect},shut-null"
 
-        (while sleep ${delay} && ! socat -u "OPEN:${XFER_FILE}" "${connect}"; do :
+        local retries=10
+        (while sleep ${delay} && test $((retries--)) -gt 0 && ! timeout --foreground -v --kill=5 90 socat -u "OPEN:${XFER_FILE}" "${connect}"; do :
          done) &
     done
 


### PR DESCRIPTION
Under some circumstances BATS tests hang, causing a CI timeout.

One prominent reason is pasta test failures: BATS will not
exit until all child processes are finished, and in some
environments the socat client can stay forever.

Workaround: run socat with a timeout, and with limited retries.

Tested on an f38 system with broken IPv6: without this fix,
bats hangs until I ^C. With this fix, bats exits as it should.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```