### PR TITLE
Rootful VMs should force "root" as remote username

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -138,6 +138,13 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		initOpts.Name = args[0]
 	}
 
+	if initOpts.Rootful {
+		if cmd.Flag("user").Changed && initOpts.Username != "root" {
+			return fmt.Errorf("cannot set username when VM is rootful")
+		}
+		initOpts.Username = "root"
+	}
+
 	// The vmtype names need to be reserved and cannot be used for podman machine names
 	if _, err := define.ParseVMType(initOpts.Name, define.UnknownVirt); err == nil {
 		return fmt.Errorf("cannot use %q for a machine name", initOpts.Name)

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -35,7 +35,6 @@ func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	// TODO should this go up the stack higher
 	if mc.HostUser.Rootful {
 		guestSock = "/run/podman/podman.sock"
-		forwardUser = "root"
 	}
 
 	cfg, err := config.Default()


### PR DESCRIPTION
Also, setting a remote username that is not "root" when creating a rootful VM should not be supported.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
