### PR TITLE
Improve cross platform support of QEMU machine

### DIFF
--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -36,3 +36,12 @@ Note: To run specific test files, add the test files to the end of the winmake c
 1. `export CONTAINERS_MACHINE_PROVIDER="applehv"`
 1. `export MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"`
 1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)
+
+### QEMU
+
+1. Install Podman and QEMU for MacOS bundle using latest release from https://github.com/containers/podman/releases
+1. `make podman-remote`
+1. `export CONTAINERS_MACHINE_PROVIDER="qemu"`
+1. Add bundled QEMU to path `export PATH=/opt/podman/qemu/bin:$PATH`
+1. Set search path to gvproxy from bundle `export CONTAINERS_HELPER_BINARY_DIR=/opt/podman/bin`
+1. `make localmachine` (Add `FOCUS_FILE=basic_test.go` to only run basic test)

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -157,7 +157,7 @@ func StopWinProxy(name string, vmtype define.VMType) error {
 	if err != nil {
 		return nil
 	}
-	sendQuit(tid)
+	SendQuit(tid)
 	_ = waitTimeout(proc, 20*time.Second)
 	_ = os.Remove(tidFile)
 
@@ -200,7 +200,7 @@ func waitTimeout(proc *os.Process, timeout time.Duration) bool {
 	return ret
 }
 
-func sendQuit(tid uint32) {
+func SendQuit(tid uint32) {
 	user32 := syscall.NewLazyDLL("user32.dll")
 	postMessage := user32.NewProc("PostThreadMessageW")
 	postMessage.Call(uintptr(tid), WM_QUIT, 0, 0)

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -53,7 +53,6 @@ func (q *QemuCmd) SetNetwork() {
 	*q = append(*q, "-netdev", "socket,id=vlan,fd=3", "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee")
 }
 
-// SetNetwork adds a network device to the machine
 func (q *QemuCmd) SetUSBHostPassthrough(usbs []USBConfig) {
 	if len(usbs) == 0 {
 		return

--- a/pkg/machine/qemu/machine_unix.go
+++ b/pkg/machine/qemu/machine_unix.go
@@ -8,27 +8,50 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/podman/v4/pkg/machine/define"
 	"golang.org/x/sys/unix"
 )
 
-func isProcessAlive(pid int) bool {
+func isProcessAlive(pid int) (bool, error) {
 	err := unix.Kill(pid, syscall.Signal(0))
 	if err == nil || err == unix.EPERM {
-		return true
+		return true, nil
 	}
-	return false
+	return false, err
+}
+
+func pingProcess(pid int) (int, error) {
+	alive, err := isProcessAlive(pid)
+	if !alive {
+		if err == unix.ESRCH {
+			return -1, nil
+		}
+		return -1, fmt.Errorf("pinging QEMU process: %w", err)
+	}
+	return pid, nil
+}
+
+func killProcess(pid int, force bool) error {
+	if force {
+		return unix.Kill(pid, unix.SIGKILL)
+	}
+	return unix.Kill(pid, unix.SIGTERM)
 }
 
 func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) error {
 	var status syscall.WaitStatus
 	pid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
 	if err != nil {
-		return fmt.Errorf("failed to read qem%su process status: %w", processHint, err)
+		return fmt.Errorf("failed to read %s process status: %w", processHint, err)
 	}
 	if pid > 0 {
 		// child exited
 		return fmt.Errorf("%s exited unexpectedly with exit code %d, stderr: %s", processHint, status.ExitStatus(), stderrBuf.String())
 	}
+	return nil
+}
+
+func podmanPipe(name string) *define.VMFile {
 	return nil
 }
 
@@ -41,18 +64,4 @@ func extractTargetPath(paths []string) string {
 		return paths[1]
 	}
 	return paths[0]
-}
-
-func sigKill(pid int) error {
-	return unix.Kill(pid, unix.SIGKILL)
-}
-
-func findProcess(pid int) (int, error) {
-	if err := unix.Kill(pid, 0); err != nil {
-		if err == unix.ESRCH {
-			return -1, nil
-		}
-		return -1, fmt.Errorf("pinging QEMU process: %w", err)
-	}
-	return pid, nil
 }


### PR DESCRIPTION
This is a subset of bugfixes and technical changes from https://github.com/containers/podman/pull/17473 as the PR in question is really struggling to get merged and will probably have some more rebase iteration. Adding this commit with technical changes will allow to reduce the PR in question to actual functional changes w/o bugfixes.

Recap of changes:
* SendQuit function promoted to public API as it has potential to be useful outside of the module
* more magic values extracted to consts
* Process ping and process termination utilities refactored to be cross platform compatible
* Usage of unix specific routines in shared code part removed (instead per platform utilities are used)
* Failed deletion of pid file now results in warning logged instead of error return as there is legit reason for it to fail, because owning process could terminate faster and remove file before this code is executed. Also podman cli process could lack rights to remove file belonging to another process
* gvproxy is now stopped with SIGTERM instead of SIGKILL to allow it to do the cleanup instead of aborting
* there is a cutoff now to how long process will wait for the VM to terminate and a warning is logged on failure
* on Windows npipe part of the connectionInfo will be populated
* Fallback UID for machine provided on Windows
* minor fixes in comments

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

[NO NEW TESTS NEEDED]
