### PR TITLE
CI: run logformatter on mac

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -821,10 +821,14 @@ podman_machine_mac_task:
     #       resize (~2min) causes test-timeout (90s default).  Should
     #       tests deal with this internally?
     test_script:
-        - make localmachine
+        - "contrib/cirrus/mac_runner.sh"
     # This host is/was shared with potentially many other CI tasks.
     # Ensure nothing is left running while waiting for the next task.
     always:
+        # Required for `contrib/cirrus/logformatter` to work properly
+        html_artifacts:
+            path: ./*.html
+            type: text/html
         task_cleanup_script: *mac_cleanup
 
 

--- a/contrib/cirrus/mac_runner.sh
+++ b/contrib/cirrus/mac_runner.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# This script is what runs mac tests. It is invoked from .cirrus.yml
+#
+# Yep, some of this is adapted from runner.sh. We can't actually
+# use that as a library, because Macintosh bash and awk lack
+# features we need.
+
+set -euo pipefail
+
+
+# Name pattern for logformatter output file, derived from environment
+function output_name() {
+    # .cirrus.yml defines this as a short readable string for web UI
+    std_name_fmt=$(sed -ne 's/^.*std_name_fmt \"\(.*\)\"/\1/p' <.cirrus.yml)
+    test -n "$std_name_fmt" || die "Could not grep 'std_name_fmt' from .cirrus.yml"
+
+    # Interpolate envariables. 'set -u' throws fatal if any are undefined
+    (
+        set -u
+        eval echo "$std_name_fmt" | tr ' ' '-'
+    )
+}
+
+function logformatter() {
+    # Mac awk barfs on this, syntax error
+#    awk --file "${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/timestamp.awk" \
+    # shellcheck disable=SC2154
+    "${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/logformatter" "$(output_name)"
+}
+
+make localmachine 2>&1 | logformatter


### PR DESCRIPTION
It works (verified in #17831). Imperfectly, because Macs don't have a useful awk, so we can't get timestamps. I will, in time, look into adding the timestamp functionality to logformatter itself.

Also imperfect because it's not linkifying: source code paths are dead text. I need to fix that, too, in logformatter, by having it recognize /Users/Mac paths.

Imperfect as it may be, it was quick, and I think could provide good bang for the buck in these Mac-intensive debugging days.

```release-note
None
```
