### PR TITLE
Fix Mount Unit Option

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1149,7 +1149,7 @@ func generateSystemDFilesForVirtiofsMounts(mounts []machine.VirtIoFs) []ignition
 		mountUnit.Add("Mount", "What", "%s")
 		mountUnit.Add("Mount", "Where", "%s")
 		mountUnit.Add("Mount", "Type", "virtiofs")
-		mountUnit.Add("Mount", "Option", "defcontext=\"system_u:object_r:nfs_t:s0\"")
+		mountUnit.Add("Mount", "Options", "defcontext=\"system_u:object_r:nfs_t:s0\"")
 		mountUnit.Add("Install", "WantedBy", "multi-user.target")
 		mountUnitFile, err := mountUnit.ToString()
 		if err != nil {


### PR DESCRIPTION
Fix https://github.com/containers/podman/pull/21297 (pull request)

Before fix
```
core@localhost:~$ grep nfs_t /etc/systemd/system/*.mount
/etc/systemd/system/Users.mount:Option=defcontext="system_u:object_r:nfs_t:s0"
/etc/systemd/system/private.mount:Option=defcontext="system_u:object_r:nfs_t:s0"
/etc/systemd/system/var-folders.mount:Option=defcontext="system_u:object_r:nfs_t:s0"
core@localhost:~$ ls -ldZ /Users /private/ /var/folders
drwxr-xr-x. 5 core core system_u:object_r:unlabeled_t:s0 160 Dec 21 18:50 /Users
drwxr-xr-x. 6 core core system_u:object_r:unlabeled_t:s0 192 Dec 23 12:04 /private/
drwxr-xr-x. 5 core core system_u:object_r:unlabeled_t:s0 160 Dec 21 18:51 /var/folders
```

After fix
```
core@localhost:~$ grep nfs_t /etc/systemd/system/*.mount
/etc/systemd/system/Users.mount:Options=defcontext="system_u:object_r:nfs_t:s0"
/etc/systemd/system/private.mount:Options=defcontext="system_u:object_r:nfs_t:s0"
/etc/systemd/system/var-folders.mount:Options=defcontext="system_u:object_r:nfs_t:s0"
core@localhost:~$ ls -ldZ /Users /private/ /var/folders
drwxr-xr-x. 5 core core system_u:object_r:nfs_t:s0 160 Dec 21 18:50 /Users
drwxr-xr-x. 6 core core system_u:object_r:nfs_t:s0 192 Dec 23 12:04 /private/
drwxr-xr-x. 5 core core system_u:object_r:nfs_t:s0 160 Dec 21 18:51 /var/folders
```



[NO NEW TESTS NEEDED]

```release-note
None
```
