### PR TITLE
Backport two docker CLI compatibility fixes

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -527,6 +527,29 @@ t GET containers/$cid/json 200 \
 
 t DELETE containers/$cid?v=true 204
 
+# test create container like Docker >= 25 cli: NetworkMode="default" but EndpointsConfig struct is explictly set and netns="host"
+t POST containers/create \
+  Image=$IMAGE \
+  HostConfig='{"NetworkMode":"default"}' \
+  NetworkingConfig='{"EndpointsConfig":{"default":{"IPAMConfig":null,"Links":null,"Aliases":null,"MacAddress":"","NetworkID":"","EndpointID":"","Gateway":"","IPAddress":"","IPPrefixLen":0,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"DriverOpts":null,"DNSNames":null}}}' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .HostConfig.NetworkMode="host"
+
+t DELETE containers/$cid?v=true 204
+
+# test creating a container fails with netns="hosts" on podman side but keep using the default network mode
+# on docker CLI side and trying to use --ip 1.2.3.4 which is only valid for the bridge network mode (docker CLI
+# will assume the default is the bridge mode, so it's valid from docker CLI point of view).
+t POST containers/create \
+  Image=$IMAGE \
+  HostConfig='{"NetworkMode":"default"}' \
+  NetworkingConfig='{"EndpointsConfig":{"default":{"IPAMConfig":null,"Links":null,"Aliases":null,"MacAddress":"","NetworkID":"","EndpointID":"","Gateway":"","IPAddress":"1.2.3.4","IPPrefixLen":0,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"DriverOpts":null,"DNSNames":null}}}' \
+  500 \
+    .cause="networks and static ip/mac address can only be used with Bridge mode networking"
+
 # Restart with the default containers.conf for next tests.
 stop_service
 start_service


### PR DESCRIPTION
Picked from #21820 

this backports in branch 4.9 (which apparently is the last version fedora 38 and 39 will get) two docker CLI compatibility fixes merged recently in podman 5:

https://github.com/containers/podman/pull/21487

    https://github.com/containers/podman/pull/21789

Note that I would also hope to see this in RHEL's 4.9 branch as we would need these two fix in the next podman upgrade in RHEL too.

Addresses:

https://issues.redhat.com/browse/RHEL-26664 - RHEL 8.10 0day [v4.9] Backport two docker CLI compatibility fixes
https://issues.redhat.com/browse/RHEL-28636 - RHEL 9.4 0day [v4.9] Backport two docker CLI compatibility fixes

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
