### PR TITLE
Reenable boltdb upgrade tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -985,8 +985,12 @@ upgrade_test_task:
     only_if: *not_tag_magic
     depends_on: *build
     matrix:
-#        - env:
-#              PODMAN_UPGRADE_FROM: v4.1.0
+        - env:
+              # 2024-02: as long as possible/reasonable, try to keep
+              #   one version < 4.8 so we can test boltdb. v4.3.1 is
+              #   the lowest we can go right now, builds before that
+              #   have netavark <1.4 which hangs on f39 kernel (#21863).
+              PODMAN_UPGRADE_FROM: v4.3.1
         - env:
               PODMAN_UPGRADE_FROM: v4.8.0
     gce_instance: *standardvm

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -41,9 +41,7 @@ setup() {
     fi
 
     if [ "$(< $PODMAN_UPGRADE_WORKDIR/status)" = "failed" ]; then
-        # FIXME: exit instead?
-        echo "*** setup failed - no point in running tests"
-        false
+        skip "*** setup failed - no point in running tests"
     fi
 
     # cgroup-manager=systemd does not work inside a container
@@ -128,7 +126,7 @@ podman \$opts run    --name myfailedcontainer  --label mylabel=$LABEL_FAILED \
 podman \$opts run -d --name myrunningcontainer --label mylabel=$LABEL_RUNNING \
                                                --network bridge \
                                                -p $HOST_PORT:80 \
-                                               -p 127.0.0.1:8080-8082:8080-8082 \
+                                               -p 127.0.0.1:9090-9092:8080-8082 \
                                                -v $pmroot/var/www:/var/www \
                                                -w /var/www \
                                                --mac-address aa:bb:cc:dd:ee:ff \
@@ -177,7 +175,7 @@ EOF
     # mount /dev/shm because the container locks are stored there
     # mount /run/containers for the dnsname plugin
     #
-    $PODMAN run -d --name podman_parent --pid=host \
+    $PODMAN run -d --name podman_parent \
             --privileged \
             --net=host \
             --cgroupns=host \
@@ -243,7 +241,7 @@ EOF
     # Port order is not guaranteed
     assert "${lines[3]}" =~ "myrunningcontainer--Up .*--$LABEL_RUNNING" "line 3, running"
     assert "${lines[3]}" =~ ".*--.*0\.0\.0\.0:$HOST_PORT->80\/tcp.*--.*"  "line 3, first port forward"
-    assert "${lines[3]}" =~ ".*--.*127\.0\.0\.1\:8080-8082->8080-8082\/tcp.*--.*" "line 3, second port forward"
+    assert "${lines[3]}" =~ ".*--.*127\.0\.0\.1\:9090-9092->8080-8082\/tcp.*--.*" "line 3, second port forward"
 
     assert "${lines[4]}" =~ ".*-infra--Created----<no value>" "line 4, infra container"
 


### PR DESCRIPTION
Upgrade-from-v4.1 was temporarily disabled in #21618: we brought
in new CI VMs, and v4.1 setup no longer works. Nobody quite
understands why, and we've hit diminishing returns in the
investigation (#21863). The current thinking is that it
is related to netavark, and versions < 1.3 do not work
in the current f39 VMs. (No clue why, because f39 kernel
did not change in #21618).

Anyhow, reenable the pre-4.8 upgrade test, using v4.3.1
which has netavark-1.4.0 which seems to work fine. For now.

Also, some upgrade test cleanup:
 - Skip, not fail, if initial setup fails. Makes for less noisy logs.
 - Remove duplicate --pid=host
 - Ports: 808x -> 909x, because 8081 is used by restraint on 1mt

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```