### PR TITLE
[WIP] feat: add cdi-spec-dir option to top level options

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -233,7 +233,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 			podmanConfig.ContainersConf.Engine.HooksDir.Set(podmanConfig.HooksDir)
 		}
 		if cmd.Flag("cdi-spec-dir").Changed {
-			podmanConfig.ContainersConf.Engine.CdiSpecDir.Set(podmanConfig.CdiSpecDir)
+			podmanConfig.ContainersConf.Engine.CdiSpecDirs.Set(podmanConfig.CdiSpecDirs)
 		}
 
 		// Currently it is only possible to restore a container with the same runtime
@@ -552,7 +552,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		_ = cmd.RegisterFlagCompletionFunc(hooksDirFlagName, completion.AutocompleteDefault)
 
 		cdiSpecDirFlagName := "cdi-spec-dir"
-		pFlags.StringArrayVar(&podmanConfig.CdiSpecDir, cdiSpecDirFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.CdiSpecDir.Get(), "Set the CDI spec directory path (may be set multiple times)")
+		pFlags.StringArrayVar(&podmanConfig.CdiSpecDirs, cdiSpecDirFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.CdiSpecDirs.Get(), "Set the CDI spec directory path (may be set multiple times)")
 		_ = cmd.RegisterFlagCompletionFunc(cdiSpecDirFlagName, completion.AutocompleteDefault)
 
 		pFlags.IntVar(&podmanConfig.MaxWorks, "max-workers", (runtime.NumCPU()*3)+1, "The maximum number of workers for parallel operations")

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -232,6 +232,9 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		if cmd.Flag("hooks-dir").Changed {
 			podmanConfig.ContainersConf.Engine.HooksDir.Set(podmanConfig.HooksDir)
 		}
+		if cmd.Flag("cdi-spec-dir").Changed {
+			podmanConfig.ContainersConf.Engine.CdiSpecDir.Set(podmanConfig.CdiSpecDir)
+		}
 
 		// Currently it is only possible to restore a container with the same runtime
 		// as used for checkpointing. It should be possible to make crun and runc
@@ -547,6 +550,10 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		hooksDirFlagName := "hooks-dir"
 		pFlags.StringArrayVar(&podmanConfig.HooksDir, hooksDirFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.HooksDir.Get(), "Set the OCI hooks directory path (may be set multiple times)")
 		_ = cmd.RegisterFlagCompletionFunc(hooksDirFlagName, completion.AutocompleteDefault)
+
+		cdiSpecDirFlagName := "cdi-spec-dir"
+		pFlags.StringArrayVar(&podmanConfig.CdiSpecDir, cdiSpecDirFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.CdiSpecDir.Get(), "Set the CDI spec directory path (may be set multiple times)")
+		_ = cmd.RegisterFlagCompletionFunc(cdiSpecDirFlagName, completion.AutocompleteDefault)
 
 		pFlags.IntVar(&podmanConfig.MaxWorks, "max-workers", (runtime.NumCPU()*3)+1, "The maximum number of workers for parallel operations")
 

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -579,7 +579,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	// Warning: CDI may alter g.Config in place.
 	if len(c.config.CDIDevices) > 0 {
 		registry, err := cdi.NewCache(
-			cdi.WithSpecDirs(c.runtime.config.Engine.CdiSpecDir.Get()...),
+			cdi.WithSpecDirs(c.runtime.config.Engine.CdiSpecDirs.Get()...),
 			cdi.WithAutoRefresh(false),
 		)
 		if err != nil {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -579,7 +579,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	// Warning: CDI may alter g.Config in place.
 	if len(c.config.CDIDevices) > 0 {
 		registry, err := cdi.NewCache(
-			cdi.WithSpecDirs(c.config.CdiSpecDir),
+			cdi.WithSpecDirs(c.runtime.config.Engine.CdiSpecDir.Get()...),
 			cdi.WithAutoRefresh(false),
 		)
 		if err != nil {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -579,6 +579,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	// Warning: CDI may alter g.Config in place.
 	if len(c.config.CDIDevices) > 0 {
 		registry, err := cdi.NewCache(
+			cdi.WithSpecDirs(c.config.CdiSpecDir),
 			cdi.WithAutoRefresh(false),
 		)
 		if err != nil {

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -35,6 +35,7 @@ type PodmanConfig struct {
 	CPUProfile               string         // Hidden: Should CPU profile be taken
 	EngineMode               EngineMode     // ABI or Tunneling mode
 	HooksDir                 []string
+	CdiSpecDir               []string
 	Identity                 string   // ssh identity for connecting to server
 	IsRenumber               bool     // Is this a system renumber command? If so, a number of checks will be relaxed
 	IsReset                  bool     // Is this a system reset command? If so, a number of checks will be skipped/omitted

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -35,7 +35,7 @@ type PodmanConfig struct {
 	CPUProfile               string         // Hidden: Should CPU profile be taken
 	EngineMode               EngineMode     // ABI or Tunneling mode
 	HooksDir                 []string
-	CdiSpecDir               []string
+	CdiSpecDirs              []string
 	Identity                 string   // ssh identity for connecting to server
 	IsRenumber               bool     // Is this a system renumber command? If so, a number of checks will be relaxed
 	IsReset                  bool     // Is this a system reset command? If so, a number of checks will be skipped/omitted


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

In response to https://github.com/containers/podman/issues/18292.

One of the primary benefits of podman is that its possible run without altering the host system. By allowing cdi directories to be passed via command line it maintains this feature.

I'm particularly interested in running podman in a nix-shell with nvidia GPU passthough. Podman and all its dependencies (including nvidia-container-toolkit) come from nix and the host system again doesn't need altering. The one problem with that right now is that I have to write /etc/cdi/nvidia.yaml to be able to use the GPU. Note that the old nvidia-runtime-hook does not work for my use case (which involves vulkan passthrough).

With this change it will be possible to generate a user nvidia.yaml and point podman at that user-specific mount instructions there.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add cdi-spec-dir option to insert additional CDI Spec search paths into the CDI loader.
```
