### PR TITLE
CI: try to fix more flakes

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -597,7 +597,8 @@ RUN touch /file
 
 		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--creds=" + registry.User + ":" + registry.Password, "--format=v2s2", "localhost:" + registry.Port + "/citest:latest"})
 		push.WaitWithDefaultTimeout()
-		Expect(push).Should(ExitCleanly())
+		// Cannot ExitCleanly() because this sometimes warns "Failed, retrying in 1s"
+		Expect(push).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"manifest", "add", "--tls-verify=false", "--creds=" + registry.User + ":" + registry.Password, "foo", "localhost:" + registry.Port + "/citest:latest"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Most of them look like our usual "assume too much about run -d".

One of them is just an unexpected warning, a push retry. Remove
the ExitCleanly() from that test, just rely on Exit(0).

The other two have to do with podman logs, which we know can lag.
Add a short 1-second retry loop.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```