### PR TITLE
Revert "Expose as-tested Mac/Windows repository state"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1158,18 +1158,14 @@ artifacts_task:
         - cd /tmp/win
         - $ARTCURL/Windows%20Cross/repo/repo.tbz
         - tar xjf repo.tbz
-        # These are both needed by podman-desktop CI
         - mv ./podman-remote*.zip $CIRRUS_WORKING_DIR/
-        - mv /tmp/win/repo.tbz $CIRRUS_WORKING_DIR/windows_podman_repo.tar.bz2
     osx_binaries_script:
         - mkdir -p /tmp/osx
         - cd /tmp/osx
         - $ARTCURL/OSX%20Cross/repo/repo.tbz
         - tar xjf repo.tbz
-        # These are all needed by podman-desktop CI
         - mv ./podman-remote-release-darwin_*.zip $CIRRUS_WORKING_DIR/
         - mv ./contrib/pkginstaller/out/podman-installer-macos-*.pkg $CIRRUS_WORKING_DIR/
-        - mv /tmp/osx/repo.tbz $CIRRUS_WORKING_DIR/mac_podman_repo.tar.bz2
     always:
       contents_script: ls -la $CIRRUS_WORKING_DIR
       # Produce downloadable files and an automatic zip-file accessible

--- a/DOWNLOADS.md
+++ b/DOWNLOADS.md
@@ -61,8 +61,3 @@ matches corresponding changes in the artifacts task.
   * [podman-release-mipsle.tar.gz](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-release-mipsle.tar.gz)
   * [podman-release-ppc64le.tar.gz](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-release-ppc64le.tar.gz)
   * [podman-release-s390x.tar.gz](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-release-s390x.tar.gz)
-
-* As-tested Mac and Windows podman repository tarballs.  These pair the source code and compiled binaries together.
-
-  * Windows [podman-repository](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/windows_podman_repo.tar.bz2) (x86_64 only).
-  * MacOS [podman-repository](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/mac_podman_repo.tar.bz2) (all arches).


### PR DESCRIPTION
Fix [artifacts task error](https://cirrus-ci.com/task/6595797815394304):

```
Failed to upload artifacts:
rpc error: code = FailedPrecondition
desc = Artifacts size is too big!
```

This reverts commit 698219cf9882ff0d229cd10bab0afd03ba09884b.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
