### PR TITLE
utils: close a couple of ReadClosers

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -77,6 +77,7 @@ func TarToFilesystem(source string, tarball *os.File) error {
 	if err != nil {
 		return err
 	}
+	defer tb.Close()
 	_, err = io.Copy(tarball, tb)
 	if err != nil {
 		return err
@@ -98,6 +99,7 @@ func TarChrootToFilesystem(source string, tarball *os.File) error {
 	if err != nil {
 		return err
 	}
+	defer tb.Close()
 	_, err = io.Copy(tarball, tb)
 	if err != nil {
 		return err


### PR DESCRIPTION
`utils.Tar()` and `utils.TarWithChroot()` both return `ReadCloser`s, but when we called them from `utils.TarToFilesystem()` and `utils.TarChrootToFilesystem()` respectively, they were not being closed.

#### Does this PR introduce a user-facing change?

```release-note
None
```