### PR TITLE
cirrus logcollector: update package list

### DIFF
--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -36,13 +36,15 @@ case $1 in
     packages)
         # These names are common to Fedora and Debian
         PKG_NAMES=(\
+                    aardvark-dns
                     buildah
                     conmon
                     containernetworking-plugins
-                    containers-common
                     criu
                     crun
                     golang
+                    netavark
+                    passt
                     podman
                     runc
                     skopeo
@@ -53,18 +55,17 @@ case $1 in
                 cat /etc/fedora-release
                 PKG_LST_CMD='rpm -q --qf=%{N}-%{V}-%{R}-%{ARCH}\n'
                 PKG_NAMES+=(\
-                    aardvark-dns
                     container-selinux
+                    containers-common
                     libseccomp
-                    netavark
-                    passt
                 )
                 ;;
             debian)
                 cat /etc/issue
                 PKG_LST_CMD='dpkg-query --show --showformat=${Package}-${Version}-${Architecture}\n'
                 PKG_NAMES+=(\
-                    cri-o-runc
+                    golang-github-containers-common
+                    golang-github-containers-image
                     libseccomp2
                 )
                 ;;


### PR DESCRIPTION
aardvark-dns, netavark and passt are installed on both debian and fedora. cri-o-runc is not installed anymore and it just uses the normal runc package on debian. This makes sure we correctly log all the package versions on debian as well.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
