### PR TITLE
Add missing vfkit entitlement

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -40,7 +40,6 @@ packagedir: podman_version package_root Distribution welcome.html
 	../../test/version/version > $(PACKAGE_DIR)/VERSION
 	echo -n $(ARCH) > $(PACKAGE_DIR)/ARCH
 	cp ../../LICENSE $(PACKAGE_DIR)/Resources/LICENSE.txt
-	cp hvf.entitlements $(PACKAGE_DIR)/
 
 package_root: clean-pkgroot $(TMP_DOWNLOAD)/gvproxy $(TMP_DOWNLOAD)/vfkit
 	mkdir -p $(PACKAGE_ROOT)/podman/bin

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -40,6 +40,7 @@ packagedir: podman_version package_root Distribution welcome.html
 	../../test/version/version > $(PACKAGE_DIR)/VERSION
 	echo -n $(ARCH) > $(PACKAGE_DIR)/ARCH
 	cp ../../LICENSE $(PACKAGE_DIR)/Resources/LICENSE.txt
+	cp vfkit.entitlements $(PACKAGE_DIR)/
 
 package_root: clean-pkgroot $(TMP_DOWNLOAD)/gvproxy $(TMP_DOWNLOAD)/vfkit
 	mkdir -p $(PACKAGE_ROOT)/podman/bin

--- a/contrib/pkginstaller/hvf.entitlements
+++ b/contrib/pkginstaller/hvf.entitlements
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.hypervisor</key>
-    <true/>
-</dict>
-</plist>

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 BASEDIR=$(dirname "$0")
 OUTPUT=$1
-CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-mock}
+CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
 PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
 NO_CODESIGN=${NO_CODESIGN:-0}
 HELPER_BINARIES_DIR="/opt/podman/bin"
@@ -25,9 +25,6 @@ function build_podman() {
 }
 
 function sign() {
-  if [ "${NO_CODESIGN}" -eq "1" ]; then
-    return
-  fi
   local opts=""
   entitlements="${BASEDIR}/$(basename "$1").entitlements"
   if [ -f "${entitlements}" ]; then

--- a/contrib/pkginstaller/vfkit.entitlements
+++ b/contrib/pkginstaller/vfkit.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
The vfkit binary shipped with podman 5.0-rc3 can't start virtual machines, see
https://github.com/containers/podman/issues/21842
The entitlements are overwritten during the signing process.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
This fixes an issue with the `vfkit` hypervisor causing this problem on Apple hardware:

$ podman machine start
Starting machine "podman-machine-default"
Error: vfkit exited unexpectedly with exit code 1
```