### PR TITLE
Secret-scanning followup fixes

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -81,6 +81,12 @@ jobs:
         name: Provide URL showing code that needs human eyes (force-push or merge)
         shell: bash
         run: |
+          if [[ "$before" =~ ^0000+ ]]; then  # Push to new branch (i.e. renovate branch)
+              echo "Please review newly opened branch for secret-leaks:"
+              # The event JSON provides the URL we need
+              jq -r -e '.compare' $GITHUB_EVENT_PATH
+              return 0
+          fi
           echo "Please review force-push or merged-pr changes for secret-leaks:"
           before=$(jq -r -e '.before' $GITHUB_EVENT_PATH)
           after=$(jq -r -e '.after' $GITHUB_EVENT_PATH)

--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -77,7 +77,7 @@ jobs:
       # Provide handy URL for examination of secret leaks for all events that
       # trigger this action.
 
-      - if: github.event_name == 'synchronize' || github.base_ref == ''
+      - if: github.event.action == 'synchronize' || github.base_ref == ''
         name: Provide URL showing code that needs human eyes (force-push or merge)
         shell: bash
         run: |

--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -86,7 +86,7 @@ jobs:
           after=$(jq -r -e '.after' $GITHUB_EVENT_PATH)
           echo "https://github.com/${{ github.repository }}/compare/${before}...${after}"
 
-      - if: github.event_name == 'opened'
+      - if: github.event.action == 'opened'
         name: Provide URL showing code that needs human eyes (newly opened PR)
         shell: bash
         run: |


### PR DESCRIPTION
Original https://github.com/containers/podman/pull/21459

This PR fixes problems observed after merging 21459.  Since testing github-actions was never considered an important aspect of its architecture, we merge and fix afterwards for expediency :confounded:

Note: I realize there _are_ ways to test them, but they're neither easy nor native.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
