### PR TITLE
image scp: don't require port for ssh URL

### DIFF
--- a/pkg/domain/utils/scp.go
+++ b/pkg/domain/utils/scp.go
@@ -205,9 +205,14 @@ func LoginUser(user string) (*exec.Cmd, error) {
 // and copies the saved image dir over to the remote host and then loads it onto the machine
 // returns a string containing output or an error
 func LoadToRemote(dest entities.ImageScpOptions, localFile string, tag string, url *url.URL, iden string, sshEngine ssh.EngineMode) (string, string, error) {
-	port, err := strconv.Atoi(url.Port())
-	if err != nil {
-		return "", "", err
+	port := 0
+	urlPort := url.Port()
+	if urlPort != "" {
+		var err error
+		port, err = strconv.Atoi(url.Port())
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	remoteFile, err := ssh.Exec(&ssh.ConnectionExecOptions{Host: url.String(), Identity: iden, Port: port, User: url.User, Args: []string{"mktemp"}}, sshEngine)
@@ -250,9 +255,14 @@ func SaveToRemote(image, localFile string, tag string, uri *url.URL, iden string
 		return fmt.Errorf("renaming of an image is currently not supported: %w", define.ErrInvalidArg)
 	}
 
-	port, err := strconv.Atoi(uri.Port())
-	if err != nil {
-		return err
+	port := 0
+	urlPort := uri.Port()
+	if urlPort != "" {
+		var err error
+		port, err = strconv.Atoi(uri.Port())
+		if err != nil {
+			return err
+		}
 	}
 
 	remoteFile, err := ssh.Exec(&ssh.ConnectionExecOptions{Host: uri.String(), Identity: iden, Port: port, User: uri.User, Args: []string{"mktemp"}}, sshEngine)


### PR DESCRIPTION
SSH uses 22 as default so it is really not necessary to require the port. The backend code already does this but the parsing in the frontend always tried to parse the port.

[NO NEW TESTS NEEDED] This would require actual remote host ssh setup in CI so it is not possible to be check but I verified it locally.

Fixes https://issues.redhat.com/browse/RHEL-17776

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman image scp no longer requires a ssh port in the remote location URL and correctly defaults to port 22.
```
