### PR TITLE
chore: delete obsolete // +build lines

### DIFF
--- a/cmd/podman-mac-helper/install.go
+++ b/cmd/podman-mac-helper/install.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package main
 

--- a/cmd/podman-mac-helper/main.go
+++ b/cmd/podman-mac-helper/main.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package main
 

--- a/cmd/podman-mac-helper/service.go
+++ b/cmd/podman-mac-helper/service.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package main
 

--- a/cmd/podman-mac-helper/uninstall.go
+++ b/cmd/podman-mac-helper/uninstall.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package main
 

--- a/cmd/podman-wslkerninst/event-hook.go
+++ b/cmd/podman-wslkerninst/event-hook.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/cmd/podman-wslkerninst/main.go
+++ b/cmd/podman-wslkerninst/main.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/cmd/podman/client_supported.go
+++ b/cmd/podman/client_supported.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package main
 

--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package main
 

--- a/cmd/podman/early_init_unsupported.go
+++ b/cmd/podman/early_init_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package main
 

--- a/cmd/podman/images/utils_unsupported.go
+++ b/cmd/podman/images/utils_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package images
 

--- a/cmd/podman/machine/client9p.go
+++ b/cmd/podman/machine/client9p.go
@@ -1,6 +1,4 @@
 //go:build linux && (amd64 || arm64)
-// +build linux
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/machine_unix.go
+++ b/cmd/podman/machine/machine_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || netbsd || openbsd || solaris
-// +build linux aix android darwin dragonfly freebsd hurd illumos ios netbsd openbsd solaris
 
 package machine
 

--- a/cmd/podman/machine/machine_unsupported.go
+++ b/cmd/podman/machine/machine_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package machine
 

--- a/cmd/podman/machine/os.go
+++ b/cmd/podman/machine/os.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/os/apply.go
+++ b/cmd/podman/machine/os/apply.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package os
 

--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package os
 

--- a/cmd/podman/machine/os/os_unsupported.go
+++ b/cmd/podman/machine/os/os_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package os
 

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/server9p.go
+++ b/cmd/podman/machine/server9p.go
@@ -1,6 +1,4 @@
 //go:build windows && (amd64 || arm64)
-// +build windows
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/cmd/podman/parse/parse.go
+++ b/cmd/podman/parse/parse.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package parse
 

--- a/cmd/podman/registry/config_abi.go
+++ b/cmd/podman/registry/config_abi.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package registry
 

--- a/cmd/podman/registry/config_tunnel.go
+++ b/cmd/podman/registry/config_tunnel.go
@@ -1,5 +1,4 @@
 //go:build remote
-// +build remote
 
 package registry
 

--- a/cmd/podman/registry/registry_common.go
+++ b/cmd/podman/registry/registry_common.go
@@ -1,5 +1,4 @@
 //go:build !freebsd
-// +build !freebsd
 
 package registry
 

--- a/cmd/podman/syslog_common.go
+++ b/cmd/podman/syslog_common.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package main
 

--- a/cmd/podman/syslog_unsupported.go
+++ b/cmd/podman/syslog_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package main
 

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package system
 

--- a/cmd/podman/system/renumber.go
+++ b/cmd/podman/system/renumber.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package system
 

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package system
 

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -1,5 +1,4 @@
 //go:build (amd64 && !remote) || (arm64 && !remote)
-// +build amd64,!remote arm64,!remote
 
 package system
 

--- a/cmd/podman/system/reset_machine_unsupported.go
+++ b/cmd/podman/system/reset_machine_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package system
 

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -1,6 +1,4 @@
 //go:build (linux || freebsd) && !remote
-// +build linux freebsd
-// +build !remote
 
 package system
 

--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -1,6 +1,4 @@
 //go:build (linux || freebsd) && !remote
-// +build linux freebsd
-// +build !remote
 
 package system
 

--- a/cmd/rootlessport/main.go
+++ b/cmd/rootlessport/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/cmd/winpath/main.go
+++ b/cmd/winpath/main.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/common_test.go
+++ b/libpod/common_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_copy_common.go
+++ b/libpod/container_copy_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/container_copy_freebsd.go
+++ b/libpod/container_copy_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_copy_linux.go
+++ b/libpod/container_copy_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_freebsd.go
+++ b/libpod/container_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_graph.go
+++ b/libpod/container_graph.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_graph_test.go
+++ b/libpod/container_graph_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_inspect_freebsd.go
+++ b/libpod/container_inspect_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_linux.go
+++ b/libpod/container_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote && linux && systemd
-// +build !remote,linux,systemd
 
 package libpod
 

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -1,6 +1,4 @@
 //go:build !remote && (!linux || !systemd)
-// +build !remote
-// +build !linux !systemd
 
 package libpod
 

--- a/libpod/container_path_resolution.go
+++ b/libpod/container_path_resolution.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_path_resolution_test.go
+++ b/libpod/container_path_resolution_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_stat_common.go
+++ b/libpod/container_stat_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/container_stat_freebsd.go
+++ b/libpod/container_stat_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_stat_linux.go
+++ b/libpod/container_stat_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_top_freebsd.go
+++ b/libpod/container_top_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/container_top_linux.c
+++ b/libpod/container_top_linux.c
@@ -1,5 +1,5 @@
 //go:build !remote
-// +build !remote
+
 
 #define _GNU_SOURCE
 #include <errno.h>

--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote && linux && cgo
-// +build !remote,linux,cgo
 
 package libpod
 

--- a/libpod/container_top_unsupported.go
+++ b/libpod/container_top_unsupported.go
@@ -1,7 +1,4 @@
 //go:build !remote && !(linux && cgo) && !freebsd
-// +build !remote
-// +build !linux !cgo
-// +build !freebsd
 
 package libpod
 

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/events/events_unsupported.go
+++ b/libpod/events/events_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package events
 

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -1,5 +1,4 @@
 //go:build systemd
-// +build systemd
 
 package events
 

--- a/libpod/events/journal_unsupported.go
+++ b/libpod/events/journal_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !systemd
-// +build !systemd
 
 package events
 

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package events
 

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote && systemd
-// +build !remote,systemd
 
 package libpod
 

--- a/libpod/healthcheck_nosystemd_linux.go
+++ b/libpod/healthcheck_nosystemd_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote && !systemd
-// +build !remote,!systemd
 
 package libpod
 

--- a/libpod/healthcheck_unsupported.go
+++ b/libpod/healthcheck_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !remote && !linux
-// +build !remote,!linux
 
 package libpod
 

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/info_freebsd.go
+++ b/libpod/info_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/info_test.go
+++ b/libpod/info_test.go
@@ -1,5 +1,4 @@
 //go:build !remote && linux
-// +build !remote,linux
 
 package libpod
 

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/linkmode/linkmode_dynamic.go
+++ b/libpod/linkmode/linkmode_dynamic.go
@@ -1,5 +1,4 @@
 //go:build !static
-// +build !static
 
 package linkmode
 

--- a/libpod/linkmode/linkmode_static.go
+++ b/libpod/linkmode/linkmode_static.go
@@ -1,5 +1,4 @@
 //go:build static
-// +build static
 
 package linkmode
 

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -1,6 +1,4 @@
 //go:build (linux || freebsd) && cgo
-// +build linux freebsd
-// +build cgo
 
 package shm
 

--- a/libpod/lock/shm/shm_lock_nocgo.go
+++ b/libpod/lock/shm/shm_lock_nocgo.go
@@ -1,5 +1,4 @@
 //go:build linux && !cgo
-// +build linux,!cgo
 
 package shm
 

--- a/libpod/lock/shm/shm_lock_test.go
+++ b/libpod/lock/shm/shm_lock_test.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package shm
 

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package lock
 

--- a/libpod/lock/shm_lock_manager_unsupported.go
+++ b/libpod/lock/shm_lock_manager_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package lock
 

--- a/libpod/mounts_linux.go
+++ b/libpod/mounts_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/networking_freebsd.go
+++ b/libpod/networking_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/networking_linux_test.go
+++ b/libpod/networking_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/networking_machine.go
+++ b/libpod/networking_machine.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/networking_pasta_linux.go
+++ b/libpod/networking_pasta_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -1,5 +1,4 @@
 //go:build !remote && linux
-// +build !remote,linux
 
 package libpod
 

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon.go
+++ b/libpod/oci_conmon.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon_attach_common.go
+++ b/libpod/oci_conmon_attach_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/oci_conmon_attach_freebsd.go
+++ b/libpod/oci_conmon_attach_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon_attach_linux.go
+++ b/libpod/oci_conmon_attach_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/oci_conmon_exec_freebsd.go
+++ b/libpod/oci_conmon_exec_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon_freebsd.go
+++ b/libpod/oci_conmon_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/oci_util.go
+++ b/libpod/oci_util.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_internal_freebsd.go
+++ b/libpod/pod_internal_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_internal_linux.go
+++ b/libpod/pod_internal_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_status.go
+++ b/libpod/pod_status.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_top_freebsd.go
+++ b/libpod/pod_top_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/pod_top_linux.go
+++ b/libpod/pod_top_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/rlimit_int64.go
+++ b/libpod/rlimit_int64.go
@@ -1,5 +1,4 @@
 //go:build !remote && freebsd
-// +build !remote,freebsd
 
 package libpod
 

--- a/libpod/rlimit_uint64.go
+++ b/libpod/rlimit_uint64.go
@@ -1,5 +1,4 @@
 //go:build !remote && linux
-// +build !remote,linux
 
 package libpod
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_ctr_freebsd.go
+++ b/libpod/runtime_ctr_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_ctr_linux.go
+++ b/libpod/runtime_ctr_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_migrate_linux.go
+++ b/libpod/runtime_migrate_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_migrate_unsupported.go
+++ b/libpod/runtime_migrate_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !remote && !linux
-// +build !remote,!linux
 
 package libpod
 

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/runtime_pod_freebsd.go
+++ b/libpod/runtime_pod_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_pre_go1.20.go
+++ b/libpod/runtime_pre_go1.20.go
@@ -1,7 +1,6 @@
 // In go 1.20 and later, the global RNG is automatically initialized.
 // Ref: https://pkg.go.dev/math/rand@go1.20#Seed
 //go:build !go1.20 && !remote
-// +build !go1.20,!remote
 
 package libpod
 

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_test.go
+++ b/libpod/runtime_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/runtime_worker.go
+++ b/libpod/runtime_worker.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/service.go
+++ b/libpod/service.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/sqlite_state_internal.go
+++ b/libpod/sqlite_state_internal.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/stats_common.go
+++ b/libpod/stats_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/stats_freebsd.go
+++ b/libpod/stats_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/stats_linux.go
+++ b/libpod/stats_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/util_freebsd.go
+++ b/libpod/util_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/util_linux_test.go
+++ b/libpod/util_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/util_test.go
+++ b/libpod/util_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/volume_internal_common.go
+++ b/libpod/volume_internal_common.go
@@ -1,6 +1,4 @@
 //go:build !remote && (linux || freebsd)
-// +build !remote
-// +build linux freebsd
 
 package libpod
 

--- a/libpod/volume_internal_freebsd.go
+++ b/libpod/volume_internal_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/libpod/volume_internal_linux.go
+++ b/libpod/volume_internal_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package libpod
 

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package autoupdate
 

--- a/pkg/bindings/containers/term_unix.go
+++ b/pkg/bindings/containers/term_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package containers
 

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/bindings/images/build_unix.go
+++ b/pkg/bindings/images/build_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package images
 

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package checkpoint
 

--- a/pkg/criu/criu_linux.go
+++ b/pkg/criu/criu_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package criu
 

--- a/pkg/criu/criu_unsupported.go
+++ b/pkg/criu/criu_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package criu
 

--- a/pkg/ctime/ctime_linux.go
+++ b/pkg/ctime/ctime_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ctime
 

--- a/pkg/ctime/ctime_unsupported.go
+++ b/pkg/ctime/ctime_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package ctime
 

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package filters
 

--- a/pkg/domain/filters/pods.go
+++ b/pkg/domain/filters/pods.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package filters
 

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package filters
 

--- a/pkg/domain/infra/abi/farm.go
+++ b/pkg/domain/infra/abi/farm.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package abi
 

--- a/pkg/domain/infra/abi/terminal/sigproxy_commn.go
+++ b/pkg/domain/infra/abi/terminal/sigproxy_commn.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package terminal
 

--- a/pkg/domain/infra/abi/terminal/terminal_common.go
+++ b/pkg/domain/infra/abi/terminal/terminal_common.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package terminal
 

--- a/pkg/domain/infra/abi/terminal/terminal_unsupported.go
+++ b/pkg/domain/infra/abi/terminal/terminal_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package terminal
 

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package infra
 

--- a/pkg/domain/infra/runtime_abi_unsupported.go
+++ b/pkg/domain/infra/runtime_abi_unsupported.go
@@ -1,5 +1,4 @@
 //go:build remote
-// +build remote
 
 package infra
 

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package infra
 

--- a/pkg/domain/infra/runtime_proxy.go
+++ b/pkg/domain/infra/runtime_proxy.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package infra
 

--- a/pkg/domain/infra/runtime_tunnel.go
+++ b/pkg/domain/infra/runtime_tunnel.go
@@ -1,5 +1,4 @@
 //go:build remote
-// +build remote
 
 package infra
 

--- a/pkg/emulation/binfmtmisc_linux.go
+++ b/pkg/emulation/binfmtmisc_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package emulation
 

--- a/pkg/emulation/binfmtmisc_linux_test.go
+++ b/pkg/emulation/binfmtmisc_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package emulation
 

--- a/pkg/emulation/binfmtmisc_other.go
+++ b/pkg/emulation/binfmtmisc_other.go
@@ -1,5 +1,4 @@
 //go:build !linux && !remote
-// +build !linux,!remote
 
 package emulation
 

--- a/pkg/emulation/elf.go
+++ b/pkg/emulation/elf.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package emulation
 

--- a/pkg/emulation/emulation.go
+++ b/pkg/emulation/emulation.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package emulation
 

--- a/pkg/env/env_unix.go
+++ b/pkg/env/env_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package env
 

--- a/pkg/fileserver/server_unsupported.go
+++ b/pkg/fileserver/server_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fileserver
 

--- a/pkg/k8s.io/apimachinery/pkg/util/intstr/instr_fuzz.go
+++ b/pkg/k8s.io/apimachinery/pkg/util/intstr/instr_fuzz.go
@@ -1,5 +1,4 @@
 //go:build !notest
-// +build !notest
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/machine/applehv/claim.go
+++ b/pkg/machine/applehv/claim.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/ignition.go
+++ b/pkg/machine/applehv/ignition.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/vfkit.go
+++ b/pkg/machine/applehv/vfkit.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package applehv
 

--- a/pkg/machine/applehv/vfkit/config.go
+++ b/pkg/machine/applehv/vfkit/config.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package vfkit
 

--- a/pkg/machine/applehv/vfkit/rest.go
+++ b/pkg/machine/applehv/vfkit/rest.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package vfkit
 

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/config_test.go
+++ b/pkg/machine/config_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/connection.go
+++ b/pkg/machine/connection.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/define/vmfile_test.go
+++ b/pkg/machine/define/vmfile_test.go
@@ -1,5 +1,4 @@
 //go:build (amd64 && !windows) || (arm64 && !windows)
-// +build amd64,!windows arm64,!windows
 
 package define
 

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/fcos_test.go
+++ b/pkg/machine/fcos_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/fedora_unix.go
+++ b/pkg/machine/fedora_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package machine
 

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package hyperv
 

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package hyperv
 

--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package vsock
 

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/ignition_darwin.go
+++ b/pkg/machine/ignition_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package machine
 

--- a/pkg/machine/ignition_freebsd.go
+++ b/pkg/machine/ignition_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package machine
 

--- a/pkg/machine/ignition_schema.go
+++ b/pkg/machine/ignition_schema.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/ignition_windows.go
+++ b/pkg/machine/ignition_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package machine
 

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/machine_unix.go
+++ b/pkg/machine/machine_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package machine
 

--- a/pkg/machine/machine_unsupported.go
+++ b/pkg/machine/machine_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package machine

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package machine
 

--- a/pkg/machine/os/config.go
+++ b/pkg/machine/os/config.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package os
 

--- a/pkg/machine/os/machine_os.go
+++ b/pkg/machine/os/machine_os.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package os
 

--- a/pkg/machine/os/ostree.go
+++ b/pkg/machine/os/ostree.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package os
 

--- a/pkg/machine/ports_unix.go
+++ b/pkg/machine/ports_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package machine
 

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/qemu/claim_unsupported.go
+++ b/pkg/machine/qemu/claim_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package qemu
 

--- a/pkg/machine/qemu/command/qemu_command_test.go
+++ b/pkg/machine/qemu/command/qemu_command_test.go
@@ -1,5 +1,4 @@
 //go:build (amd64 && !windows) || (arm64 && !windows)
-// +build amd64,!windows arm64,!windows
 
 package command
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package qemu
 

--- a/pkg/machine/qemu/machine_test.go
+++ b/pkg/machine/qemu/machine_test.go
@@ -1,5 +1,4 @@
 //go:build (amd64 && !windows) || (arm64 && !windows)
-// +build amd64,!windows arm64,!windows
 
 package qemu
 

--- a/pkg/machine/qemu/machine_unix.go
+++ b/pkg/machine/qemu/machine_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package qemu
 

--- a/pkg/machine/qemu/machine_unsupported.go
+++ b/pkg/machine/qemu/machine_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package qemu

--- a/pkg/machine/update.go
+++ b/pkg/machine/update.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package machine
 

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/fedora.go
+++ b/pkg/machine/wsl/fedora.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/filelock.go
+++ b/pkg/machine/wsl/filelock.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/machine_unsupported.go
+++ b/pkg/machine/wsl/machine_unsupported.go
@@ -1,4 +1,3 @@
 //go:build !windows
-// +build !windows
 
 package wsl

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wsl
 

--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package wutil
 

--- a/pkg/parallel/ctr/ctr.go
+++ b/pkg/parallel/ctr/ctr.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package ctr
 

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package ps
 

--- a/pkg/rctl/rctl.go
+++ b/pkg/rctl/rctl.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package rctl
 

--- a/pkg/rootless/rootless_freebsd.go
+++ b/pkg/rootless/rootless_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd && cgo
-// +build freebsd,cgo
 
 package rootless
 

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -1,5 +1,4 @@
 //go:build linux && cgo
-// +build linux,cgo
 
 package rootless
 

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !(linux || freebsd) || !cgo
-// +build !linux,!freebsd !cgo
 
 package rootless
 

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -1,5 +1,4 @@
 //go:build linux && !mips && !mipsle && !mips64 && !mips64le
-// +build linux,!mips,!mipsle,!mips64,!mips64le
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -1,6 +1,4 @@
 //go:build linux && (mips || mipsle || mips64 || mips64le)
-// +build linux
-// +build mips mipsle mips64 mips64le
 
 // Special signal handling for mips architecture
 package signal

--- a/pkg/signal/signal_unix.go
+++ b/pkg/signal/signal_unix.go
@@ -1,5 +1,4 @@
 //go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris || zos
-// +build aix darwin dragonfly freebsd netbsd openbsd solaris zos
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/signal/signal_unsupported.go
+++ b/pkg/signal/signal_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !zos
-// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!zos
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/specgen/generate/config_common.go
+++ b/pkg/specgen/generate/config_common.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/config_common_test.go
+++ b/pkg/specgen/generate/config_common_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/config_freebsd.go
+++ b/pkg/specgen/generate/config_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/config_linux_seccomp.go
+++ b/pkg/specgen/generate/config_linux_seccomp.go
@@ -1,5 +1,4 @@
 //go:build linux && !remote
-// +build linux,!remote
 
 package generate
 

--- a/pkg/specgen/generate/config_linux_test.go
+++ b/pkg/specgen/generate/config_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package kube
 

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package kube
 

--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -1,5 +1,4 @@
 //go:build linux && !remote
-// +build linux,!remote
 
 package kube
 

--- a/pkg/specgen/generate/kube/seccomp.go
+++ b/pkg/specgen/generate/kube/seccomp.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package kube
 

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package kube
 

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/namespaces_freebsd.go
+++ b/pkg/specgen/generate/namespaces_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/namespaces_linux.go
+++ b/pkg/specgen/generate/namespaces_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/pause_image.go
+++ b/pkg/specgen/generate/pause_image.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/pod_create_test.go
+++ b/pkg/specgen/generate/pod_create_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/ports_bench_test.go
+++ b/pkg/specgen/generate/ports_bench_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/ports_test.go
+++ b/pkg/specgen/generate/ports_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/security_freebsd.go
+++ b/pkg/specgen/generate/security_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/security_linux.go
+++ b/pkg/specgen/generate/security_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/storage_freebsd.go
+++ b/pkg/specgen/generate/storage_freebsd.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/storage_linux.go
+++ b/pkg/specgen/generate/storage_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/generate/validate_linux.go
+++ b/pkg/specgen/generate/validate_linux.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/specgen/specgen_local.go
+++ b/pkg/specgen/specgen_local.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package specgen
 

--- a/pkg/specgen/specgen_remote.go
+++ b/pkg/specgen/specgen_remote.go
@@ -1,5 +1,4 @@
 //go:build remote
-// +build remote
 
 package specgen
 

--- a/pkg/specgen/utils.go
+++ b/pkg/specgen/utils.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package specgen
 

--- a/pkg/specgen/utils_linux.go
+++ b/pkg/specgen/utils_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package specgen
 

--- a/pkg/specgen/winpath_unsupported.go
+++ b/pkg/specgen/winpath_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package specgen
 

--- a/pkg/specgenutil/specgenutil_test.go
+++ b/pkg/specgenutil/specgenutil_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package specgenutil
 

--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/systemd/generate/common_test.go
+++ b/pkg/systemd/generate/common_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -1,5 +1,4 @@
 //go:build !remote
-// +build !remote
 
 package generate
 

--- a/pkg/terminal/console_unix.go
+++ b/pkg/terminal/console_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package terminal
 

--- a/pkg/terminal/console_windows.go
+++ b/pkg/terminal/console_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package terminal
 

--- a/pkg/util/mountOpts_other.go
+++ b/pkg/util/mountOpts_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package util
 

--- a/pkg/util/utils_darwin.go
+++ b/pkg/util/utils_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package util
 

--- a/pkg/util/utils_freebsd.go
+++ b/pkg/util/utils_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package util
 

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package util
 

--- a/pkg/util/utils_unsupported.go
+++ b/pkg/util/utils_unsupported.go
@@ -1,5 +1,4 @@
 //go:build darwin || windows || freebsd
-// +build darwin windows freebsd
 
 package util
 

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package util
 

--- a/test/checkseccomp/checkseccomp.go
+++ b/test/checkseccomp/checkseccomp.go
@@ -1,5 +1,4 @@
 //go:build seccomp
-// +build seccomp
 
 package main
 

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -1,5 +1,4 @@
 //go:build remote_testing
-// +build remote_testing
 
 package integration
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -1,5 +1,4 @@
 //go:build !remote_testing
-// +build !remote_testing
 
 package integration
 

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -1,5 +1,4 @@
 //go:build !remote_testing
-// +build !remote_testing
 
 // build for play kube is not supported on remote yet.
 

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -1,5 +1,4 @@
 //go:build !remote_testing
-// +build !remote_testing
 
 package integration
 

--- a/test/tools/tools.go
+++ b/test/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 


### PR DESCRIPTION
This PR removes outdated `// +build` build constraints. Use `go fix ./...` to remove the `// +build` lines that have become obsolete in Go 1.18. See https://go.dev/doc/go1.18#go-build-lines.

#### Does this PR introduce a user-facing change?

```release-note
None
```
