### PR TITLE
Allow CI user to cleanup own files

### DIFF
--- a/contrib/cirrus/mac_cleanup.sh
+++ b/contrib/cirrus/mac_cleanup.sh
@@ -11,14 +11,26 @@ set +e -x
 # These are the main processes which could leak out of testing.
 killall podman vfkit gvproxy make go ginkgo
 
+# Golang will leave behind lots of read-only bits, ref:
+# https://go.dev/ref/mod#module-cache
+# However other tools/scripts could also set things read-only.
+# At this point in CI, we really want all this stuff gone-gone,
+# so there's actually zero-chance it can interfere.
+chmod -R u+w /private/tmp/ci/* /private/tmp/ci/.??*
+
 # This is defined as $TMPDIR during setup.  Name must be kept
 # "short" as sockets may reside here.  Darwin suffers from
 # the same limited socket-pathname character-length restriction
 # as Linux.
 rm -rf /private/tmp/ci/* /private/tmp/ci/.??*
 
-# Don't clobber the $CIRRUS_WORKING_DIR for this (running) task.
+# Don't change or clobber anything under $CIRRUS_WORKING_DIR for
+# the currently running task.  But make sure we have write permission
+# (go get sets dependencies ro) for everything else, before removing it.
+# First make everything writeable - see the "Golang will..." comment above.
 # shellcheck disable=SC2154
+find "${ORIGINAL_HOME:-$HOME}/ci" -mindepth 1 -maxdepth 1 \
+    -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec chmod -R u+w '{}' +
 find "${ORIGINAL_HOME:-$HOME}/ci" -mindepth 1 -maxdepth 1 \
     -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec rm -rf '{}' +
 


### PR DESCRIPTION
According to https://go.dev/ref/mod#module-cache golang will leave
behind read-only bits.  It was observed that these cause the find/rm
cleanup operations to fail fail with `permission denied` on thousands
of files.  This is preventing cleanup of cruft from unrelated Cirrus-tasks
leading to unnecessary occupation of critical, local-ssd storage space.
Fix this by ensuring the user has at least write access to the entire
contents of `$TMPDIR` and `$HOME`, `ci` subdirs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
