### PR TITLE
Quadlet docs

### DIFF
--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -9,7 +9,8 @@ podman\-generate\-systemd - [DEPRECATED] Generate systemd unit file(s) for a con
 ## DESCRIPTION
 DEPRECATED:
 Note: **podman generate systemd** is deprecated. We recommend using [Quadlet](podman-systemd.unit.5.md)
-files when running Podman containers or pods under systemd.
+files when running Podman containers or pods under systemd.  There are no plans to remove the command.
+It will receive urgent bug fixes but no new features.
 
 **podman generate systemd** creates a systemd unit file that can be used to control a container or pod.
 By default, the command prints the content of the unit files to stdout.

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -8,12 +8,16 @@ podman\-systemd.unit - systemd units using Podman Quadlet
 
 *name*.container, *name*.volume, *name*.network, *name*.kube *name*.image, *name*.pod
 
-### Podman unit search path
+### Podman rootful unit search path
+
+Quadlet files for the root user can be placed in the following two directories:
 
  * /etc/containers/systemd/
  * /usr/share/containers/systemd/
 
-### Podman user unit search path
+### Podman rootless unit search path
+
+Quadlet files for non-root users can be placed in the following directories
 
  * $XDG_CONFIG_HOME/containers/systemd/ or ~/.config/containers/systemd/
  * /etc/containers/systemd/users/$(UID)


### PR DESCRIPTION
docs: quadlet: improve docs on root/rootless dirs

Make the docs more explicit on which directories are read for root and
rootless users to avoid confusion [1].

[1] https://github.com/containers/podman/discussions/20218#discussioncomment-8721351

---

docs: generate-systemd: add clarification statement

Based on user feedback, I think it's time to clarify that there are no
plans to remove generate-systemd.  Deprecation here means that the
command will not receive new features but only urgent bug fixes.

---

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve documentation of Quadlet and generate-systemd.
```
