### PR TITLE
machine: Add `ConnectionInfo` to inspect

### DIFF
--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -72,12 +72,18 @@ func inspect(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		podmanSocket, podmanPipe, err := mc.ConnectionInfo(provider.VMType())
+		if err != nil {
+			return err
+		}
+
 		ii := machine.InspectInfo{
-			// TODO I dont think this is useful
-			ConfigPath: *dirs.ConfigDir,
-			// TODO Fill this out
-			ConnectionInfo: machine.ConnectionConfig{},
-			Created:        mc.Created,
+			ConfigDir: *dirs.ConfigDir,
+			ConnectionInfo: machine.ConnectionConfig{
+				PodmanSocket: podmanSocket,
+				PodmanPipe:   podmanPipe,
+			},
+			Created: mc.Created,
 			// TODO This is no longer applicable; we dont care about the provenance
 			// of the image
 			Image: machine.ImageConfig{

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -25,7 +25,7 @@ Print results with a Go template.
 
 | **Placeholder**     | **Description**                                                       |
 | ------------------- | --------------------------------------------------------------------- |
-| .ConfigPath ...     | Machine configuration file location                                   |
+| .ConfigDir ...      | Machine configuration directory location                                   |
 | .ConnectionInfo ... | Machine connection information                                        |
 | .Created ...        | Machine creation time (string, ISO3601)                               |
 | .Image ...          | Machine image config                                                  |

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -103,7 +103,7 @@ type DistributionDownload interface {
 	CleanCache() error
 }
 type InspectInfo struct {
-	ConfigPath         define.VMFile
+	ConfigDir          define.VMFile
 	ConnectionInfo     ConnectionConfig
 	Created            time.Time
 	Image              ImageConfig

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -270,7 +270,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(session).To(Exit(0))
 
 		inspect := new(inspectMachine)
-		inspect = inspect.withFormat("{{.ConfigPath.Path}}")
+		inspect = inspect.withFormat("{{.ConfigDir.Path}}")
 		inspectSession, err := mb.setCmd(inspect).run()
 		Expect(err).ToNot(HaveOccurred())
 		cfgpth := filepath.Join(inspectSession.outputToString(), fmt.Sprintf("%s.json", name))

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/define"
 	jsoniter "github.com/json-iterator/go"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -66,13 +67,12 @@ var _ = Describe("podman inspect stop", func() {
 		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		// TODO Re-enable this for tests once inspect is fixed
-		// switch testProvider.VMType() {
-		// case define.WSLVirt:
-		// 	Expect(inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath()).To(ContainSubstring("podman-"))
-		// default:
-		// 	Expect(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()).To(HaveSuffix("podman.sock"))
-		// }
+		switch testProvider.VMType() {
+		case define.WSLVirt:
+			Expect(inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath()).To(ContainSubstring("podman-"))
+		default:
+			Expect(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()).To(HaveSuffix("podman.sock"))
+		}
 
 		inspect := new(inspectMachine)
 		inspect = inspect.withFormat("{{.Name}}")


### PR DESCRIPTION
Adds `ConnectionInfo()` to the `MachineConfig` and fills out `InspectInfo` accordingly. Additionally fixes the "inspect with go format" test.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`ConnectionInfo` is now properly displayed in `machine inspect`
```
