### PR TITLE
Use stop timeout of zero for system reset

### DIFF
--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -108,13 +108,13 @@ func (r *Runtime) Reset(ctx context.Context) error {
 		return define.ErrRuntimeStopped
 	}
 
-	var timeout *uint
+	var timeout uint = 0
 	pods, err := r.GetAllPods()
 	if err != nil {
 		return err
 	}
 	for _, p := range pods {
-		if ctrs, err := r.RemovePod(ctx, p, true, true, timeout); err != nil {
+		if ctrs, err := r.RemovePod(ctx, p, true, true, &timeout); err != nil {
 			if errors.Is(err, define.ErrNoSuchPod) {
 				continue
 			}
@@ -133,7 +133,7 @@ func (r *Runtime) Reset(ctx context.Context) error {
 	}
 
 	for _, c := range ctrs {
-		if ctrs, _, err := r.RemoveContainerAndDependencies(ctx, c, true, true, timeout); err != nil {
+		if ctrs, _, err := r.RemoveContainerAndDependencies(ctx, c, true, true, &timeout); err != nil {
 			for ctr, err := range ctrs {
 				logrus.Errorf("Error removing container %s: %v", ctr, err)
 			}
@@ -163,7 +163,7 @@ func (r *Runtime) Reset(ctx context.Context) error {
 		return err
 	}
 	for _, v := range volumes {
-		if err := r.RemoveVolume(ctx, v, true, timeout); err != nil {
+		if err := r.RemoveVolume(ctx, v, true, &timeout); err != nil {
 			if errors.Is(err, define.ErrNoSuchVolume) {
 				continue
 			}

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -92,12 +92,16 @@ var _ = Describe("podman system reset", Serial, func() {
 		ctrName := "testctr"
 		port1 := GetPort()
 		port2 := GetPort()
-		session := podmanTest.Podman([]string{"run", "--name", ctrName, "-p", fmt.Sprintf("%d:%d", port1, port2), "-d", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "--name", ctrName, "-p", fmt.Sprintf("%d:%d", port1, port2), "-d", ALPINE, "sleep", "inf"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
+		// run system reset on a container that is running
+		// set a timeout of 9 seconds, which tests that reset is using the timeout
+		// of zero and forceable killing containers with no wait.
+		// #21874
 		reset := podmanTest.Podman([]string{"system", "reset", "--force"})
-		reset.WaitWithDefaultTimeout()
+		reset.WaitWithTimeout(9)
 		Expect(reset).Should(ExitCleanly())
 
 		session2 := podmanTest.Podman([]string{"run", "--name", ctrName, "-p", fmt.Sprintf("%d:%d", port1, port2), "-d", ALPINE, "top"})


### PR DESCRIPTION
when performing a system reset with containers that run somewhere where a soft kill wont work (like sleep), containers will wait 10 seconds before terminating with a sigkill.  But for a forceful action like system reset, we should outright set no timeout so containers stop quickly and are not waiting on a timeout

Fixes #21874

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman system reset stops containers immediately instead of waiting on a possible timeout
```
