### PR TITLE
[CI:DOCS] Improve podman-save and podman-push documentation

### DIFF
--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -28,7 +28,11 @@ $ podman push docker://quay.io/podman/stable
 
 # Push to a container registry with another tag
 $ podman push myimage quay.io/username/myimage
+```
 
+**podman push** can also be used as an alternative to **podman save**.  For example:
+
+```
 # Push to a local directory
 $ podman push myimage dir:/tmp/myimage
 
@@ -41,8 +45,8 @@ $ sudo podman push myimage docker-daemon:docker.io/library/myimage:33
 # Push to a tarball in the OCI format
 $ podman push myimage oci-archive:/tmp/myimage
 
-# Push to a directory, with a relative path, in the OCI format with another tag
-$ podman push myimage oci:directory:tag
+# Push to a directory in the OCI format with an explicitly specified tag
+$ podman push myimage oci:/tmp/myimage:tag
 ```
 
 ## OPTIONS

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -40,6 +40,9 @@ $ sudo podman push myimage docker-daemon:docker.io/library/myimage:33
 
 # Push to a tarball in the OCI format
 $ podman push myimage oci-archive:/tmp/myimage
+
+# Push to a directory, with a relative path, in the OCI format with another tag
+$ podman push myimage oci:directory:tag
 ```
 
 ## OPTIONS

--- a/docs/source/markdown/podman-save.1.md.in
+++ b/docs/source/markdown/podman-save.1.md.in
@@ -22,6 +22,8 @@ Note: `:` is a restricted character and cannot be part of the file name.
 
 **podman save [OPTIONS] NAME[:TAG]**
 
+Most or all of **podman save**'s functionality is available, with more flexibility, in **[podman-push(1)](podman-push.1.md)**.
+
 ## OPTIONS
 
 @@option dir-compress
@@ -38,6 +40,14 @@ An image format to produce, one of:
 | **oci-archive**    | A tar archive using the OCI Image Format                                     |
 | **oci-dir**        | A directory using the OCI Image Format                                       |
 | **docker-dir**     | **dir** transport (see **containers-transports(5)**) with v2s2 manifest type |
+
+If **oci-archive** or **oci-dir** saves an image specified by tag, then it will save it in the OCI Image with the same tag.  If **oci-archive** or **oci-dir** saves an image specified by hash, it will not tag it at all, which may make using the resulting image unnecessarily complicated.
+
+To explicity specify tag to be used when saving an image, use the **oci-archive:** or **oci::** schemes with **[podman-push(1)](podman-push.1.md)** instead.  For example:
+
+```
+$ podman push IMAGE oci:directoryname:tagname
+```
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-save.1.md.in
+++ b/docs/source/markdown/podman-save.1.md.in
@@ -41,9 +41,9 @@ An image format to produce, one of:
 | **oci-dir**        | A directory using the OCI Image Format                                       |
 | **docker-dir**     | **dir** transport (see **containers-transports(5)**) with v2s2 manifest type |
 
-If **oci-archive** or **oci-dir** saves an image specified by tag, then it will save it in the OCI Image with the same tag.  If **oci-archive** or **oci-dir** saves an image specified by hash, it will not tag it at all, which may make using the resulting image unnecessarily complicated.
+If **oci-archive** or **oci-dir** saves an image specified by name, then it will save it in the OCI Image with the same name (i.e. an **org.opencontainers.image.ref.name** annotation will be written).  If **oci-archive** or **oci-dir** saves an image specified by hash, the image will not be given a name in the saved image, which may make using the resulting image with tools that expect named images difficult.
 
-To explicity specify tag to be used when saving an image, use the **oci-archive:** or **oci::** schemes with **[podman-push(1)](podman-push.1.md)** instead.  For example:
+To explicity specify the name to be used in the saved image, use the **oci-archive:** or **oci::** schemes with **[podman-push(1)](podman-push.1.md)** instead.  For example:
 
 ```
 $ podman push IMAGE oci:directoryname:tagname
@@ -115,7 +115,7 @@ Storing signatures
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-load(1)](podman-load.1.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**, **[containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md)**
+**[podman(1)](podman.1.md)**, **[podman-load(1)](podman-load.1.md)**, **[podman-push(1)](podman-push.1.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**, **[containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md)**
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>


### PR DESCRIPTION
podman-save has awkward semantics with regard tagging the saved image in the output.  Improve the documentation, and suggest using podman push as an alternative.

Add a corresponding example to podman push's manpage.

See https://github.com/containers/podman/issues/20515

#### Does this PR introduce a user-facing change?

I think None.  It's user-facing in the sense that it updates documentation.  I don't think it needs a release note.  Certainly no action is required.

If a release note is required, I suggest:

```release-note
Updated podman-save documentation to suggest using podman push instead.
```
