### PR TITLE
Run lint for mac builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -466,6 +466,8 @@ osx_alt_build_task:
     # This host is/was shared with potentially many other CI tasks.
     # The previous task may have been canceled or aborted.
     prep_script: &mac_cleanup "contrib/cirrus/mac_cleanup.sh"
+    lint_script:
+        - make lint
     basic_build_script:
         - make .install.ginkgo
         - make podman-remote

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -467,7 +467,7 @@ osx_alt_build_task:
     # The previous task may have been canceled or aborted.
     prep_script: &mac_cleanup "contrib/cirrus/mac_cleanup.sh"
     lint_script:
-        - make lint
+        - make lint || true  # TODO: Enable when code passes check
     basic_build_script:
         - make .install.ginkgo
         - make podman-remote

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -3,6 +3,28 @@
 # Need to run linter twice to cover all the build tags code paths
 set -e
 
+# Dedicated block for Darwin: OS doesn't support the rest of this
+# script, only needs to check 'remote', and its golangci-lint needs
+# specialized arguments.
+if [[ $(uname -s) == "Darwin" ]] || [[ "$GOOS" == "darwin" ]]; then
+  declare -a DARWIN_SKIP_DIRS
+  DARWIN_SKIP_DIRS=(
+    libpod/events
+    pkg/api
+    pkg/domain/infra/abi
+    pkg/machine/qemu
+    pkg/trust
+    test
+  )
+  echo ""
+  echo Running golangci-lint for "remote"
+  echo Build Tags          "remote": remote
+  echo Skipped directories "remote": ${DARWIN_SKIP_DIRS[*]}
+  ./bin/golangci-lint run --build-tags="remote" \
+    --skip-dirs=$(tr ' ' ',' <<<"${DARWIN_SKIP_DIRS[@]}")
+  exit 0  # All done, don't execute anything below, it will break on Darwin
+fi
+
 declare -A BUILD_TAGS
 BUILD_TAGS[default]="apparmor,seccomp,selinux"
 BUILD_TAGS[abi]="${BUILD_TAGS[default]},systemd"


### PR DESCRIPTION
EXPERIMENTAL DO NOT MERGE

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
