### PR TITLE
Fix problem with `podman machine list` returning wrong units for Memory and Disk size

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -164,8 +164,8 @@ func toMachineFormat(vms []*machine.ListResponse, defaultCon string) []*entities
 		response.Stream = streamName(vm.Stream)
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
-		response.Memory = strUint(vm.Memory)
-		response.DiskSize = strUint(vm.DiskSize)
+		response.Memory = strUint(uint64(vm.Memory.ToBytes()))
+		response.DiskSize = strUint(uint64(vm.DiskSize.ToBytes()))
 		response.Port = vm.Port
 		response.RemoteUsername = vm.RemoteUsername
 		response.IdentityPath = vm.IdentityPath
@@ -202,8 +202,8 @@ func toHumanFormat(vms []*machine.ListResponse, defaultCon string) []*entities.L
 		response.Created = units.HumanDuration(time.Since(vm.CreatedAt)) + " ago"
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
-		response.Memory = units.BytesSize(float64(vm.Memory))
-		response.DiskSize = units.BytesSize(float64(vm.DiskSize))
+		response.Memory = units.BytesSize(float64(vm.Memory.ToBytes()))
+		response.DiskSize = units.BytesSize(float64(vm.DiskSize.ToBytes()))
 
 		humanResponses = append(humanResponses, response)
 	}

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/common/pkg/strongunits"
 	"github.com/containers/podman/v5/pkg/machine/compression"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
@@ -57,8 +58,8 @@ type ListResponse struct {
 	Stream             string
 	VMType             string
 	CPUs               uint64
-	Memory             uint64
-	DiskSize           uint64
+	Memory             strongunits.MiB
+	DiskSize           strongunits.GiB
 	Port               int
 	RemoteUsername     string
 	IdentityPath       string

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/common/pkg/strongunits"
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/connection"
 	machineDefine "github.com/containers/podman/v5/pkg/machine/define"
@@ -51,8 +52,8 @@ func List(vmstubbers []vmconfigs.VMProvider, _ machine.ListOptions) ([]*machine.
 				//Stream:             "", // No longer applicable
 				VMType:             s.VMType().String(),
 				CPUs:               mc.Resources.CPUs,
-				Memory:             mc.Resources.Memory,
-				DiskSize:           mc.Resources.DiskSize,
+				Memory:             strongunits.MiB(mc.Resources.Memory),
+				DiskSize:           strongunits.GiB(mc.Resources.DiskSize),
 				Port:               mc.SSH.Port,
 				RemoteUsername:     mc.SSH.RemoteUsername,
 				IdentityPath:       mc.SSH.IdentityPath,


### PR DESCRIPTION
units.BytesSize expects byte size as argument.
Therefore, added code to convert vm.Memory and vm.DiskSize to byte size using strongunits.

Fix: https://github.com/containers/podman/issues/21917

#### Does this PR introduce a user-facing change?

```release-note
Fix problem with `podman machine list` returning wrong units for Memory and Disk size
```
