### PR TITLE
[CI:DOCS] Fix Quadlet Options=key=value documentation/example

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1070,7 +1070,7 @@ Valid options for `[Network]` are listed below:
 | IPv6=true                           | --ipv6                               |
 | Label="XYZ"                         | --label "XYZ"                        |
 | NetworkName=foo                     | podman network create foo            |
-| Options=isolate                     | --opt isolate                        |
+| Options=isolate=true                | --opt isolate=true                   |
 | PodmanArgs=--dns=192.168.55.1       | --dns=192.168.55.1                   |
 | Subnet=192.5.0.0/16                 | --subnet 192.5.0.0/16                |
 


### PR DESCRIPTION
Quadlet `[Network]` does not accept `Options=key` for `podman network create --opt key`. Options have to be provided in `key=value` format, where the `=` is required even though the value may be empty.

One usage example is `Options=isolate=true`. In this case, passing `netavark` an empty `isolate` value may be a valid/parseable setting: `Options=isolate=`, equivalent to `Options=isolate=false`.

This commit documents the explicit `Options=key=value` usage. Compare to `[Network]` tests, which use `key=value`.

Usage verified locally by inspecting the generated network in `/run/user/${UID}/systemd/generator/example-network.service` and `podman network inspect systemd-example` using podman v4.9.2 and netavark v1.10.2.

See

- https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#network-units-network
- https://github.com/containers/podman/blob/v4.9.2/test/e2e/quadlet/options.network
- https://github.com/containers/podman/blob/v4.9.2/test/e2e/quadlet/options.multiple.network
- https://github.com/containers/netavark/blob/v1.10.2/src/network/bridge.rs#L824-L833

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
