### PR TITLE
Support data volume containers as init containers in podman kube

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -134,8 +134,8 @@ func create(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("pod") {
 			return errors.New("must specify pod value with init-ctr")
 		}
-		if !slices.Contains([]string{define.AlwaysInitContainer, define.OneShotInitContainer}, initctr) {
-			return fmt.Errorf("init-ctr value must be '%s' or '%s'", define.AlwaysInitContainer, define.OneShotInitContainer)
+		if !slices.Contains([]string{define.AlwaysInitContainer, define.IdleInitContainer, define.OneShotInitContainer}, initctr) {
+			return fmt.Errorf("init-ctr value must be '%s', '%s', or '%s'", define.AlwaysInitContainer, define.IdleInitContainer, define.OneShotInitContainer)
 		}
 		cliVals.InitContainerType = initctr
 	}

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -35,7 +35,9 @@ Only three volume types are supported by kube play, the *hostPath*, *emptyDir*, 
 
 Note: The default restart policy for containers is `always`.  You can change the default by setting the `restartPolicy` field in the spec.
 
-Note: When playing a kube YAML with init containers, the init container is created with init type value `once`. To change the default type, use the `io.podman.annotations.init.container.type` annotation to set the type to `always`.
+Note: When playing a kube YAML with init containers, the init container is created with init type value set to `once`. Use the `io.podman.annotations.init.container.type` annotation to change the type.
+- Set it to `always` to run the container when the pod restarts.
+- Set it to `idle` to create the container and not run it.
 
 Note: *hostPath* volume types created by kube play is given an SELinux shared label (z), bind mounts are not relabeled (use `chcon -t container_file_t -R <directory>`).
 

--- a/libpod/define/container.go
+++ b/libpod/define/container.go
@@ -32,6 +32,9 @@ const (
 	// AlwaysInitContainer is an init container that runs on each
 	// pod start (including restart)
 	AlwaysInitContainer = "always"
+	// IdleInitContainer is an init container that creates only, and
+	// not run
+	IdleInitContainer = "idle"
 	// OneShotInitContainer is a container that only runs as init once
 	// and is then deleted.
 	OneShotInitContainer = "once"

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 var umaskRegex = regexp.Delayed(`^[0-7]{1,4}$`)
@@ -1878,7 +1879,7 @@ func WithInitCtrType(containerType string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 		// Make sure the type is valid
-		if containerType == define.OneShotInitContainer || containerType == define.AlwaysInitContainer {
+		if slices.Contains([]string{define.AlwaysInitContainer, define.IdleInitContainer, define.OneShotInitContainer}, containerType) {
 			ctr.config.InitContainerType = containerType
 			return nil
 		}

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -24,6 +24,11 @@ func (p *Pod) startInitContainers(ctx context.Context) error {
 	}
 	// Now iterate init containers
 	for _, initCon := range initCtrs {
+		// Do not start idle init container
+		if initCon.config.InitContainerType == define.IdleInitContainer {
+			continue
+		}
+
 		if err := initCon.Start(ctx, true); err != nil {
 			return err
 		}


### PR DESCRIPTION
Data volume containers are created as init containers with a new type "idle" using annotation. Data volume containers do not have runtime execution binaries. Such containers are not started.

Related to: https://github.com/containers/podman/issues/16819

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? Yes

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The init container supports a new type "idle". The idle init containers are created but not run. This type of init container is useful in use-cases such as data volume containers that do not have runtime execution environment.
```
