### PR TITLE
[CI:DOCS] fix broken labeler.yml config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,5 @@
 # Add labels based on file paths in PR
 #   https://github.com/actions/labeler
 kind/api-change:
-  - pkg/api/**/*
+  - changed-files:
+    - any-glob-to-any-file: pkg/api/**


### PR DESCRIPTION
Commit ca66a90b87 was merged without fixing the config. Please read changelogs before merging renovate PRs, especially when it is a major version bump.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
