### PR TITLE
CI: default to sqlite

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ env:
     DISTRO_NV:               # any {PRIOR_,}{FEDORA,DEBIAN}_NAME value
     VM_IMAGE_NAME:           # One of the "Google-cloud VM Images" (above)
     CTR_FQIN:                # One of the "Container FQIN's" (above)
-    CI_DESIRED_DATABASE: boltdb # One of "", "sqlite", "boltdb"
+    CI_DESIRED_DATABASE: sqlite # 'sqlite' or 'boltdb'
 
     # Curl-command prefix for downloading task artifacts, simply add the
     # the url-encoded task name, artifact name, and path as a suffix.
@@ -104,30 +104,21 @@ build_task:
               # ID for re-use of build output
               CI_DESIRED_RUNTIME: crun
               CI_DESIRED_NETWORK: netavark
-              CI_DESIRED_DATABASE: boltdb
-        - env: &sqliteenvvars
-              DISTRO_NV: ${FEDORA_NAME}
-              # Not used here, is used in other tasks
-              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-              # ID for re-use of build output
-              CI_DESIRED_RUNTIME: crun
-              CI_DESIRED_NETWORK: netavark
-              CI_DESIRED_DATABASE: sqlite
-        - env: &priorfedora_envvars
+        - env:
               DISTRO_NV: ${PRIOR_FEDORA_NAME}
               VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
               CI_DESIRED_RUNTIME: crun
               CI_DESIRED_NETWORK: cni
+              CI_DESIRED_DATABASE: boltdb
               # Catch invalid "TMPDIR == /tmp" assumptions; PR #19281
               TMPDIR: /var/tmp
         - env:
-              <<: *sqliteenvvars
+              <<: *stdenvars
               DISTRO_NV: ${RAWHIDE_NAME}
               VM_IMAGE_NAME: ${RAWHIDE_CACHE_IMAGE_NAME}
               CTR_FQIN: ""
-        - env: &debian_envvars
+        - env:
               DISTRO_NV: ${DEBIAN_NAME}
               VM_IMAGE_NAME: ${DEBIAN_CACHE_IMAGE_NAME}
               CI_DESIRED_RUNTIME: runc
@@ -409,7 +400,6 @@ win_installer_task:
         CIRRUS_WORKING_DIR: &wincwd "${LOCALAPPDATA}\\cirrus-ci-build"
         CIRRUS_SHELL: powershell
         PATH: "${PATH};C:\\ProgramData\\chocolatey\\bin"
-        CI_DESIRED_DATABASE: ""
         DISTRO_NV: "windows"
         PRIV_NAME: "rootless"
         # Fake version, we are only testing the installer functions, so version doesn't matter
@@ -680,6 +670,7 @@ container_integration_test_task:
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
               CI_DESIRED_RUNTIME: crun
               CI_DESIRED_NETWORK: cni
+              CI_DESIRED_DATABASE: boltdb
     gce_instance: *standardvm
     timeout_in: 50m
     env:
@@ -999,6 +990,8 @@ upgrade_test_task:
         TEST_FLAVOR: upgrade_test
         DISTRO_NV: ${FEDORA_NAME}
         VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+        # FIXME: remove this once we have VMs with podman >= 4.8
+        CI_DESIRED_DATABASE: boltdb
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -290,7 +290,10 @@ remove_packaged_podman_files() {
         LISTING_CMD="rpm -ql podman"
     fi
 
-    # delete the podman socket in case it has been created previously
+    # delete the podman socket in case it has been created previously.
+    # Do so without running podman, lest that invocation initialize unwanted state.
+    rm -f /run/podman/podman.sock  /run/user/$(id -u)/podman/podman.sock || true
+
     rm -f $(podman info --format "{{.Host.RemoteSocket.Path}}")
 
     # yum/dnf/dpkg may list system directories, only remove files

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -100,7 +100,13 @@ case "$CG_FS_TYPE" in
 esac
 
 # Force the requested database backend without having to use command-line args
+# As of #20318 (2023-10-10) sqlite is the default, but for complicated reasons
+# we still (2023-11-01) have to explicitly create a containers.conf. See
+# comments in #20559.
+# FIXME: some day, when new CI VMs are in place with podman >= 4.8 installed
+# from RPM, un-comment the 'if' below. That will confirm that sqlite is default.
 # shellcheck disable=SC2154
+#if [[ "${CI_DESIRED_DATABASE:-sqlite}" != "sqlite" ]]; then
 printf "[engine]\ndatabase_backend=\"$CI_DESIRED_DATABASE\"\n" > /etc/containers/containers.conf.d/92-db.conf
 
 # For debian envs pre-configure storage driver as overlay.
@@ -179,7 +185,7 @@ case "$CI_DESIRED_NETWORK" in
 esac
 
 # Database: force SQLite or BoltDB as requested in .cirrus.yml.
-# If unset, will default to BoltDB.
+# If unset, will default to SQLite.
 # shellcheck disable=SC2154
 showrun echo "about to set up for CI_DESIRED_DATABASE [=$CI_DESIRED_DATABASE]"
 case "$CI_DESIRED_DATABASE" in

--- a/test/README.md
+++ b/test/README.md
@@ -88,7 +88,7 @@ The following environment variables are supported by the test setup:
  - `CONMON_BINARY`: path to th conmon binary, defaults to `/usr/libexec/podman/conmon`.
  - `OCI_RUNTIME`: which oci runtime to use, defaults to `crun`.
  - `NETWORK_BACKEND`: the network backend, either `netavark` (default) or `cni`.
- - `PODMAN_DB`: the database backend `boltdb` (default) or `sqlite`.
+ - `PODMAN_DB`: the database backend `sqlite` (default) or `boltdb`.
  - `PODMAN_TEST_IMAGE_CACHE_DIR`: path were the container images should be cached, defaults to `/tmp`.
 
 ### Running a single file of integration tests

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -286,9 +286,9 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	}
 	os.Setenv("DISABLE_HC_SYSTEMD", "true")
 
-	dbBackend := "boltdb"
-	if os.Getenv("PODMAN_DB") == "sqlite" {
-		dbBackend = "sqlite"
+	dbBackend := "sqlite"
+	if os.Getenv("PODMAN_DB") == "boltdb" {
+		dbBackend = "boltdb"
 	}
 
 	networkBackend := Netavark


### PR DESCRIPTION
Followup to #20318: now that sqlite is the podman default,
enforce that in CI as well. Test boltdb only in Prior Fedora.

In the process, discovered & cleaned up some duplication
and unused YAML anchors.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```