### PR TITLE
Improve compose tests to report test errors as failures

### DIFF
--- a/test/compose/simple_port_map/frontend/Dockerfile
+++ b/test/compose/simple_port_map/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 WORKDIR /app
-RUN apk update && apk add py3-pip && pip3 install flask
+RUN apk update && apk add py3-flask
 COPY . /app
 ENTRYPOINT ["python3"]
 CMD ["app.py"]

--- a/test/compose/slirp4netns_opts/teardown.sh
+++ b/test/compose/slirp4netns_opts/teardown.sh
@@ -1,4 +1,4 @@
 # -*- bash -*-
 
-kill $nc_pid &> /dev/null
+kill $nc_pid &> /dev/null || true
 rm -f $OUTFILE

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -2,6 +2,7 @@
 #
 # Usage: test-compose [testname]
 #
+set -Eu
 ME=$(basename $0)
 
 ###############################################################################
@@ -240,7 +241,10 @@ function podman() {
         --runroot $WORKDIR/runroot \
         --network-config-dir $WORKDIR/cni \
         "$@")
+    rc=$?
+
     echo -n "$output" >>$WORKDIR/output.log
+    return $rc
 }
 
 ###################
@@ -300,8 +304,8 @@ for t in "${tests_to_run[@]}"; do
     testdir="$(dirname $t)"
     testname="$(basename $testdir)"
 
-    if [ -e $test_dir/SKIP ]; then
-        reason="$(<$test_dir/SKIP)"
+    if [ -e $testdir/SKIP ]; then
+        reason="$(<$testdir/SKIP)"
         if [ -n "$reason" ]; then
             reason=" - $reason"
         fi
@@ -315,13 +319,21 @@ for t in "${tests_to_run[@]}"; do
     (
         cd $testdir || die "Cannot cd $testdir"
 
+        if [ -e teardown.sh ]; then
+            trap 'teardown' EXIT
+            function teardown() {
+                trap '_show_ok 0 "$testname - teardown" "[ok]" "[error]"' ERR
+                . teardown.sh
+                trap - ERR
+            }
+        fi
+
         # setup file may be used for creating temporary directories/files.
         # We source it so that envariables defined in it will get back to us.
         if [ -e setup.sh ]; then
+            trap '_show_ok 0 "$testname - setup" "[ok]" "[error]"' ERR
             . setup.sh
-        fi
-        if [ -e teardown.sh ]; then
-            trap '. teardown.sh' 0
+            trap - ERR
         fi
 
         podman compose up -d     &> $logfile
@@ -337,11 +349,13 @@ for t in "${tests_to_run[@]}"; do
         # Run tests. This is likely to be a series of 'test_port' checks
         # but may also include podman commands to inspect labels, state
         if [ -e tests.sh ]; then
+            trap '_show_ok 0 "$testname - tests" "[ok]" "[error]"' ERR
             . tests.sh
+            trap - ERR
         fi
         # FIXME: if any tests fail, try 'podman logs' on container?
 
-        if [ -n "$COMPOSE_WAIT" ]; then
+        if [ -n "${COMPOSE_WAIT:-}" ]; then
             echo -n "Pausing due to \$COMPOSE_WAIT. Press ENTER to continue: "
             read keepgoing
         fi
@@ -379,8 +393,8 @@ done
 test_count=$(<$testcounter_file)
 failure_count=$(<$failures_file)
 
-if [ -z "$PODMAN_TESTS_KEEP_WORKDIR" ]; then
-     if ! is_rootless; then
+if [ -z "${PODMAN_TESTS_KEEP_WORKDIR:-}" ]; then
+    if ! is_rootless; then
         rm -rf $WORKDIR
     else
         $PODMAN_BIN unshare rm -rf $WORKDIR


### PR DESCRIPTION
@Luap99 raised a concern about test errors being ignored and not causing failures  https://github.com/containers/podman/pull/21013#discussion_r1426535202. cc @edsantiago

## Improvements

* Add traps to report setup, tests, and teardown errors as failures
* Pass through return code of podman commands
* Fix unset variables
* Fix simple_port_map image build when installing flask (PEP 668 - externally managed environment error)
* Ignore kill errors in slirp4netns_opts teardown steps

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
