### PR TITLE
Ensure HyperV 9p mounts work when a dir doesn't exist

### DIFF
--- a/cmd/podman/machine/client9p.go
+++ b/cmd/podman/machine/client9p.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v5/cmd/podman/registry"
@@ -69,8 +70,22 @@ func client9p(portNum uint32, mountPath string) error {
 
 	logrus.Infof("Going to mount 9p on vsock port %d to directory %s", portNum, mountPath)
 
-	// Host connects to non-hypervisor processes on the host running the VM.
-	conn, err := vsock.Dial(vsock.Host, portNum, nil)
+	// The server is starting at the same time.
+	// Perform up to 5 retries with a backoff.
+	var (
+		conn    *vsock.Conn
+		retries = 20
+	)
+	for i := 0; i < retries; i++ {
+		// Host connects to non-hypervisor processes on the host running the VM.
+		conn, err = vsock.Dial(vsock.Host, portNum, nil)
+		// If errors.Is worked on this error, we could detect non-timeout errors.
+		// But it doesn't. So retry 5 times regardless.
+		if err == nil {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
 	if err != nil {
 		return fmt.Errorf("dialing vsock port %d: %w", portNum, err)
 	}

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -423,7 +423,7 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo b
 
 	for _, mount := range mc.Mounts {
 		if mount.VSockNumber == nil {
-			return fmt.Errorf("mount %s has not vsock port defined", mount.Source)
+			return fmt.Errorf("mount %s has no vsock port defined", mount.Source)
 		}
 		p9ServerArgs = append(p9ServerArgs, "--serve", fmt.Sprintf("%s:%s", mount.Source, winio.VsockServiceID(uint32(*mount.VSockNumber)).String()))
 	}


### PR DESCRIPTION
Before, we required that the mount target exist and be a directory for the 9p mount to successfully complete, which is not how things are supposed to work - the user should be able to mount anywhere. This should just be a simple mkdir, but with FCOS the root directory is immutable so we need to undo that before we can mkdir, and unfortunately we don't have a library that can do chattr (and I didn't want to drag in a new dependency just for that), so let's be gross and add it to the SSH command. I aggressively dislike this but it does work.

[NO NEW TESTS NEEDED] Can worry about getting a more generic mount test together for Machine later.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where HyperV could not mount volumes to some directories.
```
