### PR TITLE
Move locks to shim layer

### DIFF
--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/shim"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/spf13/cobra"
 )
@@ -136,10 +137,5 @@ func setMachine(cmd *cobra.Command, args []string) error {
 
 	// At this point, we have the known changed information, etc
 	// Walk through changes to the providers if they need them
-	if err := provider.SetProviderAttrs(mc, setOpts); err != nil {
-		return err
-	}
-
-	// Update the configuration file last if everything earlier worked
-	return mc.Write()
+	return shim.Set(mc, provider, setOpts)
 }

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -18,9 +18,6 @@ import (
 )
 
 func (a *AppleHVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
-	mc.Lock()
-	defer mc.Unlock()
-
 	return []string{}, func() error { return nil }, nil
 }
 
@@ -75,8 +72,6 @@ func (a *AppleHVStubber) State(mc *vmconfigs.MachineConfig, _ bool) (define.Stat
 }
 
 func (a *AppleHVStubber) StopVM(mc *vmconfigs.MachineConfig, _ bool) error {
-	mc.Lock()
-	defer mc.Unlock()
 	return mc.AppleHypervisor.Vfkit.Stop(false, true)
 }
 

--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -93,9 +93,6 @@ func (a AppleHVStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 }
 
 func (a AppleHVStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
-	mc.Lock()
-	defer mc.Unlock()
-
 	state, err := a.State(mc, false)
 	if err != nil {
 		return err

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -138,9 +138,6 @@ func (h HyperVStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, quiet bool)
 }
 
 func (h HyperVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
-	mc.Lock()
-	defer mc.Unlock()
-
 	_, vm, err := GetVMFromMC(mc)
 	if err != nil {
 		return nil, nil, err
@@ -247,9 +244,6 @@ func (h HyperVStubber) State(mc *vmconfigs.MachineConfig, bypass bool) (define.S
 }
 
 func (h HyperVStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
-	mc.Lock()
-	defer mc.Unlock()
-
 	vmm := hypervctl.NewVirtualMachineManager()
 	vm, err := vmm.GetMachine(mc.Name)
 	if err != nil {
@@ -306,9 +300,6 @@ func (h HyperVStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define
 	var (
 		cpuChanged, memoryChanged bool
 	)
-
-	mc.Lock()
-	defer mc.Unlock()
 
 	_, vm, err := GetVMFromMC(mc)
 	if err != nil {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -114,9 +114,6 @@ func (q *QEMUStubber) waitForMachineToStop(mc *vmconfigs.MachineConfig) error {
 
 // Stop uses the qmp monitor to call a system_powerdown
 func (q *QEMUStubber) StopVM(mc *vmconfigs.MachineConfig, _ bool) error {
-	mc.Lock()
-	defer mc.Unlock()
-
 	if err := mc.Refresh(); err != nil {
 		return err
 	}
@@ -229,9 +226,6 @@ func (q *QEMUStubber) stopLocked(mc *vmconfigs.MachineConfig) error {
 
 // Remove deletes all the files associated with a machine including the image itself
 func (q *QEMUStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
-	mc.Lock()
-	defer mc.Unlock()
-
 	qemuRmFiles := []string{
 		mc.QEMUHypervisor.QEMUPidPath.GetPath(),
 		mc.QEMUHypervisor.QMPMonitor.Address.GetPath(),

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -252,9 +252,6 @@ func (q *QEMUStubber) resizeDisk(newSize strongunits.GiB, diskPath *define.VMFil
 }
 
 func (q *QEMUStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
-	mc.Lock()
-	defer mc.Unlock()
-
 	state, err := q.State(mc, false)
 	if err != nil {
 		return err

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -108,13 +108,6 @@ func (mc *MachineConfig) Unlock() {
 	mc.lock.Unlock()
 }
 
-// Write is a locking way to the machine configuration file
-func (mc *MachineConfig) Write() error {
-	mc.Lock()
-	defer mc.Unlock()
-	return mc.write()
-}
-
 // Refresh reloads the config file from disk
 func (mc *MachineConfig) Refresh() error {
 	content, err := os.ReadFile(mc.configPath.GetPath())
@@ -125,7 +118,7 @@ func (mc *MachineConfig) Refresh() error {
 }
 
 // write is a non-locking way to write the machine configuration file to disk
-func (mc *MachineConfig) write() error {
+func (mc *MachineConfig) Write() error {
 	if mc.configPath == nil {
 		return fmt.Errorf("no configuration file associated with vm %q", mc.Name)
 	}

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -120,9 +120,6 @@ func (w WSLStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 }
 
 func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
-	mc.Lock()
-	defer mc.Unlock()
-
 	state, err := w.State(mc, false)
 	if err != nil {
 		return err
@@ -242,10 +239,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 	var (
 		err error
 	)
-	mc.Lock()
-	defer mc.Unlock()
 
-	// recheck after lock
 	if running, err := isRunning(mc.Name); !running {
 		return err
 	}


### PR DESCRIPTION
Previously, the locks were on the provider layer, which doesn't make a vm operation with a config file update atomic. Move them up a layer, so the entire function locks while doing provider and config operations.

This adds a Remove and a Set function to the shim layer.

[NO NEW TESTS NEEDED] Unsure how to test this

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
