### PR TITLE
Enable win podman-machine test failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -764,9 +764,6 @@ podman_machine_aarch64_task:
 podman_machine_windows_task:
     name: *std_name_fmt
     alias: podman_machine_windows
-    # TODO: These tests are new and mostly fail.  Disable all failures impacting overall CI status
-    # until the tests, scripts, and environment stabalize.
-    allow_failures: $CI == $CI
     # Only run for non-docs/copr PRs and non-release branch builds
     # and never for tags.  Docs: ./contrib/cirrus/CIModes.md
     only_if: >-
@@ -1061,7 +1058,9 @@ success_task:
         - rootless_integration_test
         - podman_machine
         - podman_machine_aarch64
-        - podman_machine_windows
+        # TODO: issue #20548; These tests are new and mostly fail.
+        # Ignore status until tests, scripts, and/or environment stabalize.
+        # - podman_machine_windows
         - local_system_test
         - local_system_test_aarch64
         - remote_system_test

--- a/contrib/cirrus/cirrus_yaml_test.py
+++ b/contrib/cirrus/cirrus_yaml_test.py
@@ -27,7 +27,7 @@ class TestDependsOn(TestCaseBase):
 
     ALL_TASK_NAMES = None
     SUCCESS_DEPS_EXCLUDE = set(['success', 'bench_stuff', 'artifacts',
-        'release', 'release_test'])
+        'release', 'release_test', 'podman_machine_windows'])
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Intended to serve as motivation to fix them.  Removed from status
aggregator so the failures don't block PR merging.  Updated comment text
to reference related open issue, #20548.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
