### PR TITLE
Fix user-mode net init flag on first time install

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -671,7 +671,7 @@ func configureSystem(v *MachineVM, dist string) error {
 		return err
 	}
 
-	return changeDistUserModeNetworking(dist, user, "", v.UserModeNetworking)
+	return changeDistUserModeNetworking(dist, user, v.ImagePath, v.UserModeNetworking)
 }
 
 func configureBindMounts(dist string, user string) error {


### PR DESCRIPTION
Fixes #20921 

Previously the WSL user-mode networking distribution was only installed as part of a change, when it should have been also applied installs. This mean that the init flag usage only worked after a previous set command.

```release-note
Fixed a bug on Windows (WSL) with the first-time install of user-mode networking when using the init command, as opposed to set (#20921)
```
