### PR TITLE
CI: sys: fix "kube play url" flake

### DIFF
--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -511,15 +511,19 @@ _EOF
     TESTDIR=$PODMAN_TMPDIR/testdir
     mkdir -p $TESTDIR
     echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
+    echo READY                                      > $PODMAN_TMPDIR/ready
 
     HOST_PORT=$(random_free_port)
     SERVER=http://127.0.0.1:$HOST_PORT
 
     run_podman run -d --name myyaml -p "$HOST_PORT:80" \
                -v $PODMAN_TMPDIR/test.yaml:/var/www/testpod.yaml:Z \
+               -v $PODMAN_TMPDIR/ready:/var/www/ready:Z \
                -w /var/www \
                $IMAGE /bin/busybox-extras httpd -f -p 80
+
     wait_for_port 127.0.0.1 $HOST_PORT
+    wait_for_command_output "curl -s -S $SERVER/ready" "READY"
 
     run_podman kube play $SERVER/testpod.yaml
     run_podman inspect test_pod-test --format "{{.State.Running}}"


### PR DESCRIPTION
Nasty flakes. This one has been hitting us hard, and only
f38 root (both CNI and netavark).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```