### PR TITLE
machine config: make write atomic

### DIFF
--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/lock"
 	"github.com/containers/podman/v5/utils"
+	"github.com/containers/storage/pkg/ioutils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -133,7 +134,7 @@ func (mc *MachineConfig) write() error {
 		return err
 	}
 	logrus.Debugf("writing configuration file %q", mc.configPath.Path)
-	return os.WriteFile(mc.configPath.GetPath(), b, define.DefaultFilePerm)
+	return ioutils.AtomicWriteFile(mc.configPath.GetPath(), b, define.DefaultFilePerm)
 }
 
 func (mc *MachineConfig) SetRootful(rootful bool) error {


### PR DESCRIPTION
As indicated in #21849, loading the machine config can flake/fail with an EOF JSON error indicating an incomplete file.  Address the issue by atomically writing the config.  This way, it is not possible to load an incomplete or partially written file.  The lock can be acquired later on to sync state.

[NO NEW TESTS NEEDED] as it's a hard-to-hit race.

Fixes: #21849

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a race condition in podman machine to avoid loading an incomplete config file.
```
