### PR TITLE
machine: use GlobalDataDir helper

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v4/pkg/strongunits"
 	"github.com/containers/podman/v4/pkg/systemd/parser"
-	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/podman/v4/utils"
 	"github.com/containers/storage/pkg/lockfile"
 	vfConfig "github.com/crc-org/vfkit/pkg/config"
@@ -202,7 +201,10 @@ func (m *MacMachine) Init(opts machine.InitOptions) (bool, error) {
 		return false, err
 	}
 
-	m.IdentityPath = util.GetIdentityPath(define.DefaultIdentityName)
+	m.IdentityPath, err = machine.GetSSHIdentityPath(define.DefaultIdentityName)
+	if err != nil {
+		return false, err
+	}
 	m.Rootful = opts.Rootful
 	m.RemoteUsername = opts.Username
 

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -261,6 +261,15 @@ func ConfDirPrefix() (string, error) {
 	return confDir, nil
 }
 
+// GetSSHIdentityPath returns the path to the expected SSH private key
+func GetSSHIdentityPath(name string) (string, error) {
+	datadir, err := GetGlobalDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(datadir, name), nil
+}
+
 // ImageConfig describes the bootable image for the VM
 type ImageConfig struct {
 	// IgnitionFile is the path to the filesystem where the

--- a/pkg/machine/config_test.go
+++ b/pkg/machine/config_test.go
@@ -5,8 +5,11 @@ package machine
 import (
 	"net"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoteConnectionType_MakeSSHURL(t *testing.T) {
@@ -70,4 +73,13 @@ func TestRemoteConnectionType_MakeSSHURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSSHIdentityPath(t *testing.T) {
+	name := "p-test"
+	datadir, err := GetGlobalDataDir()
+	assert.Nil(t, err)
+	identityPath, err := GetSSHIdentityPath(name)
+	assert.Nil(t, err)
+	assert.Equal(t, identityPath, filepath.Join(datadir, name))
 }

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v4/pkg/strongunits"
 	"github.com/containers/podman/v4/pkg/systemd/parser"
-	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/podman/v4/utils"
 	"github.com/containers/storage/pkg/lockfile"
 	psutil "github.com/shirou/gopsutil/v3/process"
@@ -178,8 +177,10 @@ func (m *HyperVMachine) Init(opts machine.InitOptions) (bool, error) {
 		return nil
 	})
 
-	m.IdentityPath = util.GetIdentityPath(define.DefaultIdentityName)
-
+	m.IdentityPath, err = machine.GetSSHIdentityPath(define.DefaultIdentityName)
+	if err != nil {
+		return false, err
+	}
 	if m.UID == 0 {
 		m.UID = 1000
 	}

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/sockets"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/sirupsen/logrus"
@@ -124,7 +123,10 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	defer callbackFuncs.CleanIfErr(&err)
 	go callbackFuncs.CleanOnSignal()
 
-	v.IdentityPath = util.GetIdentityPath(define.DefaultIdentityName)
+	v.IdentityPath, err = machine.GetSSHIdentityPath(define.DefaultIdentityName)
+	if err != nil {
+		return false, err
+	}
 	v.Rootful = opts.Rootful
 
 	imagePath, strm, err := machine.Pull(opts.ImagePath, opts.Name, VirtualizationProvider())

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v4/pkg/machine/wsl/wutil"
-	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/podman/v4/utils"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/lockfile"
@@ -411,7 +410,10 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	}
 
 	_ = setupWslProxyEnv()
-	v.IdentityPath = util.GetIdentityPath(define.DefaultIdentityName)
+	v.IdentityPath, err = machine.GetSSHIdentityPath(define.DefaultIdentityName)
+	if err != nil {
+		return false, err
+	}
 	v.Rootful = opts.Rootful
 	v.Version = currentMachineVersion
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/signal"
 	"github.com/containers/storage/pkg/directory"
-	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/idtools"
 	stypes "github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -1181,10 +1180,6 @@ func ExitCode(err error) int {
 	}
 
 	return 126
-}
-
-func GetIdentityPath(name string) string {
-	return filepath.Join(homedir.Get(), ".local", "share", "containers", "podman", "machine", name)
 }
 
 func Tmpdir() string {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -2,11 +2,9 @@ package util
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/idtools"
 	ruser "github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -526,12 +524,6 @@ func TestValidateSysctlBadSysctlWithExtraSpaces(t *testing.T) {
 	_, err = ValidateSysctls(strSlice2)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), fmt.Sprintf(expectedError, strSlice2[1]))
-}
-
-func TestGetIdentityPath(t *testing.T) {
-	name := "p-test"
-	identityPath := GetIdentityPath(name)
-	assert.Equal(t, identityPath, filepath.Join(homedir.Get(), ".local", "share", "containers", "podman", "machine", name))
 }
 
 func TestCoresToPeriodAndQuota(t *testing.T) {


### PR DESCRIPTION
We shouldn't hardcode `~/.local` - we should use the internal config helper APIs which honor the XDG_DATA_DIR etc. standard environment variables.


```release-note
None
```
