### PR TITLE
Makefile: remotesystem: remove custom-socket code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -666,24 +666,25 @@ remotesystem:
 	# podman server spews copious unhelpful output; ignore it.
 	rc=0;\
 	if timeout -v 1 true; then \
-		SOCK_FILE=$(shell mktemp --dry-run --tmpdir podman_tmp_XXXX);\
-		export PODMAN_SOCKET=unix://$$SOCK_FILE; \
-		./bin/podman system service --timeout=0 $$PODMAN_SOCKET > $(if $(PODMAN_SERVER_LOG),$(PODMAN_SERVER_LOG),/dev/null) 2>&1 & \
+		if ./bin/podman-remote info >/dev/null 2>&1; then \
+			echo "Error: podman server is already running";\
+			exit 1;\
+		fi;\
+		./bin/podman system service --timeout=0 > $(if $(PODMAN_SERVER_LOG),$(PODMAN_SERVER_LOG),/dev/null) 2>&1 & \
 		retry=5;\
 		while [ $$retry -ge 0 ]; do\
 			echo Waiting for server...;\
 			sleep 1;\
-			./bin/podman-remote --url $$PODMAN_SOCKET info >/dev/null 2>&1 && break;\
+			./bin/podman-remote info >/dev/null 2>&1 && break;\
 			retry=$$(expr $$retry - 1);\
 		done;\
 		if [ $$retry -lt 0 ]; then\
-			echo "Error: ./bin/podman system service did not come up on $$SOCK_FILE" >&2;\
+			echo "Error: ./bin/podman system service did not come up" >&2;\
 			exit 1;\
 		fi;\
-		env PODMAN="$(CURDIR)/bin/podman-remote --url $$PODMAN_SOCKET" bats test/system/ ;\
+		env PODMAN="$(CURDIR)/bin/podman-remote" bats test/system/ ;\
 		rc=$$?;\
 		kill %1;\
-		rm -f $$SOCK_FILE;\
 	else \
 		echo "Skipping $@: 'timeout -v' unavailable'";\
 	fi;\


### PR DESCRIPTION
It dates back to the varlink days, and now it just harms us.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```