### PR TITLE
podman farm: unhide

### DIFF
--- a/cmd/podman/farm/farm.go
+++ b/cmd/podman/farm/farm.go
@@ -20,5 +20,4 @@ func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: farmCmd,
 	})
-	farmCmd.Hidden = true
 }

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -107,7 +107,6 @@ my %Skip_Subcommand = map { $_ => 1 } (
     "help",                     # has no man page
     "completion",               # internal (hidden) subcommand
     "compose",                  # external tool, outside of our control
-    "farm",                # hidden subcommand till it is fully implemented - remove this once done
 );
 
 # END   user-customizable section


### PR DESCRIPTION
Followup to #20819 (move --farm option to podman farm build).

Remove the Hidden setting for podman farm, and enable man page
cross-checks.

[NO NEW TESTS NEEDED] -- the man-page xref is what we're testing

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```