### PR TITLE
fix userns + restart policy with slirp4netns

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -306,9 +306,13 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 		return false, err
 	}
 
-	// set up slirp4netns again because slirp4netns will die when conmon exits
-	if err := c.setupRootlessNetwork(); err != nil {
-		return false, err
+	// only do this if the container is not in a userns, if we are the cleanupNetwork()
+	// was called above and a proper network setup is needed which is part of the init() below.
+	if !c.config.PostConfigureNetNS {
+		// set up slirp4netns again because slirp4netns will die when conmon exits
+		if err := c.setupRootlessNetwork(); err != nil {
+			return false, err
+		}
 	}
 
 	if c.state.State == define.ContainerStateStopped {


### PR DESCRIPTION
Currently we deadlock in the slirp4netns setup code as we try to configure an non exissting netns. The problem happens because we tear down the netns in the userns case correctly since commit bbd6281ecc but that introduces this slirp4netns problem. The code does a proper new network setup later so we should only use the short cut when not in a userns.

Fixes #21477

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a deadlock in podman container cleanup when the slirp4netns network mode was used with a restart policy of always/unless-stopped/on-failure and a user namespace.
```
