### PR TITLE
CI: systests: fix flaking --since test

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -182,8 +182,10 @@ function _log_test_since() {
     before=$(date --iso-8601=seconds)
     run_podman run --log-driver=$driver -d --name test $IMAGE sh -c \
         "echo $s_before; trap 'echo $s_after; exit' SIGTERM; while :; do sleep 0.1; done"
+    wait_for_output "$s_before" test
 
     # sleep a second to make sure the date is after the first echo
+    # (We could instead use iso-8601=ns but seconds feels more real-world)
     sleep 1
     after=$(date --iso-8601=seconds)
     run_podman stop test

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -442,7 +442,7 @@ function run_podman() {
 
 # Wait for certain output from a container, indicating that it's ready.
 function wait_for_output {
-    local sleep_delay=5
+    local sleep_delay=1
     local how_long=$PODMAN_TIMEOUT
     local expect=
     local cid=


### PR DESCRIPTION
Very rare flake, probably caused by my nemesis, podman run -d

Solution: keep the sleep-1 (vs using nanosecond resolution), but make sure we first wait for the output from the container.

Also, bump down the iteration delay in wait_for_output, from 5s to 1. Thanks to Paul for noticing that.

Only [one instance](https://api.cirrus-ci.com/v1/artifact/task/6267658346168320/html/sys-podman-fedora-38-root-host-boltdb.log.html#t--00124) seen in my logs, over many years. Hardly seems worth it, but the fix is easy.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```