### PR TITLE
fix: correctly evaluate source path for '.' volume mounts

### DIFF
--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -78,7 +78,7 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 		src = splitVol[0]
 
 		// Support relative paths beginning with ./
-		if strings.HasPrefix(src, "./") {
+		if strings.HasPrefix(src, ".") {
 			path, err := filepath.EvalSymlinks(src)
 			if err != nil {
 				return nil, nil, nil, err
@@ -112,7 +112,7 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 			}
 		}
 
-		if strings.HasPrefix(src, "/") || strings.HasPrefix(src, ".") || isHostWinPath(src) {
+		if strings.HasPrefix(src, "/") || isHostWinPath(src) {
 			// This is not a named volume
 			overlayFlag := false
 			chownFlag := false

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -77,7 +77,7 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 
 		src = splitVol[0]
 
-		// Support relative paths beginning with ./
+		// Support relative paths beginning with .
 		if strings.HasPrefix(src, ".") {
 			path, err := filepath.EvalSymlinks(src)
 			if err != nil {


### PR DESCRIPTION
Fixes mounts like `-v .:/test` when the current directory is not the same as the directory where podman is run (I.E. remote only?). This does not do any remote path mapping or anything but it does make `.` be treated the same as any other relative path like `./xyz` (also fixes paths starting with `..`). This doesn't change anything for hidden files or directories since anything starting with `.` was already being converted to an absolute path.

- convert all paths starting with '.' to absolute (not just './')
- remove unnecessary relative path logic in named volume check

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
