### PR TITLE
[WIP] Add --userns support to podman pull 

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -1,12 +1,11 @@
 package common
 
 import (
-	"os"
-
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
 	commonFlag "github.com/containers/common/pkg/flag"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
@@ -710,7 +709,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 
 		usernsFlagName := "userns"
 		createFlags.String(
-			usernsFlagName, os.Getenv("PODMAN_USERNS"),
+			usernsFlagName, utils.DefaultUserNS(),
 			"User namespace to use",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(usernsFlagName, AutocompleteUserNamespace)

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -42,6 +42,7 @@ var (
 		RunE:              imagePull,
 		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman pull imageName
+  podman pull --userns=keep-id registry.access.redhat.com/ubi9::9.2,
   podman pull fedora:latest`,
 	}
 
@@ -92,6 +93,13 @@ func pullFlags(cmd *cobra.Command) {
 	osFlagName := "os"
 	flags.StringVar(&pullOptions.OS, osFlagName, "", "Use `OS` instead of the running OS for choosing images")
 	_ = cmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
+
+	usernsFlagName := "userns"
+	flags.StringVar(
+		&pullOptions.UserNS,
+		usernsFlagName, utils.DefaultUserNS(),
+		"User namespace to use",
+	)
 
 	variantFlagName := "variant"
 	flags.StringVar(&pullOptions.Variant, variantFlagName, "", "Use VARIANT instead of the running architecture variant for choosing images")

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -133,7 +133,7 @@ func playFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(logOptFlagName, common.AutocompleteLogOpt)
 
 	usernsFlagName := "userns"
-	flags.StringVar(&playOptions.Userns, usernsFlagName, os.Getenv("PODMAN_USERNS"),
+	flags.StringVar(&playOptions.Userns, usernsFlagName, utils.DefaultUserNS(),
 		"User namespace to use",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(usernsFlagName, common.AutocompleteUserNamespace)

--- a/cmd/podman/utils/utils.go
+++ b/cmd/podman/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
+	"github.com/containers/podman/v4/pkg/util"
 )
 
 // IsDir returns true if the specified path refers to a directory.
@@ -147,4 +148,17 @@ func RemoveSlash(input []string) []string {
 		output = append(output, strings.TrimPrefix(in, "/"))
 	}
 	return output
+}
+
+func DefaultUserNS() string {
+	if userns, ok := os.LookupEnv("PODMAN_USERNS"); ok {
+		return userns
+	}
+
+	if registry.IsRemote() {
+		return ""
+	}
+
+	containerConfig := util.DefaultContainerConfig()
+	return containerConfig.Containers.UserNS
 }

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -75,6 +75,58 @@ Suppress output information when pulling images
 
 @@option tls-verify
 
+#### **--userns**=*mode*
+
+Configure the user namespace mode for the command.
+
+If `--userns` is not set, the default value is determined as follows.
+- If the environment variable **PODMAN_USERNS** is set its value is used.
+- If `userns` is specified in `containers.conf` this value is used.
+- Otherwise, `--userns=host` is assumed.
+
+`--userns=""` (i.e., an empty string) is an alias for `--userns=host`.
+
+Rootless user --userns=Key mappings:
+
+Key                     | Host User | Container User
+------------------------|-----------|---------------------
+auto                    | $UID      | nil (Host User UID is not mapped into container.)
+host                    | $UID      | 0 (Default User account mapped to root user in container.)
+keep-id                 | $UID      | $UID (Map user account to same UID within container.)
+keep-id:uid=200,gid=210 | $UID      | 200:210 (Map user account to specified UID, GID value within container.)
+nomap                   | $UID      | nil (Host User UID is not mapped into container.)
+
+Valid _mode_ values are:
+
+**auto**[:_OPTIONS,..._]: automatically create a unique user namespace.
+
+The `--userns=auto` flag requires that the user name __containers__ be specified in the /etc/subuid and /etc/subgid files, with an unused range of subordinate user IDs that Podman containers are allowed to allocate. See subuid(5).
+
+Example: `containers:2147483647:2147483648`.
+
+Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinate user IDs. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the `size` option.
+
+The option `--userns=keep-id` uses all the subuids and subgids of the user.
+The option `--userns=nomap` uses all the subuids and subgids of the user except the user's own ID.
+Using `--userns=auto` when starting new containers does not work as long as any containers exist that were started with `--userns=keep-id` or `--userns=nomap`.
+
+  Valid `auto` options:
+
+  - *gidmapping*=_CONTAINER\_GID:HOST\_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` estimates a size for the user namespace.
+  - *uidmapping*=_CONTAINER\_UID:HOST\_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+
+**host** or **""** (empty string): run in the user namespace of the caller. The processes running in the container have the same privileges on the host as any other process launched by the calling user.
+
+**keep-id**: creates a user namespace where the current user's UID:GID are mapped to the same values in the container. For containers created by root, the current mapping is created into a new user namespace.
+
+  Valid `keep-id` options:
+
+  - *uid*=UID: override the UID inside the container that is used to map the current user to.
+  - *gid*=GID: override the GID inside the container that is used to map the current user to.
+
+**nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
+
 @@option variant.container
 
 ## FILES

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -149,6 +149,8 @@ type ImagePullOptions struct {
 	OS string
 	// Variant will overwrite the local variant for image pulls.
 	Variant string
+	// UserNS to pull the image into.
+	UserNS string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet bool


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman pull --userns is now supported.
```

[ NO NEW TESTS NEEDED] Not fully implemented yet.