### PR TITLE
[CI:DOCS] Warn about whitespace in /etc/subuid and /etc/subgid files

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -443,6 +443,10 @@ Or just add the content manually.
 
 See the `subuid(5)` and `subgid(5)` man pages for more information.
 
+
+
+Note: whitespace in any row of /etc/subuid or /etc/subgid, including trailing blanks, may result in no entry failures.
+
 Images are pulled under `XDG_DATA_HOME` when specified, otherwise in the home directory of the user under `.local/share/containers/storage`.
 
 Currently slirp4netns or pasta is required to be installed to create a network


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/21071

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
