### PR TITLE
Add support for the userns annotation in kube play

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -39,6 +39,8 @@ Note: When playing a kube YAML with init containers, the init container is creat
 
 Note: *hostPath* volume types created by kube play is given an SELinux shared label (z), bind mounts are not relabeled (use `chcon -t container_file_t -R <directory>`).
 
+Note: To set userns of a pod, use the **io.podman.annotations.userns** annotation in the pod/deployment definition. This can be overridden with the `--userns` flag.
+
 Note: If the `:latest` tag is used, Podman attempts to pull the image from a registry. If the image was built locally with Podman or Buildah, it has `localhost` as the domain, in that case, Podman uses the image from the local store even if it has the `:latest` tag.
 
 Note: The command `podman play kube` is an alias of `podman kube play`, and performs the same function.

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -149,6 +149,10 @@ const (
 	// pod creation
 	InfraNameAnnotation = "io.podman.annotations.infra.name"
 
+	// UserNsAnnotation is used by play kube when playing a kube yaml to specify userns
+	// of the container
+	UserNsAnnotation = "io.podman.annotations.userns"
+
 	// UlimitAnnotation is used by kube play when playing a kube yaml to specify the ulimits
 	// of the container
 	UlimitAnnotation = "io.podman.annotations.ulimit"

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -509,7 +509,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	}
 
 	if options.Userns == "" {
-		options.Userns = "host"
+		if v, ok := annotations[define.UserNsAnnotation]; ok {
+			options.Userns = v
+		} else {
+			options.Userns = "host"
+		}
 		if podYAML.Spec.HostUsers != nil && !*podYAML.Spec.HostUsers {
 			options.Userns = "auto"
 		}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
Add support for the userns annotation in kube play 

To set userns of a pod, use the **io.podman.annotations.userns** annotation in the pod/deployment definition. This can be overridden with the `--userns` flag.
```

Fixes #20658