### PR TITLE
pkg/machine: add custom policy.json logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ LDFLAGS_PODMAN ?= \
 	-X $(LIBPOD)/config._installPrefix=$(PREFIX) \
 	-X $(LIBPOD)/config._etcDir=$(ETCDIR) \
 	-X $(PROJECT)/v5/pkg/systemd/quadlet._binDir=$(BINDIR) \
+	-X $(PROJECT)/v5/pkg/machine/ocipull.DefaultPolicyJSONPath=$(MACHINE_POLICY_JSON_DIR) \
 	-X github.com/containers/common/pkg/config.additionalHelperBinariesDir=$(HELPER_BINARIES_DIR)\
 	$(EXTRA_LDFLAGS)
 LDFLAGS_PODMAN_STATIC ?= \

--- a/Makefile
+++ b/Makefile
@@ -763,10 +763,10 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 	$(MAKE) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		clean-binaries podman-remote-$(GOOS)-docs
 	if [[ "$(GOARCH)" != "$(NATIVE_GOARCH)" ]]; then \
-		$(MAKE) CGO_ENABLED=0 $(GOPLAT) BUILDTAGS="$(BUILDTAGS_CROSS)" \
+		$(MAKE) CGO_ENABLED=0 $(GOPLAT) BUILDTAGS="$(BUILDTAGS_CROSS)" MACHINE_POLICY_JSON_DIR="." \
 			clean-binaries podman-remote; \
 	else \
-		$(MAKE) $(GOPLAT) podman-remote; \
+		$(MAKE) $(GOPLAT) MACHINE_POLICY_JSON_DIR="." podman-remote; \
 	fi
 	if [[ "$(GOOS)" == "windows" ]]; then \
 		$(MAKE) $(GOPLAT) TMPDIR="" win-gvproxy; \
@@ -776,6 +776,7 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 	fi
 	cp -r ./docs/build/remote/$(GOOS) "$(tmpsubdir)/$(releasedir)/docs/"
 	cp ./contrib/remote/containers.conf "$(tmpsubdir)/$(releasedir)/"
+	cp ./pkg/machine/ocipull/policy.json "$(tmpsubdir)/$(releasedir)/"
 	$(MAKE) $(GOPLAT) $(_dstargs) SELINUXOPT="" install.remote
 	cd "$(tmpsubdir)" && \
 		zip --recurse-paths "$(CURDIR)/$@" "./$(releasedir)"

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -47,6 +47,8 @@ package_root: clean-pkgroot $(TMP_DOWNLOAD)/gvproxy $(TMP_DOWNLOAD)/vfkit
 	cp $(TMP_DOWNLOAD)/gvproxy $(PACKAGE_ROOT)/podman/bin/
 	cp $(TMP_DOWNLOAD)/vfkit $(PACKAGE_ROOT)/podman/bin/
 	chmod a+x $(PACKAGE_ROOT)/podman/bin/*
+	mkdir $(PACKAGE_ROOT)/podman/config
+	cp ../../pkg/machine/ocipull/policy.json $(PACKAGE_ROOT)/podman/config/policy.json
 
 %: %.in podman_version
 	@sed -e 's/__VERSION__/'$(shell ../../test/version/version)'/g' $< >$@

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -8,6 +8,7 @@ CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-mock}
 PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
 NO_CODESIGN=${NO_CODESIGN:-0}
 HELPER_BINARIES_DIR="/opt/podman/bin"
+MACHINE_POLICY_JSON_DIR="/opt/podman/config"
 
 binDir="${BASEDIR}/root/podman/bin"
 
@@ -16,7 +17,7 @@ arch=$(cat "${BASEDIR}/ARCH")
 
 function build_podman() {
   pushd "$1"
-    make GOARCH="${goArch}" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}"
+    make GOARCH="${goArch}" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}" MACHINE_POLICY_JSON_DIR="${MACHINE_POLICY_JSON_DIR}"
     make GOARCH="${goArch}" podman-mac-helper
     cp bin/darwin/podman "contrib/pkginstaller/out/packaging/${binDir}/podman"
     cp bin/darwin/podman-mac-helper "contrib/pkginstaller/out/packaging/${binDir}/podman-mac-helper"

--- a/pkg/machine/ocipull/policy.go
+++ b/pkg/machine/ocipull/policy.go
@@ -1,0 +1,47 @@
+package ocipull
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DefaultPolicyJSONPath should be overwritten at build time with the real path to the directory where
+// the shipped policy.json file is located. This can either be absolute path or a relative path. If it
+// is relative it will be resolved relative to the podman binary and NOT the CWD.
+//
+// use "-X github.com/containers/podman/v5/pkg/machine/ocipull.DefaultPolicyJSONPath=/somepath" in go ldflags to overwrite this
+var DefaultPolicyJSONPath = ""
+
+const policyfile = "policy.json"
+
+type defaultPolicyError struct {
+	errs []error
+}
+
+func (e *defaultPolicyError) Error() string {
+	return fmt.Sprintf("no DefaultPolicyJSONPath defined and no local overwrites found: %q", e.errs)
+}
+
+func policyPath() (string, error) {
+	paths := localPolicyOverwrites()
+	errs := make([]error, 0, len(paths))
+	for _, path := range paths {
+		_, err := os.Stat(path)
+		if err == nil {
+			return path, nil
+		}
+		errs = append(errs, err)
+	}
+	if DefaultPolicyJSONPath != "" {
+		if filepath.IsAbs(DefaultPolicyJSONPath) {
+			return filepath.Join(DefaultPolicyJSONPath, policyfile), nil
+		}
+		p, err := os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("could not resolve relative path to binary: %w", err)
+		}
+		return filepath.Join(p, DefaultPolicyJSONPath, policyfile), nil
+	}
+	return "", &defaultPolicyError{errs: errs}
+}

--- a/pkg/machine/ocipull/policy.json
+++ b/pkg/machine/ocipull/policy.json
@@ -1,0 +1,7 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ]
+}

--- a/pkg/machine/ocipull/policy_unix.go
+++ b/pkg/machine/ocipull/policy_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package ocipull
+
+import (
+	"path/filepath"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage/pkg/homedir"
+)
+
+func localPolicyOverwrites() []string {
+	var dirs []string
+	if p, err := homedir.GetConfigHome(); err == nil {
+		dirs = append(dirs, filepath.Join(p, "containers", policyfile))
+	}
+	dirs = append(dirs, config.DefaultSignaturePolicyPath)
+	return dirs
+}

--- a/pkg/machine/ocipull/policy_windows.go
+++ b/pkg/machine/ocipull/policy_windows.go
@@ -1,0 +1,10 @@
+package ocipull
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func localPolicyOverwrites() []string {
+	return []string{filepath.Join(os.Getenv("APPDATA"), "containers", policyfile)}
+}

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -44,9 +44,14 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 		sysCtx.DockerAuthConfig = authConf
 	}
 
-	policy, err := signature.DefaultPolicy(sysCtx)
+	path, err := policyPath()
 	if err != nil {
-		return fmt.Errorf("obtaining default signature policy: %w", err)
+		return err
+	}
+
+	policy, err := signature.NewPolicyFromFile(path)
+	if err != nil {
+		return fmt.Errorf("obtaining signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {


### PR DESCRIPTION
see commits
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman machine init requires a policy.json file to pull images from the container registry. A default policy.json file is located in our repo at pkg/machine/ocipull/policy.json which should be installed for the user. When building podman via Makefile `MACHINE_POLICY_JSON_DIR` should be used to set the directory where the installed policy.json file will be located. This can be relative directory from the podman binary.
```
