### PR TITLE
[WIP] store: Make additionalimagestores configurable as layerstore source

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -344,7 +344,7 @@ Deleted: $pauseID"
 driver="overlay"
 
 [storage.options]
-additionalimagestores = [ "$imstore/root" ]
+additionalimagestores = [ "$imstore/root|NO_REUSE" ]
 EOF
 
     skopeo copy containers-storage:$IMAGE \

--- a/vendor/github.com/containers/storage/drivers/overlay/overlay.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/overlay.go
@@ -507,6 +507,8 @@ func parseOptions(options []string) (*overlayOptions, error) {
 			}
 			for _, store := range strings.Split(val, ",") {
 				store = filepath.Clean(store)
+				intialStore := store
+				store := strings.Split(store, "|")[0]
 				if !filepath.IsAbs(store) {
 					return nil, fmt.Errorf("overlay: image path %q is not absolute.  Can not be relative", store)
 				}
@@ -517,7 +519,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				if !st.IsDir() {
 					return nil, fmt.Errorf("overlay: image path %q must be a directory", store)
 				}
-				o.imageStores = append(o.imageStores, store)
+				o.imageStores = append(o.imageStores, intialStore)
 			}
 		case "additionallayerstore":
 			logrus.Debugf("overlay: additionallayerstore=%s", val)
@@ -1210,6 +1212,7 @@ func (d *Driver) dir2(id string) (string, string, bool) {
 	}
 	if _, err := os.Stat(newpath); err != nil {
 		for _, p := range d.AdditionalImageStores() {
+			p = strings.Split(p, "|")[0]
 			l := path.Join(p, d.name, id)
 			_, err = os.Stat(l)
 			if err == nil {
@@ -1592,6 +1595,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		newpath := path.Join(d.home, l)
 		if st, err := os.Stat(newpath); err != nil {
 			for _, p := range d.AdditionalImageStores() {
+				p = strings.Split(p, "|")[0]
 				lower = path.Join(p, d.name, l)
 				if st2, err2 := os.Stat(lower); err2 == nil {
 					if !permsKnown {

--- a/vendor/github.com/containers/storage/store.go
+++ b/vendor/github.com/containers/storage/store.go
@@ -945,6 +945,7 @@ func (s *store) load() error {
 	s.containerStore = rcs
 
 	for _, store := range driver.AdditionalImageStores() {
+		store = strings.Split(store, "|")[0]
 		gipath := filepath.Join(store, driverPrefix+"images")
 		var ris roImageStore
 		if s.imageStoreDir != "" && store == s.graphRoot {
@@ -1109,6 +1110,13 @@ func (s *store) getROLayerStoresLocked() ([]roLayerStore, error) {
 		return nil, err
 	}
 	for _, store := range s.graphDriver.AdditionalImageStores() {
+		if strings.Contains(store, "|") {
+			parts := strings.Split(store, "|")
+			if parts[1] == "NO_REUSE" {
+				continue
+			}
+			store = strings.Split(store, "|")[0]
+		}
 		glpath := filepath.Join(store, driverPrefix+"layers")
 		rls, err := newROLayerStore(rlpath, glpath, s.graphDriver)
 		if err != nil {


### PR DESCRIPTION
AdditionalImageStores may alter independent of current RWLayerStore resulting in layers references to the ROImageStore, created during the reuseBlob operations, to break.

Optionally allow ignoring stores in AdditionalImageStores as layer store.

Closes: Closes: containers/storage#1751

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
