### PR TITLE
[CI:DOCS] Packit: podman5 downstream for f40+

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -67,14 +67,15 @@ jobs:
     trigger: release
     update_release: false
     dist_git_branches:
-      - fedora-all
+      - fedora-development # Implies fedora-rawhide and any branched but unreleased version, will include f40 before f40 is marked stable.
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-all
+      - fedora-development
 
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+        # TODO: Revisit once fedora 40 is branched and manual bodhi is enabled
+        #- job: bodhi_update
+        #trigger: commit
+        #dist_git_branches:
+        #- fedora-40 # rawhide updates are created automatically


### PR DESCRIPTION
Podman5 will be shipped only on f40 and higher, so packit downstream tasks should be enabled only for those.

Using `CI:DOCS` as the change only affects downstream Fedora, nothing worth spending CI minutes on.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
