### PR TITLE
Revert "Enable win podman-machine test failure"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1097,9 +1097,7 @@ success_task:
         - rootless_integration_test
         - podman_machine
         - podman_machine_aarch64
-        # TODO: issue #20548; These tests are new and mostly fail.
-        # Ignore status until tests, scripts, and/or environment stabalize.
-        # - podman_machine_windows
+        - podman_machine_windows
         # TODO: Issue #20853; Tests mostly fail then timeout after an hour.
         # - podman_machine_mac
         - local_system_test

--- a/contrib/cirrus/cirrus_yaml_test.py
+++ b/contrib/cirrus/cirrus_yaml_test.py
@@ -27,7 +27,7 @@ class TestDependsOn(TestCaseBase):
 
     ALL_TASK_NAMES = None
     SUCCESS_DEPS_EXCLUDE = set(['success', 'bench_stuff', 'artifacts',
-        'release', 'release_test', 'podman_machine_windows', 'podman_machine_mac'])
+        'release', 'release_test', 'podman_machine_mac'])
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This reverts commit f9e8585c5354748b2a77ed65d214adfe7c6ae5fe.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
