### PR TITLE
Fail if vm exists in hyperv already

### DIFF
--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -125,7 +125,7 @@ func (i *initMachine) withRootful(r bool) *initMachine {
 	return i
 }
 
-func (i *initMachine) withUserModeNetworking(r bool) *initMachine {
+func (i *initMachine) withUserModeNetworking(r bool) *initMachine { //nolint:unused
 	i.userModeNetworking = r
 	return i
 }

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -261,24 +261,6 @@ var _ = Describe("podman machine init", func() {
 		Expect(output).To(Equal("/run/podman/podman.sock"))
 	})
 
-	It("init with user mode networking", func() {
-		if testProvider.VMType() != define.WSLVirt {
-			Skip("test is only supported by WSL")
-		}
-		i := new(initMachine)
-		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withUserModeNetworking(true)).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		inspect := new(inspectMachine)
-		inspect = inspect.withFormat("{{.UserModeNetworking}}")
-		inspectSession, err := mb.setName(name).setCmd(inspect).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(inspectSession).To(Exit(0))
-		Expect(inspectSession.outputToString()).To(Equal("true"))
-	})
-
 	It("init should cleanup on failure", func() {
 		i := new(initMachine)
 		name := randomString()

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -1,0 +1,78 @@
+package e2e_test
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio/vhd"
+	"github.com/containers/libhvee/pkg/hypervctl"
+	"github.com/containers/podman/v5/pkg/machine/define"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("podman machine init - windows only", func() {
+	var (
+		mb      *machineTestBuilder
+		testDir string
+	)
+
+	BeforeEach(func() {
+		testDir, mb = setup()
+	})
+	AfterEach(func() {
+		teardown(originalHomeDir, testDir, mb)
+	})
+
+	It("init with user mode networking", func() {
+		if testProvider.VMType() != define.WSLVirt {
+			Skip("test is only supported by WSL")
+		}
+		i := new(initMachine)
+		name := randomString()
+		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withUserModeNetworking(true)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		inspect := new(inspectMachine)
+		inspect = inspect.withFormat("{{.UserModeNetworking}}")
+		inspectSession, err := mb.setName(name).setCmd(inspect).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		Expect(inspectSession.outputToString()).To(Equal("true"))
+	})
+	It("init should not should not overwrite existing HyperV vms", func() {
+		skipIfNotVmtype(define.HyperVVirt, "HyperV test only")
+		name := randomString()
+		vhdxPath := filepath.Join(testDir, fmt.Sprintf("%s.vhdx", name))
+		if err := vhd.CreateVhdx(vhdxPath, 1, 1); err != nil {
+			Fail(fmt.Sprintf("failed to create dummy vhdx %q: %q", vhdxPath, err))
+		}
+		vmm := hypervctl.NewVirtualMachineManager()
+		hwConfig := hypervctl.HardwareConfig{
+			CPUs:     1,
+			DiskPath: vhdxPath,
+			DiskSize: 0,
+			Memory:   0,
+			Network:  false,
+		}
+
+		if err := vmm.NewVirtualMachine(name, &hwConfig); err != nil {
+			Fail(fmt.Sprintf("failed to create vm %q: %q", name, err))
+		}
+		vm, err := vmm.GetMachine(name)
+		if err != nil {
+			Fail(fmt.Sprintf("failed to get vm %q: %q", name, err))
+		}
+		defer func() {
+			if err := vm.Remove(""); err != nil {
+				fmt.Printf("failed to clean up vm %q from hypervisor: %q /n", name, err)
+			}
+		}()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		Expect(session).To(Exit(125))
+		Expect(session.errorToString()).To(ContainSubstring("already exists on hypervisor"))
+	})
+})

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -119,7 +119,7 @@ func (h HyperVStubber) GetHyperVisorVMs() ([]string, error) {
 		return nil, err
 	}
 	for _, vm := range vms {
-		vmNames = append(vmNames, vm.Name)
+		vmNames = append(vmNames, vm.ElementName) // Note: elementname is human-readable name
 	}
 	return vmNames, nil
 }


### PR DESCRIPTION
Fix a bug where if a vm exists, created by some other process/user, and you attempt to make a podman machine with the same name.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
