### PR TITLE
Kube Play - allow creating image based volumes

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -61,6 +61,7 @@ A Kubernetes PersistentVolumeClaim represents a Podman named volume. Only the Pe
 - volume.podman.io/gid
 - volume.podman.io/mount-options
 - volume.podman.io/import-source
+- volume.podman.io/image
 
 Use `volume.podman.io/import-source` to import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) specified in the annotation's value into the created Podman volume
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1147,6 +1147,8 @@ func (ic *ContainerEngine) playKubePVC(ctx context.Context, mountLabel string, p
 			opts["o"] = v
 		case util.VolumeImportSourceAnnotation:
 			importFrom = v
+		case util.VolumeImageAnnotation:
+			opts["image"] = v
 		}
 	}
 	volOptions = append(volOptions, libpod.WithVolumeOptions(opts))

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -15,4 +15,6 @@ const (
 	VolumeMountOptsAnnotation = "volume.podman.io/mount-options"
 	// Kube annotation for podman volume import source.
 	VolumeImportSourceAnnotation = "volume.podman.io/import-source"
+	// Kube annotation for podman volume image.
+	VolumeImageAnnotation = "volume.podman.io/image"
 )


### PR DESCRIPTION
Add volume.podman.io/image annotation to allow setting the source image


#### Does this PR introduce a user-facing change?
Yes

```release-note
Kube Play add support for creating image based volume with K8S PVC
```
