### PR TITLE
[CI:MACHINE] [WIP] Increase Mac CI timeout in Cirrus 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -815,6 +815,7 @@ podman_machine_mac_task:
       - container_integration_test
       - rootless_integration_test
     persistent_worker: *mac_pw
+    timeout_in: 120m
     env:
         <<: *mac_env
         # Consumed by podman-machine ginkgo tests


### PR DESCRIPTION
Looks like mac CI has been timing out, so increase the timeout and see if it finishes. 
WIP.

[NO NEW TESTS NEEDED] 
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
