### PR TITLE
logformatter: strip "--url xxx" from bats podman-remote

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -421,9 +421,10 @@ END_HTML
             }
 
             # Readability: /long/path/to/podman -> podman (hover for full path)
-            # Also make it boldface, to make commands stand out
-            $line =~ s{^(#\s+(#|\$)\s+)(\S+/)(podman\S*)(\s.*)}
-                      {$1<b><span title="$3$4">$4</span>$5</b>};
+            # Also make it boldface, to make commands stand out, and strip --url
+            #           1    2    2   13    345         56              6 47    7
+            $line =~ s{^(#\s+(#|\$)\s+)(\S+/)((podman\S*)(\s+--url\s+\S+)?)(\s.*)}
+                      {$1<b><span title="$3$4">$5</span>$7</b>};
 
             if    ($line =~ /^ok\s.*\s# skip/)    { $css = 'skipped'       }
             elsif ($line =~ /^ok\s/)              { $css = 'passed'        }

--- a/contrib/cirrus/logformatter.t
+++ b/contrib/cirrus/logformatter.t
@@ -96,6 +96,7 @@ not ok 3 fail
 # (from function `assert' in file ./helpers.bash, line 343,
 #  from function `expect_output' in file ./helpers.bash, line 370,
 #  in test file ./run.bats, line 786)
+# $ /path/to/podman-remote --url /this/should/be-stripped blah blah
 # $ /path/to/podman foo -bar
 # time="2023-01-05T15:15:20Z" level=debug msg="this is debug"
 # time="2023-01-05T15:15:20Z" level=warning msg="this is warning"
@@ -109,6 +110,7 @@ ok 4 blah
 <span class='bats-log'># (from function `assert&#39; in file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L343">helpers.bash, line 343</a>,</span>
 <span class='bats-log'>#  from function `expect_output&#39; in file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L370">helpers.bash, line 370</a>,</span>
 <span class='bats-log'>#  in test file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/run.bats#L786">run.bats, line 786</a>)</span>
+<span class='bats-log'># $ <b><span title="/path/to/podman-remote --url /this/should/be-stripped">podman-remote</span> blah blah</b></span>
 <span class='bats-log'># $ <b><span title="/path/to/podman">podman</span> foo -bar</b></span>
 <span class='bats-log'># time=<span class='log-debug'>&quot;2023-01-05T15:15:20Z&quot;</span> level=<span class='log-debug'>debug</span> msg=<span class='log-debug'>&quot;this is debug&quot;</span></span>
 <span class='bats-log'># time=<span class='log-warning'>&quot;2023-01-05T15:15:20Z&quot;</span> level=<span class='log-warning'>warning</span> msg=<span class='log-warning'>&quot;this is warning&quot;</span></span>


### PR DESCRIPTION
...in failure messages. It provides nothing but visual clutter.

Been testing a few days in #17831. Here's a [sample failure](https://api.cirrus-ci.com/v1/artifact/task/4717522784616448/html/sys-remote-rawhide-root-host-sqlite.log.html#t--00356). Hover cursor over `podman-remote` to get the url, should that be of any interest to anyone.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```