### PR TITLE
[CI:DOCS] move footnotes on divisive language to exactly where divisive language is used

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -6,7 +6,7 @@
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **ramfs**, **tmpfs** and **volume**. <sup>[[1]](#Footnote1)</sup>
+Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **ramfs**, **tmpfs** and **volume**.
 
        e.g.
        type=bind,source=/path/on/host,destination=/path/in/container
@@ -65,7 +65,7 @@ Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **r
 
 	      · ro, readonly: true or false (default).
 
-	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
+	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2). <sup>[[1]](#Footnote1)</sup>
 
 	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
 

--- a/docs/source/markdown/options/volume.image.md
+++ b/docs/source/markdown/options/volume.image.md
@@ -7,12 +7,12 @@
 Mount a host directory into containers when executing RUN instructions during
 the build.
 
-The `OPTIONS` are a comma-separated list and can be: <sup>[[1]](#Footnote1)</sup>
+The `OPTIONS` are a comma-separated list and can be:
 
    * [rw|ro]
    * [z|Z|O]
    * [U]
-   * [`[r]shared`|`[r]slave`|`[r]private`]
+   * [`[r]shared`|`[r]slave`|`[r]private`] <sup>[[1]](#Footnote1)</sup>
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
 must be an absolute path as well. Podman bind-mounts the `HOST-DIR` to the

--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -15,7 +15,7 @@ the `podman rm --volumes` command.
 
 (Note when using the remote client, including Mac and Windows (excluding WSL2) machines, the volumes are mounted from the remote server, not necessarily the client machine.)
 
-The _OPTIONS_ is a comma-separated list and can be: <sup>[[1]](#Footnote1)</sup>
+The _OPTIONS_ is a comma-separated list and can be:
 
 * **rw**|**ro**
 * **z**|**Z**
@@ -26,7 +26,7 @@ The _OPTIONS_ is a comma-separated list and can be: <sup>[[1]](#Footnote1)</sup>
 * [**no**]**exec**
 * [**no**]**suid**
 * [**r**]**bind**
-* [**r**]**shared**|[**r**]**slave**|[**r**]**private**[**r**]**unbindable**
+* [**r**]**shared**|[**r**]**slave**|[**r**]**private**[**r**]**unbindable** <sup>[[1]](#Footnote1)</sup>
 * **idmap**[=**options**]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The volume
@@ -135,9 +135,9 @@ By default bind mounted volumes are `private`. That means any mounts done
 inside the <<container|pod>> is not visible on host and vice versa. One can change
 this behavior by specifying a volume mount propagation property. Making a
 volume shared mounts done under that volume inside the <<container|pod>> is
-visible on host and vice versa. Making a volume **slave** enables only one
+visible on host and vice versa. Making a volume **slave**<sup>[[1]](#Footnote1)</sup> enables only one
 way mount propagation and that is mounts done on host under that volume
-is visible inside container but not the other way around. <sup>[[1]](#Footnote1)</sup>
+is visible inside container but not the other way around.
 
 To control mount propagation property of a volume one can use the [**r**]**shared**,
 [**r**]**slave**, [**r**]**private** or the [**r**]**unbindable** propagation flag.


### PR DESCRIPTION
My commit is not signed or using a realname but I don't believe that the changes I've made can be subject to copyright.

I got a bit confused when reading the manpage as the footnote on problematic and divisive language appeared after a sentence that doesn't use problematic and divisive language and I think moving the footnote to just after the wording deemed problematic makes the manpage more readable

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
