### PR TITLE
e2e: fix potential race in file-locks test

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1449,10 +1449,11 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint and restore container with --file-locks", func() {
-		localRunString := getRunString([]string{"--name", "test_name", ALPINE, "flock", "test.lock", "sleep", "100"})
+		localRunString := getRunString([]string{"--name", "test_name", ALPINE, "flock", "test.lock", "sh", "-c", "echo READY;sleep 100"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
+		Expect(WaitContainerReady(podmanTest, "test_name", "READY", 5, 1)).To(BeTrue(), "Timed out waiting for READY")
 
 		// Checkpoint is expected to fail without --file-locks
 		result := podmanTest.Podman([]string{"container", "checkpoint", "test_name"})


### PR DESCRIPTION
Two test flakes in the past month. Looks like the usual race
between "run -d" and "assume the container is ready". I don't
know if this will resolve them, but it's still a good idea.

* fedora-38 : int podman fedora-38 root host boltdb
    * [03-04 12:22](https://api.cirrus-ci.com/v1/artifact/task/6542391172136960/html/int-podman-fedora-38-root-host-boltdb.log.html#t--Podman-checkpoint-podman-checkpoint-and-restore-container-with-file-locks--1)
    * [02-14 16:27](https://api.cirrus-ci.com/v1/artifact/task/5004742884065280/html/int-podman-fedora-38-root-host-boltdb.log.html#t--Podman-checkpoint-podman-checkpoint-and-restore-container-with-file-locks--1)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```