### PR TITLE
[CI:BUILD] rpm: Put the podmansh(1) manual in the podmansh sub-package

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -263,8 +263,8 @@ PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDI
 sed -i 's;%{buildroot};;g' %{buildroot}%{_bindir}/docker
 
 # do not include docker and podman-remote man pages in main package
-for file in `find %{buildroot}%{_mandir}/man[15] -type f | sed "s,%{buildroot},," | grep -v -e remote -e docker`; do
-    echo "$file*" >> podman.file-list
+for file in `find %{buildroot}%{_mandir}/man[15] -type f | sed "s,%{buildroot},," | grep -v -e %{name}sh.1 -e remote -e docker`; do
+    echo "$file*" >> %{name}.file-list
 done
 
 rm -f %{buildroot}%{_mandir}/man5/docker*.5
@@ -319,6 +319,7 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 %files -n %{name}sh
 %{_bindir}/%{name}sh
+%{_mandir}/man1/%{name}sh.1*
 
 %changelog
 %if %{defined autochangelog}


### PR DESCRIPTION
Currently, the `podmansh(1)` manual is shipped by the `podman` package.  It
makes one wonder where the binary is, since they can read the manual.

[NO NEW TESTS NEEDED]

Fixes: 3efaffae43cb1650 ("New command: podmansh")

Signed-off-by: Debarshi Ray <rishi@fedoraproject.org>

```release-note
The podmansh(1) manual is now in the podmansh sub-package.
```
