### PR TITLE
[CI:DOCS] Add notes on upcoming deprecations to release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,13 @@
 - The `podman kube play` command now supports a new option, `--publish-all`, which exposes all containerPorts on the host.
 - The --filter option now supports `label!=`, which filters for containers without the specified label.
 
+### Upcoming Deprecations
+- We are beginning development on Podman 5.0, which will include a number of breaking changes and deprecations. We are still finalizing what will be done, but a preliminary list is below. Please note that none of these changes are present in Podman 4.8; this is a preview of upcoming changes.
+- Podman 5.0 will deprecate the BoltDB database backend. Exact details on the transition to SQLite are still being decided - expect more news here soon.
+- The containers.conf configuration file will be broken up into multiple separate files, ensuring that it will never be rewritten by Podman.
+- Support for the CNI network backend and Cgroups V1 are being deprecated and gated by build tags. They will not be enabled in Podman builds by default.
+- A variety of small breaking changes to the REST API are planned, both to improve Docker compatibility and to better support `containers.conf` settings when creating and managing containers.
+
 ### Changes
 - Podman now defaults to sqlite as its database backend. For backwards compatibility, if a boltdb database already exists on the system, Podman will continue using it.
 - RHEL Subscriptions from the host now flow through to quay.io/podman/* images.


### PR DESCRIPTION
The 5.0 release, which is coming up fast, will make a number of deprecations and removals. We can start giving folks a heads up on them now, so there is no confusion when 5.0 drops. We will also write some blogs about the transition over the coming weeks (after we have a better idea of what the final release will look like).

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
