### PR TITLE
Complete policy.json inclusion (Also add to win installer)

### DIFF
--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -139,8 +139,16 @@ SignItem @("artifacts/win-sshproxy.exe",
 $gvExists = Test-Path "artifacts/gvproxy.exe"
 if ($gvExists) {
     SignItem @("artifacts/gvproxy.exe")
+    Remove-Item Env:\UseGVProxy -ErrorAction SilentlyContinue
 } else {
     $env:UseGVProxy = "Skip"
+}
+
+$pExists = Test-Path "artifacts/policy.json"
+if ($pExists) {
+    Remove-Item Env:\IncludePolicyJSON -ErrorAction SilentlyContinue
+} else {
+    $env:IncludePolicyJSON = "Skip"
 }
 
 .\build-msi.bat $ENV:INSTVER; ExitOnError

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -12,6 +12,12 @@
     <?define UseGVProxy = ""?>
   <?endif?>
 
+  <?ifdef env.IncludePolicyJSON?>
+    <?define IncludePolicyJSON = "$(env.IncludePolicyJSON)"?>
+  <?else?>
+    <?define IncludePolicyJSON = ""?>
+  <?endif?>
+
   <Product Name="Podman $(var.VERSION)" Id="*" UpgradeCode="696BAB5D-CA1F-4B05-B123-320F245B8D6D" Version="$(var.VERSION)" Language="1033" Manufacturer="Red Hat Inc.">
 
     <Package Id="*" Platform="x64" Keywords="Installer" Description="Red Hat's Podman $(var.VERSION) Installer" Comments="Apache 2.0 License" Manufacturer="Red Hat Inc." InstallScope="perMachine" InstallerVersion="200" Compressed="yes"/>
@@ -39,6 +45,11 @@
             <?if $(var.UseGVProxy) != Skip?>
             <Component Id="GvProxyExecutable" Guid="1A4A2975-AD2D-44AA-974B-9B343C098333" Win64="yes">
               <File Id="GvProxyExecutableFile" Name="gvproxy.exe" Source="artifacts/gvproxy.exe" KeyPath="yes"/>
+            </Component>
+            <?endif?>
+            <?if $(var.IncludePolicyJSON) != Skip?>
+            <Component Id="PolicyJSON" Guid="C6135EDA-7C17-4A0E-BC52-5AB38BD54A61" Win64="yes">
+              <File Id="PolicyJSONFile" Name="policy.json" Source="artifacts/policy.json" KeyPath="yes"/>
             </Component>
             <?endif?>
             <Component Id="GuideHTMLComponent" Guid="8B23C76B-F7D4-4030-8C46-1B5729E616B5" Win64="yes">
@@ -73,6 +84,9 @@
       <ComponentRef Id="WinSshProxyExecutable"/>
       <?if $(var.UseGVProxy) != Skip?>
       <ComponentRef Id="GvProxyExecutable"/>
+      <?endif?>
+      <?if $(var.IncludePolicyJSON) != Skip?>
+      <ComponentRef Id="PolicyJSON"/>
       <?endif?>
       <ComponentRef Id="GuideHTMLComponent"/>
       <ComponentGroupRef Id="ManFiles"/>

--- a/contrib/win-installer/process-release.ps1
+++ b/contrib/win-installer/process-release.ps1
@@ -135,6 +135,13 @@ try {
         Copy-Artifact("gvproxy.exe")
     }
 
+    $loc = Get-ChildItem -Recurse -Path . -Name policy.json
+    if (!$loc) {
+        Write-Host "Skipping policy.json artifact"
+    } else {
+        Copy-Artifact("policy.json")
+    }
+
     $docsloc = Get-ChildItem -Path . -Name docs -Recurse
     $loc = Get-ChildItem -Recurse -Path . -Name podman-for-windows.html
     if (!$loc) {


### PR DESCRIPTION
- Sets default search location to always be the peer directory
  + make podman-remote now creates binaries that work the same as release zips
- Updates release zip to match expected search location
- Updates win installer to include the file if present in the repo cross-build archive


```release-note
none
```
