### PR TITLE
CI: bump VMs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20231208t193858z-f39f38d13"
+    IMAGE_SUFFIX: "c20240102t212217z-f39f38d13"
 
 
     # EC2 images

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -689,7 +689,6 @@ function pasta_test_do() {
 }
 
 @test "TCP/IPv4 large transfer, tap" {
-    skip "FIXME: #20170 - needs passt >= 2023-11-10"
     pasta_test_do
 }
 


### PR DESCRIPTION
All VMs have pasta 2023-12-04, so, remove a skip.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```