### PR TITLE
[skip-ci] Make leak-detection readable by humans

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -73,6 +73,28 @@ jobs:
         run: |
           echo "depth=$((${{ github.event.pull_request.commits }} + 1))" >> $GITHUB_OUTPUT
 
+      # A force-push to a PR can obscure Cirrus-CI logs, but not GHA logs.
+      # Provide handy URL for examination of secret leaks for all events that
+      # trigger this action.
+
+      - if: github.event_name == 'synchronize' || github.base_ref == ''
+        name: Provide URL showing code that needs human eyes (force-push or merge)
+        shell: bash
+        run: |
+          echo "Please review force-push or merged-pr changes for secret-leaks:"
+          before=$(jq -r -e '.before' $GITHUB_EVENT_PATH)
+          after=$(jq -r -e '.after' $GITHUB_EVENT_PATH)
+          echo "https://github.com/${{ github.repository }}/compare/${before}...${after}"
+
+      - if: github.event_name == 'opened'
+        name: Provide URL showing code that needs human eyes (newly opened PR)
+        shell: bash
+        run: |
+          echo "Please review new PR changes for secret-leaks:"
+          before=$(jq -r -e '.github.event.pull_request.base.sha' $GITHUB_EVENT_PATH)
+          after=$(jq -r -e '.github.event.pull_request.head.sha' $GITHUB_EVENT_PATH)
+          echo "https://github.com/${{ github.repository }}/compare/${before}...${after}"
+
       - name: Show important context details
         shell: bash
         run: |
@@ -123,12 +145,11 @@ jobs:
           mkdir ${{ github.workspace }}/_report
           touch ${{ github.workspace }}/_report/gitleaks-report.json
 
-      # A force-push to a PR can obscure Cirrus-CI logs, but not GHA logs
-      - name: Show content being scanned
+      - name: Log all content being scanned to file for archiving
         shell: bash
         run: |
           set -exuo pipefail
-          ${{ env.gitlogcmd }} ${{ steps.gitlog.outputs.range }}
+          ${{ env.gitlogcmd }} ${{ steps.gitlog.outputs.range }} >> ${{ github.workspace }}/git_commits.log
 
       # Unfortunately gitleaks provides several in-built ways to
       # completely bypass an alert within PR-level commits.  Assume
@@ -183,12 +204,15 @@ jobs:
             $glfqin \
             detect $glargs --log-opts=${{ steps.gitlog.outputs.range }}
 
-      - name: Collect scan report artifact
+      - name: Collect git commits log and gitleaks scan report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: gitleaks-report
-          path: ${{ github.workspace }}/_report/gitleaks-report.json
+          path: |
+            ${{ github.event_path }}
+            ${{ github.workspace }}/git_commits.log
+            ${{ github.workspace }}/_report/gitleaks-report.json
 
       # Nobody monitors the actions-tab for failures, and may not see this
       # fail on push to a nefarious PR.  Send an e-mail alert to unmask


### PR DESCRIPTION
Previously when a leak was detected under any circumstance, the workflow would splat out a giant wall of gray, unreadable git-log text.  This often enormous text might contain, somewhere, possibly, maybe, a little tiny snippet of code that leaks a secret.

Improve the situation greatly by providing easy-to-use URLs that covers the relevant changes based on the triggering context (new pr, force-push, or merge).  Store the former (often) giant git-log output into a file and stuff it into the artifacts in case it's ever useful.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
