### PR TITLE
Set applehv as default darwin provider

### DIFF
--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -20,7 +20,7 @@ func Get() (machine.VirtProvider, error) {
 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
 		provider = providerOverride
 	}
-	resolvedVMType, err := machine.ParseVMType(provider, machine.QemuVirt)
+	resolvedVMType, err := machine.ParseVMType(provider, machine.AppleHvVirt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Podman 5 will not support QEMU on darwin anymore.  This PR only changes the default from `qemu` to `applehv`.  Code changes to enforce not supporting qemu will come later.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The default machine provider for MacOS is the apple hypervisor
```
