### PR TITLE
Add target win-gvproxy in winmake.ps1

### DIFF
--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -37,6 +37,7 @@ filtered_changes=$(git diff --name-only $base $head        |
                        grep -F -vx go.sum                  |
                        grep -F -vx podman.spec.rpkg        |
                        grep -F -vx .golangci.yml           |
+                       grep -F -vx winmake.ps1             |
                        grep -E -v  '/*Makefile$'           |
                        grep -E -v  '^[^/]+\.md$'           |
                        grep -E -v  '^.github'              |

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -87,7 +87,7 @@ switch ($target) {
     'clean' {
         Make-Clean
     }
-    'win-sshproxy' {
+    {$_ -in 'win-sshproxy', 'win-gvproxy'} {
         if ($args.Count -gt 1) {
             $ref = $args[1]
         }
@@ -104,5 +104,8 @@ switch ($target) {
         Write-Host
         Write-Host "Example: Run specfic machine tests "
         Write-Host " .\winmake localmachine "basic_test.go""
+        Write-Host
+        Write-Host "Example: Download win-gvproxy and win-sshproxy helpers"
+        Write-Host " .\winmake win-gvproxy"
     }
 }


### PR DESCRIPTION
For consistency with [linux/osx makefile](https://github.com/containers/podman/blob/main/Makefile#L788) I have added the `win-gvproxy` target as an alias of the already existing `win-sshproxy`.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
