### PR TITLE
libpod: fix /etc/hostname with --uts=host

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -686,6 +686,23 @@ func (c *Container) Hostname() string {
 		return c.config.Spec.Hostname
 	}
 
+	// if the container is not running in a private UTS namespace,
+	// return the host's hostname.
+	privateUTS := false
+	if c.config.Spec.Linux != nil {
+		for _, ns := range c.config.Spec.Linux.Namespaces {
+			if ns.Type == spec.UTSNamespace {
+				privateUTS = true
+				break
+			}
+		}
+	}
+	if !privateUTS {
+		hostname, err := os.Hostname()
+		if err == nil {
+			return hostname
+		}
+	}
 	if len(c.ID()) < 11 {
 		return c.ID()
 	}

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -911,4 +911,15 @@ EOF
     run_podman network rm $net1
 }
 
+# Issue #20448 - /etc/hostname with --uts=host must show "uname -n"
+@test "podman --uts=host must use 'uname -n' for /etc/hostname" {
+    run_podman info --format '{{.Host.Hostname}}'
+    hostname="$output"
+    run_podman run --rm --uts=host $IMAGE cat /etc/hostname
+    assert "$output" = $hostname "/etc/hostname with --uts=host must be equal to 'uname -n'"
+
+    run_podman run --rm --net=host --uts=host $IMAGE cat /etc/hostname
+    assert "$output" = $hostname "/etc/hostname with --uts=host --net=host must be equal to 'uname -n'"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
when --uts=host is provided, the expectation is to use the hostname from the host not the container name.

Closes: https://github.com/containers/podman/issues/20448

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now --uts=host --net=host fills /etc/hostname with the host's name
```
