### PR TITLE
systests: kube with policies test: fix race

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -325,7 +325,7 @@ spec:
   - command:
     - /bin/sh
     - -c
-    - 'printenv NOTIFY_SOCKET; while ! test -f /stop;do sleep 0.1;done'
+    - 'printenv NOTIFY_SOCKET; echo READY; while ! test -f /stop;do sleep 0.1;done'
     image: $SYSTEMD_IMAGE
     name: a
   - command:
@@ -367,6 +367,7 @@ EOF
         die "container $container_a and/or $container_b did not start"
     fi
 
+    wait_for_ready $container_a
     # Make sure the containers have the correct policy
     run_podman container inspect $container_a $container_b $service_container --format "{{.Config.SdNotifyMode}}"
     is "$output" "container


### PR DESCRIPTION
Add a wait_for_ready() to one kube-play test, to make sure
container output has made it to the journal.

Probably does not fix #18501, but I think it might fix its
most common presentation.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```