### PR TITLE
Fix regression in e2e machine test suite

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,8 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20231116t174419z-f39f38d13"
+    IMAGE_SUFFIX: "c20231206t225809z-f39f38d13"
+
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/win-podman-machine-main.ps1
+++ b/contrib/cirrus/win-podman-machine-main.ps1
@@ -4,6 +4,13 @@
 
 Set-Location "$ENV:CIRRUS_WORKING_DIR\repo"
 
+$GvTargetDir = "C:\Program Files\Redhat\Podman\"
+
+#Expand-Archive -Path "podman-remote-release-windows_amd64.zip" -DestinationPath $GvTargetDir
+
+New-Item -Path $GvTargetDir -ItemType "directory"
+Copy-Item "bin/windows/gvproxy.exe" -Destination $GvTargetDir
+
 Write-Host "Saving selection of CI env. vars."
 # Env. vars will not pass through win-sess-launch.ps1
 Get-ChildItem -Path "Env:\*" -include @("PATH", "Chocolatey*", "CIRRUS*", "TEST_*", "CI_*") `

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -234,3 +234,17 @@ func isVmtype(vmType machine.VMType) bool {
 func isWSL() bool {
 	return isVmtype(machine.WSLVirt)
 }
+
+func getFCOSDownloadLocation(p machine.VirtProvider) string {
+	dd, err := p.NewDownload("")
+	if err != nil {
+		Fail("unable to create new download")
+	}
+
+	fcd, err := dd.GetFCOSDownload(defaultStream)
+	if err != nil {
+		Fail("unable to get virtual machine image")
+	}
+
+	return fcd.Location
+}

--- a/pkg/machine/e2e/config_unix_test.go
+++ b/pkg/machine/e2e/config_unix_test.go
@@ -6,21 +6,10 @@ import (
 	"os/exec"
 
 	"github.com/containers/podman/v4/pkg/machine"
-	. "github.com/onsi/ginkgo/v2"
 )
 
 func getDownloadLocation(p machine.VirtProvider) string {
-	dd, err := p.NewDownload("")
-	if err != nil {
-		Fail("unable to create new download")
-	}
-
-	fcd, err := dd.GetFCOSDownload(defaultStream)
-	if err != nil {
-		Fail("unable to get virtual machine image")
-	}
-
-	return fcd.Location
+	return getFCOSDownloadLocation(p)
 }
 
 func pgrep(n string) (string, error) {

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -12,7 +12,10 @@ import (
 
 const podmanBinary = "../../../bin/windows/podman.exe"
 
-func getDownloadLocation(_ machine.VirtProvider) string {
+func getDownloadLocation(p machine.VirtProvider) string {
+	if p.VMType() == machine.HyperVVirt {
+		return getFCOSDownloadLocation(p)
+	}
 	fd, err := wsl.NewFedoraDownloader(machine.WSLVirt, "", defaultStream.String())
 	if err != nil {
 		Fail("unable to get WSL virtual image")

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -61,9 +61,6 @@ var _ = BeforeSuite(func() {
 		downloadLocation = getDownloadLocation(testProvider)
 		// we cannot simply use OS here because hyperv uses fcos; so WSL is just
 		// special here
-		if testProvider.VMType() != machine.WSLVirt {
-			downloadLocation = getDownloadLocation(testProvider)
-		}
 	}
 
 	compressionExtension := fmt.Sprintf(".%s", testProvider.Compression().String())


### PR DESCRIPTION
A simple regression was introduced to the test suite that overrode the default image for hyperv testing.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
