### PR TITLE
[CI:DOCS] update API doc version to 5.0.0

### DIFF
--- a/docs/source/Reference.rst
+++ b/docs/source/Reference.rst
@@ -7,6 +7,12 @@ Show the API documentation for version:
 
 * `latest (main branch) <_static/api.html>`_
 
+* `version 5.0 <_static/api.html?version=v5.0>`_
+
+* `version 4.9 <_static/api.html?version=v4.9>`_
+
+* `version 4.8 <_static/api.html?version=v4.8>`_
+
 * `version 4.7 <_static/api.html?version=v4.7>`_
 
 * `version 4.6 <_static/api.html?version=v4.6>`_

--- a/pkg/api/server/doc.go
+++ b/pkg/api/server/doc.go
@@ -27,15 +27,15 @@
 //
 //	 'podman info'
 //
-//	    curl --unix-socket /run/podman/podman.sock http://d/v4.0.0/libpod/info
+//	    curl --unix-socket /run/podman/podman.sock http://d/v5.0.0/libpod/info
 //
 //	 'podman pull quay.io/containers/podman'
 //
-//	    curl -XPOST --unix-socket /run/podman/podman.sock -v 'http://d/v4.0.0/images/create?fromImage=quay.io%2Fcontainers%2Fpodman'
+//	    curl -XPOST --unix-socket /run/podman/podman.sock -v 'http://d/v5.0.0/images/create?fromImage=quay.io%2Fcontainers%2Fpodman'
 //
 //	 'podman list images'
 //
-//	    curl --unix-socket /run/podman/podman.sock -v 'http://d/v4.0.0/libpod/images/json' | jq
+//	    curl --unix-socket /run/podman/podman.sock -v 'http://d/v5.0.0/libpod/images/json' | jq
 //
 // Terms Of Service:
 //
@@ -44,7 +44,7 @@
 //	Schemes: http, https
 //	Host: podman.io
 //	BasePath: /
-//	Version: 4.0.0
+//	Version: 5.0.0
 //	License: Apache-2.0 https://opensource.org/licenses/Apache-2.0
 //	Contact: Podman <podman@lists.podman.io> https://podman.io/community/
 //


### PR DESCRIPTION
Also update the website to display the correct swagger doc for the right version, the 5.0 swagger file will not exist until we branch but I added it anyway so we do not forget it.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
