### PR TITLE
Do not create /var/lib/containers/storage/tmp on boot

### DIFF
--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -3,7 +3,7 @@
 x /tmp/podman-run-*
 x /tmp/containers-user-*
 x /tmp/run-*/libpod
-D! /var/lib/containers/storage/tmp 0700 root root
+e! /var/lib/containers/storage/tmp
 D! /run/podman 0700 root root
 D! /var/lib/cni/networks
 # Remove /var/tmp/container_images* podman temporary directories on each


### PR DESCRIPTION
We seem to be creating this directory on boot, and I find no place where it is used. So remove it and leave it removed.

Based on discussion:
https://github.com/containers/podman/discussions/20576

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
