### PR TITLE
make podman events json output more docker compatible

### DIFF
--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -116,9 +116,8 @@ Format the output to JSON Lines or using the given Go template.
 | .Network                | Name of network being used (string)               |
 | .PodID                  | ID of pod associated with container, if any       |
 | .Status                 | Event status (e.g., create, start, died, ...)     |
-| .Time ...               | Event timestamp (string)                          |
+| .Time                   | Event timestamp (string)                          |
 | .TimeNano               | Event timestamp with nanosecond precision (int64) |
-| .ToHumanReadable *bool* | If true, truncates CID in output                  |
 | .Type                   | Event type (e.g., image, container, pod, ...)     |
 
 #### **--help**

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -104,21 +104,22 @@ In the case where an ID is used, the ID may be in its full or shortened form.  T
 
 Format the output to JSON Lines or using the given Go template.
 
-| **Placeholder**         | **Description**                               |
-|-------------------------|-----------------------------------------------|
-| .Attributes ...         | created_at, _by, labels, and more (map[])     |
-| .ContainerExitCode      | Exit code (int)                               |
-| .ContainerInspectData   | Payload of the container's inspect            |
-| .HealthStatus           | Health Status (string)                        |
-| .ID                     | Container ID (full 64-bit SHA)                |
-| .Image                  | Name of image being run (string)              |
-| .Name                   | Container name (string)                       |
-| .Network                | Name of network being used (string)           |
-| .PodID                  | ID of pod associated with container, if any   |
-| .Status                 | Event status (e.g., create, start, died, ...) |
-| .Time ...               | Event timestamp (string)                      |
-| .ToHumanReadable *bool* | If true, truncates CID in output              |
-| .Type                   | Event type (e.g., image, container, pod, ...) |
+| **Placeholder**         | **Description**                                   |
+|-------------------------|----------------------------------------------- ---|
+| .Attributes ...         | created_at, _by, labels, and more (map[])         |
+| .ContainerExitCode      | Exit code (int)                                   |
+| .ContainerInspectData   | Payload of the container's inspect                |
+| .HealthStatus           | Health Status (string)                            |
+| .ID                     | Container ID (full 64-bit SHA)                    |
+| .Image                  | Name of image being run (string)                  |
+| .Name                   | Container name (string)                           |
+| .Network                | Name of network being used (string)               |
+| .PodID                  | ID of pod associated with container, if any       |
+| .Status                 | Event status (e.g., create, start, died, ...)     |
+| .Time ...               | Event timestamp (string)                          |
+| .TimeNano               | Event timestamp with nanosecond precision (int64) |
+| .ToHumanReadable *bool* | If true, truncates CID in output                  |
+| .Type                   | Event type (e.g., image, container, pod, ...)     |
 
 #### **--help**
 

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -43,7 +43,6 @@ func (c *Container) newContainerEventWithInspectData(status events.Status, inspe
 	e.Type = events.Container
 
 	e.Details = events.Details{
-		ID:         e.ID,
 		PodID:      c.PodID(),
 		Attributes: c.Labels(),
 	}
@@ -99,7 +98,6 @@ func (c *Container) newContainerExitedEvent(exitCode int32) {
 	e.ContainerExitCode = &intExitCode
 
 	e.Details = events.Details{
-		ID:         e.ID,
 		Attributes: c.Labels(),
 	}
 
@@ -121,7 +119,6 @@ func (c *Container) newExecDiedEvent(sessionID string, exitCode int) {
 	e.Attributes["execID"] = sessionID
 
 	e.Details = events.Details{
-		ID:         e.ID,
 		Attributes: c.Labels(),
 	}
 

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -48,8 +48,6 @@ type Event struct {
 // Details describes specifics about certain events, specifically around
 // container events
 type Details struct {
-	// ID is the event ID
-	ID string
 	// ContainerInspectData includes the payload of the container's inspect
 	// data. Only set when events_container_create_inspect_data is set true
 	// in containers.conf.

--- a/test/apiv2/27-containersEvents.at
+++ b/test/apiv2/27-containersEvents.at
@@ -29,7 +29,7 @@ t GET "events?stream=false&since=$START"  200  \
   'select(.status | contains("die")).Actor.Attributes.exitCode=1'
 
 t GET "events?stream=false&since=$START&type=remove"  200  \
-  'select(.status| contains("remove")).Action=remove' \
+  'select(.status | contains("remove")).Action=remove' \
   'select(.status | contains("remove")).Actor.Attributes.containerExitCode=1'
 
 # vim: filetype=sh

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Podman events", func() {
 			"--stream=false",
 			"--since", strconv.FormatInt(start.Unix(), 10),
 			"--filter", fmt.Sprintf("container=%s", ctrName),
-			"--format", "{{json.}}",
+			"--format", "{{json .}}",
 		})
 
 		test.WaitWithDefaultTimeout()
@@ -159,9 +159,6 @@ var _ = Describe("Podman events", func() {
 		Expect(event.TimeNano).To(BeNumerically(">=", start.UnixNano()))
 		Expect(event.TimeNano).To(BeNumerically("<=", end.UnixNano()))
 		Expect(time.Unix(0, event.TimeNano).Unix()).To(BeEquivalentTo(event.Time))
-
-		date := time.Unix(0, event.TimeNano).Format("2006-01-02")
-		Expect(event.ToHumanReadable(false)).To(HavePrefix(date))
 
 		test = podmanTest.Podman([]string{"events", "--stream=false", "--filter=type=container", "--format", "ID: {{.ID}}"})
 		test.WaitWithDefaultTimeout()

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containers/podman/v5/libpod/events"
+	"github.com/containers/podman/v5/cmd/podman/system"
 	. "github.com/containers/podman/v5/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
@@ -119,7 +119,10 @@ var _ = Describe("Podman events", func() {
 	})
 
 	It("podman events format", func() {
-		_, ec, _ := podmanTest.RunLsContainer("")
+		start := time.Now()
+		ctrName := "testCtr"
+		_, ec, _ := podmanTest.RunLsContainer(ctrName)
+		end := time.Now()
 		Expect(ec).To(Equal(0))
 
 		test := podmanTest.Podman([]string{"events", "--stream=false", "--format", "json"})
@@ -129,20 +132,36 @@ var _ = Describe("Podman events", func() {
 		jsonArr := test.OutputToStringArray()
 		Expect(test.OutputToStringArray()).ShouldNot(BeEmpty())
 
-		event := events.Event{}
+		event := system.Event{}
 		err := json.Unmarshal([]byte(jsonArr[0]), &event)
 		Expect(err).ToNot(HaveOccurred())
 
-		test = podmanTest.Podman([]string{"events", "--stream=false", "--format", "{{json.}}"})
+		test = podmanTest.Podman([]string{
+			"events",
+			"--stream=false",
+			"--since", strconv.FormatInt(start.Unix(), 10),
+			"--filter", fmt.Sprintf("container=%s", ctrName),
+			"--format", "{{json.}}",
+		})
+
 		test.WaitWithDefaultTimeout()
 		Expect(test).To(ExitCleanly())
 
 		jsonArr = test.OutputToStringArray()
 		Expect(test.OutputToStringArray()).ShouldNot(BeEmpty())
 
-		event = events.Event{}
+		event = system.Event{}
 		err = json.Unmarshal([]byte(jsonArr[0]), &event)
 		Expect(err).ToNot(HaveOccurred())
+
+		Expect(event.Time).To(BeNumerically(">=", start.Unix()))
+		Expect(event.Time).To(BeNumerically("<=", end.Unix()))
+		Expect(event.TimeNano).To(BeNumerically(">=", start.UnixNano()))
+		Expect(event.TimeNano).To(BeNumerically("<=", end.UnixNano()))
+		Expect(time.Unix(0, event.TimeNano).Unix()).To(BeEquivalentTo(event.Time))
+
+		date := time.Unix(0, event.TimeNano).Format("2006-01-02")
+		Expect(event.ToHumanReadable(false)).To(HavePrefix(date))
 
 		test = podmanTest.Podman([]string{"events", "--stream=false", "--filter=type=container", "--format", "ID: {{.ID}}"})
 		test.WaitWithDefaultTimeout()

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -223,9 +223,9 @@ EOF
     # same amount of events.  We checked the contents before.
     CONTAINERS_CONF_OVERRIDE=$containersConf run_podman events --stream=false --since="2022-03-06T11:26:42.723667984+02:00" --format=json
     assert "${#lines[@]}" = 52 "Number of events returned"
-    is "${lines[0]}" "{\"Name\":\"$eventsFile\",\"Status\":\"log-rotation\",\"Time\":\".*\",\"Type\":\"system\",\"Attributes\":{\"io.podman.event.rotate\":\"begin\"}}"
-    is "${lines[-2]}" "{\"Name\":\"$eventsFile\",\"Status\":\"log-rotation\",\"Time\":\".*\",\"Type\":\"system\",\"Attributes\":{\"io.podman.event.rotate\":\"end\"}}"
-    is "${lines[-1]}" "{\"ID\":\"$ctrID\",\"Image\":\"$IMAGE\",\"Name\":\".*\",\"Status\":\"remove\",\"Time\":\".*\",\"Type\":\"container\",\"Attributes\":{.*}}"
+    is "${lines[0]}" "{\"Name\":\"$eventsFile\",\"Status\":\"log-rotation\",\"time\":[0-9]\+,\"timeNano\":[0-9]\+,\"Type\":\"system\",\"Attributes\":{\"io.podman.event.rotate\":\"begin\"}}"
+    is "${lines[-2]}" "{\"Name\":\"$eventsFile\",\"Status\":\"log-rotation\",\"time\":[0-9]\+,\"timeNano\":[0-9]\+,\"Type\":\"system\",\"Attributes\":{\"io.podman.event.rotate\":\"end\"}}"
+    is "${lines[-1]}" "{\"ID\":\"$ctrID\",\"Image\":\"$IMAGE\",\"Name\":\".*\",\"Status\":\"remove\",\"time\":[0-9]\+,\"timeNano\":[0-9]\+,\"Type\":\"container\",\"Attributes\":{.*}}"
 }
 
 @test "events log-file no duplicates" {
@@ -292,10 +292,10 @@ EOF
     # Make sure that the JSON stream looks as expected. That means it has all
     # events and no duplicates.
     run cat $eventsJSON
-    is "${lines[0]}" "{\"Name\":\"busybox\",\"Status\":\"pull\",\"Time\":\"2022-04-06T11:26:42.7236679+02:00\",\"Type\":\"image\",\"Attributes\":null}"
-    is "${lines[99]}" "{\"Name\":\"busybox\",\"Status\":\"pull\",\"Time\":\"2022-04-06T11:26:42.723667999+02:00\",\"Type\":\"image\",\"Attributes\":null}"
-    is "${lines[100]}" "{\"Name\":\"$eventsFile\",\"Status\":\"log-rotation\",\"Time\":\".*\",\"Type\":\"system\",\"Attributes\":{\"io.podman.event.rotate\":\"end\"}}"
-    is "${lines[103]}" "{\"ID\":\"$ctrID\",\"Image\":\"$IMAGE\",\"Name\":\".*\",\"Status\":\"remove\",\"Time\":\".*\",\"Type\":\"container\",\"Attributes\":{.*}}"
+    is "${lines[0]}" "{\"Name\":\"busybox\",\"Status\":\"pull\",\"time\":1649237202,\"timeNano\":1649237202723[0-9]\+,\"Type\":\"image\",\"Attributes\":null}"
+    is "${lines[99]}" "{\"Name\":\"busybox\",\"Status\":\"pull\",\"time\":1649237202,\"timeNano\":1649237202723[0-9]\+,\"Type\":\"image\",\"Attributes\":null}"
+    is "${lines[100]}" "{\"Name\":\"$eventsFile\",\"Status\":\"log-rotation\",\"time\":[0-9]\+,\"timeNano\":[0-9]\+,\"Type\":\"system\",\"Attributes\":{\"io.podman.event.rotate\":\"end\"}}"
+    is "${lines[103]}" "{\"ID\":\"$ctrID\",\"Image\":\"$IMAGE\",\"Name\":\".*\",\"Status\":\"remove\",\"time\":[0-9]\+,\"timeNano\":[0-9]\+,\"Type\":\"container\",\"Attributes\":{.*}}"
 }
 
 # Prior to #15633, container labels would not appear in 'die' log events


### PR DESCRIPTION
taken over https://github.com/containers/podman/pull/21047 + extra commit for fixes

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman events --format "{{json .}}"` output should more now more docker compatible and include the time and timeNano fields. 
```
