### PR TITLE
CI: reenable tests that are working again

### DIFF
--- a/test/system/125-import.bats
+++ b/test/system/125-import.bats
@@ -44,13 +44,9 @@ load helpers
     run_podman rmi -f $fqin
 }
 
+# Integration tag to catch future breakage in tar, e.g. #19407
+# bats test_tags=distro-integration
 @test "podman export, alter tarball, re-import" {
-    # Skip this only when running under rawhide in CI, since detecting
-    # and/or skipping for rawhide outside this environment is unhelpful.
-    if [[ "$CIRRUS_CI" == "true" ]] && [[ "$DISTRO_NV" == "rawhide" ]]; then
-        skip "FIXME: #19407 Broken in rawhide: processing tar file(): duplicates of file paths not supported"
-    fi
-
     # Create a test file following test
     mkdir $PODMAN_TMPDIR/tmp
     touch $PODMAN_TMPDIR/testfile1

--- a/test/system/180-blkio.bats
+++ b/test/system/180-blkio.bats
@@ -24,9 +24,6 @@ function teardown() {
 }
 
 @test "podman run --blkio-weight-device" {
-    # Broken on rawhide & F38 images as of c20230726t191046z-f38f37d13
-    skip "FIXME: #19471 brq / blkio / loopbackfs / something broken"
-
     skip_if_rootless "cannot create devices in rootless mode"
 
     # create loopback device

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -514,7 +514,6 @@ spec:
     skip_if_remote "resource limits only implemented on non-remote"
     skip_if_rootless "resource limits only work with root"
     skip_if_cgroupsv1 "resource limits only meaningful on cgroups V2"
-    skip_if_aarch64 "FIXME: #15074 - flakes often on aarch64"
 
     # create loopback device
     lofile=${PODMAN_TMPDIR}/disk.img

--- a/test/system/280-update.bats
+++ b/test/system/280-update.bats
@@ -16,10 +16,8 @@ function teardown() {
 }
 
 
+# bats test_tags=distro-integration
 @test "podman update - test all options" {
-    # Broken on rawhide & F38 images as of c20230726t191046z-f38f37d13
-    skip "FIXME: #19471 brq / blkio / loopbackfs / something broken"
-
     local cgv=1
     if is_cgroupsv2; then
         cgv=2;


### PR DESCRIPTION
- #15074 ("subtree_control" flake). The flake is NOT FIXED, I
  saw it six months ago on my (non-aarch64) laptop. However,
  it looks like the frequent-flake-on-aarch64 bug is resolved.
  I've been testing in #17831 and have not seen it. So,
  tentatively remove the skip and see what happens.

- Closes: #19407 (broken tar, "duplicates of file paths")
  All Fedoras now have a fixed tar. Debian DOES NOT, but
  we're handling that in our build-ci-vm code. I.e., the
  Debian VM we're using has a working tar even though there's
  currently a broken tar out in the wild.

  Added distro-integration tag so we can catch future problems
  like this in OpenQA.

- Closes: #19471 (brq / blkio / loopbackfs in rawhide)
  Bug appears to be fixed in rawhide, at least in the VMs we're
  using now.

  Added distro-integration tag because this test obviously
  relies on other system stuff.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```