### PR TITLE
Replace panic with no-op

### DIFF
--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -107,8 +107,7 @@ func (w WSLStubber) GetHyperVisorVMs() ([]string, error) {
 }
 
 func (w WSLStubber) MountType() vmconfigs.VolumeMountType {
-	//TODO implement me
-	panic("implement me")
+	return vmconfigs.Unknown
 }
 
 func (w WSLStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, quiet bool) error {
@@ -132,7 +131,6 @@ func (w WSLStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error,
 func (w WSLStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 	return nil
 }
-
 
 func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
 	mc.Lock()


### PR DESCRIPTION
Instead of panic'ing for provider.MountType(), we return the "Unknown" voluem type

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
