### PR TITLE
[v4.2.0-rhel] Use a branched runc instead of manual vendor changes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -295,28 +295,27 @@ swagger_task:
             type: text/plain
 
 
-# Disabled as we are now manually patching vendor/
-# # Check that all included go modules from other sources match
-# # what is expected in `vendor/modules.txt` vs `go.mod`.  Also
-# # make sure that the generated bindings in pkg/bindings/...
-# # are in sync with the code.
-# consistency_task:
-#     name: "Test Code Consistency"
-#     alias: consistency
-#     # Docs: ./contrib/cirrus/CIModes.md
-#     only_if: *is_pr
-#     depends_on:
-#         - build
-#     container: *smallcontainer
-#     env:
-#         <<: *stdenvars
-#         TEST_FLAVOR: consistency
-#         TEST_ENVIRON: container
-#         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-#     clone_script: *get_gosrc
-#     setup_script: *setup
-#     main_script: *main
-#     always: *runner_stats
+# Check that all included go modules from other sources match
+# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
+# make sure that the generated bindings in pkg/bindings/...
+# are in sync with the code.
+consistency_task:
+    name: "Test Code Consistency"
+    alias: consistency
+    # Docs: ./contrib/cirrus/CIModes.md
+    only_if: *is_pr
+    depends_on:
+        - build
+    container: *smallcontainer
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: consistency
+        TEST_ENVIRON: container
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+    clone_script: *get_gosrc
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
 
 
 # There are several other important variations of podman which
@@ -803,6 +802,7 @@ success_task:
         - validate
         - bindings
         - swagger
+        - consistency
         - alt_build
         - osx_alt_build
         - unit_test

--- a/go.mod
+++ b/go.mod
@@ -73,4 +73,5 @@ require (
 
 require github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316 // indirect
 
-replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+// See https://github.com/projectatomic/runc/blob/podman-v4.2.0-rhel/README.branch for details.
+replace github.com/opencontainers/runc => github.com/projectatomic/runc v0.0.0-20240307021259-c0428046ced8

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,6 @@ github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 h1:+czc/J8SlhPKLOtVLMQc+xDCFBT73ZStMsRhSsUhsSg=
 github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198/go.mod h1:j4h1pJW6ZcJTgMZWP3+7RlG3zTaP02aDZ/Qw0sppK7Q=
-github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc h1:qjkUzmFsOFbQyjObybk40mRida83j5IHRaKzLGdBbEU=
-github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc/go.mod h1:wUOQGsiKae6VzA/UvlCK3cO+pHk8F2VQHlIoITEfMM8=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1354,6 +1352,8 @@ github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhF
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU0=
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
+github.com/projectatomic/runc v0.0.0-20240307021259-c0428046ced8 h1:+Fd6Rtdi+ik531qEuoj5vPpl8lv+MhExIG8ltsB2H5A=
+github.com/projectatomic/runc v0.0.0-20240307021259-c0428046ced8/go.mod h1:wUOQGsiKae6VzA/UvlCK3cO+pHk8F2VQHlIoITEfMM8=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
@@ -106,7 +106,6 @@ func prepareOpenat2() error {
 		}
 
 		cgroupRootHandle = file
-
 		resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS
 		if st.Type == unix.CGROUP2_SUPER_MAGIC {
 			// cgroupv2 has a single mountpoint and no "cpu,cpuacct" symlinks

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -590,7 +590,7 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runc v1.1.3 => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+# github.com/opencontainers/runc v1.1.3 => github.com/projectatomic/runc v0.0.0-20240307021259-c0428046ced8
 ## explicit
 github.com/opencontainers/runc/libcontainer/apparmor
 github.com/opencontainers/runc/libcontainer/cgroups
@@ -925,4 +925,4 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # sigs.k8s.io/yaml v1.3.0
 sigs.k8s.io/yaml
-# github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+# github.com/opencontainers/runc => github.com/projectatomic/runc v0.0.0-20240307021259-c0428046ced8


### PR DESCRIPTION
Commit 3e7ca842a (PR #21483) manually patched runc/libcontainer in vendor, which is OK but creates a maintenance problem down the line.
    
Instead, let's
 - create [a branch](https://github.com/projectatomic/runc/tree/podman-v4.2.0-rhel) based on runc commit used here;
 - backport the CVE-2024-21626 fixes;
 - vendor the above branch here.
    
As a side note, all this mess could have been avoided if https://github.com/opencontainers/runc/pull/3508 was backported to a stable runc branch. Alas, this was never requested.

Also, re-enable the CI task which was disabled due to manual vendor changes (commit 47b995b10).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
