### PR TITLE
Don't require engine connection for farm

### DIFF
--- a/cmd/podman/farm/create.go
+++ b/cmd/podman/farm/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 )
@@ -16,12 +17,14 @@ var (
 	The "podman system connection add --farm" command can be used to add a new connection to a new or existing farm.`
 
 	createCommand = &cobra.Command{
-		Use:               "create NAME [CONNECTIONS...]",
-		Args:              cobra.MinimumNArgs(1),
-		Short:             "Create a new farm",
-		Long:              farmCreateDescription,
-		RunE:              create,
-		ValidArgsFunction: completion.AutocompleteNone,
+		Use:                "create NAME [CONNECTIONS...]",
+		Args:               cobra.MinimumNArgs(1),
+		Short:              "Create a new farm",
+		Long:               farmCreateDescription,
+		PersistentPreRunE:  validate.NoOp,
+		RunE:               create,
+		PersistentPostRunE: validate.NoOp,
+		ValidArgsFunction:  completion.AutocompleteNone,
 		Example: `podman farm create myfarm connection1
   podman farm create myfarm`,
 	}

--- a/cmd/podman/farm/list.go
+++ b/cmd/podman/farm/list.go
@@ -20,13 +20,15 @@ var (
 List all available farms. The output of the farms can be filtered
 and the output format can be changed to JSON or a user specified Go template.`
 	lsCommand = &cobra.Command{
-		Use:               "list [options]",
-		Aliases:           []string{"ls"},
-		Args:              validate.NoArgs,
-		Short:             "List all existing farms",
-		Long:              farmLsDescription,
-		RunE:              list,
-		ValidArgsFunction: completion.AutocompleteNone,
+		Use:                "list [options]",
+		Aliases:            []string{"ls"},
+		Args:               validate.NoArgs,
+		Short:              "List all existing farms",
+		Long:               farmLsDescription,
+		PersistentPreRunE:  validate.NoOp,
+		RunE:               list,
+		PersistentPostRunE: validate.NoOp,
+		ValidArgsFunction:  completion.AutocompleteNone,
 	}
 
 	// Temporary struct to hold cli values.

--- a/cmd/podman/farm/remove.go
+++ b/cmd/podman/farm/remove.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -14,12 +15,14 @@ import (
 var (
 	farmRmDescription = `Remove one or more existing farms.`
 	rmCommand         = &cobra.Command{
-		Use:               "remove [options] [FARM...]",
-		Aliases:           []string{"rm"},
-		Short:             "Remove one or more farms",
-		Long:              farmRmDescription,
-		RunE:              rm,
-		ValidArgsFunction: common.AutoCompleteFarms,
+		Use:                "remove [options] [FARM...]",
+		Aliases:            []string{"rm"},
+		Short:              "Remove one or more farms",
+		Long:               farmRmDescription,
+		PersistentPreRunE:  validate.NoOp,
+		RunE:               rm,
+		PersistentPostRunE: validate.NoOp,
+		ValidArgsFunction:  common.AutoCompleteFarms,
 		Example: `podman farm rm myfarm1 myfarm2
   podman farm rm --all`,
 	}

--- a/cmd/podman/farm/update.go
+++ b/cmd/podman/farm/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 )
@@ -15,12 +16,14 @@ import (
 var (
 	farmUpdateDescription = `Update an existing farm by adding a connection, removing a connection, or changing it to the default farm.`
 	updateCommand         = &cobra.Command{
-		Use:               "update [options] FARM",
-		Short:             "Update an existing farm",
-		Long:              farmUpdateDescription,
-		RunE:              farmUpdate,
-		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: common.AutoCompleteFarms,
+		Use:                "update [options] FARM",
+		Short:              "Update an existing farm",
+		Long:               farmUpdateDescription,
+		PersistentPreRunE:  validate.NoOp,
+		RunE:               farmUpdate,
+		PersistentPostRunE: validate.NoOp,
+		Args:               cobra.ExactArgs(1),
+		ValidArgsFunction:  common.AutoCompleteFarms,
 		Example: `podman farm update --add con1 farm1
 	podman farm update --remove con2 farm2
 	podman farm update --default farm3`,


### PR DESCRIPTION
Don't require the need to connect to an engine/podman machine when doing the farm create, ls, rm, and update commands.
Connection to the engine is required for the farm build command.

[NO NEW TESTS NEEDED]

Fixes https://github.com/containers/podman/issues/21383

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Don't require connection to engine for some of the farm subcommands
```
