### PR TITLE
pkg/machine: fix relative DefaultPolicyJSONPath

### DIFF
--- a/pkg/machine/ocipull/policy.go
+++ b/pkg/machine/ocipull/policy.go
@@ -41,7 +41,7 @@ func policyPath() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not resolve relative path to binary: %w", err)
 		}
-		return filepath.Join(p, DefaultPolicyJSONPath, policyfile), nil
+		return filepath.Join(filepath.Dir(p), DefaultPolicyJSONPath, policyfile), nil
 	}
 	return "", &defaultPolicyError{errs: errs}
 }


### PR DESCRIPTION
When we set a relative path (i.e. ".") it should be resolved next to binary so we need to get the base dir. If we join it directly like it did before you get a path like .../podman/policy.json where podman is the podman executable so it is not a directory and thus could not contain the policy.json file.

ref #21964

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
