### PR TITLE
Windows-cross linting

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -281,6 +281,7 @@ function _run_altbuild() {
             rm -rf $context_dir
             ;;
         *Windows*)
+            showrun make lint GOOS=windows
             showrun make podman-remote-release-windows_amd64.zip
             ;;
         *RPM*)

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -281,7 +281,7 @@ function _run_altbuild() {
             rm -rf $context_dir
             ;;
         *Windows*)
-            showrun make lint GOOS=windows
+            showrun make lint GOOS=windows || true  # TODO: Enable when code passes check
             showrun make podman-remote-release-windows_amd64.zip
             ;;
         *RPM*)


### PR DESCRIPTION
**Depends on:** https://github.com/containers/podman/pull/21372

Performing native linting on Windows is quite complex and will require updating the `winmake` PS script.  As a stop-gap, and until we have an entirely native build -> test chain, run Windows linting prior to the cross-build (on Linux).  This isn't a perfect solution, but it does find lots of lint that requires cleaning.  To that end, enforcement of cleanliness is temporarily bypassed by in a single revert-friendly commit.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
