### PR TITLE
Fix WSL machine test regressions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20231206t225809z-f39f38d13"
+    IMAGE_SUFFIX: "c20231208t193858z-f39f38d13"
 
 
     # EC2 images

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -79,7 +79,7 @@ var _ = Describe("podman machine init", func() {
 
 		testMachine := inspectBefore[0]
 		Expect(testMachine.Name).To(Equal(mb.names[0]))
-		if testProvider.VMType() == machine.WSLVirt { // WSL hardware specs are hardcoded
+		if testProvider.VMType() != machine.WSLVirt { // WSL hardware specs are hardcoded
 			Expect(testMachine.Resources.CPUs).To(Equal(uint64(cpus)))
 			Expect(testMachine.Resources.Memory).To(Equal(uint64(2048)))
 		}

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -80,6 +80,7 @@ var _ = Describe("podman machine list", func() {
 	})
 
 	It("list machine: check if running while starting", func() {
+		skipIfWSL("the below logic does not work on WSL.  #20978")
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
@@ -91,6 +92,8 @@ var _ = Describe("podman machine list", func() {
 		Expect(listSession).To(Exit(0))
 		Expect(listSession.outputToString()).To(Equal("Never"))
 
+		// The logic in this test stanza is seemingly invalid on WSL.
+		// issue #20978 reflects this change
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).runWithoutWait()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
WSL is unable to set or change CPU/memory settings.  We should not test for them.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
