### PR TITLE
Ignore SELinux relabel on unsupported file systems

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2514,7 +2514,7 @@ func (c *Container) extractSecretToCtrStorage(secr *ContainerSecret) error {
 	if err := os.Chmod(secretFile, os.FileMode(secr.Mode)); err != nil {
 		return err
 	}
-	if err := label.Relabel(secretFile, c.config.MountLabel, false); err != nil {
+	if err := c.relabel(secretFile, c.config.MountLabel, false); err != nil {
 		return err
 	}
 	return nil

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -440,7 +440,10 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 		// this is important, otherwise the iptables command will fail
 		err = label.Relabel(runDir, "system_u:object_r:iptables_var_run_t:s0", false)
 		if err != nil {
-			return nil, fmt.Errorf("could not create relabel rootless-netns run directory: %w", err)
+			if !errors.Is(err, unix.ENOTSUP) {
+				return nil, fmt.Errorf("could not create relabel rootless-netns run directory: %w", err)
+			}
+			logrus.Debugf("Labeling not supported on %q", runDir)
 		}
 		// create systemd run directory
 		err = os.MkdirAll(filepath.Join(runDir, "systemd"), 0700)

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -4,6 +4,7 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -146,7 +147,7 @@ func LabelVolumePath(path, mountLabel string) error {
 	}
 
 	if err := lvpRelabel(path, mountLabel, true); err != nil {
-		if err == syscall.ENOTSUP {
+		if errors.Is(err, unix.ENOTSUP) {
 			logrus.Debugf("Labeling not supported on %q", path)
 		} else {
 			return fmt.Errorf("setting selinux label for %s to %q as shared: %w", path, mountLabel, err)


### PR DESCRIPTION
We were ignoreing relabel requests on certain unsupported file systems and not on others, this changes to consistently logrus.Debug ENOTSUP file systems.

Fixes: https://github.com/containers/podman/discussions/20745

Still needs some work on the Buildah side.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Relabels via :Z and :z are now ignored on file systems which do not support SELinux labels
```
