### PR TITLE
Remove --latest from podman CMD --help output

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -36,7 +36,7 @@ var (
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman container checkpoint --keep ctrID
   podman container checkpoint --all
-  podman container checkpoint --leave-running --latest`,
+  podman container checkpoint --leave-running ctrID`,
 	}
 )
 

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -30,8 +30,7 @@ var (
 			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainersExited,
-		Example: `podman container cleanup --latest
-  podman container cleanup ctrID1 ctrID2 ctrID3
+		Example: `podman container cleanup ctrID1 ctrID2 ctrID3
   podman container cleanup --all`,
 	}
 )

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -24,8 +24,7 @@ var (
 			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainersCreated,
-		Example: `podman init --latest
-  podman init 3c45ef19d893
+		Example: `podman init 3c45ef19d893
   podman init test1`,
 	}
 
@@ -36,8 +35,7 @@ var (
 		RunE:              initCommand.RunE,
 		Args:              initCommand.Args,
 		ValidArgsFunction: initCommand.ValidArgsFunction,
-		Example: `podman container init --latest
-  podman container init 3c45ef19d893
+		Example: `podman container init 3c45ef19d893
   podman container init test1`,
 	}
 )

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -27,8 +27,7 @@ var (
 		},
 		ValidArgsFunction: common.AutocompleteContainerOneArg,
 		Example: `podman port --all
-  podman port ctrID 80/tcp
-  podman port --latest 80`,
+  podman port ctrID 80/tcp`,
 	}
 
 	containerPortCommand = &cobra.Command{
@@ -41,7 +40,7 @@ var (
 		},
 		ValidArgsFunction: portCommand.ValidArgsFunction,
 		Example: `podman container port --all
-  podman container port --latest 80`,
+  podman container port CTRID 80`,
 	}
 )
 

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -30,7 +30,6 @@ var (
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman restart ctrID
-  podman restart --latest
   podman restart ctrID1 ctrID2`,
 	}
 
@@ -42,7 +41,6 @@ var (
 		Args:              restartCommand.Args,
 		ValidArgsFunction: restartCommand.ValidArgsFunction,
 		Example: `podman container restart ctrID
-  podman container restart --latest
   podman container restart ctrID1 ctrID2`,
 	}
 )

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -32,7 +32,6 @@ var (
 		ValidArgsFunction: common.AutocompleteContainersAndImages,
 		Example: `podman container restore ctrID
   podman container restore imageID
-  podman container restore --latest
   podman container restore --all`,
 	}
 )

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -24,8 +24,7 @@ var (
 		RunE:              start,
 		Args:              validateStart,
 		ValidArgsFunction: common.AutocompleteContainersStartable,
-		Example: `podman start --latest
-  podman start 860a4b231279 5421ab43b45
+		Example: `podman start 860a4b231279 5421ab43b45
   podman start --interactive --attach imageID`,
 	}
 
@@ -36,8 +35,7 @@ var (
 		RunE:              startCommand.RunE,
 		Args:              startCommand.Args,
 		ValidArgsFunction: startCommand.ValidArgsFunction,
-		Example: `podman container start --latest
-  podman container start 860a4b231279 5421ab43b45
+		Example: `podman container start 860a4b231279 5421ab43b45
   podman container start --interactive --attach imageID`,
 	}
 )

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -30,7 +30,6 @@ var (
 		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman stop ctrID
-  podman stop --latest
   podman stop --time 2 mywebserver 6e534f14da9d`,
 	}
 
@@ -44,7 +43,6 @@ var (
 		},
 		ValidArgsFunction: stopCommand.ValidArgsFunction,
 		Example: `podman container stop ctrID
-  podman container stop --latest
   podman container stop --time 2 mywebserver 6e534f14da9d`,
 	}
 )

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -32,7 +32,6 @@ var (
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: common.AutocompleteTopCmd,
 		Example: `podman top ctrID
-podman top --latest
 podman top ctrID pid seccomp args %C
 podman top ctrID -eo user,pid,comm`,
 	}
@@ -44,7 +43,6 @@ podman top ctrID -eo user,pid,comm`,
 		RunE:              topCommand.RunE,
 		ValidArgsFunction: topCommand.ValidArgsFunction,
 		Example: `podman container top ctrID
-podman container top --latest
 podman container top ctrID pid seccomp args %C
 podman container top ctrID -eo user,pid,comm`,
 	}

--- a/cmd/podman/networks/reload.go
+++ b/cmd/podman/networks/reload.go
@@ -24,8 +24,7 @@ var (
 			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
-		Example: `podman network reload --latest
-  podman network reload 3c13ef6dd843
+		Example: `podman network reload 3c13ef6dd843
   podman network reload test1 test2`,
 	}
 )

--- a/cmd/podman/pods/kill.go
+++ b/cmd/podman/pods/kill.go
@@ -26,8 +26,7 @@ var (
 		},
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod kill podID
-  podman pod kill --signal TERM mywebserver
-  podman pod kill --latest`,
+  podman pod kill --signal TERM mywebserver`,
 	}
 )
 

--- a/cmd/podman/pods/pause.go
+++ b/cmd/podman/pods/pause.go
@@ -26,7 +26,6 @@ var (
 		},
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod pause podID1 podID2
-  podman pod pause --latest
   podman pod pause --all`,
 	}
 )

--- a/cmd/podman/pods/restart.go
+++ b/cmd/podman/pods/restart.go
@@ -26,7 +26,6 @@ var (
 		},
 		ValidArgsFunction: common.AutocompletePods,
 		Example: `podman pod restart podID1 podID2
-  podman pod restart --latest
   podman pod restart --all`,
 	}
 )

--- a/cmd/podman/pods/start.go
+++ b/cmd/podman/pods/start.go
@@ -35,7 +35,6 @@ var (
 		},
 		ValidArgsFunction: common.AutocompletePods,
 		Example: `podman pod start podID
-  podman pod start --latest
   podman pod start --all`,
 	}
 )

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -38,7 +38,6 @@ var (
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod stats
   podman pod stats a69b23034235 named-pod
-  podman pod stats --latest
   podman pod stats --all`,
 	}
 )

--- a/cmd/podman/pods/stop.go
+++ b/cmd/podman/pods/stop.go
@@ -40,7 +40,6 @@ var (
 		},
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod stop mywebserverpod
-  podman pod stop --latest
   podman pod stop --time 0 490eb 3557fb`,
 	}
 )

--- a/cmd/podman/pods/top.go
+++ b/cmd/podman/pods/top.go
@@ -31,7 +31,6 @@ var (
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: common.AutocompleteTopCmd,
 		Example: `podman pod top podID
-podman pod top --latest
 podman pod top podID pid seccomp args %C
 podman pod top podID -eo user,pid,comm`,
 	}

--- a/cmd/podman/pods/unpause.go
+++ b/cmd/podman/pods/unpause.go
@@ -26,8 +26,7 @@ var (
 		},
 		ValidArgsFunction: common.AutoCompletePodsPause,
 		Example: `podman pod unpause podID1 podID2
-  podman pod unpause --all
-  podman pod unpause --latest`,
+  podman pod unpause --all`,
 	}
 )
 


### PR DESCRIPTION
Because --latest is not supported on podman-remote commands we should not be showing examples using podman-remote CMD --help with --latest usage, it confuses users. Rather then hacking up the code with if remote else --latest, it is better to just remove information in help messages.

Prevents: https://github.com/containers/podman/issues/21174

[NO NEW TESTS NEEDED] Since normal tests should cover this.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
