### PR TITLE
[CI:DOCS] ci: Automatically add "podman machine" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,6 @@
 kind/api-change:
   - changed-files:
     - any-glob-to-any-file: pkg/api/**
+area/machine:
+  - changed-files:
+    - any-glob-to-any-file: pkg/machine/**


### PR DESCRIPTION
Because I want to track this sub-area myself.

BTW...any opinions on cleaning the labels up in this project?  I myself like the "area/XYZ" naming scheme.  It's used in Kubernetes ([example](https://github.com/kubernetes/kubernetes/pull/122557)) and in bootc, etc.

If agreed I'm happy to make the switch here.

```release-note
None
```
