### PR TITLE
Fix transferring data using tar

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	domainUtils "github.com/containers/podman/v4/pkg/domain/utils"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
 	utils2 "github.com/containers/podman/v4/utils"
 	"github.com/containers/storage"
@@ -330,10 +329,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tarOptions := &archive.TarOptions{
-		ChownOpts: &idtools.IDPair{
-			UID: rootless.GetRootlessUID(),
-			GID: rootless.GetRootlessGID(),
-		},
+		ChownOpts: &idtools.IDPair{UID: 0, GID: 0},
 	}
 	tar, err := chrootarchive.Tar(output, tarOptions, output)
 	if err != nil {

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -336,7 +336,7 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 		return err
 	}
 
-	return archive.Untar(f, opts.Output, nil)
+	return archive.Untar(f, opts.Output, &archive.TarOptions{NoLchown: true})
 }
 
 func (ir *ImageEngine) Search(ctx context.Context, term string, opts entities.ImageSearchOptions) ([]entities.ImageSearchReport, error) {


### PR DESCRIPTION
Instead of relying on the remote server to create tar files with the right account IDs (which the remote server doesn't even know, when the client and server run under different accounts), have the remote client ignore the account IDs when unpacking.

Then just hard-code 0 in the remote server, so that the remote server's account identity does not leak in the tar file contents.

Compare https://github.com/containers/image/issues/1627 .

[NO NEW TESTS NEEDED] : https://github.com/containers/podman/pull/18563 suggests that existing tests already cover these code paths / properties.

https://github.com/containers/storage/pull/1765 will improve the privacy of the generated tar files further, but it is not a prerequisite.

#### Does this PR introduce a user-facing change?

```release-note
None
```
