### PR TITLE
quadlet container support multiple Ulimit options

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -659,6 +659,8 @@ This key can be listed multiple times.
 
 Ulimit options. Sets the ulimits values inside of the container.
 
+This key can be listed multiple times.
+
 ### `Unmask=`
 
 Specify the paths to unmask separated by a colon. unmask=ALL or /path/1:/path/2, or shell expanded paths (/proc/*):

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -574,8 +574,8 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 		podman.add("--security-opt", fmt.Sprintf("label=level:%s", securityLabelLevel))
 	}
 
-	ulimit, ok := container.Lookup(ContainerGroup, KeyUlimit)
-	if ok && len(ulimit) > 0 {
+	ulimits := container.LookupAll(ContainerGroup, KeyUlimit)
+	for _, ulimit := range ulimits {
 		podman.add("--ulimit", ulimit)
 	}
 

--- a/test/e2e/quadlet/ulimit.container
+++ b/test/e2e/quadlet/ulimit.container
@@ -1,6 +1,8 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--ulimit nproc:1234:5678"
+## assert-podman-args --ulimit nproc=1234:5678
+## assert-podman-args --ulimit cpu=1234:5678
 
 [Container]
 Image=localhost/imagename
-Ulimit=nproc:1234:5678
+Ulimit=nproc=1234:5678
+Ulimit=cpu=1234:5678

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -815,6 +815,7 @@ BOGUS=foo
 		Entry("subidmapping-with-remap.container", "subidmapping-with-remap.container", 1, "converting \"subidmapping-with-remap.container\": deprecated Remap keys are set along with explicit mapping keys"),
 		Entry("sysctl.container", "sysctl.container", 0, ""),
 		Entry("timezone.container", "timezone.container", 0, ""),
+		Entry("ulimit.container", "ulimit.container", 0, ""),
 		Entry("unmask.container", "unmask.container", 0, ""),
 		Entry("user.container", "user.container", 0, ""),
 		Entry("userns.container", "userns.container", 0, ""),


### PR DESCRIPTION
Add support for using multiple `Ulimit=` options in `.container` files. Before, only the last `Ulimit=` option was used in the podman command.

Update podman-systemd.unit.5 docs to reflect this change.

Add `test/e2e/quadlet/ulimit.container` to e2e tests.

Side note:
It took me a bit to figure out why when I was changing the `ulimit.container` file the quadlet test wasn't failing. It turns out that it hadn't been added to the list of entries in `test/e2e/quadlet_test.go`, so it hasn't actually been a part of the test suite since the `Ulimit=` option was added. I'm not sure if there is an automated way to check if all the files in the `test/e2e/quadlet/` directory are being tested, but it might be worth looking into.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet - Add support for listing Ulimit multiple times in .container files.
```
