### PR TITLE
Use the local value of TMPDIR when copying images over SSH.

### DIFF
--- a/pkg/domain/utils/scp.go
+++ b/pkg/domain/utils/scp.go
@@ -217,7 +217,14 @@ func LoadToRemote(dest entities.ImageScpOptions, localFile string, tag string, u
 		return "", "", err
 	}
 
-	remoteFile, err := ssh.Exec(&ssh.ConnectionExecOptions{Host: url.String(), Identity: iden, Port: port, User: url.User, Args: []string{"mktemp"}}, sshEngine)
+	// If TMPDIR is specified locally, use the same value on the destination system
+	tmpdir := os.Getenv("TMPDIR")
+	tmpPrefix := ""
+	if tmpdir != "" {
+		tmpPrefix = "env TMPDIR=" + tmpdir + " "
+	}
+
+	remoteFile, err := ssh.Exec(&ssh.ConnectionExecOptions{Host: url.String(), Identity: iden, Port: port, User: url.User, Args: []string{tmpPrefix + "mktemp"}}, sshEngine)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?


```release-note

Changed the behavior of podman-image-scp, such that the local TMPDIR will be used for 
temporary files on the destination.

```
