### PR TITLE
CI: must-add-tests check: use GH label, not text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,9 +164,9 @@ Regardless of the type of PR, all PRs should include:
 * well documented code changes.
 * additional testcases. Ideally, they should fail w/o your code change applied.
   (With a few exceptions, CI hooks will block your PR unless your change
-  includes files named `*_test.go` or under the `test/` subdirectory. To
-  bypass this block, include the string `[NO NEW TESTS NEEDED]` in your
-  commit message).
+  includes files named `*_test.go` or under the `test/` subdirectory. Repo
+  admins may bypass this restriction by setting the 'No New Tests' GitHub
+  label on the PR).
 * documentation changes.
 
 Squash your commits into logical pieces of work that might want to be reviewed

--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -2,14 +2,13 @@
 #
 # Intended for use in CI: check git commits, barf if no tests added.
 #
+ME=$(basename $0)
+
+# Github label which allows overriding this check
+OVERRIDE_LABEL="No New Tests"
 
 # Docs-only changes are excused
 if [[ "${CIRRUS_CHANGE_TITLE}" =~ CI:DOCS ]]; then
-    exit 0
-fi
-
-# So are PRs where 'NO NEW TESTS NEEDED' appears in the Github message
-if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.NEW.TESTS.NEEDED ]]; then
     exit 0
 fi
 
@@ -51,14 +50,41 @@ if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
 
-# One last chance: perhaps the developer included the magic '[NO NEW TESTS NEEDED]'
-# string in an amended commit.
-if git log --format=%B ${base}..${head} | grep -F '[NO NEW TESTS NEEDED]'; then
-   exit 0
+# Nope. Only allow if the github 'no-tests-needed' label is set
+if [[ -z "$CIRRUS_PR" ]]; then
+    echo "$ME: cannot query github: \$CIRRUS_PR is undefined" >&2
+    exit 1
+fi
+if [[ -z "$CIRRUS_REPO_CLONE_TOKEN" ]]; then
+    echo "$ME: cannot query github: \$CIRRUS_REPO_CLONE_TOKEN is undefined" >&2
+    exit 1
+fi
+
+query="{
+  \"query\": \"query {
+  repository(owner: \\\"containers\\\", name: \\\"podman\\\") {
+    pullRequest(number: $CIRRUS_PR) {
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}\"
+}"
+
+result=$(curl -s -H "Authorization: bearer $CIRRUS_REPO_CLONE_TOKEN" -H "Accept: application/vnd.github.antiope-preview+json" -H "Content-Type: application/json" -X POST --data @- https://api.github.com/graphql <<<"$query")
+
+labels=$(jq -r '.data.repository.pullRequest.labels.nodes[].name' <<<"$result")
+
+if grep -F -x -q "$OVERRIDE_LABEL" <<<"$labels"; then
+    # PR has the label set
+    exit 0
 fi
 
 cat <<EOF
-$(basename $0): PR does not include changes in the 'tests' directory
+$ME: PR does not include changes in the 'tests' directory
 
 Please write a regression test for what you're fixing. Even if it
 seems trivial or obvious, try to add a test that will prevent
@@ -69,8 +95,8 @@ tests, possibly just adding a small step to a similar existing test.
 Every second counts in CI.
 
 If your commit really, truly does not need tests, you can proceed
-by adding '[NO NEW TESTS NEEDED]' to the body of your commit message.
-Please think carefully before doing so.
+by asking a repo maintainer to set the '$OVERRIDE_LABEL' github label.
+This will only be done when there's no reasonable alternative.
 EOF
 
 exit 1


### PR DESCRIPTION
Old way: edit commit message, add magic string, re-push

New way: repo maintainer adds a Github label to PR, hits Rerun

I've looked and looked for the history behind this script
and why I didn't do it this way in the first place. I've
concluded that I just never thought of it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```