### PR TITLE
machine: Remove unnecessary TODOs

### DIFF
--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -90,8 +90,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			SSHConfig:          mc.SSH,
 			State:              state,
 			UserModeNetworking: provider.UserModeNetworkEnabled(mc),
-			// TODO I think this should be the HostUser
-			Rootful: mc.HostUser.Rootful,
+			Rootful:            mc.HostUser.Rootful,
 		}
 
 		vms = append(vms, ii)

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -21,7 +21,6 @@ func (a *AppleHVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() e
 	mc.Lock()
 	defer mc.Unlock()
 
-	// TODO we could delete the vfkit pid/log files if we wanted to be thorough
 	return []string{}, func() error { return nil }, nil
 }
 

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -306,7 +306,6 @@ func getMCsOverProviders(vmstubbers []vmconfigs.VMProvider) (map[string]*vmconfi
 }
 
 // Stop stops the machine as well as supporting binaries/processes
-// TODO: I think this probably needs to go somewhere that remove can call it.
 func Stop(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDefine.MachineDirs, hardStop bool) error {
 	// state is checked here instead of earlier because stopping a stopped vm is not considered
 	// an error.  so putting in one place instead of sprinkling all over.


### PR DESCRIPTION
Remove TODO to swap `Rootful` in Inspect with `HostUser`

Additionally removes the following TODOs:

It is unnecessary to remove the vfkit logfile in the provider-specific `Remove` function. Vfkit is fed the default logfile provided by `mc.LogFile` which is removed by the generic `Remove` function.

Removes TODO regarding moving the location of Stop. False TODO.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
