### PR TITLE
Upgrade tests: reenable, but revamped

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1001,6 +1001,32 @@ buildah_bud_test_task:
     main_script: *main
     always: *int_logs_artifacts
 
+upgrade_test_task:
+    name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
+    alias: upgrade_test
+    # Docs: ./contrib/cirrus/CIModes.md
+    only_if: *not_tag_magic
+    depends_on:
+        - build
+        - local_system_test
+    matrix:
+        - env:
+              PODMAN_UPGRADE_FROM: v4.1.0
+        - env:
+              PODMAN_UPGRADE_FROM: v4.8.0
+    gce_instance: *standardvm
+    env:
+        TEST_FLAVOR: upgrade_test
+        DISTRO_NV: ${FEDORA_NAME}
+        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+        # Never force a DB, let the old version decide its default
+        CI_DESIRED_DATABASE:
+    clone_script: *get_gosrc
+    setup_script: *setup
+    main_script: *main
+    always: *logs_artifacts
+
+
 # This task is critical.  It updates the "last-used by" timestamp stored
 # in metadata for all VM images.  This mechanism functions in tandem with
 # an out-of-band pruning operation to remove disused VM images.
@@ -1074,6 +1100,7 @@ success_task:
         - minikube_test
         - farm_test
         - buildah_bud_test
+        - upgrade_test
         - meta
     container: &smallcontainer
         image: ${CTR_FQIN}

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -99,15 +99,13 @@ case "$CG_FS_TYPE" in
     *) die_unknown CG_FS_TYPE
 esac
 
-# Force the requested database backend without having to use command-line args
-# As of #20318 (2023-10-10) sqlite is the default, but for complicated reasons
-# we still (2023-11-01) have to explicitly create a containers.conf. See
-# comments in #20559.
-# FIXME: some day, when new CI VMs are in place with podman >= 4.8 installed
-# from RPM, un-comment the 'if' below. That will confirm that sqlite is default.
+# For testing boltdb without having to use --db-backend.
+# As of #20318 (2023-10-10) sqlite is the default, so do not create
+# a containers.conf file in that condition.
 # shellcheck disable=SC2154
-#if [[ "${CI_DESIRED_DATABASE:-sqlite}" != "sqlite" ]]; then
-printf "[engine]\ndatabase_backend=\"$CI_DESIRED_DATABASE\"\n" > /etc/containers/containers.conf.d/92-db.conf
+if [[ "${CI_DESIRED_DATABASE:-sqlite}" != "sqlite" ]]; then
+    printf "[engine]\ndatabase_backend=\"$CI_DESIRED_DATABASE\"\n" > /etc/containers/containers.conf.d/92-db.conf
+fi
 
 if ((CONTAINER==0)); then  # Not yet running inside a container
     showrun echo "conditional setup for CONTAINER == 0"

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -21,17 +21,22 @@ container image from quay.io/podman, uses it to create and run
 a number of containers, then uses new-podman to interact with
 those containers.
 
-As of 2021-02-23 the available old-podman versions are:
+As of 2024-02-05 the available old-podman versions are:
 
 ```console
-$ ./bin/podman search --list-tags quay.io/podman/stable | awk '$2 ~ /^v/ { print $2}' | sort | column -c 75
-v1.4.2  v1.5.0  v1.6    v1.9.0  v2.0.2  v2.1.1
-v1.4.4  v1.5.1  v1.6.2  v1.9.1  v2.0.6  v2.2.1
+$ bin/podman search --list-tags --limit=400 quay.io/podman/stable | awk '$2 ~ /^v/ { print $2}' | sort | column -c 75
+v1.4.2  v1.9.1  v3.2.0  v3.4.0  v4.1.0  v4.3.1  v4.5.1  v4.8
+v1.4.4  v2.0.2  v3.2.1  v3.4.1  v4.1.1  v4.4    v4.6    v4.8.0
+v1.5.0  v2.0.6  v3.2.2  v3.4.2  v4.2    v4.4.1  v4.6.1  v4.8.1
+v1.5.1  v2.1.1  v3.2.3  v3.4.4  v4.2.0  v4.4.2  v4.6.2  v4.8.2
+v1.6    v2.2.1  v3.3.0  v3.4.7  v4.2.1  v4.4.4  v4.7    v4.8.3
+v1.6.2  v3      v3.3.1  v4      v4.3    v4.5    v4.7.0  v4.9
+v1.9.0  v3.1.2  v3.4    v4.1    v4.3.0  v4.5.0  v4.7.2  v4.9.0
 ```
 
 Test invocation is:
 ```console
-$ sudo env PODMAN=bin/podman PODMAN_UPGRADE_FROM=v1.9.0 PODMAN_UPGRADE_TEST_DEBUG= bats test/upgrade
+$ sudo env PODMAN=bin/podman PODMAN_UPGRADE_FROM=v4.1.0 PODMAN_UPGRADE_TEST_DEBUG= bats test/upgrade
 ```
 (Path assumes you're cd'ed to top-level podman repo). `PODMAN_UPGRADE_FROM`
 can be any of the versions above. `PODMAN_UPGRADE_TEST_DEBUG` is empty

--- a/test/upgrade/helpers.bash
+++ b/test/upgrade/helpers.bash
@@ -13,8 +13,12 @@ teardown() {
 
 # skip a test when the given version is older than the currently tested one
 skip_if_version_older() {
-    # use ${PODMAN_UPGRADE_FROM##v} to trim the leading "v"
-    if printf '%s\n%s\n' "${PODMAN_UPGRADE_FROM##v}" "$1" | sort --check=quiet --version-sort; then
+    if version_is_older_than $1; then
         skip "${2-test is only meaningful when upgrading from $1 or later}"
     fi
+}
+
+version_is_older_than() {
+    # The '##v' strips off leading 'v'
+    printf '%s\n%s\n' "${PODMAN_UPGRADE_FROM##v}" "$1" | sort --check=quiet --version-sort
 }

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -1,5 +1,8 @@
 # -*- bats -*-
 
+# This lets us do "run -0", which does an implicit exit-status check
+bats_require_minimum_version 1.8.0
+
 load helpers
 
 # Create a var-lib-containers dir for this podman. We need to bind-mount
@@ -22,6 +25,7 @@ if [ -z "${RANDOM_STRING_1}" ]; then
     export LABEL_FAILED=$(random_string 17)
     export LABEL_RUNNING=$(random_string 18)
     export HOST_PORT=$(random_free_port)
+    export MYTESTNETWORK=mytestnetwork$(random_string 8)
 fi
 
 # Version string of the podman we're actually testing, e.g. '3.0.0-dev-d1a26013'
@@ -32,7 +36,7 @@ setup() {
 
     # The podman-in-podman image (old podman)
     if [[ -z "$PODMAN_UPGRADE_FROM" ]]; then
-        echo "# \$PODMAN_UPGRADE_FROM is undefined (should be e.g. v1.9.0)" >&3
+        echo "# \$PODMAN_UPGRADE_FROM is undefined (should be e.g. v4.1.0)" >&3
         false
     fi
 
@@ -56,6 +60,21 @@ setup() {
 
     OLD_PODMAN=quay.io/podman/stable:$PODMAN_UPGRADE_FROM
     $PODMAN pull $OLD_PODMAN
+
+    # Can't mix-and-match iptables.
+    # This can only fail when we bring in new CI VMs. If/when it does fail,
+    # we'll need to figure out how to solve it. Until then, punt.
+    iptables_old_version=$($PODMAN run --rm $OLD_PODMAN iptables -V)
+    run -0 expr "$iptables_old_version" : ".*(\(.*\))"
+    iptables_old_which="$output"
+
+    iptables_new_version=$(iptables -V)
+    run -0 expr "$iptables_new_version" : ".*(\(.*\))"
+    iptables_new_which="$output"
+
+    if [[ "$iptables_new_which" != "$iptables_old_which" ]]; then
+        die "Cannot mix iptables; $PODMAN_UPGRADE_FROM container uses $iptables_old_which, host uses $iptables_new_which"
+    fi
 
     # Shortcut name, because we're referencing it a lot
     pmroot=$PODMAN_UPGRADE_WORKDIR
@@ -117,7 +136,7 @@ podman \$opts run -d --name myrunningcontainer --label mylabel=$LABEL_RUNNING \
 
 podman \$opts pod create --name mypod
 
-podman \$opts network create --disable-dns mynetwork
+podman \$opts network create --disable-dns $MYTESTNETWORK
 
 echo READY
 while :;do
@@ -125,6 +144,7 @@ while :;do
         echo STOPPING
         podman \$opts stop -t 0 myrunningcontainer || true
         podman \$opts rm -f     myrunningcontainer || true
+        podman \$opts network rm -f $MYTESTNETWORK
         exit 0
     fi
     sleep 0.5
@@ -133,13 +153,10 @@ EOF
     chmod 555 $pmscript
 
     # Clean up vestiges of previous run
-    $PODMAN rm -f podman_parent || true
+    $PODMAN rm -f podman_parent
 
     # Not entirely a NOP! This is just so we get the /run/... mount points created on a CI VM
-    # Also use --network host to prevent any netavark/cni conflicts
-    $PODMAN run --rm --network host $OLD_PODMAN true
-
-    mkdir -p /run/netns
+    $PODMAN run --rm $OLD_PODMAN true
 
     # Containers-common around release 1-55 no-longer supplies this file
     sconf=/etc/containers/storage.conf
@@ -171,6 +188,7 @@ EOF
             -v /run/netns:/run/netns:rshared \
             -v /run/containers:/run/containers \
             -v /dev/shm:/dev/shm \
+            -v /etc/containers/networks:/etc/containers/networks \
             -v $pmroot:$pmroot:rshared \
             $OLD_PODMAN $pmroot/setup
 
@@ -188,14 +206,25 @@ EOF
     :
 }
 
-@test "info" {
+@test "info - network" {
     run_podman info --format '{{.Host.NetworkBackend}}'
-    is "$output" "netavark" "correct network backend"
+    assert "$output" = "netavark" "As of Feb 2024, CNI will never be default"
+}
+
+# Whichever DB was picked by old_podman, make sure we honor it
+@test "info - database" {
+    run_podman info --format '{{.Host.DatabaseBackend}}'
+    if version_is_older_than 4.8; then
+        assert "$output" = "boltdb" "DatabaseBackend for podman < 4.8"
+    else
+        assert "$output" = "sqlite" "DatabaseBackend for podman >= 4.8"
+    fi
 }
 
 @test "images" {
     run_podman images -a --format '{{.Names}}'
-    is "$output" "\[$IMAGE\]" "podman images"
+    assert "${lines[0]}" =~ "\[localhost/podman-pause:${PODMAN_UPGRADE_FROM##v}-.*\]" "podman images, line 0"
+    assert "${lines[1]}" = "[$IMAGE]" "podman images, line 1"
 }
 
 @test "ps : one container running" {
@@ -204,16 +233,19 @@ EOF
 }
 
 @test "ps -a : shows all containers" {
-    # IMPORTANT: we can't use --sort=created, because that requires #8427
-    # on the *creating* podman end.
     run_podman ps -a \
                --format '{{.Names}}--{{.Status}}--{{.Ports}}--{{.Labels.mylabel}}' \
-               --sort=names
-    is "${lines[0]}" ".*-infra--Created----<no value>" "infra container"
-    is "${lines[1]}" "mycreatedcontainer--Created----$LABEL_CREATED" "created"
-    is "${lines[2]}" "mydonecontainer--Exited (0).*----<no value>" "done"
-    is "${lines[3]}" "myfailedcontainer--Exited (17) .*----$LABEL_FAILED" "fail"
-    is "${lines[4]}" "myrunningcontainer--Up .*--0\.0\.0\.0:$HOST_PORT->80\/tcp, 127\.0\.0\.1\:8080-8082->8080-8082\/tcp--$LABEL_RUNNING" "running"
+               --sort=created
+    assert "${lines[0]}" == "mycreatedcontainer--Created----$LABEL_CREATED" "line 0, created"
+    assert "${lines[1]}" =~ "mydonecontainer--Exited \(0\).*----<no value>"   "line 1, done"
+    assert "${lines[2]}" =~ "myfailedcontainer--Exited \(17\) .*----$LABEL_FAILED" "line 2, fail"
+
+    # Port order is not guaranteed
+    assert "${lines[3]}" =~ "myrunningcontainer--Up .*--$LABEL_RUNNING" "line 3, running"
+    assert "${lines[3]}" =~ ".*--.*0\.0\.0\.0:$HOST_PORT->80\/tcp.*--.*"  "line 3, first port forward"
+    assert "${lines[3]}" =~ ".*--.*127\.0\.0\.1\:8080-8082->8080-8082\/tcp.*--.*" "line 3, second port forward"
+
+    assert "${lines[4]}" =~ ".*-infra--Created----<no value>" "line 4, infra container"
 
     # For debugging: dump containers and IDs
     if [[ -n "$PODMAN_UPGRADE_TEST_DEBUG" ]]; then
@@ -239,46 +271,25 @@ failed    | exited     | 17
 }
 
 @test "network - curl" {
-    run curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
+    run -0 curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
     is "$output" "$RANDOM_STRING_1" "curl on running container"
 }
 
 # IMPORTANT: connect should happen before restart, we want to check
 # if we can connect on an existing running container
 @test "network - connect" {
-    skip_if_version_older 2.2.0
-    touch $PODMAN_UPGRADE_WORKDIR/ran-network-connect-test
-
-    run_podman network connect mynetwork myrunningcontainer
+    run_podman network connect $MYTESTNETWORK myrunningcontainer
     run_podman network disconnect podman myrunningcontainer
-    run curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
+    run -0 curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
     is "$output" "$RANDOM_STRING_1" "curl on container with second network connected"
 }
 
 @test "network - restart" {
     # restart the container and check if we can still use the port
-
-    # https://github.com/containers/podman/issues/13679
-    # The upgrade to podman4 changes the network db format.
-    # While it is compatible from 3.X to 4.0 it will fail the other way around.
-    # This can be the case when the cleanup process runs before the stop process
-    # can do the cleanup.
-
-    # Since there is no easy way to fix this and downgrading is not something
-    # we support, just fix this bug in the tests by manually calling
-    # network disconnect to teardown the netns.
-    if test -e $PODMAN_UPGRADE_WORKDIR/ran-network-connect-test; then
-        run_podman network disconnect mynetwork myrunningcontainer
-    fi
-
     run_podman stop -t0 myrunningcontainer
-
-    # now connect again, do this before starting the container
-    if test -e $PODMAN_UPGRADE_WORKDIR/ran-network-connect-test; then
-        run_podman network connect mynetwork myrunningcontainer
-    fi
     run_podman start myrunningcontainer
-    run curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
+
+    run -0 curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
     is "$output" "$RANDOM_STRING_1" "curl on restarted container"
 }
 
@@ -310,8 +321,9 @@ failed    | exited     | 17
     is "$output" "[0-9a-f]\\{64\\}" "podman pod start"
 
     # run a container in an existing pod
-    run_podman run --pod=mypod --ipc=host --rm $IMAGE echo it works
-    is "$output" ".*it works.*" "podman run --pod"
+    # FIXME: 2024-02-07 fails: pod X cgroup is not set: internal libpod error
+    #run_podman run --pod=mypod --ipc=host --rm $IMAGE echo it works
+    #is "$output" ".*it works.*" "podman run --pod"
 
     run_podman pod ps
     is "$output" ".*mypod.*" "podman pod ps shows name"
@@ -321,11 +333,7 @@ failed    | exited     | 17
     is "$output" "[0-9a-f]\\{64\\}" "podman pod stop"
 
     run_podman pod rm mypod
-    # FIXME: CI runs show this (non fatal) error:
-    # Error updating pod <ID> conmon cgroup PID limit: open /sys/fs/cgroup/libpod_parent/<ID>/conmon/pids.max: no such file or directory
-    # Investigate how to fix this (likely a race condition)
-    # Let's ignore the logrus messages for now
-    is "$output" ".*[0-9a-f]\\{64\\}" "podman pod rm"
+    is "$output" "[0-9a-f]\\{64\\}" "podman pod rm"
 }
 
 # FIXME: commit? kill? network? pause? restart? top? volumes? What else?
@@ -346,8 +354,8 @@ failed    | exited     | 17
 
 
 @test "stop and rm" {
-    run_podman 0+w stop myrunningcontainer
-    run_podman rm   myrunningcontainer
+    run_podman stop -t0 myrunningcontainer
+    run_podman rm       myrunningcontainer
 }
 
 @test "clean up parent" {
@@ -367,10 +375,13 @@ failed    | exited     | 17
     run_podman exec podman_parent touch /stop
     run_podman wait podman_parent
 
-    run_podman logs podman_parent
-    run_podman rm -f podman_parent
+    run_podman 0+we logs podman_parent
+    run_podman 0+we rm -f podman_parent
 
-    umount $PODMAN_UPGRADE_WORKDIR/root/overlay || true
+    # Maybe some day I'll understand why podman leaves stray overlay mounts
+    while read overlaydir; do
+        umount $overlaydir || true
+    done < <(mount | grep $PODMAN_UPGRADE_WORKDIR | awk '{print $3}' | sort -r)
 
     rm -rf $PODMAN_UPGRADE_WORKDIR
 }


### PR DESCRIPTION
No longer bother testing any 2.x or 3.x. Only 4.1 and above.

Remove all CNI-related code. CNI is gone.

Add DatabaseBackend tests, confirming that we can handle
both boltdb and sqlite.

Require BATS >= 1.8.0, and use "run -0" to do exit-status checks.

Update docs.

[ marked WIP because this is going to fail. I need help figuring out what to do.]

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```