### PR TITLE
"[CI:DOCS]" Update podman-stats.1.md.in

### DIFF
--- a/docs/source/markdown/podman-stats.1.md.in
+++ b/docs/source/markdown/podman-stats.1.md.in
@@ -58,7 +58,7 @@ Valid placeholders for the Go template are listed below:
 | .PIDS               | Number of PIDs (yes, we know it's a dup)         |
 | .SystemNano         | Current system datetime, nanoseconds since epoch |
 | .Up                 | Duration (CPUNano), in human-readable form       |
-| .UpTime             | Same as UpTime                                   |
+| .UpTime             | Same as Up                                   |
 
 [1] Cgroups V1 only
 


### PR DESCRIPTION
```release-note
The description for uptime was "Same as upTime", changed it to be "same as Up", as up has a description, and saying that upTime does the same as upTime isn't particularly descriptive!
```
