### PR TITLE
Use tmpfs mounts when creating a memory-backed emptyDir volume

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -554,6 +554,13 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				SubPath:     volume.SubPath,
 			}
 			s.Volumes = append(s.Volumes, &emptyDirVolume)
+		case KubeVolumeTypeEmptyDirTmpfs:
+			memVolume := spec.Mount{
+				Destination: volume.MountPath,
+				Type:        define.TypeTmpfs,
+				Source:      define.TypeTmpfs,
+			}
+			s.Mounts = append(s.Mounts, memVolume)
 		default:
 			return nil, errors.New("unsupported volume source type")
 		}

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -34,6 +34,7 @@ const (
 	KubeVolumeTypeCharDevice
 	KubeVolumeTypeSecret
 	KubeVolumeTypeEmptyDir
+	KubeVolumeTypeEmptyDirTmpfs
 )
 
 //nolint:revive
@@ -263,7 +264,17 @@ func VolumeFromConfigMap(configMapVolumeSource *v1.ConfigMapVolumeSource, config
 
 // Create a kubeVolume for an emptyDir volume
 func VolumeFromEmptyDir(emptyDirVolumeSource *v1.EmptyDirVolumeSource, name string) (*KubeVolume, error) {
-	return &KubeVolume{Type: KubeVolumeTypeEmptyDir, Source: name}, nil
+	if emptyDirVolumeSource.Medium == v1.StorageMediumMemory {
+		return &KubeVolume{
+			Type:   KubeVolumeTypeEmptyDirTmpfs,
+			Source: name,
+		}, nil
+	} else {
+		return &KubeVolume{
+			Type:   KubeVolumeTypeEmptyDir,
+			Source: name,
+		}, nil
+	}
 }
 
 // Create a KubeVolume from one of the supported VolumeSource

--- a/pkg/specgen/generate/kube/volume_test.go
+++ b/pkg/specgen/generate/kube/volume_test.go
@@ -1,0 +1,24 @@
+//go:build !remote
+
+package kube
+
+import (
+	"testing"
+
+	v1 "github.com/containers/podman/v4/pkg/k8s.io/api/core/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVolumeFromEmptyDir(t *testing.T) {
+	emptyDirSource := v1.EmptyDirVolumeSource{}
+	emptyDirVol, err := VolumeFromEmptyDir(&emptyDirSource, "emptydir")
+	assert.NoError(t, err)
+	assert.Equal(t, emptyDirVol.Type, KubeVolumeTypeEmptyDir)
+
+	memEmptyDirSource := v1.EmptyDirVolumeSource{
+		Medium: v1.StorageMediumMemory,
+	}
+	memEmptyDirVol, err := VolumeFromEmptyDir(&memEmptyDirSource, "emptydir")
+	assert.NoError(t, err)
+	assert.Equal(t, memEmptyDirVol.Type, KubeVolumeTypeEmptyDirTmpfs)
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Implements #21367

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for memory-backed emptyDir volumes to `podman play kube`. Example:

- name: "myvolume"
  emptyDir:
    medium: "Memory"
```
