### PR TITLE
fix podman-remote exec regression with v4.8

### DIFF
--- a/pkg/bindings/containers/exec.go
+++ b/pkg/bindings/containers/exec.go
@@ -118,7 +118,7 @@ func ExecRemove(ctx context.Context, sessionID string, options *ExecRemoveOption
 	// The exec remove endpoint was added in 4.8.
 	if v.Major < 4 || (v.Major == 4 && v.Minor < 8) {
 		// Do no call this endpoint as it will not be supported on the server and throw an "NOT FOUND" error.
-		return nil
+		return bindings.NewAPIVersionError("/exec/{id}/remove", v, "4.8.0")
 	}
 	if options == nil {
 		options = new(ExecRemoveOptions)

--- a/pkg/bindings/containers/exec.go
+++ b/pkg/bindings/containers/exec.go
@@ -114,10 +114,15 @@ func ExecStart(ctx context.Context, sessionID string, options *ExecStartOptions)
 
 // ExecRemove removes a given exec session.
 func ExecRemove(ctx context.Context, sessionID string, options *ExecRemoveOptions) error {
+	v := bindings.ServiceVersion(ctx)
+	// The exec remove endpoint was added in 4.8.
+	if v.Major < 4 || (v.Major == 4 && v.Minor < 8) {
+		// Do no call this endpoint as it will not be supported on the server and throw an "NOT FOUND" error.
+		return nil
+	}
 	if options == nil {
 		options = new(ExecRemoveOptions)
 	}
-	_ = options
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return err

--- a/pkg/bindings/errors.go
+++ b/pkg/bindings/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/blang/semver/v4"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 )
 
@@ -60,4 +61,27 @@ func CheckResponseCode(inError error) (int, error) {
 	default:
 		return -1, errors.New("is not type ErrorModel")
 	}
+}
+
+type APIVersionError struct {
+	endpoint        string
+	serverVersion   *semver.Version
+	requiredVersion string
+}
+
+// NewAPIVersionError create bindings error when the endpoint on the server is not supported
+// because the version is to old.
+//   - endpoint is the name fo the endpoint (e.g. /containers/json)
+//   - version is the server API version
+//   - requiredVersion is the server version need to use said endpoint
+func NewAPIVersionError(endpoint string, version *semver.Version, requiredVersion string) *APIVersionError {
+	return &APIVersionError{
+		endpoint:        endpoint,
+		serverVersion:   version,
+		requiredVersion: requiredVersion,
+	}
+}
+
+func (e *APIVersionError) Error() string {
+	return fmt.Sprintf("API server version is %s, need at least %s to call %s", e.serverVersion.String(), e.requiredVersion, e.endpoint)
 }

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/api/handlers"
+	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/bindings/containers"
 	"github.com/containers/podman/v4/pkg/bindings/images"
 	"github.com/containers/podman/v4/pkg/domain/entities"
@@ -588,6 +589,11 @@ func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, o
 	}
 	defer func() {
 		if err := containers.ExecRemove(ic.ClientCtx, sessionID, nil); err != nil {
+			apiErr := new(bindings.APIVersionError)
+			if errors.As(err, &apiErr) {
+				// if the API is to old do not throw an error
+				return
+			}
 			if retErr == nil {
 				exitCode = -1
 				retErr = err

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -62,11 +62,17 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
+		ctrName := "test"
 		bm := basicMachine{}
-		runAlp, err := mb.setCmd(bm.withPodmanCommand([]string{"run", "-dt", "-p", "62544:80", "quay.io/libpod/alpine_nginx"})).run()
+		runAlp, err := mb.setCmd(bm.withPodmanCommand([]string{"run", "-dt", "--name", ctrName, "-p", "62544:80", "quay.io/libpod/alpine_nginx"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runAlp).To(Exit(0))
 		testHTTPServer("62544", false, "podman rulez")
+
+		// Test exec in machine scenario: https://github.com/containers/podman/issues/20821
+		exec, err := mb.setCmd(bm.withPodmanCommand([]string{"exec", ctrName, "true"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
 
 		out, err := pgrep("gvproxy")
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Commit f48a706abc added a new API endpoint to remove exec session correctly. And the bindings try to call that endpoint for exec every time. Now since client and server must not be the same version this causes a problem if a new 4.8 client calls an older 4.7 server as it has no idea about such endpoint and throws an ugly error. This is a common scenario for podman machine setups.

The client does know the server version so it should make sure to not call such endpoint if the server is older than 4.8.

I added a exec test to the machine tests as this can be reproduced with podman machine as at the moment at least the VM image does not contain podman 4.8. And it should at least make sure podman exec keeps working for podman machine without regressions.

Fixes #20821

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman-remote exec would fail if the server API version is older than 4.8.0.
```
