### PR TITLE
cmd: support --config option

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -32,6 +32,9 @@ The CGroup manager to use for container cgroups. Supported values are __cgroupfs
 Note: Setting this flag can cause certain commands to break when called on containers previously created by the other CGroup manager type.
 Note: CGroup manager is not supported in rootless mode when using CGroups Version V1.
 
+#### **--config**
+Location of config file. Mainly for docker compatibility, only the authentication parts of the config are supported.
+
 #### **--conmon**
 Path of the conmon binary (Default path is configured in `containers.conf`)
 

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -35,7 +35,7 @@ type PodmanConfig struct {
 	ContainersConf           *config.Config
 	ContainersConfDefaultsRO *config.Config // The read-only! defaults from containers.conf.
 	DBBackend                string         // Hidden: change the database backend
-	DockerConfig             string         // Used for Docker compatibility
+	DockerConfig             string         // Location of authentication config file
 	CgroupUsage              string         // rootless code determines Usage message
 	ConmonPath               string         // --conmon flag will set Engine.ConmonPath
 	CPUProfile               string         // Hidden: Should CPU profile be taken

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -35,9 +35,6 @@ function setup() {
 
     run_podman -v
     is "$output" "podman.*version \+"               "'Version line' in output"
-
-    run_podman 0+w --config foobar version
-    require_warning "The --config flag is ignored by Podman. Exists for Docker compatibility"
 }
 
 # bats test_tags=distro-integration


### PR DESCRIPTION
Let's support --config option by setting environment variable DOCKER_CONFIG instead of ignoring it for docker compatibility.

Add test case for config option.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
pdoman run --config option is now supported.
```
