### PR TITLE
properly implement pull-error event status

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1420,10 +1420,10 @@ func AutocompleteEventFilter(cmd *cobra.Command, args []string, toComplete strin
 			events.Exited.String(), events.Export.String(), events.Import.String(), events.Init.String(), events.Kill.String(),
 			events.LoadFromArchive.String(), events.Mount.String(), events.NetworkConnect.String(),
 			events.NetworkDisconnect.String(), events.Pause.String(), events.Prune.String(), events.Pull.String(),
-			events.Push.String(), events.Refresh.String(), events.Remove.String(), events.Rename.String(),
-			events.Renumber.String(), events.Restart.String(), events.Restore.String(), events.Save.String(),
-			events.Start.String(), events.Stop.String(), events.Sync.String(), events.Tag.String(), events.Unmount.String(),
-			events.Unpause.String(), events.Untag.String(),
+			events.PullError.String(), events.Push.String(), events.Refresh.String(), events.Remove.String(),
+			events.Rename.String(), events.Renumber.String(), events.Restart.String(), events.Restore.String(),
+			events.Save.String(), events.Start.String(), events.Stop.String(), events.Sync.String(), events.Tag.String(),
+			events.Unmount.String(), events.Unpause.String(), events.Untag.String(),
 		}, cobra.ShellCompDirectiveNoFileComp
 	}
 	eventTypes := func(_ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -71,6 +71,8 @@ type Event struct {
 	Type events.Type
 	// Health status of the current container
 	HealthStatus string `json:"health_status,omitempty"`
+	// Error code for certain events involving errors.
+	Error string `json:",omitempty"`
 
 	events.Details
 }
@@ -88,6 +90,7 @@ func newEventFromLibpodEvent(e *events.Event) Event {
 		HealthStatus:      e.HealthStatus,
 		Details:           e.Details,
 		TimeNano:          e.Time.UnixNano(),
+		Error:             e.Error,
 	}
 }
 

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -61,6 +61,7 @@ The *image* event type reports the following statuses:
  * loadFromArchive,
  * mount
  * pull
+ * pull-error
  * push
  * remove
  * save
@@ -104,21 +105,22 @@ In the case where an ID is used, the ID may be in its full or shortened form.  T
 
 Format the output to JSON Lines or using the given Go template.
 
-| **Placeholder**         | **Description**                                   |
-|-------------------------|----------------------------------------------- ---|
-| .Attributes ...         | created_at, _by, labels, and more (map[])         |
-| .ContainerExitCode      | Exit code (int)                                   |
-| .ContainerInspectData   | Payload of the container's inspect                |
-| .HealthStatus           | Health Status (string)                            |
-| .ID                     | Container ID (full 64-bit SHA)                    |
-| .Image                  | Name of image being run (string)                  |
-| .Name                   | Container name (string)                           |
-| .Network                | Name of network being used (string)               |
-| .PodID                  | ID of pod associated with container, if any       |
-| .Status                 | Event status (e.g., create, start, died, ...)     |
-| .Time                   | Event timestamp (string)                          |
-| .TimeNano               | Event timestamp with nanosecond precision (int64) |
-| .Type                   | Event type (e.g., image, container, pod, ...)     |
+| **Placeholder**       | **Description**                                                      |
+| --------------------- | -------------------------------------------------------------------- |
+| .Attributes ...       | created_at, _by, labels, and more (map[])                            |
+| .ContainerExitCode    | Exit code (int)                                                      |
+| .ContainerInspectData | Payload of the container's inspect                                   |
+| .Error                | Error message in case the event status is an error (e.g. pull-error) |
+| .HealthStatus         | Health Status (string)                                               |
+| .ID                   | Container ID (full 64-bit SHA)                                       |
+| .Image                | Name of image being run (string)                                     |
+| .Name                 | Container name (string)                                              |
+| .Network              | Name of network being used (string)                                  |
+| .PodID                | ID of pod associated with container, if any                          |
+| .Status               | Event status (e.g., create, start, died, ...)                        |
+| .Time                 | Event timestamp (string)                                             |
+| .TimeNano             | Event timestamp with nanosecond precision (int64)                    |
+| .Type                 | Event type (e.g., image, container, pod, ...)                        |
 
 #### **--help**
 

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -42,7 +42,7 @@ type Event struct {
 	// Health status of the current container
 	HealthStatus string `json:"health_status,omitempty"`
 	// Error code for certain events involving errors.
-	Error error `json:"error,omitempty"`
+	Error string `json:"error,omitempty"`
 
 	Details
 }

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -90,6 +90,9 @@ func (e *Event) ToHumanReadable(truncate bool) string {
 		humanFormat = fmt.Sprintf("%s %s %s %s (container=%s, name=%s)", e.Time, e.Type, e.Status, id, id, e.Network)
 	case Image:
 		humanFormat = fmt.Sprintf("%s %s %s %s %s", e.Time, e.Type, e.Status, id, e.Name)
+		if e.Error != "" {
+			humanFormat += " " + e.Error
+		}
 	case System:
 		if e.Name != "" {
 			humanFormat = fmt.Sprintf("%s %s %s %s", e.Time, e.Type, e.Status, e.Name)

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -43,8 +43,8 @@ func (e EventJournalD) Write(ee Event) error {
 	case Image:
 		m["PODMAN_NAME"] = ee.Name
 		m["PODMAN_ID"] = ee.ID
-		if ee.Error != nil {
-			m["ERROR"] = ee.Error.Error()
+		if ee.Error != "" {
+			m["ERROR"] = ee.Error
 		}
 	case Container, Pod:
 		m["PODMAN_IMAGE"] = ee.Image
@@ -231,8 +231,8 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 		newEvent.Network = entry.Fields["PODMAN_NETWORK_NAME"]
 	case Image:
 		newEvent.ID = entry.Fields["PODMAN_ID"]
-		if _, ok := entry.Fields["ERROR"]; ok {
-			newEvent.Error = errors.New(entry.Fields["ERROR"])
+		if val, ok := entry.Fields["ERROR"]; ok {
+			newEvent.Error = val
 		}
 	}
 	return &newEvent, nil

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -737,6 +737,9 @@ func (r *Runtime) libimageEvents() {
 					Time:   libimageEvent.Time,
 					Type:   events.Image,
 				}
+				if libimageEvent.Error != nil {
+					e.Error = libimageEvent.Error.Error()
+				}
 				if err := r.eventer.Write(e); err != nil {
 					logrus.Errorf("Unable to write image event: %q", err)
 				}

--- a/pkg/domain/entities/events.go
+++ b/pkg/domain/entities/events.go
@@ -33,11 +33,13 @@ func ConvertToLibpodEvent(e Event) *libpodEvents.Event {
 	name := e.Actor.Attributes["name"]
 	network := e.Actor.Attributes["network"]
 	podID := e.Actor.Attributes["podId"]
+	errorString := e.Actor.Attributes["error"]
 	details := e.Actor.Attributes
 	delete(details, "image")
 	delete(details, "name")
 	delete(details, "network")
 	delete(details, "podId")
+	delete(details, "error")
 	delete(details, "containerExitCode")
 	return &libpodEvents.Event{
 		ContainerExitCode: &exitCode,
@@ -49,6 +51,7 @@ func ConvertToLibpodEvent(e Event) *libpodEvents.Event {
 		Time:              time.Unix(0, e.TimeNano),
 		Type:              t,
 		HealthStatus:      e.HealthStatus,
+		Error:             errorString,
 		Details: libpodEvents.Details{
 			PodID:      podID,
 			Attributes: details,
@@ -70,6 +73,9 @@ func ConvertToEntitiesEvent(e libpodEvents.Event) *types.Event {
 	attributes["podId"] = e.PodID
 	if e.Network != "" {
 		attributes["network"] = e.Network
+	}
+	if e.Error != "" {
+		attributes["error"] = e.Error
 	}
 	message := dockerEvents.Message{
 		// Compatibility with clients that still look for deprecated API elements

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -343,4 +343,14 @@ t GET libpod/images/no-alias-for-sure/resolve 200 \
 t GET libpod/images/noCAPITALcharAllowed/resolve 400 \
   .cause="repository name must be lowercase"
 
+
+START=$(date +%s.%N)
+# test pull-error API response
+podman pull --retry 0 localhost:5000/idonotexist || true
+t GET "libpod/events?stream=false&since=$START"  200  \
+  .status=pull-error \
+  .Action=pull-error \
+  .Actor.Attributes.name="localhost:5000/idonotexist" \
+  .Actor.Attributes.error~".*connection refused"
+
 # vim: filetype=sh


### PR DESCRIPTION
Commit 03f6589f3 added basic support for pull-error event from libimage but it contains several problems:
1. storing the error as error type prevents it from being unmarshalled, thus change it to a string
2. the error was never propagated from the libimage event to the podman event struct
3. the error message was not wired into the cli and API

This commit fixes these problems.

Fixes #21458

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman events now supports a new pull-error event
```
