### PR TITLE
[CI:DOCS] quadlet: fix quoting of example option values in container unit file …

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -174,12 +174,12 @@ Valid options for `[Container]` are listed below:
 | GIDMap=0:10000:10                    | --gidmap=0:10000:10                                  |
 | Group=1234                           | --user UID:1234                                      |
 | GlobalArgs=--log-level=debug         | --log-level=debug                                    |
-| HealthCmd="/usr/bin/command"         | --health-cmd="/usr/bin/command"                      |
+| HealthCmd=/usr/bin/command           | --health-cmd=/usr/bin/command                        |
 | HealthInterval=2m                    | --health-interval=2m                                 |
 | HealthOnFailure=kill                 | --health-on-failure=kill                             |
 | HealthRetries=5                      | --health-retries=5                                   |
 | HealthStartPeriod=1m                 | --health-start-period=period=1m                      |
-| HealthStartupCmd="command"           | --health-startup-cmd="command"                       |
+| HealthStartupCmd=command             | --health-startup-cmd=command                         |
 | HealthStartupInterval=1m             | --health-startup-interval=1m                         |
 | HealthStartupRetries=8               | --health-startup-retries=8                           |
 | HealthStartupSuccess=2               | --health-startup-success=2                           |


### PR DESCRIPTION
…documentation

The quotes are interpreted as part of the value, so that, for example, `HealthCmd="true"` is translated to the podman argument `--health-cmd "\"true\""`.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
