### PR TITLE
Include machine-tests in cirrus-cron jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -391,7 +391,7 @@ alt_build_task:
 win_installer_task:
     name: "Verify Win Installer Build"
     alias: win_installer
-    only_if:
+    only_if:  # RHEL never releases podman windows installer binary
       $CIRRUS_TAG == '' &&
       $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
       $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
@@ -447,7 +447,7 @@ osx_alt_build_task:
     name: "OSX Cross"
     alias: osx_alt_build
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *no_rhel_release
+    only_if: *no_rhel_release  # RHEL never releases podman mac installer binary
     depends_on:
         - build
     persistent_worker: &mac_pw
@@ -723,10 +723,11 @@ podman_machine_task:
     alias: podman_machine
     # Only run for PRs and never [CI:DOCS] or [CI:BUILD]
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: &not_tag_branch_build_docs >-
-        $CIRRUS_PR != '' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
+    only_if: &machine_cron_not_tag_build_docs >-
+        ($CIRRUS_PR != '' &&
+         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
+        ) || $CIRRUS_CRON == "main"
     depends_on:
         - build
         - validate
@@ -754,7 +755,7 @@ podman_machine_task:
 podman_machine_aarch64_task:
     name: *std_name_fmt
     alias: podman_machine_aarch64
-    only_if: *not_tag_branch_build_docs
+    only_if: *machine_cron_not_tag_build_docs
     depends_on:
         - build_aarch64
         - validate_aarch64
@@ -782,7 +783,7 @@ podman_machine_windows_task:
     alias: podman_machine_windows
     # Only run for non-docs/copr PRs and non-release branch builds
     # and never for tags.  Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_tag_branch_build_docs
+    only_if: *machine_cron_not_tag_build_docs
     depends_on:
       - alt_build
       - build
@@ -808,7 +809,7 @@ podman_machine_windows_task:
 podman_machine_mac_task:
     name: *std_name_fmt
     alias: podman_machine_mac
-    only_if: *not_tag_branch_build_docs
+    only_if: *machine_cron_not_tag_build_docs
     depends_on:
       - osx_alt_build
       - local_integration_test


### PR DESCRIPTION
Irrespective of reason/cause, a commit was merged into main that broke podman-machine, and went unnoticed for several days.  Improve the situation by including podman-machine testing in the daily cirrus-cron builds.  These are monitored by e-mail when `Total Success` reports a failure.

Also: Add a comment for Windows & Mac build tasks, documenting the reason they don't execute on RHEL release branches.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
