### PR TITLE
Use configured timeout in list_test.go

### DIFF
--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -94,7 +94,9 @@ var _ = Describe("podman machine list", func() {
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).runWithoutWait()
 		Expect(err).ToNot(HaveOccurred())
-		for i := 0; i < 30; i++ {
+		wait := 3
+		retries := (int)(mb.timeout/time.Second) / wait
+		for i := 0; i < retries; i++ {
 			listSession, err := mb.setCmd(l).run()
 			Expect(listSession).To(Exit(0))
 			Expect(err).ToNot(HaveOccurred())
@@ -103,7 +105,7 @@ var _ = Describe("podman machine list", func() {
 			} else {
 				break
 			}
-			time.Sleep(3 * time.Second)
+			time.Sleep(time.Duration(wait) * time.Second)
 		}
 		Expect(startSession).To(Exit(0))
 		listSession, err = mb.setCmd(l).run()


### PR DESCRIPTION
A follow up to https://github.com/containers/podman/commit/3d88f614f7ffb24417af6ce4776e96887f3c772c by @ashley-cui  This will honor the value configured via env var in the very specific "check if running while starting" test case, where session is started w/o wait.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
