### PR TITLE
machine e2e : set default disk size to 11

### DIFF
--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -35,13 +35,15 @@ type initMachine struct {
 }
 
 func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
+	diskSize := defaultDiskSize
 	cmd := []string{"machine", "init"}
 	if i.cpus != nil {
 		cmd = append(cmd, "--cpus", strconv.Itoa(int(*i.cpus)))
 	}
 	if i.diskSize != nil {
-		cmd = append(cmd, "--disk-size", strconv.Itoa(int(*i.diskSize)))
+		diskSize = *i.diskSize
 	}
+	cmd = append(cmd, "--disk-size", strconv.Itoa(int(diskSize)))
 	if l := len(i.ignitionPath); l > 0 {
 		cmd = append(cmd, "--ignition-path", i.ignitionPath)
 	}

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -25,7 +25,8 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	defaultStream = machine.Testing
+	defaultStream        = machine.Testing
+	defaultDiskSize uint = 11
 )
 
 var (

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"runtime"
 	"strconv"
 	"strings"
@@ -131,7 +132,7 @@ var _ = Describe("podman machine set", func() {
 		sshSession3, err := mb.setName(name).setCmd(ssh3.withSSHCommand([]string{"sudo", "fdisk", "-l", "|", "grep", "Disk"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sshSession3).To(Exit(0))
-		Expect(sshSession3.outputToString()).To(ContainSubstring("100 GiB"))
+		Expect(sshSession3.outputToString()).To(ContainSubstring(fmt.Sprintf("%d GiB", defaultDiskSize)))
 	})
 
 	It("set rootful with docker sock change", func() {


### PR DESCRIPTION
this default value for podman machine disk sizes is 100GB.  On CI platforms where the IO is slow and some operations are not done sparsely, this can really slow things down.

if no disk size is provided by the init command in the test suite, we set it to 11G.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
