### PR TITLE
test/system: fix mount external container test

### DIFF
--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -249,13 +249,10 @@ EOF
     reported_mountpoint=$(echo "$output" | awk '{print $2}')
     is "$reported_mountpoint" "$mount_path" "mountpoint reported by 'podman mount'"
 
-    # umount, and make sure files are gone
+    # umount, and make sure mountpoint no longer exists
     run_podman umount $external_cid
-    if [ -d "$mount_path" ]; then
-        # Under VFS, mountpoint always exists even despite umount
-        if [[ "$(podman_storage_driver)" != "vfs" ]]; then
-            die "'podman umount' did not umount $mount_path"
-        fi
+    if findmnt "$mount_path" >/dev/null ; then
+        die "'podman umount' did not umount $mount_path"
     fi
     buildah rm $external_cid
 }


### PR DESCRIPTION
Checking for the mountdir is not relevent, a recent c/storage change[1] no longer deletes the mount point directory so the check will cause a false positive. findmnt exits 1 when the given path is not a mountpoint so let's use that to check.

[1] https://github.com/containers/storage/pull/1828/commits/3f2e81abb38926d9b908528412c25fa2e199b6b9

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
