### PR TITLE
[CI:MACHINE] TESTING: Mac speed boost

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -454,6 +454,7 @@ osx_alt_build_task:
         labels:
             os: darwin
             arch: arm64
+            purpose: cevich_testing
     env: &mac_env
         CIRRUS_SHELL: "/bin/bash"  # sh is the default
         CIRRUS_WORKING_DIR: "$HOME/ci/task-${CIRRUS_TASK_ID}"  # Isolation: $HOME will be set to "ci" dir.
@@ -815,6 +816,7 @@ podman_machine_mac_task:
       - container_integration_test
       - rootless_integration_test
     persistent_worker: *mac_pw
+    timeout_in: 120m
     env:
         <<: *mac_env
         # Consumed by podman-machine ginkgo tests

--- a/contrib/cirrus/mac_cleanup.sh
+++ b/contrib/cirrus/mac_cleanup.sh
@@ -22,5 +22,8 @@ rm -rf /private/tmp/ci/* /private/tmp/ci/.??*
 find "${ORIGINAL_HOME:-$HOME}/ci" -mindepth 1 -maxdepth 1 \
     -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec rm -rf '{}' +
 
+# SSH Has a limit to the number of keys it can handle
+rm -rf "${ORIGINAL_HOME:-$HOME}"/.ssh/*
+
 # Bash scripts exit with the status of the last command.
 true


### PR DESCRIPTION
DO NOT MERGE: TESTING

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
