### PR TITLE
Add volumes-from support using annotation in kube yaml

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -53,7 +53,7 @@ func (c *Container) volumesFrom() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ctrs, ok := ctrSpec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
+	if ctrs, ok := ctrSpec.Annotations[define.VolumesFromAnnotation]; ok {
 		return strings.Split(ctrs, ","), nil
 	}
 	return nil, nil
@@ -510,7 +510,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 		if ctrSpec.Annotations[define.InspectAnnotationAutoremove] == define.InspectResponseTrue {
 			hostConfig.AutoRemove = true
 		}
-		if ctrs, ok := ctrSpec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
+		if ctrs, ok := ctrSpec.Annotations[define.VolumesFromAnnotation]; ok {
 			hostConfig.VolumesFrom = strings.Split(ctrs, ",")
 		}
 		if ctrSpec.Annotations[define.InspectAnnotationPrivileged] == define.InspectResponseTrue {

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -18,13 +18,6 @@ const (
 	// the two supported boolean values (InspectResponseTrue and
 	// InspectResponseFalse) it will be used in the output of Inspect().
 	InspectAnnotationAutoremove = "io.podman.annotations.autoremove"
-	// InspectAnnotationVolumesFrom is used by Inspect to identify
-	// containers whose volumes are being used by this container.
-	// It is expected to be a comma-separated list of container names and/or
-	// IDs.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationVolumesFrom = "io.podman.annotations.volumes-from"
 	// InspectAnnotationPrivileged is used by Inspect to identify containers
 	// which are privileged (IE, running with elevated privileges).
 	// It is expected to be a boolean, populated by one of
@@ -157,6 +150,12 @@ const (
 	// of the container
 	UlimitAnnotation = "io.podman.annotations.ulimit"
 
+	// VolumesFromAnnotation is used by by play kube when playing a kube
+	// yaml to specify volumes-from of the container
+	// It is expected to be a semicolon-separated list of container names and/or
+	// IDs optionally with colon separated mount options.
+	VolumesFromAnnotation = "io.podman.annotations.volumes-from"
+
 	// KubeHealthCheckAnnotation is used by kube play to tell podman that any health checks should follow
 	// the k8s behavior of waiting for the intialDelaySeconds to be over before updating the status
 	KubeHealthCheckAnnotation = "io.podman.annotations.kube.health.check"
@@ -169,7 +168,7 @@ const (
 // already reserved annotation that Podman sets during container creation.
 func IsReservedAnnotation(value string) bool {
 	switch value {
-	case InspectAnnotationCIDFile, InspectAnnotationAutoremove, InspectAnnotationVolumesFrom, InspectAnnotationPrivileged, InspectAnnotationPublishAll, InspectAnnotationInit, InspectAnnotationLabel, InspectAnnotationSeccomp, InspectAnnotationApparmor, InspectResponseTrue, InspectResponseFalse:
+	case InspectAnnotationCIDFile, InspectAnnotationAutoremove, InspectAnnotationPrivileged, InspectAnnotationPublishAll, InspectAnnotationInit, InspectAnnotationLabel, InspectAnnotationSeccomp, InspectAnnotationApparmor, InspectResponseTrue, InspectResponseFalse:
 		return true
 
 	default:

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -277,7 +277,7 @@ func (p *Pod) VolumesFrom() []string {
 	if err != nil {
 		return nil
 	}
-	if ctrs, ok := infra.config.Spec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
+	if ctrs, ok := infra.config.Spec.Annotations[define.VolumesFromAnnotation]; ok {
 		return strings.Split(ctrs, ",")
 	}
 	return nil

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -140,6 +140,8 @@ type CtrSpecGenOptions struct {
 	IpcNSIsHost bool
 	// Volumes for all containers
 	Volumes map[string]*KubeVolume
+	// VolumesFrom for all containers
+	VolumesFrom []string
 	// PodID of the parent pod
 	PodID string
 	// PodName of the parent pod
@@ -558,6 +560,8 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			return nil, errors.New("unsupported volume source type")
 		}
 	}
+
+	s.VolumesFrom = opts.VolumesFrom
 
 	s.RestartPolicy = opts.RestartPolicy
 

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -152,7 +152,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if len(s.VolumesFrom) > 0 {
-		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
+		configSpec.Annotations[define.VolumesFromAnnotation] = strings.Join(s.VolumesFrom, ",")
 	}
 
 	if s.IsPrivileged() {

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -322,7 +322,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if len(s.VolumesFrom) > 0 {
-		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
+		configSpec.Annotations[define.VolumesFromAnnotation] = strings.Join(s.VolumesFrom, ",")
 	}
 
 	if s.IsPrivileged() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -1673,30 +1673,42 @@ USER test1`
 		Expect(pod.Annotations).To(Not(HaveKeyWithValue(define.BindMountPrefix, vol1+":Z")))
 	})
 
-	It("--podman-only on container with --volumes-from", func() {
-		ctr1 := "ctr1"
-		ctr2 := "ctr2"
+	It("pod on container with --volumes-from", func() {
+		// Assert that volumes-from annotation for multiple source
+		// containers along with their mount options are getting
+		// generated with semicolon as the field separator.
+
+		srcctr1, srcctr2, tgtctr := "srcctr1", "srcctr2", "tgtctr"
+		frmopt1, frmopt2 := srcctr1+":ro", srcctr2+":ro"
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
 
-		err := os.MkdirAll(vol1, 0755)
-		Expect(err).ToNot(HaveOccurred())
+		err1 := os.MkdirAll(vol1, 0755)
+		Expect(err1).ToNot(HaveOccurred())
 
-		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, CITEST_IMAGE})
+		err2 := os.MkdirAll(vol2, 0755)
+		Expect(err2).ToNot(HaveOccurred())
+
+		session := podmanTest.Podman([]string{"create", "--name", srcctr1, "-v", vol1, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"create", "--volumes-from", ctr1, "--name", ctr2, CITEST_IMAGE})
+		session = podmanTest.Podman([]string{"create", "--name", srcctr2, "-v", vol2, CITEST_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", ctr2})
+		session = podmanTest.Podman([]string{"create", "--volumes-from", frmopt1, "--volumes-from", frmopt2, "--name", tgtctr, CITEST_IMAGE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		kube := podmanTest.Podman([]string{"kube", "generate", tgtctr})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 
 		pod := new(v1.Pod)
-		err = yaml.Unmarshal(kube.Out.Contents(), pod)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(pod.Annotations).To(HaveKeyWithValue(define.InspectAnnotationVolumesFrom+"/"+ctr2, ctr1))
+		err3 := yaml.Unmarshal(kube.Out.Contents(), pod)
+		Expect(err3).ToNot(HaveOccurred())
+		Expect(pod.Annotations).To(HaveKeyWithValue(define.VolumesFromAnnotation+"/"+tgtctr, frmopt1+";"+frmopt2))
 	})
 
 	It("--podman-only on container with --rm", func() {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -492,6 +492,34 @@ spec:
 status: {}
 `
 
+var volumesFromPodYaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    io.podman.annotations.volumes-from/tgtctr: srcctr:ro
+  name: volspod
+spec:
+    containers:
+    - name: srcctr
+      image: ` + CITEST_IMAGE + `
+      command:
+        - sleep
+        - inf
+      volumeMounts:
+      - mountPath: /mnt/vol
+        name: testing
+    - name: tgtctr
+      image: ` + CITEST_IMAGE + `
+      command:
+        - sleep
+        - inf
+    volumes:
+    - name: testing
+      persistentVolumeClaim:
+        claimName: testvol
+`
+
 var configMapYamlTemplate = `
 apiVersion: v1
 kind: ConfigMap
@@ -3417,6 +3445,103 @@ spec:
 		Expect(kube).Should(ExitCleanly())
 	})
 
+	It("test with volumes-from with source containers external", func() {
+		// Assert that volumes of multiple source containers, listed in
+		// volumes-from annotation, running outside the pod are
+		// getting mounted inside the target container.
+
+		srcctr1, srcctr2, tgtctr := "srcctr1", "srcctr2", "tgtctr"
+		frmopt1, frmopt2 := srcctr1+":ro", srcctr2+":ro"
+		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
+
+		volsFromAnnotaton := "io.podman.annotations.volumes-from"
+		volsFromValue := frmopt1 + ";" + frmopt2
+
+		err1 := os.MkdirAll(vol1, 0755)
+		Expect(err1).ToNot(HaveOccurred())
+
+		err2 := os.MkdirAll(vol2, 0755)
+		Expect(err2).ToNot(HaveOccurred())
+
+		session := podmanTest.Podman([]string{"create", "--name", srcctr1, "-v", vol1, CITEST_IMAGE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"create", "--name", srcctr2, "-v", vol2, CITEST_IMAGE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		podName := tgtctr
+		pod := getPod(
+			withPodName(podName),
+			withCtr(getCtr(withName(tgtctr))),
+			withAnnotation(volsFromAnnotaton, volsFromValue))
+
+		err3 := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err3).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(ExitCleanly())
+
+		// Assert volumes are accessible inside the target container
+		// by creating contents in the volumes and accessing them from
+		// the target container.
+		vol1File := filepath.Join(vol1, RandomString(10)+".txt")
+		vol2File := filepath.Join(vol2, RandomString(10)+".txt")
+
+		err4 := os.WriteFile(vol1File, []byte(vol1File), 0644)
+		Expect(err4).ToNot(HaveOccurred())
+		err4 = os.WriteFile(vol2File, []byte(vol2File), 0644)
+		Expect(err4).ToNot(HaveOccurred())
+
+		ctrNameInKubePod := podName + "-" + tgtctr
+		exec := podmanTest.Podman([]string{"exec", ctrNameInKubePod, "ls", vol1File, vol2File})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec).Should(ExitCleanly())
+		Expect(exec.OutputToString()).To(ContainSubstring(vol1File))
+		Expect(exec.OutputToString()).To(ContainSubstring(vol2File))
+	})
+
+	It("test with volumes-from with source container in pod", func() {
+		// Assert that volume of source container, member of the pod,
+		// listed in volumes-from annotation is getting mounted inside
+		// the target container.
+
+		srcctr, tgtctr, podName := "srcctr", "tgtctr", "volspod"
+		vol := "/mnt/vol"
+
+		srcctrInKubePod := podName + "-" + srcctr
+		tgtctrInKubePod := podName + "-" + tgtctr
+
+		err := writeYaml(volumesFromPodYaml, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(ExitCleanly())
+
+		// Assert volume is accessible inside the target container
+		// by creating contents in the volume and accessing that from
+		// the target container.
+		volFile := filepath.Join(vol, RandomString(10)+".txt")
+
+		exec := podmanTest.Podman([]string{"exec", srcctrInKubePod, "touch", volFile})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec).Should(ExitCleanly())
+
+		exec = podmanTest.Podman([]string{"exec", srcctrInKubePod, "ls", volFile})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec).Should(ExitCleanly())
+		Expect(exec.OutputToString()).To(ContainSubstring(volFile))
+
+		exec = podmanTest.Podman([]string{"exec", tgtctrInKubePod, "ls", volFile})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec).Should(ExitCleanly())
+		Expect(exec.OutputToString()).To(ContainSubstring(volFile))
+	})
+
 	It("test with FileOrCreate HostPath type volume", func() {
 		hostPathLocation := filepath.Join(tempdir, "file")
 
@@ -5909,7 +6034,7 @@ spec:
 		Expect(session).Should(Exit(125))
 	})
 
-	It("test with reserved volumes-from annotation in yaml", func() {
+	It("test with volumes-from annotation in yaml", func() {
 		ctr1 := "ctr1"
 		ctr2 := "ctr2"
 		ctrNameInKubePod := ctr2 + "-pod-" + ctr2
@@ -5927,7 +6052,7 @@ spec:
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		kube := podmanTest.Podman([]string{"kube", "generate", "--podman-only", "-f", outputFile, ctr2})
+		kube := podmanTest.Podman([]string{"kube", "generate", "-f", outputFile, ctr2})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitCleanly())
 


### PR DESCRIPTION
The reserved annotation io.podman.annotations.volumes-from is made public to let user define volumes-from to have one container mount volumes of other containers.

The annotation format is: io.podman.annotations.volumes-from/toCtr: "fromCtr1:mntOpts1;fromCtr2:mntOpts;..."

Fixes: #16819

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change? Yes

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Annotation io.podman.annotations.volumes-from can be used to define list of volumes-from to have one container mount volumes of other containers. The format of the annotation is io.podman.annotations.volumes-from/<toContainer>: "fromContainer1:mntOptions1;fromContainer2:mntOptions;...".
```
