### PR TITLE
[v4.8] feat: disable pid max in the podman machine

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -312,6 +312,7 @@ ExecStart=/usr/bin/sleep infinity
 `
 	containers := `[containers]
 netns="bridge"
+pids_limit=0
 `
 	// Set deprecated machine_enabled until podman package on fcos is
 	// current enough to no longer require it


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

This is a backport of PR https://github.com/containers/podman/pull/21061 to 4.8 branch for 4.9 release

fix https://github.com/containers/podman-desktop/issues/5282

With FCOS we have a limit of 2048 files.
But when launching containers like kind containers, we're reaching easily the limit.
(kind create command is not providing
AFAIK as it's inside a dedicated machine, there should not be any limit

The limit should be only set when running a container.

default = unlimited
if using `--pids-limit=<something>` then it's using this value.

If I use docker I have the same behaviour:

```
docker run --rm -it fedora cat  /sys/fs/cgroup/pids.max                                                                                                                                
max
```
[NO NEW TESTS NEEDED]

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### Release notes:

```release-note
feat: disable pids-limit inside a podman machine.
```

