### PR TITLE
[WIP] Covert SpecGen values to be nullable where possible

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -211,10 +211,10 @@ func run(cmd *cobra.Command, args []string) error {
 	if err := specgenutil.FillOutSpecGen(s, &cliVals, args); err != nil {
 		return err
 	}
-	s.RawImageName = rawImageName
-	s.ImageOS = cliVals.OS
-	s.ImageArch = cliVals.Arch
-	s.ImageVariant = cliVals.Variant
+	s.RawImageName = &rawImageName
+	s.ImageOS = &cliVals.OS
+	s.ImageArch = &cliVals.Arch
+	s.ImageVariant = &cliVals.Variant
 	s.Passwd = &runOpts.Passwd
 	runOpts.Spec = s
 

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -270,9 +270,9 @@ func create(cmd *cobra.Command, args []string) error {
 			createOptions.InfraCommand = infraOptions.Entrypoint
 		}
 		podSpec.InfraContainerSpec = specgen.NewSpecGenerator(imageName, false)
-		podSpec.InfraContainerSpec.RawImageName = rawImageName
+		podSpec.InfraContainerSpec.RawImageName = &rawImageName
 		podSpec.InfraContainerSpec.NetworkOptions = podSpec.NetworkOptions
-		podSpec.InfraContainerSpec.RestartPolicy = podSpec.RestartPolicy
+		podSpec.InfraContainerSpec.RestartPolicy = &podSpec.RestartPolicy
 		err = specgenutil.FillOutSpecGen(podSpec.InfraContainerSpec, &infraOptions, []string{})
 		if err != nil {
 			return err

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2051,7 +2051,7 @@ func WithInfraConmonPidFile(path string, infraSpec *specgen.SpecGenerator) PodCr
 		if pod.valid {
 			return define.ErrPodFinalized
 		}
-		infraSpec.ConmonPidFile = path
+		infraSpec.ConmonPidFile = &path
 		return nil
 	}
 }

--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -57,7 +57,7 @@ func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, option
 		return nil, err
 	}
 	if p.InfraContainerSpec != nil {
-		p.InfraContainerSpec.CgroupParent = parentCgroup
+		p.InfraContainerSpec.CgroupParent = &parentCgroup
 	}
 
 	if !pod.HasInfraContainer() && pod.SharesNamespaces() {
@@ -80,8 +80,8 @@ func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, option
 			pod.config.Name = name
 		}
 
-		if p.InfraContainerSpec != nil && p.InfraContainerSpec.Hostname == "" {
-			p.InfraContainerSpec.Hostname = pod.config.Name
+		if p.InfraContainerSpec != nil && p.InfraContainerSpec.Hostname == nil {
+			p.InfraContainerSpec.Hostname = &pod.config.Name
 		}
 		if addPodErr = r.state.AddPod(pod); addPodErr == nil {
 			return pod, nil

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -115,9 +115,11 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// moby always create the working directory
-	sg.CreateWorkingDir = true
+	localTrue := true
+	sg.CreateWorkingDir = &localTrue
 	// moby doesn't inherit /etc/hosts from host
-	sg.BaseHostsFile = "none"
+	localNone := "none"
+	sg.BaseHostsFile = &localNone
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -30,11 +30,11 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	// we have to set the default before we decode to make sure the correct default is set when the field is unset
 	sg := specgen.SpecGenerator{
 		ContainerNetworkConfig: specgen.ContainerNetworkConfig{
-			UseImageHosts: conf.Containers.NoHosts,
+			UseImageHosts: &conf.Containers.NoHosts,
 		},
 		ContainerSecurityConfig: specgen.ContainerSecurityConfig{
-			Umask:      conf.Containers.Umask,
-			Privileged: conf.Containers.Privileged,
+			Umask:      &conf.Containers.Umask,
+			Privileged: &conf.Containers.Privileged,
 		},
 	}
 

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -66,11 +66,11 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// a few extra that do not have the same json tags
-		psg.InfraContainerSpec.Name = psg.InfraName
-		psg.InfraContainerSpec.ConmonPidFile = psg.InfraConmonPidFile
+		psg.InfraContainerSpec.Name = &psg.InfraName
+		psg.InfraContainerSpec.ConmonPidFile = &psg.InfraConmonPidFile
 		psg.InfraContainerSpec.ContainerCreateCommand = psg.InfraCommand
 		psg.InfraContainerSpec.Image = psg.InfraImage
-		psg.InfraContainerSpec.RawImageName = psg.InfraImage
+		psg.InfraContainerSpec.RawImageName = &psg.InfraImage
 	}
 	podSpecComplete := entities.PodSpec{PodSpecGen: psg}
 	pod, err := generate.MakePod(&podSpecComplete, runtime)

--- a/pkg/bindings/test/attach_test.go
+++ b/pkg/bindings/test/attach_test.go
@@ -66,8 +66,10 @@ var _ = Describe("Podman containers attach", func() {
 
 	It("can echo data via cat in container", func() {
 		s := specgen.NewSpecGenerator(alpine.name, false)
-		s.Name = "CatAttachTest"
-		s.Terminal = true
+		localName := "CatAttachTest"
+		s.Name = &localName
+		localTrue := true
+		s.Terminal = &localTrue
 		s.Command = []string{"/bin/cat"}
 		ctnr, err := containers.CreateWithSpec(bt.conn, s, nil)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -203,14 +203,11 @@ func (b *bindingTest) restoreImageFromCache(i testImage) {
 // and add or append the alpine image to it
 func (b *bindingTest) RunTopContainer(containerName *string, podName *string) (string, error) {
 	s := specgen.NewSpecGenerator(alpine.name, false)
-	s.Terminal = false
+	localFalse := false
+	s.Terminal = &localFalse
 	s.Command = []string{"/usr/bin/top"}
-	if containerName != nil {
-		s.Name = *containerName
-	}
-	if podName != nil {
-		s.Pod = *podName
-	}
+	s.Name = containerName
+	s.Pod = podName
 	ctr, err := containers.CreateWithSpec(b.conn, s, nil)
 	if err != nil {
 		return "", err

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -360,7 +360,8 @@ var _ = Describe("Podman containers ", func() {
 	It("logging", func() {
 		stdoutChan := make(chan string, 10)
 		s := specgen.NewSpecGenerator(alpine.name, false)
-		s.Terminal = true
+		localTrue := true
+		s.Terminal = &localTrue
 		s.Command = []string{"date", "-R"}
 		r, err := containers.CreateWithSpec(bt.conn, s, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -774,7 +775,8 @@ var _ = Describe("Podman containers ", func() {
 		_, err = bt.RunTopContainer(&name2, nil)
 		Expect(err).ToNot(HaveOccurred())
 		s := specgen.NewSpecGenerator(alpine.name, false)
-		s.Terminal = true
+		localTrue := true
+		s.Terminal = &localTrue
 		s.Command = []string{"date", "-R"}
 		_, err = containers.CreateWithSpec(bt.conn, s, nil)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/bindings/test/create_test.go
+++ b/pkg/bindings/test/create_test.go
@@ -33,8 +33,10 @@ var _ = Describe("Create containers ", func() {
 	It("create a container running top", func() {
 		s := specgen.NewSpecGenerator(alpine.name, false)
 		s.Command = []string{"top"}
-		s.Terminal = true
-		s.Name = "top"
+		localTrue := true
+		s.Terminal = &localTrue
+		localName := "top"
+		s.Name = &localName
 		ctr, err := containers.CreateWithSpec(bt.conn, s, nil)
 		Expect(err).ToNot(HaveOccurred())
 		data, err := containers.Inspect(bt.conn, ctr.ID, nil)

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -70,7 +70,12 @@ func (ic *ContainerEngine) GenerateSpec(ctx context.Context, opts *entities.Gene
 	// rename if we are looking to consume the output and make a new entity
 	if opts.Name {
 		if spec != nil {
-			spec.Name = generateUtils.CheckName(ic.Libpod, spec.Name, true)
+			name := ""
+			if spec.Name != nil {
+				name = *spec.Name
+			}
+			localName := generateUtils.CheckName(ic.Libpod, name, true)
+			spec.Name = &localName
 		} else {
 			pspec.Name = generateUtils.CheckName(ic.Libpod, pspec.Name, false)
 		}

--- a/pkg/specgen/generate/config_linux_seccomp.go
+++ b/pkg/specgen/generate/config_linux_seccomp.go
@@ -19,7 +19,13 @@ import (
 func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libimage.Image) (*spec.LinuxSeccomp, error) {
 	var seccompConfig *spec.LinuxSeccomp
 	var err error
-	scp, err := seccomp.LookupPolicy(s.SeccompPolicy)
+
+	// "" grabs us the default policy if unset in SpecGen.
+	seccompPolicy := ""
+	if s.SeccompPolicy != nil {
+		seccompPolicy = *s.SeccompPolicy
+	}
+	scp, err := seccomp.LookupPolicy(seccompPolicy)
 	if err != nil {
 		return nil, err
 	}
@@ -44,9 +50,9 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libi
 		return seccompConfig, nil
 	}
 
-	if s.SeccompProfilePath != "" {
-		logrus.Debugf("Loading seccomp profile from %q", s.SeccompProfilePath)
-		seccompProfile, err := os.ReadFile(s.SeccompProfilePath)
+	if s.SeccompProfilePath != nil {
+		logrus.Debugf("Loading seccomp profile from %q", *s.SeccompProfilePath)
+		seccompProfile, err := os.ReadFile(*s.SeccompProfilePath)
 		if err != nil {
 			return nil, fmt.Errorf("opening seccomp profile failed: %w", err)
 		}

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -224,7 +224,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 
 		// If user is not overridden, set user in the container
 		// to user running Podman.
-		if s.User == "" {
+		if s.User == nil {
 			_, uid, gid, err := util.GetKeepIDMapping(opts)
 			if err != nil {
 				return nil, err
@@ -237,7 +237,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 		}
 		// Inherit the user from the infra container if it is set and --user has not
 		// been set explicitly
-		if infraCtr.User() != "" && s.User == "" {
+		if infraCtr.User() != "" && s.User == nil {
 			toReturn = append(toReturn, libpod.WithUser(infraCtr.User()))
 		}
 		toReturn = append(toReturn, libpod.WithUserNSFrom(infraCtr))
@@ -259,8 +259,8 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 			return nil, fmt.Errorf("cannot specify a new uid/gid map when entering a pod with an infra container: %w", define.ErrInvalidArg)
 		}
 	}
-	if s.User != "" {
-		toReturn = append(toReturn, libpod.WithUser(s.User))
+	if s.User != nil {
+		toReturn = append(toReturn, libpod.WithUser(*s.User))
 	}
 	if len(s.Groups) > 0 {
 		toReturn = append(toReturn, libpod.WithGroups(s.Groups))
@@ -287,12 +287,12 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 		}
 	}
 
-	if s.CgroupParent != "" {
-		toReturn = append(toReturn, libpod.WithCgroupParent(s.CgroupParent))
+	if s.CgroupParent != nil {
+		toReturn = append(toReturn, libpod.WithCgroupParent(*s.CgroupParent))
 	}
 
-	if s.CgroupsMode != "" {
-		toReturn = append(toReturn, libpod.WithCgroupsMode(s.CgroupsMode))
+	if s.CgroupsMode != nil {
+		toReturn = append(toReturn, libpod.WithCgroupsMode(*s.CgroupsMode))
 	}
 
 	postConfigureNetNS := needPostConfigureNetNS(s)
@@ -367,7 +367,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, "bridge", s.Networks))
 	}
 
-	if s.UseImageHosts {
+	if s.UseImageHosts != nil && *s.UseImageHosts {
 		toReturn = append(toReturn, libpod.WithUseImageHosts())
 	} else if len(s.HostAdd) > 0 {
 		toReturn = append(toReturn, libpod.WithHosts(s.HostAdd))
@@ -375,7 +375,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 	if len(s.DNSSearch) > 0 {
 		toReturn = append(toReturn, libpod.WithDNSSearch(s.DNSSearch))
 	}
-	if s.UseImageResolvConf {
+	if s.UseImageResolvConf != nil && *s.UseImageResolvConf {
 		toReturn = append(toReturn, libpod.WithUseImageResolvConf())
 	} else if len(s.DNSServers) > 0 {
 		var dnsServers []string

--- a/pkg/specgen/generate/namespaces_freebsd.go
+++ b/pkg/specgen/generate/namespaces_freebsd.go
@@ -16,7 +16,10 @@ import (
 func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt *libpod.Runtime, pod *libpod.Pod) error {
 	// UTS
 
-	hostname := s.Hostname
+	hostname := ""
+	if s.Hostname != nil {
+		hostname = *s.Hostname
+	}
 	if hostname == "" {
 		switch {
 		case s.UtsNS.NSMode == specgen.FromPod:
@@ -39,14 +42,14 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	}
 
 	g.RemoveHostname()
-	if s.Hostname != "" || s.UtsNS.NSMode != specgen.Host {
+	if s.Hostname != nil || s.UtsNS.NSMode != specgen.Host {
 		// Set the hostname in the OCI configuration only if specified by
 		// the user or if we are creating a new UTS namespace.
 		// TODO: Should we be doing this for pod or container shared
 		// namespaces?
 		g.SetHostname(hostname)
 	}
-	if _, ok := s.Env["HOSTNAME"]; !ok && s.Hostname != "" {
+	if _, ok := s.Env["HOSTNAME"]; !ok && s.Hostname != nil {
 		g.AddProcessEnv("HOSTNAME", hostname)
 	}
 

--- a/pkg/specgen/generate/namespaces_linux.go
+++ b/pkg/specgen/generate/namespaces_linux.go
@@ -72,7 +72,10 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 		}
 	}
 
-	hostname := s.Hostname
+	hostname := ""
+	if s.Hostname != nil {
+		hostname = *s.Hostname
+	}
 	if hostname == "" {
 		switch {
 		case s.UtsNS.NSMode == specgen.FromPod:
@@ -95,14 +98,14 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	}
 
 	g.RemoveHostname()
-	if s.Hostname != "" || s.UtsNS.NSMode != specgen.Host {
+	if s.Hostname != nil || s.UtsNS.NSMode != specgen.Host {
 		// Set the hostname in the OCI configuration only if specified by
 		// the user or if we are creating a new UTS namespace.
 		// TODO: Should we be doing this for pod or container shared
 		// namespaces?
 		g.SetHostname(hostname)
 	}
-	if _, ok := s.Env["HOSTNAME"]; !ok && s.Hostname != "" {
+	if _, ok := s.Env["HOSTNAME"]; !ok && s.Hostname != nil {
 		g.AddProcessEnv("HOSTNAME", hostname)
 	}
 
@@ -152,7 +155,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	if g.Config.Annotations == nil {
 		g.Config.Annotations = make(map[string]string)
 	}
-	if s.PublishExposedPorts {
+	if s.PublishExposedPorts != nil && *s.PublishExposedPorts {
 		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseTrue
 	}
 

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -49,7 +49,7 @@ func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]str
 		return nil, fmt.Errorf("no command or entrypoint provided, and no CMD or ENTRYPOINT from image")
 	}
 
-	if s.Init {
+	if s.Init != nil && *s.Init {
 		// bind mount for this binary is added in addContainerInitBinary()
 		finalCommand = append([]string{define.ContainerInitPath, "--"}, finalCommand...)
 	}

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -39,11 +39,15 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		return nil, err
 	}
 
-	g.SetProcessCwd(s.WorkDir)
+	if s.WorkDir != nil {
+		g.SetProcessCwd(*s.WorkDir)
+	}
 
 	g.SetProcessArgs(finalCmd)
 
-	g.SetProcessTerminal(s.Terminal)
+	if s.Terminal != nil {
+		g.SetProcessTerminal(*s.Terminal)
+	}
 
 	for key, val := range s.Annotations {
 		g.AddAnnotation(key, val)
@@ -51,7 +55,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	// Devices
 	var userDevices []spec.LinuxDevice
-	if !s.Privileged {
+	if !s.IsPrivileged() {
 		// add default devices from containers.conf
 		for _, device := range rtc.Containers.Devices.Get() {
 			if err = DevicesFromPath(&g, device); err != nil {
@@ -145,7 +149,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		configSpec.Annotations = make(map[string]string)
 	}
 
-	if s.Remove {
+	if s.Remove != nil && *s.Remove {
 		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseTrue
 	}
 
@@ -153,11 +157,11 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
 	}
 
-	if s.Privileged {
+	if s.IsPrivileged() {
 		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseTrue
 	}
 
-	if s.Init {
+	if s.Init != nil && *s.Init {
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
 	}
 

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -100,7 +100,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	canMountSys := canMountSys(isRootless, isNewUserns, s)
 
-	if s.Privileged && canMountSys {
+	if s.IsPrivileged() && canMountSys {
 		cgroupPerm = "rw"
 		g.RemoveMount("/sys")
 		sysMnt := spec.Mount{
@@ -115,7 +115,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		addCgroup = false
 		g.RemoveMount("/sys")
 		r := "ro"
-		if s.Privileged {
+		if s.Privileged != nil && s.IsPrivileged() {
 			r = "rw"
 		}
 		sysMnt := spec.Mount{
@@ -134,7 +134,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r},
 		}
 		g.AddMount(sysFsCgroupMnt)
-		if !s.Privileged && isRootless {
+		if !s.IsPrivileged() && isRootless {
 			g.AddLinuxMaskedPaths("/sys/kernel")
 		}
 	}
@@ -207,11 +207,17 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	g.Config.Linux.Personality = s.Personality
 
-	g.SetProcessCwd(s.WorkDir)
+	if s.WorkDir != nil {
+		g.SetProcessCwd(*s.WorkDir)
+	}
 
 	g.SetProcessArgs(finalCmd)
 
-	g.SetProcessTerminal(s.Terminal)
+	if s.Terminal != nil {
+		g.SetProcessTerminal(*s.Terminal)
+	} else {
+		g.SetProcessTerminal(false)
+	}
 
 	for key, val := range s.Annotations {
 		g.AddAnnotation(key, val)
@@ -247,13 +253,13 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	// Devices
 	// set the default rule at the beginning of device configuration
-	if !inUserNS && !s.Privileged {
+	if !inUserNS && !s.IsPrivileged() {
 		g.AddLinuxResourcesDevice(false, "", nil, nil, "rwm")
 	}
 
 	var userDevices []spec.LinuxDevice
 
-	if !s.Privileged {
+	if !s.IsPrivileged() {
 		// add default devices from containers.conf
 		for _, device := range rtc.Containers.Devices.Get() {
 			if err = DevicesFromPath(&g, device); err != nil {
@@ -278,13 +284,13 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	if isRootless && len(s.DeviceCgroupRule) > 0 {
 		return nil, fmt.Errorf("device cgroup rules are not supported in rootless mode or in a user namespace")
 	}
-	if !isRootless && !s.Privileged {
+	if !isRootless && !s.IsPrivileged() {
 		for _, dev := range s.DeviceCgroupRule {
 			g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)
 		}
 	}
 
-	BlockAccessToKernelFilesystems(s.Privileged, s.PidNS.IsHost(), s.Mask, s.Unmask, &g)
+	BlockAccessToKernelFilesystems(s.IsPrivileged(), s.PidNS.IsHost(), s.Mask, s.Unmask, &g)
 
 	g.ClearProcessEnv()
 	for name, val := range s.Env {
@@ -315,7 +321,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		configSpec.Annotations = make(map[string]string)
 	}
 
-	if s.Remove {
+	if s.Remove != nil && *s.Remove {
 		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseTrue
 	}
 
@@ -323,11 +329,11 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
 	}
 
-	if s.Privileged {
+	if s.IsPrivileged() {
 		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseTrue
 	}
 
-	if s.Init {
+	if s.Init != nil && *s.Init {
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
 	}
 
@@ -336,7 +342,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	setProcOpts(s, &g)
-	if s.ReadOnlyFilesystem && !s.ReadWriteTmpfs {
+	if (s.ReadOnlyFilesystem != nil && *s.ReadOnlyFilesystem) && (s.ReadWriteTmpfs == nil || !*s.ReadWriteTmpfs) {
 		setDevOptsReadOnly(&g)
 	}
 

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -365,7 +365,7 @@ func createPortMappings(s *specgen.SpecGenerator, imageData *libimage.ImageData)
 	}
 
 	publishPorts := toExpose
-	if !s.PublishExposedPorts {
+	if s.PublishExposedPorts == nil || !*s.PublishExposedPorts {
 		publishPorts = nil
 	}
 

--- a/pkg/specgen/generate/security_freebsd.go
+++ b/pkg/specgen/generate/security_freebsd.go
@@ -18,7 +18,7 @@ func setLabelOpts(s *specgen.SpecGenerator, runtime *libpod.Runtime, pidConfig s
 
 func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator, newImage *libimage.Image, rtc *config.Config) error {
 	// If this is a privileged container, change the devfs ruleset to expose all devices.
-	if s.Privileged {
+	if s.IsPrivileged() {
 		for k, m := range g.Config.Mounts {
 			if m.Type == "devfs" {
 				m.Options = []string{

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -128,8 +128,11 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 	}
 
 	// If requested, add container init binary
-	if s.Init {
-		initPath := s.InitPath
+	if s.Init != nil && *s.Init {
+		initPath := ""
+		if s.InitPath != nil {
+			initPath = *s.InitPath
+		}
 		if initPath == "" {
 			initPath, err = rtc.FindInitBinary()
 			if err != nil {
@@ -180,7 +183,7 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 		}
 	}
 
-	if s.ReadWriteTmpfs {
+	if s.ReadWriteTmpfs != nil && *s.ReadWriteTmpfs {
 		runPath, err := imageRunPath(ctx, img)
 		if err != nil {
 			return nil, nil, nil, err
@@ -218,7 +221,10 @@ func getImageVolumes(ctx context.Context, img *libimage.Image, s *specgen.SpecGe
 	mounts := make(map[string]spec.Mount)
 	volumes := make(map[string]*specgen.NamedVolume)
 
-	mode := strings.ToLower(s.ImageVolumeMode)
+	mode := ""
+	if s.ImageVolumeMode != nil {
+		mode = strings.ToLower(*s.ImageVolumeMode)
+	}
 
 	// Image may be nil (rootfs in use), or image volume mode may be ignore.
 	if img == nil || mode == "ignore" {

--- a/pkg/specgen/resources_linux.go
+++ b/pkg/specgen/resources_linux.go
@@ -7,7 +7,7 @@ import (
 
 func (s *SpecGenerator) InitResourceLimits(rtc *config.Config) {
 	if s.ResourceLimits == nil || s.ResourceLimits.Pids == nil {
-		if s.CgroupsMode != "disabled" {
+		if s.CgroupsMode != nil && *s.CgroupsMode != "disabled" {
 			limit := rtc.PidsLimit()
 			if limit != 0 {
 				if s.ResourceLimits == nil {

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -18,14 +18,14 @@ import (
 type LogConfig struct {
 	// LogDriver is the container's log driver.
 	// Optional.
-	Driver string `json:"driver,omitempty"`
+	Driver *string `json:"driver,omitempty"`
 	// LogPath is the path the container's logs will be stored at.
 	// Only available if LogDriver is set to "json-file" or "k8s-file".
 	// Optional.
-	Path string `json:"path,omitempty"`
+	Path *string `json:"path,omitempty"`
 	// Size is the maximum size of the log file
 	// Optional.
-	Size int64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 	// A set of options to accompany the log driver.
 	// Optional.
 	Options map[string]string `json:"options,omitempty"`
@@ -36,10 +36,10 @@ type ContainerBasicConfig struct {
 	// Name is the name the container will be given.
 	// If no name is provided, one will be randomly generated.
 	// Optional.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// Pod is the ID of the pod the container will join.
 	// Optional.
-	Pod string `json:"pod,omitempty"`
+	Pod *string `json:"pod,omitempty"`
 	// Entrypoint is the container's entrypoint.
 	// If not given and Image is specified, this will be populated by the
 	// image's configuration.
@@ -52,20 +52,21 @@ type ContainerBasicConfig struct {
 	Command []string `json:"command,omitempty"`
 	// EnvHost indicates that the host environment should be added to container
 	// Optional.
-	EnvHost bool `json:"env_host,omitempty"`
+	EnvHost *bool `json:"env_host,omitempty"`
 	// EnvHTTPProxy indicates that the http host proxy environment variables
 	// should be added to container
 	// Optional.
-	HTTPProxy bool `json:"httpproxy,omitempty"`
+	HTTPProxy *bool `json:"httpproxy,omitempty"`
 	// Env is a set of environment variables that will be set in the
 	// container.
 	// Optional.
 	Env map[string]string `json:"env,omitempty"`
 	// Terminal is whether the container will create a PTY.
 	// Optional.
-	Terminal bool `json:"terminal,omitempty"`
+	Terminal *bool `json:"terminal,omitempty"`
 	// Stdin is whether the container will keep its STDIN open.
-	Stdin bool `json:"stdin,omitempty"`
+	// Optional.
+	Stdin *bool `json:"stdin,omitempty"`
 	// Labels are key-value pairs that are used to add metadata to
 	// containers.
 	// Optional.
@@ -90,8 +91,9 @@ type ContainerBasicConfig struct {
 	// Timeout is a maximum time in seconds the container will run before
 	// main process is sent SIGKILL.
 	// If 0 is used, signal will not be sent. Container can run indefinitely
+	// if they do not stop after the default termination signal.
 	// Optional.
-	Timeout uint `json:"timeout,omitempty"`
+	Timeout *uint `json:"timeout,omitempty"`
 	// LogConfiguration describes the logging for a container including
 	// driver, path, and options.
 	// Optional
@@ -100,21 +102,28 @@ type ContainerBasicConfig struct {
 	// placed.
 	// If not given, a default location will be used.
 	// Optional.
-	ConmonPidFile string `json:"conmon_pid_file,omitempty"`
+	ConmonPidFile *string `json:"conmon_pid_file,omitempty"`
 	// RawImageName is the user-specified and unprocessed input referring
 	// to a local or a remote image.
-	RawImageName string `json:"raw_image_name,omitempty"`
-	// ImageOS is the user-specified image OS
-	ImageOS string `json:"image_os,omitempty"`
-	// ImageArch is the user-specified image architecture
-	ImageArch string `json:"image_arch,omitempty"`
-	// ImageVariant is the user-specified image variant
-	ImageVariant string `json:"image_variant,omitempty"`
+	// Optional.
+	RawImageName *string `json:"raw_image_name,omitempty"`
+	// ImageOS is the user-specified OS of the image, specifying which
+	// variant of the image will be used.
+	// Optional.
+	ImageOS *string `json:"image_os,omitempty"`
+	// ImageArch is the user-specified image architecture, specifying which
+	// variant of the image will be used.
+	// Optional.
+	ImageArch *string `json:"image_arch,omitempty"`
+	// ImageVariant is the user-specified image variant, specifying which
+	// variant of the image will be used.
+	// Optional.
+	ImageVariant *string `json:"image_variant,omitempty"`
 	// RestartPolicy is the container's restart policy - an action which
 	// will be taken when the container exits.
 	// If not given, the default policy, which does nothing, will be used.
 	// Optional.
-	RestartPolicy string `json:"restart_policy,omitempty"`
+	RestartPolicy *string `json:"restart_policy,omitempty"`
 	// RestartRetries is the number of attempts that will be made to restart
 	// the container.
 	// Only available when RestartPolicy is set to "on-failure".
@@ -124,7 +133,7 @@ type ContainerBasicConfig struct {
 	// the container.
 	// If not specified, the default will be used.
 	// Optional.
-	OCIRuntime string `json:"oci_runtime,omitempty"`
+	OCIRuntime *string `json:"oci_runtime,omitempty"`
 	// Systemd is whether the container will be started in systemd mode.
 	// Valid options are "true", "false", and "always".
 	// "true" enables this mode only if the binary run in the container is
@@ -136,14 +145,12 @@ type ContainerBasicConfig struct {
 	// If not specified, "false" will be assumed.
 	// Optional.
 	Systemd string `json:"systemd,omitempty"`
-	// Determine how to handle the NOTIFY_SOCKET - do we participate or pass it through
+	// Determine how to handle the NOTIFY_SOCKET - do we participate or pass it through?
 	// "container" - let the OCI runtime deal with it, advertise conmon's MAINPID
 	// "conmon-only" - advertise conmon's MAINPID, send READY when started, don't pass to OCI
 	// "ignore" - unset NOTIFY_SOCKET
-	SdNotifyMode string `json:"sdnotifyMode,omitempty"`
-	// Namespace is the libpod namespace the container will be placed in.
 	// Optional.
-	Namespace string `json:"namespace,omitempty"`
+	SdNotifyMode *string `json:"sdnotifyMode,omitempty"`
 	// PidNS is the container's PID namespace.
 	// It defaults to private.
 	// Mandatory.
@@ -158,15 +165,16 @@ type ContainerBasicConfig struct {
 	// container ID (if UtsNS is private).
 	// Conflicts with UtsNS if UtsNS is not set to private.
 	// Optional.
-	Hostname string `json:"hostname,omitempty"`
+	Hostname *string `json:"hostname,omitempty"`
 	// HostUsers is a list of host usernames or UIDs to add to the container
 	// /etc/passwd file
 	HostUsers []string `json:"hostusers,omitempty"`
 	// Sysctl sets kernel parameters for the container
 	Sysctl map[string]string `json:"sysctl,omitempty"`
 	// Remove indicates if the container should be removed once it has been started
-	// and exits
-	Remove bool `json:"remove,omitempty"`
+	// and exits.
+	// Optional.
+	Remove *bool `json:"remove,omitempty"`
 	// ContainerCreateCommand is the command that was used to create this
 	// container.
 	// This will be shown in the output of Inspect() on the container, and
@@ -179,7 +187,7 @@ type ContainerBasicConfig struct {
 	// passed will be 3 + PreserveFDs.
 	// set tags as `json:"-"` for not supported remote
 	// Optional.
-	PreserveFDs uint `json:"-"`
+	PreserveFDs *uint `json:"-"`
 	// PreserveFD is a list of additional file descriptors (in addition
 	// to 0, 1, 2) that will be passed to the executed process.
 	// set tags as `json:"-"` for not supported remote
@@ -188,29 +196,32 @@ type ContainerBasicConfig struct {
 	// Timezone is the timezone inside the container.
 	// Local means it has the same timezone as the host machine
 	// Optional.
-	Timezone string `json:"timezone,omitempty"`
+	Timezone *string `json:"timezone,omitempty"`
 	// DependencyContainers is an array of containers this container
 	// depends on. Dependency containers must be started before this
 	// container. Dependencies can be specified by name or full/partial ID.
 	// Optional.
 	DependencyContainers []string `json:"dependencyContainers,omitempty"`
 	// PidFile is the file that saves container process id.
-	// set tags as `json:"-"` for not supported remote
+	// Not supported for remote clients, so not serialized in specgen JSON.
 	// Optional.
 	PidFile string `json:"-"`
 	// EnvSecrets are secrets that will be set as environment variables
 	// Optional.
 	EnvSecrets map[string]string `json:"secret_env,omitempty"`
 	// InitContainerType describes if this container is an init container
-	// and if so, what type: always or once
-	InitContainerType string `json:"init_container_type"`
+	// and if so, what type: always or once.
+	// Optional.
+	InitContainerType *string `json:"init_container_type"`
 	// Personality allows users to configure different execution domains.
 	// Execution domains tell Linux how to map signal numbers into signal actions.
 	// The execution domain system allows Linux to provide limited support
 	// for binaries compiled under other UNIX-like operating systems.
+	// Optional.
 	Personality *spec.LinuxPersonality `json:"personality,omitempty"`
 	// EnvMerge takes the specified environment variables from image and preprocess them before injecting them into the
 	// container.
+	// Optional.
 	EnvMerge []string `json:"envmerge,omitempty"`
 	// UnsetEnv unsets the specified default environment variables from the image or from buildin or containers.conf
 	// Optional.
@@ -218,13 +229,15 @@ type ContainerBasicConfig struct {
 	// UnsetEnvAll unsetall default environment variables from the image or from buildin or containers.conf
 	// UnsetEnvAll unsets all default environment variables from the image or from buildin
 	// Optional.
-	UnsetEnvAll bool `json:"unsetenvall,omitempty"`
+	UnsetEnvAll *bool `json:"unsetenvall,omitempty"`
 	// Passwd is a container run option that determines if we are validating users/groups before running the container
 	Passwd *bool `json:"manage_password,omitempty"`
-	// PasswdEntry specifies arbitrary data to append to a file.
-	PasswdEntry string `json:"passwd_entry,omitempty"`
-	// GroupEntry specifies arbitrary data to append to a file.
-	GroupEntry string `json:"group_entry,omitempty"`
+	// PasswdEntry specifies arbitrary data to append to the container's /etc/passwd file.
+	// Optional.
+	PasswdEntry *string `json:"passwd_entry,omitempty"`
+	// GroupEntry specifies arbitrary data to append to the container's /etc/groups file.
+	// Optional.
+	GroupEntry *string `json:"group_entry,omitempty"`
 }
 
 // ContainerStorageConfig contains information on the storage configuration of a
@@ -242,30 +255,34 @@ type ContainerStorageConfig struct {
 	// Conflicts with Image.
 	// At least one of Image or Rootfs must be specified.
 	Rootfs string `json:"rootfs,omitempty"`
-	// RootfsOverlay tells if rootfs is actually an overlay on top of base path
-	RootfsOverlay bool `json:"rootfs_overlay,omitempty"`
-	// RootfsMapping specifies if there are mappings to apply to the rootfs.
+	// RootfsOverlay tells if rootfs is actually an overlay on top of base path.
+	// Optional.
+	RootfsOverlay *bool `json:"rootfs_overlay,omitempty"`
+	// RootfsMapping specifies if there are UID/GID mappings to apply to the rootfs.
+	// Optional
 	RootfsMapping *string `json:"rootfs_mapping,omitempty"`
 	// ImageVolumeMode indicates how image volumes will be created.
 	// Supported modes are "ignore" (do not create), "tmpfs" (create as
 	// tmpfs), and "anonymous" (create as anonymous volumes).
 	// The default if unset is anonymous.
 	// Optional.
-	ImageVolumeMode string `json:"image_volume_mode,omitempty"`
+	ImageVolumeMode *string `json:"image_volume_mode,omitempty"`
 	// VolumesFrom is a set of containers whose volumes will be added to
 	// this container. The name or ID of the container must be provided, and
 	// may optionally be followed by a : and then one or more
 	// comma-separated options. Valid options are 'ro', 'rw', and 'z'.
 	// Options will be used for all volumes sourced from the container.
+	// Optional.
 	VolumesFrom []string `json:"volumes_from,omitempty"`
 	// Init specifies that an init binary will be mounted into the
 	// container, and will be used as PID1.
-	Init bool `json:"init,omitempty"`
+	// Optional.
+	Init *bool `json:"init,omitempty"`
 	// InitPath specifies the path to the init binary that will be added if
 	// Init is specified above. If not specified, the default set in the
 	// Libpod config will be used. Ignored if Init above is not set.
 	// Optional.
-	InitPath string `json:"init_path,omitempty"`
+	InitPath *string `json:"init_path,omitempty"`
 	// Mounts are mounts that will be added to the container.
 	// These will supersede Image Volumes and VolumesFrom volumes where
 	// there are conflicts.
@@ -288,9 +305,11 @@ type ContainerStorageConfig struct {
 	// DeviceCgroupRule are device cgroup rules that allow containers
 	// to use additional types of devices.
 	DeviceCgroupRule []spec.LinuxDeviceCgroup `json:"device_cgroup_rule,omitempty"`
-	// DevicesFrom is a way to ensure your container inherits device specific information from another container
+	// DevicesFrom is a way to ensure your container inherits device specific information from another container.
+	// Optional.
 	DevicesFrom []string `json:"devices_from,omitempty"`
-	// HostDeviceList is used to recreate the mounted device on inherited containers
+	// HostDeviceList is used to recreate the mounted device on inherited containers.
+	// Optional.
 	HostDeviceList []spec.LinuxDevice `json:"host_device_list,omitempty"`
 	// IpcNS is the container's IPC namespace.
 	// Default is private.
@@ -308,27 +327,29 @@ type ContainerStorageConfig struct {
 	// WorkDir is the container's working directory.
 	// If unset, the default, /, will be used.
 	// Optional.
-	WorkDir string `json:"work_dir,omitempty"`
+	WorkDir *string `json:"work_dir,omitempty"`
 	// Create the working directory if it doesn't exist.
 	// If unset, it doesn't create it.
 	// Optional.
-	CreateWorkingDir bool `json:"create_working_dir,omitempty"`
+	CreateWorkingDir *bool `json:"create_working_dir,omitempty"`
 	// StorageOpts is the container's storage options
 	// Optional.
 	StorageOpts map[string]string `json:"storage_opts,omitempty"`
 	// RootfsPropagation is the rootfs propagation mode for the container.
 	// If not set, the default of rslave will be used.
 	// Optional.
-	RootfsPropagation string `json:"rootfs_propagation,omitempty"`
+	RootfsPropagation *string `json:"rootfs_propagation,omitempty"`
 	// Secrets are the secrets that will be added to the container
 	// Optional.
 	Secrets []Secret `json:"secrets,omitempty"`
 	// Volatile specifies whether the container storage can be optimized
 	// at the cost of not syncing all the dirty files in memory.
-	Volatile bool `json:"volatile,omitempty"`
+	// Optional.
+	Volatile *bool `json:"volatile,omitempty"`
 	// ChrootDirs is an additional set of directories that need to be
 	// treated as root directories. Standard bind mounts will be mounted
 	// into paths relative to these directories.
+	// Optional.
 	ChrootDirs []string `json:"chroot_directories,omitempty"`
 }
 
@@ -343,13 +364,14 @@ type ContainerSecurityConfig struct {
 	//   (Though SELinux can be manually re-enabled).
 	// TODO: this conflicts with things.
 	// TODO: this does more.
-	Privileged bool `json:"privileged,omitempty"`
+	// Optional.
+	Privileged *bool `json:"privileged,omitempty"`
 	// User is the user the container will be run as.
 	// Can be given as a UID or a username; if a username, it will be
 	// resolved within the container, using the container's /etc/passwd.
 	// If unset, the container will be run as root.
 	// Optional.
-	User string `json:"user,omitempty"`
+	User *string `json:"user,omitempty"`
 	// Groups are a list of supplemental groups the container's user will
 	// be granted access to.
 	// Optional.
@@ -370,19 +392,20 @@ type ContainerSecurityConfig struct {
 	// ApparmorProfile is the name of the Apparmor profile the container
 	// will use.
 	// Optional.
-	ApparmorProfile string `json:"apparmor_profile,omitempty"`
+	ApparmorProfile *string `json:"apparmor_profile,omitempty"`
 	// SeccompPolicy determines which seccomp profile gets applied
 	// the container. valid values: empty,default,image
-	SeccompPolicy string `json:"seccomp_policy,omitempty"`
+	SeccompPolicy *string `json:"seccomp_policy,omitempty"`
 	// SeccompProfilePath is the path to a JSON file containing the
 	// container's Seccomp profile.
 	// If not specified, no Seccomp profile will be used.
 	// Optional.
-	SeccompProfilePath string `json:"seccomp_profile_path,omitempty"`
+	SeccompProfilePath *string `json:"seccomp_profile_path,omitempty"`
 	// NoNewPrivileges is whether the container will set the no new
 	// privileges flag on create, which disables gaining additional
 	// privileges (e.g. via setuid) in the container.
-	NoNewPrivileges bool `json:"no_new_privileges,omitempty"`
+	// Optional.
+	NoNewPrivileges *bool `json:"no_new_privileges,omitempty"`
 	// UserNS is the container's user namespace.
 	// It defaults to host, indicating that no user namespace will be
 	// created.
@@ -394,26 +417,33 @@ type ContainerSecurityConfig struct {
 	// Required if UserNS is private.
 	IDMappings *types.IDMappingOptions `json:"idmappings,omitempty"`
 	// ReadOnlyFilesystem indicates that everything will be mounted
-	// as read-only
-	ReadOnlyFilesystem bool `json:"read_only_filesystem,omitempty"`
+	// as read-only.
+	// Optional.
+	ReadOnlyFilesystem *bool `json:"read_only_filesystem,omitempty"`
 	// ReadWriteTmpfs indicates that when running with a ReadOnlyFilesystem
-	// mount temporary file systems
-	ReadWriteTmpfs bool `json:"read_write_tmpfs,omitempty"`
+	// mount temporary file systems.
+	// Optional.
+	ReadWriteTmpfs *bool `json:"read_write_tmpfs,omitempty"`
 
 	// LabelNested indicates whether or not the container is allowed to
-	// run fully nested containers including labelling
-	LabelNested bool `json:"label_nested,omitempty"`
+	// run fully nested containers including labelling.
+	// Optional.
+	LabelNested *bool `json:"label_nested,omitempty"`
 
 	// Umask is the umask the init process of the container will be run with.
-	Umask string `json:"umask,omitempty"`
+	// Optional.
+	Umask *string `json:"umask,omitempty"`
 	// ProcOpts are the options used for the proc mount.
+	// Optional.
 	ProcOpts []string `json:"procfs_opts,omitempty"`
 	// Mask is the path we want to mask in the container. This masks the paths
 	// given in addition to the default list.
 	// Optional
 	Mask []string `json:"mask,omitempty"`
-	// Unmask is the path we want to unmask in the container. To override
-	// all the default paths that are masked, set unmask=ALL.
+	// Unmask a path in the container. Some paths are masked by default,
+	// preventing them from being accessed within the container; this undoes
+	// that masking. If ALL is passed, all paths will be unmasked.
+	// Optional.
 	Unmask []string `json:"unmask,omitempty"`
 }
 
@@ -424,13 +454,14 @@ type ContainerCgroupConfig struct {
 	// It defaults to private.
 	// Mandatory.
 	CgroupNS Namespace `json:"cgroupns,omitempty"`
-	// CgroupsMode sets a policy for how cgroups will be created in the
+	// CgroupsMode sets a policy for how cgroups will be created for the
 	// container, including the ability to disable creation entirely.
-	CgroupsMode string `json:"cgroups_mode,omitempty"`
+	// Optional.
+	CgroupsMode *string `json:"cgroups_mode,omitempty"`
 	// CgroupParent is the container's Cgroup parent.
 	// If not set, the default for the current cgroup driver will be used.
 	// Optional.
-	CgroupParent string `json:"cgroup_parent,omitempty"`
+	CgroupParent *string `json:"cgroup_parent,omitempty"`
 }
 
 // ContainerNetworkConfig contains information on a container's network
@@ -449,7 +480,8 @@ type ContainerNetworkConfig struct {
 	// This is based on ports set in Expose below, and any ports specified
 	// by the Image (if one is given).
 	// Only available if NetNS is set to Bridge or Slirp.
-	PublishExposedPorts bool `json:"publish_image_ports,omitempty"`
+	// Optional.
+	PublishExposedPorts *bool `json:"publish_image_ports,omitempty"`
 	// Expose is a number of ports that will be forwarded to the container
 	// if PublishExposedPorts is set.
 	// Expose is a map of uint16 (port number) to a string representing
@@ -466,6 +498,7 @@ type ContainerNetworkConfig struct {
 	// network interface name for this container on the specific network.
 	// If the map is empty and the bridge network mode is set the container
 	// will be joined to the default network.
+	// Optional.
 	Networks map[string]nettypes.PerNetworkOptions
 	// CNINetworks is a list of CNI networks to join the container to.
 	// If this list is empty, the default CNI network will be joined
@@ -478,7 +511,8 @@ type ContainerNetworkConfig struct {
 	// UseImageResolvConf indicates that resolv.conf should not be managed
 	// by Podman, but instead sourced from the image.
 	// Conflicts with DNSServer, DNSSearch, DNSOption.
-	UseImageResolvConf bool `json:"use_image_resolve_conf,omitempty"`
+	// Optional.
+	UseImageResolvConf *bool `json:"use_image_resolve_conf,omitempty"`
 	// DNSServers is a set of DNS servers that will be used in the
 	// container's resolv.conf, replacing the host's DNS Servers which are
 	// used by default.
@@ -500,20 +534,15 @@ type ContainerNetworkConfig struct {
 	// UseImageHosts indicates that /etc/hosts should not be managed by
 	// Podman, and instead sourced from the image.
 	// Conflicts with HostAdd.
-	// Do not set omitempty here, if this is false it should be set to not get
-	// the server default.
-	// Ideally this would be a pointer so we could differentiate between an
-	// explicitly false/true and unset (containers.conf default). However
-	// specgen is stable so we can not change this right now.
-	// TODO (5.0): change to pointer
-	UseImageHosts bool `json:"use_image_hosts"`
+	// Optional.
+	UseImageHosts *bool `json:"use_image_hosts,omitempty"`
 	// BaseHostsFile is the path to a hosts file, the entries from this file
 	// are added to the containers hosts file. As special value "image" is
 	// allowed which uses the /etc/hosts file from within the image and "none"
 	// which uses no base file at all. If it is empty we should default
 	// to the base_hosts_file configuration in containers.conf.
 	// Optional.
-	BaseHostsFile string `json:"base_hosts_file,omitempty"`
+	BaseHostsFile *string `json:"base_hosts_file,omitempty"`
 	// HostAdd is a set of hosts which will be added to the container's
 	// /etc/hosts file.
 	// Conflicts with UseImageHosts.
@@ -556,17 +585,17 @@ type ContainerResourceConfig struct {
 	// that are used to configure cgroup v2.
 	// Optional.
 	CgroupConf map[string]string `json:"unified,omitempty"`
-	// CPU period of the cpuset, determined by --cpus
-	CPUPeriod uint64 `json:"cpu_period,omitempty"`
-	// CPU quota of the cpuset, determined by --cpus
-	CPUQuota int64 `json:"cpu_quota,omitempty"`
 }
 
 // ContainerHealthCheckConfig describes a container healthcheck with attributes
 // like command, retries, interval, start period, and timeout.
 type ContainerHealthCheckConfig struct {
-	HealthConfig               *manifest.Schema2HealthConfig     `json:"healthconfig,omitempty"`
-	HealthCheckOnFailureAction define.HealthCheckOnFailureAction `json:"health_check_on_failure_action,omitempty"`
+	// Configuration of the container's healthcheck.
+	// Optional.
+	HealthConfig *manifest.Schema2HealthConfig `json:"healthconfig,omitempty"`
+	// What action to take when the healthcheck fails.
+	// Optional.
+	HealthCheckOnFailureAction *define.HealthCheckOnFailureAction `json:"health_check_on_failure_action,omitempty"`
 	// Startup healthcheck for a container.
 	// Requires that HealthConfig be set.
 	// Optional.
@@ -591,7 +620,14 @@ type SpecGenerator struct {
 }
 
 func (s *SpecGenerator) IsInitContainer() bool {
-	return len(s.InitContainerType) != 0
+	return s.InitContainerType != nil
+}
+
+func (s *SpecGenerator) IsPrivileged() bool {
+	if s.Privileged != nil {
+		return *s.Privileged
+	}
+	return false
 }
 
 type Secret struct {
@@ -623,7 +659,8 @@ func NewSpecGenerator(arg string, rootfs bool) *SpecGenerator {
 		if lastColonIndex != -1 {
 			lastPart := csc.Rootfs[lastColonIndex+1:]
 			if lastPart == "O" {
-				csc.RootfsOverlay = true
+				localTrue := true
+				csc.RootfsOverlay = &localTrue
 				csc.Rootfs = csc.Rootfs[:lastColonIndex]
 			} else if lastPart == "idmap" || strings.HasPrefix(lastPart, "idmap=") {
 				csc.RootfsMapping = &lastPart


### PR DESCRIPTION
SpecGen is our primary container creation abstraction, and is used to connect our CLI to the Libpod container creation backend. Because container creation has a million options (I exaggerate only slightly), the struct is composed of several other structs, many of which are quite large.

The core problem is that SpecGen is also an API type - it's used in remote Podman. There, we have a client and a server, and we want to respect the server's containers.conf. But how do we tell what parts of SpecGen were set by the client explicitly, and what parts were not? If we're not using nullable values, an explicit empty string and a value never being set are identical - and we can't tell if it's safe to grab a default from the server's containers.conf.

Thus, this extremely large (and rather painful) refactoring. It's likely only the first step (we have yet another level of indirection in there, entities.ContainerCreateConfig, which I did not touch yet, but will probably need a similar refactor to use nullable values. That's not an API type, though, so we can do it at any time, not just in a breaking change version like Podman 5.

[NO NEW TESTS NEEDED] This is just a refactor. Just a very, very large refactor.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
