### PR TITLE
podman network inspect: include running containers

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1298,7 +1298,7 @@ func getEntityType(cmd *cobra.Command, args []string, o interface{}) interface{}
 	}
 	// network logic
 	if networks, _ := getNetworks(cmd, args[0], completeDefault); len(networks) > 0 {
-		return &types.Network{}
+		return &entities.NetworkInspectReport{}
 	}
 	return o
 }

--- a/cmd/podman/networks/inspect.go
+++ b/cmd/podman/networks/inspect.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/inspect"
 	"github.com/containers/podman/v5/cmd/podman/registry"
@@ -33,7 +32,7 @@ func init() {
 
 	formatFlagName := "format"
 	flags.StringVarP(&inspectOpts.Format, formatFlagName, "f", "", "Pretty-print network to JSON or using a Go template")
-	_ = networkinspectCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&types.Network{}))
+	_ = networkinspectCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.NetworkInspectReport{}))
 }
 
 func networkInspect(_ *cobra.Command, args []string) error {

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -16,6 +16,7 @@ Pretty-print networks to JSON or using a Go template.
 
 | **Placeholder**    | **Description**                           |
 |--------------------|-------------------------------------------|
+| .Containers ...    | Running containers on this network.       |
 | .Created ...       | Timestamp when the network was created    |
 | .DNSEnabled        | Network has dns enabled (boolean)         |
 | .Driver            | Network driver                            |
@@ -25,6 +26,7 @@ Pretty-print networks to JSON or using a Go template.
 | .IPv6Enabled       | Network has ipv6 subnet (boolean)         |
 | .Labels ...        | Network labels                            |
 | .Name              | Network name                              |
+| .Network ...       | Nested Network type                       |
 | .NetworkDNSServers | Array of DNS servers used in this network |
 | .NetworkInterface  | Name of the network interface on the host |
 | .Options ...       | Network options                           |

--- a/pkg/api/handlers/swagger/responses.go
+++ b/pkg/api/handlers/swagger/responses.go
@@ -434,7 +434,7 @@ type networkRmResponse struct {
 // swagger:response
 type networkInspectResponse struct {
 	// in:body
-	Body types.Network
+	Body entities.NetworkInspectReport
 }
 
 // Network list

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -70,8 +70,8 @@ func Update(ctx context.Context, netNameOrID string, options *UpdateOptions) err
 }
 
 // Inspect returns information about a network configuration
-func Inspect(ctx context.Context, nameOrID string, _ *InspectOptions) (types.Network, error) {
-	var net types.Network
+func Inspect(ctx context.Context, nameOrID string, _ *InspectOptions) (entitiesTypes.NetworkInspectReport, error) {
+	var net entitiesTypes.NetworkInspectReport
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return net, err

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -70,7 +70,7 @@ type ContainerEngine interface { //nolint:interfacebloat
 	NetworkUpdate(ctx context.Context, networkname string, options NetworkUpdateOptions) error
 	NetworkDisconnect(ctx context.Context, networkname string, options NetworkDisconnectOptions) error
 	NetworkExists(ctx context.Context, networkname string) (*BoolReport, error)
-	NetworkInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]netTypes.Network, []error, error)
+	NetworkInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]NetworkInspectReport, []error, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]netTypes.Network, error)
 	NetworkPrune(ctx context.Context, options NetworkPruneOptions) ([]*NetworkPruneReport, error)
 	NetworkReload(ctx context.Context, names []string, options NetworkReloadOptions) ([]*NetworkReloadReport, error)

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -82,3 +82,6 @@ type NetworkPruneReport = entitiesTypes.NetworkPruneReport
 type NetworkPruneOptions struct {
 	Filters map[string][]string
 }
+
+type NetworkInspectReport = entitiesTypes.NetworkInspectReport
+type NetworkContainerInfo = entitiesTypes.NetworkContainerInfo

--- a/pkg/domain/entities/types/network.go
+++ b/pkg/domain/entities/types/network.go
@@ -35,3 +35,17 @@ type NetworkRmReport struct {
 type NetworkCreateReport struct {
 	Name string
 }
+
+type NetworkInspectReport struct {
+	commonTypes.Network
+
+	Containers map[string]NetworkContainerInfo `json:"containers"`
+}
+
+type NetworkContainerInfo struct {
+	// Name of the container
+	Name string `json:"name"`
+
+	// Interfaces configured for this container with their addresses
+	Interfaces map[string]commonTypes.NetInterface `json:"interfaces,omitempty"`
+}

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -64,9 +64,13 @@ func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.Net
 	return nets, err
 }
 
-func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, options entities.InspectOptions) ([]types.Network, []error, error) {
+func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, options entities.InspectOptions) ([]entities.NetworkInspectReport, []error, error) {
 	var errs []error
-	networks := make([]types.Network, 0, len(namesOrIds))
+	statuses, err := ic.GetContainerNetStatuses()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get network status for containers: %w", err)
+	}
+	networks := make([]entities.NetworkInspectReport, 0, len(namesOrIds))
 	for _, name := range namesOrIds {
 		net, err := ic.Libpod.Network().NetworkInspect(name)
 		if err != nil {
@@ -77,7 +81,22 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 				return nil, nil, fmt.Errorf("inspecting network %s: %w", name, err)
 			}
 		}
-		networks = append(networks, net)
+		containerMap := make(map[string]entities.NetworkContainerInfo)
+		for _, st := range statuses {
+			// Make sure to only show the info for the correct network
+			if sb, ok := st.Status[net.Name]; ok {
+				containerMap[st.ID] = entities.NetworkContainerInfo{
+					Name:       st.Name,
+					Interfaces: sb.Interfaces,
+				}
+			}
+		}
+
+		netReport := entities.NetworkInspectReport{
+			Network:    net,
+			Containers: containerMap,
+		}
+		networks = append(networks, netReport)
 	}
 	return networks, errs, nil
 }
@@ -242,4 +261,37 @@ func (ic *ContainerEngine) createDanglingFilterFunc(wantDangling bool) (types.Fi
 		}
 		return wantDangling
 	}, nil
+}
+
+type ContainerNetStatus struct {
+	// Name of the container
+	Name string
+	// ID of the container
+	ID string
+	// Status contains the net status, the key is the network name
+	Status map[string]types.StatusBlock
+}
+
+func (ic *ContainerEngine) GetContainerNetStatuses() ([]ContainerNetStatus, error) {
+	cons, err := ic.Libpod.GetAllContainers()
+	if err != nil {
+		return nil, err
+	}
+	statuses := make([]ContainerNetStatus, 0, len(cons))
+	for _, con := range cons {
+		status, err := con.GetNetworkStatus()
+		if err != nil {
+			if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved) {
+				continue
+			}
+			return nil, err
+		}
+
+		statuses = append(statuses, ContainerNetStatus{
+			ID:     con.ID(),
+			Name:   con.Name(),
+			Status: status,
+		})
+	}
+	return statuses, nil
 }

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -22,9 +22,9 @@ func (ic *ContainerEngine) NetworkList(ctx context.Context, opts entities.Networ
 	return network.List(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]types.Network, []error, error) {
+func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]entities.NetworkInspectReport, []error, error) {
 	var (
-		reports = make([]types.Network, 0, len(namesOrIds))
+		reports = make([]entities.NetworkInspectReport, 0, len(namesOrIds))
 		errs    = []error{}
 	)
 	options := new(network.InspectOptions)

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/podman/v5/pkg/domain/entities"
 	. "github.com/containers/podman/v5/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
@@ -32,7 +33,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -84,7 +85,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -125,7 +126,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -168,7 +169,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -213,7 +214,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -254,7 +255,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -284,7 +285,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -323,7 +324,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -711,7 +712,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/podman/v5/pkg/domain/entities"
 	. "github.com/containers/podman/v5/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
@@ -530,7 +530,7 @@ var _ = Describe("Podman network", func() {
 		Expect(inspect).Should(ExitCleanly())
 
 		// JSON the network configuration into something usable
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -556,7 +556,7 @@ var _ = Describe("Podman network", func() {
 			inspect.WaitWithDefaultTimeout()
 			Expect(inspect).Should(ExitCleanly())
 
-			var results []types.Network
+			var results []entities.NetworkInspectReport
 			err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
@@ -584,7 +584,7 @@ var _ = Describe("Podman network", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(ExitCleanly())
 
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -627,7 +627,7 @@ var _ = Describe("Podman network", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(ExitCleanly())
 
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(inspect.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/podman/v5/pkg/domain/entities"
 	. "github.com/containers/podman/v5/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +36,7 @@ var _ = Describe("Podman run networking", func() {
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(ExitCleanly())
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(session.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))
@@ -83,7 +83,7 @@ var _ = Describe("Podman run networking", func() {
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(ExitCleanly())
-		var results []types.Network
+		var results []entities.NetworkInspectReport
 		err := json.Unmarshal([]byte(session.OutputToString()), &results)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).To(HaveLen(1))


### PR DESCRIPTION
Like docker podman network inspect should output the information of running container with their ip/mac address on this network. However the output format is not docker compatible as this cannot include all the info we have and the previous output was already not compatible so this is not new.

New example output:
```
[
     {
          ...
          "containers": {
               "7c0d295779cee4a6db7adc07a99e635909413a390eeab9f951edbc4aac406bf1": {
                    "name": "c2",
                    "interfaces": {
                         "eth0": {
                              "subnets": [
                                   {
                                        "ipnet": "10.89.0.4/24",
                                        "gateway": "10.89.0.1"
                                   },
                                   {
                                        "ipnet": "fda3:b4da:da1e:7e9d::4/64",
                                        "gateway": "fda3:b4da:da1e:7e9d::1"
                                   }
                              ],
                              "mac_address": "1a:bd:ca:ea:4b:3a"
                         }
                    }
               },
               "b17c6651ae6d9cc7d5825968e01d6b1e67f44460bb0c140bcc32bd9d436ac11d": {
                    "name": "c1",
                    "interfaces": {
                         "eth0": {
                              "subnets": [
                                   {
                                        "ipnet": "10.89.0.3/24",
                                        "gateway": "10.89.0.1"
                                   },
                                   {
                                        "ipnet": "fda3:b4da:da1e:7e9d::3/64",
                                        "gateway": "fda3:b4da:da1e:7e9d::1"
                                   }
                              ],
                              "mac_address": "f6:50:e6:22:d9:55"
                         }
                    }
               }
          }
     }
]
```

Fixes #14126
Fixes https://issues.redhat.com/browse/RHEL-3153

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman network inspect now includes info about running containers on that network.
```
