### PR TITLE
vmtypes names cannot be used as machine names

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -140,6 +140,12 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		}
 		initOpts.Name = args[0]
 	}
+
+	// The vmtype names need to be reserved and cannot be used for podman machine names
+	if _, err := machine.ParseVMType(initOpts.Name, machine.UnknownVirt); err == nil {
+		return fmt.Errorf("cannot use %q for a machine name", initOpts.Name)
+	}
+
 	if _, err := provider.LoadVMByName(initOpts.Name); err == nil {
 		return fmt.Errorf("%s: %w", initOpts.Name, machine.ErrVMAlreadyExists)
 	}

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -346,6 +346,7 @@ const (
 	WSLVirt
 	AppleHvVirt
 	HyperVVirt
+	UnknownVirt
 )
 
 func (v VMType) String() string {
@@ -383,7 +384,7 @@ func ParseVMType(input string, emptyFallback VMType) (VMType, error) {
 	case "":
 		return emptyFallback, nil
 	default:
-		return QemuVirt, fmt.Errorf("unknown VMType `%s`", input)
+		return UnknownVirt, fmt.Errorf("unknown VMType `%s`", input)
 	}
 }
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -41,6 +41,12 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(125))
 
+		reservedName := initMachine{}
+		reservedNameSession, err := mb.setName(testProvider.VMType().String()).setCmd(&reservedName).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reservedNameSession).To(Exit(125))
+		Expect(reservedNameSession.errorToString()).To(ContainSubstring(fmt.Sprintf("cannot use %q", testProvider.VMType().String())))
+
 		badName := "foobar"
 		bm := basicMachine{}
 		sysConn, err := mb.setCmd(bm.withPodmanCommand([]string{"system", "connection", "add", badName, "tcp://localhost:8000"})).run()


### PR DESCRIPTION
florent found a bug where he used "applehv" as a machine name.  it turns out when we use a vmtype name, esp. the active type, it really messes up directory structures for configuration and images alike.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
"applehv","qemu", "wsl", and "hyperv" are no longer valid podman machine names
```
