### PR TITLE
[v4.9] Add a net health recovery service to qemu machines

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -301,14 +301,15 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	}
 
 	builder := machine.NewIgnitionBuilder(machine.DynamicIgnition{
-		Name:      opts.Username,
-		Key:       key,
-		VMName:    v.Name,
-		VMType:    machine.QemuVirt,
-		TimeZone:  opts.TimeZone,
-		WritePath: v.getIgnitionFile(),
-		UID:       v.UID,
-		Rootful:   v.Rootful,
+		Name:       opts.Username,
+		Key:        key,
+		VMName:     v.Name,
+		VMType:     machine.QemuVirt,
+		TimeZone:   opts.TimeZone,
+		WritePath:  v.getIgnitionFile(),
+		UID:        v.UID,
+		Rootful:    v.Rootful,
+		NetRecover: useNetworkRecover(),
 	})
 
 	// If the user provides an ignition file, we need to

--- a/pkg/machine/qemu/options_darwin.go
+++ b/pkg/machine/qemu/options_darwin.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return tmpDir, nil
 }
+
+func useNetworkRecover() bool {
+	return true
+}

--- a/pkg/machine/qemu/options_freebsd.go
+++ b/pkg/machine/qemu/options_freebsd.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return tmpDir, nil
 }
+
+func useNetworkRecover() bool {
+	return false
+}

--- a/pkg/machine/qemu/options_linux.go
+++ b/pkg/machine/qemu/options_linux.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return util.GetRuntimeDir()
 }
+
+func useNetworkRecover() bool {
+	return false
+}

--- a/pkg/machine/qemu/options_windows.go
+++ b/pkg/machine/qemu/options_windows.go
@@ -11,3 +11,7 @@ func getRuntimeDir() (string, error) {
 	}
 	return tmpDir, nil
 }
+
+func useNetworkRecover() bool {
+	return false
+}


### PR DESCRIPTION
Backport of #21262

```release-note
Add a net recovery service to detect and recover from an inoperable host networking issue experienced by some mac qemu users when ran for long periods of time
```
