### PR TITLE
Set interface name same as the network_interface name.

### DIFF
--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -353,7 +353,7 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) erro
 
 	// check if network exists and if the input is an ID we get the name
 	// CNI and netavark and the libpod db only uses names so it is important that we only use the name
-	netName, err = c.runtime.normalizeNetworkName(netName)
+	netName, _, err = c.runtime.normalizeNetworkName(netName)
 	if err != nil {
 		return err
 	}
@@ -467,7 +467,8 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 
 	// check if network exists and if the input is an ID we get the name
 	// CNI and netavark and the libpod db only uses names so it is important that we only use the name
-	netName, err = c.runtime.normalizeNetworkName(netName)
+	nicName := ""
+	netName, nicName, err = c.runtime.normalizeNetworkName(netName)
 	if err != nil {
 		return err
 	}
@@ -481,6 +482,13 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 
 	netOpts.Aliases = append(netOpts.Aliases, getExtraNetworkAliases(c)...)
 
+	// check whether interface is to be named as the network_interface
+	// when name left unspecified
+	if netOpts.InterfaceName == "" && nicName != "" && c.runtime.config.Containers.InterfaceName == "device" {
+		netOpts.InterfaceName = nicName
+	}
+
+	// set default interface name
 	if netOpts.InterfaceName == "" {
 		netOpts.InterfaceName = getFreeInterfaceName(networks)
 		if netOpts.InterfaceName == "" {
@@ -632,14 +640,15 @@ func (r *Runtime) ConnectContainerToNetwork(nameOrID, netName string, netOpts ty
 	return ctr.NetworkConnect(nameOrID, netName, netOpts)
 }
 
-// normalizeNetworkName takes a network name, a partial or a full network ID and returns the network name.
+// normalizeNetworkName takes a network name, a partial or a full network ID and
+// returns the network and network_interface names.
 // If the network is not found an error is returned.
-func (r *Runtime) normalizeNetworkName(nameOrID string) (string, error) {
+func (r *Runtime) normalizeNetworkName(nameOrID string) (string, string, error) {
 	net, err := r.network.NetworkInspect(nameOrID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return net.Name, nil
+	return net.Name, net.NetworkInterface, nil
 }
 
 // ocicniPortsToNetTypesPorts convert the old port format to the new one

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -264,11 +264,18 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		}
 		i := 0
 		for nameOrID, opts := range ctr.config.Networks {
-			netName, err := r.normalizeNetworkName(nameOrID)
+			netName, nicName, err := r.normalizeNetworkName(nameOrID)
 			if err != nil {
 				return nil, err
 			}
-			// assign interface name if empty
+
+			// check whether interface is to be named as the network_interface
+			// when name left unspecified
+			if opts.InterfaceName == "" && nicName != "" && ctr.runtime.config.Containers.InterfaceName == "device" {
+				opts.InterfaceName = nicName
+			}
+
+			// assign default interface name if empty
 			if opts.InterfaceName == "" {
 				for i < 100000 {
 					ifName := fmt.Sprintf("eth%d", i)

--- a/test/e2e/container_iface_name_test.go
+++ b/test/e2e/container_iface_name_test.go
@@ -1,0 +1,339 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/containers/podman/v4/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+func createNetworkDevice(name string) {
+        session := SystemExec("ip", []string{"link", "add", name, "type", "bridge"})
+        session.WaitWithDefaultTimeout()
+}
+
+func removeNetworkDevice(name string) {
+        session := SystemExec("ip", []string{"link", "delete", name})
+        session.WaitWithDefaultTimeout()
+}
+
+func createContainersConfFileWithDeviceIfaceName(pTest *PodmanTestIntegration) {
+	configPath := filepath.Join(pTest.TempDir, "containers.conf")
+	containersConf := []byte(fmt.Sprintf("[containers]\ninterface_name = \"device\"\n"))
+	err := os.WriteFile(configPath, containersConf, os.ModePerm)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Set custom containers.conf file
+	os.Setenv("CONTAINERS_CONF", configPath)
+	if IsRemote() {
+		pTest.RestartRemoteService()
+	}
+}
+
+
+var _ = Describe("Podman container interface name", func() {
+
+	It("podman container interface name with default scheme for bridge network", func() {
+		netName1 := "bridge" + stringid.GenerateRandomID()
+		netName2 := "bridge" + stringid.GenerateRandomID()
+
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		// Inspect the network configuration
+		nic1 := podmanTest.Podman([]string{"network", "inspect", netName1, "--format", "{{.NetworkInterface}}"})
+		nic1.WaitWithDefaultTimeout()
+		Expect(nic1).Should(ExitCleanly())
+
+		// Once a container executes a new network, the nic will be
+		// created. We should clean those up best we can
+		defer removeNetworkDevice(nic1.OutputToString())
+
+		defer podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--network", netName1, "--name", "test", ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(ExitCleanly())
+
+		exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(ExitCleanly())
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		// Inspect the network configuration
+		nic2 := podmanTest.Podman([]string{"network", "inspect", netName2, "--format", "{{.NetworkInterface}}"})
+		nic2.WaitWithDefaultTimeout()
+		Expect(nic2).Should(ExitCleanly())
+
+		// Once a container executes a new network, the nic will be
+		// created. We should clean those up best we can
+		defer removeNetworkDevice(nic2.OutputToString())
+
+		conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+		conn.WaitWithDefaultTimeout()
+		Expect(conn).Should(ExitCleanly())
+		Expect(conn.ErrorToString()).Should(Equal(""))
+
+		exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+
+		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		rm.WaitWithDefaultTimeout()
+		Expect(rm).Should(ExitCleanly())
+		Expect(rm.ErrorToString()).To(Equal(""))
+	})
+
+	It("podman container interface name with default scheme for macvlan network with no parent", func() {
+		netName1 := "macvlan" + stringid.GenerateRandomID()
+		netName2 := "macvlan" + stringid.GenerateRandomID()
+
+		// There is no nic created by the macvlan driver.
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		defer podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--network", netName1, "--name", "test", ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(ExitCleanly())
+
+		exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(ExitCleanly())
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+		conn.WaitWithDefaultTimeout()
+		Expect(conn).Should(ExitCleanly())
+		Expect(conn.ErrorToString()).Should(Equal(""))
+
+		exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+
+		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		rm.WaitWithDefaultTimeout()
+		Expect(rm).Should(ExitCleanly())
+		Expect(rm.ErrorToString()).To(Equal(""))
+	})
+
+	It("podman container interface name with default scheme for macvlan network with parent", func() {
+		// Create a nic to be used as a parent for macvlan network.
+		nicName1 := "br" + stringid.GenerateRandomID()
+		nicName2 := "br" + stringid.GenerateRandomID()
+
+		netName1 := "macvlan" + stringid.GenerateRandomID()
+		netName2 := "macvlan" + stringid.GenerateRandomID()
+
+		parent1 := "parent=" + nicName1
+		parent2 := "parent=" + nicName2
+
+		defer removeNetworkDevice(nicName1)
+		createNetworkDevice(nicName1)
+
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", parent1, netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		defer podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--network", netName1, "--name", "test", ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(ExitCleanly())
+
+		exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(ExitCleanly())
+
+		defer removeNetworkDevice(nicName2)
+		createNetworkDevice(nicName2)
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", parent2, netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+		conn.WaitWithDefaultTimeout()
+		Expect(conn).Should(ExitCleanly())
+		Expect(conn.ErrorToString()).Should(Equal(""))
+
+		exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+
+		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		rm.WaitWithDefaultTimeout()
+		Expect(rm).Should(ExitCleanly())
+		Expect(rm.ErrorToString()).To(Equal(""))
+	})
+
+	It("podman container interface name with host scheme for bridge network", func() {
+		createContainersConfFileWithDeviceIfaceName(podmanTest)
+
+		netName1 := "bridge" + stringid.GenerateRandomID()
+		netName2 := "bridge" + stringid.GenerateRandomID()
+
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		// Inspect the network configuration
+		nic1 := podmanTest.Podman([]string{"network", "inspect", netName1, "--format", "{{.NetworkInterface}}"})
+		nic1.WaitWithDefaultTimeout()
+		Expect(nic1).Should(ExitCleanly())
+
+		// Once a container executes a new network, the nic will be
+		// created. We should clean those up best we can
+		defer removeNetworkDevice(nic1.OutputToString())
+
+		defer podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--network", netName1, "--name", "test", ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(ExitCleanly())
+
+		exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", nic1.OutputToString()})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(ExitCleanly())
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		// Inspect the network configuration
+		nic2 := podmanTest.Podman([]string{"network", "inspect", netName2, "--format", "{{.NetworkInterface}}"})
+		nic2.WaitWithDefaultTimeout()
+		Expect(nic2).Should(ExitCleanly())
+
+		// Once a container executes a new network, the nic will be
+		// created. We should clean those up best we can
+		defer removeNetworkDevice(nic2.OutputToString())
+
+		conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+		conn.WaitWithDefaultTimeout()
+		Expect(conn).Should(ExitCleanly())
+		Expect(conn.ErrorToString()).Should(Equal(""))
+
+		exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", nic2.OutputToString()})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+
+		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		rm.WaitWithDefaultTimeout()
+		Expect(rm).Should(ExitCleanly())
+		Expect(rm.ErrorToString()).To(Equal(""))
+	})
+
+	It("podman container interface name with host scheme for macvlan network with no parent", func() {
+		createContainersConfFileWithDeviceIfaceName(podmanTest)
+
+		netName1 := "macvlan" + stringid.GenerateRandomID()
+		netName2 := "macvlan" + stringid.GenerateRandomID()
+
+		// There is no nic created by the macvlan driver.
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		defer podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--network", netName1, "--name", "test", ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(ExitCleanly())
+
+		exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(ExitCleanly())
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+		conn.WaitWithDefaultTimeout()
+		Expect(conn).Should(ExitCleanly())
+		Expect(conn.ErrorToString()).Should(Equal(""))
+
+		exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+
+		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		rm.WaitWithDefaultTimeout()
+		Expect(rm).Should(ExitCleanly())
+		Expect(rm.ErrorToString()).To(Equal(""))
+	})
+
+	It("podman container interface name with host scheme for macvlan network with parent", func() {
+		createContainersConfFileWithDeviceIfaceName(podmanTest)
+
+		// Create a nic to be used as a parent for macvlan network.
+		nicName1 := "br" + stringid.GenerateRandomID()
+		nicName2 := "br" + stringid.GenerateRandomID()
+
+		netName1 := "macvlan" + stringid.GenerateRandomID()
+		netName2 := "macvlan" + stringid.GenerateRandomID()
+
+		parent1 := "parent=" + nicName1
+		parent2 := "parent=" + nicName2
+
+		defer removeNetworkDevice(nicName1)
+		createNetworkDevice(nicName1)
+
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", parent1, netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		defer podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--network", netName1, "--name", "test", ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(ExitCleanly())
+
+		exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", nicName1})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(ExitCleanly())
+
+		defer removeNetworkDevice(nicName2)
+		createNetworkDevice(nicName2)
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", parent2, netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+		conn.WaitWithDefaultTimeout()
+		Expect(conn).Should(ExitCleanly())
+		Expect(conn.ErrorToString()).Should(Equal(""))
+
+		exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", nicName2})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(ExitCleanly())
+
+		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+		rm.WaitWithDefaultTimeout()
+		Expect(rm).Should(ExitCleanly())
+		Expect(rm.ErrorToString()).To(Equal(""))
+	})
+
+})


### PR DESCRIPTION
When interface_name attribute in containers.conf is set to "device", then set interface names inside containers same as the network_interface names.

If the interface name is set in the user request, then that takes precedence.

Fixes: https://github.com/containers/podman/issues/21313

Signed-off-by: Vikas Goel vikas.goel@gmail.com

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? Yes

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
