### PR TITLE
Fix a compilation error in pkg/machine/config.go

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containers/podman/v5/pkg/machine/compression"


### PR DESCRIPTION
Commit c524da252e7220323e27d3f72a00107c165e48c9 has merged the outcome of two individually tested PRs, resulting in a semantic conflict.

[EDIT: that was #21573]

#### Does this PR introduce a user-facing change?

```release-note
None
```
