### PR TITLE
compose: fix build tags

### DIFF
--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -1,4 +1,8 @@
-//go:build amd64 || arm64
+//go:build !remote || amd64 || arm64
+
+// Compose requires running against a socket.  For native Linux clients (!remote),
+// we can talk directly to the local Podman socket.  For remote clients, we need
+// to run against podman-machine which is only available on amd64 and arm64.
 
 package main
 
@@ -6,20 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"text/template"
 
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/pkg/errorhandling"
-	"github.com/containers/podman/v5/pkg/machine"
-	"github.com/containers/podman/v5/pkg/machine/define"
-	"github.com/containers/podman/v5/pkg/machine/provider"
-	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -101,109 +99,15 @@ func composeProvider() (string, error) {
 	return "", fmt.Errorf("looking up compose provider failed\n%v", errorhandling.JoinErrors(lookupErrors))
 }
 
-// composeDockerHost returns the value to be set in the DOCKER_HOST environment
-// variable.
-func composeDockerHost() (string, error) {
-	if value, ok := os.LookupEnv("DOCKER_HOST"); ok {
-		return value, nil
-	}
-
-	// For local clients (Linux/FreeBSD), use the default API
-	// address.
-	if !registry.IsRemote() {
-		return registry.DefaultAPIAddress(), nil
-	}
-
-	// TODO need to add support for --connection and --url
-	connection, err := registry.PodmanConfig().ContainersConfDefaultsRO.GetConnection("", true)
-	if err != nil {
-		logrus.Info(err)
-		switch runtime.GOOS {
-		// If no default connection is set on Linux or FreeBSD,
-		// we just use the local socket by default - just as
-		// the remote client does.
-		case "linux", "freebsd":
-			return registry.DefaultAPIAddress(), nil
-		// If there is no default connection on Windows or Mac
-		// OS, we can safely assume that something went wrong.
-		// A `podman machine init` will set the connection.
-		default:
-			return "", fmt.Errorf("cannot connect to a socket or via SSH: no default connection found: consider running `podman machine init`")
-		}
-	}
-
-	parsedConnection, err := url.Parse(connection.URI)
-	if err != nil {
-		return "", fmt.Errorf("preparing connection to remote machine: %w", err)
-	}
-
-	// If the default connection does not point to a `podman
-	// machine`, we cannot use a local path and need to use SSH.
-	if !connection.IsMachine {
-		// Compose doesn't like paths, so we optimistically
-		// assume the presence of a Docker socket on the remote
-		// machine which is the case for podman machines.
-		return strings.TrimSuffix(connection.URI, parsedConnection.Path), nil
-	}
-
-	machineProvider, err := provider.Get()
-	if err != nil {
-		return "", fmt.Errorf("getting machine provider: %w", err)
-	}
-	dirs, err := machine.GetMachineDirs(machineProvider.VMType())
-	if err != nil {
-		return "", err
-	}
-
-	machineList, err := vmconfigs.LoadMachinesInDir(dirs)
-	if err != nil {
-		return "", fmt.Errorf("listing machines: %w", err)
-	}
-
-	// Now we know that the connection points to a machine and we
-	// can find the machine by looking for the one with the
-	// matching port.
-	connectionPort, err := strconv.Atoi(parsedConnection.Port())
-	if err != nil {
-		return "", fmt.Errorf("parsing connection port: %w", err)
-	}
-	for _, item := range machineList {
-		if connectionPort != item.SSH.Port {
-			continue
-		}
-
-		state, err := machineProvider.State(item, false)
-		if err != nil {
-			return "", err
-		}
-
-		if state != define.Running {
-			return "", fmt.Errorf("machine %s is not running but in state %s", item.Name, state)
-		}
-
-		// TODO This needs to be wired back in when all providers are complete
-		// TODO Need someoone to plumb in the connection information below
-		// if machineProvider.VMType() == define.WSLVirt || machineProvider.VMType() == define.HyperVVirt {
-		// 	if info.ConnectionInfo.PodmanPipe == nil {
-		// 		return "", errors.New("pipe of machine is not set")
-		// 	}
-		// 	return strings.Replace(info.ConnectionInfo.PodmanPipe.Path, `\\.\pipe\`, "npipe:////./pipe/", 1), nil
-		// }
-		// if info.ConnectionInfo.PodmanSocket == nil {
-		// 	return "", errors.New("socket of machine is not set")
-		// }
-		// return "unix://" + info.ConnectionInfo.PodmanSocket.Path, nil
-		return "", nil
-	}
-
-	return "", fmt.Errorf("could not find a matching machine for connection %q", connection.URI)
-}
-
 // composeEnv returns the compose-specific environment variables.
 func composeEnv() ([]string, error) {
-	hostValue, err := composeDockerHost()
-	if err != nil {
-		return nil, err
+	hostValue, ok := os.LookupEnv("DOCKER_HOST")
+	if !ok {
+		val, err := composeDockerHost()
+		if err != nil {
+			return nil, err
+		}
+		hostValue = val
 	}
 
 	return []string{

--- a/cmd/podman/compose_local.go
+++ b/cmd/podman/compose_local.go
@@ -1,0 +1,15 @@
+//go:build !remote
+
+// Compose requires running against a socket.  For native Linux clients (!remote),
+// we can talk directly to the local Podman socket.  For remote clients, we need
+// to run against podman-machine which is only available on amd64 and arm64.
+
+package main
+
+import "github.com/containers/podman/v5/cmd/podman/registry"
+
+// composeDockerHost returns the value to be set in the DOCKER_HOST environment
+// variable.
+func composeDockerHost() (string, error) {
+	return registry.DefaultAPIAddress(), nil
+}

--- a/cmd/podman/compose_remote.go
+++ b/cmd/podman/compose_remote.go
@@ -1,0 +1,110 @@
+//go:build remote && (amd64 || arm64)
+
+// Compose requires running against a socket.  For native Linux clients (!remote),
+// we can talk directly to the local Podman socket.  For remote clients, we need
+// to run against podman-machine which is only available on amd64 and arm64.
+
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/containers/podman/v5/cmd/podman/registry"
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/provider"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/sirupsen/logrus"
+)
+
+// composeDockerHost returns the value to be set in the DOCKER_HOST environment
+// variable.
+func composeDockerHost() (string, error) {
+	// TODO need to add support for --connection and --url
+	connection, err := registry.PodmanConfig().ContainersConfDefaultsRO.GetConnection("", true)
+	if err != nil {
+		logrus.Info(err)
+		switch runtime.GOOS {
+		// If no default connection is set on Linux or FreeBSD,
+		// we just use the local socket by default - just as
+		// the remote client does.
+		case "linux", "freebsd":
+			return registry.DefaultAPIAddress(), nil
+		// If there is no default connection on Windows or Mac
+		// OS, we can safely assume that something went wrong.
+		// A `podman machine init` will set the connection.
+		default:
+			return "", fmt.Errorf("cannot connect to a socket or via SSH: no default connection found: consider running `podman machine init`")
+		}
+	}
+
+	parsedConnection, err := url.Parse(connection.URI)
+	if err != nil {
+		return "", fmt.Errorf("preparing connection to remote machine: %w", err)
+	}
+
+	// If the default connection does not point to a `podman
+	// machine`, we cannot use a local path and need to use SSH.
+	if !connection.IsMachine {
+		// Compose doesn't like paths, so we optimistically
+		// assume the presence of a Docker socket on the remote
+		// machine which is the case for podman machines.
+		return strings.TrimSuffix(connection.URI, parsedConnection.Path), nil
+	}
+
+	machineProvider, err := provider.Get()
+	if err != nil {
+		return "", fmt.Errorf("getting machine provider: %w", err)
+	}
+	dirs, err := machine.GetMachineDirs(machineProvider.VMType())
+	if err != nil {
+		return "", err
+	}
+
+	machineList, err := vmconfigs.LoadMachinesInDir(dirs)
+	if err != nil {
+		return "", fmt.Errorf("listing machines: %w", err)
+	}
+
+	// Now we know that the connection points to a machine and we
+	// can find the machine by looking for the one with the
+	// matching port.
+	connectionPort, err := strconv.Atoi(parsedConnection.Port())
+	if err != nil {
+		return "", fmt.Errorf("parsing connection port: %w", err)
+	}
+	for _, item := range machineList {
+		if connectionPort != item.SSH.Port {
+			continue
+		}
+
+		state, err := machineProvider.State(item, false)
+		if err != nil {
+			return "", err
+		}
+
+		if state != define.Running {
+			return "", fmt.Errorf("machine %s is not running but in state %s", item.Name, state)
+		}
+
+		// TODO This needs to be wired back in when all providers are complete
+		// TODO Need someoone to plumb in the connection information below
+		// if machineProvider.VMType() == define.WSLVirt || machineProvider.VMType() == define.HyperVVirt {
+		// 	if info.ConnectionInfo.PodmanPipe == nil {
+		// 		return "", errors.New("pipe of machine is not set")
+		// 	}
+		// 	return strings.Replace(info.ConnectionInfo.PodmanPipe.Path, `\\.\pipe\`, "npipe:////./pipe/", 1), nil
+		// }
+		// if info.ConnectionInfo.PodmanSocket == nil {
+		// 	return "", errors.New("socket of machine is not set")
+		// }
+		// return "unix://" + info.ConnectionInfo.PodmanSocket.Path, nil
+		return "", nil
+	}
+
+	return "", fmt.Errorf("could not find a matching machine for connection %q", connection.URI)
+}


### PR DESCRIPTION
Compose requires running against a socket.  For native Linux clients
(!remote), we can talk directly to the local Podman socket.  For remote
clients, we need to run against podman-machine which is only available
on amd64 and arm64.

[NO NEW TESTS NEEDED] as there is no functional change.

Fixes: #21757

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enable the `podman compose` command on all architectures beyond ARM64 and AMD64.
```
