### PR TITLE
Fix socket mapping nits

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -669,24 +669,14 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 	}
 
 	logrus.Debug("waiting for ready notification")
-	var conn net.Conn
 	readyChan := make(chan error)
-	connChan := make(chan net.Conn)
-	go machine.ListenAndWaitOnSocket(readyChan, connChan, readyListen)
+	go machine.ListenAndWaitOnSocket(readyChan, readyListen)
 
 	if err := cmd.Start(); err != nil {
 		return err
 	}
 
 	err = <-readyChan
-	conn = <-connChan
-	if conn != nil {
-		defer func() {
-			if closeErr := conn.Close(); closeErr != nil {
-				logrus.Error(closeErr)
-			}
-		}()
-	}
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/hyperv/vsock.go
+++ b/pkg/machine/hyperv/vsock.go
@@ -274,16 +274,7 @@ func (hv *HVSockRegistryEntry) Listen() error {
 	}()
 
 	errChan := make(chan error)
-	connChan := make(chan net.Conn)
-	go machine.ListenAndWaitOnSocket(errChan, connChan, listener)
-	conn := <-connChan
+	go machine.ListenAndWaitOnSocket(errChan, listener)
 
-	if conn != nil {
-		defer func() {
-			if err := conn.Close(); err != nil {
-				logrus.Error(err)
-			}
-		}()
-	}
 	return <-errChan
 }

--- a/pkg/machine/sockets.go
+++ b/pkg/machine/sockets.go
@@ -30,16 +30,20 @@ func ReadySocketPath(runtimeDir, machineName string) string {
 // ListenAndWaitOnSocket waits for a new connection to the listener and sends
 // any error back through the channel. ListenAndWaitOnSocket is intended to be
 // used as a goroutine
-func ListenAndWaitOnSocket(errChan chan<- error, connChan chan<- net.Conn, listener net.Listener) {
+func ListenAndWaitOnSocket(errChan chan<- error, listener net.Listener) {
 	conn, err := listener.Accept()
 	if err != nil {
 		errChan <- err
-		connChan <- nil
 		return
 	}
 	_, err = bufio.NewReader(conn).ReadString('\n')
+
+	if closeErr := conn.Close(); closeErr != nil {
+		errChan <- closeErr
+		return
+	}
+
 	errChan <- err
-	connChan <- conn
 }
 
 // DialSocketWithBackoffs attempts to connect to the socket in maxBackoffs attempts


### PR DESCRIPTION
Fixes nits that were suggested in #20420. The caller of `ListenAndWaitOnSocket` did not use the value returned by the conn channel, therefore it was better to just close the conn in the `ListenAndWaitOnSocket` function instead.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
