### PR TITLE
e2e: Skip journalctl if journald is unavailable

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -851,17 +851,21 @@ type journaldTests struct {
 
 var journald journaldTests
 
-func SkipIfJournaldUnavailable() {
+// Check if journalctl is unavailable
+func checkAvailableJournald() {
 	f := func() {
 		journald.journaldSkip = false
 
-		// Check if journalctl is unavailable
 		cmd := exec.Command("journalctl", "-n", "1")
 		if err := cmd.Run(); err != nil {
 			journald.journaldSkip = true
 		}
 	}
 	journald.journaldOnce.Do(f)
+}
+
+func SkipIfJournaldUnavailable() {
+	checkAvailableJournald()
 
 	// In container, journalctl does not return an error even if
 	// journald is unavailable

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -64,8 +64,11 @@ WantedBy=default.target
 		start := SystemExec("systemctl", []string{dashWhat, "start", serviceName})
 		Expect(start).Should(ExitCleanly())
 
-		logs := SystemExec("journalctl", []string{dashWhat, "-n", "20", "-u", serviceName})
-		Expect(logs).Should(ExitCleanly())
+		checkAvailableJournald()
+		if !journald.journaldSkip {
+			logs := SystemExec("journalctl", []string{dashWhat, "-n", "20", "-u", serviceName})
+			Expect(logs).Should(ExitCleanly())
+		}
 
 		status := SystemExec("systemctl", []string{dashWhat, "status", serviceName})
 		Expect(status.OutputToString()).To(ContainSubstring("active (running)"))


### PR DESCRIPTION
Test "podman start container by systemd" is failed on the system in which rootless users don't have accessibility to journald. Therefore, skip the part that reads journal with journalctl.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
