### PR TITLE
new vms, with rc6 rawhide kernel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240222t143004z-f39f38d13"
+    IMAGE_SUFFIX: "c20240227t125812z-f39f38d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -99,7 +99,7 @@ if ($args.Count -lt 1 -or $args[0].Length -lt 1) {
 }
 
 # Pre-set to standard locations in-case build env does not refresh paths
-$Env:Path="$Env:Path;C:\Program Files (x86)\WiX Toolset v3.11\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;;C:\Program Files\Go\bin"
+$Env:Path="$Env:Path;C:\Program Files (x86)\WiX Toolset v3.14\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;;C:\Program Files\Go\bin"
 
 CheckRequirements
 


### PR DESCRIPTION
Source: https://github.com/containers/automation_images/pull/331#issuecomment-1966677347

Kludgy VM build, because rawhide rc6 kernel is still not stable.
I would like to merge this anyway, because the rawhide hang is
hurting us badly. (I am not guaranteeing that this fixes the hang).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```