### PR TITLE
machine/applehv: Sync vfkit cpu/memory on start

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -773,6 +773,10 @@ func loadMacMachineFromJSON(fqConfigPath string) (*MacMachine, error) {
 	if err := json.Unmarshal(b, mm); err != nil {
 		return nil, err
 	}
+	// And synchronize copied data
+	logrus.Debugf("setting %d cpus and %d memory", mm.CPUs, mm.Memory)
+	mm.Vfkit.VirtualMachine.MemoryBytes = mm.Memory
+	mm.Vfkit.VirtualMachine.Vcpus = uint(mm.CPUs)
 	return mm, nil
 }
 


### PR DESCRIPTION
We end up serializing the base VM config and the vfkit JSON into one object.  This causes `podman machine set --memory X` to have no effect.  Fix this by synchronizing when deserializing.

A better fix would likely be to stop serializing this at all but that seems like a more invasive fix.



```release-note
None
```
