### PR TITLE
machine/ociartifact: Include image name in error

### DIFF
--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -123,7 +123,7 @@ func (o *OCIArtifactDisk) Get() error {
 		}
 		// pull the image down to our local filesystem
 		if err := o.pull(destRef, artifactDigest); err != nil {
-			return err
+			return fmt.Errorf("failed to pull %s: %w", destRef.DockerReference(), err)
 		}
 		// grab the artifact disk out of the cache and lay
 		// it into our local cache in the format of


### PR DESCRIPTION
If we hit an error here, it will be really useful to know

- That we're trying to fetch a container image
- Which image we're trying to fetch

```release-note
None
```
