### PR TITLE
Quadlet - fix trailing whitespaces handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
         exclude: test/buildah-bud/buildah-tests.diff
       - id: trailing-whitespace
-        exclude: test/buildah-bud/buildah-tests.diff|test/e2e/quadlet/remap-keep-id2.container
+        exclude: test/buildah-bud/buildah-tests.diff|test/e2e/quadlet/remap-keep-id2.container|test/e2e/quadlet/line-continuation-whitespace.container
       - id: mixed-line-ending
       - id: check-byte-order-marker
       - id: check-executables-have-shebangs

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -378,12 +378,23 @@ func nextLine(data string, afterPos int) (string, string) {
 	return data, ""
 }
 
+func trimSpacesFromLines(data string) string {
+	lines := strings.Split(data, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
 // Parse an already loaded unit file (in the form of a string)
 func (f *UnitFile) Parse(data string) error {
 	p := &UnitFileParser{
 		file:   f,
 		lineNr: 1,
 	}
+
+	data = trimSpacesFromLines(data)
+
 	for len(data) > 0 {
 		origdata := data
 		nLines := 1

--- a/test/e2e/quadlet/line-continuation-whitespace.container
+++ b/test/e2e/quadlet/line-continuation-whitespace.container
@@ -1,0 +1,9 @@
+## assert-podman-final-args localhost/imagename "/some/binary file" "--arg1" "arg 2"
+## assert-podman-args "--publish" "80:80"
+
+[Container]
+Image=localhost/imagename
+# Keep whitespace at the end of the following line
+Exec="/some/binary file" --arg1 \ 
+  "arg 2"
+PublishPort=80:80

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -776,6 +776,7 @@ BOGUS=foo
 		Entry("install.container", "install.container", 0, ""),
 		Entry("ip.container", "ip.container", 0, ""),
 		Entry("label.container", "label.container", 0, ""),
+		Entry("line-continuation-whitespace.container", "line-continuation-whitespace.container", 0, ""),
 		Entry("logdriver.container", "logdriver.container", 0, ""),
 		Entry("mask.container", "mask.container", 0, ""),
 		Entry("mount.container", "mount.container", 0, ""),


### PR DESCRIPTION
Remove all trailing white spaces from all lines before the line by line processing
Add test

#### Does this PR introduce a user-facing change?
No

```release-note
None
```

Resolves: #21109