### PR TITLE
VM images: bump to 2023-11-16

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,14 +26,14 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-39β"
+    FEDORA_NAME: "fedora-39"
     FEDORA_AARCH64_NAME: "${FEDORA_NAME}-aarch64"
     PRIOR_FEDORA_NAME: "fedora-38"
     RAWHIDE_NAME: "rawhide"
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20231004t194547z-f39f38d13"
+    IMAGE_SUFFIX: "c20231116t174419z-f39f38d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1545,14 +1545,18 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		container.WaitWithDefaultTimeout()
 		Expect(container).Should(Exit(0))
 		checkLines(container.OutputToStringArray())
-		Expect(container.ErrorToString()).To(ContainSubstring("Running scope as unit: "))
+		Expect(container.ErrorToString()).To(Or(
+			ContainSubstring("Running scope as unit: "), // systemd <  255
+			ContainSubstring("Running as unit: ")))      // systemd >= 255
 
 		// check that --cgroups=split is honored also when a container runs in a pod
 		container = podmanTest.PodmanSystemdScope([]string{"run", "--rm", "--pod", "new:split-test-pod", "--cgroups=split", ALPINE, "cat", "/proc/self/cgroup"})
 		container.WaitWithDefaultTimeout()
 		Expect(container).Should(Exit(0))
 		checkLines(container.OutputToStringArray())
-		Expect(container.ErrorToString()).To(ContainSubstring("Running scope as unit: "))
+		Expect(container.ErrorToString()).To(Or(
+			ContainSubstring("Running scope as unit: "), // systemd <  255
+			ContainSubstring("Running as unit: ")))      // systemd >= 255
 	})
 
 	It("podman run with cgroups=disabled runs without cgroups", func() {

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -178,8 +178,13 @@ host.slirp4netns.executable | $expr_path
 @test "CONTAINERS_CONF_OVERRIDE" {
     skip_if_remote "remote does not support CONTAINERS_CONF*"
 
+    # Need to include runtime because it's runc in debian CI,
+    # and crun 1.11.1 barfs with "read from sync socket"
     containersConf=$PODMAN_TMPDIR/containers.conf
     cat >$containersConf <<EOF
+[engine]
+runtime="$(podman_runtime)"
+
 [containers]
 env = [ "CONF1=conf1" ]
 

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -448,10 +448,6 @@ function teardown() {
 }
 
 @test "Local forwarder, IPv4" {
-    if [[ "$CIRRUS_CI" == "true" ]] && [[ "$DISTRO_NV" == "debian-13" ]]; then
-        skip "FIXME: Needs passt 0.0~git20230625.32660ce-1 or later in debian SID, unavailable 8-2023."
-    fi
-
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --dns 198.51.100.1 \
@@ -697,7 +693,7 @@ function teardown() {
 }
 
 @test "TCP/IPv4 large transfer, tap" {
-    skip "FIXME: #20170 - test hangs"
+    skip "FIXME: #20170 - needs passt >= 2023-11-10"
     pasta_test_do
 }
 


### PR DESCRIPTION
No change in base, just newer packages (especially crun-1.11-1)

Then fix broken tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```