### PR TITLE
Windows uses USERPROFILE not HOME

### DIFF
--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -147,6 +147,11 @@ func setup() (string, *machineTestBuilder) {
 	if err := os.Setenv("HOME", homeDir); err != nil {
 		Fail("failed to set home dir")
 	}
+	if runtime.GOOS == "windows" {
+		if err := os.Setenv("USERPROFILE", homeDir); err != nil {
+			Fail("unable to set home dir on windows")
+		}
+	}
 	if err := os.Setenv("XDG_RUNTIME_DIR", homeDir); err != nil {
 		Fail("failed to set xdg_runtime dir")
 	}
@@ -202,5 +207,10 @@ func teardown(origHomeDir string, testDir string, mb *machineTestBuilder) {
 	// this needs to be last in teardown
 	if err := os.Setenv("HOME", origHomeDir); err != nil {
 		Fail("failed to set home dir")
+	}
+	if runtime.GOOS == "windows" {
+		if err := os.Setenv("USERPROFILE", origHomeDir); err != nil {
+			Fail("failed to set windows home dir back to original")
+		}
 	}
 }


### PR DESCRIPTION
When dealing with environment variables that set $HOME, we do not get the desired result.  Windows will honor USERPROFILE.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
