### PR TITLE
[CI:DOCS] Machine test timeout env var

### DIFF
--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -99,6 +100,13 @@ func newMB() (*machineTestBuilder, error) {
 	mb.podmanBinary = filepath.Join(cwd, podmanBinary)
 	if os.Getenv("PODMAN_BINARY") != "" {
 		mb.podmanBinary = os.Getenv("PODMAN_BINARY")
+	}
+	if os.Getenv("MACHINE_TEST_TIMEOUT") != "" {
+		seconds, err := strconv.Atoi(os.Getenv("MACHINE_TEST_TIMEOUT"))
+		if err != nil {
+			return nil, err
+		}
+		mb.timeout = time.Duration(seconds) * time.Second
 	}
 	return &mb, nil
 }


### PR DESCRIPTION
Introduce MACHINE_TEST_TIMEOUT, which sets the timeout for machine tests, in seconds.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
