### PR TITLE
[skip-ci] rpm: update containers-common dep on f40+

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -101,7 +101,14 @@ BuildRequires: python3
 %endif
 Requires: catatonit
 Requires: conmon >= 2:2.1.7-2
+%if %{defined fedora} && 0%{?fedora} >= 40
+# TODO: Remove the f40 conditional after a few releases to keep conditionals to
+# a minimum
+# Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2269148
+Requires: containers-common-extra >= 5:0.58.0-1
+%else
 Requires: containers-common-extra
+%endif
 %if %{defined rhel} && !%{defined eln}
 Recommends: gvisor-tap-vsock-gvforwarder
 %else


### PR DESCRIPTION
This commit bumps containers-common dep such that passt and netavark become hard deps for podman on fedora 40+.
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2269148

With this commit, f40+ envs will use the min name-version-release for containers-common-extra while other deps will use whatever's available. This change can be reverted after a few releases to keep conditionals to a minimum.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
