### PR TITLE
machine: USB passthrough

### DIFF
--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -79,17 +79,21 @@ func (a AppleHVStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 	return nil
 }
 
-func (a AppleHVStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, cpus, memory *uint64, newDiskSize *strongunits.GiB, newRootful *bool) error {
-	if newDiskSize != nil {
-		if err := resizeDisk(mc, *newDiskSize); err != nil {
+func (a AppleHVStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
+	if opts.DiskSize != nil {
+		if err := resizeDisk(mc, *opts.DiskSize); err != nil {
 			return err
 		}
 	}
 
-	if newRootful != nil && mc.HostUser.Rootful != *newRootful {
-		if err := mc.SetRootful(*newRootful); err != nil {
+	if opts.Rootful != nil && mc.HostUser.Rootful != *opts.Rootful {
+		if err := mc.SetRootful(*opts.Rootful); err != nil {
 			return err
 		}
+	}
+
+	if opts.USBs != nil {
+		return fmt.Errorf("changing USBs not supported for applehv machines")
 	}
 
 	// VFKit does not require saving memory, disk, or cpu

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -68,15 +68,6 @@ type ListResponse struct {
 	UserModeNetworking bool
 }
 
-type SetOptions struct {
-	CPUs               *uint64
-	DiskSize           *uint64
-	Memory             *uint64
-	Rootful            *bool
-	UserModeNetworking *bool
-	USBs               *[]string
-}
-
 type SSHOptions struct {
 	Username string
 	Args     []string
@@ -101,7 +92,7 @@ type VM interface {
 	Init(opts define.InitOptions) (bool, error)
 	Inspect() (*InspectInfo, error)
 	Remove(name string, opts RemoveOptions) (string, func() error, error)
-	Set(name string, opts SetOptions) ([]error, error)
+	Set(name string, opts define.SetOptions) ([]error, error)
 	SSH(name string, opts SSHOptions) error
 	Start(name string, opts StartOptions) error
 	State(bypass bool) (define.Status, error)

--- a/pkg/machine/define/setopts.go
+++ b/pkg/machine/define/setopts.go
@@ -1,0 +1,12 @@
+package define
+
+import "github.com/containers/common/pkg/strongunits"
+
+type SetOptions struct {
+	CPUs               *uint64
+	DiskSize           *strongunits.GiB
+	Memory             *uint64
+	Rootful            *bool
+	UserModeNetworking *bool
+	USBs               *[]string
+}

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -104,7 +104,7 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) (*vmconfigs.M
 		return nil, err
 	}
 
-	mc, err := vmconfigs.NewMachineConfig(opts, dirs, sshIdentityPath)
+	mc, err := vmconfigs.NewMachineConfig(opts, dirs, sshIdentityPath, mp.VMType())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/containers/common/pkg/strongunits"
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/ignition"
@@ -114,7 +113,7 @@ type VMProvider interface { //nolint:interfacebloat
 	MountVolumesToVM(mc *MachineConfig, quiet bool) error
 	Remove(mc *MachineConfig) ([]string, func() error, error)
 	RemoveAndCleanMachines(dirs *define.MachineDirs) error
-	SetProviderAttrs(mc *MachineConfig, cpus, memory *uint64, newDiskSize *strongunits.GiB, newRootful *bool) error
+	SetProviderAttrs(mc *MachineConfig, opts define.SetOptions) error
 	StartNetworking(mc *MachineConfig, cmd *gvproxy.GvproxyCommand) error
 	PostStartNetworking(mc *MachineConfig) error
 	StartVM(mc *MachineConfig) (func() error, func() error, error)

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1105,7 +1105,7 @@ func setupWslProxyEnv() (hasProxy bool) {
 	return
 }
 
-func (v *MachineVM) Set(_ string, opts machine.SetOptions) ([]error, error) {
+func (v *MachineVM) Set(_ string, opts define.SetOptions) ([]error, error) {
 	// If one setting fails to be applied, the others settings will not fail and still be applied.
 	// The setting(s) that failed to be applied will have its errors returned in setErrors
 	var setErrors []error


### PR DESCRIPTION
Sets up USB passthrough for machine. Additionally moves `SetOptions` out from `pkg/machine/config.go` to its own file in
`pkg/machine/define/setopts.go`.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Users on QEMU can now take advantage of usb passthrough using `podman machine init --usb` and `podman machine set --usb`
```
