### PR TITLE
Move the --farm flag to farm build command

### DIFF
--- a/cmd/podman/farm/farm.go
+++ b/cmd/podman/farm/farm.go
@@ -16,27 +16,9 @@ var (
 	}
 )
 
-var (
-	// Temporary struct to hold cli values.
-	farmOpts = struct {
-		Farm string
-	}{}
-)
-
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: farmCmd,
 	})
 	farmCmd.Hidden = true
-
-	flags := farmCmd.Flags()
-	podmanConfig := registry.PodmanConfig()
-
-	farmFlagName := "farm"
-	// If remote, don't read the client's containers.conf file
-	defaultFarm := ""
-	if !registry.IsRemote() {
-		defaultFarm = podmanConfig.ContainersConfDefaultsRO.Farms.Default
-	}
-	flags.StringVarP(&farmOpts.Farm, farmFlagName, "f", defaultFarm, "Farm to use for builds")
 }

--- a/docs/source/markdown/options/farm.md
+++ b/docs/source/markdown/options/farm.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman farm build
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--farm**
+
+This option specifies the name of the farm to be used in the build process.

--- a/docs/source/markdown/podman-farm-build.1.md.in
+++ b/docs/source/markdown/podman-farm-build.1.md.in
@@ -89,6 +89,10 @@ It does not affect _/etc/resolv.conf_ in the final image.
 
 @@option env.image
 
+@@option farm
+
+This option specifies the name of the farm to be used in the build process.
+
 @@option file
 
 @@option force-rm
@@ -214,9 +218,9 @@ Build only on farm nodes that match the given platforms.
 ```
 $ podman farm build --local -t name -f /path/to/containerfile .
 
-$ podman farm --farm build myfarm -t name .
+$ podman farm build --farm myfarm -t name .
 
-$ podman farm --farm myfarm build --cleanup -t name .
+$ podman farm build --farm myfarm --cleanup -t name .
 
 $ podman farm build --platforms arm64,amd64 --cleanup -t name .
 ```

--- a/test/farm/001-farm.bats
+++ b/test/farm/001-farm.bats
@@ -17,7 +17,7 @@ load helpers.bash
     empty_farm="empty-farm"
     # create an empty farm
     run_podman farm create $empty_farm
-    run_podman farm --farm $empty_farm build -t $iname $PODMAN_TMPDIR
+    run_podman farm build --farm $empty_farm -t $iname $PODMAN_TMPDIR
     assert "$output" =~ "Local builder ready"
 
     # get the system architecture


### PR DESCRIPTION
closes #20752

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The --farm flag has been moved to farm build command from farm command
```
