### PR TITLE
Gating test fixes

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1159,6 +1159,9 @@ EOF
     if is_rootless; then
         run ulimit -c -H
         max=$output
+        if [[ "$max" != "unlimited" ]] && [[ $max -lt 1000 ]]; then
+            skip "ulimit -c == $max, test requires >= 1000"
+        fi
     fi
 
     run_podman run --ulimit core=-1:-1 --rm $IMAGE grep core /proc/self/limits


### PR DESCRIPTION
Two newly-added tests, fail in gating:
 - system connection: difference in how sockets are set up
   between CI and gating
 - ulimit: gating seems to run with ulimit -c -H 0. Test, and skip.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```