### PR TITLE
Error messages not being reported unless more then one error present

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -230,7 +230,9 @@ func loadUnitsFromDir(sourcePath string) ([]*parser.UnitFile, error) {
 
 			if f, err := parser.ParseUnitFile(path); err != nil {
 				err = fmt.Errorf("error loading %q, %w", path, err)
-				if prevError != nil {
+				if prevError == nil {
+					prevError = err
+				} else {
 					prevError = fmt.Errorf("%s\n%s", prevError, err)
 				}
 			} else {

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -639,6 +639,7 @@ BOGUS=foo
 			session := podmanTest.Quadlet([]string{"-dryrun"}, podmanTest.TempDir)
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(1))
+			Expect(session.ErrorToString()).To(ContainSubstring("converting \"bogus.container\": unsupported key 'BOGUS' in group 'Container' in " + quadletfilePath))
 		})
 
 		It("Should scan and return output for files in subdirectories", func() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet will not report errors on bogus quadlets.
```
