### PR TITLE
machine: Save machine serial console by default

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -135,6 +135,12 @@ func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM,
 		return nil, err
 	}
 
+	serialPath, err := define.NewMachineFile(filepath.Join(dataDir, fmt.Sprintf("%s.console", opts.Name)), nil)
+	if err != nil {
+		return nil, err
+	}
+	m.SerialConsolePath = *serialPath
+
 	if err := ignition.SetIgnitionFile(&m.IgnitionFile, vmtype, m.Name, configDir); err != nil {
 		return nil, err
 	}

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -46,6 +46,11 @@ func (q *QemuCmd) SetQmpMonitor(monitor Monitor) {
 	*q = append(*q, "-qmp", monitor.Network+":"+monitor.Address.GetPath()+",server=on,wait=off")
 }
 
+// SetSerialConsole writes the default serial console to the target file
+func (q *QemuCmd) SetSerialConsole(console define.VMFile) {
+	*q = append(*q, "-chardev", "file,id=seriallog,path="+console.Path, "-serial", "chardev:seriallog")
+}
+
 // SetNetwork adds a network device to the machine
 func (q *QemuCmd) SetNetwork() {
 	// Right now the mac address is hardcoded so that the host networking gives it a specific IP address.  This is

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -66,6 +66,7 @@ func (v *MachineVM) setNewMachineCMD(qemuBinary string, cmdOpts *setNewMachineCM
 	v.CmdLine.SetMemory(v.Memory)
 	v.CmdLine.SetCPUs(v.CPUs)
 	v.CmdLine.SetIgnitionFile(v.IgnitionFile)
+	v.CmdLine.SetSerialConsole(v.SerialConsolePath)
 	v.CmdLine.SetQmpMonitor(v.QMPMonitor)
 	v.CmdLine.SetNetwork()
 	v.CmdLine.SetSerialPort(v.ReadySocket, v.VMPidFilePath, v.Name)
@@ -123,6 +124,10 @@ func (p *QEMUVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, e
 	// find QEMU binary
 	execPath, err := findQEMUBinary()
 	if err != nil {
+		return nil, err
+	}
+
+	if err := vm.setSerialConsolePath(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -61,6 +61,8 @@ type MachineVM struct {
 	Name string
 	// PidFilePath is the where the Proxy PID file lives
 	PidFilePath define.VMFile
+	// SerialConsolePath references the saved serial console path
+	SerialConsolePath define.VMFile
 	// VMPidFilePath is the where the VM PID file lives
 	VMPidFilePath define.VMFile
 	// QMPMonitor is the qemu monitor object for sending commands
@@ -924,6 +926,7 @@ func (v *MachineVM) collectFilesToDestroy(opts machine.RemoveOptions) ([]string,
 	if !opts.SaveImage {
 		files = append(files, v.getImageFile())
 	}
+	files = append(files, v.SerialConsolePath.Path)
 	socketPath, err := v.forwardSocketPath()
 	if err != nil {
 		return nil, err
@@ -1240,6 +1243,20 @@ func (v *MachineVM) setConfigPath() error {
 		return err
 	}
 	v.ConfigPath = *configPath
+	return nil
+}
+
+func (v *MachineVM) setSerialConsolePath() error {
+	vmConfigDir, err := machine.GetConfDir(vmtype)
+	if err != nil {
+		return err
+	}
+
+	configPath, err := define.NewMachineFile(filepath.Join(vmConfigDir, v.Name)+".console", nil)
+	if err != nil {
+		return err
+	}
+	v.SerialConsolePath = *configPath
 	return nil
 }
 


### PR DESCRIPTION
Motivated by making it easier to debug problems; I specifically want to make this change for MacOS in the future with applehv too.  But I just know how to do it with qemu today.

There's a new `podman machine get-console` verb that is hidden until:

- It's implemented on all platforms
- We bikeshed naming and functionality...for example it may make sense in theory to support the equivalent of `virsh console` which is interactive.

For now, this is just a debugging aid for us.

```release-note
None
```
