### PR TITLE
machine: change getDefaultDevices signature

### DIFF
--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -137,21 +137,11 @@ func (a AppleHVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func
 
 	netDevice.SetUnixSocketPath(gvproxySocket.GetPath())
 
-	readySocket, err := mc.ReadySocket()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logfile, err := mc.LogFile()
-	if err != nil {
-		return nil, nil, err
-	}
-
 	// create a one-time virtual machine for starting because we dont want all this information in the
 	// machineconfig if possible.  the preference was to derive this stuff
 	vm := vfConfig.NewVirtualMachine(uint(mc.Resources.CPUs), mc.Resources.Memory, mc.AppleHypervisor.Vfkit.VirtualMachine.Bootloader)
 
-	defaultDevices, err := getDefaultDevices(mc.ImagePath.GetPath(), logfile.GetPath(), readySocket.GetPath())
+	defaultDevices, readySocket, err := getDefaultDevices(mc)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Changes the signature for `getDefaultDevices` to take a `vmconfigs.MachineConfig`.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
