### PR TITLE
Add a helper for stopping pods and containers in E2E

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -142,16 +142,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(inspectOut[0].State.CheckpointLog).To(ContainSubstring("userdata/dump.log"))
 		Expect(inspectOut[0].State.RestoreLog).To(ContainSubstring("userdata/restore.log"))
 
-		result = podmanTest.Podman([]string{
-			"container",
-			"stop",
-			"--timeout",
-			"0",
-			cid,
-		})
-		result.WaitWithDefaultTimeout()
-
-		Expect(result).Should(ExitCleanly())
+		podmanTest.StopContainer(cid)
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{
@@ -416,10 +407,7 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		// Stop the container
-		result = podmanTest.Podman([]string{"container", "stop", cid})
-		result.WaitWithDefaultTimeout()
-
-		Expect(result).Should(ExitCleanly())
+		podmanTest.StopContainer(cid)
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -454,6 +454,19 @@ func (p *PodmanTestIntegration) InspectContainer(name string) []define.InspectCo
 	return session.InspectContainerToJSON()
 }
 
+// StopContainer stops a container with no timeout, ensuring a fast test.
+func (p *PodmanTestIntegration) StopContainer(nameOrID string) {
+	stop := p.Podman([]string{"stop", "-t0", nameOrID})
+	stop.WaitWithDefaultTimeout()
+	Expect(stop).Should(ExitCleanly())
+}
+
+func (p *PodmanTestIntegration) StopPod(nameOrID string) {
+	stop := p.Podman([]string{"pod", "stop", "-t0", nameOrID})
+	stop.WaitWithDefaultTimeout()
+	Expect(stop).Should(ExitCleanly())
+}
+
 func processTestResult(r SpecReport) {
 	tr := testResult{length: r.RunTime.Seconds(), name: r.FullText()}
 	_, err := timingsFile.WriteString(fmt.Sprintf("%s\t\t%f\n", tr.name, tr.length))

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -87,10 +87,10 @@ var _ = Describe("Podman events", func() {
 	It("podman events with a type", func() {
 		setup := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:foobarpod", ALPINE, "top"})
 		setup.WaitWithDefaultTimeout()
-		stop := podmanTest.Podman([]string{"pod", "stop", "-t0", "foobarpod"})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
 		Expect(setup).Should(ExitCleanly())
+
+		podmanTest.StopPod("foobarpod")
+
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "type=pod", "--filter", "pod=foobarpod"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -524,9 +524,7 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 
 		// Ensure that stop with a running detached exec session is
 		// clean.
-		stop := podmanTest.Podman([]string{"stop", ctrName})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(ctrName)
 	})
 
 	It("podman exec with env var secret", func() {

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -282,9 +282,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		stop := podmanTest.Podman([]string{"stop", "-t0", "hc"})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer("hc")
 
 		startAgain := podmanTest.Podman([]string{"start", "hc"})
 		startAgain.WaitWithDefaultTimeout()

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -179,9 +179,7 @@ var _ = Describe("Podman mount", func() {
 		Expect(lmount).Should(ExitCleanly())
 		Expect(lmount.OutputToString()).To(ContainSubstring(cid))
 
-		stop := podmanTest.Podman([]string{"stop", cid})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(cid)
 
 		lmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()

--- a/test/e2e/pod_initcontainers_test.go
+++ b/test/e2e/pod_initcontainers_test.go
@@ -94,9 +94,7 @@ var _ = Describe("Podman init containers", func() {
 		// Expect(check).Should(Exit(1))
 		Expect(check.ExitCode()).To(Equal(1), "I dont understand why the other way does not work")
 		// Let's double check with a stop and start
-		stopPod := podmanTest.Podman([]string{"pod", "stop", "foobar"})
-		stopPod.WaitWithDefaultTimeout()
-		Expect(stopPod).Should(ExitCleanly())
+		podmanTest.StopPod("foobar")
 		startPod := podmanTest.Podman([]string{"pod", "start", "foobar"})
 		startPod.WaitWithDefaultTimeout()
 		Expect(startPod).Should(ExitCleanly())
@@ -129,9 +127,7 @@ var _ = Describe("Podman init containers", func() {
 		Expect(checkLog).Should(ExitCleanly())
 
 		// Stop and start the pod
-		stopPod := podmanTest.Podman([]string{"pod", "stop", "foobar"})
-		stopPod.WaitWithDefaultTimeout()
-		Expect(stopPod).Should(ExitCleanly())
+		podmanTest.StopPod("foobar")
 		startPod := podmanTest.Podman([]string{"pod", "start", "foobar"})
 		startPod.WaitWithDefaultTimeout()
 		Expect(startPod).Should(ExitCleanly())

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -34,9 +34,7 @@ var _ = Describe("Podman prune", func() {
 		Expect(top).Should(ExitCleanly())
 		cid := top.OutputToString()
 
-		stop := podmanTest.Podman([]string{"stop", cid})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(cid)
 
 		prune := podmanTest.Podman([]string{"container", "prune", "-f"})
 		prune.WaitWithDefaultTimeout()
@@ -220,9 +218,7 @@ var _ = Describe("Podman prune", func() {
 		session = podmanTest.Podman([]string{"pod", "start", podid1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		session = podmanTest.Podman([]string{"pod", "stop", "-t0", podid1})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.StopPod(podid1)
 
 		pods := podmanTest.Podman([]string{"pod", "ps"})
 		pods.WaitWithDefaultTimeout()
@@ -293,9 +289,7 @@ var _ = Describe("Podman prune", func() {
 		session = podmanTest.Podman([]string{"pod", "start", podid1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		session = podmanTest.Podman([]string{"pod", "stop", "-t0", podid1})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.StopPod(podid1)
 
 		// Create a container. This container should be pruned.
 		create := podmanTest.Podman([]string{"create", "--name", "test", BB})
@@ -325,9 +319,7 @@ var _ = Describe("Podman prune", func() {
 		session = podmanTest.Podman([]string{"pod", "start", podid1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		session = podmanTest.Podman([]string{"pod", "stop", "-t0", podid1})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.StopPod(podid1)
 
 		// Start a pod and leave it running
 		session = podmanTest.Podman([]string{"pod", "create"})
@@ -403,10 +395,7 @@ var _ = Describe("Podman prune", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"pod", "stop", podid1})
-		session.WaitWithDefaultTimeout()
-		// FIXME - #20196: Cannot use ExitCleanly()
-		Expect(session).Should(Exit(0))
+		podmanTest.StopPod(podid1)
 
 		// Create a container. This container should be pruned.
 		create := podmanTest.Podman([]string{"create", "--name", "test", BB})

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -222,9 +222,7 @@ var _ = Describe("Podman restart", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 
-		session = podmanTest.Podman([]string{"stop", "--all"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.StopContainer("--all")
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"restart", "--all"})

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -26,9 +26,7 @@ var _ = Describe("Podman run exit", func() {
 		Expect(pmount).Should(ExitCleanly())
 		Expect(pmount.OutputToString()).To(ContainSubstring(cid))
 
-		stop := podmanTest.Podman([]string{"stop", cid})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(cid)
 
 		// We have to force cleanup so the unmount happens
 		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", cid})
@@ -69,9 +67,7 @@ var _ = Describe("Podman run exit", func() {
 		Expect(pmount).Should(ExitCleanly())
 		Expect(pmount.OutputToString()).To(ContainSubstring(cid))
 
-		stop := podmanTest.Podman([]string{"stop", cid})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(cid)
 
 		// We have to force cleanup so the unmount happens
 		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", cid})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -302,9 +302,7 @@ var _ = Describe("Podman run", func() {
 		Expect(osession).Should(ExitCleanly())
 		Expect(osession.OutputToString()).To(Equal("hello"))
 
-		osession = podmanTest.Podman([]string{"stop", "overlay-foo"})
-		osession.WaitWithDefaultTimeout()
-		Expect(osession).Should(ExitCleanly())
+		podmanTest.StopContainer("overlay-foo")
 
 		startsession := podmanTest.Podman([]string{"start", "--attach", "overlay-foo"})
 		startsession.WaitWithDefaultTimeout()
@@ -1541,9 +1539,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		ctr.WaitWithDefaultTimeout()
 		Expect(ctr).Should(ExitCleanly())
 
-		stop := podmanTest.Podman([]string{"stop", "-t0", ctrName})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(ctrName)
 
 		// This is ugly, but I don't see a better way
 		time.Sleep(10 * time.Second)
@@ -2093,9 +2089,7 @@ WORKDIR /madethis`, BB)
 		mainContainer.WaitWithDefaultTimeout()
 		Expect(mainContainer).Should(ExitCleanly())
 
-		stop := podmanTest.Podman([]string{"stop", "--all"})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer("--all")
 
 		start := podmanTest.Podman([]string{"start", mainName})
 		start.WaitWithDefaultTimeout()

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -386,9 +386,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(mountOut2).To(ContainSubstring(volName))
 
 		// Stop the container to unmount
-		podmanStopSession := podmanTest.Podman([]string{"stop", "--time", "0", ctrName})
-		podmanStopSession.WaitWithDefaultTimeout()
-		Expect(podmanStopSession).Should(ExitCleanly())
+		podmanTest.StopContainer(ctrName)
 
 		// We have to force cleanup so the unmount happens
 		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", ctrName})
@@ -675,9 +673,7 @@ VOLUME /test/`, ALPINE)
 		session = podmanTest.Podman([]string{"exec", "-l", "ls", "/run/test/container"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		session = podmanTest.Podman([]string{"stop", "-l"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.StopContainer("-l")
 		session = podmanTest.Podman([]string{"start", "-l"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -140,9 +140,7 @@ var _ = Describe("Podman volume plugins", func() {
 		Expect(arrOutput).To(HaveLen(1))
 		Expect(arrOutput[0]).To(ContainSubstring(volName))
 
-		stop := podmanTest.Podman([]string{"stop", "--timeout", "0", ctrName})
-		stop.WaitWithDefaultTimeout()
-		Expect(stop).Should(ExitCleanly())
+		podmanTest.StopContainer(ctrName)
 
 		// Remove should exit non-zero because missing plugin
 		remove := podmanTest.Podman([]string{"volume", "rm", volName})


### PR DESCRIPTION
This removes a lot of boilerplate, but also ensures that every stop test that is not directly testing podman stop or podman pod stop uses `-t0` for quick, error-free stopping.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
