### PR TITLE
Set stdin to nil for HyperV execs

### DIFF
--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -164,6 +164,7 @@ func runWrapper(podmanBinary string, cmdArgs []string, timeout time.Duration, wa
 	}
 	GinkgoWriter.Println(podmanBinary + " " + strings.Join(cmdArgs, " "))
 	c := exec.Command(podmanBinary, cmdArgs...)
+	c.Stdin = nil
 	session, err := Start(c, GinkgoWriter, GinkgoWriter)
 	if err != nil {
 		Fail(fmt.Sprintf("Unable to start session: %q", err))

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -775,6 +775,8 @@ func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingStat
 
 	logrus.Debugf("Starting gvproxy with command: %s %v", gvproxyBinary, c.Args)
 
+	c.Stdin = nil
+
 	if err := c.Start(); err != nil {
 		return "", 0, fmt.Errorf("unable to execute: %s: %w", cmd.ToCmdline(), err)
 	}
@@ -810,6 +812,8 @@ func (m *HyperVMachine) startHostNetworking() (string, machine.APIForwardingStat
 			return "", 0, err
 		}
 	}
+
+	fsCmd.Stdin = nil
 
 	if err := fsCmd.Start(); err != nil {
 		return "", 0, fmt.Errorf("unable to execute: %s %v: %w", executable, args, err)


### PR DESCRIPTION
We're seeing a bug where failed Podman commands can hang in the test suite, but somehow un-hang on STDIN activity (e.g. pressing enter). On Brent's vague suspicion that it was related to STDIN, I disabled STDIN on all execs from HyperV, and the hangs disappear. I don't know why this is, or why the hangs happen in the first place, but since this seems to work and should not have any negative consequences that I can think of, here we go.

[NO NEW TESTS NEEDED] I have no idea how to test this one.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
