### PR TITLE
test/compose: remove debug leftovers

### DIFF
--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -173,14 +173,6 @@ function test_port() {
 
     if [ $curl_rc -ne 0 ]; then
         _show_ok 0 "$testname - curl (port $port) failed with status $curl_rc"
-        echo "# podman ps -a:"
-        $PODMAN_BIN --storage-driver=vfs --root $WORKDIR/root --runroot $WORKDIR/runroot ps -a
-        if type -p ss; then
-            echo "# ss -tulpn:"
-            ss -tulpn
-            echo "# podman unshare --rootless-cni ss -tulpn:"
-            $PODMAN_BIN --storage-driver=vfs --root $WORKDIR/root --runroot $WORKDIR/runroot unshare --rootless-cni ss -tulpn
-        fi
         echo "# cat $WORKDIR/server.log:"
         cat $WORKDIR/server.log
         echo "# cat $logfile:"


### PR DESCRIPTION
I noticed these old debug code while looking at a log. These were needed to debug a nasty flake[1] in the compose tests. However it has been fixed[2] for a while and I am not aware of any flakes around that logic so we are good to remove it.

I still leave the server logs in there as they may be useful for all kinds of issues and are only printed when the test fails so it does not clutter the logs.

[1] https://github.com/containers/podman/issues/10052
[2] https://github.com/containers/podman/pull/11091

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
