### PR TITLE
Fix command failure not resulting in task failure

### DIFF
--- a/contrib/cirrus/win-lib.ps1
+++ b/contrib/cirrus/win-lib.ps1
@@ -51,7 +51,7 @@ function Check-Exit {
         # https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.callstackframe
         $caller = (Get-PSCallStack)[1]
         Write-Host "Exit code = '$result' from $($caller.ScriptName):$($caller.ScriptLineNumber)"
-        Exit $result
+        Throw "Non-zero exit code"
     }
 }
 


### PR DESCRIPTION
For whatever reason (I don't understand this stuff well) the
`win-podman-machine-main.ps1` script exits successfully despite the
final `Check-Exit` showing a non-zero exit code was detected.  Attempt
to fix this by throwing an exception instead of calling `Exit`.

Ref: https://github.com/containers/podman/pull/20852#issuecomment-1834453550

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
