### PR TITLE
machine: Refactor Ready socket flow to be more generic

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"path/filepath"
 	"time"
 
@@ -44,6 +45,10 @@ func VirtualizationProvider() machine.VirtProvider {
 
 func (v AppleHVVirtualization) DeleteReadySock(sock interface{}) error {
 	return sock.(*define.VMFile).Delete()
+}
+
+func (v AppleHVVirtualization) ListenReadySock(path interface{}, args ...interface{}) (interface{}, error) {
+	return net.Listen("unix", path.(string))
 }
 
 func (v AppleHVVirtualization) CheckExclusiveActiveVM() (bool, string, error) {

--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -42,6 +42,10 @@ func VirtualizationProvider() machine.VirtProvider {
 	}
 }
 
+func (v AppleHVVirtualization) DeleteReadySock(sock interface{}) error {
+	return sock.(*define.VMFile).Delete()
+}
+
 func (v AppleHVVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
 	fsVms, err := getVMInfos()
 	if err != nil {

--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/compression"
 	"github.com/containers/podman/v4/pkg/machine/define"
 	"github.com/containers/podman/v4/pkg/machine/ignition"
+	"github.com/containers/podman/v4/pkg/machine/sockets"
 	"github.com/containers/podman/v4/pkg/machine/vmconfigs"
 	vfConfig "github.com/crc-org/vfkit/pkg/config"
 	"github.com/docker/go-units"
@@ -110,6 +111,10 @@ func (v AppleHVVirtualization) List(opts machine.ListOptions) ([]*machine.ListRe
 func (v AppleHVVirtualization) LoadVMByName(name string) (machine.VM, error) {
 	m := MacMachine{Name: name}
 	return m.loadFromFile()
+}
+
+func (v AppleHVVirtualization) CreateReadySock(loc interface{}, name, path string) error {
+	return sockets.SetSocket(loc.(*define.VMFile), sockets.ReadySocketPath(path+"/podman/", name), nil)
 }
 
 func (v AppleHVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -660,14 +660,14 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 	}
 
 	logrus.Debugf("listening for ready on: %s", m.ReadySocket.GetPath())
-	readyListen, err := net.Listen("unix", m.ReadySocket.GetPath())
+	readyListen, err := VirtualizationProvider().ListenReadySock(m.ReadySocket.GetPath())
 	if err != nil {
 		return err
 	}
 
 	logrus.Debug("waiting for ready notification")
 	readyChan := make(chan error)
-	go sockets.ListenAndWaitOnSocket(readyChan, readyListen)
+	go sockets.ListenAndWaitOnSocket(readyChan, readyListen.(net.Listener))
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -194,7 +194,7 @@ func (m *MacMachine) Init(opts machine.InitOptions) (bool, error) {
 		return false, err
 	}
 
-	if err := sockets.SetSocket(&m.ReadySocket, sockets.ReadySocketPath(runtimeDir, m.Name), nil); err != nil {
+	if err := VirtualizationProvider().CreateReadySock(&m.ReadySocket, m.Name, runtimeDir); err != nil {
 		return false, err
 	}
 
@@ -573,7 +573,7 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 	}
 
 	if _, err := m.getRuntimeDir(); err != nil {
-	     return err
+		return err
 	}
 
 	// TODO handle returns from startHostNetworking

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -655,7 +655,7 @@ func (m *MacMachine) Start(name string, opts machine.StartOptions) error {
 		}()
 	}
 
-	if err := m.ReadySocket.Delete(); err != nil {
+	if err := VirtualizationProvider().DeleteReadySock(&m.ReadySocket); err != nil {
 		return err
 	}
 

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -313,6 +313,7 @@ type VirtProvider interface { //nolint:interfacebloat
 	VMType() define.VMType
 	CreateReadySock(loc interface{}, name, path string) error
 	DeleteReadySock(sock interface{}) error
+	ListenReadySock(path interface{}, args ...interface{}) (interface{}, error)
 }
 
 type Virtualization struct {

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -312,6 +312,7 @@ type VirtProvider interface { //nolint:interfacebloat
 	RemoveAndCleanMachines() error
 	VMType() define.VMType
 	CreateReadySock(loc interface{}, name, path string) error
+	DeleteReadySock(sock interface{}) error
 }
 
 type Virtualization struct {

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -311,6 +311,7 @@ type VirtProvider interface { //nolint:interfacebloat
 	NewDownload(vmName string) (Download, error)
 	RemoveAndCleanMachines() error
 	VMType() define.VMType
+	CreateReadySock(loc interface{}, name, path string) error
 }
 
 type Virtualization struct {

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -31,6 +31,10 @@ func VirtualizationProvider() machine.VirtProvider {
 	}
 }
 
+func (v HyperVVirtualization) ListenReadySock(path interface{}, args ...interface{}) (interface{}, error) {
+	return nil, path.(*vsock.HVSockRegistryEntry).Listen()
+}
+
 func (v HyperVVirtualization) DeleteReadySock(sock interface{}) error {
 	return sock.(*vsock.HVSockRegistryEntry).Remove()
 }

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/compression"
 	"github.com/containers/podman/v4/pkg/machine/define"
+	"github.com/containers/podman/v4/pkg/machine/hyperv/vsock"
 	"github.com/containers/podman/v4/pkg/machine/ignition"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
@@ -114,6 +115,17 @@ func (v HyperVVirtualization) List(opts machine.ListOptions) ([]*machine.ListRes
 func (v HyperVVirtualization) LoadVMByName(name string) (machine.VM, error) {
 	m := &HyperVMachine{Name: name}
 	return m.loadFromFile()
+}
+
+func (v HyperVVirtualization) CreateReadySock(loc interface{}, name, runtimedir string) error {
+	readySock, err := vsock.NewHVSockRegistryEntry(name, vsock.Events)
+	if err != nil {
+		return err
+	}
+
+	location := loc.(*vsock.HVSockRegistryEntry)
+	*location = *readySock
+	return nil
 }
 
 func (v HyperVVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {

--- a/pkg/machine/hyperv/config.go
+++ b/pkg/machine/hyperv/config.go
@@ -31,6 +31,10 @@ func VirtualizationProvider() machine.VirtProvider {
 	}
 }
 
+func (v HyperVVirtualization) DeleteReadySock(sock interface{}) error {
+	return sock.(*vsock.HVSockRegistryEntry).Remove()
+}
+
 func (v HyperVVirtualization) CheckExclusiveActiveVM() (bool, string, error) {
 	vmm := hypervctl.NewVirtualMachineManager()
 

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -105,13 +105,9 @@ func (m *HyperVMachine) addNetworkAndReadySocketsToRegistry() error {
 	if err != nil {
 		return err
 	}
-	eventHVSocket, err := vsock.NewHVSockRegistryEntry(m.Name, vsock.Events)
-	if err != nil {
-		return err
-	}
 	m.NetworkHVSock = *networkHVSock
-	m.ReadyHVSock = *eventHVSocket
-	return nil
+
+	return VirtualizationProvider().CreateReadySock(&m.ReadyHVSock, m.Name, "")
 }
 
 // readAndSplitIgnition reads the ignition file and splits it into key:value pairs

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -387,7 +387,7 @@ func (m *HyperVMachine) removeNetworkAndReadySocketsFromRegistry() {
 	}
 
 	// Remove the HVSOCK for events
-	if err := m.ReadyHVSock.Remove(); err != nil {
+	if err := VirtualizationProvider().DeleteReadySock(&m.ReadyHVSock); err != nil {
 		logrus.Errorf("unable to remove registry entry for %s: %q", m.ReadyHVSock.KeyName, err)
 	}
 }

--- a/pkg/machine/hyperv/machine.go
+++ b/pkg/machine/hyperv/machine.go
@@ -572,7 +572,8 @@ func (m *HyperVMachine) Start(name string, opts machine.StartOptions) error {
 		return err
 	}
 	// Wait on notification from the guest
-	if err := m.ReadyHVSock.Listen(); err != nil {
+	_, err = VirtualizationProvider().ListenReadySock(&m.ReadyHVSock)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -139,8 +139,8 @@ func (p *QEMUVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, e
 	if err != nil {
 		return nil, err
 	}
-	symlink := vm.Name + "_ready.sock"
-	if err := sockets.SetSocket(&vm.ReadySocket, sockets.ReadySocketPath(runtimeDir+"/podman/", vm.Name), &symlink); err != nil {
+
+	if err := p.CreateReadySock(&vm.ReadySocket, vm.Name, runtimeDir); err != nil {
 		return nil, err
 	}
 
@@ -338,6 +338,11 @@ func (p *QEMUVirtualization) RemoveAndCleanMachines() error {
 
 func (p *QEMUVirtualization) VMType() define.VMType {
 	return vmtype
+}
+
+func (p *QEMUVirtualization) CreateReadySock(loc interface{}, name, path string) error {
+	symlink := name + "_ready.sock"
+	return sockets.SetSocket(loc.(*define.VMFile), sockets.ReadySocketPath(path+"/podman/", name), &symlink)
 }
 
 func VirtualizationProvider() machine.VirtProvider {

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -345,6 +345,10 @@ func (p *QEMUVirtualization) CreateReadySock(loc interface{}, name, path string)
 	return sockets.SetSocket(loc.(*define.VMFile), sockets.ReadySocketPath(path+"/podman/", name), &symlink)
 }
 
+func (p *QEMUVirtualization) DeleteReadySock(sock interface{}) error {
+	return sock.(*define.VMFile).Delete()
+}
+
 func VirtualizationProvider() machine.VirtProvider {
 	return &QEMUVirtualization{
 		machine.NewVirtualization(define.Qemu, compression.Xz, define.Qcow, vmtype),

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -853,7 +853,7 @@ func (v *MachineVM) stopLocked() error {
 	}
 	disconnected = true
 
-	if err := v.ReadySocket.Delete(); err != nil {
+	if err := VirtualizationProvider().DeleteReadySock(&v.ReadySocket); err != nil {
 		return err
 	}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -570,7 +570,7 @@ func (v *MachineVM) Start(name string, opts machine.StartOptions) error {
 		fmt.Println("Waiting for VM ...")
 	}
 
-	conn, err = sockets.DialSocketWithBackoffsAndProcCheck(maxBackoffs, defaultBackoff, v.ReadySocket.GetPath(), checkProcessStatus, "qemu", cmd.Process.Pid, stderrBuf)
+	_, err = VirtualizationProvider().ListenReadySock(v.ReadySocket.GetPath(), &conn, maxBackoffs, defaultBackoff, checkProcessStatus, cmd.Process.Pid, stderrBuf)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -30,6 +30,10 @@ func (p *WSLVirtualization) CreateReadySock(loc interface{}, name, runtimeDir st
 	return fmt.Errorf("Not Implemented")
 }
 
+func (p *WSLVirtualization) DeleteReadySock(sock interface{}) error {
+	return fmt.Errorf("Not Implemented")
+}
+
 // NewMachine initializes an instance of a wsl machine
 func (p *WSLVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 	vm := new(MachineVM)

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -26,12 +26,16 @@ func VirtualizationProvider() machine.VirtProvider {
 	}
 }
 
+func (p *WSLVirtualization) ListenReadySock(path interface{}, args ...interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("WSL does not utilize a ready socket")
+}
+
 func (p *WSLVirtualization) CreateReadySock(loc interface{}, name, runtimeDir string) error {
-	return fmt.Errorf("Not Implemented")
+	return fmt.Errorf("WSL does not utilize a ready socket")
 }
 
 func (p *WSLVirtualization) DeleteReadySock(sock interface{}) error {
-	return fmt.Errorf("Not Implemented")
+	return fmt.Errorf("WSL does not utilize a ready socket")
 }
 
 // NewMachine initializes an instance of a wsl machine

--- a/pkg/machine/wsl/config.go
+++ b/pkg/machine/wsl/config.go
@@ -26,6 +26,10 @@ func VirtualizationProvider() machine.VirtProvider {
 	}
 }
 
+func (p *WSLVirtualization) CreateReadySock(loc interface{}, name, runtimeDir string) error {
+	return fmt.Errorf("Not Implemented")
+}
+
 // NewMachine initializes an instance of a wsl machine
 func (p *WSLVirtualization) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 	vm := new(MachineVM)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Implement generic `CreateReadySock`, `DeleteReadySock`, and `ListenReadySock` functions for the `VirtProvider` interface. The intent of this is to enforce a more generic flow for the ready socket across the providers (except WSL which does not use a ready socket). 

[NO NEW TESTS NEEDED]

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
