### PR TITLE
Set up podman machine remote user correctly

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -991,7 +991,7 @@ func (m *MacMachine) setupAPIForwarding(cmd gvproxy.GvproxyCommand) (gvproxy.Gvp
 	}
 
 	destSock := fmt.Sprintf("/run/user/%d/podman/podman.sock", m.UID)
-	forwardUser := "core"
+	forwardUser := m.RemoteUsername
 
 	if m.Rootful {
 		destSock = "/run/podman/podman.sock"

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -856,7 +856,7 @@ func (m *HyperVMachine) setupAPIForwarding(cmd gvproxy.GvproxyCommand) (gvproxy.
 	}
 
 	destSock := fmt.Sprintf("/run/user/%d/podman/podman.sock", m.UID)
-	forwardUser := "core"
+	forwardUser := m.RemoteUsername
 
 	if m.Rootful {
 		destSock = "/run/podman/podman.sock"

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -73,6 +73,51 @@ func (ign *DynamicIgnition) Write() error {
 	return os.WriteFile(ign.WritePath, b, 0644)
 }
 
+func (ign *DynamicIgnition) getUsers() []PasswdUser {
+	var (
+		users []PasswdUser
+	)
+
+	isCoreUser := ign.Name == DefaultIgnitionUserName
+
+	// if we are not using the 'core' user, we need to tell ignition to
+	// not add it
+	if !isCoreUser {
+		coreUser := PasswdUser{
+			Name:        DefaultIgnitionUserName,
+			ShouldExist: BoolToPtr(false),
+		}
+		users = append(users, coreUser)
+	}
+
+	// Adding the user
+	user := PasswdUser{
+		Name:              ign.Name,
+		SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
+		UID:               IntToPtr(ign.UID),
+	}
+
+	// If we are not using the core user, we need to make the user part
+	// of the following groups
+	if !isCoreUser {
+		user.Groups = []Group{
+			Group("sudo"),
+			Group("adm"),
+			Group("wheel"),
+			Group("systemd-journal")}
+	}
+
+	// set root SSH key
+	root := PasswdUser{
+		Name:              "root",
+		SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
+	}
+	// add them all in
+	users = append(users, user, root)
+
+	return users
+}
+
 // GenerateIgnitionConfig
 func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 	if len(ign.Name) < 1 {
@@ -82,18 +127,7 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 		Version: "3.2.0",
 	}
 	ignPassword := Passwd{
-		Users: []PasswdUser{
-			{
-				Name:              ign.Name,
-				SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
-				// Set the UID of the core user inside the machine
-				UID: IntToPtr(ign.UID),
-			},
-			{
-				Name:              "root",
-				SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
-			},
-		},
+		Users: ign.getUsers(),
 	}
 
 	ignStorage := Storage{

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1127,8 +1127,8 @@ func (v *MachineVM) startHostNetworking() (string, machine.APIForwardingState, e
 		cmd.Debug = true
 		logrus.Debug(cmd)
 	}
-
 	c := cmd.Cmd(binary)
+	logrus.Debugf("gvproxy args: %v", c.Args)
 	if err := c.Start(); err != nil {
 		return "", 0, fmt.Errorf("unable to execute: %q: %w", cmd.ToCmdline(), err)
 	}
@@ -1143,7 +1143,8 @@ func (v *MachineVM) setupAPIForwarding(cmd gvproxy.GvproxyCommand) (gvproxy.Gvpr
 	}
 
 	destSock := fmt.Sprintf("/run/user/%d/podman/podman.sock", v.UID)
-	forwardUser := "core"
+
+	forwardUser := v.RemoteUsername
 
 	if v.Rootful {
 		destSock = "/run/podman/podman.sock"


### PR DESCRIPTION
The remote user functionality was not quite correct.  This PR breaks out the accumulation of user descriptions into a separate function.  One odditiy is ignition must be told to NOT create the core user (or it will by default) by "adding" the core user with a set bool.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
