### PR TITLE
Vendor c/common pasta branch for testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.0.0
 	github.com/containernetworking/plugins v1.4.0
 	github.com/containers/buildah v1.34.1-0.20240201124221-b850c711ff5c
-	github.com/containers/common v0.57.1-0.20240229151045-1c65e0de241a
+	github.com/containers/common v0.57.1-0.20240229165734-cec09922602e
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.3
 	github.com/containers/image/v5 v5.29.3-0.20240227090231-5bef5e1e1506

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/containernetworking/plugins v1.4.0 h1:+w22VPYgk7nQHw7KT92lsRmuToHvb7w
 github.com/containernetworking/plugins v1.4.0/go.mod h1:UYhcOyjefnrQvKvmmyEKsUA+M9Nfn7tqULPpH0Pkcj0=
 github.com/containers/buildah v1.34.1-0.20240201124221-b850c711ff5c h1:r+1vFyTAoXptJrsPsnOMI3G0jm4+BCfXAcIyuA33lzo=
 github.com/containers/buildah v1.34.1-0.20240201124221-b850c711ff5c/go.mod h1:Hw4qo2URFpWvZ2tjLstoQMpNC6+gR4PtxQefvV/UKaA=
-github.com/containers/common v0.57.1-0.20240229151045-1c65e0de241a h1:N/AOv7bQBTD/+inld7Qpc2WzxtpbsPgPDB/gg7JGQKA=
-github.com/containers/common v0.57.1-0.20240229151045-1c65e0de241a/go.mod h1:8irlyBcVooYx0F+YmoY7PQPAIgdJvCj17bvL7PqeaxI=
+github.com/containers/common v0.57.1-0.20240229165734-cec09922602e h1:TPgCd6bWFyliJxCXEiCI1LnbB3kBUkpx1dw51ngDjWI=
+github.com/containers/common v0.57.1-0.20240229165734-cec09922602e/go.mod h1:8irlyBcVooYx0F+YmoY7PQPAIgdJvCj17bvL7PqeaxI=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.3 h1:yORnf15sP+sLFhxLNLgmB5/lOhldn9dRMHx/tmYtSOQ=

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -41,6 +41,8 @@ type Event struct {
 	Type Type
 	// Health status of the current container
 	HealthStatus string `json:"health_status,omitempty"`
+	// Error code for certain events involving errors.
+	Error error `json:"error,omitempty"`
 
 	Details
 }
@@ -170,6 +172,8 @@ const (
 	Prune Status = "prune"
 	// Pull ...
 	Pull Status = "pull"
+	// PullError is an error pulling an image
+	PullError Status = "pull-error"
 	// Push ...
 	Push Status = "push"
 	// Refresh indicates that the system refreshed the state after a

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -194,6 +194,8 @@ func StringToStatus(name string) (Status, error) {
 		return Prune, nil
 	case Pull.String():
 		return Pull, nil
+	case PullError.String():
+		return PullError, nil
 	case Push.String():
 		return Push, nil
 	case Refresh.String():

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -43,6 +43,9 @@ func (e EventJournalD) Write(ee Event) error {
 	case Image:
 		m["PODMAN_NAME"] = ee.Name
 		m["PODMAN_ID"] = ee.ID
+		if ee.Error != nil {
+			m["ERROR"] = ee.Error.Error()
+		}
 	case Container, Pod:
 		m["PODMAN_IMAGE"] = ee.Image
 		m["PODMAN_NAME"] = ee.Name
@@ -228,6 +231,9 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 		newEvent.Network = entry.Fields["PODMAN_NETWORK_NAME"]
 	case Image:
 		newEvent.ID = entry.Fields["PODMAN_ID"]
+		if _, ok := entry.Fields["ERROR"]; ok {
+			newEvent.Error = errors.New(entry.Fields["ERROR"])
+		}
 	}
 	return &newEvent, nil
 }

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -696,15 +696,16 @@ func (r *Runtime) GetConfig() (*config.Config, error) {
 
 // libimageEventsMap translates a libimage event type to a libpod event status.
 var libimageEventsMap = map[libimage.EventType]events.Status{
-	libimage.EventTypeImagePull:    events.Pull,
-	libimage.EventTypeImagePush:    events.Push,
-	libimage.EventTypeImageRemove:  events.Remove,
-	libimage.EventTypeImageLoad:    events.LoadFromArchive,
-	libimage.EventTypeImageSave:    events.Save,
-	libimage.EventTypeImageTag:     events.Tag,
-	libimage.EventTypeImageUntag:   events.Untag,
-	libimage.EventTypeImageMount:   events.Mount,
-	libimage.EventTypeImageUnmount: events.Unmount,
+	libimage.EventTypeImagePull:      events.Pull,
+	libimage.EventTypeImagePullError: events.PullError,
+	libimage.EventTypeImagePush:      events.Push,
+	libimage.EventTypeImageRemove:    events.Remove,
+	libimage.EventTypeImageLoad:      events.LoadFromArchive,
+	libimage.EventTypeImageSave:      events.Save,
+	libimage.EventTypeImageTag:       events.Tag,
+	libimage.EventTypeImageUntag:     events.Untag,
+	libimage.EventTypeImageMount:     events.Mount,
+	libimage.EventTypeImageUnmount:   events.Unmount,
 }
 
 // libimageEvents spawns a goroutine which will listen for events on

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -69,7 +69,7 @@ t GET libpod/containers/json?all=true 200 \
   .[0].IsInfra=false
 
 # Test compat API for Network Settings (.Network is N/A when rootless)
-network_expect="Networks.slirp4netns.NetworkID=slirp4netns"
+network_expect="Networks.pasta.NetworkID=pasta"
 if root; then
     network_expect="Networks.podman.NetworkID=podman"
 fi

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -9,14 +9,6 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-// podman unshare --rootless-netns leaks the process by design.
-// Running a container will cause the cleanup to kick in when this container gets stopped.
-func cleanupRootlessSlirp4netns(p *PodmanTestIntegration) {
-	session := p.Podman([]string{"run", "--network", "bridge", ALPINE, "true"})
-	session.WaitWithDefaultTimeout()
-	Expect(session).Should(ExitCleanly())
-}
-
 var _ = Describe("Podman unshare", func() {
 	BeforeEach(func() {
 		if _, err := os.Stat("/proc/self/uid_map"); err != nil {
@@ -35,15 +27,6 @@ var _ = Describe("Podman unshare", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).ToNot(ContainSubstring(userNS))
-	})
-
-	It("podman unshare --rootless-netns", func() {
-		SkipIfRemote("podman-remote unshare is not supported")
-		defer cleanupRootlessSlirp4netns(podmanTest)
-		session := podmanTest.Podman([]string{"unshare", "--rootless-netns", "ip", "addr"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(ContainSubstring("tap0"))
 	})
 
 	It("podman unshare exit codes", func() {

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -5,6 +5,7 @@
 
 load helpers
 load helpers.systemd
+load helpers.network
 
 SERVICE_NAME="podman_test_$(random_string)"
 
@@ -294,7 +295,7 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
 }
 
 # https://github.com/containers/podman/issues/13153
-@test "podman rootless-netns slirp4netns process should be in different cgroup" {
+@test "podman rootless-netns pasta processes should be in different cgroup" {
     is_rootless || skip "only meaningful for rootless"
 
     cname=$(random_string)
@@ -314,9 +315,11 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     # stop systemd container
     service_cleanup
 
+    pasta_iface=$(default_ifname)
+
     # now check that the rootless netns slirp4netns process is still alive and working
     run_podman unshare --rootless-netns ip addr
-    is "$output" ".*tap0.*" "slirp4netns interface exists in the netns"
+    is "$output" ".*$pasta_iface.*" "pasta interface exists in the netns"
     run_podman exec $cname2 nslookup google.com
 
     run_podman rm -f -t0 $cname2

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -144,6 +144,8 @@ function remove_secret() {
 }
 
 @test "quadlet - basic" {
+    # Network=none is to work around a Pasta bug, can be removed once a patched Pasta is available.
+    # Ref https://github.com/containers/podman/pull/21563#issuecomment-1965145324
     local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
     cat > $quadlet_file <<EOF
 [Container]
@@ -151,6 +153,7 @@ Image=$IMAGE
 Exec=sh -c "echo STARTED CONTAINER; echo "READY=1" | socat -u STDIN unix-sendto:\$NOTIFY_SOCKET; sleep inf"
 Notify=yes
 LogDriver=passthrough
+Network=none
 EOF
 
     # FIXME: Temporary until podman fully removes cgroupsv1 support; see #21431

--- a/test/system/270-socket-activation.bats
+++ b/test/system/270-socket-activation.bats
@@ -4,7 +4,16 @@
 #
 
 load helpers
+load helpers.registry
 load helpers.systemd
+
+function setup_file() {
+    # We have to stop the background registry here. These tests kill the podman pause
+    # process which means commands after that are in a new one and when the cleanup
+    # later tries to stop the registry container it will be in the wrong ns and can fail.
+    # https://github.com/containers/podman/pull/21563#issuecomment-1960047648
+    stop_registry
+}
 
 SERVICE_NAME="podman_test_$(random_string)"
 

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -857,7 +857,7 @@ EOF
     cid=${output}
     run_podman inspect --format '{{ .NetworkSettings.Networks }}' $cid
     if is_rootless; then
-        is "$output" "map\[slirp4netns:.*" "NeworkSettings should contain one network named slirp4netns"
+        is "$output" "map\[pasta:.*" "NeworkSettings should contain one network named pasta"
     else
         is "$output" "map\[podman:.*" "NeworkSettings should contain one network named podman"
     fi

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -18,21 +18,6 @@ function setup() {
     XFER_FILE="${PODMAN_TMPDIR}/pasta.bin"
 }
 
-function default_ifname() {
-    local ip_ver="${1}"
-
-    local expr='[.[] | select(.dst == "default").dev] | .[0]'
-    ip -j -"${ip_ver}" route show | jq -rM "${expr}"
-}
-
-function default_addr() {
-    local ip_ver="${1}"
-    local ifname="${2:-$(default_ifname "${ip_ver}")}"
-
-    local expr='.[0] | .addr_info[0].local'
-    ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}"
-}
-
 # _set_opt() - meta-helper for pasta_test_do.
 #
 # Sets an option, but panics if option is already set (e.g. UDP+TCP, IPv4/v6)
@@ -788,4 +773,15 @@ EOF
     mac2="aa:bb:cc:dd:ee:ff"
     CONTAINERS_CONF_OVERRIDE=$containersconf run_podman run --net=pasta:--ns-mac-addr,"$mac2" $IMAGE ip link show myname
     assert "$output" =~ "$mac2" "mac address from cli is set on custom interface"
+}
+
+### Rootless unshare testins
+
+@test "Podman unshare --rootless-netns with Pasta" {
+    skip_if_remote "unshare is local-only"
+
+    pasta_iface=$(default_ifname)
+
+    run_podman unshare --rootless-netns ip addr
+    is "$output" ".*${pasta_iface}.*"
 }

--- a/test/system/550-pause-process.bats
+++ b/test/system/550-pause-process.bats
@@ -4,7 +4,16 @@
 #
 
 load helpers
+load helpers.registry
 load helpers.sig-proxy
+
+function setup_file() {
+    # We have to stop the background registry here. These tests kill the podman pause
+    # process which means commands after that are in a new one and when the cleanup
+    # later tries to stop the registry container it will be in the wrong ns and can fail.
+    # https://github.com/containers/podman/pull/21563#issuecomment-1960047648
+    stop_registry
+}
 
 function _check_pause_process() {
     pause_pid=

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -369,3 +369,20 @@ function tcp_port_probe() {
 
     : | nc "${address}" "${1}"
 }
+
+### Pasta Helpers ##############################################################
+
+function default_ifname() {
+    local ip_ver="${1}"
+
+    local expr='[.[] | select(.dst == "default").dev] | .[0]'
+    ip -j -"${ip_ver}" route show | jq -rM "${expr}"
+}
+
+function default_addr() {
+    local ip_ver="${1}"
+    local ifname="${2:-$(default_ifname "${ip_ver}")}"
+
+    local expr='.[0] | .addr_info[0].local'
+    ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}"
+}

--- a/vendor/github.com/containers/common/libimage/events.go
+++ b/vendor/github.com/containers/common/libimage/events.go
@@ -18,6 +18,8 @@ const (
 	EventTypeUnknown EventType = iota
 	// EventTypeImagePull represents an image pull.
 	EventTypeImagePull
+	// EventTypeImagePullError represents an image pull failed.
+	EventTypeImagePullError
 	// EventTypeImagePush represents an image push.
 	EventTypeImagePush
 	// EventTypeImageRemove represents an image removal.
@@ -46,6 +48,8 @@ type Event struct {
 	Time time.Time
 	// Type of the event.
 	Type EventType
+	// Error in case of failure.
+	Error error
 }
 
 // writeEvent writes the specified event to the Runtime's event channel.  The

--- a/vendor/github.com/containers/common/libimage/pull.go
+++ b/vendor/github.com/containers/common/libimage/pull.go
@@ -53,9 +53,16 @@ type PullOptions struct {
 // The error is storage.ErrImageUnknown iff the pull policy is set to "never"
 // and no local image has been found.  This allows for an easier integration
 // into some users of this package (e.g., Buildah).
-func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullPolicy, options *PullOptions) ([]*Image, error) {
+func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullPolicy, options *PullOptions) (_ []*Image, pullError error) {
 	logrus.Debugf("Pulling image %s (policy: %s)", name, pullPolicy)
-
+	if r.eventChannel != nil {
+		defer func() {
+			if pullError != nil {
+				// Note that we use the input name here to preserve the transport data.
+				r.writeEvent(&Event{Name: name, Time: time.Now(), Type: EventTypeImagePullError, Error: pullError})
+			}
+		}()
+	}
 	if options == nil {
 		options = &PullOptions{}
 	}
@@ -150,28 +157,25 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		options.Variant = r.systemContext.VariantChoice
 	}
 
-	var (
-		pulledImages []string
-		pullError    error
-	)
+	var pulledImages []string
 
 	// Dispatch the copy operation.
 	switch ref.Transport().Name() {
 	// DOCKER REGISTRY
 	case registryTransport.Transport.Name():
-		pulledImages, pullError = r.copyFromRegistry(ctx, ref, possiblyUnqualifiedName, pullPolicy, options)
+		pulledImages, err = r.copyFromRegistry(ctx, ref, possiblyUnqualifiedName, pullPolicy, options)
 
 	// DOCKER ARCHIVE
 	case dockerArchiveTransport.Transport.Name():
-		pulledImages, pullError = r.copyFromDockerArchive(ctx, ref, &options.CopyOptions)
+		pulledImages, err = r.copyFromDockerArchive(ctx, ref, &options.CopyOptions)
 
 	// ALL OTHER TRANSPORTS
 	default:
-		pulledImages, pullError = r.copyFromDefault(ctx, ref, &options.CopyOptions)
+		pulledImages, err = r.copyFromDefault(ctx, ref, &options.CopyOptions)
 	}
 
-	if pullError != nil {
-		return nil, pullError
+	if err != nil {
+		return nil, err
 	}
 
 	localImages := []*Image{}

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -384,9 +384,9 @@ default_sysctls = [
 
 
 # Configure which rootless network program to use by default. Valid options are
-# `slirp4netns` (default) and `pasta`.
+# `slirp4netns` and `pasta` (default).
 #
-#default_rootless_network_cmd = "slirp4netns"
+#default_rootless_network_cmd = "pasta"
 
 # Path to the directory where network configuration files are located.
 # For the CNI backend the default is "/etc/cni/net.d" as root

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -257,7 +257,7 @@ func defaultConfig() (*Config, error) {
 			DefaultNetwork:            "podman",
 			DefaultSubnet:             DefaultSubnet,
 			DefaultSubnetPools:        DefaultSubnetPools,
-			DefaultRootlessNetworkCmd: "slirp4netns",
+			DefaultRootlessNetworkCmd: "pasta",
 			DNSBindPort:               0,
 			CNIPluginDirs:             attributedstring.NewSlice(DefaultCNIPluginDirs),
 			NetavarkPluginDirs:        attributedstring.NewSlice(DefaultNetavarkPluginDirs),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.57.1-0.20240229151045-1c65e0de241a
+# github.com/containers/common v0.57.1-0.20240229165734-cec09922602e
 ## explicit; go 1.20
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
Test swapping the default from Slirp4netns to Pasta

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Connectivity for rootless containers is now provided by Pasta by default, instead of slirp4netns
```
