### PR TITLE
applehv: return socket path from setupAPIForwarding

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -572,12 +572,6 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 		return machine.ErrVMAlreadyRunning
 	}
 
-	ioEater, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
-	if err != nil {
-		return err
-	}
-	defer ioEater.Close()
-
 	// TODO handle returns from startHostNetworking
 	forwardSock, forwardState, err := m.startHostNetworking()
 	if err != nil {
@@ -640,8 +634,6 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 		cmd.Args = append(cmd.Args, debugDevArgs...)
 		cmd.Args = append(cmd.Args, "--gui") // add command line switch to pop the gui open
 	}
-
-	cmd.ExtraFiles = []*os.File{ioEater, ioEater, ioEater}
 
 	readSocketBaseDir := filepath.Dir(m.ReadySocket.GetPath())
 	if err := os.MkdirAll(readSocketBaseDir, 0755); err != nil {

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1031,7 +1031,8 @@ func (m *MacMachine) setupAPIForwarding(cmd gvproxy.GvproxyCommand) (gvproxy.Gvp
 		}
 	}
 
-	return cmd, "", machine.MachineLocal
+	return cmd, socket.GetPath(), machine.MachineLocal
+
 }
 
 func (m *MacMachine) dockerSock() (string, error) {


### PR DESCRIPTION
When starting podman machine with applehv, this warning is printed: 
WARN[0025] API socket failed ping test

This is due to a bug in applehv.setupAPIForwarding which is not returning
the path to the socket, which causes `WaitAndPingAPI` to be called with
`""` as the socket path, triggering the warning.

This commit changes setupAPIForwarding to be similar to the implementation
in the other machine implementations.

#### Does this PR introduce a user-facing change?
```release-note
none
```