### PR TITLE
CI: e2e: fix a smattering of test bugs that slipped in

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -31,31 +31,43 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create container based on a remote image", func() {
-		session := podmanTest.Podman([]string{"create", "-q", BB_GLIBC, "ls"})
+		session := podmanTest.Podman([]string{"create", BB_GLIBC, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		Expect(session).Should(Exit(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull " + BB_GLIBC))
+		Expect(session.ErrorToString()).To(ContainSubstring("Writing manifest to image destination"))
+
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 	})
 
-	It("podman container create container based on a remote image", func() {
-		containerCreate := podmanTest.Podman([]string{"container", "create", "-q", BB_GLIBC, "ls"})
-		containerCreate.WaitWithDefaultTimeout()
-		Expect(containerCreate).Should(ExitCleanly())
-
-		lock := GetPortLock("5000")
+	It("podman container create --tls-verify", func() {
+		port := "5040"
+		lock := GetPortLock(port)
 		defer lock.Unlock()
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", port + ":5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
 		if !WaitContainerReady(podmanTest, "registry", "listening on", 20, 1) {
-			Skip("Cannot start docker registry.")
+			Fail("Cannot start docker registry.")
 		}
 
-		create := podmanTest.Podman([]string{"container", "create", "--tls-verify=false", ALPINE})
+		pushedImage := "localhost:" + port + "/pushed" + strings.ToLower(RandomString(5)) + ":" + RandomString(8)
+		push := podmanTest.Podman([]string{"push", "--tls-verify=false", ALPINE, pushedImage})
+		push.WaitWithDefaultTimeout()
+		Expect(push).To(Exit(0))
+		Expect(push.ErrorToString()).To(ContainSubstring("Writing manifest to image destination"))
+
+		create := podmanTest.Podman([]string{"container", "create", pushedImage})
 		create.WaitWithDefaultTimeout()
-		Expect(create).Should(ExitCleanly())
-		Expect(podmanTest.NumberOfContainers()).To(Equal(3))
+		Expect(create).Should(Exit(125))
+		Expect(create.ErrorToString()).To(ContainSubstring("pinging container registry localhost:" + port))
+		Expect(create.ErrorToString()).To(ContainSubstring("http: server gave HTTP response to HTTPS client"))
+
+		create = podmanTest.Podman([]string{"create", "--tls-verify=false", pushedImage, "echo", "got here"})
+		create.WaitWithDefaultTimeout()
+		Expect(create).Should(Exit(0))
+		Expect(create.ErrorToString()).To(ContainSubstring("Trying to pull " + pushedImage))
 	})
 
 	It("podman create using short options", func() {


### PR DESCRIPTION
...while Ed was napping:
 - create/run based on remote image: was not actually testing anything
 - create/run --tls-verify: ditto
 - run --decryption-key: sort of testing but not really
 - Fail(), not Skip(), if we can't start registry.
 - never Skip() halfway through a test: emit a message, and return

The Skip-in-the-middle thing deserves to be shouted from the rooftops.
Let's please never do that again. Skip() says "this entire test was
skipped", which can be misleading to a spelunker trying to track
down a problem related to those tests.

Also, more minor:
 - reduce use of port 5000
 - rename a confusingly-named test

Ref: #11205, #12009

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```