### PR TITLE
[skip-ci] Packit: Update downstream task targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -72,10 +72,9 @@ jobs:
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-development
+      - fedora-all
 
-        # TODO: Revisit once fedora 40 is branched and manual bodhi is enabled
-        #- job: bodhi_update
-        #trigger: commit
-        #dist_git_branches:
-        #- fedora-40 # rawhide updates are created automatically
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
When I added commit b73eec88, I was under the impression that the packit config for a downstream Fedora branch should only contain the tasks for that particular branch. But, that's not quite the case.

For all downstream tasks like `koji builds` and `bodhi updates`, Packit now uses the config from the `rawhide` branch on dist-git https://src.fedoraproject.org/rpms/podman/tree/rawhide . So, this means all downstream tasks including the ones for F38 and F39 which use a different version of Podman, need to be specified in the packit config file that lands in the `rawhide` branch.

This commit re-enables koji and bodhi tasks for all Fedora branches. Enabling F38 and F39 koji and bodhi will still end up building from the sources in dist-git, so it's not a conflict to have them enabled on an upstream branch that won't make its way into F38 and F39.

Labelling as `[skip-ci]` as this doesn't need to go through upstream CI.

Thanks to @majamassarini.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
