### PR TITLE
systests: add a last-minute check for db backend

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -96,6 +96,11 @@ host.slirp4netns.executable | $expr_path
 }
 
 @test "podman info - confirm desired database" {
+    # Always run this and preserve its value. We will check again in 999-*.bats
+    run_podman info --format '{{.Host.DatabaseBackend}}'
+    db_backend="$output"
+    echo "$db_backend" > $BATS_SUITE_TMPDIR/db-backend
+
     if [[ -z "$CI_DESIRED_DATABASE" ]]; then
         # When running in Cirrus, CI_DESIRED_DATABASE *must* be defined
         # in .cirrus.yml so we can double-check that all CI VMs are
@@ -109,8 +114,7 @@ host.slirp4netns.executable | $expr_path
         skip "CI_DESIRED_DATABASE is unset--OK, because we're not in Cirrus"
     fi
 
-    run_podman info --format '{{.Host.DatabaseBackend}}'
-    is "$output" "$CI_DESIRED_DATABASE" "CI_DESIRED_DATABASE (from .cirrus.yml)"
+    is "$db_backend" "$CI_DESIRED_DATABASE" "CI_DESIRED_DATABASE (from .cirrus.yml)"
 }
 
 

--- a/test/system/999-final.bats
+++ b/test/system/999-final.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+#
+# Final set of tests to run.
+#
+
+load helpers
+
+# Confirm that we're still using the same database we started with.
+#
+# This should never fail! If it does, it means that some test somewhere
+# has run podman with --db-backend, which is known to wreak havoc.
+#
+# See  https://github.com/containers/podman/issues/20563
+@test "podman database backend has not changed" {
+    # File is always written in 005-info.bats. It must always exist
+    # by the time we get here...
+    db_backend_file=$BATS_SUITE_TMPDIR/db-backend
+
+    if [[ ! -e "$db_backend_file" ]]; then
+        # ...except in a manual run like "hack/bats 999"
+        if [[ $BATS_SUITE_TEST_NUMBER -le 5 ]]; then
+            skip "$db_backend_file missing, but this is a short manual bats run, so, ok"
+        fi
+
+        die "Internal error: $db_backend_file does not exist! (check 005-*.bats)"
+    fi
+
+    run_podman info --format '{{.Host.DatabaseBackend}}'
+    assert "$output" = "$(<$db_backend_file)" ".Host.DatabaseBackend has changed!"
+}


### PR DESCRIPTION
This will only fail if someone ever adds a system test that
runs podman with "--db-backend boltdb", which nobody should
ever do, but this is a cheap way to make sure it never happens.

See #20563

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```