### PR TITLE
new testimage and systemd-image

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -54,8 +54,8 @@ t POST "libpod/images/pull?reference=alpine&compatMode=true" 200 .error~null .st
 t POST "images/create?fromImage=alpine&tag=latest" 200
 
 # 10977 - handle platform parameter correctly
-t POST "images/create?fromImage=quay.io/libpod/testimage:20210610&platform=linux/arm64" 200
-t GET  "images/testimage:20210610/json" 200 \
+t POST "images/create?fromImage=quay.io/libpod/testimage:20240123&platform=linux/arm64" 200
+t GET  "images/testimage:20240123/json" 200 \
   .Architecture=arm64
 
 # Make sure that new images are pulled

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -4,7 +4,7 @@
 #
 
 # WORKDIR=/data
-ENV_WORKDIR_IMG=quay.io/libpod/testimage:20200929
+ENV_WORKDIR_IMG=quay.io/libpod/testimage:20240123
 MultiTagName=localhost/test/testformultitag:tag
 
 podman pull $IMAGE &>/dev/null

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -2,7 +2,7 @@ package integration
 
 var (
 	REDIS_IMAGE       = "quay.io/libpod/redis:alpine" //nolint:revive,stylecheck
-	fedoraMinimal     = "quay.io/libpod/systemd-image:20230531"
+	fedoraMinimal     = "quay.io/libpod/systemd-image:20240124"
 	ALPINE            = "quay.io/libpod/alpine:latest"
 	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
 	ALPINELISTDIGEST  = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -1,15 +1,15 @@
 package integration
 
 var (
-	STORAGE_FS               = "overlay"                                                                                                                                                 //nolint:revive,stylecheck
-	STORAGE_OPTIONS          = "--storage-driver overlay"                                                                                                                                //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_FS      = "overlay"                                                                                                                                                 //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_OPTIONS = "--storage-driver overlay"                                                                                                                                //nolint:revive,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
-	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                                                      //nolint:revive,stylecheck
-	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
-	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
-	CITEST_IMAGE             = "quay.io/libpod/testimage:20221018"                                                                                                                       //nolint:revive,stylecheck
-	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20230106"                                                                                                                   //nolint:revive,stylecheck
-	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck
+	STORAGE_FS               = "overlay"                                                                                                                                  //nolint:revive,stylecheck
+	STORAGE_OPTIONS          = "--storage-driver overlay"                                                                                                                 //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_FS      = "overlay"                                                                                                                                  //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_OPTIONS = "--storage-driver overlay"                                                                                                                 //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
+	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                                       //nolint:revive,stylecheck
+	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                          //nolint:revive,stylecheck
+	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                            //nolint:revive,stylecheck
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"                                                                                                        //nolint:revive,stylecheck
+	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20240124"                                                                                                    //nolint:revive,stylecheck
+	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                             //nolint:revive,stylecheck
 )

--- a/test/e2e/config_arm64.go
+++ b/test/e2e/config_arm64.go
@@ -9,7 +9,7 @@ var (
 	NGINX_IMAGE              = "quay.io/lsm5/alpine_nginx-aarch64:latest"                                                                                                                //nolint:revive,stylecheck
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
 	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
-	CITEST_IMAGE             = "quay.io/libpod/testimage:20221018"                                                                                                                       //nolint:revive,stylecheck
-	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20230106"                                                                                                                   //nolint:revive,stylecheck
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"                                                                                                                       //nolint:revive,stylecheck
+	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20240124"                                                                                                                   //nolint:revive,stylecheck
 	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck
 )

--- a/test/e2e/config_ppc64le.go
+++ b/test/e2e/config_ppc64le.go
@@ -8,6 +8,6 @@ var (
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, INFRA_IMAGE, CITEST_IMAGE}
 	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx-ppc64le:latest"
 	BB_GLIBC                 = "docker.io/ppc64le/busybox:glibc"
-	CITEST_IMAGE             = "quay.io/libpod/testimage:20221018"
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"
 	REGISTRY_IMAGE           string
 )

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Podman images", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=quay.io/libpod/*"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
-		Expect(result.OutputToStringArray()).To(HaveLen(10))
+		Expect(result.OutputToStringArray()).To(HaveLen(9))
 
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=*lpine*"})
 		retalpine.WaitWithDefaultTimeout()

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Podman rmi", func() {
 		session = podmanTest.Podman([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(HaveLen(142))
+		Expect(session.OutputToStringArray()).To(HaveLen(len(CACHE_IMAGES)))
 	})
 
 	It("podman rmi -a with no images should be exit 0", func() {

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -324,16 +324,13 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
 }
 
 @test "podman create --health-on-failure=kill" {
-    img="healthcheck_i"
-    _build_health_check_image $img
-
     cname=c_$(random_string)
-    run_podman create --name $cname      \
-               --health-cmd /healthcheck \
-               --health-on-failure=kill  \
-               --health-retries=1        \
-               --restart=on-failure      \
-               $img
+    run_podman create --name $cname                  \
+               --health-cmd /home/podman/healthcheck \
+               --health-on-failure=kill              \
+               --health-retries=1                    \
+               --restart=on-failure                  \
+               $IMAGE /home/podman/pause
 
     # run container in systemd unit
     service_setup
@@ -376,7 +373,6 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
 
     # stop systemd container
     service_cleanup
-    run_podman rmi -f $img
 }
 
 @test "podman-kube@.service template" {

--- a/test/system/320-system-df.bats
+++ b/test/system/320-system-df.bats
@@ -45,22 +45,28 @@ function teardown() {
     run_podman system df --format json
     local results="$output"
 
+    # FIXME! This needs to be fiddled with every time we bump testimage.
+    local size=11
+    if [[ "$(uname -m)" = "aarch64" ]]; then
+        size=13
+    fi
+
     # FIXME: we can't check exact RawSize or Size because every CI system
     # computes a different value: 12701526, 12702113, 12706209... and
     # those are all amd64. aarch64 gets 12020148, 12019561.
     #
     # WARNING: RawSize and Size tests may fail if $IMAGE is updated. Since
     # that tends to be done yearly or less, and only by Ed, that's OK.
-    local tests='
-Type           | Images    | Containers | Local Volumes
-Total          |         1 |          2 |             0
-Active         |         1 |          1 |             0
-RawSize        | ~12...... |         !0 |             0
-RawReclaimable |         0 |         !0 |             0
-Reclaimable    |   ~\(0%\) |   ~\(50%\) |       ~\(0%\)
-TotalCount     |         1 |          2 |             0
-Size           |   ~12.*MB |        !0B |            0B
-'
+    local tests="
+Type           | Images         | Containers | Local Volumes
+Total          |              1 |          2 |             0
+Active         |              1 |          1 |             0
+RawSize        | ~${size}...... |         !0 |             0
+RawReclaimable |              0 |         !0 |             0
+Reclaimable    |        ~\(0%\) |   ~\(50%\) |       ~\(0%\)
+TotalCount     |              1 |          2 |             0
+Size           |   ~${size}.*MB |        !0B |            0B
+"
     while read -a fields; do
         for i in 0 1 2;do
             expect="${fields[$((i+1))]}"

--- a/test/system/build-systemd-image
+++ b/test/system/build-systemd-image
@@ -31,11 +31,10 @@ cd $tmpdir
 echo $YMD >testimage-id
 
 cat >Containerfile <<EOF
-FROM registry.fedoraproject.org/fedora-minimal:38
+FROM registry.fedoraproject.org/fedora-minimal:39
 LABEL created_by="$create_script @ $create_script_rev"
 LABEL created_at=$create_time_z
-# Note the reinstall of tzdata is required (https://bugzilla.redhat.com/show_bug.cgi?id=1870814)
-RUN microdnf install -y systemd && microdnf reinstall -y tzdata && microdnf clean all && sed -i -e 's/.*LogColor.*/LogColor=no/' /etc/systemd/system.conf
+RUN microdnf install -y systemd tzdata && microdnf clean all && sed -i -e 's/.*LogColor.*/LogColor=no/' /etc/systemd/system.conf
 ADD testimage-id /home/podman/
 WORKDIR /home/podman
 CMD ["/bin/echo", "This image is intended for podman CI testing"]

--- a/test/system/build-testimage
+++ b/test/system/build-testimage
@@ -51,12 +51,33 @@ cat >pause <<EOF
 #
 # Trivial little pause script, used in one of the pod tests
 #
+trap 'exit 0' SIGTERM
 echo Confirmed: testimage pause invoked as \$0
 while :; do
     sleep 0.1
 done
 EOF
 chmod 755 pause
+
+# Add a health check
+cat >healthcheck <<EOF
+#!/bin/sh
+
+if test -e /uh-oh || test -e /uh-oh-only-once; then
+    echo "Uh-oh on stdout!"
+    echo "Uh-oh on stderr!" >&2
+
+    # Special file causes us to fail healthcheck only once
+    rm -f /uh-oh-only-once
+
+    exit 1
+else
+    echo "Life is Good on stdout"
+    echo "Life is Good on stderr" >&2
+    exit 0
+fi
+EOF
+chmod 755 healthcheck
 
 # alpine because it's small and light and reliable
 #    - check for updates @ https://hub.docker.com/_/alpine
@@ -73,9 +94,9 @@ chmod 755 pause
 #
 cat >Containerfile1 <<EOF
 ARG REPO=please-override-repo
-FROM docker.io/\${REPO}/alpine:3.16.2
+FROM docker.io/\${REPO}/alpine:3.19.0
 RUN apk add busybox-extras iproute2 socat
-ADD testimage-id pause /home/podman/
+ADD testimage-id healthcheck pause /home/podman/
 RUN rm -f /var/cache/apk/*
 EOF
 


### PR DESCRIPTION
Simply because it's been a while since the last testimage
build, and I want to confirm that our image build process
still works.

Added /home/podman/healthcheck. This saves us having to
podman-build on each healthcheck test. Removed now-
unneeded _build_health_check_image helper.

testimage: bump alpine 3.16.2 to 3.19.0

systemd-image: f38 to f39
  - tzdata now requires dnf **install**, not reinstall
    (this is exactly the sort of thing I was looking for)

PROBLEMS DISCOVERED:
  - in e2e, fedoraMinimal is now == SYSTEMD_IMAGE. This
    screws up some of the image-count tests (CACHE_IMAGES).
    
  - "alter tarball" system test now barfs with tar < 1.35.
    
TODO: completely replace fedoraMinimal with SYSTEMD_IMAGE in all tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```