### PR TITLE
Adjust some tests to work with Zstd in containers.conf

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Podman manifest", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		push := podmanTest.Podman([]string{"manifest", "push", "--all", "--add-compression", "zstd", "--tls-verify=false", "--remove-signatures", "foobar", "localhost:5000/list"})
+		push := podmanTest.Podman([]string{"manifest", "push", "--all", "--compression-format", "gzip", "--add-compression", "zstd", "--tls-verify=false", "--remove-signatures", "foobar", "localhost:5000/list"})
 		push.WaitWithDefaultTimeout()
 		Expect(push).Should(Exit(0))
 		output := push.ErrorToString()

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Podman push", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--remove-signatures", "imageone", "localhost:5000/image"})
+		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--force-compression=true", "--compression-format", "gzip", "--remove-signatures", "imageone", "localhost:5000/image"})
 		push.WaitWithDefaultTimeout()
 		Expect(push).Should(ExitCleanly())
 
@@ -115,7 +115,6 @@ var _ = Describe("Podman push", func() {
 		skopeo.WaitWithDefaultTimeout()
 		Expect(skopeo).Should(ExitCleanly())
 		output := skopeo.OutputToString()
-		// Default compression is gzip and push with `--force-compression=false` no traces of `zstd` should be there.
 		Expect(output).ToNot(ContainSubstring("zstd"))
 
 		push = podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--force-compression=false", "--compression-format", "zstd", "--remove-signatures", "imageone", "localhost:5000/image"})

--- a/test/system/012-manifest.bats
+++ b/test/system/012-manifest.bats
@@ -131,7 +131,7 @@ EOF
 
     # Push to local registry; the magic key here is --add-compression...
     local manifestpushed="localhost:${PODMAN_LOGIN_REGISTRY_PORT}/test:1.0"
-    run_podman manifest push --authfile=$authfile --all --add-compression zstd --tls-verify=false $manifestlocal $manifestpushed
+    run_podman manifest push --authfile=$authfile --all --compression-format gzip --add-compression zstd --tls-verify=false $manifestlocal $manifestpushed
 
     # ...and use skopeo to confirm that each component has the right settings
     echo "$_LOG_PROMPT skopeo inspect ... $manifestpushed"


### PR DESCRIPTION
These are immediately-applicable parts of #21571 , so that tests which require gzip compression to be used don’t rely on the `containers.conf` default.

That this does work with Zstd can be verified in #21571.

#### Does this PR introduce a user-facing change?

```release-note
None
```
