### PR TITLE
[CI:DOCS] Update suggested commands to view and remove buildah containers

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -41,9 +41,9 @@ NOTE: `podman build` uses code sourced from the `Buildah` project to build
 container images.  This `Buildah` code creates `Buildah` containers for the
 `RUN` options in container storage. In certain situations, when the
 `podman build` crashes or users kill the `podman build` process, these external
-containers can be left in container storage. Use the `podman ps --all --storage`
+containers can be left in container storage. Use the `podman ps --external`
 command to see these containers. External containers can be removed with the
-`podman rm --storage` command.
+`podman rm --force` command.
 
 `podman buildx build` command is an alias of `podman build`.  Not all `buildx build` features are available in Podman. The `buildx build` option is provided for scripting compatibility.
 


### PR DESCRIPTION
The `podman --rm --storage` command fails to remove these containers with the following error:

```
Error: container "476981d18f08" is mounted and cannot be removed without using force: container state improper
```

The `podman ps --external` command no longer requires `--all` to also be specified since 4.0.0.

Fixes: #20733

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed podman-build man page to suggest `podman ps --external` and `podman rm --force` for viewing and removing external buildah containers from interrupted builds.
```
