### PR TITLE
libpod: Allow using just one jail per container on FreeBSD

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -296,7 +296,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 		toReturn = append(toReturn, libpod.WithCgroupsMode(s.CgroupsMode))
 	}
 
-	postConfigureNetNS := !s.UserNS.IsHost()
+	postConfigureNetNS := needPostConfigureNetNS(s)
 
 	switch s.NetNS.NSMode {
 	case specgen.FromPod:

--- a/pkg/specgen/generate/namespaces_freebsd.go
+++ b/pkg/specgen/generate/namespaces_freebsd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containers/buildah/pkg/jail"
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -51,4 +52,11 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	}
 
 	return nil
+}
+
+// On FreeBSD 13.3 and later, we can avoid creating a separate vnet jail but
+// only if we can initialise the network after the OCI container is created -
+// the OCI container will own the vnet in this case.
+func needPostConfigureNetNS(s *specgen.SpecGenerator) bool {
+	return jail.NeedVnetJail() == false
 }

--- a/pkg/specgen/generate/namespaces_linux.go
+++ b/pkg/specgen/generate/namespaces_linux.go
@@ -159,3 +159,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 
 	return nil
 }
+
+func needPostConfigureNetNS(s *specgen.SpecGenerator) bool {
+	return !s.UserNS.IsHost()
+}


### PR DESCRIPTION
In FreeBSD-14.0, it is possible to configure a jail's network settings from outside the jail using ifconfig and route's new '-j' option. This removes the need for a separate jail to own the container's vnet.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
