### PR TITLE
Fix podman stop -t -1 CID

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1332,10 +1332,10 @@ func ParseRestartPolicy(policy string) (string, uint, error) {
 	return policyType, retriesUint, nil
 }
 
-// ConvertTimeout converts negative timeout to MaxInt, which indicates approximately infinity, waiting to stop containers
+// ConvertTimeout converts negative timeout to MaxUint32, which indicates approximately infinity, waiting to stop containers
 func ConvertTimeout(timeout int) uint {
 	if timeout < 0 {
-		return math.MaxInt
+		return math.MaxUint32
 	}
 	return uint(timeout)
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -572,4 +573,18 @@ func TestConvertMappings(t *testing.T) {
 		assert.Equal(t, start[i].HostID, convertedBack[i].HostID)
 		assert.Equal(t, start[i].Size, convertedBack[i].Size)
 	}
+}
+
+func TestConvertTimeout(t *testing.T) {
+	timeout := ConvertTimeout(0)
+	assert.Equal(t, uint(0), timeout)
+
+	timeout = ConvertTimeout(100)
+	assert.Equal(t, uint(100), timeout)
+
+	timeout = ConvertTimeout(-1)
+	assert.Equal(t, uint(math.MaxUint32), timeout)
+
+	timeout = ConvertTimeout(-100)
+	assert.Equal(t, uint(math.MaxUint32), timeout)
 }

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1079,7 +1079,7 @@ $IMAGE--c_ok" \
     run_podman stop -t 0 $cid
 
     # Actual test for 15895: with --systemd, no ttyN devices are passed through
-    run_podman run -d --privileged --systemd=always $IMAGE top
+    run_podman run -d --privileged --stop-signal=TERM --systemd=always $IMAGE top
     cid="$output"
 
     run_podman exec $cid sh -c "find /dev -regex '/dev/tty[0-9].*' | wc -w"
@@ -1087,12 +1087,7 @@ $IMAGE--c_ok" \
            "ls /dev/tty[0-9] with --systemd=always: should have no ttyN devices"
 
     # Make sure run_podman stop supports -1 option
-    # FIXME: do we really really mean to say FFFFFFFFFFFFFFFF here???
-    run_podman 0+w stop -t -1 $cid
-    if ! is_remote; then
-        require_warning "StopSignal \(37\) failed to stop container .* in 18446744073709551615 seconds, resorting to SIGKILL" \
-                        "stop -t -1 (negative 1) issues warning"
-    fi
+    run_podman stop -t -1 $cid
     run_podman rm -t -1 -f $cid
 }
 


### PR DESCRIPTION
Currently if a user specifies a negative time to stop a container the code ends up specifying the negative time to time.Duration which treats it as 0. By settine the default to max.Unint32 we end up with a positive number which indicates > 68 years which is probably close enough to infinity for our use case.

Fixes: https://github.com/containers/podman/issues/21811

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
