### PR TITLE
Change QEMU netdev to Unix domain socket

### DIFF
--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -52,10 +52,16 @@ func (q *QemuCmd) SetQmpMonitor(monitor Monitor) {
 }
 
 // SetNetwork adds a network device to the machine
-func (q *QemuCmd) SetNetwork() {
+func (q *QemuCmd) SetNetwork(vlanSocket *define.VMFile) error {
 	// Right now the mac address is hardcoded so that the host networking gives it a specific IP address.  This is
 	// why we can only run one vm at a time right now
-	*q = append(*q, "-netdev", "socket,id=vlan,fd=3", "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee")
+	*q = append(*q, "-netdev", socketVlanNetdev(vlanSocket.GetPath()))
+	*q = append(*q, "-device", "virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee")
+	return nil
+}
+
+func socketVlanNetdev(path string) string {
+	return fmt.Sprintf("stream,id=vlan,server=off,addr.type=unix,addr.path=%s", path)
 }
 
 // SetNetwork adds a network device to the machine


### PR DESCRIPTION
Fixes https://github.com/containers/podman/issues/21544

This change migrates to new QEMU stream netdev added in 7.2.0. It also unifies how gvproxy is used in QEMU and AppleHV.

This change will require manual fixes to QEMU machine configurations migrated from 4.x, but 5.0 version is the only good point to do so. My previous work was with preserving old FD code, but it makes the codebase really messy.

It replaces my previous work from:
https://github.com/containers/podman/pull/21252
https://github.com/containers/podman/pull/17473
https://github.com/containers/podman/pull/18488

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
QEMU machine uses Unix domain socket netdev device type
```

[NO NEW TESTS NEEDED]