### PR TITLE
[CI:DOCS] fix podman-systemd.unit.5 Mask/Unmask placement

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -190,6 +190,7 @@ Valid options for `[Container]` are listed below:
 | IP6=2001:db8::1                      | --ip6 2001:db8::1                                    |
 | Label="XYZ"                          | --label "XYZ"                                        |
 | LogDriver=journald                   | --log-driver journald                                |
+| Mask=/proc/sys/foo\:/proc/sys/bar    | --security-opt mask=/proc/sys/foo:/proc/sys/bar      |
 | Mount=type=...                       | --mount type=...                                     |
 | Network=host                         | --net host                                           |
 | NoNewPrivileges=true                 | --security-opt no-new-privileges                     |
@@ -217,6 +218,7 @@ Valid options for `[Container]` are listed below:
 | Tmpfs=/work                          | --tmpfs /work                                        |
 | UIDMap=0:10000:10                    | --uidmap=0:10000:10                                  |
 | Ulimit=nofile=1000:10000             | --ulimit nofile=1000:10000                           |
+| Unmask=ALL                           | --security-opt unmask=ALL                            |
 | User=bin                             | --user bin                                           |
 | UserNS=keep-id:uid=200,gid=210       | --userns keep-id:uid=200,gid=210                     |
 | Volume=/source:/dest                 | --volume /source:/dest                               |
@@ -454,6 +456,10 @@ This key can be listed multiple times.
 Set the log-driver used by Podman when running the container.
 Equivalent to the Podman `--log-driver` option.
 
+### `Mask=`
+
+Specify the paths to mask separated by a colon. `Mask=/path/1:/path/2`. A masked path cannot be accessed inside the container.
+
 ### `Mount=`
 
 Attach a filesystem mount to the container.
@@ -646,6 +652,16 @@ This key can be listed multiple times.
 
 Ulimit options. Sets the ulimits values inside of the container.
 
+### `Unmask=`
+
+Specify the paths to unmask separated by a colon. unmask=ALL or /path/1:/path/2, or shell expanded paths (/proc/*):
+
+If set to `ALL`, Podman will unmask all the paths that are masked or made read-only by default.
+
+The default masked paths are /proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.
+
+The default paths that are read-only are /proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup.
+
 ### `User=`
 
 The (numeric) UID to run as inside the container. This does not need to match the UID on the host,
@@ -821,10 +837,6 @@ Equivalent to the Podman `--force` option.
 Set the log-driver Podman uses when running the container.
 Equivalent to the Podman `--log-driver` option.
 
-### `Mask=`
-
-Specify the paths to mask separated by a colon. `Mask=/path/1:/path/2`. A masked path cannot be accessed inside the container.
-
 ### `Network=`
 
 Specify a custom network for the container. This has the same format as the `--network` option
@@ -877,16 +889,6 @@ Supported values are `yaml` and `unit` to set the working directory to that of t
 Alternatively, users can explicitly set the `WorkingDirectory` field of the `Service` group in the `.kube` file.
 Please note that if the `WorkingDirectory` field of the `Service` group is set,
 Quadlet will not set it even if `SetWorkingDirectory` is set
-
-### `Unmask=`
-
-Specify the paths to unmask separated by a colon. unmask=ALL or /path/1:/path/2, or shell expanded paths (/proc/*):
-
-If set to `ALL`, Podman will unmask all the paths that are masked or made read-only by default.
-
-The default masked paths are /proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.
-
-The default paths that are read-only are /proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup.
 
 ### `UserNS=`
 


### PR DESCRIPTION
While I was working on [podlet](https://github.com/k9withabone/podlet), I discovered that the docs for the `Mask=` and `Unmask=` quadlet options seemed to be in the wrong place. Judging from the e2e tests for [mask](https://github.com/containers/podman/blob/8d0be64093484963ed3dc9252a764ad7ded52943/test/e2e/quadlet/mask.container) and [unmask](https://github.com/containers/podman/blob/8d0be64093484963ed3dc9252a764ad7ded52943/test/e2e/quadlet/unmask.container) they should be in the [Container] section instead of the [Kube] section. I corrected the mistake and added example usage to the [Container] options table, using examples from the e2e tests.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
