### PR TITLE
Support lookup of intermediate ID for uidmapping and gidmapping in `--userns=auto`

### DIFF
--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -48,6 +48,10 @@ Using `--userns=auto` when starting new containers does not work as long as any 
   - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` estimates a size for the user namespace.
   - *uidmapping*=_CONTAINER\_UID:HOST\_UID:SIZE_: to force a UID mapping to be present in the user namespace.
 
+The host UID and GID in *gidmapping* and *uidmapping* can optionally be prefixed with the `@` symbol.
+In this case, podman will look up the intermediate ID corresponding to host ID and it will map the found intermediate ID to the container id.
+For details see **--uidmap**.
+
 **container:**_id_: join the user namespace of the specified container.
 
 **host** or **""** (empty string): run in the user namespace of the caller. The processes running in the container have the same privileges on the host as any other process launched by the calling user.

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -282,7 +282,7 @@ func ParseIDMapping(mode namespaces.UsernsMode, uidMapSlice, gidMapSlice []strin
 		options.HostUIDMapping = false
 		options.HostGIDMapping = false
 		options.AutoUserNs = true
-		opts, err := mode.GetAutoOptions()
+		opts, err := util.GetAutoOptions(mode)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/containers/storage/types"
 )
 
 const (
@@ -120,48 +118,6 @@ func (n UsernsMode) IsAuto() bool {
 // IsDefaultValue indicates whether the user namespace has the default value.
 func (n UsernsMode) IsDefaultValue() bool {
 	return n == "" || n == defaultType
-}
-
-// GetAutoOptions returns an AutoUserNsOptions with the settings to automatically set up
-// a user namespace.
-func (n UsernsMode) GetAutoOptions() (*types.AutoUserNsOptions, error) {
-	parts := strings.SplitN(string(n), ":", 2)
-	if parts[0] != "auto" {
-		return nil, fmt.Errorf("wrong user namespace mode")
-	}
-	options := types.AutoUserNsOptions{}
-	if len(parts) == 1 {
-		return &options, nil
-	}
-	for _, o := range strings.Split(parts[1], ",") {
-		v := strings.SplitN(o, "=", 2)
-		if len(v) != 2 {
-			return nil, fmt.Errorf("invalid option specified: %q", o)
-		}
-		switch v[0] {
-		case "size":
-			s, err := strconv.ParseUint(v[1], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			options.Size = uint32(s)
-		case "uidmapping":
-			mapping, err := types.ParseIDMapping([]string{v[1]}, nil, "", "")
-			if err != nil {
-				return nil, err
-			}
-			options.AdditionalUIDMappings = append(options.AdditionalUIDMappings, mapping.UIDMap...)
-		case "gidmapping":
-			mapping, err := types.ParseIDMapping(nil, []string{v[1]}, "", "")
-			if err != nil {
-				return nil, err
-			}
-			options.AdditionalGIDMappings = append(options.AdditionalGIDMappings, mapping.GIDMap...)
-		default:
-			return nil, fmt.Errorf("unknown option specified: %q", v[0])
-		}
-	}
-	return &options, nil
 }
 
 // GetKeepIDOptions returns a KeepIDUserNsOptions with the settings to keepIDmatically set up

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -391,6 +391,42 @@ func TestParseIDMapUserGroupFlags(t *testing.T) {
 	assert.Equal(t, expectedResultGroup, result)
 }
 
+func TestParseAutoIDMap(t *testing.T) {
+	result, err := parseAutoIDMap("3:4:5", "UID", []ruser.IDMap{})
+	assert.Equal(t, err, nil)
+	assert.Equal(t, result, []idtools.IDMap{
+		{
+			ContainerID: 3,
+			HostID:      4,
+			Size:        5,
+		},
+	})
+}
+
+func TestParseAutoIDMapRelative(t *testing.T) {
+	parentMapping := []ruser.IDMap{
+		{
+			ID:       0,
+			ParentID: 1000,
+			Count:    1,
+		},
+		{
+			ID:       1,
+			ParentID: 100000,
+			Count:    65536,
+		},
+	}
+	result, err := parseAutoIDMap("100:@100000:1", "UID", parentMapping)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, result, []idtools.IDMap{
+		{
+			ContainerID: 100,
+			HostID:      1,
+			Size:        1,
+		},
+	})
+}
+
 func TestFillIDMap(t *testing.T) {
 	availableRanges := [][2]int{{0, 10}, {10000, 20000}}
 	idmap := []idtools.IDMap{

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -147,3 +147,12 @@ EOF
     is "${output}" "$user" "Container should run as the current user"
     run_podman rmi -f $(pause_image)
 }
+
+@test "podman userns=auto with id mapping" {
+    skip_if_not_rootless
+    run_podman unshare awk '{if(NR == 2){print $2}}' /proc/self/uid_map
+    first_id=$output
+    mapping=1:@$first_id:1
+    run_podman run --rm --userns=auto:uidmapping=$mapping $IMAGE awk '{if($1 == 1){print $2}}' /proc/self/uid_map
+    assert "$output" == 1
+}


### PR DESCRIPTION
In rootless mode, the host IDs in the `uidmapping` and `gidmapping` options of `--userns=auto` are mapped from an intermediate namespace, just like when using the `--uidmap` and `--gidmap` options.
This means that for a given _host ID_, the user first has to look up the _intermediate ID_ manually. 

The `--uidmap` and `--gidmap` options also support prefixing the _host ID_ in the mapping with the `@` symbol, which means that podman will look up the _intermediate ID_ corresponding to the given _host ID_ and it will map the found _intermediate ID_ to the given _container ID_.

This PR adds the functionality mentioned above to the `uidmapping` and `gidmapping` options in `--userns=auto`.


```release-note
`uidmapping` and `gidmapping` options of `--userns=auto` in rootless mode: 
Added the possibility to map actual host IDs (instead of intermediate IDs) by prefixing the host ID 
with the `@` symbol. 
```
