### PR TITLE
Allow PublishPorts to be used with [Pod] entry

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -719,6 +719,7 @@ Valid options for `[Pod]` are listed below:
 | Network=host                        | --network host                         |
 | PodmanArgs=\-\-cpus=2               | --cpus=2                               |
 | PodName=name                        | --name=name                            |
+| PublishPort=50-59                   | --publish 50-59                        |
 | Volume=/source:/dest                | --volume /source:/dest                 |
 
 Supported keys in the `[Pod]` section are:
@@ -774,6 +775,23 @@ prefix to avoid conflicts with user-managed containers.
 
 Please note that pods and containers cannot have the same name.
 So, if PodName is set, it must not conflict with any container.
+
+### `PublishPort=`
+
+Exposes a port, or a range of ports (e.g. `50-59`), from the pod to the host. Equivalent
+to the Podman `--publish` option. The format is similar to the Podman options, which is of
+the form `ip:hostPort:containerPort`, `ip::containerPort`, `hostPort:containerPort` or
+`containerPort`, where the number of host and container ports must be the same (in the case
+of a range).
+
+If the IP is set to 0.0.0.0 or not set at all, the port is bound on all IPv4 addresses on
+the host; use [::] for IPv6.
+
+Note that not listing a host port means that Podman automatically selects one, and it
+may be different for each invocation of service. This makes that a less useful option. The
+allocated port can be found with the `podman port` command.
+
+This key can be listed multiple times.
 
 ### `Volume=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -324,8 +324,9 @@ var (
 		KeyContainersConfModule: true,
 		KeyGlobalArgs:           true,
 		KeyNetwork:              true,
-		KeyPodmanArgs:           true,
 		KeyPodName:              true,
+		KeyPodmanArgs:           true,
+		KeyPublishPort:          true,
 		KeyVolume:               true,
 	}
 )
@@ -1301,6 +1302,10 @@ func ConvertPod(podUnit *parser.UnitFile, name string, podsInfoMap map[string]*P
 		"--exit-policy=stop",
 		"--replace",
 	)
+
+	if err := handlePublishPorts(podUnit, PodGroup, execStartPre); err != nil {
+		return nil, err
+	}
 
 	addNetworks(podUnit, PodGroup, service, names, execStartPre)
 

--- a/test/e2e/quadlet/network.pod
+++ b/test/e2e/quadlet/network.pod
@@ -1,4 +1,6 @@
 ## assert-podman-pre-args "--network=host"
+## assert-podman-pre-args --publish 127.0.0.1:80:90
 
 [Pod]
 Network=host
+PublishPort=127.0.0.1:80:90


### PR DESCRIPTION
Fixed: https://github.com/containers/podman/issues/21035

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
[Pod] quadlets now support PublishPorts.
```
