### PR TITLE
apiv2 tests: fix race

### DIFF
--- a/test/apiv2/27-containersEvents.at
+++ b/test/apiv2/27-containersEvents.at
@@ -8,7 +8,7 @@ podman pull $IMAGE &>/dev/null
 # Ensure clean slate
 podman rm -a -f &>/dev/null
 
-START=$(date +%s)
+START=$(date +%s.%N)
 
 podman run --rm $IMAGE false || true
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -147,7 +147,8 @@ function like() {
 function _show_ok() {
     local ok=$1
     # Exec tests include control characters; filter them out
-    local testname=$(tr -d \\012 <<<"$2"|cat -vT)
+    # Also filter out timestamps, to get consistent test names in logs
+    local testname=$(tr -d \\012 <<<"$2"|sed -e 's/since=[0-9.]\+/since=(T)/'|cat -vT)
 
     # If output is a tty, colorize pass/fail
     local red=


### PR DESCRIPTION
Test flaking because (I think) one-second resolution isn't
good enough for --since. Use NS resolution.

Also, more test-name cleanup: strip off timestamps in 'since='.
This yields consistent test names in logs, which makes it easier
for me to categorize flakes.

Fixes: #20896

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```