### PR TITLE
[v4.9] AppleHV Backports

### DIFF
--- a/pkg/machine/applehv/config.go
+++ b/pkg/machine/applehv/config.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	defaultVFKitEndpoint = "http://localhost:8081"
-	ignitionSocketName   = "ignition.sock"
+	localhostURI       = "http://localhost"
+	ignitionSocketName = "ignition.sock"
 )
 
 type AppleHVVirtualization struct {

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -741,8 +741,13 @@ func (m *MacMachine) Stop(name string, opts machine.StopOptions) error {
 			logrus.Error(err)
 		}
 	}()
+	if err := m.Vfkit.stop(false, true); err != nil {
+		return err
+	}
 
-	return m.Vfkit.stop(false, true)
+	// keep track of last up
+	m.LastUp = time.Now()
+	return m.writeConfig()
 }
 
 // getVMConfigPath is a simple wrapper for getting the fully-qualified

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -129,7 +129,12 @@ func (m *MacMachine) setVfkitInfo(cfg *config.Config, readySocket define.VMFile)
 	}
 
 	m.Vfkit.VirtualMachine.Devices = defaultDevices
-	m.Vfkit.Endpoint = defaultVFKitEndpoint
+	randPort, err := utils.GetRandomPort()
+	if err != nil {
+		return err
+	}
+
+	m.Vfkit.Endpoint = localhostURI + ":" + strconv.Itoa(randPort)
 	m.Vfkit.VfkitBinaryPath = vfkitBinaryPath
 
 	return nil

--- a/pkg/machine/e2e/config_inspect_test.go
+++ b/pkg/machine/e2e/config_inspect_test.go
@@ -13,7 +13,7 @@ func (i *inspectMachine) buildCmd(m *machineTestBuilder) []string {
 	if len(i.format) > 0 {
 		cmd = append(cmd, "--format", i.format)
 	}
-	cmd = append(cmd, m.names...)
+	cmd = append(cmd, m.name)
 	i.cmd = cmd
 	return cmd
 }

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -131,7 +131,7 @@ func (m *machineTestBuilder) setCmd(mc machineCommand) *machineTestBuilder {
 	return m
 }
 
-func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuilder {
+func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuilder { //nolint: unparam
 	m.timeout = timeout
 	return m
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman machine commands were not relayed to the correct machine on AppleHV.
Fixed a bug where the podman machine list and podman machine inspect commands would not show the correct Last Up time on AppleHV
```
