### PR TITLE
Change API socket to be machine name isolated

### DIFF
--- a/pkg/machine/env/dir.go
+++ b/pkg/machine/env/dir.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/storage/pkg/homedir"
@@ -148,4 +149,11 @@ func GetSSHIdentityPath(name string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(datadir, name), nil
+}
+
+func WithPodmanPrefix(name string) string {
+	if !strings.HasPrefix(name, "podman") {
+		name = "podman-" + name
+	}
+	return name
 }

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -81,7 +81,7 @@ address can't be used by podman. `
 			fmtString = `You can %sconnect Docker API clients by setting DOCKER_HOST using the
 following command in your terminal session:
 
-        %s'
+        %s
 
 `
 			prefix := ""

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -123,7 +123,7 @@ func LaunchWinProxy(opts WinProxyOpts, noInfo bool) {
 }
 
 func launchWinProxy(opts WinProxyOpts) (bool, string, error) {
-	machinePipe := ToDist(opts.Name)
+	machinePipe := env.WithPodmanPrefix(opts.Name)
 	if !PipeNameAvailable(machinePipe, MachineNameWait) {
 		return false, "", fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
 	}
@@ -261,13 +261,6 @@ func GetWinProxyStateDir(name string, vmtype define.VMType) (string, error) {
 	}
 
 	return stateDir, nil
-}
-
-func ToDist(name string) string {
-	if !strings.HasPrefix(name, "podman") {
-		name = "podman-" + name
-	}
-	return name
 }
 
 func GetEnvSetString(env string, val string) string {

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -111,7 +111,7 @@ func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 		return "", 0, err
 	}
 
-	hostSocks, forwardSock, forwardingState, err := setupMachineSockets(mc.Name, dirs)
+	hostSocks, forwardSock, forwardingState, err := setupMachineSockets(mc, dirs)
 	if err != nil {
 		return "", 0, err
 	}

--- a/pkg/machine/shim/networking_unix.go
+++ b/pkg/machine/shim/networking_unix.go
@@ -10,63 +10,92 @@ import (
 
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 )
 
-func setupMachineSockets(name string, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
-	hostSocket, err := dirs.DataDir.AppendToNewVMFile("podman.sock", nil)
+func setupMachineSockets(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
+	hostSocket, err := mc.APISocket()
 	if err != nil {
 		return nil, "", 0, err
 	}
 
-	linkSocketPath := filepath.Dir(dirs.DataDir.GetPath())
-	linkSocket, err := define.NewMachineFile(filepath.Join(linkSocketPath, "podman.sock"), nil)
+	forwardSock, state, err := setupForwardingLinks(hostSocket, dirs.DataDir)
 	if err != nil {
 		return nil, "", 0, err
 	}
-
-	forwardSock, state := setupForwardingLinks(hostSocket, linkSocket)
 	return []string{hostSocket.GetPath()}, forwardSock, state, nil
 }
 
-func setupForwardingLinks(hostSocket, linkSocket *define.VMFile) (string, machine.APIForwardingState) {
-	// The linking pattern is /var/run/docker.sock -> user global sock (link) -> machine sock (socket)
-	// This allows the helper to only have to maintain one constant target to the user, which can be
-	// repositioned without updating docker.sock.
+func setupForwardingLinks(hostSocket, dataDir *define.VMFile) (string, machine.APIForwardingState, error) {
+	// Sets up a cooperative link structure to help a separate privileged
+	// service manage /var/run/docker.sock (currently only on MacOS via
+	// podman-mac-helper, but potentially other OSs in the future).
+	//
+	// The linking pattern is:
+	//
+	// /var/run/docker.sock (link) -> user global sock (link) -> machine sock
+	//
+	// This allows the helper to only have to maintain one constant target to
+	// the user, which can be repositioned without updating docker.sock.
+	//
+	// Since these link locations are global/shared across multiple machine
+	// instances, they must coordinate on the winner. The scheme is first come
+	// first serve, whoever is actively answering on the socket first wins. All
+	// other machine instances backs off. As soon as the winner is no longer
+	// active another machine instance start will become the new active winner.
+	// The same applies to a competing container runtime trying to use
+	// /var/run/docker.sock, if the socket is in use by another runtime, podman
+	// machine will back off. In the start message "Losing" machine instances
+	// will instead advertise the direct machine socket, while "winning"
+	// instances will simply note they listen on the standard
+	// /var/run/docker.sock address. The APIForwardingState return value is
+	// returned by this function to indicate how the start message should behave
 
+	// Skip any OS not supported for helper usage
 	if !dockerClaimSupported() {
-		return hostSocket.GetPath(), machine.ClaimUnsupported
+		return hostSocket.GetPath(), machine.ClaimUnsupported, nil
 	}
 
+	// Verify the helper system service was installed and report back if not
 	if !dockerClaimHelperInstalled() {
-		return hostSocket.GetPath(), machine.NotInstalled
+		return hostSocket.GetPath(), machine.NotInstalled, nil
 	}
 
-	if !alreadyLinked(hostSocket.GetPath(), linkSocket.GetPath()) {
-		if checkSockInUse(linkSocket.GetPath()) {
-			return hostSocket.GetPath(), machine.MachineLocal
+	dataPath := filepath.Dir(dataDir.GetPath())
+	userGlobalSocket, err := define.NewMachineFile(filepath.Join(dataPath, "podman.sock"), nil)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Setup the user global socket if not in use
+	// (e.g ~/.local/share/containers/podman/machine/podman.sock)
+	if !alreadyLinked(hostSocket.GetPath(), userGlobalSocket.GetPath()) {
+		if checkSockInUse(userGlobalSocket.GetPath()) {
+			return hostSocket.GetPath(), machine.MachineLocal, nil
 		}
 
-		_ = linkSocket.Delete()
+		_ = userGlobalSocket.Delete()
 
-		if err := os.Symlink(hostSocket.GetPath(), linkSocket.GetPath()); err != nil {
+		if err := os.Symlink(hostSocket.GetPath(), userGlobalSocket.GetPath()); err != nil {
 			logrus.Warnf("could not create user global API forwarding link: %s", err.Error())
-			return hostSocket.GetPath(), machine.MachineLocal
+			return hostSocket.GetPath(), machine.MachineLocal, nil
 		}
 	}
 
-	if !alreadyLinked(linkSocket.GetPath(), dockerSock) {
+	// Setup /var/run/docker.sock if not in use
+	if !alreadyLinked(userGlobalSocket.GetPath(), dockerSock) {
 		if checkSockInUse(dockerSock) {
-			return hostSocket.GetPath(), machine.MachineLocal
+			return hostSocket.GetPath(), machine.MachineLocal, nil
 		}
 
 		if !claimDockerSock() {
 			logrus.Warn("podman helper is installed, but was not able to claim the global docker sock")
-			return hostSocket.GetPath(), machine.MachineLocal
+			return hostSocket.GetPath(), machine.MachineLocal, nil
 		}
 	}
 
-	return dockerSock, machine.DockerGlobal
+	return dockerSock, machine.DockerGlobal, nil
 }
 
 func alreadyLinked(target string, link string) bool {

--- a/pkg/machine/shim/networking_windows.go
+++ b/pkg/machine/shim/networking_windows.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/env"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 )
 
-func setupMachineSockets(name string, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
-	machinePipe := machine.ToDist(name)
+func setupMachineSockets(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
+	machinePipe := env.WithPodmanPrefix(mc.Name)
 	if !machine.PipeNameAvailable(machinePipe, machine.MachineNameWait) {
 		return nil, "", 0, fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
 	}

--- a/pkg/machine/vmconfigs/sockets.go
+++ b/pkg/machine/vmconfigs/sockets.go
@@ -15,3 +15,7 @@ func gvProxySocket(name string, machineRuntimeDir *define.VMFile) (*define.VMFil
 func readySocket(name string, machineRuntimeDir *define.VMFile) (*define.VMFile, error) {
 	return machineRuntimeDir.AppendToNewVMFile(name+".sock", nil)
 }
+
+func apiSocket(name string, socketDir *define.VMFile) (*define.VMFile, error) {
+	return socketDir.AppendToNewVMFile(name+"-api.sock", nil)
+}

--- a/pkg/machine/vmconfigs/sockets_darwin.go
+++ b/pkg/machine/vmconfigs/sockets_darwin.go
@@ -15,3 +15,8 @@ func readySocket(name string, machineRuntimeDir *define.VMFile) (*define.VMFile,
 	socketName := name + ".sock"
 	return machineRuntimeDir.AppendToNewVMFile(socketName, &socketName)
 }
+
+func apiSocket(name string, socketDir *define.VMFile) (*define.VMFile, error) {
+	socketName := name + "-api.sock"
+	return socketDir.AppendToNewVMFile(socketName, &socketName)
+}

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -60,7 +60,7 @@ func getConfigPathExt(name string, extension string) (string, error) {
 // TODO like provisionWSL, i think this needs to be pushed to use common
 // paths and types where possible
 func unprovisionWSL(mc *vmconfigs.MachineConfig) error {
-	dist := machine.ToDist(mc.Name)
+	dist := env.WithPodmanPrefix(mc.Name)
 	if err := terminateDist(dist); err != nil {
 		logrus.Error(err)
 	}
@@ -92,7 +92,7 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 		return "", fmt.Errorf("could not create wsldist directory: %w", err)
 	}
 
-	dist := machine.ToDist(name)
+	dist := env.WithPodmanPrefix(name)
 	fmt.Println(prompt)
 	if err = runCmdPassThrough(wutil.FindWSL(), "--import", dist, distTarget, imagePath, "--version", "2"); err != nil {
 		return "", fmt.Errorf("the WSL import of guest OS failed: %w", err)
@@ -684,7 +684,7 @@ func unregisterDist(dist string) error {
 }
 
 func isRunning(name string) (bool, error) {
-	dist := machine.ToDist(name)
+	dist := env.WithPodmanPrefix(name)
 	wsl, err := isWSLRunning(dist)
 	if err != nil {
 		return false, err
@@ -719,7 +719,7 @@ func getDiskSize(name string) strongunits.GiB {
 
 //nolint:unused
 func getCPUs(name string) (uint64, error) {
-	dist := machine.ToDist(name)
+	dist := env.WithPodmanPrefix(name)
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}
@@ -744,7 +744,7 @@ func getCPUs(name string) (uint64, error) {
 
 //nolint:unused
 func getMem(name string) (strongunits.MiB, error) {
-	dist := machine.ToDist(name)
+	dist := env.WithPodmanPrefix(name)
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -102,7 +102,7 @@ func startUserModeNetworking(mc *vmconfigs.MachineConfig) error {
 		}
 	}
 
-	if err := createUserModeResolvConf(machine.ToDist(mc.Name)); err != nil {
+	if err := createUserModeResolvConf(env.WithPodmanPrefix(mc.Name)); err != nil {
 		return err
 	}
 
@@ -260,7 +260,7 @@ func addUserModeNetEntry(mc *vmconfigs.MachineConfig) error {
 		return err
 	}
 
-	path := filepath.Join(entriesDir, machine.ToDist(mc.Name))
+	path := filepath.Join(entriesDir, env.WithPodmanPrefix(mc.Name))
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("could not add user-mode networking registration: %w", err)
@@ -275,7 +275,7 @@ func removeUserModeNetEntry(name string) error {
 		return err
 	}
 
-	path := filepath.Join(entriesDir, machine.ToDist(name))
+	path := filepath.Join(entriesDir, env.WithPodmanPrefix(name))
 	return os.Remove(path)
 }
 


### PR DESCRIPTION
Fixes  #21899

Change API socket to be machine name isolated

- Fixes conflicts such as removal of second machine deleting a socket of a the first machine while it's running
- Move API socket into runtime directory for consistency
- Add API and gvproxy sockets to removal list
- Cleanup related logic

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a problem where podman machine rm removes a socket used by other machines - #21899
```
