### PR TITLE
Don't panic on podman4 machine configs

### DIFF
--- a/pkg/machine/define/errors.go
+++ b/pkg/machine/define/errors.go
@@ -40,3 +40,12 @@ type ErrNewDiskSizeTooSmall struct {
 func (err *ErrNewDiskSizeTooSmall) Error() string {
 	return fmt.Sprintf("invalid disk size %d: new disk must be larger than %dGB", err.OldSize, err.NewSize)
 }
+
+type ErrIncompatibleMachineConfig struct {
+	Name string
+	Path string
+}
+
+func (err *ErrIncompatibleMachineConfig) Error() string {
+	return fmt.Sprintf("incompatible machine config %q (%s) for this version of Podman", err.Path, err.Name)
+}

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -235,18 +235,3 @@ func isVmtype(vmType define.VMType) bool {
 func isWSL() bool {
 	return isVmtype(define.WSLVirt)
 }
-
-// TODO temporarily suspended
-// func getFCOSDownloadLocation(p vmconfigs.VMStubber) string {
-// 	dd, err := p.NewDownload("")
-// 	if err != nil {
-// 		Fail("unable to create new download")
-// 	}
-//
-// 	fcd, err := dd.GetFCOSDownload(defaultStream)
-// 	if err != nil {
-// 		Fail("unable to get virtual machine image")
-// 	}
-//
-// 	return fcd.Location
-// }

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -109,6 +109,8 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) (*vmconfigs.M
 		return nil, err
 	}
 
+	mc.Version = vmconfigs.MachineConfigVersion
+
 	createOpts := machineDefine.CreateVMOpts{
 		Name: opts.Name,
 		Dirs: dirs,

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/containers/storage/pkg/lockfile"
 )
 
+const MachineConfigVersion = 1
+
 type MachineConfig struct {
 	// Common stuff
 	Created  time.Time

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -312,6 +312,16 @@ func LoadMachineByName(name string, dirs *define.MachineDirs) (*MachineConfig, e
 	}
 	mc.dirs = dirs
 	mc.configPath = fullPath
+
+	// If we find an incompatible configuration, we return a hard
+	// error because the user wants to deal directly with this
+	// machine
+	if mc.Version == 0 {
+		return mc, &define.ErrIncompatibleMachineConfig{
+			Name: name,
+			Path: fullPath.GetPath(),
+		}
+	}
 	return mc, nil
 }
 
@@ -344,6 +354,16 @@ func LoadMachinesInDir(dirs *define.MachineDirs) (map[string]*MachineConfig, err
 			mc, err := loadMachineFromFQPath(fullPath)
 			if err != nil {
 				return err
+			}
+			// if we find an incompatible machine configuration file, we emit and error
+			//
+			if mc.Version == 0 {
+				tmpErr := &define.ErrIncompatibleMachineConfig{
+					Name: mc.Name,
+					Path: fullPath.GetPath(),
+				}
+				logrus.Error(tmpErr)
+				return nil
 			}
 			mc.configPath = fullPath
 			mc.dirs = dirs


### PR DESCRIPTION
we should not panic podman when it has to deal with a podman4 machine config.  instead, we throw a soft error for `machine ls` and in all other cases, we throw a hard error stating that the machine config is incompatible.

a future PR will provide instructions on how to recover from this. current idea is something like `podman machine reset` which blows everything away machine-wise.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
