### PR TITLE
[CI:DOCS} labeler: Use `machine` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,6 @@
 kind/api-change:
   - changed-files:
     - any-glob-to-any-file: pkg/api/**
-area/machine:
+machine:
   - changed-files:
     - any-glob-to-any-file: pkg/machine/**


### PR DESCRIPTION
Consensus was against area/ in
https://github.com/containers/podman/pull/21146

```release-note
None
```
