### PR TITLE
systests: add [NNN] prefix in logs, NNN = filename

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -8,7 +8,8 @@ load helpers.network
 
 # Override standard setup! We don't yet trust podman-images or podman-rm
 function setup() {
-    :
+    # Makes test logs easier to read
+    BATS_TEST_NAME_PREFIX="[001] "
 }
 
 #### DO NOT ADD ANY TESTS HERE! ADD NEW TESTS AT BOTTOM!

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -57,17 +57,16 @@ function pasta_test_do() {
 
     # Normalize test name back to human-readable form. BATS gives us a
     # sanitized string with non-alnum converted to '-XX' (dash-hexbyte)
-    # and spaces converted to underscores. Convert all of those to
-    # spaces, then strip off the boilerplate "blah blah with pasta(1)".
+    # and spaces converted to underscores. Convert all of those to spaces.
     # This then gives us only the important (mutable) part of the test:
     #
-    #    test_...pasta..._-2d_TCP_translated_..._forwarding-2c_IPv4-2c_loopback
-    # -> test ...pasta ...... TCP translated ... forwarding    IPv4    loopback
-    # ->                      TCP translated     forwarding    IPv4    loopback
+    #    test_TCP_translated_..._forwarding-2c_IPv4-2c_loopback
+    # ->      TCP translated ... forwarding    IPv4    loopback
+    # ->      TCP translated     forwarding    IPv4    loopback
     local test_name=$(printf "$(sed \
+                      -e 's/^test_//'                 \
                       -e 's/-\([0-9a-f]\{2\}\)/ /gI' \
                       -e 's/_/ /g'                   \
-                      -e 's/^.* with pasta[ ]*1//'   \
                       <<<"${BATS_TEST_NAME}")")
 
     # We now have the @test name as specified in the script, minus punctuation.
@@ -261,7 +260,7 @@ function teardown() {
 
 ### Addresses ##################################################################
 
-@test "podman networking with pasta(1) - IPv4 default address assignment" {
+@test "IPv4 default address assignment" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --net=pasta $IMAGE ip -j -4 address show
@@ -273,7 +272,7 @@ function teardown() {
            "Container address not matching host"
 }
 
-@test "podman networking with pasta(1) - IPv4 address assignment" {
+@test "IPv4 address assignment" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --net=pasta:-a,192.0.2.1 $IMAGE ip -j -4 address show
@@ -284,7 +283,7 @@ function teardown() {
            "Container address not matching configured value"
 }
 
-@test "podman networking with pasta(1) - No IPv4" {
+@test "No IPv4" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
@@ -296,7 +295,7 @@ function teardown() {
            "Container has IPv4 global address with IPv4 disabled"
 }
 
-@test "podman networking with pasta(1) - IPv6 default address assignment" {
+@test "IPv6 default address assignment" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     run_podman run --net=pasta $IMAGE ip -j -6 address show
@@ -308,7 +307,7 @@ function teardown() {
            "Container address not matching host"
 }
 
-@test "podman networking with pasta(1) - IPv6 address assignment" {
+@test "IPv6 address assignment" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     run_podman run --net=pasta:-a,2001:db8::1 $IMAGE ip -j -6 address show
@@ -319,7 +318,7 @@ function teardown() {
            "Container address not matching configured value"
 }
 
-@test "podman networking with pasta(1) - No IPv6" {
+@test "No IPv6" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
@@ -331,7 +330,7 @@ function teardown() {
            "Container has IPv6 global address with IPv6 disabled"
 }
 
-@test "podman networking with pasta(1) - podman puts pasta IP in /etc/hosts" {
+@test "podman puts pasta IP in /etc/hosts" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     pname="p$(random_string 30)"
@@ -348,7 +347,7 @@ function teardown() {
 
 ### Routes #####################################################################
 
-@test "podman networking with pasta(1) - IPv4 default route" {
+@test "IPv4 default route" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --net=pasta $IMAGE ip -j -4 route show
@@ -360,7 +359,7 @@ function teardown() {
            "Container route not matching host"
 }
 
-@test "podman networking with pasta(1) - IPv4 default route assignment" {
+@test "IPv4 default route assignment" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --net=pasta:-a,192.0.2.2,-g,192.0.2.1 $IMAGE \
@@ -372,7 +371,7 @@ function teardown() {
            "Container route not matching configured value"
 }
 
-@test "podman networking with pasta(1) - IPv6 default route" {
+@test "IPv6 default route" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     run_podman run --net=pasta $IMAGE ip -j -6 route show
@@ -384,7 +383,7 @@ function teardown() {
            "Container route not matching host"
 }
 
-@test "podman networking with pasta(1) - IPv6 default route assignment" {
+@test "IPv6 default route assignment" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     run_podman run --net=pasta:-a,2001:db8::2,-g,2001:db8::1 $IMAGE \
@@ -398,7 +397,7 @@ function teardown() {
 
 ### Interfaces #################################################################
 
-@test "podman networking with pasta(1) - Default MTU" {
+@test "Default MTU" {
     run_podman run --net=pasta $IMAGE ip -j link show
 
     container_tap_mtu="$(ether_get_mtu "${output}")"
@@ -407,7 +406,7 @@ function teardown() {
            "Container's default MTU not 65220 bytes by default"
 }
 
-@test "podman networking with pasta(1) - MTU assignment" {
+@test "MTU assignment" {
     run_podman run --net=pasta:-m,1280 $IMAGE ip -j link show
 
     container_tap_mtu="$(ether_get_mtu "${output}")"
@@ -416,7 +415,7 @@ function teardown() {
            "Container's default MTU not matching configured 1280 bytes"
 }
 
-@test "podman networking with pasta(1) - Loopback interface state" {
+@test "Loopback interface state" {
     run_podman run --net=pasta $IMAGE ip -j link show
 
     local jq_expr='.[] | select(.link_type == "loopback").flags | '\
@@ -430,7 +429,7 @@ function teardown() {
 
 ### DNS ########################################################################
 
-@test "podman networking with pasta(1) - External resolver, IPv4" {
+@test "External resolver, IPv4" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman '?' run --net=pasta $IMAGE nslookup 127.0.0.1
@@ -439,7 +438,7 @@ function teardown() {
            "127.0.0.1 not resolved"
 }
 
-@test "podman networking with pasta(1) - External resolver, IPv6" {
+@test "External resolver, IPv6" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     run_podman run --net=pasta $IMAGE nslookup ::1 || :
@@ -448,7 +447,7 @@ function teardown() {
            "::1 not resolved"
 }
 
-@test "podman networking with pasta(1) - Local forwarder, IPv4" {
+@test "Local forwarder, IPv4" {
     if [[ "$CIRRUS_CI" == "true" ]] && [[ "$DISTRO_NV" == "debian-13" ]]; then
         skip "FIXME: Needs passt 0.0~git20230625.32660ce-1 or later in debian SID, unavailable 8-2023."
     fi
@@ -461,7 +460,7 @@ function teardown() {
     assert "$output" =~ "1.0.0.127.in-addr.arpa" "No answer from resolver"
 }
 
-@test "podman networking with pasta(1) - Local forwarder, IPv6" {
+@test "Local forwarder, IPv6" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
     # TODO: Two issues here:
@@ -489,280 +488,280 @@ function teardown() {
 
 ### TCP/IPv4 Port Forwarding ###################################################
 
-@test "podman networking with pasta(1) - Single TCP port forwarding, IPv4, tap" {
+@test "Single TCP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Single TCP port forwarding, IPv4, loopback" {
+@test "Single TCP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP port range forwarding, IPv4, tap" {
+@test "TCP port range forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP port range forwarding, IPv4, loopback" {
+@test "TCP port range forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated TCP port forwarding, IPv4, tap" {
+@test "Translated TCP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated TCP port forwarding, IPv4, loopback" {
+@test "Translated TCP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, tap" {
+@test "TCP translated port range forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP translated port range forwarding, IPv4, loopback" {
+@test "TCP translated port range forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv4, tap" {
+@test "Address-bound TCP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv4, loopback" {
+@test "Address-bound TCP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound TCP port forwarding, IPv4, tap" {
+@test "Interface-bound TCP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound TCP port forwarding, IPv4, loopback" {
+@test "Interface-bound TCP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
 ### TCP/IPv6 Port Forwarding ###################################################
 
-@test "podman networking with pasta(1) - Single TCP port forwarding, IPv6, tap" {
+@test "Single TCP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Single TCP port forwarding, IPv6, loopback" {
+@test "Single TCP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP port range forwarding, IPv6, tap" {
+@test "TCP port range forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP port range forwarding, IPv6, loopback" {
+@test "TCP port range forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated TCP port forwarding, IPv6, tap" {
+@test "Translated TCP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated TCP port forwarding, IPv6, loopback" {
+@test "Translated TCP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, tap" {
+@test "TCP translated port range forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP translated port range forwarding, IPv6, loopback" {
+@test "TCP translated port range forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv6, tap" {
+@test "Address-bound TCP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound TCP port forwarding, IPv6, loopback" {
+@test "Address-bound TCP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound TCP port forwarding, IPv6, tap" {
+@test "Interface-bound TCP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound TCP port forwarding, IPv6, loopback" {
+@test "Interface-bound TCP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
 ### UDP/IPv4 Port Forwarding ###################################################
 
-@test "podman networking with pasta(1) - Single UDP port forwarding, IPv4, tap" {
+@test "Single UDP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Single UDP port forwarding, IPv4, loopback" {
+@test "Single UDP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP port range forwarding, IPv4, tap" {
+@test "UDP port range forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP port range forwarding, IPv4, loopback" {
+@test "UDP port range forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated UDP port forwarding, IPv4, tap" {
+@test "Translated UDP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated UDP port forwarding, IPv4, loopback" {
+@test "Translated UDP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP translated port range forwarding, IPv4, tap" {
+@test "UDP translated port range forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP translated port range forwarding, IPv4, loopback" {
+@test "UDP translated port range forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound UDP port forwarding, IPv4, tap" {
+@test "Address-bound UDP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound UDP port forwarding, IPv4, loopback" {
+@test "Address-bound UDP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound UDP port forwarding, IPv4, tap" {
+@test "Interface-bound UDP port forwarding, IPv4, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound UDP port forwarding, IPv4, loopback" {
+@test "Interface-bound UDP port forwarding, IPv4, loopback" {
     pasta_test_do
 }
 
 ### UDP/IPv6 Port Forwarding ###################################################
 
-@test "podman networking with pasta(1) - Single UDP port forwarding, IPv6, tap" {
+@test "Single UDP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Single UDP port forwarding, IPv6, loopback" {
+@test "Single UDP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP port range forwarding, IPv6, tap" {
+@test "UDP port range forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP port range forwarding, IPv6, loopback" {
+@test "UDP port range forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated UDP port forwarding, IPv6, tap" {
+@test "Translated UDP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Translated UDP port forwarding, IPv6, loopback" {
+@test "Translated UDP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP translated port range forwarding, IPv6, tap" {
+@test "UDP translated port range forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP translated port range forwarding, IPv6, loopback" {
+@test "UDP translated port range forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound UDP port forwarding, IPv6, tap" {
+@test "Address-bound UDP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Address-bound UDP port forwarding, IPv6, loopback" {
+@test "Address-bound UDP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound UDP port forwarding, IPv6, tap" {
+@test "Interface-bound UDP port forwarding, IPv6, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - Interface-bound UDP port forwarding, IPv6, loopback" {
+@test "Interface-bound UDP port forwarding, IPv6, loopback" {
     pasta_test_do
 }
 
 ### TCP/IPv4 transfer ##########################################################
 
-@test "podman networking with pasta(1) - TCP/IPv4 small transfer, tap" {
+@test "TCP/IPv4 small transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP/IPv4 small transfer, loopback" {
+@test "TCP/IPv4 small transfer, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP/IPv4 large transfer, tap" {
+@test "TCP/IPv4 large transfer, tap" {
     skip "FIXME: #20170 - test hangs"
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP/IPv4 large transfer, loopback" {
+@test "TCP/IPv4 large transfer, loopback" {
     pasta_test_do
 }
 
 ### TCP/IPv6 transfer ##########################################################
 
-@test "podman networking with pasta(1) - TCP/IPv6 small transfer, tap" {
+@test "TCP/IPv6 small transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP/IPv6 small transfer, loopback" {
+@test "TCP/IPv6 small transfer, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP/IPv6 large transfer, tap" {
+@test "TCP/IPv6 large transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - TCP/IPv6 large transfer, loopback" {
+@test "TCP/IPv6 large transfer, loopback" {
     pasta_test_do
 }
 
 ### UDP/IPv4 transfer ##########################################################
 
-@test "podman networking with pasta(1) - UDP/IPv4 small transfer, tap" {
+@test "UDP/IPv4 small transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP/IPv4 small transfer, loopback" {
+@test "UDP/IPv4 small transfer, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP/IPv4 large transfer, tap" {
+@test "UDP/IPv4 large transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP/IPv4 large transfer, loopback" {
+@test "UDP/IPv4 large transfer, loopback" {
     pasta_test_do
 }
 
 ### UDP/IPv6 transfer ##########################################################
 
-@test "podman networking with pasta(1) - UDP/IPv6 small transfer, tap" {
+@test "UDP/IPv6 small transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP/IPv6 small transfer, loopback" {
+@test "UDP/IPv6 small transfer, loopback" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP/IPv6 large transfer, tap" {
+@test "UDP/IPv6 large transfer, tap" {
     pasta_test_do
 }
 
-@test "podman networking with pasta(1) - UDP/IPv6 large transfer, loopback" {
+@test "UDP/IPv6 large transfer, loopback" {
     pasta_test_do
 }
 
 ### Lifecycle ##################################################################
 
-@test "podman networking with pasta(1) - pasta(1) quits when the namespace is gone" {
+@test "pasta(1) quits when the namespace is gone" {
     local pidfile="${PODMAN_TMPDIR}/pasta.pid"
 
     run_podman run "--net=pasta:--pid,${pidfile}" $IMAGE true
@@ -771,14 +770,14 @@ function teardown() {
 }
 
 ### Options ####################################################################
-@test "podman networking with pasta(1) - Unsupported protocol in port forwarding" {
+@test "Unsupported protocol in port forwarding" {
     local port=$(random_free_port "" "" tcp)
 
     run_podman 126 run --net=pasta -p "${port}:${port}/sctp" $IMAGE true
     is "$output" "Error: .*can't forward protocol: sctp"
 }
 
-@test "podman networking with pasta(1) - Use options from containers.conf" {
+@test "Use options from containers.conf" {
     skip_if_remote "containers.conf must be set for the server"
 
     containersconf=$PODMAN_TMPDIR/containers.conf


### PR DESCRIPTION
This is something I've long wanted in logs: an indicator of
which bats file the test lives in. As of v1.7.0 there is
now a way to do that, BATS_TEST_NAME_PREFIX. Use it. Logs
now look like:

     ok 14 [001] podman - shutdown engines
     ok 15 [005] podman info - basic test
     ...
     not ok 195 [065] podman cp - dot notation ....

(As a bonus, we can remove the super-long "test blah blah pasta"
duplication from 505.bats).

Also, removed no-longer-necessary (fingers crossed) debug code
for the recently fixed containers-storage umount/EINVAL flake.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```