### PR TITLE
e2e: reenable warning checks on Debian

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1173,7 +1173,13 @@ var _ = Describe("Podman checkpoint", func() {
 
 			// As the container has been started with '--rm' it will be completely
 			// cleaned up after checkpointing.
-			Expect(result).To(ExitCleanly())
+			// #11784 (closed wontfix): runc warns "lstat /sys/.../machine.slice/...: ENOENT"
+			// so we can't use ExitCleanly()
+			if podmanTest.OCIRuntime == "runc" {
+				Expect(result).To(Exit(0))
+			} else {
+				Expect(result).To(ExitCleanly())
+			}
 			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 			Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
@@ -1254,7 +1260,13 @@ var _ = Describe("Podman checkpoint", func() {
 				result.OutputToString(),
 			})
 			result.WaitWithDefaultTimeout()
-			Expect(result).To(ExitCleanly())
+			// #11784 (closed wontfix): runc warns "lstat /sys/.../machine.slice/...: ENOENT"
+			// so we can't use ExitCleanly()
+			if podmanTest.OCIRuntime == "runc" {
+				Expect(result).To(Exit(0))
+			} else {
+				Expect(result).To(ExitCleanly())
+			}
 			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 			Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -409,14 +409,20 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec cannot be invoked", func() {
-		SkipIfNotFedora("FIXME: #19552 fails on Debian SID w/ runc 1.1.5")
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(ExitCleanly())
 
 		session := podmanTest.Podman([]string{"exec", "test1", "/etc"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(126))
+
+		if podmanTest.OCIRuntime == "runc" {
+			// #19552 and others: some versions of runc exit 255.
+			Expect(session).Should(ExitWithError())
+		} else {
+			// crun (and, we hope, any other future runtimes)
+			Expect(session).Should(Exit(126))
+		}
 	})
 
 	It("podman exec command not found", func() {

--- a/test/e2e/generate_spec_test.go
+++ b/test/e2e/generate_spec_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman generate spec", func() {
@@ -57,6 +58,12 @@ var _ = Describe("Podman generate spec", func() {
 
 		session = podmanTest.Podman([]string{"generate", "spec", "--compact", "podspecgen"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+
+		if isRootless() && !CGROUPSV2 {
+			Expect(session).Should(Exit(0))
+			Expect(session.ErrorToString()).Should(ContainSubstring("Resource limits are not supported and ignored on cgroups V1 rootless"))
+		} else {
+			Expect(session).Should(ExitCleanly())
+		}
 	})
 })

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -198,15 +198,7 @@ func (matcher *exitCleanlyMatcher) Match(actual interface{}) (success bool, err 
 		return false, nil
 	}
 
-	// Exit status is 0. Now check for anything on stderr... except:
-	info := GetHostDistributionInfo()
-	if info.Distribution != "fedora" {
-		// runc on debian:
-		// FIXME: #11784 - lstat /sys/fs/.../*.scope: ENOENT
-		// FIXME: #11785 - cannot toggle freezer: cgroups not configured
-		return true, nil
-	}
-
+	// Exit status is 0. Now check for anything on stderr
 	if stderr != "" {
 		matcher.msg = fmt.Sprintf("Unexpected warnings seen on stderr: %q", stderr)
 		return false, nil


### PR DESCRIPTION
Back when we introduced ExitCleanly(), we couldn't use it
on Debian because of too many runc bugs. Now, early 2024:

 - #11784 has been closed-wontfix, so add a runc special-case
   in the specific test that triggers it.

 - #11785 seems to have gone away? Treat it as fixed.

 - #19552 is languishing, so let's just close-wontfix it too and
   add another runc special case.

 - and, one new rootless-cgroupsV1 exception for a warning msg
   that snuck in recently.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```