### PR TITLE
Fixed Typo in help command

### DIFF
--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -131,7 +131,7 @@ address can't be used by podman. `
 					fmtString += `If you would like to install it, run the following commands:
 
         sudo %s install
-        podman machine stop%[1]s; podman machine start%[1]s
+        podman machine stop %[1]s; podman machine start %[1]s
 
                 `
 					fmt.Printf(fmtString, helper, suffix)


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

None 


```release-note
None
```

[NO NEW TESTS NEEDED]