### PR TITLE
Create `pkg/machine/ignition` package

### DIFF
--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -187,7 +187,7 @@ func composeDockerHost() (string, error) {
 		if info.State != define.Running {
 			return "", fmt.Errorf("machine %s is not running but in state %s", item.Name, info.State)
 		}
-		if machineProvider.VMType() == machine.WSLVirt {
+		if machineProvider.VMType() == define.WSLVirt {
 			if info.ConnectionInfo.PodmanPipe == nil {
 				return "", errors.New("pipe of machine is not set")
 			}

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/spf13/cobra"
 )
 
@@ -141,7 +142,7 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	}
 
 	// The vmtype names need to be reserved and cannot be used for podman machine names
-	if _, err := machine.ParseVMType(initOpts.Name, machine.UnknownVirt); err == nil {
+	if _, err := define.ParseVMType(initOpts.Name, define.UnknownVirt); err == nil {
 		return fmt.Errorf("cannot use %q for a machine name", initOpts.Name)
 	}
 

--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/compression"
 	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
+	"github.com/containers/podman/v4/pkg/machine/ignition"
 	vfConfig "github.com/crc-org/vfkit/pkg/config"
 	"github.com/docker/go-units"
 	"golang.org/x/sys/unix"
@@ -55,7 +56,7 @@ func (v AppleHVVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
 }
 
 func (v AppleHVVirtualization) IsValidVMName(name string) (bool, error) {
-	configDir, err := machine.GetConfDir(machine.AppleHvVirt)
+	configDir, err := machine.GetConfDir(define.AppleHvVirt)
 	if err != nil {
 		return false, err
 	}
@@ -93,7 +94,7 @@ func (v AppleHVVirtualization) List(opts machine.ListOptions) ([]*machine.ListRe
 			Running:        vmState == define.Running,
 			Starting:       vmState == define.Starting,
 			Stream:         mm.ImageStream,
-			VMType:         machine.AppleHvVirt.String(),
+			VMType:         define.AppleHvVirt.String(),
 			CPUs:           mm.CPUs,
 			Memory:         mm.Memory * units.MiB,
 			DiskSize:       mm.DiskSize * units.GiB,
@@ -118,7 +119,7 @@ func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM,
 		return nil, fmt.Errorf("USB host passthrough is not supported for applehv machines")
 	}
 
-	configDir, err := machine.GetConfDir(machine.AppleHvVirt)
+	configDir, err := machine.GetConfDir(define.AppleHvVirt)
 	if err != nil {
 		return nil, err
 	}
@@ -129,12 +130,12 @@ func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM,
 	}
 	m.ConfigPath = *configPath
 
-	dataDir, err := machine.GetDataDir(machine.AppleHvVirt)
+	dataDir, err := machine.GetDataDir(define.AppleHvVirt)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := machine.SetIgnitionFile(&m.IgnitionFile, vmtype, m.Name); err != nil {
+	if err := ignition.SetIgnitionFile(&m.IgnitionFile, vmtype, m.Name, configDir); err != nil {
 		return nil, err
 	}
 
@@ -161,7 +162,7 @@ func (v AppleHVVirtualization) RemoveAndCleanMachines() error {
 	return machine.ErrNotImplemented
 }
 
-func (v AppleHVVirtualization) VMType() machine.VMType {
+func (v AppleHVVirtualization) VMType() define.VMType {
 	return vmtype
 }
 

--- a/pkg/machine/define/vmtype.go
+++ b/pkg/machine/define/vmtype.go
@@ -1,0 +1,54 @@
+package define
+
+import (
+	"fmt"
+	"strings"
+)
+
+type VMType int64
+
+const (
+	QemuVirt VMType = iota
+	WSLVirt
+	AppleHvVirt
+	HyperVVirt
+	UnknownVirt
+)
+
+// these constants are not exported due to a conflict with the constants defined
+// in define/machine_artifact.go
+const (
+	wsl     = "wsl"
+	qemu    = "qemu"
+	appleHV = "applehv"
+	hyperV  = "hyperv"
+)
+
+func (v VMType) String() string {
+	switch v {
+	case WSLVirt:
+		return wsl
+	case AppleHvVirt:
+		return appleHV
+	case HyperVVirt:
+		return hyperV
+	}
+	return qemu
+}
+
+func ParseVMType(input string, emptyFallback VMType) (VMType, error) {
+	switch strings.TrimSpace(strings.ToLower(input)) {
+	case qemu:
+		return QemuVirt, nil
+	case wsl:
+		return WSLVirt, nil
+	case appleHV:
+		return AppleHvVirt, nil
+	case hyperV:
+		return HyperVVirt, nil
+	case "":
+		return emptyFallback, nil
+	default:
+		return UnknownVirt, fmt.Errorf("unknown VMType `%s`", input)
+	}
+}

--- a/pkg/machine/define/vmtype_test.go
+++ b/pkg/machine/define/vmtype_test.go
@@ -1,0 +1,58 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
+// +build amd64,!windows arm64,!windows
+
+package define
+
+import "testing"
+
+func TestParseVMType(t *testing.T) {
+	type fields struct {
+		input    string
+		fallback VMType
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   VMType
+	}{
+		{
+			name:   "Qemu input",
+			fields: fields{"qemu", QemuVirt},
+			want:   QemuVirt,
+		},
+		{
+			name:   "Applehv input",
+			fields: fields{"applehv", QemuVirt},
+			want:   AppleHvVirt,
+		},
+		{
+			name:   "Hyperv input",
+			fields: fields{"hyperv", QemuVirt},
+			want:   HyperVVirt,
+		},
+		{
+			name:   "WSL input",
+			fields: fields{"wsl", QemuVirt},
+			want:   WSLVirt,
+		},
+		{
+			name:   "Qemu empty fallback",
+			fields: fields{"", QemuVirt},
+			want:   QemuVirt,
+		},
+		{
+			name:   "Invalid input",
+			fields: fields{"riscv", AppleHvVirt},
+			want:   UnknownVirt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := ParseVMType(tt.fields.input, tt.fields.fallback); got != tt.want {
+				t.Errorf("ParseVMType(%s, %v) = %v, want %v", tt.fields.input, tt.fields.fallback, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
@@ -210,29 +211,29 @@ func (matcher *ValidJSONMatcher) NegatedFailureMessage(actual interface{}) (mess
 	return format.Message(actual, "to _not_ be valid JSON")
 }
 
-func skipIfVmtype(vmType machine.VMType, message string) {
+func skipIfVmtype(vmType define.VMType, message string) {
 	if isVmtype(vmType) {
 		Skip(message)
 	}
 }
 
-func skipIfNotVmtype(vmType machine.VMType, message string) {
+func skipIfNotVmtype(vmType define.VMType, message string) {
 	if !isVmtype(vmType) {
 		Skip(message)
 	}
 }
 
 func skipIfWSL(message string) {
-	skipIfVmtype(machine.WSLVirt, message)
+	skipIfVmtype(define.WSLVirt, message)
 }
 
-func isVmtype(vmType machine.VMType) bool {
+func isVmtype(vmType define.VMType) bool {
 	return testProvider.VMType() == vmType
 }
 
 // isWSL is a simple wrapper to determine if the testprovider is WSL
 func isWSL() bool {
-	return isVmtype(machine.WSLVirt)
+	return isVmtype(define.WSLVirt)
 }
 
 func getFCOSDownloadLocation(p machine.VirtProvider) string {

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/wsl"
 	. "github.com/onsi/ginkgo/v2"
 )
@@ -13,10 +14,10 @@ import (
 const podmanBinary = "../../../bin/windows/podman.exe"
 
 func getDownloadLocation(p machine.VirtProvider) string {
-	if p.VMType() == machine.HyperVVirt {
+	if p.VMType() == define.HyperVVirt {
 		return getFCOSDownloadLocation(p)
 	}
-	fd, err := wsl.NewFedoraDownloader(machine.WSLVirt, "", defaultStream.String())
+	fd, err := wsl.NewFedoraDownloader(define.WSLVirt, "", defaultStream.String())
 	if err != nil {
 		Fail("unable to get WSL virtual image")
 	}

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/utils"
 	. "github.com/onsi/ginkgo/v2"
@@ -80,7 +79,7 @@ var _ = Describe("podman machine init", func() {
 
 		testMachine := inspectBefore[0]
 		Expect(testMachine.Name).To(Equal(mb.names[0]))
-		if testProvider.VMType() != machine.WSLVirt { // WSL hardware specs are hardcoded
+		if testProvider.VMType() != define.WSLVirt { // WSL hardware specs are hardcoded
 			Expect(testMachine.Resources.CPUs).To(Equal(uint64(cpus)))
 			Expect(testMachine.Resources.Memory).To(Equal(uint64(2048)))
 		}
@@ -136,7 +135,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(inspectBefore).ToNot(BeEmpty())
 		testMachine := inspectBefore[0]
 		Expect(testMachine.Name).To(Equal(mb.names[0]))
-		if testProvider.VMType() != machine.WSLVirt { // memory and cpus something we cannot set with WSL
+		if testProvider.VMType() != define.WSLVirt { // memory and cpus something we cannot set with WSL
 			Expect(testMachine.Resources.CPUs).To(Equal(uint64(cpus)))
 			Expect(testMachine.Resources.Memory).To(Equal(uint64(2048)))
 		}
@@ -186,7 +185,7 @@ var _ = Describe("podman machine init", func() {
 	})
 
 	It("machine init with volume", func() {
-		if testProvider.VMType() == machine.HyperVVirt {
+		if testProvider.VMType() == define.HyperVVirt {
 			Skip("volumes are not supported on hyperv yet")
 		}
 		skipIfWSL("WSL volumes are much different.  This test will not pass as is")
@@ -262,7 +261,7 @@ var _ = Describe("podman machine init", func() {
 	})
 
 	It("init with user mode networking", func() {
-		if testProvider.VMType() != machine.WSLVirt {
+		if testProvider.VMType() != define.WSLVirt {
 			Skip("test is only supported by WSL")
 		}
 		i := new(initMachine)
@@ -327,7 +326,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).To(HaveOccurred())
 
 		// WSL does not use ignition
-		if testProvider.VMType() != machine.WSLVirt {
+		if testProvider.VMType() != define.WSLVirt {
 			_, err = os.Stat(ign)
 			Expect(err).To(HaveOccurred())
 		}

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	jsoniter "github.com/json-iterator/go"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -66,7 +67,7 @@ var _ = Describe("podman inspect stop", func() {
 		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
 		Expect(err).ToNot(HaveOccurred())
 		switch testProvider.VMType() {
-		case machine.WSLVirt:
+		case define.WSLVirt:
 			Expect(inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath()).To(ContainSubstring("podman-"))
 		default:
 			Expect(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()).To(HaveSuffix("podman.sock"))

--- a/pkg/machine/e2e/proxy_test.go
+++ b/pkg/machine/e2e/proxy_test.go
@@ -3,7 +3,7 @@ package e2e_test
 import (
 	"os"
 
-	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -24,7 +24,7 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 
 	It("ssh to running machine and check proxy settings", func() {
 		// https://github.com/containers/podman/issues/20129
-		if testProvider.VMType() == machine.HyperVVirt {
+		if testProvider.VMType() == define.HyperVVirt {
 			Skip("proxy settings not yet supported")
 		}
 		name := randomString()

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -120,7 +120,7 @@ var _ = Describe("podman machine rm", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// WSL does not use ignition
-		if testProvider.VMType() != machine.WSLVirt {
+		if testProvider.VMType() != define.WSLVirt {
 			_, err = os.Stat(ign)
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -76,7 +76,7 @@ var _ = Describe("podman machine set", func() {
 	})
 
 	It("wsl cannot change disk, memory, processor", func() {
-		skipIfNotVmtype(machine.WSLVirt, "tests are only for WSL provider")
+		skipIfNotVmtype(define.WSLVirt, "tests are only for WSL provider")
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
@@ -168,7 +168,7 @@ var _ = Describe("podman machine set", func() {
 	})
 
 	It("set user mode networking", func() {
-		if testProvider.VMType() != machine.WSLVirt {
+		if testProvider.VMType() != define.WSLVirt {
 			Skip("Test is only for WSL")
 		}
 		name := randomString()

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -1,7 +1,7 @@
 package e2e_test
 
 import (
-	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -44,7 +44,7 @@ var _ = Describe("podman machine ssh", func() {
 	})
 
 	It("ssh to running machine and check os-type", func() {
-		wsl := testProvider.VMType() == machine.WSLVirt
+		wsl := testProvider.VMType() == define.WSLVirt
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/compression"
 	"github.com/containers/podman/v4/pkg/machine/define"
+	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
 )
@@ -97,7 +98,7 @@ func (v HyperVVirtualization) List(opts machine.ListOptions) ([]*machine.ListRes
 			Running:        vm.State() == hypervctl.Enabled,
 			Starting:       mm.isStarting(),
 			Stream:         mm.ImageStream,
-			VMType:         machine.HyperVVirt.String(),
+			VMType:         define.HyperVVirt.String(),
 			CPUs:           mm.CPUs,
 			Memory:         mm.Memory * units.MiB,
 			DiskSize:       mm.DiskSize * units.GiB,
@@ -126,7 +127,7 @@ func (v HyperVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, 
 
 	m.RemoteUsername = opts.Username
 
-	configDir, err := machine.GetConfDir(machine.HyperVVirt)
+	configDir, err := machine.GetConfDir(define.HyperVVirt)
 	if err != nil {
 		return nil, err
 	}
@@ -138,14 +139,14 @@ func (v HyperVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, 
 
 	m.ConfigPath = *configPath
 
-	if err := machine.SetIgnitionFile(&m.IgnitionFile, vmtype, m.Name); err != nil {
+	if err := ignition.SetIgnitionFile(&m.IgnitionFile, vmtype, m.Name, configDir); err != nil {
 		return nil, err
 	}
 
 	// Set creation time
 	m.Created = time.Now()
 
-	dataDir, err := machine.GetDataDir(machine.HyperVVirt)
+	dataDir, err := machine.GetDataDir(define.HyperVVirt)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (v HyperVVirtualization) RemoveAndCleanMachines() error {
 	return prevErr
 }
 
-func (v HyperVVirtualization) VMType() machine.VMType {
+func (v HyperVVirtualization) VMType() define.VMType {
 	return vmtype
 }
 

--- a/pkg/machine/ignition/ignition_darwin.go
+++ b/pkg/machine/ignition/ignition_darwin.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package machine
+package ignition
 
 import (
 	"os"

--- a/pkg/machine/ignition/ignition_freebsd.go
+++ b/pkg/machine/ignition/ignition_freebsd.go
@@ -1,6 +1,6 @@
 //go:build freebsd
 
-package machine
+package ignition
 
 func getLocalTimeZone() (string, error) {
 	return "", nil

--- a/pkg/machine/ignition/ignition_linux.go
+++ b/pkg/machine/ignition/ignition_linux.go
@@ -1,4 +1,4 @@
-package machine
+package ignition
 
 import (
 	"errors"

--- a/pkg/machine/ignition/ignition_schema.go
+++ b/pkg/machine/ignition/ignition_schema.go
@@ -1,6 +1,6 @@
 //go:build amd64 || arm64
 
-package machine
+package ignition
 
 /*
 	This file was taken from https://github.com/coreos/ignition/blob/master/config/v3_2/types/schema.go in an effort to

--- a/pkg/machine/ignition/ignition_windows.go
+++ b/pkg/machine/ignition/ignition_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package machine
+package ignition
 
 func getLocalTimeZone() (string, error) {
 	return "", nil

--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/sirupsen/logrus"
 )
@@ -21,14 +22,14 @@ func Get() (machine.VirtProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := machine.ParseVMType(provider, machine.QemuVirt)
+	resolvedVMType, err := define.ParseVMType(provider, define.QemuVirt)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
-	case machine.QemuVirt:
+	case define.QemuVirt:
 		return qemu.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/applehv"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/sirupsen/logrus"
 )
@@ -20,16 +21,16 @@ func Get() (machine.VirtProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := machine.ParseVMType(provider, machine.AppleHvVirt)
+	resolvedVMType, err := define.ParseVMType(provider, define.AppleHvVirt)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
-	case machine.QemuVirt:
+	case define.QemuVirt:
 		return qemu.VirtualizationProvider(), nil
-	case machine.AppleHvVirt:
+	case define.AppleHvVirt:
 		return applehv.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/hyperv"
 	"github.com/containers/podman/v4/pkg/machine/wsl"
 	"github.com/sirupsen/logrus"
@@ -20,16 +21,16 @@ func Get() (machine.VirtProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := machine.ParseVMType(provider, machine.WSLVirt)
+	resolvedVMType, err := define.ParseVMType(provider, define.WSLVirt)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
-	case machine.WSLVirt:
+	case define.WSLVirt:
 		return wsl.VirtualizationProvider(), nil
-	case machine.HyperVVirt:
+	case define.HyperVVirt:
 		return hyperv.VirtualizationProvider(), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -28,7 +28,7 @@ type GenericDownload struct {
 }
 
 // NewGenericDownloader is used when the disk image is provided by the user
-func NewGenericDownloader(vmType VMType, vmName, pullPath string) (DistributionDownload, error) {
+func NewGenericDownloader(vmType define.VMType, vmName, pullPath string) (DistributionDownload, error) {
 	var (
 		imageName string
 	)

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/compression"
 	"github.com/containers/podman/v4/pkg/machine/define"
+	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/containers/podman/v4/pkg/machine/qemu/command"
 	"github.com/containers/podman/v4/pkg/machine/sockets"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
@@ -84,8 +85,13 @@ func (p *QEMUVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, e
 		return nil, err
 	}
 
+	confDir, err := machine.GetConfDir(vmtype)
+	if err != nil {
+		return nil, err
+	}
+
 	// set VM ignition file
-	if err := machine.SetIgnitionFile(&vm.IgnitionFile, vmtype, vm.Name); err != nil {
+	if err := ignition.SetIgnitionFile(&vm.IgnitionFile, vmtype, vm.Name, confDir); err != nil {
 		return nil, err
 	}
 
@@ -330,7 +336,7 @@ func (p *QEMUVirtualization) RemoveAndCleanMachines() error {
 	return prevErr
 }
 
-func (p *QEMUVirtualization) VMType() machine.VMType {
+func (p *QEMUVirtualization) VMType() define.VMType {
 	return vmtype
 }
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -23,6 +23,7 @@ import (
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/define"
+	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/containers/podman/v4/pkg/machine/qemu/command"
 	"github.com/containers/podman/v4/pkg/machine/sockets"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
@@ -36,7 +37,7 @@ import (
 var (
 	// vmtype refers to qemu (vs libvirt, krun, etc).
 	// Could this be moved into  Provider
-	vmtype = machine.QemuVirt
+	vmtype = define.QemuVirt
 )
 
 const (
@@ -208,11 +209,11 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		logrus.Warn("ignoring init option to disable user-mode networking: this mode is not supported by the QEMU backend")
 	}
 
-	builder := machine.NewIgnitionBuilder(machine.DynamicIgnition{
+	builder := ignition.NewIgnitionBuilder(ignition.DynamicIgnition{
 		Name:      opts.Username,
 		Key:       key,
 		VMName:    v.Name,
-		VMType:    machine.QemuVirt,
+		VMType:    define.QemuVirt,
 		TimeZone:  opts.TimeZone,
 		WritePath: v.getIgnitionFile(),
 		UID:       v.UID,
@@ -229,10 +230,10 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		return false, err
 	}
 
-	readyUnit := machine.Unit{
-		Enabled:  machine.BoolToPtr(true),
+	readyUnit := ignition.Unit{
+		Enabled:  ignition.BoolToPtr(true),
 		Name:     "ready.service",
-		Contents: machine.StrToPtr(fmt.Sprintf(qemuReadyUnit, "vport1p1", "vport1p1")),
+		Contents: ignition.StrToPtr(fmt.Sprintf(qemuReadyUnit, "vport1p1", "vport1p1")),
 	}
 	builder.WithUnit(readyUnit)
 
@@ -1222,7 +1223,7 @@ func (v *MachineVM) isIncompatible() bool {
 }
 
 func (v *MachineVM) userGlobalSocketLink() (string, error) {
-	path, err := machine.GetDataDir(machine.QemuVirt)
+	path, err := machine.GetDataDir(define.QemuVirt)
 	if err != nil {
 		logrus.Errorf("Resolving data dir: %s", err.Error())
 		return "", err
@@ -1233,7 +1234,7 @@ func (v *MachineVM) userGlobalSocketLink() (string, error) {
 
 func (v *MachineVM) forwardSocketPath() (*define.VMFile, error) {
 	sockName := "podman.sock"
-	path, err := machine.GetDataDir(machine.QemuVirt)
+	path, err := machine.GetDataDir(define.QemuVirt)
 	if err != nil {
 		logrus.Errorf("Resolving data dir: %s", err.Error())
 		return nil, err

--- a/pkg/machine/update.go
+++ b/pkg/machine/update.go
@@ -5,12 +5,13 @@ package machine
 import (
 	"fmt"
 
+	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/sirupsen/logrus"
 )
 
 func UpdatePodmanDockerSockService(vm VM, name string, uid int, rootful bool) error {
-	content := GetPodmanDockerTmpConfig(uid, rootful, false)
-	command := fmt.Sprintf("'echo %q > %s'", content, PodmanDockerTmpConfPath)
+	content := ignition.GetPodmanDockerTmpConfig(uid, rootful, false)
+	command := fmt.Sprintf("'echo %q > %s'", content, ignition.PodmanDockerTmpConfPath)
 	args := []string{"sudo", "bash", "-c", command}
 	if err := vm.SSH(name, SSHOptions{Args: args}); err != nil {
 		logrus.Warnf("Could not not update internal docker sock config")

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -230,6 +230,6 @@ func (p *WSLVirtualization) RemoveAndCleanMachines() error {
 	return prevErr
 }
 
-func (p *WSLVirtualization) VMType() machine.VMType {
+func (p *WSLVirtualization) VMType() define.VMType {
 	return vmtype
 }

--- a/pkg/machine/wsl/fedora.go
+++ b/pkg/machine/wsl/fedora.go
@@ -27,7 +27,7 @@ type FedoraDownload struct {
 	machine.Download
 }
 
-func NewFedoraDownloader(vmType machine.VMType, vmName, releaseStream string) (machine.DistributionDownload, error) {
+func NewFedoraDownloader(vmType define.VMType, vmName, releaseStream string) (machine.DistributionDownload, error) {
 	downloadURL, version, arch, size, err := getFedoraDownload()
 	if err != nil {
 		return nil, err

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
+	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/containers/podman/v4/pkg/machine/wsl/wutil"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/podman/v4/utils"
@@ -32,7 +33,7 @@ import (
 
 var (
 	// vmtype refers to qemu (vs libvirt, krun, etc)
-	vmtype = machine.WSLVirt
+	vmtype = define.WSLVirt
 )
 
 const (
@@ -717,9 +718,9 @@ func getBindMountFsTab(dist string) string {
 }
 
 func (v *MachineVM) setupPodmanDockerSock(dist string, rootful bool) error {
-	content := machine.GetPodmanDockerTmpConfig(1000, rootful, true)
+	content := ignition.GetPodmanDockerTmpConfig(1000, rootful, true)
 
-	if err := wslPipe(content, dist, "sh", "-c", "cat > "+machine.PodmanDockerTmpConfPath); err != nil {
+	if err := wslPipe(content, dist, "sh", "-c", "cat > "+ignition.PodmanDockerTmpConfPath); err != nil {
 		return fmt.Errorf("could not create internal docker sock conf: %w", err)
 	}
 


### PR DESCRIPTION
Moves all of the ignition files out of the `machine` package and into its own called `ignition`. This required `VMType` to get moved out of the `machine` package and into the `define` package in order to prevent a circular dependency.

Also uses the systemd parser UnitFile type to compose unit files instead of having hard-coded strings scattered around the files. 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
