### PR TITLE
pkg/machine: ignore gvproxy pidfile not exists error

### DIFF
--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -1,7 +1,9 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"strconv"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
@@ -11,7 +13,12 @@ import (
 func CleanupGVProxy(f define.VMFile) error {
 	gvPid, err := f.Read()
 	if err != nil {
-		return fmt.Errorf("unable to read gvproxy pid file %s: %v", f.GetPath(), err)
+		// The file will also be removed by gvproxy when it exits so
+		// we need to account for the race and can just ignore it here.
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("unable to read gvproxy pid file: %v", err)
 	}
 	proxyPid, err := strconv.Atoi(string(gvPid))
 	if err != nil {

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -341,12 +341,9 @@ func Stop(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDef
 		if err != nil {
 			return err
 		}
-
-		defer func() {
-			if err := machine.CleanupGVProxy(*gvproxyPidFile); err != nil {
-				logrus.Errorf("unable to clean up gvproxy: %q", err)
-			}
-		}()
+		if err := machine.CleanupGVProxy(*gvproxyPidFile); err != nil {
+			return fmt.Errorf("unable to clean up gvproxy: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When gvproxy exits it will delete the pidfile itself so we need to account for that and juts ignore the case, it just means gvproxy was able to exit successfully on its own.

Also remove the useless defer and return the error so we can get an error exit code not just a print on stderr.

Currently it shows this error which is not helpful to any user: unable to clean up gvproxy: "unable to read gvproxy pid file /run/user/1000/podman/gvproxy.pid: open /run/user/1000/podman/gvproxy.pid: no such file or directory"

[NO NEW TESTS NEEDED] TODO: make machine tests check stderr for such things.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
