### PR TITLE
Set interface name to the network_interface name for macvlan and ipvlan networks

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -264,11 +264,18 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		}
 		i := 0
 		for nameOrID, opts := range ctr.config.Networks {
-			netName, err := r.normalizeNetworkName(nameOrID)
+			netName, nicName, err := r.normalizeNetworkName(nameOrID)
 			if err != nil {
 				return nil, err
 			}
-			// assign interface name if empty
+
+			// check whether interface is to be named as the network_interface
+			// when name left unspecified
+			if opts.InterfaceName == "" {
+				opts.InterfaceName = nicName
+			}
+
+			// assign default interface name if empty
 			if opts.InterfaceName == "" {
 				for i < 100000 {
 					ifName := fmt.Sprintf("eth%d", i)

--- a/test/e2e/container_iface_name_test.go
+++ b/test/e2e/container_iface_name_test.go
@@ -1,0 +1,280 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/containers/podman/v4/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func isDebianRunc(pTest *PodmanTestIntegration) bool {
+	info := GetHostDistributionInfo()
+	if info.Distribution == "debian" && pTest.OCIRuntime == "runc" {
+		return true
+	}
+
+	return false
+}
+
+func createNetworkDevice(name string) {
+	session := SystemExec("ip", []string{"link", "add", name, "type", "bridge"})
+	session.WaitWithDefaultTimeout()
+	Expect(session).Should(ExitCleanly())
+}
+
+func deleteNetworkDevice(name string) {
+	session := SystemExec("ip", []string{"link", "delete", name})
+	session.WaitWithDefaultTimeout()
+	Expect(session).Should(ExitCleanly())
+}
+
+func createContainersConfFileWithDeviceIfaceName(pTest *PodmanTestIntegration) {
+	configPath := filepath.Join(pTest.TempDir, "containers.conf")
+	containersConf := []byte("[containers]\ninterface_name = \"device\"\n")
+	err := os.WriteFile(configPath, containersConf, os.ModePerm)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Set custom containers.conf file
+	os.Setenv("CONTAINERS_CONF_OVERRIDE", configPath)
+	if IsRemote() {
+		pTest.RestartRemoteService()
+	}
+}
+
+var _ = Describe("Podman container interface name", func() {
+
+	It("podman container interface name for bridge network", func() {
+		// Assert that the network interface name inside container for
+		// bridge network is ethX regardless of interface_name setting
+		// in the containers.conf file.
+
+		netName1 := createNetworkName("bridge")
+		netName2 := createNetworkName("bridge")
+
+		defer podmanTest.removeNetwork(netName1)
+		nc1 := podmanTest.Podman([]string{"network", "create", netName1})
+		nc1.WaitWithDefaultTimeout()
+		Expect(nc1).Should(ExitCleanly())
+
+		defer podmanTest.removeNetwork(netName2)
+		nc2 := podmanTest.Podman([]string{"network", "create", netName2})
+		nc2.WaitWithDefaultTimeout()
+		Expect(nc2).Should(ExitCleanly())
+
+		for _, override := range []bool{false, true} {
+			if override {
+				createContainersConfFileWithDeviceIfaceName(podmanTest)
+			}
+
+			ctr := podmanTest.Podman([]string{"run", "-d", "--network", netName1, "--name", "test", ALPINE, "top"})
+			ctr.WaitWithDefaultTimeout()
+			Expect(ctr).Should(ExitCleanly())
+
+			exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+			exec1.WaitWithDefaultTimeout()
+			Expect(exec1).Should(ExitCleanly())
+			Expect(exec1.OutputToString()).Should(ContainSubstring("eth0"))
+
+			conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+			conn.WaitWithDefaultTimeout()
+			Expect(conn).Should(ExitCleanly())
+
+			exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+			exec2.WaitWithDefaultTimeout()
+			Expect(exec2).Should(ExitCleanly())
+			Expect(exec2.OutputToString()).Should(ContainSubstring("eth1"))
+
+			rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+			rm.WaitWithDefaultTimeout()
+			Expect(rm).Should(ExitCleanly())
+		}
+	})
+
+	It("podman container interface name for macvlan/ipvlan network with no parent", func() {
+		// Assert that the network interface name inside container for
+		// macvlan/ipvlan network with no parent interface is ethX
+		// regardless of interface_name setting in the containers.conf
+		// file.
+
+		for _, override := range []bool{false, true} {
+			if override {
+				createContainersConfFileWithDeviceIfaceName(podmanTest)
+			}
+
+			for _, driverType := range []string{"macvlan", "ipvlan"} {
+				if driverType == "ipvlan" && isDebianRunc(podmanTest) {
+					GinkgoWriter.Println("FIXME: Fails with netavark < 1.10. Re-enable once Debian gets an update")
+					continue
+				}
+
+				netName1 := createNetworkName(driverType)
+				netName2 := createNetworkName(driverType)
+
+				// There is no nic created by the macvlan/ipvlan driver.
+				defer podmanTest.removeNetwork(netName1)
+				nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "--subnet", "10.10.0.0/24", netName1})
+				nc1.WaitWithDefaultTimeout()
+				Expect(nc1).Should(ExitCleanly())
+
+				ctr := podmanTest.Podman([]string{"run", "-d", "--network", netName1, "--name", "test", ALPINE, "top"})
+				ctr.WaitWithDefaultTimeout()
+				Expect(ctr).Should(ExitCleanly())
+
+				exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+				exec1.WaitWithDefaultTimeout()
+				Expect(exec1).Should(ExitCleanly())
+				Expect(exec1.OutputToString()).Should(ContainSubstring("eth0"))
+
+				defer podmanTest.removeNetwork(netName2)
+				nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "--subnet", "10.25.40.0/24", netName2})
+				nc2.WaitWithDefaultTimeout()
+				Expect(nc2).Should(ExitCleanly())
+
+				conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+				conn.WaitWithDefaultTimeout()
+				Expect(conn).Should(ExitCleanly())
+
+				exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+				exec2.WaitWithDefaultTimeout()
+				Expect(exec2).Should(ExitCleanly())
+				Expect(exec2.OutputToString()).Should(ContainSubstring("eth1"))
+
+				rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+				rm.WaitWithDefaultTimeout()
+				Expect(rm).Should(ExitCleanly())
+			}
+		}
+	})
+
+	It("podman container interface name with default scheme for macvlan/ipvlan network with parent", func() {
+		// Assert that the network interface name inside container for
+		// macvlan/ipvlan network, created with a specific parent
+		// interface, continues to be ethX when interface_name in the
+		// containers.conf file is set to default value, i.e., "".
+
+		SkipIfRootless("cannot create network device in rootless mode.")
+
+		for _, driverType := range []string{"macvlan", "ipvlan"} {
+			if driverType == "ipvlan" && isDebianRunc(podmanTest) {
+				GinkgoWriter.Println("FIXME: Fails with netavark < 1.10. Re-enable once Debian gets an update")
+				continue
+			}
+
+			// Create a nic to be used as a parent for macvlan/ipvlan network.
+			nicName1 := createNetworkName("nic")[:8]
+			nicName2 := createNetworkName("nic")[:8]
+
+			netName1 := createNetworkName(driverType)
+			netName2 := createNetworkName(driverType)
+
+			parent1 := "parent=" + nicName1
+			parent2 := "parent=" + nicName2
+
+			defer deleteNetworkDevice(nicName1)
+			createNetworkDevice(nicName1)
+
+			defer podmanTest.removeNetwork(netName1)
+			nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent1, "--subnet", "10.10.0.0/24", netName1})
+			nc1.WaitWithDefaultTimeout()
+			Expect(nc1).Should(ExitCleanly())
+
+			ctr := podmanTest.Podman([]string{"run", "-d", "--network", netName1, "--name", "test", ALPINE, "top"})
+			ctr.WaitWithDefaultTimeout()
+			Expect(ctr).Should(ExitCleanly())
+
+			exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth0"})
+			exec1.WaitWithDefaultTimeout()
+			Expect(exec1).Should(ExitCleanly())
+			Expect(exec1.OutputToString()).Should(ContainSubstring("eth0"))
+
+			defer deleteNetworkDevice(nicName2)
+			createNetworkDevice(nicName2)
+
+			defer podmanTest.removeNetwork(netName2)
+			nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent2, "--subnet", "10.25.40.0/24", netName2})
+			nc2.WaitWithDefaultTimeout()
+			Expect(nc2).Should(ExitCleanly())
+
+			conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+			conn.WaitWithDefaultTimeout()
+			Expect(conn).Should(ExitCleanly())
+
+			exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", "eth1"})
+			exec2.WaitWithDefaultTimeout()
+			Expect(exec2).Should(ExitCleanly())
+			Expect(exec2.OutputToString()).Should(ContainSubstring("eth1"))
+
+			rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+			rm.WaitWithDefaultTimeout()
+			Expect(rm).Should(ExitCleanly())
+		}
+	})
+
+	It("podman container interface name with device scheme for macvlan/ipvlan network with parent", func() {
+		// Assert that the network interface name inside container for
+		// macvlan/ipvlan network, created with a specific parent
+		// interface, is the parent interface name ethX when
+		// interface_name in the containers.conf file is set to "device"
+
+		SkipIfRootless("cannot create network device in rootless mode.")
+
+		createContainersConfFileWithDeviceIfaceName(podmanTest)
+
+		for _, driverType := range []string{"macvlan", "ipvlan"} {
+			if driverType == "ipvlan" && isDebianRunc(podmanTest) {
+				GinkgoWriter.Println("FIXME: Fails with netavark < 1.10. Re-enable once Debian gets an update")
+				continue
+			}
+
+			// Create a nic to be used as a parent for the network.
+			nicName1 := createNetworkName("nic")[:8]
+			nicName2 := createNetworkName("nic")[:8]
+
+			netName1 := createNetworkName(driverType)
+			netName2 := createNetworkName(driverType)
+
+			parent1 := "parent=" + nicName1
+			parent2 := "parent=" + nicName2
+
+			defer deleteNetworkDevice(nicName1)
+			createNetworkDevice(nicName1)
+
+			defer podmanTest.removeNetwork(netName1)
+			nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent1, "--subnet", "10.10.0.0/24", netName1})
+			nc1.WaitWithDefaultTimeout()
+			Expect(nc1).Should(ExitCleanly())
+
+			ctr := podmanTest.Podman([]string{"run", "-d", "--network", netName1, "--name", "test", ALPINE, "top"})
+			ctr.WaitWithDefaultTimeout()
+			Expect(ctr).Should(ExitCleanly())
+
+			exec1 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", nicName1})
+			exec1.WaitWithDefaultTimeout()
+			Expect(exec1).Should(ExitCleanly())
+			Expect(exec1.OutputToString()).Should(ContainSubstring(nicName1))
+
+			defer deleteNetworkDevice(nicName2)
+			createNetworkDevice(nicName2)
+
+			defer podmanTest.removeNetwork(netName2)
+			nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent2, "--subnet", "10.25.40.0/24", netName2})
+			nc2.WaitWithDefaultTimeout()
+			Expect(nc2).Should(ExitCleanly())
+
+			conn := podmanTest.Podman([]string{"network", "connect", netName2, "test"})
+			conn.WaitWithDefaultTimeout()
+			Expect(conn).Should(ExitCleanly())
+
+			exec2 := podmanTest.Podman([]string{"exec", "test", "ip", "addr", "show", nicName2})
+			exec2.WaitWithDefaultTimeout()
+			Expect(exec2).Should(ExitCleanly())
+			Expect(exec2.OutputToString()).Should(ContainSubstring(nicName2))
+
+			rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})
+			rm.WaitWithDefaultTimeout()
+			Expect(rm).Should(ExitCleanly())
+		}
+	})
+})


### PR DESCRIPTION
When interface_name attribute in containers.conf file is set to "device", then set interface names inside containers same as the network_interface names of the respective network.

The change applies to macvlan and ipvlan networks only. The interface_name attribute value has no impact on any other types of networks.

If the interface name is set in the user request, then that takes precedence.

The interface_name attribute in the containers.conf file was added via https://github.com/containers/common/pull/1814.

Fixes: #21313

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? Yes

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A new global attribute interface_name has been added to the containers.conf file. The default value of the attribute is "". The attribute value can be overridden to "device". This setting is effective for macvlan and ipvlan networks only. When set to "device", the network interface names inside containers will be set to the network_interface property value as seen in the podman inspect of the respective network, by default. If the network_interface property is not set or the global attribute is left unmodified, then the network interface name is set to the ethX pattern as usual, by default. 
```
