### PR TITLE
More test tweaks to avoid "StopSignal ... 10 seconds" warning

### DIFF
--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Podman events", func() {
 	It("podman events with a type", func() {
 		setup := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:foobarpod", ALPINE, "top"})
 		setup.WaitWithDefaultTimeout()
-		stop := podmanTest.Podman([]string{"pod", "stop", "foobarpod"})
+		stop := podmanTest.Podman([]string{"pod", "stop", "-t0", "foobarpod"})
 		stop.WaitWithDefaultTimeout()
 		Expect(stop).Should(ExitCleanly())
 		Expect(setup).Should(ExitCleanly())

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -405,7 +405,8 @@ var _ = Describe("Podman prune", func() {
 
 		session = podmanTest.Podman([]string{"pod", "stop", podid1})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		// FIXME - #20196: Cannot use ExitCleanly()
+		Expect(session).Should(Exit(0))
 
 		// Create a container. This container should be pruned.
 		create := podmanTest.Podman([]string{"create", "--name", "test", BB})

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -248,7 +248,8 @@ var _ = Describe("Podman restart", func() {
 
 		result := podmanTest.Podman([]string{"restart", "--cidfile", tmpFile})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(ExitCleanly())
+		// FIXME - #20196: Cannot use ExitCleanly()
+		Expect(result).Should(Exit(0))
 		output := result.OutputToString()
 		Expect(output).To(ContainSubstring(cid))
 	})

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -329,7 +329,7 @@ var _ = Describe("Podman rm", func() {
 		Expect(ctr2).Should(ExitCleanly())
 		cid2 := ctr2.OutputToString()
 
-		rm := podmanTest.Podman([]string{"rm", "-fa"})
+		rm := podmanTest.Podman([]string{"rm", "-t0", "-fa"})
 		rm.WaitWithDefaultTimeout()
 		Expect(rm).Should(ExitCleanly())
 		Expect(rm.ErrorToString()).To(BeEmpty(), "rm -fa error logged")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1541,7 +1541,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		ctr.WaitWithDefaultTimeout()
 		Expect(ctr).Should(ExitCleanly())
 
-		stop := podmanTest.Podman([]string{"stop", ctrName})
+		stop := podmanTest.Podman([]string{"stop", "-t0", ctrName})
 		stop.WaitWithDefaultTimeout()
 		Expect(stop).Should(ExitCleanly())
 
@@ -1693,13 +1693,15 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		session := podmanTest.Podman([]string{"create", "--replace", ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
+		Expect(session.ErrorToString()).To(ContainSubstring("cannot replace container without --name being set"))
 
 		// Run and replace 5 times in a row the "same" container.
 		ctrName := "testCtr"
 		for i := 0; i < 5; i++ {
 			session := podmanTest.Podman([]string{"run", "--detach", "--replace", "--name", ctrName, ALPINE, "top"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitCleanly())
+			// FIXME - #20196: Cannot use ExitCleanly()
+			Expect(session).Should(Exit(0))
 
 			// make sure Podman prints only one ID
 			Expect(session.OutputToString()).To(HaveLen(64))

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -77,16 +77,13 @@ load helpers
     # stop -a must print the IDs
     run_podman run -d $IMAGE top
     ctrID="$output"
-    # Output means container has set up its signal handlers
-    wait_for_output "Mem:" $ctrID
-    run_podman stop --all
+    run_podman stop -t0 --all
     is "$output" "$ctrID"
 
     # stop $input must print $input
     cname=$(random_string)
     run_podman run -d --name $cname $IMAGE top
-    wait_for_output "Mem:" $cname
-    run_podman stop $cname
+    run_podman stop -t0 $cname
     is "$output" $cname
 
     run_podman rm -t 0 -f $ctrID $cname

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -155,7 +155,7 @@ Labels.l       | $mylabel
     cid=$output
     run_podman 2 volume rm myvol
     is "$output" "Error: volume myvol is being used by the following container(s): $cid: volume is being used" "should error since container is running"
-    run_podman volume rm myvol --force
+    run_podman volume rm myvol --force -t0
 }
 
 # Running scripts (executables) from a volume


### PR DESCRIPTION
Continuing to see CI failures of the form "StopSignal SIGTERM
failed to stop container in 10 seconds". Work around those,
either by adding "-t0" to podman stop, or by using Expect(Exit(0))
instead of ExitCleanly().

Addresses, but does not close, #20196

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```