### PR TITLE
make podman pod inspect output a json array

### DIFF
--- a/cmd/podman/common/inspect.go
+++ b/cmd/podman/common/inspect.go
@@ -11,10 +11,6 @@ const (
 	NetworkType = "network"
 	// PodType is the pod type.
 	PodType = "pod"
-	// PodLegacyType is the pod type for backwards compatibility with the old pod inspect code.
-	// This allows us to use the shared inspect code but still provide the correct output format
-	// when podman pod inspect was called.
-	PodLegacyType = "pod-legacy"
 	// VolumeType is the volume type
 	VolumeType = "volume"
 )

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -123,7 +123,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 		for i := range ctrData {
 			data = append(data, ctrData[i])
 		}
-	case common.PodType, common.PodLegacyType:
+	case common.PodType:
 		podData, allErrs, err := i.containerEngine.PodInspect(ctx, namesOrIDs, i.options)
 		if err != nil {
 			return err
@@ -163,14 +163,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 	var err error
 	switch {
 	case report.IsJSON(i.options.Format) || i.options.Format == "":
-		if i.options.Type == common.PodLegacyType && len(data) == 1 {
-			// We need backwards compat with the old podman pod inspect behavior.
-			// https://github.com/containers/podman/pull/15675
-			// TODO (5.0): consider removing this to better match other commands.
-			err = printJSON(data[0])
-		} else {
-			err = printJSON(data)
-		}
+		err = printJSON(data)
 	default:
 		// Landing here implies user has given a custom --format
 		var rpt *report.Formatter

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -41,8 +41,6 @@ func init() {
 }
 
 func inspectExec(cmd *cobra.Command, args []string) error {
-	// We need backwards compat with the old podman pod inspect behavior.
-	// https://github.com/containers/podman/pull/15675
-	inspectOpts.Type = common.PodLegacyType
+	inspectOpts.Type = common.PodType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/docs/source/markdown/podman-pod-inspect.1.md.in
+++ b/docs/source/markdown/podman-pod-inspect.1.md.in
@@ -62,31 +62,32 @@ Valid placeholders for the Go template are listed below:
 ## EXAMPLE
 ```
 # podman pod inspect foobar
-{
-
-     "Id": "3513ca70583dd7ef2bac83331350f6b6c47d7b4e526c908e49d89ebf720e4693",
-     "Name": "foobar",
-     "Labels": {},
-     "CgroupParent": "/libpod_parent",
-     "CreateCgroup": true,
-     "Created": "2018-08-08T11:15:18.823115347-05:00"
-     "State": "created",
-     "Hostname": "",
-     "SharedNamespaces": [
-          "uts",
-          "ipc",
-          "net"
-     ]
-     "CreateInfra": false,
-     "InfraContainerID": "1020dd70583dd7ff2bac83331350f6b6e007de0d026c908e49d89ebf891d4699"
-     "CgroupPath": ""
-     "Containers": [
-          {
-               "id": "d53f8bf1e9730281264aac6e6586e327429f62c704abea4b6afb5d8a2b2c9f2c",
-               "state": "configured"
-          }
-     ]
-}
+[
+     {
+         "Id": "3513ca70583dd7ef2bac83331350f6b6c47d7b4e526c908e49d89ebf720e4693",
+         "Name": "foobar",
+         "Labels": {},
+         "CgroupParent": "/libpod_parent",
+         "CreateCgroup": true,
+         "Created": "2018-08-08T11:15:18.823115347-05:00"
+         "State": "created",
+         "Hostname": "",
+         "SharedNamespaces": [
+              "uts",
+              "ipc",
+              "net"
+         ]
+         "CreateInfra": false,
+         "InfraContainerID": "1020dd70583dd7ff2bac83331350f6b6e007de0d026c908e49d89ebf891d4699"
+         "CgroupPath": ""
+         "Containers": [
+              {
+                   "id": "d53f8bf1e9730281264aac6e6586e327429f62c704abea4b6afb5d8a2b2c9f2c",
+                   "state": "configured"
+              }
+         ]
+     }
+]
 ```
 
 ## SEE ALSO

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -695,10 +695,11 @@ func (s *PodmanSessionIntegration) InspectContainerToJSON() []define.InspectCont
 
 // InspectPodToJSON takes the sessions output from a pod inspect and returns json
 func (s *PodmanSessionIntegration) InspectPodToJSON() define.InspectPodData {
-	var i define.InspectPodData
+	var i []define.InspectPodData
 	err := jsoniter.Unmarshal(s.Out.Contents(), &i)
 	Expect(err).ToNot(HaveOccurred())
-	return i
+	Expect(i).To(HaveLen(1))
+	return i[0]
 }
 
 // InspectPodToJSON takes the sessions output from an inspect and returns json

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -1,9 +1,6 @@
 package integration
 
 import (
-	"encoding/json"
-
-	"github.com/containers/podman/v4/libpod/define"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,9 +66,7 @@ var _ = Describe("Podman pod inspect", func() {
 		inspectOut.WaitWithDefaultTimeout()
 		Expect(inspectOut).Should(ExitCleanly())
 
-		inspectJSON := new(define.InspectPodData)
-		err := json.Unmarshal(inspectOut.Out.Contents(), inspectJSON)
-		Expect(err).ToNot(HaveOccurred())
+		inspectJSON := inspectOut.InspectPodToJSON()
 		Expect(inspectJSON.InfraConfig).To(Not(BeNil()))
 		Expect(inspectJSON.InfraConfig.PortBindings["80/tcp"]).To(HaveLen(1))
 		Expect(inspectJSON.InfraConfig.PortBindings["80/tcp"][0]).To(HaveField("HostPort", "8383"))

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -716,8 +716,8 @@ function thingy_with_unique_id() {
         podid="$output"
         run_podman run -d --pod $podid $IMAGE top -d 2
 
-        run_podman pod inspect $podid
-        result=$(jq -r .CgroupPath <<< $output)
+        run_podman pod inspect $podid --format "{{.CgroupPath}}"
+        result="$output"
         assert "$result" =~ "/" ".CgroupPath is a valid path"
 
         if is_cgroupsv2; then


### PR DESCRIPTION
Just like all the other inspect commands that accept multiple args we should just make podman pod inspect output a json array. This makes the code more consistent and removes the extra workaround which was needed before to support this.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman pod inspect now outputs a json array by default just like all the other inspect commands.
```
