### PR TITLE
hyperv: rework stop functions

### DIFF
--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -53,6 +53,21 @@ var _ = Describe("run basic podman commands", func() {
 		rmCon, err := mb.setCmd(bm.withPodmanCommand([]string{"rm", "-a"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rmCon).To(Exit(0))
+
+		// make sure gvproxy is running
+		before, beforeErr := pgrep(gvproxyBinaryName)
+		Expect(beforeErr).ToNot(HaveOccurred())
+		Expect(before).To(ContainSubstring(gvproxyBinaryName))
+
+		rm := rmMachine{}
+		removeSession, err := mb.setCmd(rm.withForce()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(removeSession).To(Exit(0))
+
+		// Make sure machine rm -f stopped gvproxy
+		after, afterError := pgrep(gvproxyBinaryName)
+		Expect(afterError).To(HaveOccurred())
+		Expect(after).ToNot(ContainSubstring(gvproxyBinaryName))
 	})
 
 	It("Podman ops with port forwarding and gvproxy", func() {
@@ -74,7 +89,8 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exec).To(Exit(0))
 
-		out, err := pgrep("gvproxy")
+		// make sure gvproxy is running
+		out, err := pgrep(gvproxyBinaryName)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).ToNot(BeEmpty())
 
@@ -89,8 +105,8 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(stopSession).To(Exit(0))
 
 		// gxproxy should exit after machine is stopped
-		out, _ = pgrep("gvproxy")
-		Expect(out).ToNot(ContainSubstring("gvproxy"))
+		out, _ = pgrep(gvproxyBinaryName)
+		Expect(out).ToNot(ContainSubstring(gvproxyBinaryName))
 	})
 
 })

--- a/pkg/machine/e2e/config_unix_test.go
+++ b/pkg/machine/e2e/config_unix_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 )
 
+var gvproxyBinaryName string = "gvproxy"
+
 func getDownloadLocation(p machine.VirtProvider) string {
 	return getFCOSDownloadLocation(p)
 }

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -12,6 +12,8 @@ import (
 
 const podmanBinary = "../../../bin/windows/podman.exe"
 
+var gvproxyBinaryName string = "gvproxy.exe"
+
 func getDownloadLocation(p machine.VirtProvider) string {
 	if p.VMType() == machine.HyperVVirt {
 		return getFCOSDownloadLocation(p)
@@ -33,7 +35,9 @@ func pgrep(n string) (string, error) {
 	}
 	strOut := string(out)
 	// in pgrep, if no running process is found, it exits 1 and the output is zilch
-	if strings.Contains(strOut, "INFO: No tasks are running which match the specified search") {
+	// also, originally in windows, the following substring had an append of "search" but it looks
+	// like some windows implementations use "criteria".  removed the append all-together
+	if strings.Contains(strOut, "INFO: No tasks are running which match the specified") {
 		return "", fmt.Errorf("no task found")
 	}
 	return strOut, nil

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -224,9 +224,9 @@ func (v HyperVVirtualization) RemoveAndCleanMachines() error {
 		if err != nil {
 			prevErr = handlePrevError(err, prevErr)
 		}
-
+		// using the mm stop so gvproxy will also be torn down
 		if vm.State() != hypervctl.Disabled {
-			if err := vm.StopWithForce(); err != nil {
+			if err := mm.stop(vm, true); err != nil {
 				prevErr = handlePrevError(err, prevErr)
 			}
 		}


### PR DESCRIPTION
in our hyperv code, we had cases like Remove, where we called directly to libhvee's stop code.  while this does work nicely, it leaks a gvproxy process.  resolution is have everything through an unexported stop function that also stops gvproxy.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
