### PR TITLE
Fix push endpoint stream

### DIFF
--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -81,7 +81,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		ForceCompressionFormat: query.ForceCompressionFormat,
 		Format:                 query.Format,
 		Password:               password,
-		Quiet:                  true,
+		Quiet:                  query.Quiet,
 		RemoveSignatures:       query.RemoveSignatures,
 		Username:               username,
 	}
@@ -150,9 +150,9 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 			}
 			if pushError != nil {
 				stream.Error = pushError.Error()
-				if err := enc.Encode(stream); err != nil {
-					logrus.Warnf("Failed to encode json: %v", err)
-				}
+			}
+			if err := enc.Encode(stream); err != nil {
+				logrus.Warnf("Failed to encode json: %v", err)
 			}
 			flush()
 			return

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -43,8 +43,23 @@ s1=$(jq -r .status <<<"${lines[1]}")
 like "$s1" "mytag: digest: sha256:[0-9a-f]\{64\} size: [0-9]\+" \
      "Push to local registry: second status line"
 
+# Push to local registry using the libpod endpoint with quiet=false...
+# First create a new tag for the image to push
+t POST "libpod/images/$IMAGE/tag?repo=localhost:$REGISTRY_PORT/myrepo&tag=quiet-false" 201
+
+t POST "libpod/images/localhost:$REGISTRY_PORT/myrepo:quiet-false/push?tlsVerify=false&quiet=false" 200
+
+# ...and check output. We can't use our built-in checks because this output
+# is a sequence of JSON objects, i.e., individual ones, not in a JSON array.
+# The lines themselves are valid JSON, but taken together they are not.
+readarray lines <<<"$output"
+s0=$(jq -r .manifestdigest <<<"${lines[-1]}")
+like "$s0" "sha256:[0-9a-f]\{64\}" \
+   "Push to local registry: last line in push report"
+
 # Untag the image
 t POST "libpod/images/$iid/untag?repo=localhost:$REGISTRY_PORT/myrepo&tag=mytag" 201
+t POST "libpod/images/$iid/untag?repo=localhost:$REGISTRY_PORT/myrepo&tag=quiet-false" 201
 
 # Try to push non-existing image
 t POST "images/localhost:$REGISTRY_PORT/idonotexist/push?tlsVerify=false" 404


### PR DESCRIPTION
The push binding endpoint wasn't actually writing the output data to the stream when quiet=false and there was no push error.
Do not hard code quiet=true anymore, take into account the user input.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the push binding endpoint where the output wasn't being added to the stream when the push was successful. 
```
