### PR TITLE
Fix Docker API compatibility with network alias

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -291,6 +291,12 @@ type ContainerNetworkConfig struct {
 	// bind-mounted inside the container.
 	// Conflicts with HostAdd.
 	UseImageHosts bool
+	// BaseHostsFile is the path to a hosts file, the entries from this file
+	// are added to the containers hosts file. As special value "image" is
+	// allowed which uses the /etc/hosts file from within the image and "none"
+	// which uses no base file at all. If it is empty we should default
+	// to the base_hosts_file configuration in containers.conf.
+	BaseHostsFile string `json:"baseHostsFile,omitempty"`
 	// Hosts to add in container
 	// Will be appended to host's host file
 	HostAdd []string `json:"hostsAdd,omitempty"`

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2267,7 +2267,14 @@ func (c *Container) addHosts() error {
 	if err != nil {
 		return fmt.Errorf("failed to get container ip host entries: %w", err)
 	}
-	baseHostFile, err := etchosts.GetBaseHostFile(c.runtime.config.Containers.BaseHostsFile, c.state.Mountpoint)
+
+	// Consider container level BaseHostsFile configuration first.
+	// If it is empty, fallback to containers.conf level configuration.
+	baseHostsFileConf := c.config.BaseHostsFile
+	if baseHostsFileConf == "" {
+		baseHostsFileConf = c.runtime.config.Containers.BaseHostsFile
+	}
+	baseHostFile, err := etchosts.GetBaseHostFile(baseHostsFileConf, c.state.Mountpoint)
 	if err != nil {
 		return err
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2373,6 +2373,19 @@ func WithGroupEntry(groupEntry string) CtrCreateOption {
 	}
 }
 
+// WithBaseHostsFile sets the option to copy /etc/hosts file.
+func WithBaseHostsFile(baseHostsFile string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.BaseHostsFile = baseHostsFile
+
+		return nil
+	}
+}
+
 // WithMountAllDevices sets the option to mount all of a privileged container's
 // host devices
 func WithMountAllDevices() CtrCreateOption {

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -116,6 +116,8 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	// moby always create the working directory
 	sg.CreateWorkingDir = true
+	// moby doesn't inherit /etc/hosts from host
+	sg.BaseHostsFile = "none"
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -378,6 +378,9 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 	if s.GroupEntry != "" {
 		options = append(options, libpod.WithGroupEntry(s.GroupEntry))
 	}
+	if s.BaseHostsFile != "" {
+		options = append(options, libpod.WithBaseHostsFile(s.BaseHostsFile))
+	}
 
 	if s.Privileged {
 		options = append(options, libpod.WithMountAllDevices())

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -507,6 +507,13 @@ type ContainerNetworkConfig struct {
 	// specgen is stable so we can not change this right now.
 	// TODO (5.0): change to pointer
 	UseImageHosts bool `json:"use_image_hosts"`
+	// BaseHostsFile is the path to a hosts file, the entries from this file
+	// are added to the containers hosts file. As special value "image" is
+	// allowed which uses the /etc/hosts file from within the image and "none"
+	// which uses no base file at all. If it is empty we should default
+	// to the base_hosts_file configuration in containers.conf.
+	// Optional.
+	BaseHostsFile string `json:"base_hosts_file,omitempty"`
 	// HostAdd is a set of hosts which will be added to the container's
 	// /etc/hosts file.
 	// Conflicts with UseImageHosts.

--- a/test/compose/etc_hosts/README.md
+++ b/test/compose/etc_hosts/README.md
@@ -1,0 +1,10 @@
+etc hosts
+===========
+
+This test mounts a /etc/hosts file in the host containing an entry `foobar`, then create a container with an alias of the same hostname.
+
+Validation
+------------
+
+* No /etc/hosts entries are copied from the host. There should be only one entry of the hostname, which is IP address of the alias.
+* The hostname is resolved to IP address of the alias.

--- a/test/compose/etc_hosts/docker-compose.yml
+++ b/test/compose/etc_hosts/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.3'
+
+services:
+  test:
+    image: alpine
+    command: ["top"]
+    hostname: foobar
+    networks:
+      net1:
+        aliases:
+          - foobar
+
+networks:
+  net1:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.123.0.0/24

--- a/test/compose/etc_hosts/hosts
+++ b/test/compose/etc_hosts/hosts
@@ -1,0 +1,2 @@
+127.0.0.1 localhost
+127.0.0.1 foobar

--- a/test/compose/etc_hosts/setup.sh
+++ b/test/compose/etc_hosts/setup.sh
@@ -1,0 +1,5 @@
+if ! is_rootless; then
+    mount --bind $TEST_ROOTDIR/etc_hosts/hosts /etc/hosts
+else
+    $PODMAN_BIN unshare mount --bind $TEST_ROOTDIR/etc_hosts/hosts /etc/hosts
+fi

--- a/test/compose/etc_hosts/teardown.sh
+++ b/test/compose/etc_hosts/teardown.sh
@@ -1,0 +1,5 @@
+if ! is_rootless; then
+    umount /etc/hosts
+else
+    $PODMAN_BIN unshare umount /etc/hosts
+fi

--- a/test/compose/etc_hosts/tests.sh
+++ b/test/compose/etc_hosts/tests.sh
@@ -1,0 +1,12 @@
+# -*- bash -*-
+
+ctr_name="etc_hosts_test_1"
+if [ "$TEST_FLAVOR" = "compose_v2" ]; then
+    ctr_name="etc_hosts-test-1"
+fi
+
+podman exec "$ctr_name" sh -c 'grep "foobar" /etc/hosts'
+like "$output" "10\.123\.0\." "$testname : no entries are copied from the host"
+
+podman exec "$ctr_name" sh -c 'getent hosts foobar | awk "{print \$1}"'
+like "$output" "10\.123\.0\." "$testname : hostname is resolved to IP address of the alias"

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -207,7 +207,7 @@ function start_service() {
 
     $PODMAN_BIN \
         --log-level debug \
-	--storage-driver=vfs \
+        --storage-driver=vfs \
         --root $WORKDIR/root \
         --runroot $WORKDIR/runroot \
         --cgroup-manager=systemd \


### PR DESCRIPTION
Fixes #17167

I fixed this issue by applying @Luap99's suggestions - https://github.com/containers/podman/issues/17167#issuecomment-1486959315

> This is needed for it to work:
> 1. Add the `base_hosts_file` option to the container spec and config so it can be set for specific containers.
> 2. Then make sure the docker compat api sets this field to `none` to match the docker behavior.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in Docker API where the entries in /etc/hosts file are copied into the container resulting in incompatibility with network alias.
```
