### PR TITLE
logging: new mode -l passthrough-tty

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -980,12 +980,12 @@ func AutocompleteImageVolume(cmd *cobra.Command, args []string, toComplete strin
 }
 
 // AutocompleteLogDriver - Autocomplete log-driver options.
-// -> "journald", "none", "k8s-file", "passthrough"
+// -> "journald", "none", "k8s-file", "passthrough", "passthrough-tty"
 func AutocompleteLogDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// don't show json-file
 	logDrivers := []string{define.JournaldLogging, define.NoLogging, define.KubernetesLogging}
 	if !registry.IsRemote() {
-		logDrivers = append(logDrivers, define.PassthroughLogging)
+		logDrivers = append(logDrivers, define.PassthroughLogging, define.PassthroughTTYLogging)
 	}
 	return logDrivers, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -189,7 +189,7 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if cliVals.LogDriver != define.PassthroughLogging {
+	if cliVals.LogDriver != define.PassthroughLogging && cliVals.LogDriver != define.PassthroughTTYLogging {
 		fmt.Println(report.Id)
 	}
 	return nil
@@ -239,10 +239,15 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 
 	if cliVals.LogDriver == define.PassthroughLogging {
 		if term.IsTerminal(0) || term.IsTerminal(1) || term.IsTerminal(2) {
-			return vals, errors.New("the '--log-driver passthrough' option cannot be used on a TTY")
+			return vals, errors.New("the '--log-driver passthrough' option cannot be used on a TTY.  If you really want it, use '--log-driver passthrough-tty'")
 		}
 		if registry.IsRemote() {
 			return vals, errors.New("the '--log-driver passthrough' option is not supported in remote mode")
+		}
+	}
+	if cliVals.LogDriver == define.PassthroughTTYLogging {
+		if registry.IsRemote() {
+			return vals, errors.New("the '--log-driver passthrough-tty' option is not supported in remote mode")
 		}
 	}
 

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -173,7 +173,7 @@ func run(cmd *cobra.Command, args []string) error {
 		runOpts.InputStream = nil
 	}
 
-	passthrough := cliVals.LogDriver == define.PassthroughLogging
+	passthrough := cliVals.LogDriver == define.PassthroughLogging || cliVals.LogDriver == define.PassthroughTTYLogging
 
 	// If attach is set, clear stdin/stdout/stderr and only attach requested
 	if cmd.Flag("attach").Changed {

--- a/docs/source/markdown/options/log-driver.md
+++ b/docs/source/markdown/options/log-driver.md
@@ -4,7 +4,7 @@
 ####> are applicable to all of those.
 #### **--log-driver**=*driver*
 
-Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility. (Default **journald**).
+Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none**, **passthrough** and **passthrough-tty**, with **json-file** aliased to **k8s-file** for scripting compatibility. (Default **journald**).
 
 The podman info command below displays the default log-driver for the system.
 ```
@@ -14,3 +14,5 @@ journald
 The **passthrough** driver passes down the standard streams (stdin, stdout, stderr) to the
 container.  It is not allowed with the remote Podman client, including Mac and Windows (excluding WSL2) machines, and on a tty, since it is
 vulnerable to attacks via TIOCSTI.
+
+The **passthrough-tty** driver is the same as **passthrough** except that it also allows it to be used on a TTY if the user really wants it.

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -172,7 +172,7 @@ func (c *Container) StartAndAttach(ctx context.Context, streams *define.AttachSt
 	// Attach to the container before starting it
 	go func() {
 		// Start resizing
-		if c.LogDriver() != define.PassthroughLogging {
+		if c.LogDriver() != define.PassthroughLogging && c.LogDriver() != define.PassthroughTTYLogging {
 			registerResizeFunc(resize, c.bundlePath())
 		}
 
@@ -304,6 +304,9 @@ func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-
 	if c.LogDriver() == define.PassthroughLogging {
 		return fmt.Errorf("this container is using the 'passthrough' log driver, cannot attach: %w", define.ErrNoLogs)
 	}
+	if c.LogDriver() == define.PassthroughTTYLogging {
+		return fmt.Errorf("this container is using the 'passthrough-tty' log driver, cannot attach: %w", define.ErrNoLogs)
+	}
 	if !c.batched {
 		c.lock.Lock()
 		if err := c.syncContainer(); err != nil {
@@ -336,7 +339,7 @@ func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-
 	}
 
 	// Start resizing
-	if c.LogDriver() != define.PassthroughLogging {
+	if c.LogDriver() != define.PassthroughLogging && c.LogDriver() != define.PassthroughTTYLogging {
 		registerResizeFunc(resize, c.bundlePath())
 	}
 

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -82,6 +82,9 @@ const NoLogging = "none"
 // PassthroughLogging is the string conmon expects when specifying to use the passthrough driver
 const PassthroughLogging = "passthrough"
 
+// PassthroughTTYLogging is the string conmon expects when specifying to use the passthrough driver even on a tty.
+const PassthroughTTYLogging = "passthrough-tty"
+
 // DefaultRlimitValue is the value set by default for nofile and nproc
 const RLimitDefaultValue = uint64(1048576)
 

--- a/libpod/oci_conmon_attach_common.go
+++ b/libpod/oci_conmon_attach_common.go
@@ -33,7 +33,7 @@ const (
 // Does not check if state is appropriate.
 // started is only required if startContainer is true.
 func (r *ConmonOCIRuntime) Attach(c *Container, params *AttachOptions) error {
-	passthrough := c.LogDriver() == define.PassthroughLogging
+	passthrough := c.LogDriver() == define.PassthroughLogging || c.LogDriver() == define.PassthroughTTYLogging
 
 	if params == nil || params.Streams == nil {
 		return fmt.Errorf("must provide parameters to Attach: %w", define.ErrInternal)

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1417,7 +1417,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 		logDriverArg = define.JournaldLogging
 	case define.NoLogging:
 		logDriverArg = define.NoLogging
-	case define.PassthroughLogging:
+	case define.PassthroughLogging, define.PassthroughTTYLogging:
 		logDriverArg = define.PassthroughLogging
 	//lint:ignore ST1015 the default case has to be here
 	default: //nolint:gocritic

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1101,7 +1101,7 @@ func WithLogDriver(driver string) CtrCreateOption {
 		switch driver {
 		case "":
 			return fmt.Errorf("log driver must be set: %w", define.ErrInvalidArg)
-		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging, define.NoLogging, define.PassthroughLogging:
+		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging, define.NoLogging, define.PassthroughLogging, define.PassthroughTTYLogging:
 			break
 		default:
 			return fmt.Errorf("invalid log driver: %w", define.ErrInvalidArg)


### PR DESCRIPTION
it works in a similar way to passthrough but it allows to be used also on a TTY.

conmon support: https://github.com/containers/conmon/pull/465

Closes: https://github.com/containers/podman/issues/20767

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new logging mode --passthrough-tty that works like passthrough but can be used with TTYs
```
