### PR TITLE
[CI:DOCS] Corrected markdown documentation for `--stars`

### DIFF
--- a/docs/source/markdown/podman-search.1.md.in
+++ b/docs/source/markdown/podman-search.1.md.in
@@ -47,7 +47,7 @@ Filter output based on conditions provided (default [])
 
 Supported filters are:
 
-* stars (int - number of stars the image has)
+* stars (int) - minimum number of stars required for images to show
 * is-automated (boolean - true | false) - is the image automated or not
 * is-official (boolean - true | false) - is the image official or not
 


### PR DESCRIPTION
The `--stars` option was incorrectly documented as meaning the number of stars to filter by, instead of the minimum number of stars to filter by.

This addresses [Issue #21346](https://github.com/containers/podman/issues/21346).

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

Yes, the markdown documentation used.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Documentation Correction: `--stars` Option in Podman

The documentation for the `--stars` option in the Markdown section has been updated for clarity. Previously, the option was incorrectly described as filtering by the exact number of stars, when it is actually used to specify the minimum number of stars to filter by.
```