### PR TITLE
machine: Use a single ssh key for all machines

### DIFF
--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -41,9 +41,6 @@ func init() {
 	formatFlagName := "force"
 	flags.BoolVarP(&destroyOptions.Force, formatFlagName, "f", false, "Stop and do not prompt before rming")
 
-	keysFlagName := "save-keys"
-	flags.BoolVar(&destroyOptions.SaveKeys, keysFlagName, false, "Do not delete SSH keys")
-
 	ignitionFlagName := "save-ignition"
 	flags.BoolVar(&destroyOptions.SaveIgnition, ignitionFlagName, false, "Do not delete ignition file")
 

--- a/docs/source/locale/ja/LC_MESSAGES/markdown.po
+++ b/docs/source/locale/ja/LC_MESSAGES/markdown.po
@@ -18478,10 +18478,6 @@ msgstr ""
 msgid "Do not delete the VM image."
 msgstr ""
 
-#: ../../source/markdown/podman-machine-rm.1.md:43
-msgid "**--save-keys**"
-msgstr ""
-
 #: ../../source/markdown/podman-machine-rm.1.md:45
 msgid ""
 "Do not delete the SSH keys for the VM.  The system connection is always "

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -10,7 +10,7 @@ podman\-machine\-rm - Remove a virtual machine
 
 Remove a virtual machine and its related files.  What is actually deleted
 depends on the virtual machine type.  For all virtual machines, the generated
-SSH keys and the podman system connection are deleted.  The ignition files
+podman system connections are deleted.  The ignition files
 generated for that VM are also removed as is its image file on the filesystem.
 
 Users get a display of what is deleted and are required to confirm unless the option `--force`
@@ -39,11 +39,6 @@ Do not delete the generated ignition file.
 
 Do not delete the VM image.
 
-#### **--save-keys**
-
-Do not delete the SSH keys for the VM.  The system connection is always
-deleted.
-
 ## EXAMPLES
 
 Remove a VM named "test1":
@@ -53,8 +48,6 @@ $ podman machine rm test1
 
 The following files will be deleted:
 
-/home/user/.ssh/test1
-/home/user/.ssh/test1.pub
 /home/user/.config/containers/podman/machine/qemu/test1.ign
 /home/user/.local/share/containers/podman/machine/qemu/test1_fedora-coreos-33.20210315.1.0-qemu.x86_64.qcow2
 /home/user/.config/containers/podman/machine/qemu/test1.json

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -259,7 +259,8 @@ func (m *MacMachine) Init(opts machine.InitOptions) (bool, error) {
 	})
 
 	if len(opts.IgnitionPath) > 0 {
-		return false, builder.BuildWithIgnitionFile(opts.IgnitionPath)
+		err = builder.BuildWithIgnitionFile(opts.IgnitionPath)
+		return false, err
 	}
 
 	if err := builder.GenerateIgnitionConfig(); err != nil {

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -113,7 +113,6 @@ type StopOptions struct{}
 
 type RemoveOptions struct {
 	Force        bool
-	SaveKeys     bool
 	SaveImage    bool
 	SaveIgnition bool
 }

--- a/pkg/machine/define/config.go
+++ b/pkg/machine/define/config.go
@@ -1,3 +1,4 @@
 package define
 
 const UserCertsTargetPath = "/etc/containers/certs.d"
+const DefaultIdentityName = "machine"

--- a/pkg/machine/e2e/config_rm_test.go
+++ b/pkg/machine/e2e/config_rm_test.go
@@ -5,13 +5,11 @@ type rmMachine struct {
 	  -f, --force           Stop and do not prompt before rming
 	      --save-ignition   Do not delete ignition file
 	      --save-image      Do not delete the image file
-	      --save-keys       Do not delete SSH keys
 
 	*/
 	force        bool
 	saveIgnition bool
 	saveImage    bool
-	saveKeys     bool
 
 	cmd []string
 }
@@ -26,9 +24,6 @@ func (i *rmMachine) buildCmd(m *machineTestBuilder) []string {
 	}
 	if i.saveImage {
 		cmd = append(cmd, "--save-image")
-	}
-	if i.saveKeys {
-		cmd = append(cmd, "--save-keys")
 	}
 	cmd = append(cmd, m.name)
 	i.cmd = cmd
@@ -47,10 +42,5 @@ func (i *rmMachine) withSaveIgnition() *rmMachine {
 
 func (i *rmMachine) withSaveImage() *rmMachine {
 	i.saveImage = true
-	return i
-}
-
-func (i *rmMachine) withSaveKeys() *rmMachine {
-	i.saveKeys = true
 	return i
 }

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -303,7 +303,7 @@ var _ = Describe("podman machine init", func() {
 		img := inspectSession.outputToString()
 
 		rm := rmMachine{}
-		removeSession, err := mb.setCmd(rm.withForce().withSaveKeys()).run()
+		removeSession, err := mb.setCmd(rm.withForce()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(removeSession).To(Exit(0))
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -313,20 +313,21 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ec).To(Equal(125))
 
-		// Clashing keys - init fails
-		i = new(initMachine)
-		session, err = mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(125))
-
-		// ensure files created by init are cleaned up on init failure
-		_, err = os.Stat(img)
-		Expect(err).To(HaveOccurred())
-		_, err = os.Stat(cfgpth)
-		Expect(err).To(HaveOccurred())
-
 		// WSL does not use ignition
 		if testProvider.VMType() != define.WSLVirt {
+			// Bad ignition path - init fails
+			i = new(initMachine)
+			i.ignitionPath = "/bad/path"
+			session, err = mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session).To(Exit(125))
+
+			// ensure files created by init are cleaned up on init failure
+			_, err = os.Stat(img)
+			Expect(err).To(HaveOccurred())
+			_, err = os.Stat(cfgpth)
+			Expect(err).To(HaveOccurred())
+
 			_, err = os.Stat(ign)
 			Expect(err).To(HaveOccurred())
 		}

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -232,7 +232,8 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 	// If the user provides an ignition file, we need to
 	// copy it into the conf dir
 	if len(opts.IgnitionPath) > 0 {
-		return false, builder.BuildWithIgnitionFile(opts.IgnitionPath)
+		err = builder.BuildWithIgnitionFile(opts.IgnitionPath)
+		return false, err
 	}
 	callbackFuncs.Add(m.IgnitionFile.Delete)
 

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -36,6 +36,20 @@ func CreateSSHKeys(writeLocation string) (string, error) {
 	return strings.TrimSuffix(string(b), "\n"), nil
 }
 
+// GetSSHKeys checks to see if there is a ssh key at the provided location.
+// If not, we create the priv and pub keys. The ssh key is then returned.
+func GetSSHKeys(identityPath string) (string, error) {
+	if _, err := os.Stat(identityPath); err == nil {
+		b, err := os.ReadFile(identityPath + ".pub")
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSuffix(string(b), "\n"), nil
+	}
+
+	return CreateSSHKeys(identityPath)
+}
+
 func CreateSSHKeysPrefix(identityPath string, passThru bool, skipExisting bool, prefix ...string) (string, error) {
 	_, e := os.Stat(identityPath)
 	if !skipExisting || errors.Is(e, os.ErrNotExist) {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -205,7 +205,8 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	// If the user provides an ignition file, we need to
 	// copy it into the conf dir
 	if len(opts.IgnitionPath) > 0 {
-		return false, builder.BuildWithIgnitionFile(opts.IgnitionPath)
+		err = builder.BuildWithIgnitionFile(opts.IgnitionPath)
+		return false, err
 	}
 
 	if err := builder.GenerateIgnitionConfig(); err != nil {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1184,7 +1184,7 @@ func ExitCode(err error) int {
 }
 
 func GetIdentityPath(name string) string {
-	return filepath.Join(homedir.Get(), ".ssh", name)
+	return filepath.Join(homedir.Get(), ".local", "share", "containers", "podman", "machine", name)
 }
 
 func Tmpdir() string {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -531,7 +531,7 @@ func TestValidateSysctlBadSysctlWithExtraSpaces(t *testing.T) {
 func TestGetIdentityPath(t *testing.T) {
 	name := "p-test"
 	identityPath := GetIdentityPath(name)
-	assert.Equal(t, identityPath, filepath.Join(homedir.Get(), ".ssh", name))
+	assert.Equal(t, identityPath, filepath.Join(homedir.Get(), ".local", "share", "containers", "podman", "machine", name))
 }
 
 func TestCoresToPeriodAndQuota(t *testing.T) {


### PR DESCRIPTION
Changes SSH key behavior such that there is a single persisted key for all
machines across all providers. If there is no key that is located at
`.local/share/containers/podman/machine/` then it is created. The keys are
not deleted when the last machine on the host is removed.

The main motivation for this change is it leads to fewer files created on the
host as a result of vm configuration. Having `n` machines on your system doesn't
result in `2n` machine-related files in `.ssh` on your system anymore.

As a result of ssh keys being persisted by default, the `--save-keys` flag on `podman machine rm` will no longer be supported.

Also fixes a bug where if a machine failed during init due to a bad ignition path,
it would not be properly torn down.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
All future machines created on the system will utilize the same persisted ssh key across all providers. The key will be located at `.local/share/containers/podman/machine/machine`. If the ssh key does not exist during machine initialization, it will be created. It is important to note when a machine is being removed, it will no longer remove the ssh keys. As a result, the `--save-keys` flag on `podman machine rm` will no longer be supported since the ssh keys are being persisted by default. If the user would like to override the default ssh keys with their own, they must place their key at `.local/share/containers/podman/machine/` and name it `machine`. 
```
