### PR TITLE
machine: `machine set` only in `Stopped` state

### DIFF
--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -192,4 +192,23 @@ var _ = Describe("podman machine set", func() {
 		Expect(inspectSession).To(Exit(0))
 		Expect(inspectSession.outputToString()).To(Equal("true"))
 	})
+
+	It("set while machine already running", func() {
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		s := new(startMachine)
+		startSession, err := mb.setCmd(s).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(startSession).To(Exit(0))
+
+		set := setMachine{}
+		setSession, err := mb.setName(name).setCmd(set.withRootful(true)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(setSession).To(Exit(125))
+		Expect(setSession.errorToString()).To(ContainSubstring("Error: unable to change settings unless vm is stopped"))
+	})
 })

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -317,7 +317,6 @@ func (h HyperVStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define
 		return err
 	}
 
-	// TODO lets move this up into set as a "rule" for all machines
 	if vm.State() != hypervctl.Disabled {
 		return errors.New("unable to change settings unless vm is stopped")
 	}

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -133,27 +133,17 @@ func (w WSLStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 	return nil
 }
 
-
 func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
 	mc.Lock()
 	defer mc.Unlock()
 
-	// TODO the check for running when setting rootful is something I have not
-	// seen in the other distributions.  I wonder if this is true everywhere or just
-	// with WSL?
-	// TODO maybe the "rule" for set is that it must be done when the machine is
-	// stopped?
-	// if opts.Rootful != nil && v.Rootful != *opts.Rootful {
-	// 	err := v.setRootful(*opts.Rootful)
-	// 	if err != nil {
-	// 		setErrors = append(setErrors, fmt.Errorf("setting rootful option: %w", err))
-	// 	} else {
-	// 		if v.isRunning() {
-	// 			logrus.Warn("restart is necessary for rootful change to go into effect")
-	// 		}
-	// 		v.Rootful = *opts.Rootful
-	// 	}
-	// }
+	state, err := w.State(mc, false)
+	if err != nil {
+		return err
+	}
+	if state != define.Stopped {
+		return errors.New("unable to change settings unless vm is stopped")
+	}
 
 	if opts.Rootful != nil && mc.HostUser.Rootful != *opts.Rootful {
 		if err := mc.SetRootful(*opts.Rootful); err != nil {

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -34,12 +34,6 @@ func (w WSLStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConf
 	defer callbackFuncs.CleanIfErr(&err)
 	go callbackFuncs.CleanOnSignal()
 	mc.WSLHypervisor = new(vmconfigs.WSLConfig)
-	// TODO
-	// USB opts are unsupported in WSL.  Need to account for that here
-	// or up the stack
-	//	if len(opts.USBs) > 0 {
-	//		return nil, fmt.Errorf("USB host passthrough is not supported for WSL machines")
-	//	}
 
 	if cont, err := checkAndInstallWSL(opts.ReExec); !cont {
 		appendOutputIfError(opts.ReExec, err)
@@ -159,10 +153,9 @@ func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.Se
 		return errors.New("changing memory not supported for WSL machines")
 	}
 
-	// TODO USB still needs to be plumbed for all providers
-	// if USBs != nil {
-	// 	setErrors = append(setErrors, errors.New("changing USBs not supported for WSL machines"))
-	// }
+	if opts.USBs != nil {
+		return errors.New("changing USBs not supported for WSL machines")
+	}
 
 	if opts.DiskSize != nil {
 		return errors.New("changing disk size not supported for WSL machines")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->


Adds a check for all providers that will only allow the user to execute the `podman machine set` command if the machine is in the `Stopped` state. 

Additionally made the following WSL changes:
- re-enables the `opts.USBs` check in `SetProviderAttrs` to prevent the user from modifying unsupported settings 
- removes a TODO for a check on init to see if the user passed a USB device. This check is already done higher up the stack in a generic fashion. 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->


```release-note
Users will no longer be able to execute `podman machine set --<setting>` if the machine is not in the `Stopped` state.
```
