### PR TITLE
[CI:DOCS] docs: make CNI removal explicit

### DIFF
--- a/cni/README.md
+++ b/cni/README.md
@@ -1,7 +1,7 @@
 ## `cni` ##
 
-**Note**: CNI is being deprecated from Podman and support will be dropped at a future date.  Use of netavark is now
-advised and is the default network backend for Podman.
+**Note**: The CNI backend is deprecated and will be removed in the next major Podman version 5.0, in preference
+of Netavark, see **[podman-network(1)](../docs/source/markdown/podman-network.1.md)** on how to change the backend.
 
 There are a wide variety of different [CNI](https://github.com/containernetworking/cni) network configurations. This
 directory just contains an example configuration that can be used as the

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -15,8 +15,10 @@ If no options are provided, Podman assigns a free subnet and name for the networ
 
 Upon completion of creating the network, Podman displays the name of the newly added network.
 
-NOTE: The support for the network name "pasta" is deprecated and will be removed in the next major
-release because it is used as a special network mode in **podman run/create --network**.
+NOTE: The support for "pasta" as network *name* value is deprecated and will not be accepted in the next major
+Podman version 5.0, because it is used as a special network mode in **podman run/create --network**.
+The CNI backend is also deprecated and will also be removed in the next major Podman version 5.0, in preference
+of Netavark, see **[podman-network(1)](podman-network.1.md)** on how to change the backend.
 
 ## OPTIONS
 #### **--disable-dns**
@@ -87,7 +89,9 @@ ipam driver automatically based on the network driver.
 
 Valid values are:
 
- - `dhcp`: IP addresses are assigned from a dhcp server on the network. This driver is not yet supported with netavark. For CNI the *dhcp* plugin needs to be activated before.
+ - `dhcp`: IP addresses are assigned from a dhcp server on the network. When using the netavark backend
+  the `netavark-dhcp-proxy.socket` must be enabled in order to start the dhcp-proxy when a container is
+  started, for CNI use the `cni-dhcp.socket` unit instead.
  - `host-local`: IP addresses are assigned locally.
  - `none`: No ip addresses are assigned to the interfaces.
 

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -10,9 +10,9 @@ podman\-network - Manage Podman networks
 The network command manages networks for Podman.
 
 Podman supports two network backends [Netavark](https://github.com/containers/netavark)
-and [CNI](https://www.cni.dev/). Netavark is the default network backend and was added in Podman v4.0. CNI will be deprecated in the future in preference of
-Netavark. To configure
-the network backend use the `network_backend` key under the `[Network]` in
+and [CNI](https://www.cni.dev/). Netavark is the default network backend and was added in Podman version 4.0.
+CNI is deprecated and will be removed in the next major Podman version 5.0, in preference of Netavark.
+To configure the network backend use the `network_backend` key under the `[Network]` in
 **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**.
 New systems use netavark by default, to check what backend is used run
 `podman info --format {{.Host.NetworkBackend}}`.

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -106,7 +106,8 @@ Path to the directory where network configuration files are located.
 For the netavark backend "/etc/containers/networks" is used as root
 and "$graphroot/networks" as rootless.
 For the CNI backend the default is "/etc/cni/net.d" as root
-and "$HOME/.config/cni/net.d" as rootless. CNI is deprecated from Podman in the future, use netavark.
+and "$HOME/.config/cni/net.d" as rootless.
+CNI is deprecated and will be removed in the next major Podman version 5.0 in preference of Netavark.
 
 #### **--out**=*path*
 Redirect the output of podman to the specified path without affecting the container output or its logs. This parameter can be used to capture the output from any of podman's commands directly into a file and enable suppression of podman's output by specifying /dev/null as the path. To explicitly disable the container logging, the **--log-driver** option should be used.


### PR DESCRIPTION
The docs were rather vague about the deprecation of CNI, make it clear that we are going to remove it with 5.0 as we decided to do that in our planning.

Also while looking at the podman network create docs I noticed --ipam-driver dhcp was still documented as not supported with netavark so I fixed that as well.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Deprecation notice: CNI support will be removed in the next major version 5.0.
```
