### PR TITLE
podman machine image from oci updates

### DIFF
--- a/pkg/machine/ocipull/oci.go
+++ b/pkg/machine/ocipull/oci.go
@@ -67,12 +67,6 @@ func StripOCIReference(input string) string {
 
 func getVersion() *OSVersion {
 	v := version.Version
-
-	// OVERRIDES FOR DEV ONLY
-	v.Minor = 6
-	v.Pre = nil
-	// OVERRIDES FOR DEV ONLY
-
 	return &OSVersion{&v}
 }
 
@@ -80,8 +74,8 @@ func (o *OSVersion) majorMinor() string {
 	return fmt.Sprintf("%d.%d", o.Major, o.Minor)
 }
 
-func (o *OSVersion) diskImage(diskFlavor define.ImageFormat) string {
-	return fmt.Sprintf("%s/%s/%s:%s-%s", registry, repo, diskImages, o.majorMinor(), diskFlavor.Kind())
+func (o *OSVersion) diskImage(vmType string) string {
+	return fmt.Sprintf("%s/%s/%s:%s-%s", registry, repo, diskImages, o.majorMinor(), vmType)
 }
 
 func unpackOCIDir(ociTb, machineImageDir string) (*define.VMFile, error) {

--- a/pkg/machine/ocipull/versioned.go
+++ b/pkg/machine/ocipull/versioned.go
@@ -20,20 +20,20 @@ type Versioned struct {
 	blobDirPath     string
 	cacheDir        string
 	ctx             context.Context
-	imageFormat     define.ImageFormat
 	imageName       string
 	machineImageDir string
 	machineVersion  *OSVersion
 	vmName          string
+	vmType          string
 }
 
-func NewVersioned(ctx context.Context, machineImageDir, vmName string) (*Versioned, error) {
+func NewVersioned(ctx context.Context, machineImageDir, vmName string, vmType string) (*Versioned, error) {
 	imageCacheDir := filepath.Join(machineImageDir, "cache")
 	if err := os.MkdirAll(imageCacheDir, 0777); err != nil {
 		return nil, err
 	}
 	o := getVersion()
-	return &Versioned{ctx: ctx, cacheDir: imageCacheDir, machineImageDir: machineImageDir, machineVersion: o, vmName: vmName}, nil
+	return &Versioned{ctx: ctx, cacheDir: imageCacheDir, machineImageDir: machineImageDir, machineVersion: o, vmName: vmName, vmType: vmType}, nil
 }
 
 func (d *Versioned) LocalBlob() *types.BlobInfo {
@@ -41,7 +41,7 @@ func (d *Versioned) LocalBlob() *types.BlobInfo {
 }
 
 func (d *Versioned) DiskEndpoint() string {
-	return d.machineVersion.diskImage(d.imageFormat)
+	return d.machineVersion.diskImage(d.vmType)
 }
 
 func (d *Versioned) versionedOCICacheDir() string {
@@ -74,7 +74,7 @@ func (d *Versioned) Pull() error {
 		remoteDescriptor *v1.Descriptor
 	)
 
-	remoteDiskImage := d.machineVersion.diskImage(define.Qcow)
+	remoteDiskImage := d.machineVersion.diskImage(d.vmType)
 	logrus.Debugf("podman disk image name: %s", remoteDiskImage)
 
 	// is there a valid oci dir in our cache

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -270,7 +270,7 @@ func Pull(input, machineName string, vp VirtProvider) (*define.VMFile, FCOSStrea
 		if len(strippedInput) > 0 {
 			return nil, 0, errors.New("image names are not supported yet")
 		}
-		disk, err = ocipull.NewVersioned(context.Background(), dataDir, machineName)
+		disk, err = ocipull.NewVersioned(context.Background(), dataDir, machineName, vp.VMType().String())
 		if err != nil {
 			return nil, 0, err
 		}


### PR DESCRIPTION
It makes more sense to key off the hypervisor/provider when pulling disks from oci registries.

i.e. quay.io/libpod/podman-machine-images:5.0-qemu

Also, now that we are in 5.0-dev, I also removed the overrides always making the podman version 4.6.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
