### PR TITLE
Use machine image as specified in containers.conf

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/shim"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -101,9 +102,17 @@ func init() {
 	flags.StringVar(&initOpts.Username, UsernameFlagName, cfg.ContainersConfDefaultsRO.Machine.User, "Username used in image")
 	_ = initCmd.RegisterFlagCompletionFunc(UsernameFlagName, completion.AutocompleteDefault)
 
+	ImageFlagName := "image"
+	flags.StringVar(&initOpts.Image, ImageFlagName, cfg.ContainersConfDefaultsRO.Machine.Image, "Bootable image for machine")
+	_ = initCmd.RegisterFlagCompletionFunc(ImageFlagName, completion.AutocompleteDefault)
+
+	// Deprecate image-path option, use --image instead
 	ImagePathFlagName := "image-path"
-	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, "", "Path to bootable image")
+	flags.StringVar(&initOpts.Image, ImagePathFlagName, cfg.ContainersConfDefaultsRO.Machine.Image, "Bootable image for machine")
 	_ = initCmd.RegisterFlagCompletionFunc(ImagePathFlagName, completion.AutocompleteDefault)
+	if err := flags.MarkDeprecated(ImagePathFlagName, "use --image instead"); err != nil {
+		logrus.Error("unable to mark image-path flag deprecated")
+	}
 
 	VolumeFlagName := "volume"
 	flags.StringArrayVarP(&initOpts.Volumes, VolumeFlagName, "v", cfg.ContainersConfDefaultsRO.Machine.Volumes.Get(), "Volumes to mount, source:target")

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -73,11 +73,10 @@ Fully qualified path of the ignition file.
 If an ignition file is provided, the file
 is copied into the user's CONF_DIR and renamed.  Additionally, no SSH keys are generated, nor are any system connections made.  It is assumed that the user does these things manually or handled otherwise.
 
-#### **--image-path**
+#### **--image**
 
-Fully qualified path or URL to the VM image.
-Can also be set to `testing`, `next`, or `stable` to pull down default image.
-Defaults to `testing`.
+Fully qualified registry, path, or URL to a VM image.
+Registry target must be in the form of `docker://registry/repo/image:version`.
 
 #### **--memory**, **-m**=*number*
 

--- a/pkg/machine/define/initopts.go
+++ b/pkg/machine/define/initopts.go
@@ -6,7 +6,7 @@ type InitOptions struct {
 	CPUS               uint64
 	DiskSize           uint64
 	IgnitionPath       string
-	ImagePath          string
+	Image              string
 	Volumes            []string
 	VolumeDriver       string
 	IsDefault          bool

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -34,7 +34,7 @@ var _ = Describe("run basic podman commands", func() {
 		// so skip it on cirrus envs and where CIRRUS_CI isn't set.
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -62,7 +62,7 @@ var _ = Describe("run basic podman commands", func() {
 	It("Podman ops with port forwarding and gvproxy", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -110,7 +110,7 @@ var _ = Describe("run basic podman commands", func() {
 
 		name := randomString()
 		machinePath := "/does/not/exist"
-		init := new(initMachine).withVolume(fmt.Sprintf("%s:%s", dir, machinePath)).withImagePath(mb.imagePath).withNow()
+		init := new(initMachine).withVolume(fmt.Sprintf("%s:%s", dir, machinePath)).withImage(mb.imagePath).withNow()
 		session, err := mb.setName(name).setCmd(init).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -23,7 +23,7 @@ type initMachine struct {
 	diskSize           *uint
 	ignitionPath       string
 	username           string
-	imagePath          string
+	image              string
 	memory             *uint
 	now                bool
 	timezone           string
@@ -50,8 +50,8 @@ func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
 	if l := len(i.username); l > 0 {
 		cmd = append(cmd, "--username", i.username)
 	}
-	if l := len(i.imagePath); l > 0 {
-		cmd = append(cmd, "--image-path", i.imagePath)
+	if l := len(i.image); l > 0 {
+		cmd = append(cmd, "--image-path", i.image)
 	}
 	if i.memory != nil {
 		cmd = append(cmd, "--memory", strconv.Itoa(int(*i.memory)))
@@ -95,8 +95,8 @@ func (i *initMachine) withUsername(username string) *initMachine {
 	return i
 }
 
-func (i *initMachine) withImagePath(path string) *initMachine {
-	i.imagePath = path
+func (i *initMachine) withImage(path string) *initMachine {
+	i.image = path
 	return i
 }
 

--- a/pkg/machine/e2e/info_test.go
+++ b/pkg/machine/e2e/info_test.go
@@ -39,7 +39,7 @@ var _ = Describe("podman machine info", func() {
 
 		// Create a machine and check if info has been updated
 		i := new(initMachine)
-		initSession, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		initSession, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(initSession).To(Exit(0))
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -61,7 +61,7 @@ var _ = Describe("podman machine init", func() {
 
 		bi := new(initMachine)
 		want := fmt.Sprintf("system connection \"%s\" already exists", badName)
-		badInit, berr := mb.setName(badName).setCmd(bi.withImagePath(mb.imagePath)).run()
+		badInit, berr := mb.setName(badName).setCmd(bi.withImage(mb.imagePath)).run()
 		Expect(berr).ToNot(HaveOccurred())
 		Expect(badInit).To(Exit(125))
 		Expect(badInit.errorToString()).To(ContainSubstring(want))
@@ -81,7 +81,7 @@ var _ = Describe("podman machine init", func() {
 
 	It("simple init", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -100,7 +100,7 @@ var _ = Describe("podman machine init", func() {
 
 	It("simple init with start", func() {
 		i := initMachine{}
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -137,7 +137,7 @@ var _ = Describe("podman machine init", func() {
 	It("simple init with username", func() {
 		i := new(initMachine)
 		remoteUsername := "remoteuser"
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath).withUsername(remoteUsername)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath).withUsername(remoteUsername)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -160,7 +160,7 @@ var _ = Describe("podman machine init", func() {
 		skipIfWSL("setting hardware resource numbers and timezone are not supported on WSL")
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withCPUs(2).withDiskSize(102).withMemory(4096).withTimezone("Pacific/Honolulu")).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withCPUs(2).withDiskSize(102).withMemory(4096).withTimezone("Pacific/Honolulu")).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -212,7 +212,7 @@ var _ = Describe("podman machine init", func() {
 
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withVolume(mount).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withVolume(mount).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -226,7 +226,7 @@ var _ = Describe("podman machine init", func() {
 	It("machine init rootless docker.sock check", func() {
 		i := initMachine{}
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -249,7 +249,7 @@ var _ = Describe("podman machine init", func() {
 	It("machine init rootful with docker.sock check", func() {
 		i := initMachine{}
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withRootful(true)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withRootful(true)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -276,7 +276,7 @@ var _ = Describe("podman machine init", func() {
 	It("init should cleanup on failure", func() {
 		i := new(initMachine)
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
@@ -303,7 +303,7 @@ var _ = Describe("podman machine init", func() {
 			// Bad ignition path - init fails
 			i = new(initMachine)
 			i.ignitionPath = "/bad/path"
-			session, err = mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+			session, err = mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(session).To(Exit(125))
 
@@ -355,7 +355,7 @@ var _ = Describe("podman machine init", func() {
 		// We should be able to init with a bad config present
 		i := new(initMachine)
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -33,7 +33,7 @@ var _ = Describe("podman machine init - windows only", func() {
 		}
 		i := new(initMachine)
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withUserModeNetworking(true)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withUserModeNetworking(true)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -86,7 +86,7 @@ var _ = Describe("podman machine init - windows only", func() {
 			}
 		}()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(125))
 		Expect(session.errorToString()).To(ContainSubstring("already exists on hypervisor"))
@@ -104,7 +104,7 @@ var _ = Describe("podman machine init - windows only", func() {
 
 		// create a bogus machine
 		i := new(initMachine)
-		session, err := mb.setName("foobarexport").setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName("foobarexport").setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -129,7 +129,7 @@ var _ = Describe("podman machine init - windows only", func() {
 		}()
 
 		// Trying to make a vm with the same name as an existing name should result in a 125
-		checkSession, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		checkSession, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkSession).To(Exit(125))
 	})

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -33,12 +33,12 @@ var _ = Describe("podman inspect stop", func() {
 
 	It("inspect two machines", func() {
 		i := new(initMachine)
-		foo1, err := mb.setName("foo1").setCmd(i.withImagePath(mb.imagePath)).run()
+		foo1, err := mb.setName("foo1").setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(foo1).To(Exit(0))
 
 		ii := new(initMachine)
-		foo2, err := mb.setName("foo2").setCmd(ii.withImagePath(mb.imagePath)).run()
+		foo2, err := mb.setName("foo2").setCmd(ii.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(foo2).To(Exit(0))
 
@@ -53,7 +53,7 @@ var _ = Describe("podman inspect stop", func() {
 	It("inspect with go format", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -33,7 +33,7 @@ var _ = Describe("podman machine list", func() {
 		Expect(firstList.outputToStringSlice()).To(HaveLen(1)) // just the header
 
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -60,11 +60,11 @@ var _ = Describe("podman machine list", func() {
 		Expect(noheaderSession.outputToStringSlice()).To(BeEmpty())
 
 		i := new(initMachine)
-		session, err := mb.setName(name1).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name1).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
-		session2, err := mb.setName(name2).setCmd(i.withImagePath(mb.imagePath)).run()
+		session2, err := mb.setName(name2).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session2).To(Exit(0))
 
@@ -82,7 +82,7 @@ var _ = Describe("podman machine list", func() {
 	It("list machine: check if running while starting", func() {
 		skipIfWSL("the below logic does not work on WSL.  #20978")
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -123,7 +123,7 @@ var _ = Describe("podman machine list", func() {
 		name1 := randomString()
 
 		i := new(initMachine)
-		session, err := mb.setName(name1).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name1).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/machine_pull_test.go
+++ b/pkg/machine/e2e/machine_pull_test.go
@@ -22,7 +22,7 @@ func pullOCITestDisk(finalDir string, vmType define.VMType) error {
 		return err
 	}
 	dirs := define.MachineDirs{ImageCacheDir: imageCacheDir}
-	ociArtPull, err := ocipull.NewOCIArtifactPull(context.Background(), &dirs, "e2emachine", vmType, unusedFinalPath)
+	ociArtPull, err := ocipull.NewOCIArtifactPull(context.Background(), &dirs, "", "e2emachine", vmType, unusedFinalPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/e2e/os_test.go
+++ b/pkg/machine/e2e/os_test.go
@@ -21,7 +21,7 @@ package e2e_test
 
 // 	It("apply machine", func() {
 // 		i := new(initMachine)
-// 		foo1, err := mb.setName("foo1").setCmd(i.withImagePath(mb.imagePath)).run()
+// 		foo1, err := mb.setName("foo1").setCmd(i.withImage(mb.imagePath)).run()
 // 		Expect(err).ToNot(HaveOccurred())
 // 		Expect(foo1).To(Exit(0))
 
@@ -33,7 +33,7 @@ package e2e_test
 
 // 	It("apply machine from containers-storage", func() {
 // 		i := new(initMachine)
-// 		foo1, err := mb.setName("foo1").setCmd(i.withImagePath(mb.imagePath)).run()
+// 		foo1, err := mb.setName("foo1").setCmd(i.withImage(mb.imagePath)).run()
 // 		Expect(err).ToNot(HaveOccurred())
 // 		Expect(foo1).To(Exit(0))
 

--- a/pkg/machine/e2e/proxy_test.go
+++ b/pkg/machine/e2e/proxy_test.go
@@ -44,7 +44,7 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/reset_test.go
+++ b/pkg/machine/e2e/reset_test.go
@@ -29,7 +29,7 @@ var _ = Describe("podman machine reset", func() {
 	It("reset machine with one defined machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -53,7 +53,7 @@ var _ = Describe("podman machine reset", func() {
 	It("reset with running machine and other machines idle ", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -65,7 +65,7 @@ var _ = Describe("podman machine reset", func() {
 
 		name2 := randomString()
 		i2 := new(initMachine)
-		session2, err := mb.setName(name2).setCmd(i2.withImagePath(mb.imagePath)).run()
+		session2, err := mb.setName(name2).setCmd(i2.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session2).To(Exit(0))
 

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -35,7 +35,7 @@ var _ = Describe("podman machine rm", func() {
 	It("Remove machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		rm := rmMachine{}
@@ -59,7 +59,7 @@ var _ = Describe("podman machine rm", func() {
 	It("Remove running machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		rm := new(rmMachine)
@@ -83,7 +83,7 @@ var _ = Describe("podman machine rm", func() {
 
 	It("machine rm --save-ignition --save-image", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -125,13 +125,13 @@ var _ = Describe("podman machine rm", func() {
 
 		fooName := "foo"
 		foo := new(initMachine)
-		session, err := mb.setName(fooName).setCmd(foo.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(fooName).setCmd(foo.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
 		barName := "bar"
 		bar := new(initMachine)
-		session, err = mb.setName(barName).setCmd(bar.withImagePath(mb.imagePath).withNow()).run()
+		session, err = mb.setName(barName).setCmd(bar.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -165,7 +165,7 @@ var _ = Describe("podman machine rm", func() {
 	It("Removing all machines doesn't delete ssh keys", func() {
 		fooName := "foo"
 		foo := new(initMachine)
-		session, err := mb.setName(fooName).setCmd(foo.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(fooName).setCmd(foo.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -29,7 +29,7 @@ var _ = Describe("podman machine set", func() {
 		skipIfWSL("WSL cannot change set properties of disk, processor, or memory")
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -79,7 +79,7 @@ var _ = Describe("podman machine set", func() {
 		skipIfNotVmtype(define.WSLVirt, "tests are only for WSL provider")
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -104,7 +104,7 @@ var _ = Describe("podman machine set", func() {
 		skipIfWSL("WSL cannot change set properties of disk, processor, or memory")
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -138,7 +138,7 @@ var _ = Describe("podman machine set", func() {
 	It("set rootful with docker sock change", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -176,7 +176,7 @@ var _ = Describe("podman machine set", func() {
 
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -196,7 +196,7 @@ var _ = Describe("podman machine set", func() {
 	It("set while machine already running", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -32,7 +32,7 @@ var _ = Describe("podman machine ssh", func() {
 	It("ssh to non-running machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -47,7 +47,7 @@ var _ = Describe("podman machine ssh", func() {
 		wsl := testProvider.VMType() == define.WSLVirt
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -23,7 +23,7 @@ var _ = Describe("podman machine start", func() {
 
 	It("start simple machine", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		s := new(startMachine)
@@ -68,7 +68,7 @@ var _ = Describe("podman machine start", func() {
 
 	It("start machine already started", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		s := new(startMachine)
@@ -90,13 +90,13 @@ var _ = Describe("podman machine start", func() {
 	It("start only starts specified machine", func() {
 		i := initMachine{}
 		startme := randomString()
-		session, err := mb.setName(startme).setCmd(i.withImagePath(mb.imagePath)).run()
+		session, err := mb.setName(startme).setCmd(i.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
 		j := initMachine{}
 		dontstartme := randomString()
-		session2, err := mb.setName(dontstartme).setCmd(j.withImagePath(mb.imagePath)).run()
+		session2, err := mb.setName(dontstartme).setCmd(j.withImage(mb.imagePath)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session2).To(Exit(0))
 

--- a/pkg/machine/e2e/stop_test.go
+++ b/pkg/machine/e2e/stop_test.go
@@ -34,7 +34,7 @@ var _ = Describe("podman machine stop", func() {
 		name := randomString()
 		i := new(initMachine)
 		starttime := time.Now()
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	// TODO This is temporary until we decide on a proper image name
+	// Also should be moved into c/common once stabilized
 	artifactRegistry     = "quay.io"
 	artifactRepo         = "baude"
 	artifactImageName    = "stage-podman-machine-image"
@@ -71,7 +72,7 @@ type DiskArtifactOpts struct {
 
 */
 
-func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, vmName string, vmType define.VMType, finalPath *define.VMFile) (*OCIArtifactDisk, error) {
+func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, endpoint string, vmName string, vmType define.VMType, finalPath *define.VMFile) (*OCIArtifactDisk, error) {
 	var (
 		arch string
 	)
@@ -91,12 +92,17 @@ func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, vmName st
 		diskType: vmType.String(),
 		os:       machineOS,
 	}
+
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("docker://%s/%s/%s:%s", artifactRegistry, artifactRepo, artifactImageName, artifactVersion.majorMinor())
+	}
+
 	ociDisk := OCIArtifactDisk{
 		ctx:              ctx,
 		dirs:             dirs,
 		diskArtifactOpts: &diskOpts,
 		finalPath:        finalPath.GetPath(),
-		imageEndpoint:    fmt.Sprintf("docker://%s/%s/%s:%s", artifactRegistry, artifactRepo, artifactImageName, artifactVersion.majorMinor()),
+		imageEndpoint:    endpoint,
 		machineVersion:   artifactVersion,
 		name:             vmName,
 		pullOptions:      &PullOptions{},

--- a/pkg/machine/shim/diskpull/diskpull.go
+++ b/pkg/machine/shim/diskpull/diskpull.go
@@ -15,8 +15,8 @@ func GetDisk(userInputPath string, dirs *define.MachineDirs, imagePath *define.V
 		mydisk ocipull.Disker
 	)
 
-	if userInputPath == "" {
-		mydisk, err = ocipull.NewOCIArtifactPull(context.Background(), dirs, name, vmType, imagePath)
+	if userInputPath == "" || strings.HasPrefix(userInputPath, "docker://") {
+		mydisk, err = ocipull.NewOCIArtifactPull(context.Background(), dirs, userInputPath, name, vmType, imagePath)
 	} else {
 		if strings.HasPrefix(userInputPath, "http") {
 			// TODO probably should use tempdir instead of datadir

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -140,7 +140,7 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) (*vmconfigs.M
 	// "/path
 	// "docker://quay.io/something/someManifest
 
-	if err := mp.GetDisk(opts.ImagePath, dirs, mc); err != nil {
+	if err := mp.GetDisk(opts.Image, dirs, mc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/ocipull"
+	"github.com/containers/podman/v5/pkg/machine/shim/diskpull"
 	"github.com/containers/podman/v5/pkg/machine/stdpull"
 	"github.com/containers/podman/v5/pkg/machine/wsl/wutil"
 
@@ -281,10 +282,14 @@ func (w WSLStubber) VMType() define.VMType {
 	return define.WSLVirt
 }
 
-func (w WSLStubber) GetDisk(_ string, dirs *define.MachineDirs, mc *vmconfigs.MachineConfig) error {
+func (w WSLStubber) GetDisk(userInputPath string, dirs *define.MachineDirs, mc *vmconfigs.MachineConfig) error {
 	var (
 		myDisk ocipull.Disker
 	)
+
+	if userInputPath != "" {
+		return diskpull.GetDisk(userInputPath, dirs, mc.ImagePath, w.VMType(), mc.Name)
+	}
 
 	// check github for the latest version of the WSL dist
 	downloadURL, downloadVersion, _, _, err := GetFedoraDownloadForWSL()


### PR DESCRIPTION
Use machine image as specified in containers.conf
For podman machine init, deprecate the --image-path option for --image.
--image now accepts the correct image from containers.conf

Also, add the ability to specify an OCI image from the --image flag using the docker:// transport.

Signed-off-by: Ashley Cui <acui@redhat.com>

```release-note
The --image flag replaces the now deprecated --image-path flag for podman machine init.
```
