### PR TITLE
Match Docker pull/push by defaulting to progress write to stdout

### DIFF
--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -172,7 +172,7 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	pullOptions.OciDecryptConfig = decConfig
 
 	if !pullOptions.Quiet {
-		pullOptions.Writer = os.Stderr
+		pullOptions.Writer = os.Stdout
 	}
 
 	// Let's do all the remaining Yoga in the API to prevent us from

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -191,7 +191,7 @@ func imagePush(cmd *cobra.Command, args []string) error {
 	}
 
 	if !pushOptions.Quiet {
-		pushOptions.Writer = os.Stderr
+		pushOptions.Writer = os.Stdout
 	}
 
 	signingCleanup, err := common.PrepareSigning(&pushOptions.ImagePushOptions,

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -38,6 +38,18 @@ var _ = Describe("Podman pull", func() {
 		Expect(session.ErrorToString()).To(ContainSubstring("unauthorized: access to the requested resource is not authorized"))
 	})
 
+	It("podman pull with tag all output to stdout", func() {
+		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/testdigest_v2s2:20200210"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.ErrorToString()).To(BeEmpty())
+		Expect(session.OutputToString()).To(ContainSubstring("Trying to pull quay.io/libpod/testdigest_v2s2:20200210"))
+
+		session = podmanTest.Podman([]string{"rmi", "testdigest_v2s2:20200210"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+	})
+
 	It("podman pull with tag --quiet", func() {
 		session := podmanTest.Podman([]string{"pull", "-q", "quay.io/libpod/testdigest_v2s2:20200210"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/21181

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman pull and push progress now goes to stdout.
```
