### PR TITLE
remote,test: remove `.dockerignore` which is a symlink

### DIFF
--- a/test/e2e/build/containerignore-symlink/.dockerignore
+++ b/test/e2e/build/containerignore-symlink/.dockerignore
@@ -1,1 +1,0 @@
-/tmp/private_file

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -441,12 +441,24 @@ RUN find /test`, CITEST_IMAGE)
 	It("podman remote build must not allow symlink for ignore files", func() {
 		// Create a random file where symlink must be resolved
 		// but build should not be able to access it.
-		f, err := os.Create(filepath.Join("/tmp", "private_file"))
+		privateFile := filepath.Join("/tmp", "private_file")
+		f, err := os.Create(privateFile)
 		Expect(err).ToNot(HaveOccurred())
 		// Mark hello to be ignored in outerfile, but it should not be ignored.
 		_, err = f.WriteString("hello\n")
 		Expect(err).ToNot(HaveOccurred())
 		defer f.Close()
+
+		// Create .dockerignore which is a symlink to /tmp/private_file.
+		currentDir, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		ignoreFile := filepath.Join(currentDir, "build/containerignore-symlink/.dockerignore")
+		err = os.Symlink(privateFile, ignoreFile)
+		Expect(err).ToNot(HaveOccurred())
+		// Remove created .dockerignore for this test when test ends.
+		defer func() {
+			os.Remove(ignoreFile)
+		}()
 
 		if IsRemote() {
 			podmanTest.StopRemoteService()


### PR DESCRIPTION
It seems certain test infrastructure prevents cloning repo which contains symlink outside of the repo itself, generate symlink for such test by the testsuite itself just before running test and remove it when test is completed.

Following symlink was added to repo here: https://github.com/containers/podman/pull/16315

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
