### PR TITLE
create machine dirs at discovery

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -193,12 +193,25 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 	}
 
 	rtDirFile, err := define.NewMachineFile(rtDir, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	dirs := define.MachineDirs{
 		ConfigDir:  configDirFile,
 		DataDir:    dataDirFile,
 		RuntimeDir: rtDirFile,
 	}
+
+	// make sure all machine dirs are present
+	if err := os.MkdirAll(rtDir, 0755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return nil, err
+	}
+	err = os.MkdirAll(dataDir, 0755)
+
 	return &dirs, err
 }
 


### PR DESCRIPTION
in various use cases, the required machine dirs are not created.  the machine dirs are runtimedir, datadir, and configdir.  example in Linux would be:

    configDir /<HOME>/.config/containers/podman/machine/<provider>
    dataDir /<HOME>/.local/share/containers/podman/machine/<provider>
    runtimeDir /run/user/1000/podman/machine

now we blindly create them without checking for their existence (because it is faster).

this fixes a bug where runtimedir does not exist on macos after a reboot


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
