### PR TITLE
If API calls for kube play --replace, then replace pod

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -714,6 +714,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		podSpec.PodSpecGen.ServiceContainerID = serviceContainer.ID()
 	}
 
+	if options.Replace {
+		if _, err := ic.PodRm(ctx, []string{podName}, entities.PodRmOptions{Force: true, Ignore: true}); err != nil {
+			return nil, nil, fmt.Errorf("replacing pod %v: %w", podName, err)
+		}
+	}
 	// Create the Pod
 	pod, err := generate.MakePod(&podSpec, ic.Libpod)
 	if err != nil {

--- a/test/apiv2/80-kube.at
+++ b/test/apiv2/80-kube.at
@@ -48,6 +48,13 @@ t POST   libpod/kube/play $YAML 200 \
   .Pods[0].ContainerErrors=null \
   .Pods[0].Containers[0]~[0-9a-f]\\{64\\}
 
+t POST   libpod/kube/play $YAML 500
+
+t POST   'libpod/kube/play?replace=true' $YAML 200 \
+  .Pods[0].ID~[0-9a-f]\\{64\\} \
+  .Pods[0].ContainerErrors=null \
+  .Pods[0].Containers[0]~[0-9a-f]\\{64\\}
+
 t DELETE libpod/kube/play $YAML 200 \
   .StopReport[0].Id~[0-9a-f]\\{64\\} \
   .RmReport[0].Id~[0-9a-f]\\{64\\}


### PR DESCRIPTION
Currently if user specifies podman kube play --replace, the pod is removed on the client side, not the server side.  If the API is called with replace=true, the pod was not being removed and this called the API to fail. This PR removes the pod if it exists and the caller specifies replace=true.

Fixes: https://github.com/containers/podman/discussions/20705

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remote API for podman kube play now supports replace=true
```
