### PR TITLE
Fix SSH Host argument in tag command during scp.

### DIFF
--- a/pkg/domain/utils/scp.go
+++ b/pkg/domain/utils/scp.go
@@ -238,7 +238,7 @@ func LoadToRemote(dest entities.ImageScpOptions, localFile string, tag string, u
 	outArr := strings.Split(rep, " ")
 	id := outArr[len(outArr)-1]
 	if len(dest.Tag) > 0 { // tag the remote image using the output ID
-		_, err := ssh.Exec(&ssh.ConnectionExecOptions{Host: url.Hostname(), Identity: iden, Port: port, User: url.User, Args: []string{"podman", "image", "tag", id, dest.Tag}}, sshEngine)
+		_, err := ssh.Exec(&ssh.ConnectionExecOptions{Host: url.String(), Identity: iden, Port: port, User: url.User, Args: []string{"podman", "image", "tag", id, dest.Tag}}, sshEngine)
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
While working on #21420 , I noticed that the tag command failed when using `--ssh=native`.  Tracing the process showed:

`execve("/usr/bin/ssh", ["/usr/bin/ssh", "-F", "/home/gordon/.ssh/config", "root@", "podman", "image", "tag", "docker.io/library/alpine:latest", "alpine"], `

Changing url.Hostname() to url.String() is consistent with the previous use, on line 230, and appears to fix that problem.

#### Does this PR introduce a user-facing change?


```release-note
None
```
