### PR TITLE
zstd now default compression for podman machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hugelgupf/p9 v0.3.1-0.20230822151754-54f5c5530921
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.17.5
 	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.21
@@ -149,7 +150,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/klauspost/compress v1.17.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/fs v0.1.0 // indirect

--- a/pkg/machine/compression/compression_test.go
+++ b/pkg/machine/compression/compression_test.go
@@ -33,11 +33,11 @@ func Test_compressionFromFile(t *testing.T) {
 			want: Bz2,
 		},
 		{
-			name: "default is xz",
+			name: "default is zstd",
 			args: args{
 				path: "/tmp/foo",
 			},
-			want: Xz,
+			want: Zstd,
 		},
 	}
 	for _, tt := range tests {
@@ -76,9 +76,9 @@ func TestImageCompression_String(t *testing.T) {
 			want: "zip",
 		},
 		{
-			name: "xz is default",
+			name: "zstd is default",
 			c:    99,
-			want: "xz",
+			want: "zst",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/machine/compression/config.go
+++ b/pkg/machine/compression/config.go
@@ -9,6 +9,7 @@ const (
 	Zip
 	Gz
 	Bz2
+	Zstd
 )
 
 func KindFromFile(path string) ImageCompression {
@@ -19,8 +20,10 @@ func KindFromFile(path string) ImageCompression {
 		return Gz
 	case strings.HasSuffix(path, Zip.String()):
 		return Zip
+	case strings.HasSuffix(path, Xz.String()):
+		return Xz
 	}
-	return Xz
+	return Zstd
 }
 
 func (c ImageCompression) String() string {
@@ -31,6 +34,8 @@ func (c ImageCompression) String() string {
 		return "zip"
 	case Bz2:
 		return "bz2"
+	case Xz:
+		return "xz"
 	}
-	return "xz"
+	return "zst"
 }

--- a/pkg/machine/define/image_format.go
+++ b/pkg/machine/define/image_format.go
@@ -1,5 +1,7 @@
 package define
 
+import "fmt"
+
 type ImageFormat int64
 
 const (
@@ -22,13 +24,9 @@ func (imf ImageFormat) Kind() string {
 }
 
 func (imf ImageFormat) KindWithCompression() string {
-	switch imf {
-	case Vhdx:
-		return "vhdx.zip"
-	case Tar:
+	// Tar uses xz; all others use zstd
+	if imf == Tar {
 		return "tar.xz"
-	case Raw:
-		return "raw.gz"
 	}
-	return "qcow2.xz"
+	return fmt.Sprintf("%s.zst", imf.Kind())
 }

--- a/pkg/machine/define/image_format_test.go
+++ b/pkg/machine/define/image_format_test.go
@@ -45,19 +45,19 @@ func TestImageFormat_KindWithCompression(t *testing.T) {
 		want string
 	}{
 		{
-			name: "vhdx.zip",
+			name: "vhdx",
 			imf:  Vhdx,
-			want: "vhdx.zip",
+			want: "vhdx.zst",
 		},
 		{
 			name: "qcow2",
 			imf:  Qcow,
-			want: "qcow2.xz",
+			want: "qcow2.zst",
 		},
 		{
-			name: "raw.gz",
+			name: "raw",
 			imf:  Raw,
-			want: "raw.gz",
+			want: "raw.zst",
 		}, {
 			name: "tar.xz",
 			imf:  Tar,

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -178,24 +178,6 @@ ExecStart=
 ExecStart=-/usr/sbin/agetty --autologin root --noclear %I $TERM
 `
 
-	deMoby := parser.NewUnitFile()
-	deMoby.Add("Unit", "Description", "Remove moby-engine")
-	deMoby.Add("Unit", "After", "systemd-machine-id-commit.service")
-	deMoby.Add("Unit", "Before", "zincati.service")
-	deMoby.Add("Unit", "ConditionPathExists", "!/var/lib/%N.stamp")
-
-	deMoby.Add("Service", "Type", "oneshot")
-	deMoby.Add("Service", "RemainAfterExit", "yes")
-	deMoby.Add("Service", "ExecStart", "/usr/bin/rpm-ostree override remove moby-engine")
-	deMoby.Add("Service", "ExecStart", "/usr/bin/rpm-ostree ex apply-live --allow-replacement")
-	deMoby.Add("Service", "ExecStartPost", "/bin/touch /var/lib/%N.stamp")
-
-	deMoby.Add("Install", "WantedBy", "default.target")
-	deMobyFile, err := deMoby.ToString()
-	if err != nil {
-		return err
-	}
-
 	// This service gets environment variables that are provided
 	// through qemu fw_cfg and then sets them into systemd/system.conf.d,
 	// profile.d and environment.d files
@@ -251,11 +233,6 @@ ExecStart=-/usr/sbin/agetty --autologin root --noclear %I $TERM
 				Enabled: BoolToPtr(false),
 				Name:    "docker.socket",
 				Mask:    BoolToPtr(true),
-			},
-			{
-				Enabled:  BoolToPtr(true),
-				Name:     "remove-moby.service",
-				Contents: &deMobyFile,
 			},
 			{
 				// Disable auto-updating of fcos images
@@ -871,7 +848,7 @@ func GetNetRecoveryUnitFile() *parser.UnitFile {
 
 func DefaultReadyUnitFile() parser.UnitFile {
 	u := parser.NewUnitFile()
-	u.Add("Unit", "After", "remove-moby.service sshd.socket sshd.service")
+	u.Add("Unit", "After", "sshd.socket sshd.service")
 	u.Add("Unit", "OnFailure", "emergency.target")
 	u.Add("Unit", "OnFailureJobMode", "isolate")
 	u.Add("Service", "Type", "oneshot")

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -27,7 +27,7 @@ const (
 	// TODO This is temporary until we decide on a proper image name
 	artifactRegistry     = "quay.io"
 	artifactRepo         = "baude"
-	artifactImageName    = "podman-machine-images-art"
+	artifactImageName    = "stage-podman-machine"
 	artifactOriginalName = "org.opencontainers.image.title"
 	machineOS            = "linux"
 )


### PR DESCRIPTION
given that we are moving to building our own machine images, we have decided to use zstd compression as it is superior in speed to the alternatives.  as such, this pr adds zstd to our machine code; and also has to account for dealing with sparseness on darwin; which the default zstd golang library does not.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
