### PR TITLE
Make --gpus work with nvidia gpus

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -700,6 +700,10 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(gidmapFlagName, completion.AutocompleteNone)
 
+		gpuFlagName := "gpus"
+		createFlags.StringSliceVar(&cf.GPUs, gpuFlagName, []string{}, "GPU devices to add to the container ('all' to pass all GPUs)")
+		_ = cmd.RegisterFlagCompletionFunc(gpuFlagName, completion.AutocompleteNone)
+
 		uidmapFlagName := "uidmap"
 		createFlags.StringSliceVar(
 			&cf.UIDMap,

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -80,11 +80,6 @@ func runFlags(cmd *cobra.Command) {
 	flags.StringVar(&runOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
-	gpuFlagName := "gpus"
-	flags.String(gpuFlagName, "", "This is a Docker specific option and is a NOOP")
-	_ = cmd.RegisterFlagCompletionFunc(gpuFlagName, completion.AutocompleteNone)
-	_ = flags.MarkHidden("gpus")
-
 	passwdFlagName := "passwd"
 	flags.BoolVar(&runOpts.Passwd, passwdFlagName, true, "add entries to /etc/passwd and /etc/group")
 

--- a/docs/source/markdown/options/gpus.md
+++ b/docs/source/markdown/options/gpus.md
@@ -1,0 +1,8 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--gpus**=*ENTRY*
+
+GPU devices to add to the container ('all' to pass all GPUs) Currently only
+Nvidia devices are supported.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -159,6 +159,8 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 @@option gidmap.container
 
+@@option gpus
+
 @@option group-add
 
 @@option group-entry

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -41,6 +41,8 @@ Note: the pod implements devices by storing the initial configuration passed by 
 
 @@option gidmap.pod
 
+@@option gpus
+
 #### **--help**, **-h**
 
 Print usage statement.

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -80,6 +80,8 @@ Set the exit policy of the pod when the last container exits.  Supported policie
 
 @@option gidmap.pod
 
+@@option gpus
+
 #### **--help**, **-h**
 
 Print usage statement.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -193,6 +193,8 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 @@option gidmap.container
 
+@@option gpus
+
 @@option group-add
 
 @@option group-entry

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -211,6 +211,7 @@ type ContainerCreateOptions struct {
 	EnvFile            []string
 	Expose             []string
 	GIDMap             []string
+	GPUs               []string
 	GroupAdd           []string
 	HealthCmd          string
 	HealthInterval     string

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -784,7 +784,12 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.ImageVolumes = imageVolumes
 	}
 
-	for _, dev := range c.Devices {
+	devices := c.Devices
+	for _, gpu := range c.GPUs {
+		devices = append(devices, "nvidia.com/gpu="+gpu)
+	}
+
+	for _, dev := range devices {
 		s.Devices = append(s.Devices, specs.LinuxDevice{Path: dev})
 	}
 

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -119,12 +119,6 @@ var _ = Describe("Podman run device", func() {
 		Expect(session).Should(ExitCleanly())
 	})
 
-	It("podman run --gpus noop", func() {
-		session := podmanTest.Podman([]string{"run", "--gpus", "all", ALPINE, "true"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-	})
-
 	It("podman run cannot access non default devices", func() {
 		session := podmanTest.Podman([]string{"run", "-v /dev:/dev-host", ALPINE, "head", "-1", "/dev-host/kmsg"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Somewhat documented here:
https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html https://stackoverflow.com/questions/25185405/using-gpu-from-a-docker-container

Fixes: https://github.com/containers/podman/issues/21156
Don't have access to nvidia GPUS, relying on contributor testing.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
--gpus will now work with nvidia gpus.
```
