### PR TITLE
[CI:DOCS] Update health-start-periods docs

### DIFF
--- a/docs/source/markdown/options/health-start-period.md
+++ b/docs/source/markdown/options/health-start-period.md
@@ -6,3 +6,9 @@
 
 The initialization time needed for a container to bootstrap. The value can be expressed in time format like
 **2m3s**. The default value is **0s**.
+
+Note: The health check command is executed as soon as a container is started, if the health check is successful
+the container's health state will be updated to `healthy`. However, if the health check fails, the health state will
+stay as `starting` until either the health check is successful or until the `--health-start-period` time is over. If the
+health check command fails after the `--health-start-period` time is over, the health state will be updated to `unhealthy`.
+The health check command is executed periodically based on the value of `--health-interval`.


### PR DESCRIPTION
Update the health-start-period docs to clarify what exactly the health-start-period flag does based on whether the health check command succeeds or fails.

Fixes https://github.com/containers/podman/issues/19272
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update --health-start-period docs clarifying exactly how it behaves
```
