### PR TITLE
test/e2e: unskip netavark macvlan/ipvlan tests

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -506,8 +506,6 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan", func() {
-		// Netavark currently does not do dhcp so the this test fails
-		SkipIfNetavark(podmanTest)
 		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
 		nc.WaitWithDefaultTimeout()
@@ -521,8 +519,6 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan as driver (-d) no device name", func() {
-		// Netavark currently does not do dhcp so the this test fails
-		SkipIfNetavark(podmanTest)
 		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})
 		nc.WaitWithDefaultTimeout()
@@ -550,8 +546,6 @@ var _ = Describe("Podman network", func() {
 	for _, opt := range []string{"-o=parent=lo", "--interface-name=lo"} {
 		opt := opt
 		It(fmt.Sprintf("podman network create/remove macvlan as driver (-d) with %s", opt), func() {
-			// Netavark currently does not do dhcp so the this test fails
-			SkipIfNetavark(podmanTest)
 			net := "macvlan" + stringid.GenerateRandomID()
 			nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", opt, net})
 			nc.WaitWithDefaultTimeout()
@@ -580,10 +574,8 @@ var _ = Describe("Podman network", func() {
 	}
 
 	It("podman network create/remove ipvlan as driver (-d) with device name", func() {
-		// Netavark currently does not support ipvlan
-		SkipIfNetavark(podmanTest)
 		net := "ipvlan" + stringid.GenerateRandomID()
-		nc := podmanTest.Podman([]string{"network", "create", "-d", "ipvlan", "-o", "parent=lo", net})
+		nc := podmanTest.Podman([]string{"network", "create", "-d", "ipvlan", "-o", "parent=lo", "--subnet", "10.0.2.0/24", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(ExitCleanly())
@@ -600,8 +592,8 @@ var _ = Describe("Podman network", func() {
 
 		Expect(result).To(HaveField("Driver", "ipvlan"))
 		Expect(result).To(HaveField("NetworkInterface", "lo"))
-		Expect(result.IPAMOptions).To(HaveKeyWithValue("driver", "dhcp"))
-		Expect(result.Subnets).To(BeEmpty())
+		Expect(result.IPAMOptions).To(HaveKeyWithValue("driver", "host-local"))
+		Expect(result.Subnets).To(HaveLen(1))
 
 		nc = podmanTest.Podman([]string{"network", "rm", net})
 		nc.WaitWithDefaultTimeout()


### PR DESCRIPTION
These should all work with the latest netavark. The ipvlan case needs a subnet because it does not support DHCP.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
