### PR TITLE
[v4.8] Gating test fixes

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1154,6 +1154,9 @@ EOF
     if is_rootless; then
         run ulimit -c -H
         max=$output
+        if [[ "$max" != "unlimited" ]] && [[ $max -lt 1000 ]]; then
+            skip "ulimit -c == $max, test requires >= 1000"
+        fi
     fi
 
     run_podman run --ulimit core=-1:-1 --rm $IMAGE grep core /proc/self/limits


### PR DESCRIPTION
Two newly-added tests, fail in gating:
 - system connection: difference in how sockets are set up between CI and gating
 - ulimit: gating seems to run with ulimit -c -H 0. Check, and skip if ulimit is less than what we need

```release-note
None
```
