### PR TITLE
[v4.8] podman kube play: fix broken annotation parsing

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -239,7 +239,7 @@ func play(cmd *cobra.Command, args []string) error {
 
 	for _, annotation := range playOptions.annotations {
 		splitN := strings.SplitN(annotation, "=", 2)
-		if len(splitN) > 2 {
+		if len(splitN) != 2 {
 			return fmt.Errorf("annotation %q must include an '=' sign", annotation)
 		}
 		if playOptions.Annotations == nil {

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -443,6 +443,10 @@ _EOF
     run_podman inspect --format "{{ .Config.Annotations }}" test_pod-test
     is "$output" ".*name:$RANDOMSTRING" "Annotation should be added to pod"
 
+    # invalid annotation
+    run_podman 125 kube play --annotation "val" $PODMAN_TMPDIR/test.yaml
+    assert "$output" == "Error: annotation \"val\" must include an '=' sign" "invalid annotation error"
+
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod
 }


### PR DESCRIPTION
If a user did not set an equal sign in the annotation that old code
would panic when accessing the second element in the slice.

Picked from main https://github.com/containers/podman/pull/20976/commits/48ab4aec31e6e9db162e6d9bfd32f61a6f367a38.

Partially addresses: https://issues.redhat.com/browse/RHEL-21422

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
