### PR TITLE
Disable goproxy

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -235,6 +235,8 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 %endif
 
+export GOPROXY=direct
+
 LDFLAGS="-X %{ld_libpod}/define.buildInfo=$(date +%s) \
          -X %{ld_libpod}/config._installPrefix=%{_prefix} \
          -X %{ld_libpod}/config._etcDir=%{_sysconfdir} \


### PR DESCRIPTION
GOPROXY is currently causing build issues like so:
```
go: github.com/containernetworking/cni@v0.7.1: GOPROXY list is not the empty string, but contains no entries
```
    
This commit sets `GOPROXY=direct` in rpm spec file.
    
Ref: https://download.copr.fedorainfracloud.org/results/packit/containers-podman-20627/centos-stream+epel-next-9-aarch64/06611633-podman/builder-live.log.gz
    
[NO NEW TESTS NEEDED]


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
