### PR TITLE
[CI:DOCS]use nginx in podman tutorial

### DIFF
--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -21,10 +21,7 @@ For installing or building Podman, see the [installation instructions](https://p
 This sample container will run a very basic httpd server (named basic_httpd) that serves only its index
 page.
 ```console
-podman run --name basic_httpd -dt -p 8080:8080/tcp -e HTTPD_VAR_RUN=/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
-                  -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
-                  -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-                  registry.fedoraproject.org/f29/httpd /usr/bin/run-httpd
+podman run --name basic_httpd -dt -p 8080:80/tcp docker.io/nginx
 ```
 Because the container is being run in detached mode, represented by the *-d* in the `podman run` command, Podman
 will print the container ID after it has run. Note that we use port forwarding to be able to

--- a/docs/tutorials/podman_tutorial_cn.md
+++ b/docs/tutorials/podman_tutorial_cn.md
@@ -23,10 +23,7 @@ Podman是由libpod库提供一个实用的程序，可以被用于创建和管�
 这个示例容器会运行一个简单的只有主页的 httpd 服务器。
 
 ```console
-podman run -dt -p 8080:8080/tcp -e HTTPD_VAR_RUN=/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
-                  -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
-                  -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-                  registry.fedoraproject.org/f29/httpd /usr/bin/run-httpd
+podman run --name basic_httpd -dt -p 8080:80/tcp docker.io/nginx
 ```
 
 因为命令中的 *-d* 参数表明容器以 "detached" 模式运行，所以 Podman 会在容器运行后打印容器的 ID。


### PR DESCRIPTION
the podman tutorial refers to an old httpd image based on Fedora 29.  It is x86_64 only so Apple Silicon Macs and RPI's cannot follow the tutorial.  Switch to nginx

Fixes #20916 

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
