### PR TITLE
Fix wsl.conf generation when user-mode-networking is disabled

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1150,11 +1150,8 @@ func (v *MachineVM) Set(_ string, opts machine.SetOptions) ([]error, error) {
 		if v.isRunning() {
 			update = false
 			setErrors = append(setErrors, fmt.Errorf("user-mode networking can only be changed when the machine is not running"))
-		}
-
-		if update && *opts.UserModeNetworking {
+		} else {
 			dist := toDist(v.Name)
-
 			if err := changeDistUserModeNetworking(dist, v.RemoteUsername, v.ImagePath, *opts.UserModeNetworking); err != nil {
 				update = false
 				setErrors = append(setErrors, err)

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -4,6 +4,7 @@
 package wsl
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -320,7 +321,10 @@ func (v *MachineVM) obtainUserModeNetLock() (*fileLock, error) {
 
 func changeDistUserModeNetworking(dist string, user string, image string, enable bool) error {
 	// Only install if user-mode is being enabled and there was an image path passed
-	if enable && len(image) > 0 {
+	if enable {
+		if len(image) <= 0 {
+			return errors.New("existing machine configuration is corrupt, no image is defined")
+		}
 		if err := installUserModeDist(dist, image); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #20625 

```release-note
Fixed a bug on Windows (WSL) where resolv.conf was not restored when user-mode networking was disabled after being enabled.
```
