### PR TITLE
[CI:BUILD] Build universal Podman binary for Mac installer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -351,6 +351,7 @@ osx_alt_build_task:
         - cd contrib/pkginstaller
         - make ARCH=amd64 NO_CODESIGN=1 pkginstaller
         - make ARCH=aarch64 NO_CODESIGN=1 pkginstaller
+        - make ARCH=universal NO_CODESIGN=1 pkginstaller
     # Produce a new repo.tbz artifact for consumption by dependent tasks.
     repo_prep_script: *repo_prep
     repo_artifacts: *repo_artifacts

--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -67,6 +67,7 @@ jobs:
         URI="https://github.com/containers/podman/releases/download/${{steps.getversion.outputs.version}}"
         ARM_FILE="podman-installer-macos-arm64.pkg"
         AMD_FILE="podman-installer-macos-amd64.pkg"
+        UNIVERSAL_FILE="podman-installer-macos-universal.pkg"
 
         status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${ARM_FILE}")
         if [[ "$status" == "404" ]] ; then
@@ -83,10 +84,19 @@ jobs:
           echo "::warning::AMD installer already exists, skipping"
           echo "buildamd=false" >> $GITHUB_OUTPUT
         fi
+
+        status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${UNIVERSAL_FILE}")
+        if [[ "$status" == "404" ]] ; then
+          echo "builduniversal=true" >> $GITHUB_OUTPUT
+        else
+          echo "::warning::Universal installer already exists, skipping"
+          echo "builduniversal=false" >> $GITHUB_OUTPUT
+        fi
     - name: Checkout Version
       if: >-
         steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
+        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
@@ -96,6 +106,7 @@ jobs:
       if: >-
         steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
+        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/setup-go@v5
       with:
@@ -104,6 +115,7 @@ jobs:
       if: >-
         steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
+        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       run: |
         echo $APPLICATION_CERTIFICATE | base64 --decode -o appcert.p12
@@ -129,10 +141,17 @@ jobs:
       run: |
         make ARCH=amd64 notarize &> /dev/null
         cd out && shasum -a 256 podman-installer-macos-amd64.pkg >> shasums
+    - name: Build and Sign Universal
+      if: steps.check.outputs.builduniversal == 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
+      working-directory: contrib/pkginstaller
+      run: |
+        make ARCH=universal notarize &> /dev/null
+        cd out && shasum -a 256 podman-installer-macos-universal.pkg >> shasums
     - name: Artifact
       if: >-
         steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
+        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/upload-artifact@v4
       with:
@@ -144,7 +163,8 @@ jobs:
       if: >-
         steps.actual_dryrun.outputs.dryrun == 'false' &&
         (steps.check.outputs.buildamd == 'true' ||
-         steps.check.outputs.buildarm == 'true')
+         steps.check.outputs.buildarm == 'true'||
+         steps.check.outputs.builduniversal == 'true' )
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/contrib/pkginstaller/.gitignore
+++ b/contrib/pkginstaller/.gitignore
@@ -1,6 +1,6 @@
 out
 Distribution
 welcome.html
-tmp-download
+tmp-bin
 .vscode
 root

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -11,22 +11,22 @@ VFKIT_VERSION ?= 0.5.1
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
 PACKAGE_DIR ?= out/packaging
-TMP_DOWNLOAD ?= tmp-download
+TMP_BIN ?= tmp-bin
 PACKAGE_ROOT ?= root
 PKG_NAME := podman-installer-macos-$(GOARCH).pkg
 
 default: pkginstaller
 
 podman_version:
-	make -C ../../ test/version/version
+	make -B -C ../../ test/version/version
 
-$(TMP_DOWNLOAD)/gvproxy:
-	mkdir -p $(TMP_DOWNLOAD)
-	cd $(TMP_DOWNLOAD) && curl -sLo gvproxy $(GVPROXY_RELEASE_URL)
+$(TMP_BIN)/gvproxy:
+	mkdir -p $(TMP_BIN)
+	cd $(TMP_BIN) && curl -sLo gvproxy $(GVPROXY_RELEASE_URL)
 
-$(TMP_DOWNLOAD)/vfkit:
-	mkdir -p $(TMP_DOWNLOAD)
-	cd $(TMP_DOWNLOAD) && curl -sLo vfkit $(VFKIT_RELEASE_URL)
+$(TMP_BIN)/vfkit:
+	mkdir -p $(TMP_BIN)
+	cd $(TMP_BIN) && curl -sLo vfkit $(VFKIT_RELEASE_URL)
 
 packagedir: podman_version package_root Distribution welcome.html
 	mkdir -p $(PACKAGE_DIR)
@@ -42,10 +42,10 @@ packagedir: podman_version package_root Distribution welcome.html
 	cp ../../LICENSE $(PACKAGE_DIR)/Resources/LICENSE.txt
 	cp vfkit.entitlements $(PACKAGE_DIR)/
 
-package_root: clean-pkgroot $(TMP_DOWNLOAD)/gvproxy $(TMP_DOWNLOAD)/vfkit
+package_root: clean-pkgroot $(TMP_BIN)/gvproxy $(TMP_BIN)/vfkit
 	mkdir -p $(PACKAGE_ROOT)/podman/bin
-	cp $(TMP_DOWNLOAD)/gvproxy $(PACKAGE_ROOT)/podman/bin/
-	cp $(TMP_DOWNLOAD)/vfkit $(PACKAGE_ROOT)/podman/bin/
+	cp $(TMP_BIN)/gvproxy $(PACKAGE_ROOT)/podman/bin/
+	cp $(TMP_BIN)/vfkit $(PACKAGE_ROOT)/podman/bin/
 	chmod a+x $(PACKAGE_ROOT)/podman/bin/*
 	mkdir $(PACKAGE_ROOT)/podman/config
 	cp ../../pkg/machine/ocipull/policy.json $(PACKAGE_ROOT)/podman/config/policy.json
@@ -64,7 +64,7 @@ notarize: _notarize
 
 .PHONY: clean clean-pkgroot
 clean:
-	rm -rf $(TMP_DOWNLOAD) $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html ../../test/version/version
+	rm -rf $(TMP_BIN) $(PACKAGE_ROOT) $(PACKAGE_DIR) out Distribution welcome.html ../../test/version/version
 
 clean-pkgroot:
 	rm -rf $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html

--- a/contrib/pkginstaller/README.md
+++ b/contrib/pkginstaller/README.md
@@ -1,13 +1,13 @@
 ## How to build
 
 ```sh
-$ make ARCH=<amd64 | aarch64> NO_CODESIGN=1 pkginstaller
+$ make ARCH=<amd64 | aarch64 | universal> NO_CODESIGN=1 pkginstaller
 
 # or to create signed pkg
-$ make ARCH=<amd64 | aarch64> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> pkginstaller
+$ make ARCH=<amd64 | aarch64 | universal> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> pkginstaller
 
 # or to prepare a signed and notarized pkg for release
-$ make ARCH=<amd64 | aarch64> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> NOTARIZE_TEAM=<team-id> notarize
+$ make ARCH=<amd64 | aarch64 | universal> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> NOTARIZE_TEAM=<team-id> notarize
 ```
 
 The generated pkg will be written to `out/podman-macos-installer-*.pkg`.


### PR DESCRIPTION
Build universal Podman binary and installer for Mac. Update GitHub action to build it too.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
