### PR TITLE
machine: Address some QEMU TODOs

### DIFF
--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -67,10 +67,6 @@ func inspect(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		ignFile, err := mc.IgnitionFile()
-		if err != nil {
-			return err
-		}
 
 		podmanSocket, podmanPipe, err := mc.ConnectionInfo(provider.VMType())
 		if err != nil {
@@ -83,13 +79,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 				PodmanSocket: podmanSocket,
 				PodmanPipe:   podmanPipe,
 			},
-			Created: mc.Created,
-			// TODO This is no longer applicable; we dont care about the provenance
-			// of the image
-			Image: machine.ImageConfig{
-				IgnitionFile: *ignFile,
-				ImagePath:    *mc.ImagePath,
-			},
+			Created:            mc.Created,
 			LastUp:             mc.LastUp,
 			Name:               mc.Name,
 			Resources:          mc.Resources,

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -120,14 +120,12 @@ func rm(_ *cobra.Command, args []string) error {
 	// All actual removal of files and vms should occur after this
 	//
 
-	// TODO Should this be a hard error?
 	if err := providerRm(); err != nil {
-		logrus.Errorf("failed to remove virtual machine from provider for %q", vmName)
+		logrus.Errorf("failed to remove virtual machine from provider for %q: %v", vmName, err)
 	}
 
-	// TODO Should this be a hard error?
 	if err := genericRm(); err != nil {
-		logrus.Error("failed to remove machines files")
+		return fmt.Errorf("failed to remove machines files: %v", err)
 	}
 	newMachineEvent(events.Remove, events.Event{Name: vmName})
 	return nil

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -28,7 +28,6 @@ Print results with a Go template.
 | .ConfigDir ...      | Machine configuration directory location                                   |
 | .ConnectionInfo ... | Machine connection information                                        |
 | .Created ...        | Machine creation time (string, ISO3601)                               |
-| .Image ...          | Machine image config                                                  |
 | .LastUp ...         | Time when machine was last booted                                     |
 | .Name               | Name of the machine                                                   |
 | .Resources ...      | Resources used by the machine                                         |

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -110,7 +110,6 @@ type InspectInfo struct {
 	ConfigDir          define.VMFile
 	ConnectionInfo     ConnectionConfig
 	Created            time.Time
-	Image              ImageConfig
 	LastUp             time.Time
 	Name               string
 	Resources          vmconfigs.ResourceConfig

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -94,16 +94,6 @@ var _ = Describe("podman machine rm", func() {
 		key := inspectSession.outputToString()
 		pubkey := key + ".pub"
 
-		inspect = inspect.withFormat("{{.Image.IgnitionFile.Path}}")
-		inspectSession, err = mb.setCmd(inspect).run()
-		Expect(err).ToNot(HaveOccurred())
-		ign := inspectSession.outputToString()
-
-		inspect = inspect.withFormat("{{.Image.ImagePath.Path}}")
-		inspectSession, err = mb.setCmd(inspect).run()
-		Expect(err).ToNot(HaveOccurred())
-		img := inspectSession.outputToString()
-
 		rm := rmMachine{}
 		removeSession, err := mb.setCmd(rm.withForce().withSaveIgnition().withSaveImage()).run()
 		Expect(err).ToNot(HaveOccurred())
@@ -122,10 +112,11 @@ var _ = Describe("podman machine rm", func() {
 
 		// WSL does not use ignition
 		if testProvider.VMType() != define.WSLVirt {
-			_, err = os.Stat(ign)
+			ignPath := filepath.Join(testDir, ".config", "containers", "podman", "machine", testProvider.VMType().String(), mb.name+".ign")
+			_, err = os.Stat(ignPath)
 			Expect(err).ToNot(HaveOccurred())
 		}
-		_, err = os.Stat(img)
+		_, err = os.Stat(mb.imagePath)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/podman/v5/pkg/errorhandling"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/digitalocean/go-qemu/qmp"
@@ -237,7 +238,15 @@ func (q *QEMUStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() erro
 	}
 
 	return qemuRmFiles, func() error {
-		return nil
+		var errs []error
+		if err := mc.QEMUHypervisor.QEMUPidPath.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+
+		if err := mc.QEMUHypervisor.QMPMonitor.Address.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+		return errorhandling.JoinErrors(errs)
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Addresses the following TODOs that were found in the podman 5 machine refactor code:
- We no longer care about the image provenance in `InspectInfo`, so remove the `Image` field
- Address whether `providerRm` failures should be a hard error
- Address whether a failure to remove machine files should be a hard error
- Implement QEMU-specific file removal
- Remove system connections first and remove machine config files last, this allows us to "see" the machine still in `podman machine list` if there was an error removing any prior files

```release-note
`ConfigPath` and `Image` are not longer provided to the user when they execute `podman machine inspect`. Users can also no longer use `{{ .ConfigPath }}` or `{{ .Image }}` when doing `podman machine inspect --format`
```
