### PR TITLE
Add support for Entrypoint in quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -168,6 +168,7 @@ Valid options for `[Container]` are listed below:
 | Environment=foo=bar                  | --env foo=bar                                        |
 | EnvironmentFile=/tmp/env             | --env-file /tmp/env                                  |
 | EnvironmentHost=true                 | --env-host                                           |
+| Entrypoint=/foo.sh                   | --entrypoint=/foo.sh                                 |
 | Exec=/usr/bin/command                | Command after image specification - /usr/bin/command |
 | ExposeHostPort=50-59                 | --expose 50-59                                       |
 | GIDMap=0:10000:10                    | --gidmap=0:10000:10                                  |
@@ -319,6 +320,12 @@ This key may be used multiple times, and the order persists when passed to `podm
 ### `EnvironmentHost=`
 
 Use the host environment inside of the container.
+
+#### `Entrypoint=`
+
+Override the default ENTRYPOINT from the image.
+Equivalent to the Podman `--entrypoint` option.
+Specify multi option commands in the form of a json string.
 
 ### `Exec=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -72,6 +72,7 @@ const (
 	KeyEnvironment           = "Environment"
 	KeyEnvironmentFile       = "EnvironmentFile"
 	KeyEnvironmentHost       = "EnvironmentHost"
+	KeyEntrypoint            = "Entrypoint"
 	KeyExec                  = "Exec"
 	KeyExitCodePropagation   = "ExitCodePropagation"
 	KeyExposeHostPort        = "ExposeHostPort"
@@ -180,6 +181,7 @@ var (
 		KeyEnvironment:           true,
 		KeyEnvironmentFile:       true,
 		KeyEnvironmentHost:       true,
+		KeyEntrypoint:            true,
 		KeyExec:                  true,
 		KeyExposeHostPort:        true,
 		KeyGIDMap:                true,
@@ -626,6 +628,11 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	shmSize, hasShmSize := container.Lookup(ContainerGroup, KeyShmSize)
 	if hasShmSize {
 		podman.addf("--shm-size=%s", shmSize)
+	}
+
+	entrypoint, hasEntrypoint := container.Lookup(ContainerGroup, KeyEntrypoint)
+	if hasEntrypoint {
+		podman.addf("--entrypoint=%s", entrypoint)
 	}
 
 	sysctl := container.LookupAllStrv(ContainerGroup, KeySysctl)

--- a/test/e2e/quadlet/entrypoint.container
+++ b/test/e2e/quadlet/entrypoint.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--entrypoint=top"
+
+[Container]
+Image=localhost/imagename
+Entrypoint=top

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -765,6 +765,7 @@ BOGUS=foo
 		Entry("env-host-false.container", "env-host-false.container", 0, ""),
 		Entry("env-host.container", "env-host.container", 0, ""),
 		Entry("env.container", "env.container", 0, ""),
+		Entry("entrypoint.container", "entrypoint.container", 0, ""),
 		Entry("escapes.container", "escapes.container", 0, ""),
 		Entry("exec.container", "exec.container", 0, ""),
 		Entry("health.container", "health.container", 0, ""),

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1467,22 +1467,4 @@ EOF
 
     run_podman rmi $(pause_image)
 }
-@test "quadlet - entrypoint" {
- local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
-    cat > $quadlet_file <<EOF
-[Container]
-Image=$IMAGE
-Entrypoint=top
-EOF
-
-    run_quadlet "$quadlet_file"
-    service_setup $QUADLET_SERVICE_NAME
-
-    # Create a container based on that
-    run_podman container inspect  --format '{{index .Args}}' $QUADLET_CONTAINER_NAME
-    is "$output" "[top]"
-
-    service_cleanup $QUADLET_SERVICE_NAME failed
-}
-
 # vim: filetype=sh

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1467,4 +1467,22 @@ EOF
 
     run_podman rmi $(pause_image)
 }
+@test "quadlet - entrypoint" {
+ local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    cat > $quadlet_file <<EOF
+[Container]
+Image=$IMAGE
+Entrypoint=top
+EOF
+
+    run_quadlet "$quadlet_file"
+    service_setup $QUADLET_SERVICE_NAME
+
+    # Create a container based on that
+    run_podman container inspect  --format '{{index .Args}}' $QUADLET_CONTAINER_NAME
+    is "$output" "[top]"
+
+    service_cleanup $QUADLET_SERVICE_NAME failed
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
This PR closes #20585

Add Inital support for Entrypoint on quadlets
Add e2e Tests for Entrypoint
Updates the documentation with one example to use the Entrypoint option

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Yes
```release-note
Quadlets - Add support for Entrypoint Option 
```
