### PR TITLE
[CI:DOCS] podman farm is no longer hidden. Enable doc checks.

### DIFF
--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -109,7 +109,6 @@ my %Skip_Subcommand = map { $_ => 1 } (
     "help",                     # has no man page
     "completion",               # internal (hidden) subcommand
     "compose",                  # external tool, outside of our control
-    "farm",                # hidden subcommand till it is fully implemented - remove this once done
 );
 
 # END   user-customizable section


### PR DESCRIPTION
Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```