### PR TITLE
Allow podman pull to specify --retry and --retry-delay

### DIFF
--- a/docs/source/markdown/options/retry-delay.md
+++ b/docs/source/markdown/options/retry-delay.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, farm build
+####>   podman build, farm build, pull
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--retry-delay**=*duration*

--- a/docs/source/markdown/options/retry.md
+++ b/docs/source/markdown/options/retry.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, farm build
+####>   podman build, farm build, pull
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--retry**=*attempts*

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -73,6 +73,10 @@ Print the usage statement.
 
 Suppress output information when pulling images
 
+@@option retry
+
+@@option retry-delay
+
 @@option tls-verify
 
 @@option variant.container
@@ -204,6 +208,10 @@ Writing manifest to image destination
 Storing signatures
 3cba58dad5d9b35e755b48b634acb3fdd185ab1c996ac11510cc72c17780e13c
 ```
+
+Pull an image with up to 6 retries, delaying 10 seconds between retries in quet mode.
+$ podman --remote pull -q --retry 6 --retry-delay 10s ubi9
+4d6addf62a90e392ff6d3f470259eb5667eab5b9a8e03d20b41d0ab910f92170
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-push(1)](podman-push.1.md)**, **[podman-login(1)](podman-login.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)**, **[containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md)**

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -217,6 +217,10 @@ type PullOptions struct {
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet *bool
+	// Retry number of times to retry pull in case of failure
+	Retry *uint
+	// RetryDelay between retries in case of pull failures
+	RetryDelay *string
 	// SkipTLSVerify to skip HTTPS and certificate verification.
 	SkipTLSVerify *bool `schema:"-"`
 	// Username for authenticating against the registry.

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -138,6 +138,36 @@ func (o *PullOptions) GetQuiet() bool {
 	return *o.Quiet
 }
 
+// WithRetry set field Retry to given value
+func (o *PullOptions) WithRetry(value uint) *PullOptions {
+	o.Retry = &value
+	return o
+}
+
+// GetRetry returns value of field Retry
+func (o *PullOptions) GetRetry() uint {
+	if o.Retry == nil {
+		var z uint
+		return z
+	}
+	return *o.Retry
+}
+
+// WithRetryDelay set field RetryDelay to given value
+func (o *PullOptions) WithRetryDelay(value string) *PullOptions {
+	o.RetryDelay = &value
+	return o
+}
+
+// GetRetryDelay returns value of field RetryDelay
+func (o *PullOptions) GetRetryDelay() string {
+	if o.RetryDelay == nil {
+		var z string
+		return z
+	}
+	return *o.RetryDelay
+}
+
 // WithSkipTLSVerify set field SkipTLSVerify to given value
 func (o *PullOptions) WithSkipTLSVerify(value bool) *PullOptions {
 	o.SkipTLSVerify = &value

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -102,6 +102,10 @@ type ImagePullOptions struct {
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet bool
+	// Retry number of times to retry pull in case of failure
+	Retry *uint
+	// RetryDelay between retries in case of pull failures
+	RetryDelay string
 	// SignaturePolicy to use when pulling.  Ignored for remote calls.
 	SignaturePolicy string
 	// SkipTLSVerify to skip HTTPS and certificate verification.

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	bdefine "github.com/containers/buildah/define"
 	"github.com/containers/common/libimage"
@@ -253,6 +254,15 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	pullOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
 	pullOptions.Writer = options.Writer
 	pullOptions.OciDecryptConfig = options.OciDecryptConfig
+
+	pullOptions.MaxRetries = options.Retry
+	if options.RetryDelay != "" {
+		duration, err := time.ParseDuration(options.RetryDelay)
+		if err != nil {
+			return nil, err
+		}
+		pullOptions.RetryDelay = &duration
+	}
 
 	if !options.Quiet && pullOptions.Writer == nil {
 		pullOptions.Writer = os.Stderr

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -123,6 +123,12 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.
 			options.WithSkipTLSVerify(false)
 		}
 	}
+	if opts.Retry != nil {
+		options.WithRetry(*opts.Retry)
+	}
+	if opts.RetryDelay != "" {
+		options.WithRetryDelay(opts.RetryDelay)
+	}
 	pulledImages, err := images.Pull(ir.ClientCtx, rawImage, options)
 	if err != nil {
 		return nil, err

--- a/test/system/helpers.registry.bash
+++ b/test/system/helpers.registry.bash
@@ -115,3 +115,23 @@ function stop_registry() {
         die "Socket still seems open"
     fi
 }
+
+function pause_registry() {
+    if [[ ! -d "$PODMAN_LOGIN_WORKDIR/auth" ]]; then
+        # No registry running
+        return
+    fi
+
+    opts="--storage-driver vfs $(podman_isolation_opts ${PODMAN_LOGIN_WORKDIR})"
+    run_podman $opts stop registry
+}
+
+function unpause_registry() {
+    if [[ ! -d "$PODMAN_LOGIN_WORKDIR/auth" ]]; then
+        # No registry running
+        return
+    fi
+
+    opts="--storage-driver vfs $(podman_isolation_opts ${PODMAN_LOGIN_WORKDIR})"
+    run_podman $opts start registry
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/19770

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman pull now supports --retry and --retry-delay.
```
