### PR TITLE
Send container stats over API on a per-interface basis

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -215,7 +215,15 @@ func (s *containerStats) MemPerc() string {
 }
 
 func (s *containerStats) NetIO() string {
-	return combineHumanValues(s.NetInput, s.NetOutput)
+	var netInput uint64
+	var netOutput uint64
+
+	for _, net := range s.Network {
+		netInput += net.RxBytes
+		netOutput += net.TxBytes
+	}
+
+	return combineHumanValues(netInput, netOutput)
 }
 
 func (s *containerStats) BlockIO() string {

--- a/docs/source/markdown/podman-stats.1.md.in
+++ b/docs/source/markdown/podman-stats.1.md.in
@@ -50,9 +50,8 @@ Valid placeholders for the Go template are listed below:
 | .MemUsage           | Memory usage                                     |
 | .MemUsageBytes      | Memory usage (IEC)                               |
 | .Name               | Container Name                                   |
-| .NetInput           | Network Input                                    |
 | .NetIO              | Network IO                                       |
-| .NetOutput          | Network Output                                   |
+| .Network            | Network I/O, separated by network interface      |
 | .PerCPU             | CPU time consumed by all tasks [1]               |
 | .PIDs               | Number of PIDs                                   |
 | .PIDS               | Number of PIDs (yes, we know this is a dup)      |

--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -141,11 +141,23 @@ type ContainerStats struct {
 	MemUsage      uint64
 	MemLimit      uint64
 	MemPerc       float64
-	NetInput      uint64
-	NetOutput     uint64
-	BlockInput    uint64
-	BlockOutput   uint64
-	PIDs          uint64
-	UpTime        time.Duration
-	Duration      uint64
+	// Map of interface name to network statistics for that interface.
+	Network     map[string]ContainerNetworkStats
+	BlockInput  uint64
+	BlockOutput uint64
+	PIDs        uint64
+	UpTime      time.Duration
+	Duration    uint64
+}
+
+// Statistics for an individual container network interface
+type ContainerNetworkStats struct {
+	RxBytes   uint64
+	RxDropped uint64
+	RxErrors  uint64
+	RxPackets uint64
+	TxBytes   uint64
+	TxDropped uint64
+	TxErrors  uint64
+	TxPackets uint64
 }

--- a/libpod/stats_common.go
+++ b/libpod/stats_common.go
@@ -41,6 +41,12 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 		}
 	}
 
+	netStats, err := getContainerNetIO(c)
+	if err != nil {
+		return nil, err
+	}
+	stats.Network = netStats
+
 	if err := c.getPlatformContainerStats(stats, previousStats); err != nil {
 		return nil, err
 	}

--- a/libpod/stats_freebsd.go
+++ b/libpod/stats_freebsd.go
@@ -80,20 +80,6 @@ func (c *Container) getPlatformContainerStats(stats *define.ContainerStats, prev
 	stats.MemLimit = c.getMemLimit()
 	stats.SystemNano = now
 
-	netStats, err := getContainerNetIO(c)
-	if err != nil {
-		return err
-	}
-
-	// Handle case where the container is not in a network namespace
-	if netStats != nil {
-		stats.NetInput = netStats.RxBytes
-		stats.NetOutput = netStats.TxBytes
-	} else {
-		stats.NetInput = 0
-		stats.NetOutput = 0
-	}
-
 	return nil
 }
 

--- a/libpod/stats_linux.go
+++ b/libpod/stats_linux.go
@@ -39,10 +39,6 @@ func (c *Container) getPlatformContainerStats(stats *define.ContainerStats, prev
 		return fmt.Errorf("unable to obtain cgroup stats: %w", err)
 	}
 	conState := c.state.State
-	netStats, err := getContainerNetIO(c)
-	if err != nil {
-		return err
-	}
 
 	// If the current total usage in the cgroup is less than what was previously
 	// recorded then it means the container was restarted and runs in a new cgroup
@@ -69,14 +65,6 @@ func (c *Container) getPlatformContainerStats(stats *define.ContainerStats, prev
 	stats.CPUSystemNano = cgroupStats.CpuStats.CpuUsage.UsageInKernelmode
 	stats.SystemNano = now
 	stats.PerCPU = cgroupStats.CpuStats.CpuUsage.PercpuUsage
-	// Handle case where the container is not in a network namespace
-	if netStats != nil {
-		stats.NetInput = netStats.RxBytes
-		stats.NetOutput = netStats.TxBytes
-	} else {
-		stats.NetInput = 0
-		stats.NetOutput = 0
-	}
 
 	return nil
 }

--- a/pkg/api/handlers/compat/containers_stats_linux.go
+++ b/pkg/api/handlers/compat/containers_stats_linux.go
@@ -119,23 +119,20 @@ streamLabel: // A label to flatten the scope
 			return
 		}
 
-		// FIXME: network inspection does not yet work entirely
 		net := make(map[string]docker.NetworkStats)
-		networkName := inspect.NetworkSettings.EndpointID
-		if networkName == "" {
-			networkName = "network"
-		}
-		net[networkName] = docker.NetworkStats{
-			RxBytes:    stats.NetInput,
-			RxPackets:  0,
-			RxErrors:   0,
-			RxDropped:  0,
-			TxBytes:    stats.NetOutput,
-			TxPackets:  0,
-			TxErrors:   0,
-			TxDropped:  0,
-			EndpointID: inspect.NetworkSettings.EndpointID,
-			InstanceID: "",
+		for netName, netStats := range stats.Network {
+			net[netName] = docker.NetworkStats{
+				RxBytes:    netStats.RxBytes,
+				RxPackets:  netStats.RxPackets,
+				RxErrors:   netStats.RxErrors,
+				RxDropped:  netStats.RxDropped,
+				TxBytes:    netStats.TxBytes,
+				TxPackets:  netStats.TxPackets,
+				TxErrors:   netStats.TxErrors,
+				TxDropped:  netStats.TxDropped,
+				EndpointID: inspect.NetworkSettings.EndpointID,
+				InstanceID: "",
+			}
 		}
 
 		resources := ctnr.LinuxResources()

--- a/pkg/domain/infra/abi/pods_stats.go
+++ b/pkg/domain/infra/abi/pods_stats.go
@@ -44,12 +44,19 @@ func (ic *ContainerEngine) podsToStatsReport(pods []*libpod.Pod) ([]*entities.Po
 		}
 		podID := pods[i].ID()[:12]
 		for j := range podStats {
+			var podNetInput uint64
+			var podNetOutput uint64
+			for _, stats := range podStats[j].Network {
+				podNetInput += stats.RxBytes
+				podNetOutput += stats.TxBytes
+			}
+
 			r := entities.PodStatsReport{
 				CPU:           floatToPercentString(podStats[j].CPU),
 				MemUsage:      combineHumanValues(podStats[j].MemUsage, podStats[j].MemLimit),
 				MemUsageBytes: combineBytesValues(podStats[j].MemUsage, podStats[j].MemLimit),
 				Mem:           floatToPercentString(podStats[j].MemPerc),
-				NetIO:         combineHumanValues(podStats[j].NetInput, podStats[j].NetOutput),
+				NetIO:         combineHumanValues(podNetInput, podNetOutput),
 				BlockIO:       combineHumanValues(podStats[j].BlockInput, podStats[j].BlockOutput),
 				PIDS:          pidsToString(podStats[j].PIDs),
 				CID:           podStats[j].ContainerID[:12],

--- a/test/apiv2/19-stats.at
+++ b/test/apiv2/19-stats.at
@@ -9,3 +9,21 @@ if root; then
     # regression for https://github.com/containers/podman/issues/15754
     t GET libpod/containers/container1/stats?stream=false 200 .cpu_stats.online_cpus=1
 fi
+
+podman run -dt --name testctr1 $IMAGE top &>/dev/null
+
+t GET libpod/containers/testctr1/stats?stream=false 200 '.networks | length'=1
+
+podman rm -f testctr1
+
+podman network create testnet1
+podman network create testnet2
+
+podman run -dt --name testctr2 --net testnet1,testnet2 $IMAGE top &>/dev/null
+
+t GET libpod/containers/testctr2/stats?stream=false 200 '.networks | length'=2
+
+podman rm -f testctr2
+
+podman network rm testnet1
+podman network rm testnet2


### PR DESCRIPTION
    This mirrors how the Docker API handles things, allowing us to be
    more compatible with Docker and more verbose on the Libpod API.
    Stats are given as per network interface in the container, but
    still aggregated for `podman stats` and `podman pod stats`
    display (so the CLI does not change, only the Libpod and Compat
    APIs).


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
BREAKING: API: Container network statistics are now per-interface, and not aggregated. CLI is not affected.
```
