### PR TITLE
Label host volume mounted content in machine as nfs_t 

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1145,6 +1145,7 @@ func generateSystemDFilesForVirtiofsMounts(mounts []machine.VirtIoFs) []ignition
 		mountUnit.Add("Mount", "What", "%s")
 		mountUnit.Add("Mount", "Where", "%s")
 		mountUnit.Add("Mount", "Type", "virtiofs")
+		mountUnit.Add("Mount", "Option", "defcontext=\"system_u:object_r:nfs_t:s0\"")
 		mountUnit.Add("Install", "WantedBy", "multi-user.target")
 		mountUnitFile, err := mountUnit.ToString()
 		if err != nil {


### PR DESCRIPTION
While this is potentially a security problem, it solves the issues of users sharing content from the host into containers and attempting to relabel it. From a security point of view this means all content volume mounted from the host into the podman machine on apple hypervisor is read/write from an SELinux point of view if it is volume mounted into the container. If the user attempts to use :Z or :z it will work and relabel the content to be only usable bu the specify container. 

Helps Fix: https://github.com/containers/podman/issues/21269

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Default labeling for content in podman machines on apple hypervisor is now container_file_t so it can be shared with all containers from an SELinux point of view.
```

[NO NEW TESTS NEEDED]