### PR TITLE
Auto-correct previous bad image installs of podman-net-usermode

### DIFF
--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -29,6 +29,8 @@ fi
 if [[ ! $ROUTE =~ default\ via ]]; then
 	exit 3
 fi
+# auto-correct previous installs of known bad image v39.0.3
+chmod 755 /usr/local/bin/vm
 nohup /usr/local/bin/vm -iface podman-usermode -stop-if-exist ignore -url "stdio:$GVPROXY?listen-stdio=accept" > /var/log/vm.log 2> /var/log/vm.err  < /dev/null &
 echo $! > $STATE/vm.pid
 sleep 1


### PR DESCRIPTION
Additional improvement to resolution of #20982

v39.0.1-3 introduced an update to gvforwarder with defunct perms.  Detect and correct this condition so that users do not need to reinit a fresh user-mode dist.

```release-note
Auto-corrects previous installs of podman-net-usermode that were created from a defective image update (v39.0.1) 
```