### PR TITLE
Add back --latest examples but only for local podman

### DIFF
--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -55,6 +55,10 @@ func attachFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		attachCommand.Example += "\n  podman attach --latest"
+		containerAttachCommand.Example += "\n  podman container attach --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: attachCommand,
 	})

--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -48,6 +48,9 @@ type checkpointStatistics struct {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		checkpointCommand.Example += "\n  podman container checkpoint --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: checkpointCommand,
 		Parent:  containerCmd,

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -101,6 +101,10 @@ func execFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		execCommand.Example += "\n  podman exec --latest"
+		containerExecCommand.Example += "\n  podman container exec --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: execCommand,
 	})

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -49,6 +49,10 @@ func initFlags(flags *pflag.FlagSet) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		initCommand.Example += "\n  podman init --latest"
+		containerInitCommand.Example += "\n  podman container init --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: initCommand,
 	})

--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// podman container _inspect_
-	inspectCmd = &cobra.Command{
+	containerInspectCmd = &cobra.Command{
 		Use:               "inspect [options] CONTAINER [CONTAINER...]",
 		Short:             "Display the configuration of a container",
 		Long:              `Displays the low-level information on a container identified by name or ID.`,
@@ -25,19 +25,22 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		containerInspectCmd.Example += "\n  podman container inspect --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
-		Command: inspectCmd,
+		Command: containerInspectCmd,
 		Parent:  containerCmd,
 	})
 	inspectOpts = new(entities.InspectOptions)
-	flags := inspectCmd.Flags()
+	flags := containerInspectCmd.Flags()
 	flags.BoolVarP(&inspectOpts.Size, "size", "s", false, "Display total file size")
 
 	formatFlagName := "format"
 	flags.StringVarP(&inspectOpts.Format, formatFlagName, "f", "json", "Format the output to a Go template or json")
-	_ = inspectCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&define.InspectContainerData{}))
+	_ = containerInspectCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&define.InspectContainerData{}))
 
-	validate.AddLatestFlag(inspectCmd, &inspectOpts.Latest)
+	validate.AddLatestFlag(containerInspectCmd, &inspectOpts.Latest)
 }
 
 func inspectExec(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -67,6 +67,10 @@ func killFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		killCommand.Example += "\n  podman kill --latest"
+		containerKillCommand.Example += "\n  podman container kill --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: killCommand,
 	})

--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -74,6 +74,10 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		logsCommand.Example += "\n  podman logs --latest"
+		containerLogsCommand.Example += "\n  podman container logs --latest"
+	}
 	// if run remotely we only allow one container arg
 	if registry.IsRemote() {
 		logsCommand.Use = "logs [options] CONTAINER"

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -67,6 +67,10 @@ func mountFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		mountCommand.Example += "\n  podman mount --latest"
+		containerMountCommand.Example += "\n  podman container mount --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: mountCommand,
 	})

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -72,6 +72,10 @@ func pauseFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		pauseCommand.Example += "\n  podman pause --latest"
+		containerPauseCommand.Example += "\n  podman container pause --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: pauseCommand,
 	})

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -40,7 +40,7 @@ var (
 		},
 		ValidArgsFunction: portCommand.ValidArgsFunction,
 		Example: `podman container port --all
-  podman container port CTRID 80`,
+  podman container port ctrID 80/tcp`,
 	}
 )
 
@@ -53,6 +53,10 @@ func portFlags(flags *pflag.FlagSet) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		portCommand.Example += "\n  podman port --latest"
+		containerPortCommand.Example += "\n  podman container port --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: portCommand,
 	})

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -55,6 +55,10 @@ var (
 
 func restartFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
+	if !registry.IsRemote() {
+		restartCommand.Example += "\n  podman restart --latest"
+		containerRestartCommand.Example += "\n  podman container restart --latest"
+	}
 
 	flags.BoolVarP(&restartOpts.All, "all", "a", false, "Restart all non-running containers")
 	flags.BoolVar(&restartOpts.Running, "running", false, "Restart only running containers")

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -44,6 +44,9 @@ type restoreStatistics struct {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		restoreCommand.Example += "\n  podman container restore --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: restoreCommand,
 		Parent:  containerCmd,

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -86,6 +86,10 @@ func rmFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		rmCommand.Example += "\n  podman rm --latest"
+		containerRmCommand.Example += "\n  podman container rm --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: rmCommand,
 	})

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -69,6 +69,10 @@ func startFlags(cmd *cobra.Command) {
 	}
 }
 func init() {
+	if !registry.IsRemote() {
+		startCommand.Example += "\n  podman start --latest"
+		containerStartCommand.Example += "\n  podman container start --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: startCommand,
 	})

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -81,6 +81,10 @@ func statFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		statsCommand.Example += "\n  podman stats --latest"
+		containerStatsCommand.Example += "\n  podman container stats --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: statsCommand,
 	})

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -82,6 +82,10 @@ func stopFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		stopCommand.Example += "\n  podman stop --latest"
+		containerStopCommand.Example += "\n  podman container stop --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: stopCommand,
 	})

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -55,6 +55,10 @@ func topFlags(flags *pflag.FlagSet) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		topCommand.Example += "\n  podman top --latest"
+		containerTopCommand.Example += "\n  podman container top --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: topCommand,
 	})

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -62,6 +62,10 @@ func unmountFlags(flags *pflag.FlagSet) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		unmountCommand.Example += "\n  podman unmount --latest"
+		containerUnmountCommand.Example += "\n  podman container unmount --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: unmountCommand,
 	})

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -73,6 +73,10 @@ func unpauseFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		unpauseCommand.Example += "\n  podman unpause --latest"
+		containerUnpauseCommand.Example += "\n  podman container unpause --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: unpauseCommand,
 	})

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -59,6 +59,10 @@ func waitFlags(cmd *cobra.Command) {
 }
 
 func init() {
+	if !registry.IsRemote() {
+		waitCommand.Example += "\n  podman wait --latest"
+		containerWaitCommand.Example += "\n  podman container wait --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: waitCommand,
 	})

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -27,6 +27,9 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		inspectCmd.Example += "\n  podman pod inspect --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: inspectCmd,
 		Parent:  podCmd,

--- a/cmd/podman/pods/kill.go
+++ b/cmd/podman/pods/kill.go
@@ -35,6 +35,10 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		killCommand.Example += "\n  podman pod kill --latest"
+	}
+
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: killCommand,
 		Parent:  podCmd,

--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -28,7 +28,7 @@ type logsOptionsWrapper struct {
 var (
 	logsPodOptions     logsOptionsWrapper
 	logsPodDescription = `Displays logs for pod with one or more containers.`
-	podLogsCommand     = &cobra.Command{
+	logsCommand        = &cobra.Command{
 		Use:   "logs [options] POD",
 		Short: "Fetch logs for pod with one or more containers",
 		Long:  logsPodDescription,
@@ -57,13 +57,16 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		logsCommand.Example += "\n  podman pod logs --latest"
+	}
 	// pod logs
 	registry.Commands = append(registry.Commands, registry.CliCommand{
-		Command: podLogsCommand,
+		Command: logsCommand,
 		Parent:  podCmd,
 	})
-	logsFlags(podLogsCommand)
-	validate.AddLatestFlag(podLogsCommand, &logsPodOptions.Latest)
+	logsFlags(logsCommand)
+	validate.AddLatestFlag(logsCommand, &logsPodOptions.Latest)
 }
 
 func logsFlags(cmd *cobra.Command) {

--- a/cmd/podman/pods/pause.go
+++ b/cmd/podman/pods/pause.go
@@ -35,6 +35,9 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		pauseCommand.Example += "\n  podman pod pause --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: pauseCommand,
 		Parent:  podCmd,

--- a/cmd/podman/pods/restart.go
+++ b/cmd/podman/pods/restart.go
@@ -35,6 +35,10 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		restartCommand.Example += "\n  podman pod restart --latest"
+	}
+
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: restartCommand,
 		Parent:  podCmd,

--- a/cmd/podman/pods/start.go
+++ b/cmd/podman/pods/start.go
@@ -44,6 +44,10 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		startCommand.Example += "\n  podman pod start --latest"
+	}
+
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: startCommand,
 		Parent:  podCmd,

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -43,6 +43,9 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		statsCmd.Example += "\n  podman pod stats --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: statsCmd,
 		Parent:  podCmd,

--- a/cmd/podman/pods/stop.go
+++ b/cmd/podman/pods/stop.go
@@ -65,6 +65,8 @@ func init() {
 
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("ignore")
+	} else {
+		stopCommand.Example += "\n  podman pod stop --latest"
 	}
 
 	flags.SetNormalizeFunc(utils.AliasFlags)

--- a/cmd/podman/pods/top.go
+++ b/cmd/podman/pods/top.go
@@ -37,6 +37,9 @@ podman pod top podID -eo user,pid,comm`,
 )
 
 func init() {
+	if !registry.IsRemote() {
+		topCommand.Example += "\npodman pod top --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: topCommand,
 		Parent:  podCmd,

--- a/cmd/podman/pods/unpause.go
+++ b/cmd/podman/pods/unpause.go
@@ -35,6 +35,9 @@ var (
 )
 
 func init() {
+	if !registry.IsRemote() {
+		unpauseCommand.Example += "\npodman pod unpause --latest"
+	}
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: unpauseCommand,
 		Parent:  podCmd,


### PR DESCRIPTION
Also add --latest example to all commands that support it.

podman-remote does not support --latest option.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
--latest option now documented for all commands that support it in examples, not in podman-remote.
```
