### PR TITLE
WIP: Add `io.kubernetes.cri-o.ImageDigests` annotation

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -40,6 +40,9 @@ const (
 	// ImageRef is the container image ref annotation.
 	ImageRef = "io.kubernetes.cri-o.ImageRef"
 
+	// ImageDigests is the container image digests annotation.
+	ImageDigests = "io.kubernetes.cri-o.ImageDigests"
+
 	// KubeName is the kubernetes name annotation.
 	KubeName = "io.kubernetes.cri-o.KubeName"
 


### PR DESCRIPTION
The new annotation will be used by CRI-O to persistently store the image digests for a container.

Refers to https://github.com/cri-o/cri-o/pull/7767

```release-note
Added `io.kubernetes.cri-o.ImageDigests` annotation.
```
