### PR TITLE
Fix nightly cron checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,7 +132,7 @@ build_task:
     #       the 'origin' remote must be defined, and all remote branches/tags
     #       must be available for reference from CI scripts.
     clone_script: &full_clone |
-          set -exuo pipefail
+          set -exo pipefail
           cd /
           rm -rf $CIRRUS_WORKING_DIR
           mkdir -p $CIRRUS_WORKING_DIR


### PR DESCRIPTION
Broken by #21777: "set -u" causes clone_script to barf with

    CIRRUS_PR: unbound variable

See [log](https://cirrus-ci.com/task/6607825602871296)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```