### PR TITLE
fix invalid HTTP header values when hijacking a connection

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -217,7 +217,7 @@ func writeHijackHeader(r *http.Request, conn io.Writer, tty bool) {
 		// Upgraded
 		fmt.Fprintf(conn,
 			"HTTP/1.1 101 UPGRADED\r\nContent-Type: %s\r\nConnection: Upgrade\r\nUpgrade: %s\r\n\r\n",
-			proto, header)
+			header, proto)
 	}
 }
 

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -45,6 +45,11 @@ t POST "/v4.7.0/libpod/containers/foo/attach?logs=true&stream=false" 200
 response_headers=$(cat "$WORKDIR/curl.headers.out")
 like "$response_headers" ".*Content-Type: application/vnd\.docker\.multiplexed-stream.*" "vnd.docker.multiplexed-stream libpod v4.7.0"
 
+t POST "containers/foo/attach?logs=true&stream=false" 101
+response_headers=$(cat "$WORKDIR/curl.headers.out")
+like "$response_headers" ".*Content-Type: application/vnd\.docker\.raw-stream.*" "hijacked connection header: Content-type: application/vnd.docker.raw-stream"
+like "$response_headers" ".*Upgrade: tcp.*" "hijacked connection header: Upgrade: tcp"
+
 t POST "containers/foo/kill" 204
 
 podman run --replace --name=foo -v /tmp:/tmp $IMAGE true

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -322,6 +322,10 @@ function t() {
 
     local expected_code=$1; shift
 
+    if [[ "$expected_code" == "101" ]]; then
+        curl_args+=("-H" "Connection: upgrade" "-H" "Upgrade: tcp")
+    fi
+
     # Log every action we do
     echo "-------------------------------------------------------------" >>$LOG
     echo "\$ $testname"                                                  >>$LOG


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

The issue is a regression in an interactive exec session (/exec/{id}/start endpoint) where the values for the HTTP headers are incorrect:

Content-type: tcp
Upgrade: application/vnd.docker.raw-stream

Expected:

Content-type: application/vnd.docker.raw-stream
Upgrade: tcp

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that caused incorrect header values when upgrading a connection for an interactive exec session.
```