### PR TITLE
vendor: update github.com/coreos/go-systemd/v22 to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containers/ocicrypt v1.1.9
 	github.com/containers/psgo v1.8.0
 	github.com/containers/storage v1.50.3-0.20231101112703-6e72f11598fb
-	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09
 	github.com/coreos/stream-metadata-go v0.4.3
 	github.com/crc-org/vfkit v0.1.2-0.20231030102423-f3c783d34420
 	github.com/cyphar/filepath-securejoin v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,9 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 h1:OoRAFlvDGCUqDLampLQjk0yeeSGdF9zzst/3G9IkBbc=
+github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09/go.mod h1:m2r/smMKsKwgMSAoFKHaa68ImdCSNuKE1MxvQ64xuCQ=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/stream-metadata-go v0.4.3 h1:5GykJ8dtZSx1rdlzEAiDVzA73cwmUF3ceTuIP293L6E=

--- a/vendor/github.com/coreos/go-systemd/v22/internal/dlopen/dlopen.go
+++ b/vendor/github.com/coreos/go-systemd/v22/internal/dlopen/dlopen.go
@@ -23,6 +23,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -56,6 +57,10 @@ func GetHandle(libs []string) (*LibHandle, error) {
 
 // GetSymbolPointer takes a symbol name and returns a pointer to the symbol.
 func (l *LibHandle) GetSymbolPointer(symbol string) (unsafe.Pointer, error) {
+	// Locking the thread is critical here as the dlerror() is thread local so
+	// go should not reschedule this onto another thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	sym := C.CString(symbol)
 	defer C.free(unsafe.Pointer(sym))
 
@@ -71,6 +76,10 @@ func (l *LibHandle) GetSymbolPointer(symbol string) (unsafe.Pointer, error) {
 
 // Close closes a LibHandle.
 func (l *LibHandle) Close() error {
+	// Locking the thread is critical here as the dlerror() is thread local so
+	// go should not reschedule this onto another thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	C.dlerror()
 	C.dlclose(l.Handle)
 	e := C.dlerror()

--- a/vendor/github.com/coreos/go-systemd/v22/sdjournal/journal.go
+++ b/vendor/github.com/coreos/go-systemd/v22/sdjournal/journal.go
@@ -59,7 +59,7 @@ package sdjournal
 // void
 // my_sd_journal_close(void *f, sd_journal *j)
 // {
-//   int (*sd_journal_close)(sd_journal *);
+//   void (*sd_journal_close)(sd_journal *);
 //
 //   sd_journal_close = f;
 //   sd_journal_close(j);
@@ -104,7 +104,7 @@ package sdjournal
 // void
 // my_sd_journal_flush_matches(void *f, sd_journal *j)
 // {
-//   int (*sd_journal_flush_matches)(sd_journal *);
+//   void (*sd_journal_flush_matches)(sd_journal *);
 //
 //   sd_journal_flush_matches = f;
 //   sd_journal_flush_matches(j);

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -403,7 +403,7 @@ github.com/coreos/go-oidc/v3/oidc
 # github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 ## explicit
 github.com/coreos/go-systemd/activation
-# github.com/coreos/go-systemd/v22 v22.5.0
+# github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09
 ## explicit; go 1.12
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/daemon


### PR DESCRIPTION
This fixes a CI flake. go-systemd was not handling the dlerror() function correctly which lead to wrong errors being reported.

[NO NEW TESTS NEEDED]

Fixes #20569

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
