### PR TITLE
AppleHV: Fix machine rm error message

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -53,12 +53,11 @@ func (v AppleHVVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
 }
 
 func (v AppleHVVirtualization) IsValidVMName(name string) (bool, error) {
-	mm := MacMachine{Name: name}
 	configDir, err := machine.GetConfDir(machine.AppleHvVirt)
 	if err != nil {
 		return false, err
 	}
-	if err := loadMacMachineFromJSON(configDir, &mm); err != nil {
+	if _, err := loadMacMachineFromJSON(configDir); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -183,14 +182,14 @@ func (v AppleHVVirtualization) loadFromLocalJson() ([]*MacMachine, error) {
 	}
 
 	for _, jsonFile := range jsonFiles {
-		mm := MacMachine{}
-		if err := loadMacMachineFromJSON(jsonFile, &mm); err != nil {
+		mm, err := loadMacMachineFromJSON(jsonFile)
+		if err != nil {
 			return nil, err
 		}
 		if err != nil {
 			return nil, err
 		}
-		mms = append(mms, &mm)
+		mms = append(mms, mm)
 	}
 	return mms, nil
 }

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -32,8 +32,9 @@ var _ = Describe("podman machine rm", func() {
 	})
 
 	It("Remove machine", func() {
+		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		rm := rmMachine{}
@@ -46,6 +47,12 @@ var _ = Describe("podman machine rm", func() {
 		_, ec, err := mb.toQemuInspectInfo()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
+
+		// Removing non-existent machine should fail
+		removeSession2, err := mb.setCmd(rm.withForce()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(removeSession2).To(Exit(125))
+		Expect(removeSession2.errorToString()).To(ContainSubstring(fmt.Sprintf("%s: VM does not exist", name)))
 	})
 
 	It("Remove running machine", func() {


### PR DESCRIPTION
Fix machine not found error message on rm to be consistent with qemu.

Plus a small readability refactor. 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
