### PR TITLE
rm pod with run, create if ctr creation failed with --pod new:

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -228,6 +228,13 @@ func run(cmd *cobra.Command, args []string) error {
 		registry.SetExitCode(report.ExitCode)
 	}
 	if err != nil {
+		// if pod was created as part of run
+		// remove it in case ctr creation fails
+		if err := rmPodIfNecessary(cmd, s); err != nil {
+			if !errors.Is(err, define.ErrNoSuchPod) {
+				logrus.Error(err.Error())
+			}
+		}
 		return err
 	}
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1399,4 +1399,20 @@ search               | $IMAGE           |
     run_podman rm -f -t0 $cid
 }
 
+@test "podman run - rm pod if container creation failed with -pod new:" {
+    run_podman run -d --name foobar $IMAGE hostname
+    cid=$output
+
+    podname=pod$(random_string)
+    run_podman 125 run --rm --pod "new:$podname" --name foobar $IMAGE hostname
+    is "$output" ".*creating container storage: the container name \"foobar\" is already in use by"
+
+    # pod should've been cleaned up
+    # if container creation failed
+    run_podman 1 pod exists $podname
+
+    run_podman rm $cid
+    run_podman rmi $(pause_image)
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Currently, if the container creation failed with
either run or create and you've used --pod with new:
the pod would be created nonetheless. This change ensures
the pod just created is also cleaned up in case
of container creation failure

Fixes #21228

```release-note
Fix a bug (21228) wherein `run --pod new:foo` could leave behind stray containers even if pod creation fails
```