### PR TITLE
Refactor: replace 'multierror.Append' with 'errors.Join'

### DIFF
--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 )
 
@@ -135,7 +134,7 @@ func importCon(cmd *cobra.Command, args []string) error {
 		importOpts.SourceIsURL = true
 	}
 	if errFileName != nil && errURL != nil {
-		return multierror.Append(errFileName, errURL)
+		return errors.Join(errFileName, errURL)
 	}
 
 	importOpts.Source = source

--- a/hack/podman-registry-go/registry_test.go
+++ b/hack/podman-registry-go/registry_test.go
@@ -1,9 +1,9 @@
 package registry
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,11 +18,11 @@ func TestStartAndStopMultipleRegistries(t *testing.T) {
 	}
 
 	// Start registries.
-	var errors *multierror.Error
+	var errs error
 	for i := 0; i < 3; i++ {
 		reg, err := StartWithOptions(registryOptions)
 		if err != nil {
-			errors = multierror.Append(errors, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 		assert.True(t, len(reg.Image) > 0)
@@ -35,10 +35,10 @@ func TestStartAndStopMultipleRegistries(t *testing.T) {
 	// Stop registries.
 	for _, reg := range registries {
 		// Make sure we can stop it properly.
-		errors = multierror.Append(errors, reg.Stop())
+		errs = errors.Join(errs, reg.Stop())
 		// Stopping an already stopped registry is fine as well.
-		errors = multierror.Append(errors, reg.Stop())
+		errs = errors.Join(errs, reg.Stop())
 	}
 
-	require.NoError(t, errors.ErrorOrNil())
+	require.NoError(t, errs)
 }

--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/specgen"
-	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 )
 
@@ -162,13 +161,13 @@ func (r *Runtime) removeMalformedPod(ctx context.Context, p *Pod, ctrs []*Contai
 
 	// So, technically, no containers have been *removed*.
 	// They're still in the DB.
-	// So just return nil for removed containers. Squash all the errors into
-	// a multierror so we don't lose them.
+	// So just return nil for removed containers. Squash all the errors
+	// with errors.Join so we don't lose them.
 	if errored {
 		var allErrors error
 		for ctr, err := range removedCtrs {
 			if err != nil {
-				allErrors = multierror.Append(allErrors, fmt.Errorf("removing container %s: %w", ctr, err))
+				allErrors = errors.Join(allErrors, fmt.Errorf("removing container %s", ctr), err)
 			}
 		}
 		return nil, fmt.Errorf("no containers were removed due to the following errors: %w", allErrors)

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -20,7 +20,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgenutil"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/gorilla/schema"
-	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 )
 
@@ -252,11 +251,11 @@ func PodDelete(w http.ResponseWriter, r *http.Request) {
 		if len(ctrs) > 0 {
 			// We have container errors to send as well.
 			// Since we're just writing an error, and we don't want
-			// special error-handling for just this endpoint: use a
-			// multierror to package up all container errors.
+			// special error-handling for just this endpoint:
+			// package up all container errors with errors.Join.
 			var allCtrErrors error
 			for _, ctrErr := range ctrs {
-				allCtrErrors = multierror.Append(allCtrErrors, ctrErr)
+				allCtrErrors = errors.Join(allCtrErrors, ctrErr)
 			}
 
 			err = fmt.Errorf("%w. %s", err, allCtrErrors.Error())

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -130,7 +130,7 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string, o
 		if latestErr == nil {
 			latestErr = e
 		} else {
-			// FIXME should we use multierror package instead?
+			// FIXME should we use errors.Join instead?
 
 			// we want the new line here so ignore the linter
 			latestErr = fmt.Errorf("tried %v\n: %w", e, latestErr)

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -380,8 +380,8 @@ func (ic *ContainerEngine) PodClone(ctx context.Context, podClone entities.PodCl
 		_, err = ic.Libpod.RemovePod(ctx, p, true, true, timeout)
 		if err != nil {
 			// TODO: Possibly should handle case where containers
-			// failed to remove - maybe compact the errors into a
-			// multierror and return that?
+			// failed to remove - maybe compact the errors with
+			// errors.Join and return that?
 			return &entities.PodCloneReport{Id: pod.ID()}, err
 		}
 	}

--- a/pkg/errorhandling/errorhandling_test.go
+++ b/pkg/errorhandling/errorhandling_test.go
@@ -51,3 +51,46 @@ func TestCause(t *testing.T) {
 		})
 	}
 }
+
+func TestJoinErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		errs        []error
+		expectedErr error
+	}{
+		{
+			name:        "nil error",
+			errs:        nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "empty errors",
+			errs:        []error{},
+			expectedErr: nil,
+		},
+		{
+			name:        "one error",
+			errs:        []error{errors.New("e1")},
+			expectedErr: errors.New("e1"),
+		},
+		{
+			name:        "two errors",
+			errs:        []error{errors.New("e1"), errors.New("e2")},
+			expectedErr: errors.New("2 errors occurred:\n\t* e1\n\t* e2"),
+		},
+		{
+			name:        "three errors",
+			errs:        []error{errors.New("e1"), errors.New("e2"), errors.New("e3")},
+			expectedErr: errors.New("3 errors occurred:\n\t* e1\n\t* e2\n\t* e3"),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := JoinErrors(tc.errs)
+
+			assert.Equal(t, fmt.Sprint(tc.expectedErr), fmt.Sprint(err))
+		})
+	}
+}

--- a/pkg/farm/farm.go
+++ b/pkg/farm/farm.go
@@ -135,18 +135,18 @@ func (f *Farm) Status(ctx context.Context) (map[string]error, error) {
 // collects their results, continuing until it finishes visiting every node or
 // a function call returns true as its first return value.
 func (f *Farm) forEach(ctx context.Context, fn func(context.Context, string, entities.ImageEngine) (bool, error)) error {
-	var merr *multierror.Error
+	var merr error
 	for name, engine := range f.builders {
 		stop, err := fn(ctx, name, engine)
 		if err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("%s: %w", engine.FarmNodeName(ctx), err))
+			merr = errors.Join(merr, fmt.Errorf("%s", engine.FarmNodeName(ctx)), err)
 		}
 		if stop {
 			break
 		}
 	}
 
-	return merr.ErrorOrNil()
+	return merr
 }
 
 // NativePlatforms returns a list of the set of platforms for which the farm


### PR DESCRIPTION
This PR replaces usages of [`multierror.Append`](https://pkg.go.dev/github.com/hashicorp/go-multierror#Append) with native errors joining using [`errors.Join`](https://pkg.go.dev/errors#Join).

Additionally, added tests for `errorhandling.JoinErrors`.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
