### PR TITLE
Remove redundant code in generateSpec()

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -607,9 +607,6 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		if err != nil {
 			return nil, nil, err
 		}
-		if err != nil {
-			return nil, nil, err
-		}
 		for name, secr := range c.config.EnvSecrets {
 			_, data, err := manager.LookupSecretData(secr.Name)
 			if err != nil {


### PR DESCRIPTION
Conditional expression duplicates the
code above, therefore, remove it

Found by Linux Verification Center (linuxtesting.org) with SVACE.

```release-note
None
```