### PR TITLE
[CI:DOCS] man-page xref: make nested-structure warnings fatal

### DIFF
--- a/docs/source/markdown/podman-stats.1.md.in
+++ b/docs/source/markdown/podman-stats.1.md.in
@@ -51,7 +51,7 @@ Valid placeholders for the Go template are listed below:
 | .MemUsageBytes      | Memory usage (IEC)                               |
 | .Name               | Container Name                                   |
 | .NetIO              | Network IO                                       |
-| .Network            | Network I/O, separated by network interface      |
+| .Network ...        | Network I/O, separated by network interface      |
 | .PerCPU             | CPU time consumed by all tasks [1]               |
 | .PIDs               | Number of PIDs                                   |
 | .PIDS               | Number of PIDs (yes, we know this is a dup)      |

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -256,6 +256,7 @@ sub xref_by_help {
                     }
 
                     warn "$ME: 'podman @subcommand {{$k' $msg\n";
+                    ++$Errs;
                 }
             }
         }


### PR DESCRIPTION
Followup to:
  - #21060, where I added new struct checks (but did not make them fatal)

  - #21534, which added per-interface stats and a .Network field,
    but its documentation was slightly off

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Very minor tweak to the .Network format field in podman-stats, not worth mentioning in release notes IMO
```