### PR TITLE
system: enhance check for re-exec into rootless userns

### DIFF
--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -88,7 +88,8 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) 
 	if err != nil {
 		return err
 	}
-	if hasCapSysAdmin {
+	// check for both euid == 0 and CAP_SYS_ADMIN because we may be running in a container with CAP_SYS_ADMIN set.
+	if os.Geteuid() == 0 && hasCapSysAdmin {
 		ownsCgroup, err := cgroups.UserOwnsCurrentSystemdCgroup()
 		if err != nil {
 			logrus.Infof("Failed to detect the owner for the current cgroup: %v", err)


### PR DESCRIPTION
Previously, the setup only checked for the CAP_SYS_ADMIN capability, which could be not enough with containerized Podman where CAP_SYS_ADMIN might be set for an unprivileged user.

Closes: https://github.com/containers/podman/issues/20766

[NO NEW TESTS NEEDED] needs containerized Podman

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix crash when running in a containerized environment with euid != 0 and capabilities set
```
