### PR TITLE
Quadlet - Add support for .pod units

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -29,6 +29,7 @@ const (
 	InstallGroup    = "Install"
 	KubeGroup       = "Kube"
 	NetworkGroup    = "Network"
+	PodGroup        = "Pod"
 	ServiceGroup    = "Service"
 	UnitGroup       = "Unit"
 	VolumeGroup     = "Volume"
@@ -36,6 +37,7 @@ const (
 	XContainerGroup = "X-Container"
 	XKubeGroup      = "X-Kube"
 	XNetworkGroup   = "X-Network"
+	XPodGroup       = "X-Pod"
 	XVolumeGroup    = "X-Volume"
 	XImageGroup     = "X-Image"
 )
@@ -114,6 +116,8 @@ const (
 	KeyOS                    = "OS"
 	KeyPidsLimit             = "PidsLimit"
 	KeyPodmanArgs            = "PodmanArgs"
+	KeyPodName               = "PodName"
+	KeyPod                   = "Pod"
 	KeyPublishPort           = "PublishPort"
 	KeyPull                  = "Pull"
 	KeyReadOnly              = "ReadOnly"
@@ -152,6 +156,11 @@ const (
 	KeyWorkingDir            = "WorkingDir"
 	KeyYaml                  = "Yaml"
 )
+
+type PodInfo struct {
+	ServiceName string
+	Containers  []string
+}
 
 var (
 	validPortRange = regexp.Delayed(`\d+(-\d+)?(/udp|/tcp)?$`)
@@ -199,6 +208,7 @@ var (
 		KeyNoNewPrivileges:       true,
 		KeyNotify:                true,
 		KeyPidsLimit:             true,
+		KeyPod:                   true,
 		KeyPodmanArgs:            true,
 		KeyPublishPort:           true,
 		KeyPull:                  true,
@@ -307,6 +317,13 @@ var (
 		KeyTLSVerify:            true,
 		KeyVariant:              true,
 	}
+
+	supportedPodKeys = map[string]bool{
+		KeyContainersConfModule: true,
+		KeyGlobalArgs:           true,
+		KeyPodmanArgs:           true,
+		KeyPodName:              true,
+	}
 )
 
 func replaceExtension(name string, extension string, extraPrefix string, extraSuffix string) string {
@@ -382,7 +399,7 @@ func usernsOpts(kind string, opts []string) string {
 // service file (unit file with Service group) based on the options in the
 // Container group.
 // The original Container group is kept around as X-Container.
-func ConvertContainer(container *parser.UnitFile, names map[string]string, isUser bool) (*parser.UnitFile, error) {
+func ConvertContainer(container *parser.UnitFile, names map[string]string, isUser bool, podsInfoMap map[string]*PodInfo) (*parser.UnitFile, error) {
 	service := container.Dup()
 	service.Filename = replaceExtension(container.Filename, ".service", "", "")
 
@@ -765,6 +782,10 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	pull, ok := container.Lookup(ContainerGroup, KeyPull)
 	if ok && len(pull) > 0 {
 		podman.add("--pull", pull)
+	}
+
+	if err := handlePod(container, service, ContainerGroup, podsInfoMap, podman); err != nil {
+		return nil, err
 	}
 
 	handlePodmanArgs(container, ContainerGroup, podman)
@@ -1223,6 +1244,95 @@ func ConvertImage(image *parser.UnitFile) (*parser.UnitFile, string, error) {
 	}
 
 	return service, imageName, nil
+}
+
+func GetPodServiceName(podUnit *parser.UnitFile) string {
+	return replaceExtension(podUnit.Filename, "", "", "-pod")
+}
+
+func ConvertPod(podUnit *parser.UnitFile, name string, podsInfoMap map[string]*PodInfo) (*parser.UnitFile, error) {
+	podInfo, ok := podsInfoMap[podUnit.Filename]
+	if !ok {
+		return nil, fmt.Errorf("internal error while processing pod %s", podUnit.Filename)
+	}
+
+	service := podUnit.Dup()
+	service.Filename = replaceExtension(podInfo.ServiceName, ".service", "", "")
+
+	if podUnit.Path != "" {
+		service.Add(UnitGroup, "SourcePath", podUnit.Path)
+	}
+
+	if err := checkForUnknownKeys(podUnit, PodGroup, supportedPodKeys); err != nil {
+		return nil, err
+	}
+
+	// Derive pod name from unit name (with added prefix), or use user-provided name.
+	podName, ok := podUnit.Lookup(PodGroup, KeyPodName)
+	if !ok || len(podName) == 0 {
+		podName = replaceExtension(name, "", "systemd-", "")
+	}
+
+	/* Rename old Pod group to x-Pod so that systemd ignores it */
+	service.RenameGroup(PodGroup, XPodGroup)
+
+	// Need the containers filesystem mounted to start podman
+	service.Add(UnitGroup, "RequiresMountsFor", "%t/containers")
+
+	for _, containerService := range podInfo.Containers {
+		service.Add(UnitGroup, "Wants", containerService)
+		service.Add(UnitGroup, "Before", containerService)
+	}
+
+	if !podUnit.HasKey(ServiceGroup, "SyslogIdentifier") {
+		service.Set(ServiceGroup, "SyslogIdentifier", "%N")
+	}
+
+	execStart := createBasePodmanCommand(podUnit, PodGroup)
+	execStart.add("pod", "start", "--pod-id-file=%t/%N.pod-id")
+	service.AddCmdline(ServiceGroup, "ExecStart", execStart.Args)
+
+	execStop := createBasePodmanCommand(podUnit, PodGroup)
+	execStop.add("pod", "stop")
+	execStop.add(
+		"--pod-id-file=%t/%N.pod-id",
+		"--ignore",
+		"--time=10",
+	)
+	service.AddCmdline(ServiceGroup, "ExecStop", execStop.Args)
+
+	execStopPost := createBasePodmanCommand(podUnit, PodGroup)
+	execStopPost.add("pod", "rm")
+	execStopPost.add(
+		"--pod-id-file=%t/%N.pod-id",
+		"--ignore",
+		"--force",
+	)
+	service.AddCmdline(ServiceGroup, "ExecStopPost", execStopPost.Args)
+
+	execStartPre := createBasePodmanCommand(podUnit, PodGroup)
+	execStartPre.add("pod", "create")
+	execStartPre.add(
+		"--infra-conmon-pidfile=%t/%N.pid",
+		"--pod-id-file=%t/%N.pod-id",
+		"--exit-policy=stop",
+		"--replace",
+	)
+
+	execStartPre.addf("--name=%s", podName)
+
+	handlePodmanArgs(podUnit, PodGroup, execStartPre)
+
+	service.AddCmdline(ServiceGroup, "ExecStartPre", execStartPre.Args)
+
+	service.Setv(ServiceGroup,
+		"Environment", "PODMAN_SYSTEMD_UNIT=%n",
+		"Type", "forking",
+		"Restart", "on-failure",
+		"PIDFile", "%t/%N.pid",
+	)
+
+	return service, nil
 }
 
 func handleUser(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline) error {
@@ -1684,4 +1794,27 @@ func createBasePodmanCommand(unitFile *parser.UnitFile, groupName string) *Podma
 	}
 
 	return podman
+}
+
+func handlePod(quadletUnitFile, serviceUnitFile *parser.UnitFile, groupName string, podsInfoMap map[string]*PodInfo, podman *PodmanCmdline) error {
+	pod, ok := quadletUnitFile.Lookup(groupName, KeyPod)
+	if ok && len(pod) > 0 {
+		if !strings.HasSuffix(pod, ".pod") {
+			return fmt.Errorf("pod %s is not Quadlet based", pod)
+		}
+
+		podInfo, ok := podsInfoMap[pod]
+		if !ok {
+			return fmt.Errorf("quadlet pod unit %s does not exist", pod)
+		}
+
+		podman.add("--pod-id-file", fmt.Sprintf("%%t/%s.pod-id", podInfo.ServiceName))
+
+		podServiceName := fmt.Sprintf("%s.service", podInfo.ServiceName)
+		serviceUnitFile.Add(UnitGroup, "BindsTo", podServiceName)
+		serviceUnitFile.Add(UnitGroup, "After", podServiceName)
+
+		podInfo.Containers = append(podInfo.Containers, serviceUnitFile.Filename)
+	}
+	return nil
 }

--- a/test/e2e/quadlet/basic.pod
+++ b/test/e2e/quadlet/basic.pod
@@ -1,0 +1,9 @@
+## assert-key-is Unit RequiresMountsFor "%t/containers"
+## assert-key-is Service Type forking
+## assert-key-is Service SyslogIdentifier "%N"
+## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --pod-id-file=%t/%N.pod-id --exit-policy=stop --replace --name=systemd-basic"
+## assert-key-is-regex Service ExecStart ".*/podman pod start --pod-id-file=%t/%N.pod-id"
+## assert-key-is-regex Service ExecStop ".*/podman pod stop --pod-id-file=%t/%N.pod-id --ignore --time=10"
+## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --pod-id-file=%t/%N.pod-id --ignore --force"
+
+[Pod]

--- a/test/e2e/quadlet/name.pod
+++ b/test/e2e/quadlet/name.pod
@@ -1,0 +1,4 @@
+## assert-podman-pre-args "--name=test-pod"
+
+[Pod]
+PodName=test-pod

--- a/test/e2e/quadlet/pod.non-quadlet.container
+++ b/test/e2e/quadlet/pod.non-quadlet.container
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "pod test-pod is not Quadlet based"
+
+[Container]
+Image=localhost/imagename
+Pod=test-pod

--- a/test/e2e/quadlet/pod.not-found.container
+++ b/test/e2e/quadlet/pod.not-found.container
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "quadlet pod unit not-found.pod does not exist"
+
+[Container]
+Image=localhost/imagename
+Pod=not-found.pod

--- a/test/e2e/quadlet/podmanargs.pod
+++ b/test/e2e/quadlet/podmanargs.pod
@@ -1,0 +1,13 @@
+## assert-podman-pre-args "--foo"
+## assert-podman-pre-args "--bar"
+## assert-podman-pre-args "--also"
+## assert-podman-pre-args "--with-key=value"
+## assert-podman-pre-args "--with-space" "yes"
+
+
+[Pod]
+PodmanArgs="--foo" \
+  --bar
+PodmanArgs=--also
+PodmanArgs=--with-key=value
+PodmanArgs=--with-space yes

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -39,6 +39,8 @@ func loadQuadletTestcase(path string) *quadletTestcase {
 		service += "-network"
 	case ".image":
 		service += "-image"
+	case ".pod":
+		service += "-pod"
 	}
 	service += ".service"
 
@@ -331,6 +333,46 @@ func (t *quadletTestcase) assertStartPodmanFinalArgsRegex(args []string, unit *p
 	return t.assertPodmanFinalArgsRegex(args, unit, "ExecStart")
 }
 
+func (t *quadletTestcase) assertStartPrePodmanArgs(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgs(args, unit, "ExecStartPre", false, false)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanArgsRegex(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgs(args, unit, "ExecStartPre", true, false)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanGlobalArgs(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgs(args, unit, "ExecStartPre", false, true)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanGlobalArgsRegex(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgs(args, unit, "ExecStartPre", true, true)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanArgsKeyVal(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgsKeyVal(args, unit, "ExecStartPre", false, false)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanArgsKeyValRegex(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgsKeyVal(args, unit, "ExecStartPre", true, false)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanGlobalArgsKeyVal(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgsKeyVal(args, unit, "ExecStartPre", false, true)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanGlobalArgsKeyValRegex(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanArgsKeyVal(args, unit, "ExecStartPre", true, true)
+}
+
+func (t *quadletTestcase) assertStartPrePodmanFinalArgs(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanFinalArgs(args, unit, "ExecStartPre")
+}
+
+func (t *quadletTestcase) assertStartPrePodmanFinalArgsRegex(args []string, unit *parser.UnitFile) bool {
+	return t.assertPodmanFinalArgsRegex(args, unit, "ExecStartPre")
+}
+
 func (t *quadletTestcase) assertStopPodmanArgs(args []string, unit *parser.UnitFile) bool {
 	return t.assertPodmanArgs(args, unit, "ExecStop", false, false)
 }
@@ -440,6 +482,26 @@ func (t *quadletTestcase) doAssert(check []string, unit *parser.UnitFile, sessio
 		ok = t.assertStartPodmanFinalArgs(args, unit)
 	case "assert-podman-final-args-regex":
 		ok = t.assertStartPodmanFinalArgsRegex(args, unit)
+	case "assert-podman-pre-args":
+		ok = t.assertStartPrePodmanArgs(args, unit)
+	case "assert-podman-pre-args-regex":
+		ok = t.assertStartPrePodmanArgsRegex(args, unit)
+	case "assert-podman-pre-args-key-val":
+		ok = t.assertStartPrePodmanArgsKeyVal(args, unit)
+	case "assert-podman-pre-args-key-val-regex":
+		ok = t.assertStartPrePodmanArgsKeyValRegex(args, unit)
+	case "assert-podman-pre-global-args":
+		ok = t.assertStartPrePodmanGlobalArgs(args, unit)
+	case "assert-podman-pre-global-args-regex":
+		ok = t.assertStartPrePodmanGlobalArgsRegex(args, unit)
+	case "assert-podman-pre-global-args-key-val":
+		ok = t.assertStartPrePodmanGlobalArgsKeyVal(args, unit)
+	case "assert-podman-pre-global-args-key-val-regex":
+		ok = t.assertStartPrePodmanGlobalArgsKeyValRegex(args, unit)
+	case "assert-podman-pre-final-args":
+		ok = t.assertStartPrePodmanFinalArgs(args, unit)
+	case "assert-podman-pre-final-args-regex":
+		ok = t.assertStartPrePodmanFinalArgsRegex(args, unit)
 	case "assert-symlink":
 		ok = t.assertSymlink(args, unit)
 	case "assert-podman-stop-args":
@@ -714,6 +776,8 @@ BOGUS=foo
 		Entry("notify.container", "notify.container", 0, ""),
 		Entry("oneshot.container", "oneshot.container", 0, ""),
 		Entry("other-sections.container", "other-sections.container", 0, ""),
+		Entry("pod.non-quadlet.container", "pod.non-quadlet.container", 1, "converting \"pod.non-quadlet.container\": pod test-pod is not Quadlet based"),
+		Entry("pod.not-found.container", "pod.not-found.container", 1, "converting \"pod.not-found.container\": quadlet pod unit not-found.pod does not exist"),
 		Entry("podmanargs.container", "podmanargs.container", 0, ""),
 		Entry("ports.container", "ports.container", 0, ""),
 		Entry("ports_ipv6.container", "ports_ipv6.container", 0, ""),
@@ -821,6 +885,10 @@ BOGUS=foo
 		Entry("Image - Arch and OS", "arch-os.image", 0, ""),
 		Entry("Image - global args", "globalargs.image", 0, ""),
 		Entry("Image - Containers Conf Modules", "containersconfmodule.image", 0, ""),
+
+		Entry("basic.pod", "basic.pod", 0, ""),
+		Entry("name.pod", "name.pod", 0, ""),
+		Entry("podmanargs.pod", "podmanargs.pod", 0, ""),
 	)
 
 })

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -1139,5 +1139,33 @@ function sleep_to_next_second() {
     sleep 0.$(printf '%04d' $((10000 - 10#$(date +%4N))))
 }
 
+function wait_for_command_output() {
+    local cmd="$1"
+    local want="$2"
+    local tries=20
+    local sleep_delay=0.5
+
+    case "${#*}" in
+        2) ;;
+        4) tries="$3"
+           sleep_delay="$4"
+           ;;
+        *) die "Internal error: 'wait_for_command_output' requires two or four arguments" ;;
+    esac
+
+    while [[ $tries -gt 0 ]]; do
+        echo "$_LOG_PROMPT $cmd"
+        run $cmd
+        echo "$output"
+        if [[ "$output" = "$want" ]]; then
+            return
+        fi
+
+        sleep $sleep_delay
+        tries=$((tries - 1))
+    done
+    die "Timed out waiting for '$cmd' to return '$want'"
+}
+
 # END   miscellaneous tools
 ###############################################################################

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -59,6 +59,8 @@ quadlet_to_service_name() {
         suffix="-network"
     elif [ "$extension" == "image" ]; then
         suffix="-image"
+    elif [ "$extension" == "pod" ]; then
+        suffix="-pod"
     fi
 
     echo "$filename$suffix.service"


### PR DESCRIPTION
Add support for .pod unit files with only PodmanArgs, GlobalArgs, ContainersConfModule and PodName
Add support for linking .container units with .pod ones
Add e2e and system tests
Add to man page

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - Add support for .pod unit files
```

Resolves: #17687
