### PR TITLE
Do not log error if gvproxy PID does not exist

### DIFF
--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
@@ -11,6 +12,9 @@ import (
 func CleanupGVProxy(f define.VMFile) error {
 	gvPid, err := f.Read()
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("unable to read gvproxy pid file %s: %v", f.GetPath(), err)
 	}
 	proxyPid, err := strconv.Atoi(string(gvPid))


### PR DESCRIPTION
When trying to clean up behind gvproxy, we were logging an error if we could not read the PID file.  But if the PID file is gone, gvproxy has likely cleaned itself up already.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
