### PR TITLE
[machine-dev-5] Run mac jobs on labeled hosts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -454,6 +454,7 @@ osx_alt_build_task:
         labels:
             os: darwin
             arch: arm64
+            purpose: prod
     env: &mac_env
         CIRRUS_SHELL: "/bin/bash"  # sh is the default
         CIRRUS_WORKING_DIR: "$HOME/ci/task-${CIRRUS_TASK_ID}"  # Isolation: $HOME will be set to "ci" dir.


### PR DESCRIPTION
Port from https://github.com/containers/podman/pull/21224

This is needed to support an upcoming management script change. I've already updated all the workers to be sensitive to this label.

Ref:
https://github.com/cirruslabs/cirrus-cli/blob/master/PERSISTENT-WORKERS.md#reserved-labels

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
