### PR TITLE
Farm build should read server registries.conf

### DIFF
--- a/cmd/podman/farm/build.go
+++ b/cmd/podman/farm/build.go
@@ -109,11 +109,17 @@ func build(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	opts.IIDFile = iidFile
-	tlsVerify, err := cmd.Flags().GetBool("tls-verify")
-	if err != nil {
-		return err
+	// only set tls-verify if it has been changed by the user
+	// if it hasn't we will read the registries.conf on the farm
+	// nodes for further configuration
+	if changed := cmd.Flags().Changed("tls-verify"); changed {
+		tlsVerify, err := cmd.Flags().GetBool("tls-verify")
+		if err != nil {
+			return err
+		}
+		skipTLSVerify := !tlsVerify
+		opts.SkipTLSVerify = &skipTLSVerify
 	}
-	opts.SkipTLSVerify = !tlsVerify
 
 	localEngine := registry.ImageEngine()
 	ctx := registry.Context()

--- a/pkg/domain/entities/types/types.go
+++ b/pkg/domain/entities/types/types.go
@@ -56,7 +56,7 @@ type FarmBuildOptions struct {
 	// Authfile is the path to the file holding registry credentials
 	Authfile string
 	// SkipTLSVerify skips tls verification when set to true
-	SkipTLSVerify bool
+	SkipTLSVerify *bool
 }
 
 // BuildOptions describe the options for building container images.

--- a/test/farm/setup_suite.bash
+++ b/test/farm/setup_suite.bash
@@ -36,7 +36,7 @@ function setup_suite(){
     run_podman system connection add --identity $sshkey test-node $ROOTLESS_USER@localhost
     run_podman farm create $FARMNAME test-node
 
-     export PODMAN_LOGIN_WORKDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-${TMPDIR:-/tmp}} podman-bats-registry.XXXXXX)
+    export PODMAN_LOGIN_WORKDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-${TMPDIR:-/tmp}} podman-bats-registry.XXXXXX)
 
     export PODMAN_LOGIN_USER="user$(random_string 4)"
     export PODMAN_LOGIN_PASS="pw$(random_string 15)"


### PR DESCRIPTION
Fix the way we set skipTLSVerify on the client side to ensure that the push stage in farm build takes into account the configuration in the farm node's registries.conf when the user hasn't set it on the client side.


Fixes https://github.com/containers/podman/issues/21352

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Only set skipTLSVerfiy for farm build on client side when changed by user.
```
