### PR TITLE
Enforcing mac tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -803,48 +803,48 @@ podman_machine_aarch64_task:
 
 
 podman_machine_mac_task:
-   name: *std_name_fmt
-   alias: podman_machine_mac
-   only_if: *machine_cron_not_tag_build_docs
-   depends_on:
-     - osx_alt_build
-     - local_integration_test
-     - remote_integration_test
-     - container_integration_test
-     - rootless_integration_test
-   persistent_worker: *mac_pw
-   env:
-       <<: *mac_env
-       # Consumed by podman-machine ginkgo tests
-       CONTAINERS_MACHINE_PROVIDER: "applehv"
-       # TODO: Should not require a special image, for now it does.
-       # Simply remove the line below when a mac image is GA.
-       # MACHINE_IMAGE: "https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"
-       # Values necessary to populate std_name_fmt alias
-       TEST_FLAVOR: "machine-mac"
-       DISTRO_NV: "darwin"
-       PRIV_NAME: "rootless"  # intended use-case
-   clone_script:  # artifacts from osx_alt_build_task
-       - mkdir -p $CIRRUS_WORKING_DIR
-       - cd $CIRRUS_WORKING_DIR
-       - $ARTCURL/OSX%20Cross/repo/repo.tbz
-       - tar xjf repo.tbz
-   # This host is/was shared with potentially many other CI tasks.
-   # The previous task may have been canceled or aborted.
-   prep_script: *mac_cleanup
-   setup_script: "contrib/cirrus/mac_setup.sh"
-   env_script: "contrib/cirrus/mac_env.sh"
-   # TODO: Timeout bumped b/c initial image download (~5min) and VM
-   #       resize (~2min) causes test-timeout (90s default).  Should
-   #       tests deal with this internally?
-   smoke_test_script:
-       - MACHINE_TEST_TIMEOUT=500 make localmachine FOCUS_FILE="basic_test.go"
-   test_script:
-       - make localmachine
-   # This host is/was shared with potentially many other CI tasks.
-   # Ensure nothing is left running while waiting for the next task.
-   always:
-       task_cleanup_script: *mac_cleanup
+    name: *std_name_fmt
+    alias: podman_machine_mac
+    only_if: *machine_cron_not_tag_build_docs
+    depends_on:
+      - osx_alt_build
+      - local_integration_test
+      - remote_integration_test
+      - container_integration_test
+      - rootless_integration_test
+    persistent_worker: *mac_pw
+    env:
+        <<: *mac_env
+        # Consumed by podman-machine ginkgo tests
+        CONTAINERS_MACHINE_PROVIDER: "applehv"
+        # TODO: Should not require a special image, for now it does.
+        # Simply remove the line below when a mac image is GA.
+        # MACHINE_IMAGE: "https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"
+        # Values necessary to populate std_name_fmt alias
+        TEST_FLAVOR: "machine-mac"
+        DISTRO_NV: "darwin"
+        PRIV_NAME: "rootless"  # intended use-case
+    clone_script:  # artifacts from osx_alt_build_task
+        - mkdir -p $CIRRUS_WORKING_DIR
+        - cd $CIRRUS_WORKING_DIR
+        - $ARTCURL/OSX%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+    # This host is/was shared with potentially many other CI tasks.
+    # The previous task may have been canceled or aborted.
+    prep_script: *mac_cleanup
+    setup_script: "contrib/cirrus/mac_setup.sh"
+    env_script: "contrib/cirrus/mac_env.sh"
+    # TODO: Timeout bumped b/c initial image download (~5min) and VM
+    #       resize (~2min) causes test-timeout (90s default).  Should
+    #       tests deal with this internally?
+    smoke_test_script:
+        - MACHINE_TEST_TIMEOUT=500 make localmachine FOCUS_FILE="basic_test.go"
+    test_script:
+        - make localmachine
+    # This host is/was shared with potentially many other CI tasks.
+    # Ensure nothing is left running while waiting for the next task.
+    always:
+        task_cleanup_script: *mac_cleanup
 
 # Always run subsequent to integration tests.  While parallelism is lost
 # with runtime, debugging system-test failures can be more challenging
@@ -1088,8 +1088,7 @@ success_task:
         - rootless_integration_test
         - podman_machine
         - podman_machine_aarch64
-          #- podman_machine_windows
-        # TODO: Issue #20853; Tests mostly fail then timeout after an hour.
+        #- podman_machine_windows
         - podman_machine_mac
         - local_system_test
         - local_system_test_aarch64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -779,7 +779,7 @@ podman_machine_aarch64_task:
 #    alias: podman_machine_windows
 #    # Only run for non-docs/copr PRs and non-release branch builds
 #    # and never for tags.  Docs: ./contrib/cirrus/CIModes.md
-#    only_if: *not_tag_branch_build_docs
+#    only_if: *not_tag_branch_build_docs_machine
 #    depends_on:
 #      - alt_build
 #      - build
@@ -794,57 +794,57 @@ podman_machine_aarch64_task:
 #        platform: windows
 #    env: *winenv
 #    matrix:
-#      - env:
-#          TEST_FLAVOR: "machine-wsl"
+#      #- env:
+#      #    TEST_FLAVOR: "machine-wsl"
 #      - env:
 #          TEST_FLAVOR: "machine-hyperv"
 #    clone_script: *winclone
 #    main_script: ".\\repo\\contrib\\cirrus\\win-podman-machine-main.ps1"
 
 
-#podman_machine_mac_task:
-#    name: *std_name_fmt
-#    alias: podman_machine_mac
-#    only_if: *not_tag_branch_build_docs
-#    depends_on:
-#      - osx_alt_build
-#      - local_integration_test
-#      - remote_integration_test
-#      - container_integration_test
-#      - rootless_integration_test
-#    persistent_worker: *mac_pw
-#    env:
-#        <<: *mac_env
-#        # Consumed by podman-machine ginkgo tests
-#        CONTAINERS_MACHINE_PROVIDER: "applehv"
-#        # TODO: Should not require a special image, for now it does.
-#        # Simply remove the line below when a mac image is GA.
-#        # MACHINE_IMAGE: "https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"
-#        # Values necessary to populate std_name_fmt alias
-#        TEST_FLAVOR: "machine-mac"
-#        DISTRO_NV: "darwin"
-#        PRIV_NAME: "rootless"  # intended use-case
-#    clone_script:  # artifacts from osx_alt_build_task
-#        - mkdir -p $CIRRUS_WORKING_DIR
-#        - cd $CIRRUS_WORKING_DIR
-#        - $ARTCURL/OSX%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#    # This host is/was shared with potentially many other CI tasks.
-#    # The previous task may have been canceled or aborted.
-#    prep_script: *mac_cleanup
-#    setup_script: "contrib/cirrus/mac_setup.sh"
-#    env_script: "contrib/cirrus/mac_env.sh"
-#    # TODO: Timeout bumped b/c initial image download (~5min) and VM
-#    #       resize (~2min) causes test-timeout (90s default).  Should
-#    #       tests deal with this internally?
-#    smoke_test_script:
-#        - MACHINE_TEST_TIMEOUT=500 make localmachine FOCUS_FILE="basic_test.go"
-#    test_script:
-#        - make localmachine
-#    # This host is/was shared with potentially many other CI tasks.
-#    # Ensure nothing is left running while waiting for the next task.
-#    always:
-#        task_cleanup_script: *mac_cleanup
+podman_machine_mac_task:
+   name: *std_name_fmt
+   alias: podman_machine_mac
+   only_if: *not_tag_branch_build_docs_machine
+   depends_on:
+     - osx_alt_build
+     - local_integration_test
+     - remote_integration_test
+     - container_integration_test
+     - rootless_integration_test
+   persistent_worker: *mac_pw
+   env:
+       <<: *mac_env
+       # Consumed by podman-machine ginkgo tests
+       CONTAINERS_MACHINE_PROVIDER: "applehv"
+       # TODO: Should not require a special image, for now it does.
+       # Simply remove the line below when a mac image is GA.
+       # MACHINE_IMAGE: "https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"
+       # Values necessary to populate std_name_fmt alias
+       TEST_FLAVOR: "machine-mac"
+       DISTRO_NV: "darwin"
+       PRIV_NAME: "rootless"  # intended use-case
+   clone_script:  # artifacts from osx_alt_build_task
+       - mkdir -p $CIRRUS_WORKING_DIR
+       - cd $CIRRUS_WORKING_DIR
+       - $ARTCURL/OSX%20Cross/repo/repo.tbz
+       - tar xjf repo.tbz
+   # This host is/was shared with potentially many other CI tasks.
+   # The previous task may have been canceled or aborted.
+   prep_script: *mac_cleanup
+   setup_script: "contrib/cirrus/mac_setup.sh"
+   env_script: "contrib/cirrus/mac_env.sh"
+   # TODO: Timeout bumped b/c initial image download (~5min) and VM
+   #       resize (~2min) causes test-timeout (90s default).  Should
+   #       tests deal with this internally?
+   smoke_test_script:
+       - MACHINE_TEST_TIMEOUT=500 make localmachine FOCUS_FILE="basic_test.go"
+   test_script:
+       - make localmachine
+   # This host is/was shared with potentially many other CI tasks.
+   # Ensure nothing is left running while waiting for the next task.
+   always:
+       task_cleanup_script: *mac_cleanup
 
 # Always run subsequent to integration tests.  While parallelism is lost
 # with runtime, debugging system-test failures can be more challenging
@@ -1088,9 +1088,9 @@ success_task:
         - rootless_integration_test
         - podman_machine
         - podman_machine_aarch64
-        #- podman_machine_windows
+          #- podman_machine_windows
         # TODO: Issue #20853; Tests mostly fail then timeout after an hour.
-        # - podman_machine_mac
+        - podman_machine_mac
         - local_system_test
         - local_system_test_aarch64
         - remote_system_test
@@ -1122,84 +1122,84 @@ success_task:
 # WARNING: Most of the artifacts captured here are also have their
 # permalinks present in the `DOWNLOADS.md` file.  Any changes made
 # here, should probably be reflected in that document.
-#artifacts_task:
-#    name: "Artifacts"
-#    alias: artifacts
-#    # Docs: ./contrib/cirrus/CIModes.md
-#    only_if: >-
-#        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-#        $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
-#        $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
-#    depends_on:
-#        - success
-#    # This task is a secondary/convenience for downstream consumers, don't
-#    # block development progress if there is a failure in a PR, only break
-#    # when running on branches or tags.
-#    allow_failures: $CIRRUS_PR != ''
-#    container: *smallcontainer
-#    env:
-#        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-#        TEST_ENVIRON: container
-#    # In order to keep the download URL and Cirrus-CI artifact.zip contents
-#    # simple, nothing should exist in $CIRRUS_WORKING_DIR except for artifacts.
-#    clone_script: *noop
-#    fedora_binaries_script:
-#        - mkdir -p /tmp/fed
-#        - cd /tmp/fed
-#        - $ARTCURL/Build%20for%20${FEDORA_NAME}/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - cp ./bin/* $CIRRUS_WORKING_DIR/
-#    alt_binaries_intel_script:
-#        - mkdir -p /tmp/alt
-#        - cd /tmp/alt
-#        - $ARTCURL/Alt%20Arch.%20x86%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
-#    alt_binaries_arm_script:
-#        - mkdir -p /tmp/alt
-#        - cd /tmp/alt
-#        - $ARTCURL/Alt%20Arch.%20ARM%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
-#    alt_binaries_mips_script:
-#        - mkdir -p /tmp/alt
-#        - cd /tmp/alt
-#        - $ARTCURL/Alt%20Arch.%20MIPS%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
-#    alt_binaries_mips64_script:
-#        - mkdir -p /tmp/alt
-#        - cd /tmp/alt
-#        - $ARTCURL/Alt%20Arch.%20MIPS64%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
-#    alt_binaries_other_script:
-#        - mkdir -p /tmp/alt
-#        - cd /tmp/alt
-#        - $ARTCURL/Alt%20Arch.%20Other%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
-#    win_binaries_script:
-#        - mkdir -p /tmp/win
-#        - cd /tmp/win
-#        - $ARTCURL/Windows%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./podman-remote*.zip $CIRRUS_WORKING_DIR/
-#    osx_binaries_script:
-#        - mkdir -p /tmp/osx
-#        - cd /tmp/osx
-#        - $ARTCURL/OSX%20Cross/repo/repo.tbz
-#        - tar xjf repo.tbz
-#        - mv ./podman-remote-release-darwin_*.zip $CIRRUS_WORKING_DIR/
-#        - mv ./contrib/pkginstaller/out/podman-installer-macos-*.pkg $CIRRUS_WORKING_DIR/
-#    always:
-#      contents_script: ls -la $CIRRUS_WORKING_DIR
-#      # Produce downloadable files and an automatic zip-file accessible
-#      # by a consistent URL, based on contents of $CIRRUS_WORKING_DIR
-#      # Ref: https://cirrus-ci.org/guide/writing-tasks/#latest-build-artifacts
-#      binary_artifacts:
-#          path: ./*
-#          type: application/octet-stream
+artifacts_task:
+    name: "Artifacts"
+    alias: artifacts
+    # Docs: ./contrib/cirrus/CIModes.md
+    only_if: >-
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
+        $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
+    depends_on:
+        - success
+    # This task is a secondary/convenience for downstream consumers, don't
+    # block development progress if there is a failure in a PR, only break
+    # when running on branches or tags.
+    allow_failures: $CIRRUS_PR != ''
+    container: *smallcontainer
+    env:
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        TEST_ENVIRON: container
+    # In order to keep the download URL and Cirrus-CI artifact.zip contents
+    # simple, nothing should exist in $CIRRUS_WORKING_DIR except for artifacts.
+    clone_script: *noop
+    fedora_binaries_script:
+        - mkdir -p /tmp/fed
+        - cd /tmp/fed
+        - $ARTCURL/Build%20for%20${FEDORA_NAME}/repo/repo.tbz
+        - tar xjf repo.tbz
+        - cp ./bin/* $CIRRUS_WORKING_DIR/
+    alt_binaries_intel_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20x86%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_arm_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20ARM%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_mips_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20MIPS%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_mips64_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20MIPS64%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    alt_binaries_other_script:
+        - mkdir -p /tmp/alt
+        - cd /tmp/alt
+        - $ARTCURL/Alt%20Arch.%20Other%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./*.tar.gz $CIRRUS_WORKING_DIR/
+    win_binaries_script:
+        - mkdir -p /tmp/win
+        - cd /tmp/win
+        - $ARTCURL/Windows%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./podman-remote*.zip $CIRRUS_WORKING_DIR/
+    osx_binaries_script:
+        - mkdir -p /tmp/osx
+        - cd /tmp/osx
+        - $ARTCURL/OSX%20Cross/repo/repo.tbz
+        - tar xjf repo.tbz
+        - mv ./podman-remote-release-darwin_*.zip $CIRRUS_WORKING_DIR/
+        - mv ./contrib/pkginstaller/out/podman-installer-macos-*.pkg $CIRRUS_WORKING_DIR/
+    always:
+      contents_script: ls -la $CIRRUS_WORKING_DIR
+      # Produce downloadable files and an automatic zip-file accessible
+      # by a consistent URL, based on contents of $CIRRUS_WORKING_DIR
+      # Ref: https://cirrus-ci.org/guide/writing-tasks/#latest-build-artifacts
+      binary_artifacts:
+          path: ./*
+          type: application/octet-stream
 
 
 # When a new tag is pushed, confirm that the code and commits

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -779,7 +779,7 @@ podman_machine_aarch64_task:
 #    alias: podman_machine_windows
 #    # Only run for non-docs/copr PRs and non-release branch builds
 #    # and never for tags.  Docs: ./contrib/cirrus/CIModes.md
-#    only_if: *not_tag_branch_build_docs_machine
+#    only_if: *machine_cron_not_tag_build_docs
 #    depends_on:
 #      - alt_build
 #      - build
@@ -805,7 +805,7 @@ podman_machine_aarch64_task:
 podman_machine_mac_task:
    name: *std_name_fmt
    alias: podman_machine_mac
-   only_if: *not_tag_branch_build_docs_machine
+   only_if: *machine_cron_not_tag_build_docs
    depends_on:
      - osx_alt_build
      - local_integration_test

--- a/contrib/cirrus/cirrus_yaml_test.py
+++ b/contrib/cirrus/cirrus_yaml_test.py
@@ -27,7 +27,7 @@ class TestDependsOn(TestCaseBase):
 
     ALL_TASK_NAMES = None
     SUCCESS_DEPS_EXCLUDE = set(['success', 'bench_stuff', 'artifacts',
-        'release', 'release_test', 'podman_machine_mac'])
+        'release', 'release_test'])
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
***Depends on https://github.com/containers/podman/pull/21551***

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
