### PR TITLE
Fix running container from docker client with rootful in rootless podman

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -45,6 +45,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
+	"github.com/containers/storage/pkg/unshare"
 	stypes "github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	runcuser "github.com/moby/sys/user"
@@ -632,14 +633,15 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	nofileSet := false
 	nprocSet := false
 	isRootless := rootless.IsRootless()
-	if isRootless {
-		if g.Config.Process != nil && g.Config.Process.OOMScoreAdj != nil {
-			var err error
-			*g.Config.Process.OOMScoreAdj, err = maybeClampOOMScoreAdj(*g.Config.Process.OOMScoreAdj)
-			if err != nil {
-				return nil, nil, err
-			}
+	isRunningInUserNs := unshare.IsRootless()
+	if isRunningInUserNs && g.Config.Process != nil && g.Config.Process.OOMScoreAdj != nil {
+		var err error
+		*g.Config.Process.OOMScoreAdj, err = maybeClampOOMScoreAdj(*g.Config.Process.OOMScoreAdj)
+		if err != nil {
+			return nil, nil, err
 		}
+	}
+	if isRootless {
 		for _, rlimit := range c.config.Spec.Process.Rlimits {
 			if rlimit.Type == "RLIMIT_NOFILE" {
 				nofileSet = true


### PR DESCRIPTION
This effectively fix errors like "unable to upgrade to tcp, received 409" like #19930 in the special case where podman itself is running rootful but inside a container which itself is rootless.

Here is how to reproduce my variant of #19930 which this pull request tries to fix:
 - podman must be configured to run container in rootless mode
 - start a first "podman server" container, which will run a rootful podman inside a rootless container:
 ```
 > podman run -t -i --rm --pull=always --privileged --name=podman-server -v /shared-volume quay️️.io/podman/stable podman system service -t 0 unix:///shared-volume/podman.sock 
Trying to pull quay.io/podman/stable:latest...
️Getting image source signatures
Copying blob sha256:511a60f584271fcdbcda6b21445093519de4eb54ee41c3f46823dc3799ab485d
Copying blob sha256:718a00fe32127ad01ddab9fc4b7c968ab2679c92c6385ac6865ae6e2523275e4
Copying blob sha256:3c5909b2317f79eb301452b3c9bc8044f8e31d44781d03029a7b4d3d486e78c8
Copying blob sha256:9267f18b51370daa20aa467ffa4e910b2f02703e2591d854ecbb6570522c5bbf
Copying blob sha256:4e476fc2a089d9360734d4801441b8e7c0c654b7dbab01b624d23c725d55a00c
Copying blob sha256:38c91c6a9745a9c3e1e51d3d5deada53990df98556beddaacf0538d28c823f1a
Copying blob sha256:0aabe5f4b70ff08c369eb89daab44f143774878e15ab4486907fa1f0be7e8a42 
Copying blob sha256:48c9c013b76544edacdc9f477e84949bc992ce7b270ea60025b9a0430ae0b619
Copying blob sha256:c5a9086534cadda7148f878df18fb91368b960dde30c9b133573a607acde5410 
Copying config sha256:d9339a084b4b074d946b82ba66039e6adabb3493648bb3e691135cdbc78e6ab7
Writing manifest to image destination
```
 - In another shell, try to run a fedora container, using a docker client, which will connect to the podman running in the first container:
 ```
> podman run -t -i --rm --pull=always --volumes-from=podman-server -e DOCKER_HOST=unix:///shared-volume/podman.sock docker:24-cli docker run -t -i --rm quay.io/fedora/fedora
Trying to pull docker.io/library/docker:24-cli...
Getting image source signatures
Copying blob sha256:9908927dc97522b6d63aaaf9953c4095be9b24a1d080edb1ada9124d56bf41ad
Copying blob sha256:1db5a4f146e2df1f17a2c0db7ffd672b18d1750d31c7e58e352a6536d4b7ad52
Copying blob sha256:5aed6b72066db35b8929c11c552f9e827431de2b2de62b4384a1eaed88221787
Copying blob sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8
Copying blob sha256:248ec8ed73b325a9cff9ec3c5bbd2c249065ee96053dfc3beafb911ef652a195
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:d280e8e81156b63b7306ac0701738e22b333c7a26bdd96ddafb3ec8f607d2a32
Copying blob sha256:97f6ee5ccb7fa02811eb89d903666095e18e38c42a635369912f9ba0fd11e6eb
Copying blob sha256:d4462dfff57f9ac45d562ae18d1ca53fef4918ae18e003d21ebf960b3ade6f94
Copying blob sha256:a474f84a4abb535fa3a05ee5a59bff31a53d0857d4d53bab82a9f2f3684c4c7c
Copying config sha256:b4e4d47cb84703dc6042823b7e29e3111074beb09b50848a31cdb9cd9565ed9a
Writing manifest to image destination
Unable to find image 'quay.io/fedora/fedora:latest' locally
718a00fe3212: Download complete
368a084ba17d: Download complete
unable to upgrade to tcp, received 409
 ```
 
 With this pull request, the container can run, and a warning like:
 
 ```
WARN[0095] Requested oom_score_adj=0 is lower than the current one, changing to 200
 ```
 
 is printed.
 
 Not that the underlying issue is really the docker client hardcoding a wrong default of oom_score_adj=0, which I have just reported in https://github.com/docker/cli/issues/4846.

#### Does this PR introduce a user-facing change?

```release-note
None
```
