### PR TITLE
Implement generic providers

### DIFF
--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/machine"
 	machineDefine "github.com/containers/podman/v4/pkg/machine/define"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -102,10 +101,7 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 	host.Arch = runtime.GOARCH
 	host.OS = runtime.GOOS
 
-	// TODO This is temporary
-	s := new(qemu.QEMUStubber)
-
-	dirs, err := machine.GetMachineDirs(s.VMType())
+	dirs, err := machine.GetMachineDirs(provider.VMType())
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +125,7 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 			host.DefaultMachine = vm.Name
 		}
 		// If machine is running or starting, it is automatically the current machine
-		state, err := s.State(vm, false)
+		state, err := provider.State(vm, false)
 		if err != nil {
 			return nil, err
 		}
@@ -152,7 +148,7 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 		}
 	}
 
-	host.VMType = s.VMType().String()
+	host.VMType = provider.VMType().String()
 
 	host.MachineImageDir = dirs.DataDir.GetPath()
 	host.MachineConfigDir = dirs.ConfigDir.GetPath()

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -12,8 +12,7 @@ import (
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/define"
-	"github.com/containers/podman/v4/pkg/machine/p5"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
+	"github.com/containers/podman/v4/pkg/machine/shim"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/spf13/cobra"
 )
@@ -145,10 +144,8 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot use %q for a machine name", initOpts.Name)
 	}
 
-	s := new(qemu.QEMUStubber)
-
 	// Check if machine already exists
-	_, exists, err := p5.VMExists(initOpts.Name, []vmconfigs.VMStubber{s})
+	_, exists, err := shim.VMExists(initOpts.Name, []vmconfigs.VMProvider{provider})
 	if err != nil {
 		return err
 	}
@@ -192,7 +189,7 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	// }
 
 	// TODO this is for QEMU only (change to generic when adding second provider)
-	mc, err := p5.Init(initOpts, s)
+	mc, err := shim.Init(initOpts, provider)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/spf13/cobra"
 )
@@ -48,8 +47,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	s := new(qemu.QEMUStubber)
-	dirs, err := machine.GetMachineDirs(s.VMType())
+	dirs, err := machine.GetMachineDirs(provider.VMType())
 	if err != nil {
 		return err
 	}
@@ -65,7 +63,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		state, err := s.State(mc, false)
+		state, err := provider.State(mc, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -9,10 +9,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/machine/p5"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
-	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
-
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/report"
@@ -21,6 +17,8 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/shim"
+	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
@@ -68,8 +66,7 @@ func list(cmd *cobra.Command, args []string) error {
 		err  error
 	)
 
-	s := new(qemu.QEMUStubber)
-	listResponse, err := p5.List([]vmconfigs.VMStubber{s}, opts)
+	listResponse, err := shim.List([]vmconfigs.VMProvider{provider}, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -41,6 +41,10 @@ var (
 	}
 )
 
+var (
+	provider vmconfigs.VMProvider
+)
+
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: machineCmd,
@@ -48,14 +52,11 @@ func init() {
 }
 
 func machinePreRunE(c *cobra.Command, args []string) error {
-	// TODO this should get enabled again once we define what a new provider is
-	// this can be done when the second "provider" is enabled.
-
-	// var err error
-	// provider, err = provider2.Get()
-	// if err != nil {
-	// 	return err
-	// }
+	var err error
+	provider, err = provider2.Get()
+	if err != nil {
+		return err
+	}
 	return rootlessOnly(c, args)
 }
 

--- a/cmd/podman/machine/os/apply.go
+++ b/cmd/podman/machine/os/apply.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/machine/os"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
+	provider2 "github.com/containers/podman/v4/pkg/machine/provider"
 	"github.com/spf13/cobra"
 )
 
@@ -49,10 +49,11 @@ func apply(cmd *cobra.Command, args []string) error {
 		Restart: restart,
 	}
 
-	// TODO This is temporary
-	s := new(qemu.QEMUStubber)
-
-	osManager, err := NewOSManager(managerOpts, s)
+	provider, err := provider2.Get()
+	if err != nil {
+		return err
+	}
+	osManager, err := NewOSManager(managerOpts, provider)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -8,12 +8,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
-
 	machineconfig "github.com/containers/common/pkg/machine"
 	pkgMachine "github.com/containers/podman/v4/pkg/machine"
 	pkgOS "github.com/containers/podman/v4/pkg/machine/os"
 	"github.com/containers/podman/v4/pkg/machine/provider"
+	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 )
 
 type ManagerOpts struct {
@@ -23,7 +22,7 @@ type ManagerOpts struct {
 }
 
 // NewOSManager creates a new OSManager depending on the mode of the call
-func NewOSManager(opts ManagerOpts, p vmconfigs.VMStubber) (pkgOS.Manager, error) {
+func NewOSManager(opts ManagerOpts, p vmconfigs.VMProvider) (pkgOS.Manager, error) {
 	// If a VM name is specified, then we know that we are not inside a
 	// Podman VM, but rather outside of it.
 	if machineconfig.IsPodmanMachine() && opts.VMName == "" {
@@ -44,7 +43,7 @@ func guestOSManager() (pkgOS.Manager, error) {
 }
 
 // machineOSManager returns an os manager that manages outside the VM.
-func machineOSManager(opts ManagerOpts, _ vmconfigs.VMStubber) (pkgOS.Manager, error) {
+func machineOSManager(opts ManagerOpts, _ vmconfigs.VMProvider) (pkgOS.Manager, error) {
 	vmName := opts.VMName
 	if opts.VMName == "" {
 		vmName = pkgMachine.DefaultMachineName

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v4/pkg/strongunits"
 	"github.com/spf13/cobra"
@@ -100,7 +99,6 @@ func setMachine(cmd *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	provider := new(qemu.QEMUStubber)
 	dirs, err := machine.GetMachineDirs(provider.VMType())
 	if err != nil {
 		return err

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/spf13/cobra"
 )
@@ -56,9 +55,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 		validVM bool
 	)
 
-	// TODO Temporary
-	q := new(qemu.QEMUStubber)
-	dirs, err := machine.GetMachineDirs(q.VMType())
+	dirs, err := machine.GetMachineDirs(provider.VMType())
 	if err != nil {
 		return err
 	}
@@ -110,7 +107,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	state, err := q.State(mc, false)
+	state, err := provider.State(mc, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/machine/p5"
-
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
+	"github.com/containers/podman/v4/pkg/machine/shim"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,9 +46,7 @@ func stop(cmd *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	// TODO this is for QEMU only (change to generic when adding second provider)
-	q := new(qemu.QEMUStubber)
-	dirs, err := machine.GetMachineDirs(q.VMType())
+	dirs, err := machine.GetMachineDirs(provider.VMType())
 	if err != nil {
 		return err
 	}
@@ -59,7 +55,7 @@ func stop(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := p5.Stop(mc, q, dirs, false); err != nil {
+	if err := shim.Stop(mc, provider, dirs, false); err != nil {
 		return err
 	}
 

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -3,7 +3,14 @@
 package system
 
 import (
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/machine/connection"
+	"github.com/containers/podman/v4/pkg/machine/define"
 	p "github.com/containers/podman/v4/pkg/machine/provider"
+	"github.com/containers/podman/v4/pkg/machine/shim"
+	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
+	"github.com/containers/podman/v4/utils"
+	"github.com/sirupsen/logrus"
 )
 
 func resetMachine() error {
@@ -11,5 +18,58 @@ func resetMachine() error {
 	if err != nil {
 		return err
 	}
-	return provider.RemoveAndCleanMachines()
+	dirs, err := machine.GetMachineDirs(provider.VMType())
+	if err != nil {
+		return err
+	}
+
+	mcs, err := vmconfigs.LoadMachinesInDir(dirs)
+	if err != nil {
+		// Note: the reason we might be cleaning is because a JSON file is messed
+		// up and is unreadable.  This should not be fatal.  Keep going ...
+		logrus.Errorf("unable to load machines: %q", err)
+	}
+
+	for _, mc := range mcs {
+		state, err := provider.State(mc, false)
+		if err != nil {
+			logrus.Errorf("unable to determine state of %s: %q", mc.Name, err)
+		}
+
+		if state == define.Running {
+			if err := shim.Stop(mc, provider, dirs, true); err != nil {
+				logrus.Errorf("unable to stop running machine %s: %q", mc.Name, err)
+			}
+		}
+
+		if err := connection.RemoveConnections(mc.Name, mc.Name+"-root"); err != nil {
+			logrus.Error(err)
+		}
+
+		// the thinking here is that the we dont need to remove machine specific files because
+		// we will nuke them all at the end of this.  Just do what provider needs
+		_, providerRm, err := provider.Remove(mc)
+		if err != nil {
+			logrus.Errorf("unable to prepare provider machine removal: %q", err)
+		}
+
+		if err := providerRm(); err != nil {
+			logrus.Errorf("unable remove machine %s from provider: %q", mc.Name, err)
+		}
+	}
+
+	if err := utils.GuardedRemoveAll(dirs.DataDir.GetPath()); err != nil {
+		logrus.Errorf("unable to remove machine data dir %q: %q", dirs.DataDir.GetPath(), err)
+	}
+
+	if err := utils.GuardedRemoveAll(dirs.RuntimeDir.GetPath()); err != nil {
+		logrus.Errorf("unable to remove machine runtime dir %q: %q", dirs.RuntimeDir.GetPath(), err)
+	}
+
+	if err := utils.GuardedRemoveAll(dirs.ConfigDir.GetPath()); err != nil {
+		logrus.Errorf("unable to remove machine config dir %q: %q", dirs.ConfigDir.GetPath(), err)
+	}
+
+	// Just in case a provider needs something general done
+	return provider.RemoveAndCleanMachines(dirs)
 }

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -48,7 +48,7 @@ func TestMachine(t *testing.T) {
 	RunSpecs(t, "Podman Machine tests")
 }
 
-var testProvider vmconfigs.VMStubber
+var testProvider vmconfigs.VMProvider
 
 var _ = BeforeSuite(func() {
 	var err error

--- a/pkg/machine/os/machine_os.go
+++ b/pkg/machine/os/machine_os.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/p5"
+	"github.com/containers/podman/v4/pkg/machine/shim"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 )
 
@@ -14,7 +14,7 @@ import (
 type MachineOS struct {
 	Args     []string
 	VM       *vmconfigs.MachineConfig
-	Provider vmconfigs.VMStubber
+	Provider vmconfigs.VMProvider
 	VMName   string
 	Restart  bool
 }
@@ -33,10 +33,10 @@ func (m *MachineOS) Apply(image string, opts ApplyOptions) error {
 	}
 
 	if m.Restart {
-		if err := p5.Stop(m.VM, m.Provider, dirs, false); err != nil {
+		if err := shim.Stop(m.VM, m.Provider, dirs, false); err != nil {
 			return err
 		}
-		if err := p5.Start(m.VM, m.Provider, dirs, machine.StartOptions{NoInfo: true}); err != nil {
+		if err := shim.Start(m.VM, m.Provider, dirs, machine.StartOptions{NoInfo: true}); err != nil {
 			return err
 		}
 		fmt.Printf("Machine %q restarted successfully\n", m.VMName)

--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -6,15 +6,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
-
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/qemu"
+	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 )
 
-func Get() (vmconfigs.VMStubber, error) {
+func Get() (vmconfigs.VMProvider, error) {
 	cfg, err := config.Default()
 	if err != nil {
 		return nil, err

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -252,8 +252,9 @@ func (q *QEMUStubber) StartNetworking(mc *vmconfigs.MachineConfig, cmd *gvproxy.
 	return nil
 }
 
-func (q *QEMUStubber) RemoveAndCleanMachines() error {
-	return define.ErrNotImplemented
+func (q *QEMUStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
+	// nothing to do but remove files
+	return nil
 }
 
 // mountVolumesToVM iterates through the machine's volumes and mounts them to the

--- a/pkg/machine/shim/claim_darwin.go
+++ b/pkg/machine/shim/claim_darwin.go
@@ -1,4 +1,4 @@
-package p5
+package shim
 
 import (
 	"fmt"

--- a/pkg/machine/shim/claim_unsupported.go
+++ b/pkg/machine/shim/claim_unsupported.go
@@ -1,6 +1,6 @@
 //build: !darwin
 
-package p5
+package shim
 
 func dockerClaimHelperInstalled() bool {
 	return false

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -1,4 +1,4 @@
-package p5
+package shim
 
 import (
 	"fmt"
@@ -22,7 +22,7 @@ const (
 	dockerConnectTimeout = 5 * time.Second
 )
 
-func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMStubber) (string, machine.APIForwardingState, error) {
+func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider) (string, machine.APIForwardingState, error) {
 	var (
 		forwardingState machine.APIForwardingState
 		forwardSock     string

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -105,13 +105,13 @@ func (f fcosMachineImage) path() string {
 	return ""
 }
 
-type VMStubber interface { //nolint:interfacebloat
+type VMProvider interface { //nolint:interfacebloat
 	CreateVM(opts define.CreateVMOpts, mc *MachineConfig) error
 	GetHyperVisorVMs() ([]string, error)
 	MountType() VolumeMountType
 	MountVolumesToVM(mc *MachineConfig, quiet bool) error
 	Remove(mc *MachineConfig) ([]string, func() error, error)
-	RemoveAndCleanMachines() error
+	RemoveAndCleanMachines(dirs *define.MachineDirs) error
 	SetProviderAttrs(mc *MachineConfig, cpus, memory *uint64, newDiskSize *strongunits.GiB) error
 	StartNetworking(mc *MachineConfig, cmd *gvproxy.GvproxyCommand) error
 	StartVM(mc *MachineConfig) (func() error, func() error, error)


### PR DESCRIPTION
The intial refactor used specifically qemu for testing and infra bring up.  But the whole point was to have things interfaced.  This PR results in an interface experience like podman 4 using the same term `provider` to generically represent 'a provider' like qemu/applehv/etc.

This PR is required to move forward with new providers.

Also renamed pkg/machine/p5 to pkg/machine/shim.

[NO NEW TESTS REQUIRED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
