### PR TITLE
[CI:DOCS] Fix `podman save` command example to use correct image format with `--compress` flag

### DIFF
--- a/docs/source/markdown/podman-save.1.md.in
+++ b/docs/source/markdown/podman-save.1.md.in
@@ -75,7 +75,7 @@ $ podman save -o oci-alpine.tar --format oci-archive alpine
 ```
 
 ```
-$ podman save --compress --format oci-dir -o alp-dir alpine
+$ podman save --compress --format docker-dir -o alp-dir alpine
 Getting image source signatures
 Copying blob sha256:2fdfe1cd78c20d05774f0919be19bc1a3e4729bce219968e4188e7e0f1af679d
  1.97 MB / 1.97 MB [========================================================] 0s


### PR DESCRIPTION
The docs have this note for the `--compress` flag

> Note: This flag can only be set with --format=docker-dir.

Yet the provided example has `--compress` with `--format=oci-dir`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix `podman save` command example to use correct image format with `--compress` flag
```
