### PR TITLE
[FreeBSD] Fix crash when running podman inspect

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -315,7 +315,7 @@ func (c *Container) GetSecurityOptions() []string {
 	if apparmor, ok := ctrSpec.Annotations[define.InspectAnnotationApparmor]; ok {
 		SecurityOpt = append(SecurityOpt, fmt.Sprintf("apparmor=%s", apparmor))
 	}
-	if c.config.Spec.Linux.MaskedPaths == nil {
+	if c.config.Spec != nil && c.config.Spec.Linux != nil && c.config.Spec.Linux.MaskedPaths == nil {
 		SecurityOpt = append(SecurityOpt, "unmask=all")
 	}
 


### PR DESCRIPTION
When preparing container inspection output, ensure we actually have masked paths to work with.
These will only be available on Linux, which is no longer always true as we also support FreeBSD now.

Fixes #21117

#### Does this PR introduce a user-facing change?

```release-note
None
```
