### PR TITLE
sqlite: set busy timeout to 100s

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -40,13 +40,17 @@ const (
 	sqliteOptionForeignKeys = "&_foreign_keys=1"
 	// Make sure that transactions happen exclusively.
 	sqliteOptionTXLock = "&_txlock=exclusive"
+	// Make sure busy timeout is set to high value to keep retying when the db is locked.
+	// Timeout is in ms, so set it to 100s to have enough time to retry the operations.
+	sqliteOptionBusyTimeout = "&_busy_timeout=100000"
 
 	// Assembled sqlite options used when opening the database.
 	sqliteOptions = "db.sql?" +
 		sqliteOptionLocation +
 		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
-		sqliteOptionTXLock
+		sqliteOptionTXLock +
+		sqliteOptionBusyTimeout
 )
 
 // NewSqliteState creates a new SQLite-backed state database.


### PR DESCRIPTION
Only one process can write to the sqlite db at the same time, if another process tries to use it at that time it fails and a database is locked error is returned. If this happens sqlite should keep retrying until it can write. To do that we can just set the _busy_timeout option. A 100s timeout should be enough even on slower systems but not to much in case there is a deadlock so it still returns in a reasonable time.

[NO NEW TESTS NEEDED] I think we strongly need to consider some form of parallel stress testing to catch bugs like this.

Fixes #20809

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix `database is locked` errors with the new sqlite database backend.
```
