### PR TITLE
Reuse timezone code from containers/common

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -25,6 +24,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/hooks"
 	"github.com/containers/common/pkg/hooks/exec"
+	"github.com/containers/common/pkg/timezone"
 	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/events"
@@ -1706,45 +1706,18 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 	}
 
 	tz := c.Timezone()
-	if tz != "" {
-		timezonePath := filepath.Join("/usr/share/zoneinfo", tz)
-		if tz == "local" {
-			timezonePath, err = filepath.EvalSymlinks("/etc/localtime")
-			if err != nil {
-				return "", fmt.Errorf("finding local timezone for container %s: %w", c.ID(), err)
-			}
+	localTimePath, err := timezone.ConfigureContainerTimeZone(tz, c.state.RunDir, mountPoint, etcInTheContainerPath, c.ID())
+	if err != nil {
+		return "", fmt.Errorf("configuring timezone for container %s: %w", c.ID(), err)
+	}
+	if localTimePath != "" {
+		if err := c.relabel(localTimePath, c.config.MountLabel, false); err != nil {
+			return "", err
 		}
-		// make sure to remove any existing localtime file in the container to not create invalid links
-		err = unix.Unlinkat(etcInTheContainerFd, "localtime", 0)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("removing /etc/localtime: %w", err)
+		if c.state.BindMounts == nil {
+			c.state.BindMounts = make(map[string]string)
 		}
-
-		hostPath, err := securejoin.SecureJoin(mountPoint, timezonePath)
-		if err != nil {
-			return "", fmt.Errorf("resolve zoneinfo path in the container: %w", err)
-		}
-
-		_, err = os.Stat(hostPath)
-		if err != nil {
-			// file does not exists which means tzdata is not installed in the container, just create /etc/locatime which a copy from the host
-			logrus.Debugf("Timezone %s does not exist in the container, create our own copy from the host", timezonePath)
-			localtimePath, err := c.copyTimezoneFile(timezonePath)
-			if err != nil {
-				return "", fmt.Errorf("setting timezone for container %s: %w", c.ID(), err)
-			}
-			if c.state.BindMounts == nil {
-				c.state.BindMounts = make(map[string]string)
-			}
-			c.state.BindMounts["/etc/localtime"] = localtimePath
-		} else {
-			// file exists lets just symlink according to localtime(5)
-			logrus.Debugf("Create locatime symlink for %s", timezonePath)
-			err = unix.Symlinkat(".."+timezonePath, etcInTheContainerFd, "localtime")
-			if err != nil {
-				return "", fmt.Errorf("creating /etc/localtime symlink: %w", err)
-			}
-		}
+		c.state.BindMounts["/etc/localtime"] = localTimePath
 	}
 
 	// Request a mount of all named volumes

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2782,38 +2782,6 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 	return passwdPath, groupPath, nil
 }
 
-func (c *Container) copyTimezoneFile(zonePath string) (string, error) {
-	localtimeCopy := filepath.Join(c.state.RunDir, "localtime")
-	file, err := os.Stat(zonePath)
-	if err != nil {
-		return "", err
-	}
-	if file.IsDir() {
-		return "", errors.New("invalid timezone: is a directory")
-	}
-	src, err := os.Open(zonePath)
-	if err != nil {
-		return "", err
-	}
-	defer src.Close()
-	dest, err := os.Create(localtimeCopy)
-	if err != nil {
-		return "", err
-	}
-	defer dest.Close()
-	_, err = io.Copy(dest, src)
-	if err != nil {
-		return "", err
-	}
-	if err := c.relabel(localtimeCopy, c.config.MountLabel, false); err != nil {
-		return "", err
-	}
-	if err := dest.Chown(c.RootUID(), c.RootGID()); err != nil {
-		return "", err
-	}
-	return localtimeCopy, err
-}
-
 func (c *Container) cleanupOverlayMounts() error {
 	return overlay.CleanupContent(c.config.StaticDir)
 }

--- a/vendor/github.com/containers/common/pkg/timezone/timezone.go
+++ b/vendor/github.com/containers/common/pkg/timezone/timezone.go
@@ -1,0 +1,103 @@
+//go:build !windows
+
+package timezone
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// ConfigureContainerTimeZone configure the time zone for a container.
+// It returns the path of the created /etc/localtime file if needed.
+func ConfigureContainerTimeZone(timezone, containerRunDir, mountPoint, etcPath, containerID string) (localTimePath string, err error) {
+	var timezonePath string
+	switch {
+	case timezone == "":
+		return "", nil
+	case os.Getenv("TZDIR") != "":
+		// Allow using TZDIR per:
+		// https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzfile.c;h=8a923d0cccc927a106dc3e3c641be310893bab4e;hb=HEAD#l149
+
+		timezonePath = filepath.Join(os.Getenv("TZDIR"), timezone)
+	case timezone == "local":
+		timezonePath, err = filepath.EvalSymlinks("/etc/localtime")
+		if err != nil {
+			return "", fmt.Errorf("finding local timezone for container %s: %w", containerID, err)
+		}
+	default:
+		timezonePath = filepath.Join("/usr/share/zoneinfo", timezone)
+	}
+
+	etcFd, err := openDirectory(etcPath)
+	if err != nil {
+		return "", fmt.Errorf("open /etc in the container: %w", err)
+	}
+	defer unix.Close(etcFd)
+
+	// Make sure to remove any existing localtime file in the container to not create invalid links
+	err = unix.Unlinkat(etcFd, "localtime", 0)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("removing /etc/localtime: %w", err)
+	}
+
+	hostPath, err := securejoin.SecureJoin(mountPoint, timezonePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve zoneinfo path in the container: %w", err)
+	}
+
+	var localtimePath string
+	if _, err := os.Stat(hostPath); err != nil {
+		// File does not exist, which means tzdata is not installed in the container.
+		// Create /etc/localtime as a copy from the host.
+		logrus.Debugf("Timezone %s does not exist in the container, create our own copy from the host", timezonePath)
+		localtimePath, err = copyTimezoneFile(containerRunDir, timezonePath)
+		if err != nil {
+			return "", fmt.Errorf("setting timezone for container %s: %w", containerID, err)
+		}
+	} else {
+		// File exists, let's create a symlink according to localtime(5)
+		logrus.Debugf("Create localtime symlink for %s", timezonePath)
+		err = unix.Symlinkat(".."+timezonePath, etcFd, "localtime")
+		if err != nil {
+			return "", fmt.Errorf("creating /etc/localtime symlink: %w", err)
+		}
+	}
+	return localtimePath, nil
+}
+
+// copyTimezoneFile copies the timezone file from the host to the container.
+func copyTimezoneFile(containerRunDir, zonePath string) (string, error) {
+	localtimeCopy := filepath.Join(containerRunDir, "localtime")
+	file, err := os.Stat(zonePath)
+	if err != nil {
+		return "", err
+	}
+	if file.IsDir() {
+		return "", errors.New("invalid timezone: is a directory")
+	}
+	src, err := os.Open(zonePath)
+	if err != nil {
+		return "", err
+	}
+	defer src.Close()
+
+	dest, err := os.Create(localtimeCopy)
+	if err != nil {
+		return "", err
+	}
+	defer dest.Close()
+
+	_, err = io.Copy(dest, src)
+	if err != nil {
+		return "", err
+	}
+	return localtimeCopy, err
+}

--- a/vendor/github.com/containers/common/pkg/timezone/timezone_linux.go
+++ b/vendor/github.com/containers/common/pkg/timezone/timezone_linux.go
@@ -1,0 +1,9 @@
+package timezone
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func openDirectory(path string) (fd int, err error) {
+	return unix.Open(path, unix.O_RDONLY|unix.O_PATH|unix.O_CLOEXEC, 0)
+}

--- a/vendor/github.com/containers/common/pkg/timezone/timezone_unix.go
+++ b/vendor/github.com/containers/common/pkg/timezone/timezone_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows && !linux
+
+package timezone
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func openDirectory(path string) (fd int, err error) {
+	const O_PATH = 0x00400000
+	return unix.Open(path, unix.O_RDONLY|O_PATH|unix.O_CLOEXEC, 0)
+}

--- a/vendor/github.com/containers/common/pkg/timezone/timezone_windows.go
+++ b/vendor/github.com/containers/common/pkg/timezone/timezone_windows.go
@@ -1,0 +1,5 @@
+package timezone
+
+func ConfigureContainerTimeZone(timezone, containerRunDir, mountPoint, etcPath, containerID string) (string, error) {
+	return "", nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -227,6 +227,7 @@ github.com/containers/common/pkg/supplemented
 github.com/containers/common/pkg/sysinfo
 github.com/containers/common/pkg/systemd
 github.com/containers/common/pkg/timetype
+github.com/containers/common/pkg/timezone
 github.com/containers/common/pkg/umask
 github.com/containers/common/pkg/util
 github.com/containers/common/pkg/version


### PR DESCRIPTION
Replaces: https://github.com/containers/podman/pull/21077

[NO NEW TESTS NEEDED] Existing tests should handle this.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
