### PR TITLE
Fix small bug in ocipull

### DIFF
--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -29,6 +29,7 @@ const (
 	artifactRepo         = "baude"
 	artifactImageName    = "podman-machine-images-art"
 	artifactOriginalName = "org.opencontainers.image.title"
+	machineOS            = "linux"
 )
 
 type OCIArtifactDisk struct {
@@ -88,7 +89,7 @@ func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, vmName st
 	diskOpts := DiskArtifactOpts{
 		arch:     arch,
 		diskType: vmType.String(),
-		os:       runtime.GOOS,
+		os:       machineOS,
 	}
 	ociDisk := OCIArtifactDisk{
 		ctx:              ctx,

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/pkg/machine/define"
-	specV1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // PullOptions includes data to alter certain knobs when pulling a source
@@ -49,10 +48,6 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 		sysCtx.DockerAuthConfig = authConf
 	}
 
-	if err := validateSourceImageReference(ctx, imageInput, sysCtx); err != nil {
-		return err
-	}
-
 	policy, err := signature.DefaultPolicy(sysCtx)
 	if err != nil {
 		return fmt.Errorf("obtaining default signature policy: %w", err)
@@ -86,21 +81,4 @@ func stringToImageReference(imageInput string) (types.ImageReference, error) { /
 	}
 
 	return ref, nil
-}
-
-func validateSourceImageReference(ctx context.Context, ref types.ImageReference, sysCtx *types.SystemContext) error {
-	src, err := ref.NewImageSource(ctx, sysCtx)
-	if err != nil {
-		return fmt.Errorf("creating image source from reference: %w", err)
-	}
-	defer src.Close()
-
-	ociManifest, _, _, err := readManifestFromImageSource(ctx, src)
-	if err != nil {
-		return err
-	}
-	if ociManifest.Config.MediaType != specV1.MediaTypeImageConfig {
-		return fmt.Errorf("invalid media type of image config %q (expected: %q)", ociManifest.Config.MediaType, specV1.MediaTypeImageConfig)
-	}
-	return nil
 }

--- a/pkg/machine/ocipull/source.go
+++ b/pkg/machine/ocipull/source.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/types"
@@ -15,26 +13,6 @@ import (
 	specV1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
-
-// readManifestFromImageSource reads the manifest from the specified image
-// source.  Note that the manifest is expected to be an OCI v1 manifest.
-func readManifestFromImageSource(ctx context.Context, src types.ImageSource) (*specV1.Manifest, *digest.Digest, int64, error) {
-	rawData, mimeType, err := src.GetManifest(ctx, nil)
-	if err != nil {
-		return nil, nil, -1, err
-	}
-	if mimeType != specV1.MediaTypeImageManifest {
-		return nil, nil, -1, fmt.Errorf("image %q is of type %q (expected: %q)", strings.TrimPrefix(src.Reference().StringWithinTransport(), "//"), mimeType, specV1.MediaTypeImageManifest)
-	}
-
-	mannyFest := specV1.Manifest{}
-	if err := json.Unmarshal(rawData, &mannyFest); err != nil {
-		return nil, nil, -1, fmt.Errorf("reading manifest: %w", err)
-	}
-
-	manifestDigest := digest.FromBytes(rawData)
-	return &mannyFest, &manifestDigest, int64(len(rawData)), nil
-}
 
 func GetLocalBlob(ctx context.Context, path string) (*types.BlobInfo, error) {
 	ociRef, err := layout.ParseReference(path)
@@ -64,27 +42,6 @@ func GetLocalBlob(ctx context.Context, path string) (*types.BlobInfo, error) {
 	}
 	fmt.Println(blobs[0].Digest.Hex())
 	return &blobs[0], nil
-}
-
-func GetRemoteManifest(ctx context.Context, dest string) (*specV1.Manifest, error) { //nolint:unused
-	ref, err := docker.ParseReference(fmt.Sprintf("//%s", dest))
-	if err != nil {
-		return nil, err
-	}
-
-	imgSrc, err := ref.NewImage(ctx, &types.SystemContext{})
-	if err != nil {
-		return nil, err
-	}
-
-	b, _, err := imgSrc.Manifest(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	remoteManifest := specV1.Manifest{}
-	err = json.Unmarshal(b, &remoteManifest)
-	return &remoteManifest, err
 }
 
 func GetDiskArtifactReference(ctx context.Context, imgSrc types.ImageSource, opts *DiskArtifactOpts) (digest.Digest, error) {


### PR DESCRIPTION
This PR fixes a small bug in pulling disk artifacts where the machine os was accidently being set to GOOS instead of "linux".  Also removed the manifest type verification because it served no purpose.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
