### PR TITLE
Add a net health recovery service to qemu machines

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -194,14 +194,15 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	}
 
 	builder := ignition.NewIgnitionBuilder(ignition.DynamicIgnition{
-		Name:      opts.Username,
-		Key:       key,
-		VMName:    v.Name,
-		VMType:    define.QemuVirt,
-		TimeZone:  opts.TimeZone,
-		WritePath: v.getIgnitionFile(),
-		UID:       v.UID,
-		Rootful:   v.Rootful,
+		Name:       opts.Username,
+		Key:        key,
+		VMName:     v.Name,
+		VMType:     define.QemuVirt,
+		TimeZone:   opts.TimeZone,
+		WritePath:  v.getIgnitionFile(),
+		UID:        v.UID,
+		Rootful:    v.Rootful,
+		NetRecover: useNetworkRecover(),
 	})
 
 	// If the user provides an ignition file, we need to

--- a/pkg/machine/qemu/options_darwin.go
+++ b/pkg/machine/qemu/options_darwin.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return tmpDir, nil
 }
+
+func useNetworkRecover() bool {
+	return true
+}

--- a/pkg/machine/qemu/options_freebsd.go
+++ b/pkg/machine/qemu/options_freebsd.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return tmpDir, nil
 }
+
+func useNetworkRecover() bool {
+	return false
+}

--- a/pkg/machine/qemu/options_linux.go
+++ b/pkg/machine/qemu/options_linux.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return util.GetRootlessRuntimeDir()
 }
+
+func useNetworkRecover() bool {
+	return false
+}

--- a/pkg/machine/qemu/options_windows.go
+++ b/pkg/machine/qemu/options_windows.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return tmpDir, nil
 }
+
+func useNetworkRecover() bool {
+	return false
+}


### PR DESCRIPTION
There is a network stability issue in qemu + virtio, affecting some users after long periods of usage, which can lead to suspended queue delivery. Until the issue is resolved, add a temporary recovery service which restarts networking when host communication becomes inoperable. Only qemu based machines on mac activate this service as the issue is understood to be qemu specific. 

Works around issue in #20639

How to verify:

```
export CONTAINERS_MACHINE_PROVIDER=qemu
podman machine rm
podman machine init
podman machine start
podman machine ssh
# wait at least 2 minutes until the service becomes active, then take down the network to simulate a failure
ifconfig enp0s1 down
# After a minute networking should resume and the next command prompt should appear
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a net recovery service to detect and recover from an inoperable host networking issue experienced by some mac qemu users when ran for long periods of time
```
