### PR TITLE
[CI:DOCS] Improve the documentation of quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -25,6 +25,9 @@ Podman supports starting containers (and creating volumes) via systemd by using 
 [systemd generator](https://www.freedesktop.org/software/systemd/man/systemd.generator.html).
 These files are read during boot (and when `systemctl daemon-reload` is run) and generate
 corresponding regular systemd service unit files. Both system and user systemd units are supported.
+All options and tables available in standard systemd unit files are supported. For example, options defined in
+the [Service] table and [Install] tables pass directly to systemd and are handled by it.
+See systemd.unit(5) man page for more information.
 
 The Podman generator reads the search paths above and reads files with the extensions `.container`
 `.volume` and `*.kube`, and for each file generates a similarly named `.service` file. Be aware that
@@ -1219,6 +1222,8 @@ Exec=sleep 60
 Restart=always
 # Extend Timeout to allow time to pull the image
 TimeoutStartSec=900
+# ExecStartPre flag and other systemd commands can go here, see systemd.unit(5) man page.
+ExecStartPre=/usr/share/mincontainer/setup.sh
 
 [Install]
 # Start by default on boot
@@ -1263,3 +1268,4 @@ Label=org.test.Key=value
 **[podman-run(1)](podman-run.1.md)**,
 **[podman-network-create(1)](podman-network-create.1.md)**,
 **[podman-auto-update(1)](podman-auto-update.1.md)**
+**[systemd.unit(5)]**


### PR DESCRIPTION
Users fail to realize that they can use other systemd options within the quadlet files, like ExecStartPre. This change should make it clearer to the users.

https://github.com/containers/podman/discussions/20642

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
