### PR TITLE
Ignore docker's end point config when the final network mode isn't bridge

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -373,7 +373,17 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 				}
 			}
 
-			networks[netName] = netOpts
+			// Report configuration error in case bridge mode is not used.
+			if !nsmode.IsBridge() && (len(netOpts.Aliases) > 0 || len(netOpts.StaticIPs) > 0 || len(netOpts.StaticMAC) > 0) {
+				return nil, nil, fmt.Errorf("networks and static ip/mac address can only be used with Bridge mode networking")
+			} else if nsmode.IsBridge() {
+				// Docker CLI now always sends the end point config when using the default (bridge) mode
+				// however podman configuration doesn't expect this to define this at all when not in bridge
+				// mode and the podman server config might override the default network mode to something
+				// else than bridge. So adapt to the podman expectation and define custom end point config
+				// only when really using the bridge mode.
+				networks[netName] = netOpts
+			}
 		}
 
 		netInfo.Networks = networks

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -527,6 +527,29 @@ t GET containers/$cid/json 200 \
 
 t DELETE containers/$cid?v=true 204
 
+# test create container like Docker >= 25 cli: NetworkMode="default" but EndpointsConfig struct is explictly set and netns="host"
+t POST containers/create \
+  Image=$IMAGE \
+  HostConfig='{"NetworkMode":"default"}' \
+  NetworkingConfig='{"EndpointsConfig":{"default":{"IPAMConfig":null,"Links":null,"Aliases":null,"MacAddress":"","NetworkID":"","EndpointID":"","Gateway":"","IPAddress":"","IPPrefixLen":0,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"DriverOpts":null,"DNSNames":null}}}' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .HostConfig.NetworkMode="host"
+
+t DELETE containers/$cid?v=true 204
+
+# test creating a container fails with netns="hosts" on podman side but keep using the default network mode
+# on docker CLI side and trying to use --ip 1.2.3.4 which is only valid for the bridge network mode (docker CLI
+# will assume the default is the bridge mode, so it's valid from docker CLI point of view).
+t POST containers/create \
+  Image=$IMAGE \
+  HostConfig='{"NetworkMode":"default"}' \
+  NetworkingConfig='{"EndpointsConfig":{"default":{"IPAMConfig":null,"Links":null,"Aliases":null,"MacAddress":"","NetworkID":"","EndpointID":"","Gateway":"","IPAddress":"1.2.3.4","IPPrefixLen":0,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"DriverOpts":null,"DNSNames":null}}}' \
+  500 \
+    .cause="networks and static ip/mac address can only be used with Bridge mode networking"
+
 # Restart with the default containers.conf for next tests.
 stop_service
 start_service


### PR DESCRIPTION
Closes #21754

See the discussion in the above mentionned issue.

```release-note
None
```
