### PR TITLE
Add missing check for errors returned from SpecGenToOCI to MakeContainer

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -250,6 +250,9 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		options = append(options, opts...)
 	}
 	runtimeSpec, err := SpecGenToOCI(ctx, s, rt, rtc, newImage, finalMounts, pod, command, compatibleOptions)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	if clone { // the container fails to start if cloned due to missing Linux spec entries
 		if c == nil {
 			return nil, nil, nil, errors.New("the given container could not be retrieved")


### PR DESCRIPTION
[MakeContainer](https://github.com/containers/podman/blob/20b22f8f100c4465ad15db33e8b09f2337327cb6/pkg/specgen/generate/container_create.go#L33) checks many things for error conditions, but for some reason not [the call to SpecGenToOCI](https://github.com/containers/podman/blob/20b22f8f100c4465ad15db33e8b09f2337327cb6/pkg/specgen/generate/container_create.go#L252).

This PR adds the missing check, thus avoiding nil pointer dereference exceptions in the subsequent code that tries to access the `runtimeSpec` returned from `SpecGenToOCI`. With this check in place, if `SpecGenToOCI` fails, one gets much more useful error messages.

#### Does this PR introduce a user-facing change?

```release-note
None
```
