### PR TITLE
Use semi-colon as the field separator for internal volumes-from inspect annotation

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -54,7 +54,7 @@ func (c *Container) volumesFrom() ([]string, error) {
 		return nil, err
 	}
 	if ctrs, ok := ctrSpec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
-		return strings.Split(ctrs, ","), nil
+		return strings.Split(ctrs, ";"), nil
 	}
 	return nil, nil
 }
@@ -511,7 +511,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 			hostConfig.AutoRemove = true
 		}
 		if ctrs, ok := ctrSpec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
-			hostConfig.VolumesFrom = strings.Split(ctrs, ",")
+			hostConfig.VolumesFrom = strings.Split(ctrs, ";")
 		}
 		if ctrSpec.Annotations[define.InspectAnnotationPrivileged] == define.InspectResponseTrue {
 			hostConfig.Privileged = true

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -278,7 +278,7 @@ func (p *Pod) VolumesFrom() []string {
 		return nil
 	}
 	if ctrs, ok := infra.config.Spec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
-		return strings.Split(ctrs, ",")
+		return strings.Split(ctrs, ";")
 	}
 	return nil
 }

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -152,7 +152,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if len(s.VolumesFrom) > 0 {
-		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
+		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ";")
 	}
 
 	if s.IsPrivileged() {

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -322,7 +322,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if len(s.VolumesFrom) > 0 {
-		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
+		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ";")
 	}
 
 	if s.IsPrivileged() {

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -1,6 +1,9 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/annotations"
 	. "github.com/containers/podman/v4/test/utils"
@@ -43,5 +46,28 @@ var _ = Describe("Podman container inspect", func() {
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
 			To(Equal(map[string][]define.InspectHostPort{"80/tcp": nil, "8989/tcp": nil}))
+	})
+
+	It("podman inspect shows volumes-from with mount options", func() {
+		ctr1 := "volfctr"
+		ctr2 := "voltctr"
+		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		volsctr := ctr1 + ":z,ro"
+
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, CITEST_IMAGE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"create", "--volumes-from", volsctr, "--name", ctr2, CITEST_IMAGE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		data := podmanTest.InspectContainer(ctr2)
+		Expect(data).To(HaveLen(1))
+		Expect(data[0].HostConfig.VolumesFrom).To(Equal([]string{volsctr}))
+		Expect(data[0].Config.Annotations[define.InspectAnnotationVolumesFrom]).To(Equal(volsctr))
 	})
 })


### PR DESCRIPTION
The current field separator comma of the inspect annotation conflicts with the mount options of --volumes-from as the mount options itself can be comma separated.

When a volumes-from value is ctr1:z,ro, the container inspect shows the following:
```
               "VolumesFrom": [
                    "f91dc2fa04d6cd3997c7b3f5c300ceca39bc37e5c5dbb847e89d342d8141c663:z",
                    "ro"
               ],
```
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? No

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
