### PR TITLE
AppleHV: update LastUp time

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -759,8 +759,13 @@ func (m *MacMachine) Stop(name string, opts machine.StopOptions) error {
 			logrus.Error(err)
 		}
 	}()
+	if err := m.Vfkit.Stop(false, true); err != nil {
+		return err
+	}
 
-	return m.Vfkit.Stop(false, true)
+	// keep track of last up
+	m.LastUp = time.Now()
+	return m.writeConfig()
 }
 
 // getVMConfigPath is a simple wrapper for getting the fully-qualified


### PR DESCRIPTION
LastUp now correctly reports the lastUp time for podman machine on AppleHV, for both inspect and list.

[NO NEW TESTS NEEDED]
since this fixes an existing failing test.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Fixes: https://github.com/containers/podman/issues/21244
Related: https://github.com/containers/podman/issues/21245

```release-note
Fixed a bug where the podman machine list and podman machine inspect commands would not show the correct Last Up time on AppleHV
```
