### PR TITLE
remote: fix podman-remote kube play --publish-all

### DIFF
--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -27,6 +27,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		NoTrunc          bool              `schema:"noTrunc"`
 		Replace          bool              `schema:"replace"`
 		PublishPorts     []string          `schema:"publishPorts"`
+		PublishAllPorts  bool              `schema:"publishAllPorts"`
 		ServiceContainer bool              `schema:"serviceContainer"`
 		Start            bool              `schema:"start"`
 		StaticIPs        []string          `schema:"staticIPs"`
@@ -97,6 +98,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		NoHosts:            query.NoHosts,
 		Password:           password,
 		PublishPorts:       query.PublishPorts,
+		PublishAllPorts:    query.PublishAllPorts,
 		Quiet:              true,
 		Replace:            query.Replace,
 		ServiceContainer:   query.ServiceContainer,

--- a/pkg/api/server/register_kube.go
+++ b/pkg/api/server/register_kube.go
@@ -53,6 +53,10 @@ func (s *APIServer) registerKubeHandlers(r *mux.Router) error {
 	//    items:
 	//         type: string
 	//  - in: query
+	//    name: publishAllPorts
+	//    type: boolean
+	//    description: Whether to publish all ports defined in the K8S YAML file (containerPort, hostPort), if false only hostPort will be published
+	//  - in: query
 	//    name: replace
 	//    type: boolean
 	//    default: false

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5644,6 +5644,18 @@ spec:
 		testHTTPServer("19003", false, "podman rulez")
 	})
 
+	It("podman play kube should publish containerPort with --publish-all", func() {
+		SkipIfRootless("rootlessport can't expose privileged port 80")
+		err := writeYaml(publishPortsPodWithContainerPort, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", "--publish-all=true", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+
+		testHTTPServer("80", false, "podman rulez")
+	})
+
 	It("with Host Ports - curl should succeed", func() {
 		err := writeYaml(publishPortsPodWithContainerHostPort, kubeYaml)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fix `podman kube play --publish-all` to work in remote environment.

**Before this PR:**

  podman-remote doesn't expose a host port (`PORTS`) corresponding to `containerPort` in k8s yaml if `--publish-all` is specified.

```
# podman-remote kube play --publish-all pod.yaml 
Pod:
3e5c844a6096f650bb5746415f5d70b5cff59a382d92538a3b6432b3eb4336bc
Container:
97f373367607259edbb1cec627617e518b690cb443a78b921c2aaa98ed1c7616

# podman-remote ps
CONTAINER ID  IMAGE                                        COMMAND               CREATED         STATUS                     PORTS       NAMES
c827dd896efc  localhost/podman-pause:5.0.0-dev-1703821817                        37 seconds ago  Up 35 seconds                          3e5c844a6096-infra
97f373367607  quay.io/libpod/alpine_nginx:latest           nginx -g daemon o...  35 seconds ago  Up 35 seconds (unhealthy)              nginx-pod-nginx-container
```

**After this PR:**

  podman-remote expose a host port (`PORTS`) corresponding to `containerPort` in k8s yaml if `--publish-all` is specifed.


```
# podman-remote kube play --publish-all pod.yaml 
Pod:
fb8778ffa24dc6135784507786d760fdee2ded84067a170687f3b3414f9c7f1a
Container:
b349ba916326cb2e5bf448aa7744274e31855d23ade5f00bcb5622f21199872c

# podman ps
CONTAINER ID  IMAGE                                        COMMAND               CREATED        STATUS                  PORTS               NAMES
e4b413342b04  localhost/podman-pause:5.0.0-dev-1703823286                        4 seconds ago  Up 2 seconds            0.0.0.0:80->80/tcp  fb8778ffa24d-infra
b349ba916326  quay.io/libpod/alpine_nginx:latest           nginx -g daemon o...  2 seconds ago  Up 2 seconds (healthy)  0.0.0.0:80->80/tcp  nginx-pod-nginx-container
```

<details><summary>pod.yaml</summary><div>

```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-pod
spec:
  containers:
    - name: nginx-container
      image: quay.io/libpod/alpine_nginx:latest
      ports:
      - containerPort: 80
```
</div></details>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The remote Podman client's `podman kube play --publish-all` option work now.
```
