### PR TITLE
Ensure podman temp directory is created on Start as well.

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -572,6 +572,10 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 		return machine.ErrVMAlreadyRunning
 	}
 
+	if _, err := m.getRuntimeDir(); err != nil {
+	     return err
+	}
+
 	// TODO handle returns from startHostNetworking
 	forwardSock, forwardState, err := m.startHostNetworking()
 	if err != nil {


### PR DESCRIPTION
`getRuntimeDir()` (which is also responsible for creating TMPDIR if it doesn't exist) was being called on `Init()` but not on `Start()` which meant that after the host was restarted and TMPDIR was wiped, `startHostNetworking()` would try to start gvproxy and immediately bail.

Fixes #21288 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]