### PR TITLE
[v4.8] System tests: fixes for RHEL8 gating failures

### DIFF
--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -308,6 +308,21 @@ EOF
 }
 
 @test "podman mount noswap memory mounts" {
+    # tmpfs+noswap new in kernel 6.x, mid-2023; likely not in RHEL for a while
+    if ! is_rootless; then
+        testmount=$PODMAN_TMPDIR/testmount
+        mkdir $testmount
+        run mount -t tmpfs -o noswap none $testmount
+        if [[ $status -ne 0 ]]; then
+            if [[ $output =~ "bad option" ]]; then
+                skip "requires kernel with tmpfs + noswap support"
+            fi
+            die "Could not test for tmpfs + noswap support: $output"
+        else
+            umount $testmount
+        fi
+    fi
+
     # if volumes source and dest match then pass
     run_podman run --rm --mount type=ramfs,destination=${PODMAN_TMPDIR} $IMAGE stat -f -c "%T" ${PODMAN_TMPDIR}
     is "$output" "ramfs" "ramfs mounted"

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -352,16 +352,18 @@ EOF
         $PODMAN play kube --service-container=true --log-driver journald $yaml_source &>/dev/null &
 
     # Wait for both containers to be running
+    containers_running=
     for i in $(seq 1 20); do
         run_podman "?" container wait $container_a $container_b --condition="running"
         if [[ $status == 0 ]]; then
+            containers_running=1
             break
         fi
         sleep 0.5
         # Just for debugging
         run_podman ps -a
     done
-    if [[ $status != 0 ]]; then
+    if [[ -z "$containers_running" ]]; then
         die "container $container_a and/or $container_b did not start"
     fi
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -184,16 +184,18 @@ EOF
 
     # Wait for the container to be running
     container_a=test_pod-test
+    container_running=
     for i in $(seq 1 20); do
         run_podman "?" container wait $container_a --condition="running"
         if [[ $status == 0 ]]; then
+            container_running=1
             break
         fi
         sleep 0.5
         # Just for debugging
         run_podman ps -a
     done
-    if [[ $status != 0 ]]; then
+    if [[ -z "$container_running" ]]; then
         die "container $container_a did not start"
     fi
 
@@ -573,7 +575,7 @@ EOF
     # Create the YAMl file, with two pods, each with one container
     yaml_source="$PODMAN_TMPDIR/test.yaml"
     for n in 1 2;do
-        _write_test_yaml labels="app: pod$n" name="pod$n" ctrname="ctr$n"
+        _write_test_yaml labels="app: pod$n" name="pod$n" ctrname="ctr$n" command=top
 
         # Separator between two yaml halves
         if [[ $n = 1 ]]; then
@@ -592,17 +594,19 @@ EOF
     service_container="${yaml_sha:0:12}-service"
     # Wait for the containers to be running
     container_1=pod1-ctr1
-    container_2=pod1-ctr2
+    container_2=pod2-ctr2
+    containers_running=
     for i in $(seq 1 20); do
         run_podman "?" container wait $container_1 $container_2 $service_container --condition="running"
         if [[ $status == 0 ]]; then
+            containers_running=1
             break
         fi
         sleep 0.5
         # Just for debugging
         run_podman ps -a
     done
-    if [[ $status != 0 ]]; then
+    if [[ -z "$containers_running" ]]; then
         die "container $container_1, $container_2 and/or $service_container did not start"
     fi
 


### PR DESCRIPTION
[manual backport of #21201 because cherrypickbot is napping. No conflicts.]

- tmpfs + noswap test: requires noswap feature in kernel. Check for it, and skip if unimplemented. (Root only. Rootless test works regardless of kernel).

- podman generate systemd tests: always use --files option, because otherwise the "DEPRECATED" warning gets written to the systemd unit file.

- kube play tests: yikes. Fix longstanding bugs when checking for containers running. This revealed a longstanding bug in one test: multi-pod YAML never actually worked. Fixed now.

- run_podman(): that new check-for-warnings code we added in #19878, duh, I skipped it on Debian but should've skipped when *runc*. Do so now and update the comment. Requires minor surgery to podman_runtime() helper to avoid infinite recursion.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
