### PR TITLE
RHEL-14922: accept a config blob alongside the "changes" slice when committing

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -400,7 +400,7 @@ func createPodIfNecessary(cmd *cobra.Command, s *specgen.SpecGenerator, netOpts 
 	var err error
 	uns := specgen.Namespace{NSMode: specgen.Default}
 	if cliVals.UserNS != "" {
-		uns, err = specgen.ParseNamespace(cliVals.UserNS)
+		uns, err = specgen.ParseUserNamespace(cliVals.UserNS)
 		if err != nil {
 			return err
 		}

--- a/docs/source/markdown/options/volume.image.md
+++ b/docs/source/markdown/options/volume.image.md
@@ -4,9 +4,8 @@
 ####> are applicable to all of those.
 #### **--volume**, **-v**=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*
 
-Create a bind mount. Specifying the `-v /HOST-DIR:/CONTAINER-DIR` option, Podman
-bind mounts `/HOST-DIR` from the host to `/CONTAINER-DIR` in the Podman
-container.
+Mount a host directory into containers when executing RUN instructions during
+the build.
 
 The `OPTIONS` are a comma-separated list and can be: <sup>[[1]](#Footnote1)</sup>
 
@@ -17,12 +16,9 @@ The `OPTIONS` are a comma-separated list and can be: <sup>[[1]](#Footnote1)</sup
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
 must be an absolute path as well. Podman bind-mounts the `HOST-DIR` to the
-specified path. For example, when specifying the host path `/foo`,
-Podman copies the contents of `/foo` to the container filesystem on the host
-and bind mounts that into the container.
+specified path when processing RUN instructions.
 
-You can specify multiple  **-v** options to mount one or more mounts to a
-container.
+You can specify multiple  **-v** options to mount one or more mounts.
 
 You can add the `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -36,6 +36,13 @@ Apply the following possible instructions to the created image:
 
 Can be set multiple times.
 
+#### **--config**=*ConfigBlobFile*
+
+Merge the container configuration from the specified file into the configuration for the image
+as it is being committed. The file contents should be a JSON-encoded version of
+a Schema2Config structure, which is defined at
+https://github.com/containers/image/blob/v5.29.0/manifest/docker_schema2.go#L67.
+
 #### **--format**, **-f**=**oci** | *docker*
 
 Set the format of the image manifest and metadata.  The currently supported formats are **oci** and *docker*.\

--- a/pkg/api/handlers/changes.go
+++ b/pkg/api/handlers/changes.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"strings"
+	"unicode"
+)
+
+// DecodeChanges reads one or more changes from a slice and cleans them up,
+// since what we've advertised as being acceptable in the past isn't really.
+func DecodeChanges(changes []string) []string {
+	result := make([]string, 0, len(changes))
+	for _, possiblyMultilineChange := range changes {
+		for _, change := range strings.Split(possiblyMultilineChange, "\n") {
+			// In particular, we document that we accept values
+			// like "CMD=/bin/sh", which is not valid Dockerfile
+			// syntax, so we can't just pass such a value directly
+			// to a parser that's going to rightfully reject it.
+			// If we trim the string of whitespace at both ends,
+			// and the first occurrence of "=" is before the first
+			// whitespace, replace that "=" with whitespace.
+			change = strings.TrimSpace(change)
+			if change == "" {
+				continue
+			}
+			firstEqualIndex := strings.Index(change, "=")
+			firstSpaceIndex := strings.IndexFunc(change, unicode.IsSpace)
+			if firstEqualIndex != -1 && (firstSpaceIndex == -1 || firstEqualIndex < firstSpaceIndex) {
+				change = change[:firstEqualIndex] + " " + change[firstEqualIndex+1:]
+			}
+			result = append(result, change)
+		}
+	}
+	return result
+}

--- a/pkg/api/handlers/changes_test.go
+++ b/pkg/api/handlers/changes_test.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeChanges(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       string
+		output      []string
+	}{
+		{
+			description: "nothing",
+			input:       "",
+			output:      []string{},
+		},
+		{
+			description: "space",
+			input:       `CMD=/bin/bash`,
+			output:      []string{"CMD /bin/bash"},
+		},
+		{
+			description: "equal",
+			input:       `CMD=/bin/bash`,
+			output:      []string{"CMD /bin/bash"},
+		},
+		{
+			description: "both-but-right-first",
+			input:       `LABEL A=B`,
+			output:      []string{"LABEL A=B"},
+		},
+		{
+			description: "both-but-right-second",
+			input:       `LABEL A=B C=D`,
+			output:      []string{"LABEL A=B C=D"},
+		},
+		{
+			description: "both-but-wrong",
+			input:       `LABEL=A=B C=D`,
+			output:      []string{"LABEL A=B C=D"},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			output := DecodeChanges([]string{testCase.input})
+			assert.Equalf(t, testCase.output, output, "decoded value was not what we expected")
+		})
+	}
+}

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -483,6 +483,13 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		SystemContext:         sc,
 		PreferredManifestType: mimeType,
 	}
+	if r.Body != nil {
+		defer r.Body.Close()
+		if options.CommitOptions.OverrideConfig, err = abi.DecodeOverrideConfig(r.Body); err != nil {
+			utils.Error(w, http.StatusBadRequest, err)
+			return
+		}
+	}
 	if len(query.Tag) > 0 {
 		tag = query.Tag
 	}
@@ -490,7 +497,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	options.Author = query.Author
 	options.Pause = query.Pause
 	options.Squash = query.Squash
-	options.Changes = query.Changes
+	options.Changes = handlers.DecodeChanges(query.Changes)
 	ctr, err := runtime.LookupContainer(query.Container)
 	if err != nil {
 		utils.Error(w, http.StatusNotFound, err)

--- a/pkg/bindings/containers/commit.go
+++ b/pkg/bindings/containers/commit.go
@@ -33,7 +33,11 @@ func Commit(ctx context.Context, nameOrID string, options *CommitOptions) (entit
 		return entities.IDResponse{}, err
 	}
 	params.Set("container", nameOrID)
-	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/commit", params, nil)
+	var requestBody io.Reader
+	if options.Config != nil {
+		requestBody = *options.Config
+	}
+	response, err := conn.DoRequest(ctx, requestBody, http.MethodPost, "/commit", params, nil)
 	if err != nil {
 		return id, err
 	}

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -29,6 +29,7 @@ type LogOptions struct {
 type CommitOptions struct {
 	Author  *string
 	Changes []string
+	Config  *io.Reader `schema:"-"`
 	Comment *string
 	Format  *string
 	Pause   *bool

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -2,6 +2,7 @@
 package containers
 
 import (
+	"io"
 	"net/url"
 
 	"github.com/containers/podman/v4/pkg/bindings/internal/util"
@@ -45,6 +46,21 @@ func (o *CommitOptions) GetChanges() []string {
 		return z
 	}
 	return o.Changes
+}
+
+// WithConfig set field Config to given value
+func (o *CommitOptions) WithConfig(value io.Reader) *CommitOptions {
+	o.Config = &value
+	return o
+}
+
+// GetConfig returns value of field Config
+func (o *CommitOptions) GetConfig() io.Reader {
+	if o.Config == nil {
+		var z io.Reader
+		return z
+	}
+	return *o.Config
 }
 
 // WithComment set field Comment to given value

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -164,6 +164,7 @@ type ContainerStatReport struct {
 type CommitOptions struct {
 	Author         string
 	Changes        []string
+	Config         []byte
 	Format         string
 	ImageName      string
 	IncludeVolumes bool

--- a/pkg/domain/infra/abi/config.go
+++ b/pkg/domain/infra/abi/config.go
@@ -1,0 +1,22 @@
+package abi
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/containers/image/v5/manifest"
+)
+
+// DecodeOverrideConfig reads a Schema2Config from a Reader, suppressing EOF
+// errors.
+func DecodeOverrideConfig(reader io.Reader) (*manifest.Schema2Config, error) {
+	config := manifest.Schema2Config{}
+	if reader != nil {
+		err := json.NewDecoder(reader).Decode(&config)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
+	}
+	return &config, nil
+}

--- a/pkg/domain/infra/abi/config_test.go
+++ b/pkg/domain/infra/abi/config_test.go
@@ -1,0 +1,56 @@
+package abi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/containers/image/v5/manifest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeOverrideConfig(t *testing.T) {
+	testCases := []struct {
+		description   string
+		body          string
+		expectedValue *manifest.Schema2Config
+		expectedError bool
+	}{
+		{
+			description:   "nothing",
+			body:          ``,
+			expectedValue: &manifest.Schema2Config{},
+		},
+		{
+			description:   "empty",
+			body:          `{}`,
+			expectedValue: &manifest.Schema2Config{},
+		},
+		{
+			description:   "user",
+			body:          `{"User":"0:0"}`,
+			expectedValue: &manifest.Schema2Config{User: "0:0"},
+		},
+		{
+			description:   "malformed",
+			body:          `{"User":`,
+			expectedError: true,
+		},
+	}
+	t.Run("no reader", func(t *testing.T) {
+		value, err := DecodeOverrideConfig(nil)
+		assert.NoErrorf(t, err, "decoding nothing")
+		assert.NotNilf(t, value, "decoded value was unexpectedly nil")
+	})
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			value, err := DecodeOverrideConfig(strings.NewReader(testCase.body))
+			if testCase.expectedError {
+				assert.Errorf(t, err, "decoding sample data")
+			} else {
+				assert.NoErrorf(t, err, "decoding sample data")
+				assert.NotNilf(t, value, "decoded value was unexpectedly nil")
+				assert.Equalf(t, *testCase.expectedValue, *value, "decoded value was not what we expected")
+			}
+		})
+	}
+}

--- a/test/apiv2/14-commit.at
+++ b/test/apiv2/14-commit.at
@@ -1,0 +1,30 @@
+# Create a container for testing the container initializing later
+podman create -t -i --name myctr $IMAGE ls
+
+config=$(mktemp -t config.XXXXXXXXXX.json)
+cat > "$config" <<- EOF
+{
+  "Entrypoint": ["/bin/crash"],
+  "Cmd": ["and", "burn"],
+  "Labels": {"for": "ever", "and": "ever"}
+}
+EOF
+
+# Create a new image based on the container
+t POST 'libpod/commit?container=myctr&repo=nativeimage&tag=1' $config 200
+
+# Check some things
+t GET libpod/images/nativeimage:1/json 200 ".Config.Cmd=$(jq .Cmd $config)" ".Config.Entrypoint=$(jq .Entrypoint $config)"
+
+# Create a new image based on the container
+t POST 'commit?container=myctr&repo=compatimage&tag=1' $config 201
+
+# Check some things
+t GET images/compatimage:1/json 200 ".Config.Cmd=$(jq .Cmd $config)" ".Config.Entrypoint=$(jq .Entrypoint $config)"
+
+# Clean up
+t DELETE containers/myctr 204
+t DELETE images/nativeimage:1 200
+t DELETE images/compatimage:1 200
+rm -f "$config"
+unset config


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
`podman container commit` now features a `--config` option which accepts a filename containing a JSON-encoded container configuration to be merged in to the newly-created image.
```

Fixes #13770.