### PR TITLE
drop support for "pasta" as a network name

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -95,7 +95,7 @@ func DefineNetFlags(cmd *cobra.Command) {
 }
 
 // NetFlagsToNetOptions parses the network flags for the given cmd.
-func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet, pastaNetworkNameExists bool) (*entities.NetOptions, error) {
+func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*entities.NetOptions, error) {
 	var (
 		err error
 	)
@@ -192,7 +192,7 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet, pastaN
 			return nil, err
 		}
 
-		ns, networks, options, err := specgen.ParseNetworkFlag(network, pastaNetworkNameExists)
+		ns, networks, options, err := specgen.ParseNetworkFlag(network)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -105,15 +105,8 @@ func init() {
 
 func commonFlags(cmd *cobra.Command) error {
 	var err error
-
-	report, err := registry.ContainerEngine().NetworkExists(registry.Context(), "pasta")
-	if err != nil {
-		return err
-	}
-	pastaNetworkNameExists := report.Value
-
 	flags := cmd.Flags()
-	cliVals.Net, err = common.NetFlagsToNetOptions(nil, *flags, pastaNetworkNameExists)
+	cliVals.Net, err = common.NetFlagsToNetOptions(nil, *flags)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -133,18 +133,12 @@ func create(cmd *cobra.Command, args []string) error {
 		createOptions.Infra = false
 	}
 
-	report, err := registry.ContainerEngine().NetworkExists(registry.Context(), "pasta")
-	if err != nil {
-		return err
-	}
-	pastaNetworkNameExists := report.Value
-
 	if !createOptions.Infra {
 		if cmd.Flag("no-hosts").Changed {
 			return fmt.Errorf("cannot specify --no-hosts without an infra container")
 		}
 		flags := cmd.Flags()
-		createOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags, pastaNetworkNameExists)
+		createOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags)
 		if err != nil {
 			return err
 		}
@@ -170,7 +164,7 @@ func create(cmd *cobra.Command, args []string) error {
 	} else {
 		// reassign certain options for lbpod api, these need to be populated in spec
 		flags := cmd.Flags()
-		infraOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags, pastaNetworkNameExists)
+		infraOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags)
 		if err != nil {
 			return err
 		}

--- a/docs/source/markdown/options/network.md
+++ b/docs/source/markdown/options/network.md
@@ -76,5 +76,3 @@ Valid _mode_ values are:
     - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to
         host, using the loopback interface instead of the tap interface for improved
         performance
-
-    NOTE: For backward compatibility reasons, if there is an existing network named `pasta`, Podman uses it instead of the pasta mode."?

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -15,11 +15,6 @@ If no options are provided, Podman assigns a free subnet and name for the networ
 
 Upon completion of creating the network, Podman displays the name of the newly added network.
 
-NOTE: The support for "pasta" as network *name* value is deprecated and will not be accepted in the next major
-Podman version 5.0, because it is used as a special network mode in **podman run/create --network**.
-The CNI backend is also deprecated and will also be removed in the next major Podman version 5.0, in preference
-of Netavark, see **[podman-network(1)](podman-network.1.md)** on how to change the backend.
-
 ## OPTIONS
 #### **--disable-dns**
 

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -289,7 +289,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		}
 	}
 
-	nsmode, networks, netOpts, err := specgen.ParseNetworkFlag([]string{netmode}, false)
+	nsmode, networks, netOpts, err := specgen.ParseNetworkFlag([]string{netmode})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/containers/common/libnetwork/pasta"
+	"github.com/containers/common/libnetwork/slirp4netns"
 	"github.com/containers/common/libnetwork/types"
 	netutil "github.com/containers/common/libnetwork/util"
 	"github.com/containers/podman/v4/libpod/define"
@@ -150,8 +152,7 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 }
 
 func (ic *ContainerEngine) NetworkCreate(ctx context.Context, network types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error) {
-	// TODO (5.0): Stop accepting "pasta" as value here
-	if slices.Contains([]string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns", "default"}, network.Name) {
+	if slices.Contains([]string{"none", "host", "bridge", "private", slirp4netns.BinaryName, pasta.BinaryName, "container", "ns", "default"}, network.Name) {
 		return nil, fmt.Errorf("cannot create network with name %q because it conflicts with a valid network mode", network.Name)
 	}
 	network, err := ic.Libpod.Network().NetworkCreate(network, createOptions)

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -491,14 +491,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	}
 
 	if len(options.Networks) > 0 {
-		var pastaNetworkNameExists bool
-
-		_, err := ic.Libpod.Network().NetworkInspect("pasta")
-		if err == nil {
-			pastaNetworkNameExists = true
-		}
-
-		ns, networks, netOpts, err := specgen.ParseNetworkFlag(options.Networks, pastaNetworkNameExists)
+		ns, networks, netOpts, err := specgen.ParseNetworkFlag(options.Networks)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -90,7 +90,7 @@ func GetDefaultNamespaceMode(nsType string, cfg *config.Config, pod *libpod.Pod)
 	case "cgroup":
 		return specgen.ParseCgroupNamespace(cfg.Containers.CgroupNS)
 	case "net":
-		ns, _, _, err := specgen.ParseNetworkFlag(nil, false)
+		ns, _, _, err := specgen.ParseNetworkFlag(nil)
 		return ns, err
 	}
 

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -326,8 +326,7 @@ func ParseUserNamespace(ns string) (Namespace, error) {
 
 // ParseNetworkFlag parses a network string slice into the network options
 // If the input is nil or empty it will use the default setting from containers.conf
-// TODO (5.0): Drop pastaNetworkNameExists
-func ParseNetworkFlag(networks []string, pastaNetworkNameExists bool) (Namespace, map[string]types.PerNetworkOptions, map[string][]string, error) {
+func ParseNetworkFlag(networks []string) (Namespace, map[string]types.PerNetworkOptions, map[string][]string, error) {
 	var networkOptions map[string][]string
 	// by default we try to use the containers.conf setting
 	// if we get at least one value use this instead
@@ -379,19 +378,11 @@ func ParseNetworkFlag(networks []string, pastaNetworkNameExists bool) (Namespace
 		toReturn.Value = value
 	case ns == string(Pasta), strings.HasPrefix(ns, string(Pasta)+":"):
 		key, options, hasOptions := strings.Cut(ns, ":")
-
-		if pastaNetworkNameExists {
-			goto nextCase
-		}
-
 		if hasOptions {
 			networkOptions = make(map[string][]string)
 			networkOptions[key] = strings.Split(options, ",")
 		}
 		toReturn.NSMode = Pasta
-		break
-	nextCase:
-		fallthrough
 	default:
 		// we should have a normal network
 		name, options, hasOptions := strings.Cut(ns, ":")
@@ -426,8 +417,7 @@ func ParseNetworkFlag(networks []string, pastaNetworkNameExists bool) (Namespace
 			if name == "" {
 				return toReturn, nil, nil, fmt.Errorf("network name cannot be empty: %w", define.ErrInvalidArg)
 			}
-			// TODO (5.0): Don't accept string(Pasta) here once we drop pastaNetworkNameExists
-			if slices.Contains([]string{string(Bridge), string(Slirp), string(FromPod), string(NoNetwork),
+			if slices.Contains([]string{string(Bridge), string(Slirp), string(Pasta), string(FromPod), string(NoNetwork),
 				string(Default), string(Private), string(Path), string(FromContainer), string(Host)}, name) {
 				return toReturn, nil, nil, fmt.Errorf("can only set extra network names, selected mode %s conflicts with bridge: %w", name, define.ErrInvalidArg)
 			}

--- a/pkg/specgen/namespaces_test.go
+++ b/pkg/specgen/namespaces_test.go
@@ -241,7 +241,7 @@ func TestParseNetworkFlag(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2, err := ParseNetworkFlag(tt.args, false)
+			got, got1, got2, err := ParseNetworkFlag(tt.args)
 			if tt.err != "" {
 				assert.EqualError(t, err, tt.err, tt.name)
 			} else {

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid name", func() {
-		for _, name := range []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns", "default"} {
+		for _, name := range []string{"none", "host", "bridge", "private", "slirp4netns", "pasta", "container", "ns", "default"} {
 			nc := podmanTest.Podman([]string{"network", "create", name})
 			nc.WaitWithDefaultTimeout()
 			Expect(nc).To(Exit(125))


### PR DESCRIPTION
The pasta network mode has been added in podman v4.4 and this causes a conflict with named networks that could also be called "pasta". To not break anything we had special logic to prefer the named network over the network mode. Now with 5.0 we can break this and remove this awkward special handling from the code.

Containers created with 4.X that use a named network pasta will also continue to work fine, this chnage will only effect the creation of new containers with a named network pasta and instead always used the network mode pasta. We now also block the creation of networks with the name "pasta".

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A named network with the name `pasta` is no longer supported with `--network`, instead it will always use the actual network mode `pasta` (i.e. the pasta binary) to setup the netns. `podman network create` will also no longer accept `pasta` as a name to prevent creating such name conflicts. 
```
