### PR TITLE
podman: new option --preserve-fd

### DIFF
--- a/docs/source/markdown/options/preserve-fd.md
+++ b/docs/source/markdown/options/preserve-fd.md
@@ -1,0 +1,10 @@
+####> This option file is used in:
+####>   podman exec, run
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--preserve-fd**=*FD1[,FD2,...]*
+
+Pass down to the process the additional file descriptors specified in the comma separated list.  It can be specified multiple times.
+This option is only supported with the crun OCI runtime.  It might be a security risk to use this option with other OCI runtimes.
+
+(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -27,6 +27,8 @@ Start the exec session, but do not attach to it. The command runs in the backgro
 
 @@option latest
 
+@@option preserve-fd
+
 @@option preserve-fds
 
 @@option privileged

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -308,6 +308,8 @@ This is used to override the Podman provided user setup in favor of entrypoint c
 
 @@option pod-id-file.container
 
+@@option preserve-fd
+
 @@option preserve-fds
 
 @@option privileged

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -416,6 +416,9 @@ type ContainerMiscConfig struct {
 	// to 0, 1, 2) that will be passed to the executed process. The total FDs
 	// passed will be 3 + PreserveFDs.
 	PreserveFDs uint `json:"preserveFds,omitempty"`
+	// PreserveFD is a list of additional file descriptors (in addition
+	// to 0, 1, 2) that will be passed to the executed process.
+	PreserveFD []uint `json:"preserveFd,omitempty"`
 	// Timezone is the timezone inside the container.
 	// Local means it has the same timezone as the host machine
 	Timezone string `json:"timezone,omitempty"`

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -66,6 +66,9 @@ type ExecConfig struct {
 	// given is the number that will be passed into the exec session,
 	// starting at 3.
 	PreserveFDs uint `json:"preserveFds,omitempty"`
+	// PreserveFD is a list of additional file descriptors (in addition
+	// to 0, 1, 2) that will be passed to the executed process.
+	PreserveFD []uint `json:"preserveFd,omitempty"`
 	// ExitCommand is the exec session's exit command.
 	// This command will be executed when the exec session exits.
 	// If unset, no command will be executed.
@@ -1092,6 +1095,7 @@ func prepareForExec(c *Container, session *ExecSession) (*ExecOptions, error) {
 	opts.Cwd = session.Config.WorkDir
 	opts.User = session.Config.User
 	opts.PreserveFDs = session.Config.PreserveFDs
+	opts.PreserveFD = session.Config.PreserveFD
 	opts.DetachKeys = session.Config.DetachKeys
 	opts.ExitCommand = session.Config.ExitCommand
 	opts.ExitCommandDelay = session.Config.ExitCommandDelay

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -202,6 +202,9 @@ type ExecOptions struct {
 	// to 0, 1, 2) that will be passed to the executed process. The total FDs
 	// passed will be 3 + PreserveFDs.
 	PreserveFDs uint
+	// PreserveFD is a list of additional file descriptors (in addition
+	// to 0, 1, 2) that will be passed to the executed process.
+	PreserveFD []uint
 	// DetachKeys is a set of keys that, when pressed in sequence, will
 	// detach from the container.
 	// If not provided, the default keys will be used.

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -391,8 +391,13 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 
 	args := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), ociLog, define.NoLogging, c.config.LogTag)
 
-	if options.PreserveFDs > 0 {
-		args = append(args, formatRuntimeOpts("--preserve-fds", strconv.FormatUint(uint64(options.PreserveFDs), 10))...)
+	preserveFDs, filesToClose, extraFiles, err := getPreserveFdExtraFiles(options.PreserveFD, options.PreserveFDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if preserveFDs > 0 {
+		args = append(args, formatRuntimeOpts("--preserve-fds", strconv.FormatUint(uint64(preserveFDs), 10))...)
 	}
 
 	if options.Terminal {
@@ -442,19 +447,12 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 		return nil, nil, fmt.Errorf("configuring conmon env: %w", err)
 	}
 
-	var filesToClose []*os.File
-	if options.PreserveFDs > 0 {
-		for fd := 3; fd < int(3+options.PreserveFDs); fd++ {
-			f := os.NewFile(uintptr(fd), fmt.Sprintf("fd-%d", fd))
-			filesToClose = append(filesToClose, f)
-			execCmd.ExtraFiles = append(execCmd.ExtraFiles, f)
-		}
-	}
+	execCmd.ExtraFiles = extraFiles
 
 	// we don't want to step on users fds they asked to preserve
 	// Since 0-2 are used for stdio, start the fds we pass in at preserveFDs+3
 	execCmd.Env = r.conmonEnv
-	execCmd.Env = append(execCmd.Env, fmt.Sprintf("_OCI_SYNCPIPE=%d", options.PreserveFDs+3), fmt.Sprintf("_OCI_STARTPIPE=%d", options.PreserveFDs+4), fmt.Sprintf("_OCI_ATTACHPIPE=%d", options.PreserveFDs+5))
+	execCmd.Env = append(execCmd.Env, fmt.Sprintf("_OCI_SYNCPIPE=%d", preserveFDs+3), fmt.Sprintf("_OCI_STARTPIPE=%d", preserveFDs+4), fmt.Sprintf("_OCI_ATTACHPIPE=%d", preserveFDs+5))
 	execCmd.Env = append(execCmd.Env, conmonEnv...)
 
 	execCmd.ExtraFiles = append(execCmd.ExtraFiles, childSyncPipe, childStartPipe, childAttachPipe)

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1555,6 +1555,18 @@ func WithPreserveFDs(fd uint) CtrCreateOption {
 	}
 }
 
+// WithPreserveFD forwards from the process running Libpod into the container
+// the given list of extra FDs to the created container
+func WithPreserveFD(fds []uint) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.PreserveFD = fds
+		return nil
+	}
+}
+
 // WithCreateCommand adds the full command plus arguments of the current
 // process to the container config.
 func WithCreateCommand(cmd []string) CtrCreateOption {

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -297,6 +297,7 @@ type ExecOptions struct {
 	Interactive bool
 	Latest      bool
 	PreserveFDs uint
+	PreserveFD  []uint
 	Privileged  bool
 	Tty         bool
 	User        string
@@ -360,6 +361,7 @@ type ContainerRunOptions struct {
 	InputStream  *os.File
 	OutputStream *os.File
 	PreserveFDs  uint
+	PreserveFD   []uint
 	Rm           bool
 	SigProxy     bool
 	Spec         *specgen.SpecGenerator

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -250,6 +250,7 @@ type ContainerCreateOptions struct {
 	PodIDFile          string
 	Personality        string
 	PreserveFDs        uint
+	PreserveFD         []uint
 	Privileged         bool
 	PublishAll         bool
 	Pull               string

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -809,6 +809,7 @@ func makeExecConfig(options entities.ExecOptions, rt *libpod.Runtime) (*libpod.E
 	execConfig.WorkDir = options.WorkDir
 	execConfig.DetachKeys = &options.DetachKeys
 	execConfig.PreserveFDs = options.PreserveFDs
+	execConfig.PreserveFD = options.PreserveFD
 	execConfig.AttachStdin = options.Interactive
 
 	// Make an exit command
@@ -858,6 +859,7 @@ func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, o
 	if err != nil {
 		return ec, err
 	}
+
 	containers, err := getContainers(ic.Libpod, getContainersOptions{latest: options.Latest, names: []string{nameOrID}})
 	if err != nil {
 		return ec, err

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -355,6 +355,10 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		options = append(options, libpod.WithPreserveFDs(s.PreserveFDs))
 	}
 
+	if s.PreserveFD != nil {
+		options = append(options, libpod.WithPreserveFD(s.PreserveFD))
+	}
+
 	if s.Stdin {
 		options = append(options, libpod.WithStdin())
 	}

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -180,6 +180,11 @@ type ContainerBasicConfig struct {
 	// set tags as `json:"-"` for not supported remote
 	// Optional.
 	PreserveFDs uint `json:"-"`
+	// PreserveFD is a list of additional file descriptors (in addition
+	// to 0, 1, 2) that will be passed to the executed process.
+	// set tags as `json:"-"` for not supported remote
+	// Optional.
+	PreserveFD []uint `json:"-"`
 	// Timezone is the timezone inside the container.
 	// Local means it has the same timezone as the host machine
 	// Optional.

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -838,8 +838,16 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if len(s.Name) == 0 || len(c.Name) != 0 {
 		s.Name = c.Name
 	}
+
+	if c.PreserveFDs != 0 && c.PreserveFD != nil {
+		return errors.New("cannot specify both --preserve-fds and --preserve-fd")
+	}
+
 	if s.PreserveFDs == 0 || c.PreserveFDs != 0 {
 		s.PreserveFDs = c.PreserveFDs
+	}
+	if s.PreserveFD == nil || c.PreserveFD != nil {
+		s.PreserveFD = c.PreserveFD
 	}
 
 	if s.OOMScoreAdj == nil || c.OOMScoreAdj != nil {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -80,6 +80,25 @@ echo $rand        |   0 | $rand
     is "$output" "$content" "container read input from fd 4"
 }
 
+# 'run --preserve-fd' passes a list of additional file descriptors into the container
+@test "podman run --preserve-fd" {
+    skip_if_remote "preserve-fd is meaningless over remote"
+
+    runtime=$(podman_runtime)
+    if [[ $runtime != "crun" ]]; then
+        skip "runtime is $runtime; preserve-fd requires crun"
+    fi
+
+    content=$(random_string 20)
+    echo "$content" > $PODMAN_TMPDIR/tempfile
+
+    # /proc/self/fd will have 0 1 2, possibly 3 & 4, but no 2-digit fds other than 40
+    run_podman run --rm -i --preserve-fd=9,40 $IMAGE sh -c '/bin/ls -C -w999 /proc/self/fd; cat <&9; cat <&40' 9<<<"fd9" 10</dev/null 40<$PODMAN_TMPDIR/tempfile
+    assert "${lines[0]}" !~ [123][0-9] "/proc/self/fd must not contain 10-39"
+    assert "${lines[1]}" = "fd9"       "cat from fd 9"
+    assert "${lines[2]}" = "$content"  "cat from fd 40"
+}
+
 @test "podman run - uidmapping has no /sys/kernel mounts" {
     skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "cannot umount as rootless"


### PR DESCRIPTION
add a new option --preserve-fd that allows to specify a list of FDs to pass down to the container.

It is similar to --preserve-fds but it allows to specify a list of FDs instead of the maximum FD number to preserve.

--preserve-fd and --preserve-fds are mutually exclusive.

It requires crun since runc would complain if any fd below --preserve-fds is not preserved.

Closes: https://github.com/containers/podman/issues/20844

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now podman run and exec support --preserve-fd to specify the FDs to pass down to the container
```
