### PR TITLE
machine: ocipull do not error if downloaddir exists

### DIFF
--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -28,10 +28,6 @@ type PullOptions struct {
 
 // Pull `imageInput` from a container registry to `sourcePath`.
 func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *define.VMFile, options *PullOptions) error {
-	if _, err := os.Stat(localDestPath.GetPath()); err == nil {
-		return fmt.Errorf("%q already exists", localDestPath.GetPath())
-	}
-
 	destRef, err := layout.ParseReference(localDestPath.GetPath())
 	if err != nil {
 		return err


### PR DESCRIPTION
If users cancel the image download with CTRL-C for example then the blob dir will stay around. The next time we run the download we should just start the download again and not complain about the existing directory.

[NO NEW TEST NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
