### PR TITLE
Pass pod restart policy to individual containers

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -934,6 +934,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			PodInfraID:         podInfraID,
 			PodName:            podName,
 			PodSecurityContext: podYAML.Spec.SecurityContext,
+			RestartPolicy:      podSpec.PodSpecGen.RestartPolicy, // pass the restart policy to the container (https://github.com/containers/podman/issues/20903)
 			ReadOnly:           readOnly,
 			SeccompPaths:       seccompPaths,
 			SecretsManager:     secretsManager,

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -731,7 +731,7 @@ func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, re
 			return err
 		}
 		// if restart policy is in place, ensure the health check enforces it
-		if restartPolicy == "always" || restartPolicy == "onfailure" {
+		if restartPolicy == define.RestartPolicyAlways || restartPolicy == define.RestartPolicyOnFailure {
 			s.HealthCheckOnFailureAction = define.HealthCheckOnFailureActionRestart
 		}
 		return nil
@@ -763,7 +763,7 @@ func setupStartupProbe(s *specgen.SpecGenerator, containerYAML v1.Container, res
 			Successes:           int(containerYAML.StartupProbe.SuccessThreshold),
 		}
 		// if restart policy is in place, ensure the health check enforces it
-		if restartPolicy == "always" || restartPolicy == "onfailure" {
+		if restartPolicy == define.RestartPolicyAlways || restartPolicy == define.RestartPolicyOnFailure {
 			s.HealthCheckOnFailureAction = define.HealthCheckOnFailureActionRestart
 		}
 		return nil


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When using a `RestartPolicy` together with a `livenessProbe`, the policy is now passed
down to the individual containers. Previously, this wasn't the case. (#20903)
```

---

Healthchecks, defined in a .yaml file as livenessProbe did not had any effect. They were executing as intended, containers were marked as unhealthy, yet no action was taken. This was never the intended behaviour, as observed by the following comment:

> if restart policy is in place, ensure the health check enforces it

A minimal example is tracked in #20903 with the following YAML:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: ubi-httpd-24
spec:
  restartPolicy: Always
  containers:
    - name: ubi8-httpd
      image: registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-217
      livenessProbe:
        httpGet:
          path: "/"
          port: 8081
```

By passing down the restart policy (and using constants instead of actually wrong hard-coded ones), Podman actually restarts the container now.