### PR TITLE
Support templates in quadlet

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -254,10 +254,22 @@ func loadUnitDropins(unit *parser.UnitFile, sourcePaths []string) error {
 		prevError = err
 	}
 
-	var dropinPaths = make(map[string]string)
-	for _, sourcePath := range sourcePaths {
-		dropinDir := path.Join(sourcePath, unit.Filename+".d")
+	dropinDirs := []string{}
 
+	for _, sourcePath := range sourcePaths {
+		dropinDirs = append(dropinDirs, path.Join(sourcePath, unit.Filename+".d"))
+	}
+
+	// For instantiated templates, also look in the non-instanced template dropin dirs
+	templateBase, templateInstance := unit.GetTemplateParts()
+	if templateBase != "" && templateInstance != "" {
+		for _, sourcePath := range sourcePaths {
+			dropinDirs = append(dropinDirs, path.Join(sourcePath, templateBase+".d"))
+		}
+	}
+
+	var dropinPaths = make(map[string]string)
+	for _, dropinDir := range dropinDirs {
 		dropinFiles, err := os.ReadDir(dropinDir)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
@@ -918,4 +919,14 @@ func (f *UnitFile) PrependComment(groupName string, comments ...string) {
 	for i := len(comments) - 1; i >= 0; i-- {
 		group.prependComment(newUnitLine("", "# "+comments[i], true))
 	}
+}
+
+func (f *UnitFile) GetTemplateParts() (string, string) {
+	ext := filepath.Ext(f.Filename)
+	basename := strings.TrimSuffix(f.Filename, ext)
+	parts := strings.SplitN(basename, "@", 2)
+	if len(parts) < 2 {
+		return "", ""
+	}
+	return parts[0] + "@" + ext, parts[1]
 }

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -439,7 +439,11 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	containerName, ok := container.Lookup(ContainerGroup, KeyContainerName)
 	if !ok || len(containerName) == 0 {
 		// By default, We want to name the container by the service name
-		containerName = "systemd-%N"
+		if strings.Contains(container.Filename, "@") {
+			containerName = "systemd-%P_%I"
+		} else {
+			containerName = "systemd-%N"
+		}
 	}
 
 	// Set PODMAN_SYSTEMD_UNIT so that podman auto-update can restart the service.

--- a/test/e2e/quadlet/template@.container
+++ b/test/e2e/quadlet/template@.container
@@ -1,0 +1,11 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--name=systemd-%P_%I"
+## assert-symlink want.service.wants/template@default.service ../template@.service
+## assert-podman-args --env "FOO=bar"
+
+[Container]
+Image=localhost/imagename
+
+[Install]
+WantedBy=want.service
+DefaultInstance=default

--- a/test/e2e/quadlet/template@.container.d/10-env.conf
+++ b/test/e2e/quadlet/template@.container.d/10-env.conf
@@ -1,0 +1,2 @@
+[Container]
+Environment=FOO=bar

--- a/test/e2e/quadlet/template@instance.container
+++ b/test/e2e/quadlet/template@instance.container
@@ -1,0 +1,11 @@
+## assert-podman-final-args localhost/changed-image
+## assert-podman-args "--name=systemd-%P_%I"
+## assert-symlink want.service.wants/template@instance.service ../template@instance.service
+## assert-podman-args --env "FOO=bar"
+
+[Container]
+# Will be changed by /template@instance.container.d/10-image.conf
+Image=localhost/imagename
+
+[Install]
+WantedBy=want.service

--- a/test/e2e/quadlet/template@instance.container.d/10-image.conf
+++ b/test/e2e/quadlet/template@instance.container.d/10-image.conf
@@ -1,0 +1,2 @@
+[Container]
+Image=localhost/changed-image


### PR DESCRIPTION
As discussed in https://github.com/containers/podman/discussions/17744 we would like to support template systemd unit, and also have a good way to enable them.

This PR makes the service files work, and adds support for `[Install]` to handle enabling default instances as well as individual instances by using symlinks.

```release-note
* support template units in quadlet
```
