### PR TITLE
kube play: always pull when both imagePullPolicy and tag are missing

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1050,7 +1050,7 @@ func (ic *ContainerEngine) getImageAndLabelInfo(ctx context.Context, cwd string,
 		} else {
 			if named, err := reference.ParseNamed(container.Image); err == nil {
 				tagged, isTagged := named.(reference.NamedTagged)
-				if isTagged && tagged.Tag() == "latest" {
+				if !isTagged || tagged.Tag() == "latest" {
 					// Make sure to always pull the latest image in case it got updated.
 					pullPolicy = config.PullPolicyNewer
 				}

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -3163,6 +3163,46 @@ var _ = Describe("Podman kube play", func() {
 		Expect(oldBBinspect[0].Digest).To(Not(Equal(newBBinspect[0].Digest)))
 	})
 
+	It("with no tag and no pull policy should always pull", func() {
+		oldBB := "quay.io/libpod/busybox:1.30.1"
+		pull := podmanTest.Podman([]string{"pull", oldBB})
+		pull.WaitWithDefaultTimeout()
+		Expect(pull).Should(Exit(0))
+
+		tag := podmanTest.Podman([]string{"tag", oldBB, BB})
+		tag.WaitWithDefaultTimeout()
+		Expect(tag).Should(ExitCleanly())
+
+		rmi := podmanTest.Podman([]string{"rmi", oldBB})
+		rmi.WaitWithDefaultTimeout()
+		Expect(rmi).Should(ExitCleanly())
+
+		inspect := podmanTest.Podman([]string{"inspect", BB})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		oldBBinspect := inspect.InspectImageJSON()
+
+		noTagBB := "quay.io/libpod/busybox"
+		ctr := getCtr(withImage(noTagBB), withPullPolicy(""))
+		err := generateKubeYaml("pod", getPod(withCtr(ctr)), kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+		if IsRemote() {
+			Expect(kube.ErrorToString()).To(BeEmpty())
+		} else {
+			Expect(kube.ErrorToString()).To(ContainSubstring("Copying blob "))
+		}
+
+		inspect = podmanTest.Podman([]string{"inspect", noTagBB})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		newBBinspect := inspect.InspectImageJSON()
+		Expect(oldBBinspect[0].Digest).To(Not(Equal(newBBinspect[0].Digest)))
+	})
+
 	It("with image data", func() {
 		testyaml := `
 apiVersion: v1


### PR DESCRIPTION
Align the behaviour of `podman kube play file.yaml` to Kubernetes' by forcing an image pull when `imagePullPolicy` is omitted and the container image does not specify a tag.

Fixes #21211 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
