### PR TITLE
libpod: Detect whether we have a private UTS namespace on FreeBSD

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -688,15 +688,7 @@ func (c *Container) Hostname() string {
 
 	// if the container is not running in a private UTS namespace,
 	// return the host's hostname.
-	privateUTS := false
-	if c.config.Spec.Linux != nil {
-		for _, ns := range c.config.Spec.Linux.Namespaces {
-			if ns.Type == spec.UTSNamespace {
-				privateUTS = true
-				break
-			}
-		}
-	}
+	privateUTS := c.hasPrivateUTS()
 	if !privateUTS {
 		hostname, err := os.Hostname()
 		if err == nil {

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -392,3 +392,10 @@ func (c *Container) getPlatformRunPath() (string, error) {
 func (c *Container) addMaskedPaths(g *generate.Generator) {
 	// There are currently no FreeBSD-specific masked paths
 }
+
+func (c *Container) hasPrivateUTS() bool {
+	// Currently we always use a private UTS namespace on FreeBSD. This
+	// should be optional but needs a FreeBSD section in the OCI runtime
+	// specification.
+	return true
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -811,3 +811,16 @@ func (c *Container) addMaskedPaths(g *generate.Generator) {
 		g.AddLinuxMaskedPaths("/sys/devices/virtual/powercap")
 	}
 }
+
+func (c *Container) hasPrivateUTS() bool {
+	privateUTS := false
+	if c.config.Spec.Linux != nil {
+		for _, ns := range c.config.Spec.Linux.Namespaces {
+			if ns.Type == spec.UTSNamespace {
+				privateUTS = true
+				break
+			}
+		}
+	}
+	return privateUTS
+}


### PR DESCRIPTION
Right now, we always use a private UTS namespace on FreeBSD. This should be made optional but implementing that cleanly needs a FreeBSD extension to the OCI runtime config. The process for that is starting (https://github.com/opencontainers/tob/pull/133) but in the meantime, assume that the UTS namespace is private on FreeBSD.

This moves the Linux-specific namespace logic to container_internal_linux.go and adds a FreeBSD stub.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
