### PR TITLE
[CI:DOCS] docs: fix relabeling command

### DIFF
--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -86,7 +86,7 @@ on each file, if the volume has thousands of inodes, this process takes a
 long time, delaying the start of the <<container|pod>>. If the volume
 was previously relabeled with the `z` option, Podman is optimized to not relabel
 a second time. If files are moved into the volume, then the labels can be
-manually change with the `chcon -R container_file_t PATH` command.
+manually change with the `chcon -Rt container_file_t PATH` command.
 
 Note: Do not relabel system files and directories. Relabeling system content
 might cause other confined services on the machine to fail.  For these types


### PR DESCRIPTION
Fixes the `chcon` relabeling command in the podman volume options docs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
