### PR TITLE
do not require policy.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ FISHINSTALLDIR=${PREFIX}/share/fish/vendor_completions.d
 
 SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
 
-MACHINE_POLICY_JSON_DIR ?= .
 
 COMMIT_NO ?= $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),$(call err_if_empty,COMMIT_NO)-dirty,$(COMMIT_NO))
@@ -121,7 +120,6 @@ LDFLAGS_PODMAN ?= \
 	-X $(LIBPOD)/config._installPrefix=$(PREFIX) \
 	-X $(LIBPOD)/config._etcDir=$(ETCDIR) \
 	-X $(PROJECT)/v5/pkg/systemd/quadlet._binDir=$(BINDIR) \
-	-X $(PROJECT)/v5/pkg/machine/ocipull.DefaultPolicyJSONPath=$(MACHINE_POLICY_JSON_DIR) \
 	-X github.com/containers/common/pkg/config.additionalHelperBinariesDir=$(HELPER_BINARIES_DIR)\
 	$(EXTRA_LDFLAGS)
 LDFLAGS_PODMAN_STATIC ?= \
@@ -782,10 +780,6 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 	cp -r ./docs/build/remote/$(GOOS) "$(tmpsubdir)/$(releasedir)/docs/"
 	cp ./contrib/remote/containers.conf "$(tmpsubdir)/$(releasedir)/"
 	$(MAKE) $(GOPLAT) $(_dstargs) SELINUXOPT="" install.remote
-	# Placing the policy file in the bin directory is intentional This
-	# could be changed in the future to mirror LSB on Linux/Unix but would
-	# require path resolution logic changes to sustain the Win flat model
-	cp ./pkg/machine/ocipull/policy.json "$(tmpsubdir)/$(releasedir)/$(RELEASE_PREFIX)/bin"
 	cd "$(tmpsubdir)" && \
 		zip --recurse-paths "$(CURDIR)/$@" "./$(releasedir)"
 	if [[ "$(GOARCH)" != "$(NATIVE_GOARCH)" ]]; then $(MAKE) clean-binaries; fi

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -47,8 +47,9 @@ package_root: clean-pkgroot $(TMP_BIN)/gvproxy $(TMP_BIN)/vfkit
 	cp $(TMP_BIN)/gvproxy $(PACKAGE_ROOT)/podman/bin/
 	cp $(TMP_BIN)/vfkit $(PACKAGE_ROOT)/podman/bin/
 	chmod a+x $(PACKAGE_ROOT)/podman/bin/*
-	mkdir $(PACKAGE_ROOT)/podman/config
-	cp ../../pkg/machine/ocipull/policy.json $(PACKAGE_ROOT)/podman/config/policy.json
+	# Leaving for future considerations
+	# mkdir $(PACKAGE_ROOT)/podman/config
+	# cp ../../pkg/machine/ocipull/policy.json $(PACKAGE_ROOT)/podman/config/policy.json
 
 %: %.in podman_version
 	@sed -e 's/__VERSION__/'$(shell ../../test/version/version)'/g' $< >$@

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -41,7 +41,7 @@ function build_podman() {
 }
 
 function build_podman_arch(){
-    make -B GOARCH="$1" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}" MACHINE_POLICY_JSON_DIR="${MACHINE_POLICY_JSON_DIR}"
+    make -B GOARCH="$1" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}"
     make -B GOARCH="$1" podman-mac-helper
     mkdir -p "${tmpBin}"
     cp bin/darwin/podman "${tmpBin}/podman-$1"

--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -144,13 +144,13 @@ if ($gvExists) {
     $env:UseGVProxy = "Skip"
 }
 
-$pExists = Test-Path "artifacts/policy.json"
-if ($pExists) {
-    Remove-Item Env:\IncludePolicyJSON -ErrorAction SilentlyContinue
-} else {
-    $env:IncludePolicyJSON = "Skip"
-}
-
+# Retaining for possible future additions
+# $pExists = Test-Path "artifacts/policy.json"
+# if ($pExists) {
+#     Remove-Item Env:\IncludePolicyJSON -ErrorAction SilentlyContinue
+# } else {
+#     $env:IncludePolicyJSON = "Skip"
+# }
 .\build-msi.bat $ENV:INSTVER; ExitOnError
 SignItem @("podman.msi")
 

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -12,11 +12,6 @@
     <?define UseGVProxy = ""?>
   <?endif?>
 
-  <?ifdef env.IncludePolicyJSON?>
-    <?define IncludePolicyJSON = "$(env.IncludePolicyJSON)"?>
-  <?else?>
-    <?define IncludePolicyJSON = ""?>
-  <?endif?>
 
   <Product Name="Podman $(var.VERSION)" Id="*" UpgradeCode="696BAB5D-CA1F-4B05-B123-320F245B8D6D" Version="$(var.VERSION)" Language="1033" Manufacturer="Red Hat Inc.">
 
@@ -45,11 +40,6 @@
             <?if $(var.UseGVProxy) != Skip?>
             <Component Id="GvProxyExecutable" Guid="1A4A2975-AD2D-44AA-974B-9B343C098333" Win64="yes">
               <File Id="GvProxyExecutableFile" Name="gvproxy.exe" Source="artifacts/gvproxy.exe" KeyPath="yes"/>
-            </Component>
-            <?endif?>
-            <?if $(var.IncludePolicyJSON) != Skip?>
-            <Component Id="PolicyJSON" Guid="C6135EDA-7C17-4A0E-BC52-5AB38BD54A61" Win64="yes">
-              <File Id="PolicyJSONFile" Name="policy.json" Source="artifacts/policy.json" KeyPath="yes"/>
             </Component>
             <?endif?>
             <Component Id="GuideHTMLComponent" Guid="8B23C76B-F7D4-4030-8C46-1B5729E616B5" Win64="yes">
@@ -84,9 +74,6 @@
       <ComponentRef Id="WinSshProxyExecutable"/>
       <?if $(var.UseGVProxy) != Skip?>
       <ComponentRef Id="GvProxyExecutable"/>
-      <?endif?>
-      <?if $(var.IncludePolicyJSON) != Skip?>
-      <ComponentRef Id="PolicyJSON"/>
       <?endif?>
       <ComponentRef Id="GuideHTMLComponent"/>
       <ComponentGroupRef Id="ManFiles"/>

--- a/contrib/win-installer/process-release.ps1
+++ b/contrib/win-installer/process-release.ps1
@@ -135,12 +135,13 @@ try {
         Copy-Artifact("gvproxy.exe")
     }
 
-    $loc = Get-ChildItem -Recurse -Path . -Name policy.json
-    if (!$loc) {
-        Write-Host "Skipping policy.json artifact"
-    } else {
-        Copy-Artifact("policy.json")
-    }
+    # Retaining for future additions
+    # $loc = Get-ChildItem -Recurse -Path . -Name policy.json
+    # if (!$loc) {
+    #     Write-Host "Skipping policy.json artifact"
+    # } else {
+    #     Copy-Artifact("policy.json")
+    # }
 
     $docsloc = Get-ChildItem -Path . -Name docs -Recurse
     $loc = Get-ChildItem -Recurse -Path . -Name podman-for-windows.html


### PR DESCRIPTION
we are having second thoughts about *requiring* a policy.json on podman machine hosts.  we are concerned that we need to work out some more use cases to be sure we do not make choices now that limit us in the near term future. for example, should the policy files be the same for container images and machine images? And should one live on the host machine and the other live in the machine?

therefore, if a policy.json *is* present in the correct location, we will use and honor it; however, if it does not, we will allow the machine image to be pulled without a policy.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
policy.json is not required for podman machines, though if present, will be honored in pulling
```
