### PR TITLE
[v4.9] [skip-ci] Packit: remove koji and bodhi tasks for v4.9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -66,14 +66,6 @@ jobs:
   - job: propose_downstream
     trigger: release
     update_release: false
-    dist_git_branches: &stable_fedora
+    dist_git_branches:
       - fedora-39
       - fedora-38
-
-  - job: koji_build
-    trigger: commit
-    dist_git_branches: *stable_fedora
-
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches: *stable_fedora


### PR DESCRIPTION
For downstream tasks like koji and bodhi, the packit config is pulled
from the `rawhide` branch of dist-git. So, these tasks shouldn't be
specified in places which won't end up in rawhide.
    
Ref: https://github.com/containers/podman/pull/21743
    
Labelling as [skip-ci] as this doesn't need to go through upstream CI.
    
Thanks to @majamassarini.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
