### PR TITLE
Allow passing the OCI runtime an empty command

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -226,10 +226,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		options = append(options, libpod.WithHostUsers(s.HostUsers))
 	}
 
-	command, err := makeCommand(s, imageData)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	command := makeCommand(s, imageData)
 
 	infraVol := len(compatibleOptions.Mounts) > 0 || len(compatibleOptions.Volumes) > 0 || len(compatibleOptions.ImageVolumes) > 0 || len(compatibleOptions.OverlayVolumes) > 0
 	opts, err := createContainerOptions(rt, s, pod, finalVolumes, finalOverlays, imageData, command, infraVol, *compatibleOptions)

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -3,13 +3,13 @@
 package generate
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/containers/common/libimage"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/sirupsen/logrus"
 )
 
 func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) {
@@ -23,7 +23,7 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) {
 }
 
 // Produce the final command for the container.
-func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]string, error) {
+func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData) []string {
 	finalCommand := []string{}
 
 	entrypoint := s.Entrypoint
@@ -46,7 +46,8 @@ func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]str
 	finalCommand = append(finalCommand, command...)
 
 	if len(finalCommand) == 0 {
-		return nil, fmt.Errorf("no command or entrypoint provided, and no CMD or ENTRYPOINT from image")
+		logrus.Debug("no command or entrypoint provided, and no CMD or ENTRYPOINT from image: defaulting to empty string")
+		finalCommand = []string{""}
 	}
 
 	if s.Init {
@@ -54,5 +55,5 @@ func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]str
 		finalCommand = append([]string{define.ContainerInitPath, "--"}, finalCommand...)
 	}
 
-	return finalCommand, nil
+	return finalCommand
 }

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -17,7 +17,7 @@ CMD []
 		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
 		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(Or(Exit(126), Exit(127)))
 	})
 
 	It("podman run entrypoint == [\"\"]", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1415,4 +1415,20 @@ search               | $IMAGE           |
     run_podman rmi $(pause_image)
 }
 
+@test "podman run - no entrypoint" {
+    run_podman 127 run --rm --rootfs "$PODMAN_TMPDIR"
+
+    # runc and crun emit different diagnostics
+    runtime=$(podman_runtime)
+    case "$runtime" in
+        crun) expect='crun: executable file `` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found' ;;
+        runc) expect='runc: runc create failed: unable to start container process: exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found' ;;
+        *)    skip "Unknown runtime '$runtime'" ;;
+    esac
+
+    # The '.*' in the error below is for dealing with podman-remote, which
+    # includes "error preparing container <sha> for attach" in output.
+    is "$output" "Error.*: $expect" "podman emits useful diagnostic when no entrypoint is set"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Some OCI runtimes (cf. [1]) may tolerate container images that don't specify an entrypoint together with no entrypoint being specified in the command line. In those cases, it's annoying for the user to have to pass a "" argument to podman.

[1] https://github.com/containers/crun-vm

#### Does this PR introduce a user-facing change?

```release-note
podman-create and podman-run no longer require specifying an entrypoint on the command line when the container image does not define one. In this case, an empty command will be passed to the OCI runtime, and the resulting behavior is runtime-specific.
```
