### PR TITLE
Allow searching $TZDIR for timezone data

### DIFF
--- a/docs/source/markdown/options/tz.md
+++ b/docs/source/markdown/options/tz.md
@@ -4,5 +4,5 @@
 ####> are applicable to all of those.
 #### **--tz**=*timezone*
 
-Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
+Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones. Podman honors the `$TZDIR` environment variable to modify the `/usr/share/zoneinfo` search path for valid timezones.
 Remote connections use local containers.conf for defaults

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1708,6 +1708,14 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 	tz := c.Timezone()
 	if tz != "" {
 		timezonePath := filepath.Join("/usr/share/zoneinfo", tz)
+
+		// Allow using TZDIR per:
+		// https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzfile.c;h=8a923d0cccc927a106dc3e3c641be310893bab4e;hb=HEAD#l149
+		tzdir := os.Getenv("TZDIR")
+		if tzdir != "" {
+			timezonePath = filepath.Join(tzdir, tz)
+		}
+
 		if tz == "local" {
 			timezonePath, err = filepath.EvalSymlinks("/etc/localtime")
 			if err != nil {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -513,6 +513,11 @@ json-file | f
     assert "$output" == "../usr/share/zoneinfo/Europe/Berlin" "localtime is linked correctly"
 }
 
+@test "podman run --tz with zoneinfo and custom TZDIR env" {
+    # Setting the timezone should fail because it does not exist
+    TZDIR="$PODMAN_TMPDIR/zoneinfo" run_podman 127 run --rm --tz Europe/Berlin "$SYSTEMD_IMAGE"
+}
+
 # run with --runtime should preserve the named runtime
 @test "podman run : full path to --runtime is preserved" {
     skip_if_remote "podman-remote does not support --runtime option"


### PR DESCRIPTION
glibc supports the environment variable as additional search path, means we allow to override the `/usr/share/zoneinfo` path by setting the variable.

Analogous change to https://github.com/containers/common/pull/1772


#### Does this PR introduce a user-facing change?


```release-note
Added `TZDIR` environment variable support to modify the global timezone search path of `/usr/share/zoneinfo`.
```
