### PR TITLE
[CI:DOCS] Add farm command to commands list

### DIFF
--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -27,6 +27,8 @@ Commands
 
 :doc:`export <markdown/podman-export.1>` Export container's filesystem contents as a tar archive
 
+:doc:`export <markdown/podman-farm.1>` Farm out builds to machines running podman for different architectures
+
 :doc:`generate <markdown/podman-generate.1>` Generated structured data
 
 :doc:`healthcheck <markdown/podman-healthcheck.1>` Manage Healthcheck


### PR DESCRIPTION
Add the farm command to the commands list so
that it is rendered correctly in readthedocs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add farm command to command list for readthedocs
```
