### PR TITLE
Fix CI: Bump to FreeBSD 13.3 (13.2 vanished)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -379,7 +379,7 @@ freebsd_alt_build_task:
         TEST_FLAVOR: "altbuild"
         ALT_NAME: 'FreeBSD Cross'
     freebsd_instance:
-        image_family: freebsd-13-2
+        image_family: freebsd-13-3
     setup_script:
         - pkg install -y gpgme bash go-md2man gmake gsed gnugrep go pkgconf
     build_amd64_script:


### PR DESCRIPTION
Without this CI fails on FreeBSD build since 13.2 image family no longer exists in cloud

[NO NEW TESTS NEEDED]

```release-note
none
```
