### PR TITLE
[CI:DOCS] Pass secrets from the host down to internal podman containers

### DIFF
--- a/contrib/podmanimage/stable/Containerfile
+++ b/contrib/podmanimage/stable/Containerfile
@@ -41,6 +41,9 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            /usr/share/containers/storage.conf \
            > /etc/containers/storage.conf
 
+# Setup internal Podman to pass subscriptions down from host to internal container
+RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
+
 # Note VOLUME options must always happen after the chown call above
 # RUN commands can not modify existing volumes
 VOLUME /var/lib/containers

--- a/contrib/podmanimage/testing/Containerfile
+++ b/contrib/podmanimage/testing/Containerfile
@@ -40,6 +40,9 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            /usr/share/containers/storage.conf \
            > /etc/containers/storage.conf
 
+# Setup internal Podman to pass secrets/subscriptions down from host to internal container
+RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
+
 # Note VOLUME options must always happen after the chown call above
 # RUN commands can not modify existing volumes
 VOLUME /var/lib/containers

--- a/contrib/podmanimage/upstream/Containerfile
+++ b/contrib/podmanimage/upstream/Containerfile
@@ -47,6 +47,9 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            /usr/share/containers/storage.conf \
            > /etc/containers/storage.conf
 
+# Setup internal Podman to pass secrets/subscriptions down from host to internal container
+RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
+
 # Note VOLUME options must always happen after the chown call above
 # RUN commands can not modify existing volumes
 VOLUME /var/lib/containers


### PR DESCRIPTION
This change will allow RHEL subscriptions from the host to flow to internal containers.

Fixes: https://github.com/containers/common/issues/1735

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
RHEL Subscriptions from the host now flow through to quay.io/podman/* images
```
