### PR TITLE
Assign separate ports for each appleHV machine

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -12,16 +12,16 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/compression"
 	"github.com/containers/podman/v4/pkg/machine/define"
-	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v4/pkg/machine/ignition"
+	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	vfConfig "github.com/crc-org/vfkit/pkg/config"
 	"github.com/docker/go-units"
 	"golang.org/x/sys/unix"
 )
 
 const (
-	defaultVFKitEndpoint = "http://localhost:8081"
-	ignitionSocketName   = "ignition.sock"
+	localhostURI       = "http://localhost"
+	ignitionSocketName = "ignition.sock"
 )
 
 type AppleHVVirtualization struct {

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -116,7 +116,12 @@ func (m *MacMachine) setVfkitInfo(cfg *config.Config, readySocket define.VMFile)
 	}
 
 	m.Vfkit.VirtualMachine.Devices = defaultDevices
-	m.Vfkit.Endpoint = defaultVFKitEndpoint
+	randPort, err := utils.GetRandomPort()
+	if err != nil {
+		return err
+	}
+
+	m.Vfkit.Endpoint = localhostURI + ":" + strconv.Itoa(randPort)
 	m.Vfkit.VfkitBinaryPath = vfkitBinaryPath
 
 	return nil

--- a/pkg/machine/e2e/config_inspect_test.go
+++ b/pkg/machine/e2e/config_inspect_test.go
@@ -13,7 +13,7 @@ func (i *inspectMachine) buildCmd(m *machineTestBuilder) []string {
 	if len(i.format) > 0 {
 		cmd = append(cmd, "--format", i.format)
 	}
-	cmd = append(cmd, m.names...)
+	cmd = append(cmd, m.name)
 	i.cmd = cmd
 	return cmd
 }

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -132,7 +132,7 @@ func (m *machineTestBuilder) setCmd(mc machineCommand) *machineTestBuilder {
 	return m
 }
 
-func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuilder {
+func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuilder { //nolint: unparam
 	m.timeout = timeout
 	return m
 }

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -1,6 +1,8 @@
 package e2e_test
 
 import (
+	"time"
+
 	"github.com/containers/podman/v4/pkg/machine/define"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -83,5 +85,37 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(125))
 		Expect(startSession.errorToString()).To(ContainSubstring("VM already running or starting"))
+	})
+	It("start only starts specified machine", func() {
+		i := initMachine{}
+		startme := randomString()
+		session, err := mb.setName(startme).setCmd(i.withImagePath(mb.imagePath)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		j := initMachine{}
+		dontstartme := randomString()
+		session2, err := mb.setName(dontstartme).setCmd(j.withImagePath(mb.imagePath)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session2).To(Exit(0))
+
+		s := startMachine{}
+		session3, err := mb.setName(startme).setCmd(s).setTimeout(time.Minute * 10).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session3).Should(Exit(0))
+
+		inspect := new(inspectMachine)
+		inspect = inspect.withFormat("{{.State}}")
+		inspectSession, err := mb.setName(startme).setCmd(inspect).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		Expect(inspectSession.outputToString()).To(Equal(define.Running))
+
+		inspect2 := new(inspectMachine)
+		inspect2 = inspect2.withFormat("{{.State}}")
+		inspectSession2, err := mb.setName(dontstartme).setCmd(inspect2).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession2).To(Exit(0))
+		Expect(inspectSession2.outputToString()).To(Not(Equal(define.Running)))
 	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Fixes: https://github.com/containers/podman/issues/21115
```release-note
Fixed a bug where podman machine commands were not relayed to the correct machine on AppleHV.
```
