### PR TITLE
Podman push --help should reveal default compression

### DIFF
--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -129,13 +129,13 @@ func pushFlags(cmd *cobra.Command) {
 
 	flags.BoolVar(&pushOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
-	compressionFormat := "compression-format"
-	flags.StringVar(&pushOptions.CompressionFormat, compressionFormat, "", "compression format to use")
-	_ = cmd.RegisterFlagCompletionFunc(compressionFormat, common.AutocompleteCompressionFormat)
+	compFormat := "compression-format"
+	flags.StringVar(&pushOptions.CompressionFormat, compFormat, compressionFormat(), "compression format to use")
+	_ = cmd.RegisterFlagCompletionFunc(compFormat, common.AutocompleteCompressionFormat)
 
-	compressionLevel := "compression-level"
-	flags.Int(compressionLevel, 0, "compression level to use")
-	_ = cmd.RegisterFlagCompletionFunc(compressionLevel, completion.AutocompleteNone)
+	compLevel := "compression-level"
+	flags.Int(compLevel, compressionLevel(), "compression level to use")
+	_ = cmd.RegisterFlagCompletionFunc(compLevel, completion.AutocompleteNone)
 
 	encryptionKeysFlagName := "encryption-key"
 	flags.StringSliceVar(&pushOptions.EncryptionKeys, encryptionKeysFlagName, nil, "Key with the encryption protocol to use to encrypt the image (e.g. jwe:/path/to/key.pem)")
@@ -238,4 +238,20 @@ func imagePush(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func compressionFormat() string {
+	if registry.IsRemote() {
+		return ""
+	}
+
+	return containerConfig.ContainersConfDefaultsRO.Engine.CompressionFormat
+}
+
+func compressionLevel() int {
+	if registry.IsRemote() || containerConfig.ContainersConfDefaultsRO.Engine.CompressionLevel == nil {
+		return 0
+	}
+
+	return *containerConfig.ContainersConfDefaultsRO.Engine.CompressionLevel
 }

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -249,4 +249,22 @@ EOF
     run_podman rm -f -t0 $cname
 }
 
+@test "podman push CONTAINERS_CONF" {
+    skip_if_remote "containers.conf does not effect client side of --remote"
+
+    CONTAINERS_CONF=/dev/null run_podman push --help
+    assert "$output" =~ "--compression-format string.*compression format to use \(default \"gzip\"\)" "containers.conf should set default to gzip"
+    assert "$output" !~ "compression level to use \(default" "containers.conf should not set default compressionlevel"
+
+    conf_tmp="$PODMAN_TMPDIR/containers.conf"
+    cat >$conf_tmp <<EOF
+[engine]
+compression_format="zstd:chunked"
+compression_level=1
+EOF
+    CONTAINERS_CONF="$conf_tmp" run_podman push --help
+    assert "$output" =~ "--compression-format string.*compression format to use \(default \"zstd:chunked\"\)" "containers.conf should set default to zstd:chunked"
+    assert "$output" =~ "--compression-level int.*compression level to use \(default 1\)" "containers.conf should set default compressionlevel to 1"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
When using the local client, we should display the compression algorithm.

If the compression level is set, then show this also.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman push --help will show compression algorithm when run locally.
```
