### PR TITLE
System tests: enable debugging for parallel-rm test

### DIFF
--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -216,6 +216,7 @@ EOF
     is "$output" "$rand_value"
 
     run_podman pod rm -t 0 -f test
+    run_podman rmi $(pause_image)
 }
 
 @test "podman ps --format PodName" {
@@ -229,6 +230,8 @@ EOF
     is "$output" ".*$rand_value"
 
     run_podman rm -t 0 -f $cid
+    run_podman pod rm -t 0 -f $rand_value
+    run_podman rmi $(pause_image)
 }
 
 # vim: filetype=sh

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -249,12 +249,19 @@ EOF
     local count=30
     for i in $(seq --format '%02g' 1 $count); do
         timeout --foreground -v --kill=10 60 \
-                $PODMAN build -t i$i $PODMAN_TMPDIR &>/dev/null &
+                $PODMAN build -t i$i $PODMAN_TMPDIR &> $PODMAN_TMPDIR/log.$i &
     done
 
     # Wait for all background builds to complete. Note that this succeeds
     # even if some of the individual builds fail! Our actual test is below.
     wait
+
+    # For debugging, e.g., #21742
+    for log in $PODMAN_TMPDIR/log.*;do
+        echo
+        echo $log ":"
+        cat $log
+    done
 
     # Now delete all built images. If any image wasn't built, rmi will fail
     # and test will fail.


### PR DESCRIPTION
There's currently no way to inspect failures of the
parallel-remove test (#21742). Add debugging ability.

Also, clean up nasty red warnings

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```