### PR TITLE
Switch podman save default to oci-archive

### DIFF
--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -23,7 +23,7 @@ var (
 )
 
 var (
-	saveDescription = `Save an image to docker-archive or oci-archive on the local machine. Default is docker-archive.`
+	saveDescription = `Save an image to docker-archive or oci-archive on the local machine. Default is oci-archive.`
 
 	saveCommand = &cobra.Command{
 		Use:   "save [options] IMAGE [IMAGE...]",
@@ -87,7 +87,7 @@ func saveFlags(cmd *cobra.Command) {
 	flags.BoolVar(&saveOpts.OciAcceptUncompressedLayers, "uncompressed", false, "Accept uncompressed layers when copying OCI images")
 
 	formatFlagName := "format"
-	flags.StringVar(&saveOpts.Format, formatFlagName, define.V2s2Archive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
+	flags.StringVar(&saveOpts.Format, formatFlagName, define.OCIArchive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteImageSaveFormat)
 
 	outputFlagName := "output"

--- a/docs/source/markdown/podman-save.1.md.in
+++ b/docs/source/markdown/podman-save.1.md.in
@@ -32,12 +32,14 @@ Note: This flag can only be set with **--format=docker-dir**.
 
 An image format to produce, one of:
 
-| Format             | Description                                                                  |
-| ------------------ | ---------------------------------------------------------------------------- |
-| **docker-archive** | A tar archive interoperable with **docker load(1)** (the default)            |
-| **oci-archive**    | A tar archive using the OCI Image Format                                     |
-| **oci-dir**        | A directory using the OCI Image Format                                       |
-| **docker-dir**     | **dir** transport (see **containers-transports(5)**) with v2s2 manifest type |
+| Format             | Description                                                                     |
+| ------------------ | ------------------------------------------------------------------------------- |
+| **docker-archive** | tar archive using Docker Image Format (**podman load(1)** compatible)           |
+| **oci-archive**    | tar archive using OCI Image Format (**podman load(1)** compatible) (the default)|
+| **oci-dir**        | directory using the OCI Image Format                                            |
+| **docker-dir**     | **dir** transport (see **containers-transports(5)**) with v2s2 manifest type    |
+
+Note: Prior to Podman 5.0, the default was docker-archive.x
 
 #### **--help**, **-h**
 
@@ -62,22 +64,18 @@ Accept uncompressed layers when using one of the OCI formats.
 
 ## EXAMPLES
 
-Save image to a local file without displaying progress.
 ```
 $ podman save --quiet -o alpine.tar alpine:2.6
 ```
 
-Save image to stdout and redirect content via shell.
 ```
-$ podman save alpine > alpine-all.tar
+$ podman save > alpine-all.tar alpine
 ```
 
-Save image in oci-archive format to the local file.
 ```
 $ podman save -o oci-alpine.tar --format oci-archive alpine
 ```
 
-Save image compressed in docker-dir format.
 ```
 $ podman save --compress --format docker-dir -o alp-dir alpine
 Getting image source signatures
@@ -85,6 +83,25 @@ Copying blob sha256:2fdfe1cd78c20d05774f0919be19bc1a3e4729bce219968e4188e7e0f1af
  1.97 MB / 1.97 MB [========================================================] 0s
 Copying config sha256:501d1a8f0487e93128df34ea349795bc324d5e0c0d5112e08386a9dfaff620be
  584 B / 584 B [============================================================] 0s
+Writing manifest to image destination
+Storing signatures
+```
+
+```
+$ podman save --format docker-dir -o ubuntu-dir ubuntu
+Getting image source signatures
+Copying blob sha256:660c48dd555dcbfdfe19c80a30f557ac57a15f595250e67bfad1e5663c1725bb
+ 45.55 MB / 45.55 MB [======================================================] 8s
+Copying blob sha256:4c7380416e7816a5ab1f840482c9c3ca8de58c6f3ee7f95e55ad299abbfe599f
+ 846 B / 846 B [============================================================] 0s
+Copying blob sha256:421e436b5f80d876128b74139531693be9b4e59e4f1081c9a3c379c95094e375
+ 620 B / 620 B [============================================================] 0s
+Copying blob sha256:e4ce6c3651b3a090bb43688f512f687ea6e3e533132bcbc4a83fb97e7046cea3
+ 849 B / 849 B [============================================================] 0s
+Copying blob sha256:be588e74bd348ce48bb7161350f4b9d783c331f37a853a80b0b4abc0a33c569e
+ 169 B / 169 B [============================================================] 0s
+Copying config sha256:20c44cd7596ff4807aef84273c99588d22749e2a7e15a7545ac96347baa65eda
+ 3.53 KB / 3.53 KB [========================================================] 0s
 Writing manifest to image destination
 Storing signatures
 ```

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -255,7 +255,7 @@ t POST libpod/images/prune 200 length=0 []
 
 # compat api must allow loading tar which contain multiple images
 podman pull quay.io/libpod/alpine:latest quay.io/libpod/busybox:latest
-podman save -o ${TMPD}/test.tar quay.io/libpod/alpine:latest quay.io/libpod/busybox:latest
+podman save --format docker-archive -o ${TMPD}/test.tar quay.io/libpod/alpine:latest quay.io/libpod/busybox:latest
 t POST "images/load" ${TMPD}/test.tar 200 \
   .stream="Loaded image: quay.io/libpod/busybox:latest,quay.io/libpod/alpine:latest"
 t GET libpod/images/quay.io/libpod/alpine:latest/exists  204

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -426,7 +426,7 @@ func (p *PodmanTestIntegration) createArtifact(image string) {
 			time.Sleep(time.Duration(try+1) * 5 * time.Second)
 		}
 
-		save := p.PodmanNoCache([]string{"save", "-o", destName, image})
+		save := p.PodmanNoCache([]string{"save", "--format", "docker-archive", "-o", destName, image})
 		save.Wait(90)
 		Expect(save).Should(Exit(0))
 		GinkgoWriter.Printf("\n")

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Podman load", func() {
 		pull.WaitWithDefaultTimeout()
 		Expect(pull).Should(ExitCleanly())
 
-		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, ALPINE, alpVersion})
+		save := podmanTest.Podman([]string{"save", "--format", "docker-archive", "-q", "-o", outfile, ALPINE, alpVersion})
 		save.WaitWithDefaultTimeout()
 		Expect(save).Should(ExitCleanly())
 

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Podman pull", func() {
 		tmpDir := filepath.Join(podmanTest.TempDir, "splitstore")
 		outfile := filepath.Join(podmanTest.TempDir, "image.tar")
 
-		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, "--format", "oci-archive", imgName})
+		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, imgName})
 		save.WaitWithDefaultTimeout()
 		Expect(save).Should(ExitCleanly())
 
@@ -317,7 +317,7 @@ var _ = Describe("Podman pull", func() {
 
 		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		tarfn := filepath.Join(podmanTest.TempDir, "cirros.tar")
-		session := podmanTest.Podman([]string{"save", "-q", "-o", tarfn, "cirros"})
+		session := podmanTest.Podman([]string{"save", "--format", "docker-archive", "-q", "-o", tarfn, "cirros"})
 		session.WaitWithDefaultTimeout()
 
 		Expect(session).Should(ExitCleanly())
@@ -377,7 +377,7 @@ var _ = Describe("Podman pull", func() {
 
 		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		tarfn := filepath.Join(podmanTest.TempDir, "oci-cirrus.tar")
-		session := podmanTest.Podman([]string{"save", "-q", "--format", "oci-archive", "-o", tarfn, "cirros"})
+		session := podmanTest.Podman([]string{"save", "-q", "-o", tarfn, "cirros"})
 		session.WaitWithDefaultTimeout()
 
 		Expect(session).Should(ExitCleanly())

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save oci flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, "--format", "oci-archive", ALPINE})
+		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save).Should(ExitCleanly())
 	})
@@ -104,7 +104,7 @@ var _ = Describe("Podman save", func() {
 		// should not be 0
 		Expect(save).To(ExitWithError())
 
-		save = podmanTest.Podman([]string{"save", "-q", "--compress", "--format", "oci-archive", "-o", outdir, ALPINE})
+		save = podmanTest.Podman([]string{"save", "-q", "--compress", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		// should not be 0
 		Expect(save).To(ExitWithError())
@@ -239,7 +239,7 @@ default-docker:
 func multiImageSave(podmanTest *PodmanTestIntegration, images []string) {
 	// Create the archive.
 	outfile := filepath.Join(podmanTest.TempDir, "temp.tar")
-	session := podmanTest.Podman(append([]string{"save", "-q", "-o", outfile, "--multi-image-archive"}, images...))
+	session := podmanTest.Podman(append([]string{"save", "-q", "--format", "docker-archive", "-o", outfile, "--multi-image-archive"}, images...))
 	session.WaitWithDefaultTimeout()
 	Expect(session).Should(ExitCleanly())
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -268,7 +268,7 @@ echo $rand        |   0 | $rand
     # Save it as a tar archive
     run_podman commit myc myi
     archive=$PODMAN_TMPDIR/archive.tar
-    run_podman save --quiet myi -o $archive
+    run_podman save --format "docker-archive" --quiet myi -o $archive
     is "$output" "" "podman save"
 
     # Clean up image and container from container storage...

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -60,7 +60,7 @@ load helpers
     # Force using the file backend since the journal backend is eating events
     # (see containers/podman/pull/10219#issuecomment-842325032).
     run_podman --events-backend=file push $IMAGE dir:$pushedDir
-    run_podman --events-backend=file save $IMAGE -o $tarball
+    run_podman --events-backend=file save --format "docker-archive" $IMAGE -o $tarball
     run_podman --events-backend=file load -i $tarball
     run_podman --events-backend=file pull docker-archive:$tarball
     run_podman --events-backend=file tag $IMAGE $tag

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -254,7 +254,7 @@ verify_iid_and_name() {
     _prefetch $img1
     _prefetch $img2
 
-    run_podman save -m -o $archive $img1 $img2
+    run_podman save --format docker-archive -m -o $archive $img1 $img2
     run_podman rmi -f $img1 $img2
     run_podman load -i $archive
 
@@ -275,7 +275,7 @@ verify_iid_and_name() {
     # We can't use run_podman because that uses the BATS 'run' function
     # which redirects stdout and stderr. Here we need to guarantee
     # that podman's stdout is a pipe, not any other form of redirection
-    $PODMAN save -m $img1 $img2 | cat >$archive
+    $PODMAN save --format docker-archive -m $img1 $img2 | cat >$archive
     assert "$?" -eq 0 "Command failed: podman save ... | cat"
 
     run_podman rmi -f $img1 $img2
@@ -292,10 +292,15 @@ verify_iid_and_name() {
     mkdir -p $untar
 
     # Create a tarball, unpack it and make sure the layers are uncompressed.
-    run_podman save -o $archive --format oci-archive --uncompressed $IMAGE
+    run_podman save -o $archive --uncompressed $IMAGE
     tar -C $untar -xvf $archive
     run file $untar/blobs/sha256/*
     is "$output" ".*POSIX tar archive" "layers are uncompressed"
+}
+
+@test "podman save --help" {
+    run_podman save --help
+    is "$output" '.*--format.*(default "oci-archive")' "--format default should be oci-archive"
 }
 
 # vim: filetype=sh

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -157,7 +157,7 @@ function _confirm_update() {
 
     # Requires docker (or no) transport
     archive=$PODMAN_TMPDIR/archive.tar
-    run_podman save -o $archive $IMAGE
+    run_podman save --format "docker-archive" -o $archive $IMAGE
     run_podman 125 create --label io.containers.autoupdate=registry docker-archive:$archive
     is "$output" ".*Error: auto updates require the docker image transport but image is of transport \"docker-archive\""
 

--- a/test/system/330-corrupt-images.bats
+++ b/test/system/330-corrupt-images.bats
@@ -100,7 +100,7 @@ function _corrupt_image_test() {
 @test "podman corrupt images - initialize" {
     # Pull once, save cached copy.
     run_podman pull $PODMAN_CORRUPT_TEST_IMAGE_CANONICAL_FQIN
-    run_podman save -o ${PODMAN_CORRUPT_TEST_WORKDIR}/img.tar \
+    run_podman save --format "docker-archive" -o ${PODMAN_CORRUPT_TEST_WORKDIR}/img.tar \
                $PODMAN_CORRUPT_TEST_IMAGE_CANONICAL_FQIN
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman save now defaults to oci-archive format.
```
