### PR TITLE
Improve error handling in win-lib.ps1

### DIFF
--- a/contrib/cirrus/win-lib.ps1
+++ b/contrib/cirrus/win-lib.ps1
@@ -46,12 +46,16 @@ if ($Env:CI -eq "true") {
 # (builtins)!  They set '$?' to "True" (failed) or "False" success so calling
 # this would mask failures.  Rely on $ErrorActionPreference = 'Stop' instead.
 function Check-Exit {
+    param (
+        [int] $stackPos = 1,
+        [string] $command = 'command'
+    )
+
     $result = $LASTEXITCODE  # WARNING: might not be a number!
     if ( ($result -ne $null) -and ($result -ne 0) ) {
         # https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.callstackframe
-        $caller = (Get-PSCallStack)[1]
-        Write-Host "Exit code = '$result' from $($caller.ScriptName):$($caller.ScriptLineNumber)"
-        Throw "Non-zero exit code"
+        $caller = (Get-PSCallStack)[$stackPos]
+        throw "Exit code = '$result' running $command at $($caller.ScriptName):$($caller.ScriptLineNumber)"
     }
 }
 
@@ -68,5 +72,5 @@ function Run-Command {
     Write-Host $command
 
     Invoke-Expression $command
-    Check-Exit
+    Check-Exit 2 "'$command'"
 }


### PR DESCRIPTION
This is just a small change to improve Windows CI testing:

- Modified Check-Exit to take a relative stack postition so that reusing functions like Run-Command report on their callers as opposed to the source position of the wrapper.
- Record and print the last command executed as it likely scrolled off with test output.

```release-note
none
```
