### PR TITLE
Show network name network events with podman -remote events

### DIFF
--- a/pkg/domain/entities/events.go
+++ b/pkg/domain/entities/events.go
@@ -31,16 +31,20 @@ func ConvertToLibpodEvent(e Event) *libpodEvents.Event {
 	}
 	image := e.Actor.Attributes["image"]
 	name := e.Actor.Attributes["name"]
-	details := e.Actor.Attributes
+	network := e.Actor.Attributes["network"]
 	podID := e.Actor.Attributes["podId"]
+	details := e.Actor.Attributes
 	delete(details, "image")
 	delete(details, "name")
+	delete(details, "network")
+	delete(details, "podId")
 	delete(details, "containerExitCode")
 	return &libpodEvents.Event{
 		ContainerExitCode: &exitCode,
 		ID:                e.Actor.ID,
 		Image:             image,
 		Name:              name,
+		Network:           network,
 		Status:            status,
 		Time:              time.Unix(0, e.TimeNano),
 		Type:              t,
@@ -64,6 +68,9 @@ func ConvertToEntitiesEvent(e libpodEvents.Event) *types.Event {
 		attributes["containerExitCode"] = strconv.Itoa(*e.ContainerExitCode)
 	}
 	attributes["podId"] = e.PodID
+	if e.Network != "" {
+		attributes["network"] = e.Network
+	}
 	message := dockerEvents.Message{
 		// Compatibility with clients that still look for deprecated API elements
 		Status: e.Status.String(),


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/21311

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman -remote network events now show network name
```

