### PR TITLE
[v4.8] systests: cp: add wait_for_ready

### DIFF
--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -22,7 +22,8 @@ load helpers
     mkdir -p $srcdir/subdir
     echo "${randomcontent[2]}" > $srcdir/subdir/dotfile.
 
-    run_podman run -d --name destrunning --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir; sleep infinity"
+    run_podman run -d --name destrunning --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir; echo READY; sleep infinity"
+    wait_for_ready destrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q destrunning
@@ -175,7 +176,9 @@ load helpers
          echo ${randomcontent[0]} > /tmp/dotfile.;
          echo ${randomcontent[1]} > /srv/containerfile1;
          echo ${randomcontent[2]} > /srv/subdir/containerfile2;
+         echo READY;
          sleep infinity"
+    wait_for_ready srcrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q srcrunning
@@ -234,7 +237,9 @@ load helpers
          echo ${randomcontent[0]} > /tmp/dotfile.;
          echo ${randomcontent[1]} > /srv/containerfile1;
          echo ${randomcontent[2]} > /srv/subdir/containerfile2;
+         echo READY;
          sleep infinity"
+    wait_for_ready srcrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q srcrunning
@@ -323,7 +328,8 @@ load helpers
     mkdir -p $srcdir/dir.
     cp -r $srcdir/dir/* $srcdir/dir.
 
-    run_podman run -d --name destrunning --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir; sleep infinity"
+    run_podman run -d --name destrunning --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir; echo READY;sleep infinity"
+    wait_for_ready destrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q destrunning
@@ -383,7 +389,9 @@ load helpers
          echo ${randomcontent[0]} > /srv/subdir/containerfile0; \
          echo ${randomcontent[1]} > /srv/subdir/containerfile1; \
          mkdir /tmp/subdir.; cp /srv/subdir/* /tmp/subdir./; \
+         echo READY;
          sleep infinity"
+    wait_for_ready srcrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q srcrunning
@@ -450,7 +458,9 @@ load helpers
          echo ${randomcontent[0]} > /srv/subdir/containerfile0; \
          echo ${randomcontent[1]} > /srv/subdir/containerfile1; \
          mkdir /tmp/subdir.; cp /srv/subdir/* /tmp/subdir./; \
+         echo READY;
          sleep infinity"
+    wait_for_ready srcrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q srcrunning
@@ -537,7 +547,9 @@ load helpers
     run_podman run -d --name srcrunning $IMAGE sh -c "echo ${randomcontent[0]} > /tmp/containerfile0; \
          echo ${randomcontent[1]} > /tmp/containerfile1; \
          mkdir /tmp/sub && cd /tmp/sub && ln -s .. weirdlink; \
+         echo READY;
          sleep infinity"
+    wait_for_ready srcrunning
 
     # Commit the image for testing non-running containers
     run_podman commit -q srcrunning
@@ -737,7 +749,8 @@ load helpers
                sh -c "mkdir /tmp/d1;ln -s /tmp/nonesuch1 /tmp/d1/x;
                       mkdir /tmp/d2;ln -s /tmp/nonesuch2 /tmp/d2/x;
                       mkdir /tmp/d3;
-                      trap 'exit 0' 15;while :;do sleep 0.5;done"
+                      trap 'exit 0' 15;echo READY;while :;do sleep 0.5;done"
+    wait_for_ready cpcontainer
 
     # Copy file from host into container, into a file named 'x'
     # Note that the second has a trailing slash, implying a directory.
@@ -900,8 +913,10 @@ load helpers
     rand_content_file=$(random_string 50)
     rand_content_dir=$(random_string 50)
 
-    run_podman run -d --name ctr-file $IMAGE sh -c "echo '$rand_content_file' > /tmp/foo; sleep infinity"
-    run_podman run -d --name ctr-dir  $IMAGE sh -c "mkdir /tmp/foo; echo '$rand_content_dir' > /tmp/foo/file.txt; sleep infinity"
+    run_podman run -d --name ctr-file $IMAGE sh -c "echo '$rand_content_file' > /tmp/foo; echo READY; sleep infinity"
+    run_podman run -d --name ctr-dir  $IMAGE sh -c "mkdir /tmp/foo; echo '$rand_content_dir' > /tmp/foo/file.txt; echo READY; sleep infinity"
+    wait_for_ready ctr-file
+    wait_for_ready ctr-dir
 
     # overwrite a directory with a file
     run_podman 125 cp ctr-file:/tmp/foo ctr-dir:/tmp
@@ -934,8 +949,10 @@ load helpers
     rand_content_file=$(random_string 50)
     rand_content_dir=$(random_string 50)
 
-    run_podman run -d --name ctr-file $IMAGE sh -c "echo '$rand_content_file' > /tmp/foo; sleep infinity"
-    run_podman run -d --name ctr-dir  $IMAGE sh -c "mkdir /tmp/foo; echo '$rand_content_dir' > /tmp/foo/file.txt; sleep infinity"
+    run_podman run -d --name ctr-file $IMAGE sh -c "echo '$rand_content_file' > /tmp/foo; echo READY; sleep infinity"
+    run_podman run -d --name ctr-dir  $IMAGE sh -c "mkdir /tmp/foo; echo '$rand_content_dir' > /tmp/foo/file.txt; echo READY; sleep infinity"
+    wait_for_ready ctr-file
+    wait_for_ready ctr-dir
 
     # overwrite a directory with a file
     mkdir $hostdir/foo
@@ -966,8 +983,10 @@ load helpers
     rand_content_file=$(random_string 50)
     rand_content_dir=$(random_string 50)
 
-    run_podman run -d --name ctr-dir  $IMAGE sh -c "mkdir /tmp/foo; sleep infinity"
-    run_podman run -d --name ctr-file $IMAGE sh -c "touch /tmp/foo; sleep infinity"
+    run_podman run -d --name ctr-dir  $IMAGE sh -c "mkdir /tmp/foo; echo READY; sleep infinity"
+    run_podman run -d --name ctr-file $IMAGE sh -c "touch /tmp/foo; echo READY; sleep infinity"
+    wait_for_ready ctr-dir
+    wait_for_ready ctr-file
 
     # overwrite a directory with a file
     echo "$rand_content_file" > $hostdir/foo
@@ -1013,7 +1032,9 @@ load helpers
     dstdir=$PODMAN_TMPDIR/dst
     mkdir -p $dstdir
 
-    run_podman run -d --name=test-ctr --rm $IMAGE sh -c "mkdir -p /foo/test1. /foo/test2; touch /foo/test1./file1 /foo/test2/file2; sleep infinity"
+    run_podman run -d --name=test-ctr --rm $IMAGE sh -c "mkdir -p /foo/test1. /foo/test2; touch /foo/test1./file1 /foo/test2/file2; echo READY;sleep infinity"
+    wait_for_ready test-ctr
+
     run_podman cp test-ctr:/foo/test1. $dstdir/foo
     run /bin/ls -1 $dstdir/foo
     assert "$output" = "file1" "ls [local]/foo: only file1 was copied, nothing more"
@@ -1022,7 +1043,9 @@ load helpers
 }
 
 @test "podman cp - dot notation - container to container" {
-    run_podman run -d --name=src-ctr --rm $IMAGE sh -c "mkdir -p /foo/test1. /foo/test2; touch /foo/test1./file1 /foo/test2/file2; sleep infinity"
+    run_podman run -d --name=src-ctr --rm $IMAGE sh -c "mkdir -p /foo/test1. /foo/test2; touch /foo/test1./file1 /foo/test2/file2; echo READY;sleep infinity"
+    wait_for_ready src-ctr
+
     run_podman run -d --name=dest-ctr --rm $IMAGE sleep infinity
     run_podman cp src-ctr:/foo/test1. dest-ctr:/foo
 


### PR DESCRIPTION
[Manual backport of #20912, needed because #20282 is cropping up on v4.8 CI runs. Clean cherrypick.]

Some of the tests were doing "podman run -d" without wait_for_ready. This may be the cause of some of the CI flakes. Maybe even all? It's not clear why the tests have been working reliably for years under overlay, and only started failing under vfs, but shrug.

Thanks to Chris for making that astute observation.

```release-note
None
```
