### PR TITLE
applehv: Rosetta support

### DIFF
--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -74,6 +74,11 @@ func inspect(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		rosetta, err := provider.GetRosetta(mc)
+		if err != nil {
+			return err
+		}
+
 		ii := machine.InspectInfo{
 			ConfigDir: *dirs.ConfigDir,
 			ConnectionInfo: machine.ConnectionConfig{
@@ -88,6 +93,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			State:              state,
 			UserModeNetworking: provider.UserModeNetworkEnabled(mc),
 			Rootful:            mc.HostUser.Rootful,
+			Rosetta:            rosetta,
 		}
 
 		vms = append(vms, ii)

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -32,6 +32,7 @@ Print results with a Go template.
 | .Name               | Name of the machine                                                   |
 | .Resources ...      | Resources used by the machine                                         |
 | .Rootful            | Whether the machine prefers rootful or rootless container execution   |
+| .Rosetta            | Whether this machine uses Rosetta                               |
 | .SSHConfig ...      | SSH configuration info for communicating with machine                 |
 | .State              | Machine state                                                         |
 | .UserModeNetworking | Whether this machine uses user-mode networking                        |

--- a/pkg/machine/apple/vfkit.go
+++ b/pkg/machine/apple/vfkit.go
@@ -42,6 +42,18 @@ func GetDefaultDevices(mc *vmconfigs.MachineConfig) ([]vfConfig.VirtioDevice, *d
 		return nil, nil, err
 	}
 	devices = append(devices, disk, rng, serial, readyDevice)
+
+	rosettaCfg := mc.AppleHypervisor.Vfkit.Rosetta
+	if rosettaCfg {
+		rosetta := &vfConfig.RosettaShare{
+			DirectorySharingConfig: vfConfig.DirectorySharingConfig{
+				MountTag: define.MountTag,
+			},
+			InstallRosetta: true,
+		}
+		devices = append(devices, rosetta)
+	}
+
 	return devices, readySocket, nil
 }
 

--- a/pkg/machine/apple/vfkit/helper.go
+++ b/pkg/machine/apple/vfkit/helper.go
@@ -124,4 +124,5 @@ type Helper struct {
 	Endpoint       string
 	BinaryPath     *define.VMFile
 	VirtualMachine *config.VirtualMachine
+	Rosetta        bool
 }

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -71,8 +71,9 @@ type SSHOptions struct {
 }
 
 type StartOptions struct {
-	NoInfo bool
-	Quiet  bool
+	NoInfo  bool
+	Quiet   bool
+	Rosetta bool
 }
 
 type StopOptions struct{}
@@ -117,6 +118,7 @@ type InspectInfo struct {
 	State              define.Status
 	UserModeNetworking bool
 	Rootful            bool
+	Rosetta            bool
 }
 
 // ImageConfig describes the bootable image for the VM

--- a/pkg/machine/define/config.go
+++ b/pkg/machine/define/config.go
@@ -5,6 +5,10 @@ import "os"
 const UserCertsTargetPath = "/etc/containers/certs.d"
 const DefaultIdentityName = "machine"
 
+// MountTag is an identifier to mount a VirtioFS file system tag on a mount point in the VM.
+// Ref: https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta
+const MountTag = "rosetta"
+
 var (
 	DefaultFilePerm os.FileMode = 0644
 )

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -62,7 +63,13 @@ var _ = BeforeSuite(func() {
 	if pullError != nil {
 		Fail(fmt.Sprintf("failed to pull wsl disk: %q", pullError))
 	}
-
+	if testProvider.VMType() == define.AppleHvVirt {
+		cmd := exec.Command("softwareupdate", "--install-rosetta", "--agree-to-license")
+		err := cmd.Run()
+		if err != nil {
+			Fail(fmt.Sprintf("Command failed with error: %q", err))
+		}
+	}
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {})

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -557,3 +557,7 @@ func createNetworkUnit(netPort uint64) (string, error) {
 	netUnit.Add("Install", "WantedBy", "multi-user.target")
 	return netUnit.ToString()
 }
+
+func (h HyperVStubber) GetRosetta(mc *vmconfigs.MachineConfig) (bool, error) {
+	return false, nil
+}

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -139,3 +139,7 @@ func (l LibKrunStubber) RequireExclusiveActive() bool {
 func (l LibKrunStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) error {
 	return nil
 }
+
+func (l LibKrunStubber) GetRosetta(mc *vmconfigs.MachineConfig) (bool, error) {
+	return false, nil
+}

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -360,3 +360,7 @@ func (q *QEMUStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) error
 func (q *QEMUStubber) GetDisk(userInputPath string, dirs *define.MachineDirs, mc *vmconfigs.MachineConfig) error {
 	return diskpull.GetDisk(userInputPath, dirs, mc.ImagePath, q.VMType(), mc.Name)
 }
+
+func (q *QEMUStubber) GetRosetta(mc *vmconfigs.MachineConfig) (bool, error) {
+	return false, nil
+}

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -51,6 +51,8 @@ type MachineConfig struct {
 
 	// Starting is defined as "on" but not fully booted
 	Starting bool
+
+	Rosetta bool
 }
 
 type machineImage interface { //nolint:unused
@@ -99,6 +101,7 @@ type VMProvider interface { //nolint:interfacebloat
 	UseProviderNetworkSetup() bool
 	RequireExclusiveActive() bool
 	UpdateSSHPort(mc *MachineConfig, port int) error
+	GetRosetta(mc *MachineConfig) (bool, error)
 }
 
 // HostUser describes the host user

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -342,3 +342,7 @@ func (w WSLStubber) GetDisk(userInputPath string, dirs *define.MachineDirs, mc *
 	// pull if needed and decompress to image location
 	return myDisk.Get()
 }
+
+func (w WSLStubber) GetRosetta(mc *vmconfigs.MachineConfig) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
This PR adds Rosetta support to the AppleHV Podman machine(only v5).
Rosetta is only available on macOS with Apple Silicon.
With Rosetta, the execution performance is several times better than QEMU emulation.
https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta

Todo
- [x] GOARCH and Provider check
- [x] ~~CLI option docs~~
- [x] Appropriate location in machine configuration(or containers common)
- [x] `rosetta.InstallRosetta` vfkit option
- [x] containers/common PR https://github.com/containers/common/pull/1877
- [x] Release notes
- [x] Consideration of SELinux context
- [x] ship the unit file/script in the Containerfile https://github.com/containers/podman-machine-os/pull/7
- [x] Checking Test Code Execution


> [!NOTE] 
> [SELinux context] > resolved
> ~~Perhaps because of the use of vfkit, the SELinux context needs to be with `*exec_t` when mounting the Rosetta directory.~~
> ~~On lima and UTM which support Rosetta, it can be executed with `nfs_t` without error.~~
> 
> ~~https://github.com/lima-vm/lima/blob/88c89165273d87b33753a593af867b20c1d1c67d/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh#L22~~

#### Does this PR introduce a user-facing change?

```release-note
Podman machine can now use Rosetta 2 (a.k.a Rosetta) on macOS with Apple Silicon. This is enabled by default. If you wish to change this option, you can set via the CONTAINERS_MACHINE_ROSETTA environment variable or via containers.conf.
```

[no new tests needed]