### PR TITLE
[systests] new defer-assertion-failure

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -23,6 +23,8 @@ runRoot:
 cgroupManager: \\\(systemd\\\|cgroupfs\\\)
 cgroupVersion: v[12]
 "
+    defer-assertion-failures
+
     while read expect; do
         is "$output" ".*$expect" "output includes '$expect'"
     done < <(parse_table "$expected_keys")
@@ -52,11 +54,13 @@ store.imageStore.number   | 1
 host.slirp4netns.executable | $expr_path
 "
 
-    parse_table "$tests" | while read field expect; do
+    defer-assertion-failures
+
+    while read field expect; do
         actual=$(echo "$output" | jq -r ".$field")
         dprint "# actual=<$actual> expect=<$expect>"
         is "$actual" "$expect" "jq .$field"
-    done
+    done < <(parse_table "$tests")
 }
 
 @test "podman info - confirm desired runtime" {

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -26,10 +26,12 @@ load helpers
 {{.Labels.created_at}}   | 20[0-9-]\\\+T[0-9:]\\\+Z
 "
 
-    parse_table "$tests" | while read fmt expect; do
+    defer-assertion-failures
+
+    while read fmt expect; do
         run_podman images --format "$fmt"
         is "$output" "$expect" "podman images --format '$fmt'"
-    done
+    done < <(parse_table "$tests")
 
     run_podman images --format "{{.ID}}" --no-trunc
     is "$output" "sha256:[0-9a-f]\\{64\\}\$" "podman images --no-trunc"
@@ -49,12 +51,11 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
 
     run_podman images -a --format json
 
-    parse_table "$tests" | while read field expect; do
+    while read field expect; do
         actual=$(echo "$output" | jq -r ".[0].$field")
         dprint "# actual=<$actual> expect=<$expect}>"
         is "$actual" "$expect" "jq .$field"
-    done
-
+    done < <(parse_table "$tests")
 }
 
 @test "podman images - history output" {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -21,6 +21,8 @@ echo $rand        |   0 | $rand
 /etc              | 126 | $err_no_exec_dir
 "
 
+    defer-assertion-failures
+
     tests_run=0
     while read cmd expected_rc expected_output; do
         if [ "$expected_output" = "''" ]; then expected_output=""; fi
@@ -389,6 +391,9 @@ journald  | -
 k8s-file  | y
 json-file | f
 "
+
+    defer-assertion-failures
+
     while read driver do_check; do
         msg=$(random_string 15)
         run_podman run --name myctr --log-driver $driver $IMAGE echo $msg
@@ -1284,6 +1289,8 @@ search               | $IMAGE           |
 
     bogus=$PODMAN_TMPDIR/bogus-authfile
     touch $PODMAN_TMPDIR/Containerfile
+
+    defer-assertion-failures
 
     while read command args local_only;do
         # skip commands that don't work in podman-remote

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -47,6 +47,8 @@ load helpers
 0 | subdir               | /srv/subdir/hostfile0 | copy to workdir/subdir
 "
 
+    defer-assertion-failures
+
     # RUNNING container
     while read id dest dest_fullname description; do
         run_podman cp $srcdir/hostfile$id destrunning:$dest
@@ -192,6 +194,8 @@ load helpers
 2 | subdir/containerfile2 | /        | /containerfile2 | copy from workdir/subdir (rel path) to srcdir
 "
 
+    defer-assertion-failures
+
     # RUNNING container
     while read id src dest dest_fullname description; do
         # dest may be "''" for empty table cells
@@ -250,6 +254,8 @@ load helpers
 1 | containerfile1        | /        | /containerfile1 | copy from workdir (rel path) to /
 2 | subdir/containerfile2 | /        | /containerfile2 | copy from workdir/subdir (rel path) to /
 "
+
+    defer-assertion-failures
 
     # From RUNNING container
     local -a destcontainers=()
@@ -342,6 +348,8 @@ load helpers
  dir/.     | /newdir3 | /newdir3/sub | copy dir/. to newdir3
 "
 
+    defer-assertion-failures
+
     # RUNNING container
     while read src dest dest_fullname description; do
         run_podman cp $srcdir/$src destrunning:$dest
@@ -399,6 +407,8 @@ load helpers
 /srv/subdir/. |         |                | copy /srv/subdir/.
 /tmp/subdir.  |         | /subdir.       | copy /tmp/subdir.
 "
+
+    defer-assertion-failures
 
     # RUNNING container
     while read src dest dest_fullname description; do
@@ -466,6 +476,8 @@ load helpers
 /srv/subdir/. | /       |                | copy /srv/subdir/.
 /tmp/subdir.  | /       | /subdir.       | copy /tmp/subdir.
 "
+
+    defer-assertion-failures
 
     # From RUNNING container
     local -a destcontainers=()

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -167,6 +167,9 @@ load helpers
 }
 
 @test "podman exec --tty" {
+    # Run all tests, report failures at end
+    defer-assertion-failures
+
     # Outer loops: different variations on the RUN container
     for run_opt_t in "" "-t"; do
         for run_term_env in "" "explicit_RUN_term"; do

--- a/test/system/110-history.bats
+++ b/test/system/110-history.bats
@@ -11,14 +11,16 @@ load helpers
 --no-trunc                       | .*[0-9a-f]\\\{64\\\}
 "
 
-    parse_table "$tests" | while read options expect; do
+    defer-assertion-failures
+
+    while read options expect; do
         if [ "$options" = "''" ]; then options=; fi
 
         eval set -- "$options"
 
         run_podman history "$@" $IMAGE
         is "$output" "$expect" "podman history $options"
-    done
+    done < <(parse_table "$tests")
 }
 
 @test "podman history - custom format" {
@@ -42,7 +44,9 @@ size      | -\\\?[0-9]\\\+
 
     run_podman history --format json $IMAGE
 
-    parse_table "$tests" | while read field expect; do
+    defer-assertion-failures
+
+    while read field expect; do
         # HACK: we can't include '|' in the table
         if [ "$field" = "id" ]; then expect="$expect\|<missing>";fi
 
@@ -54,8 +58,7 @@ size      | -\\\?[0-9]\\\+
             is "$actual" "$expect\$" "jq .[$i].$field"
             i=$(expr $i + 1)
         done
-    done
-
+    done < <(parse_table "$tests")
 }
 
 @test "podman image history Created" {

--- a/test/system/620-option-conflicts.bats
+++ b/test/system/620-option-conflicts.bats
@@ -18,6 +18,9 @@ container cleanup | --all          | --exec=foo
 container cleanup | --exec=foo     | --rmi                  | foo
 "
 
+    # Run all tests, continue even if any fail
+    defer-assertion-failures
+
     # FIXME: parse_table is what does all the work, giving us test cases.
     while read subcommands opt1 opt2 args; do
         opt1_name=${opt1%=*}


### PR DESCRIPTION
Some system tests run deep loops:

  for x in a b c; do
    for y in d e f; do
        .... check condition $x + $y

Normally, if one of these fails, game over. This can be frustrating to a developer looking for failure patterns.

Here we introduce a new defer-assertion-failure function, meant to be called before loops like these. Everything is the same, except that tests will continue running even after failure.

When test finishes, or if test runs immediate-assertion-failure, a new message indicates that multiple tests failed:

  FAIL: X test assertions failed. Search for 'FAIL': above this line.

```release-note
None
```
