### PR TITLE
Build tag out QEMU for Darwin

### DIFF
--- a/pkg/machine/define/usb.go
+++ b/pkg/machine/define/usb.go
@@ -1,0 +1,77 @@
+package define
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type USBConfig struct {
+	Bus       string
+	DevNumber string
+	Vendor    int
+	Product   int
+}
+
+func ParseUSBs(usbs []string) ([]USBConfig, error) {
+	configs := []USBConfig{}
+	for _, str := range usbs {
+		if str == "" {
+			// Ignore --usb="" as it can be used to reset USBConfigs
+			continue
+		}
+
+		vals := strings.Split(str, ",")
+		if len(vals) != 2 {
+			return configs, fmt.Errorf("usb: fail to parse: missing ',': %s", str)
+		}
+
+		left := strings.Split(vals[0], "=")
+		if len(left) != 2 {
+			return configs, fmt.Errorf("usb: fail to parse: missing '=': %s", str)
+		}
+
+		right := strings.Split(vals[1], "=")
+		if len(right) != 2 {
+			return configs, fmt.Errorf("usb: fail to parse: missing '=': %s", str)
+		}
+
+		option := left[0] + "_" + right[0]
+
+		switch option {
+		case "bus_devnum", "devnum_bus":
+			bus, devnumber := left[1], right[1]
+			if right[0] == "bus" {
+				bus, devnumber = devnumber, bus
+			}
+
+			configs = append(configs, USBConfig{
+				Bus:       bus,
+				DevNumber: devnumber,
+			})
+		case "vendor_product", "product_vendor":
+			vendorStr, productStr := left[1], right[1]
+			if right[0] == "vendor" {
+				vendorStr, productStr = productStr, vendorStr
+			}
+
+			vendor, err := strconv.ParseInt(vendorStr, 16, 0)
+			if err != nil {
+				return configs, fmt.Errorf("usb: fail to convert vendor of %s: %s", str, err)
+			}
+
+			product, err := strconv.ParseInt(productStr, 16, 0)
+			if err != nil {
+				return configs, fmt.Errorf("usb: fail to convert product of %s: %s", str, err)
+			}
+
+			configs = append(configs, USBConfig{
+				Vendor:  int(vendor),
+				Product: int(product),
+			})
+		default:
+			return configs, fmt.Errorf("usb: fail to parse: %s", str)
+		}
+	}
+	return configs, nil
+}

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package command
 
 import (
@@ -6,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
@@ -58,7 +59,7 @@ func (q *QemuCmd) SetNetwork() {
 }
 
 // SetNetwork adds a network device to the machine
-func (q *QemuCmd) SetUSBHostPassthrough(usbs []USBConfig) {
+func (q *QemuCmd) SetUSBHostPassthrough(usbs []define.USBConfig) {
 	if len(usbs) == 0 {
 		return
 	}
@@ -113,76 +114,6 @@ func (q *QemuCmd) SetPropagatedHostEnvs() {
 
 func (q *QemuCmd) Build() []string {
 	return *q
-}
-
-type USBConfig struct {
-	Bus       string
-	DevNumber string
-	Vendor    int
-	Product   int
-}
-
-func ParseUSBs(usbs []string) ([]USBConfig, error) {
-	configs := []USBConfig{}
-	for _, str := range usbs {
-		if str == "" {
-			// Ignore --usb="" as it can be used to reset USBConfigs
-			continue
-		}
-
-		vals := strings.Split(str, ",")
-		if len(vals) != 2 {
-			return configs, fmt.Errorf("usb: fail to parse: missing ',': %s", str)
-		}
-
-		left := strings.Split(vals[0], "=")
-		if len(left) != 2 {
-			return configs, fmt.Errorf("usb: fail to parse: missing '=': %s", str)
-		}
-
-		right := strings.Split(vals[1], "=")
-		if len(right) != 2 {
-			return configs, fmt.Errorf("usb: fail to parse: missing '=': %s", str)
-		}
-
-		option := left[0] + "_" + right[0]
-
-		switch option {
-		case "bus_devnum", "devnum_bus":
-			bus, devnumber := left[1], right[1]
-			if right[0] == "bus" {
-				bus, devnumber = devnumber, bus
-			}
-
-			configs = append(configs, USBConfig{
-				Bus:       bus,
-				DevNumber: devnumber,
-			})
-		case "vendor_product", "product_vendor":
-			vendorStr, productStr := left[1], right[1]
-			if right[0] == "vendor" {
-				vendorStr, productStr = productStr, vendorStr
-			}
-
-			vendor, err := strconv.ParseInt(vendorStr, 16, 0)
-			if err != nil {
-				return configs, fmt.Errorf("usb: fail to convert vendor of %s: %s", str, err)
-			}
-
-			product, err := strconv.ParseInt(productStr, 16, 0)
-			if err != nil {
-				return configs, fmt.Errorf("usb: fail to convert product of %s: %s", str, err)
-			}
-
-			configs = append(configs, USBConfig{
-				Vendor:  int(vendor),
-				Product: int(product),
-			})
-		default:
-			return configs, fmt.Errorf("usb: fail to parse: %s", str)
-		}
-	}
-	return configs, nil
 }
 
 type Monitor struct {

--- a/pkg/machine/qemu/command/command_test.go
+++ b/pkg/machine/qemu/command/command_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package command
 
 import (

--- a/pkg/machine/qemu/command/helpers.go
+++ b/pkg/machine/qemu/command/helpers.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package command
 
 import (

--- a/pkg/machine/qemu/command/qemu_command_test.go
+++ b/pkg/machine/qemu/command/qemu_command_test.go
@@ -1,4 +1,4 @@
-//go:build (amd64 && !windows) || (arm64 && !windows)
+//go:build ((amd64 && !windows) || (arm64 && !windows)) && !darwin
 
 package command
 

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/config_test.go
+++ b/pkg/machine/qemu/config_test.go
@@ -1,23 +1,25 @@
+//go:build !darwin
+
 package qemu
 
 import (
 	"reflect"
 	"testing"
 
-	"github.com/containers/podman/v5/pkg/machine/qemu/command"
+	"github.com/containers/podman/v5/pkg/machine/define"
 )
 
 func TestUSBParsing(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    []string
-		result  []command.USBConfig
+		result  []define.USBConfig
 		wantErr bool
 	}{
 		{
 			name: "Good vendor and product",
 			args: []string{"vendor=13d3,product=5406", "vendor=08ec,product=0016"},
-			result: []command.USBConfig{
+			result: []define.USBConfig{
 				{
 					Vendor:  5075,
 					Product: 21510,
@@ -32,7 +34,7 @@ func TestUSBParsing(t *testing.T) {
 		{
 			name: "Good bus and device number",
 			args: []string{"bus=1,devnum=4", "bus=1,devnum=3"},
-			result: []command.USBConfig{
+			result: []define.USBConfig{
 				{
 					Bus:       "1",
 					DevNumber: "4",
@@ -47,26 +49,26 @@ func TestUSBParsing(t *testing.T) {
 		{
 			name:    "Bad vendor and product, not hexa",
 			args:    []string{"vendor=13dk,product=5406"},
-			result:  []command.USBConfig{},
+			result:  []define.USBConfig{},
 			wantErr: true,
 		},
 		{
 			name:    "Bad vendor and product, bad separator",
 			args:    []string{"vendor=13d3:product=5406"},
-			result:  []command.USBConfig{},
+			result:  []define.USBConfig{},
 			wantErr: true,
 		},
 		{
 			name:    "Bad vendor and product, missing equal",
 			args:    []string{"vendor=13d3:product-5406"},
-			result:  []command.USBConfig{},
+			result:  []define.USBConfig{},
 			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := command.ParseUSBs(test.args)
+			got, err := define.ParseUSBs(test.args)
 			if (err != nil) != test.wantErr {
 				t.Errorf("parseUUBs error = %v, wantErr %v", err, test.wantErr)
 				return

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !darwin
 
 package qemu
 

--- a/pkg/machine/qemu/machine_unsupported.go
+++ b/pkg/machine/qemu/machine_unsupported.go
@@ -1,3 +1,3 @@
-//go:build !amd64 && !arm64
+//go:build !amd64 && !arm64 && darwin
 
 package qemu

--- a/pkg/machine/qemu/machine_windows.go
+++ b/pkg/machine/qemu/machine_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/options_freebsd.go
+++ b/pkg/machine/qemu/options_freebsd.go
@@ -1,3 +1,5 @@
+//go:build freebsd
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/options_freebsd_amd64.go
+++ b/pkg/machine/qemu/options_freebsd_amd64.go
@@ -1,3 +1,5 @@
+//go:build freebsd && amd64
+
 package qemu
 
 var (

--- a/pkg/machine/qemu/options_freebsd_arm64.go
+++ b/pkg/machine/qemu/options_freebsd_arm64.go
@@ -1,3 +1,5 @@
+//go:build freebsd && arm64
+
 package qemu
 
 var (

--- a/pkg/machine/qemu/options_linux_amd64.go
+++ b/pkg/machine/qemu/options_linux_amd64.go
@@ -1,3 +1,5 @@
+//go:build linux && amd64
+
 package qemu
 
 var (

--- a/pkg/machine/qemu/options_linux_arm64.go
+++ b/pkg/machine/qemu/options_linux_arm64.go
@@ -1,3 +1,5 @@
+//go:build linux && arm64
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/options_windows.go
+++ b/pkg/machine/qemu/options_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -1,3 +1,5 @@
+//go:build windows && amd64
+
 package qemu
 
 var (

--- a/pkg/machine/qemu/options_windows_arm64.go
+++ b/pkg/machine/qemu/options_windows_arm64.go
@@ -1,3 +1,5 @@
+//go:build windows && arm64
+
 package qemu
 
 var (

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package qemu
 
 import (
@@ -276,7 +278,7 @@ func (q *QEMUStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.
 	}
 
 	if opts.USBs != nil {
-		usbs, err := command.ParseUSBs(*opts.USBs)
+		usbs, err := define.ParseUSBs(*opts.USBs)
 		if err != nil {
 			return err
 		}

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -8,7 +8,6 @@ import (
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/ignition"
-	"github.com/containers/podman/v5/pkg/machine/qemu/command"
 	"github.com/containers/storage/pkg/lockfile"
 )
 
@@ -161,7 +160,7 @@ type ResourceConfig struct {
 	// Memory in megabytes assigned to the vm
 	Memory uint64
 	// Usbs
-	USBs []command.USBConfig
+	USBs []define.USBConfig
 }
 
 // SSHConfig contains remote access information for SSH

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/connection"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/lock"
-	"github.com/containers/podman/v5/pkg/machine/qemu/command"
 	"github.com/containers/podman/v5/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -63,7 +62,7 @@ func NewMachineConfig(opts define.InitOptions, dirs *define.MachineDirs, sshIden
 		return nil, fmt.Errorf("USB host passthrough not supported for %s machines", vmtype)
 	}
 
-	usbs, err := command.ParseUSBs(opts.USBs)
+	usbs, err := define.ParseUSBs(opts.USBs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Macs no longer support QEMU as a provider, build tag it out.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman machine on Mac no longer supports QEMU as a provider. Instead, AppleHV is used. 
```
