### PR TITLE
Set correct exitcode in remove events

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -820,7 +820,7 @@ func (c *Container) exec(config *ExecConfig, streams *define.AttachStreams, resi
 			if err != nil {
 				return -1, fmt.Errorf("retrieving exec session %s exit code: %w", sessionID, err)
 			}
-			return diedEvent.ContainerExitCode, nil
+			return *diedEvent.ContainerExitCode, nil
 		}
 		return -1, err
 	}

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -77,6 +77,14 @@ func (c *Container) newContainerEventWithInspectData(status events.Status, inspe
 		e.HealthStatus = containerHealthStatus
 	}
 
+	if status == events.Remove {
+		exitCode, err := c.runtime.state.GetContainerExitCode(c.ID())
+		if err == nil {
+			intExitCode := int(exitCode)
+			e.ContainerExitCode = &intExitCode
+		}
+	}
+
 	return c.runtime.eventer.Write(e)
 }
 
@@ -88,7 +96,8 @@ func (c *Container) newContainerExitedEvent(exitCode int32) {
 	e.Image = c.config.RootfsImageName
 	e.Type = events.Container
 	e.PodID = c.PodID()
-	e.ContainerExitCode = int(exitCode)
+	intExitCode := int(exitCode)
+	e.ContainerExitCode = &intExitCode
 
 	e.Details = events.Details{
 		ID:         e.ID,
@@ -107,7 +116,8 @@ func (c *Container) newExecDiedEvent(sessionID string, exitCode int) {
 	e.Name = c.Name()
 	e.Image = c.config.RootfsImageName
 	e.Type = events.Container
-	e.ContainerExitCode = exitCode
+	intExitCode := exitCode
+	e.ContainerExitCode = &intExitCode
 	e.Attributes = make(map[string]string)
 	e.Attributes["execID"] = sessionID
 

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -24,7 +24,7 @@ const (
 type Event struct {
 	// ContainerExitCode is for storing the exit code of a container which can
 	// be used for "internal" event notification
-	ContainerExitCode int `json:",omitempty"`
+	ContainerExitCode *int `json:",omitempty"`
 	// ID can be for the container, image, volume, etc
 	ID string `json:",omitempty"`
 	// Image used where applicable

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -69,6 +69,9 @@ func (e *Event) ToJSONString() (string, error) {
 
 // ToHumanReadable returns human-readable event as a formatted string
 func (e *Event) ToHumanReadable(truncate bool) string {
+	if e == nil {
+		return ""
+	}
 	var humanFormat string
 	id := e.ID
 	if truncate {

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -48,8 +48,8 @@ func (e EventJournalD) Write(ee Event) error {
 		m["PODMAN_IMAGE"] = ee.Image
 		m["PODMAN_NAME"] = ee.Name
 		m["PODMAN_ID"] = ee.ID
-		if ee.ContainerExitCode != 0 {
-			m["PODMAN_EXIT_CODE"] = strconv.Itoa(ee.ContainerExitCode)
+		if ee.ContainerExitCode != nil {
+			m["PODMAN_EXIT_CODE"] = strconv.Itoa(*ee.ContainerExitCode)
 		}
 		if ee.PodID != "" {
 			m["PODMAN_POD_ID"] = ee.PodID
@@ -206,7 +206,7 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 			if err != nil {
 				logrus.Errorf("Parsing event exit code %s", code)
 			} else {
-				newEvent.ContainerExitCode = intCode
+				newEvent.ContainerExitCode = &intCode
 			}
 		}
 

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -934,8 +934,7 @@ func (s *SQLiteState) GetContainerExitCode(id string) (int32, error) {
 	}
 
 	row := s.conn.QueryRow("SELECT ExitCode FROM ContainerExitCode WHERE ID=?;", id)
-
-	var exitCode int32
+	var exitCode int32 = -1
 	if err := row.Scan(&exitCode); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return -1, fmt.Errorf("getting exit code of container %s from DB: %w", id, define.ErrNoSuchExitCode)

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -238,7 +238,10 @@ func waitNextExit(ctx context.Context, containerName string) (int32, error) {
 
 	evt, ok := <-eventChannel
 	if ok {
-		return int32(evt.ContainerExitCode), nil
+		if evt.ContainerExitCode != nil {
+			return int32(*evt.ContainerExitCode), nil
+		}
+		return -1, nil
 	}
 	// if ok == false then containerEngine.Events() has exited
 	// it may happen if request was canceled (e.g. client closed connection prematurely) or

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1192,7 +1192,8 @@ func (ic *ContainerEngine) GetContainerExitCode(ctx context.Context, ctr *libpod
 	exitCode, err := ctr.Wait(ctx)
 	if err != nil {
 		logrus.Errorf("Waiting for container %s: %v", ctr.ID(), err)
-		return define.ExecErrorCodeNotFound
+		intExitCode := int(define.ExecErrorCodeNotFound)
+		return intExitCode
 	}
 	return int(exitCode)
 }

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -773,7 +773,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 					logrus.Errorf("Cannot get exit code: %v", err)
 					report.ExitCode = define.ExecErrorCodeNotFound
 				} else {
-					report.ExitCode = event.ContainerExitCode
+					report.ExitCode = *event.ContainerExitCode
 				}
 			} else {
 				report.ExitCode = int(exitCode)
@@ -962,7 +962,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 		return &report, nil //nolint: nilerr
 	}
 
-	report.ExitCode = lastEvent.ContainerExitCode
+	report.ExitCode = *lastEvent.ContainerExitCode
 	return &report, err
 }
 

--- a/test/apiv2/27-containersEvents.at
+++ b/test/apiv2/27-containersEvents.at
@@ -10,7 +10,7 @@ podman rm -a -f &>/dev/null
 
 START=$(date +%s)
 
-podman run $IMAGE false || true
+podman run --rm $IMAGE false || true
 
 # libpod api
 t GET "libpod/events?stream=false&since=$START"  200  \
@@ -27,5 +27,9 @@ t GET "events?stream=false&since=$START"  200  \
   'select(.status | contains("start")).Action=start' \
   'select(.status | contains("die")).Action=die' \
   'select(.status | contains("die")).Actor.Attributes.exitCode=1'
+
+t GET "events?stream=false&since=$START&type=remove"  200  \
+  'select(.status| contains("remove")).Action=remove' \
+  'select(.status | contains("remove")).Actor.Attributes.containerExitCode=1'
 
 # vim: filetype=sh


### PR DESCRIPTION
Added additional check for event type to be remove and set the correct exitcode by fetching it from runtime state

closes #19124

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman remove events now contain correct exit-code.
```
