### PR TITLE
Move ignition functions into Containerfiles

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -820,8 +820,6 @@ podman_machine_mac_task:
     # TODO: Timeout bumped b/c initial image download (~5min) and VM
     #       resize (~2min) causes test-timeout (90s default).  Should
     #       tests deal with this internally?
-    smoke_test_script:
-        - MACHINE_TEST_TIMEOUT=500 make localmachine FOCUS_FILE="basic_test.go"
     test_script:
         - make localmachine
     # This host is/was shared with potentially many other CI tasks.

--- a/contrib/cirrus/mac_setup.sh
+++ b/contrib/cirrus/mac_setup.sh
@@ -32,6 +32,11 @@ echo "TMPDIR=/private/tmp/ci" >> $CIRRUS_ENV
 # Removed completely during cleanup.
 mkdir -p /private/tmp/ci
 
+# Add policy.json
+mkdir -p $HOME/ci/.config/containers
+cp pkg/machine/ocipull/policy.json /$HOME/ci/.config/containers/
+
+
 # Some test operations & checks require a git "identity"
 # N/B: $HOME in this context does not include the /ci part automatically
 # (see above) but it will when the next Cirrus-CI "_script" section

--- a/contrib/cirrus/win-podman-machine-test.ps1
+++ b/contrib/cirrus/win-podman-machine-test.ps1
@@ -29,5 +29,9 @@ Set-Location "$ENV:CIRRUS_WORKING_DIR\repo"
 # Tests hard-code this location for podman-remote binary, make sure it actually runs.
 Run-Command ".\bin\windows\podman.exe --version"
 
+# Add policy.json to filesystem for podman machine pulls
+New-Item -ItemType "directory" -Path "$env:AppData\containers"
+Copy-Item -Path pkg\machine\ocipull\policy.json -Destination "$env:AppData\containers"
+
 Write-Host "`nRunning podman-machine e2e tests"
 Run-Command ".\winmake localmachine"

--- a/pkg/machine/e2e/machine_pull_test.go
+++ b/pkg/machine/e2e/machine_pull_test.go
@@ -1,0 +1,43 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/containers/podman/v5/pkg/machine/compression"
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/ocipull"
+)
+
+func pullOCITestDisk(finalDir string, vmType define.VMType) error {
+	imageCacheDir, err := define.NewMachineFile(finalDir, nil)
+	if err != nil {
+		return err
+	}
+	unusedFinalPath, err := imageCacheDir.AppendToNewVMFile(fmt.Sprintf("machinetest-%s", runtime.GOOS), nil)
+	if err != nil {
+		return err
+	}
+	dirs := define.MachineDirs{ImageCacheDir: imageCacheDir}
+	ociArtPull, err := ocipull.NewOCIArtifactPull(context.Background(), &dirs, "e2emachine", vmType, unusedFinalPath)
+	if err != nil {
+		return err
+	}
+	err = ociArtPull.GetNoCompress()
+	if err != nil {
+		return err
+	}
+	fp, originalName := ociArtPull.OriginalFileName()
+	// Rename the download to something we recognize
+	compressionExt := filepath.Ext(fp)
+	fqImageName = filepath.Join(tmpDir, strings.TrimSuffix(originalName, compressionExt))
+	suiteImageName = filepath.Base(fqImageName)
+	compressedImage, err := define.NewMachineFile(fp, nil)
+	if err != nil {
+		return err
+	}
+	return compression.Decompress(compressedImage, fqImageName)
+}

--- a/pkg/machine/e2e/machine_wsl_test.go
+++ b/pkg/machine/e2e/machine_wsl_test.go
@@ -1,0 +1,55 @@
+package e2e_test
+
+import (
+	"errors"
+	"fmt"
+	url2 "net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/compression"
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/wsl"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func pullWSLDisk() error {
+	downloadLocation := os.Getenv("MACHINE_IMAGE")
+	if downloadLocation == "" {
+		dl, _, _, _, err := wsl.GetFedoraDownloadForWSL()
+		if err != nil {
+			return errors.New("unable to determine WSL download")
+		}
+		downloadLocation = dl.String()
+	}
+
+	if downloadLocation == "" {
+		return errors.New("machine tests require a file reference to a disk image right now")
+	}
+	compressionExtension := ".xz"
+	suiteImageName = strings.TrimSuffix(path.Base(downloadLocation), compressionExtension)
+	fqImageName = filepath.Join(tmpDir, suiteImageName)
+	getMe, err := url2.Parse(downloadLocation)
+	if err != nil {
+		return fmt.Errorf("unable to create url for download: %q", err)
+	}
+	now := time.Now()
+	if err := machine.DownloadVMImage(getMe, suiteImageName, fqImageName+compressionExtension); err != nil {
+		return fmt.Errorf("unable to download machine image: %q", err)
+	}
+	GinkgoWriter.Println("Download took: ", time.Since(now).String())
+	diskImage, err := define.NewMachineFile(fqImageName+compressionExtension, nil)
+	if err != nil {
+		return fmt.Errorf("unable to create vmfile %q: %v", fqImageName+compressionExtension, err)
+	}
+	compressionStart := time.Now()
+	if err := compression.Decompress(diskImage, fqImageName); err != nil {
+		return fmt.Errorf("unable to decompress image file: %q", err)
+	}
+	GinkgoWriter.Println("compression took: ", time.Since(compressionStart))
+	return nil
+}


### PR DESCRIPTION
We used to use ignition to perform any customization required for podman machine because our input was a generic FCOS image.  Now that we are building our own images, some of this customization can be migrated to the Containerfile itself and be less of a burden in our code at boot up.

At the time of this PR, the Containerfile can be found at https://github.com/baude/podman-machine-images/tree/main.  It is only present for a so-called daily image.  There is little liklihood that this would the final location for the Containerfile so consider it a working version only.

Note: the change to the pull image name is so PRs are not immediately broken that are already in the queue.

[NO NEW TESTS REQUIRED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
