### PR TITLE
Makefile: drop tests-included from validate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ codespell:
 	codespell -S bin,vendor,.git,go.sum,.cirrus.yml,"*.fish,RELEASE_NOTES.md,*.xz,*.gz,*.ps1,*.tar,swagger.yaml,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L secon,passt,bu,hastable,te,clos,ans,pullrequest,uint,iff,od,seeked,splitted,marge,erro,hist,ether,specif -w
 
 .PHONY: validate
-validate: lint .gitvalidation validate.completions man-page-check swagger-check tests-included tests-expect-exit pr-removes-fixed-skips
+validate: lint .gitvalidation validate.completions man-page-check swagger-check tests-expect-exit pr-removes-fixed-skips
 
 .PHONY: build-all-new-commits
 build-all-new-commits:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -22,10 +22,6 @@ source $(dirname $0)/lib.sh
 showrun echo "starting"
 
 function _run_validate() {
-    # TODO: aarch64 images need python3-devel installed
-    # https://github.com/containers/automation_images/issues/159
-    showrun bigto ooe.sh dnf install -y python3-devel
-
     # git-validation tool fails if $EPOCH_TEST_COMMIT is empty
     # shellcheck disable=SC2154
     if [[ -n "$EPOCH_TEST_COMMIT" ]]; then
@@ -33,7 +29,8 @@ function _run_validate() {
     else
         warn "Skipping git-validation since \$EPOCH_TEST_COMMIT is empty"
     fi
-
+    # make sure PRs have tests
+    showrun make tests-included
 }
 
 function _run_unit() {


### PR DESCRIPTION
make validate should work locally, this check makes no sense in a local context as it checks for a github label.
To fix this remove this check from the validate target and only use it as part of the CI validate run.

While at it remove old dnf install step, the issue has been closed for a long time and it shoudl already be part of our base images.

Fixes #22031

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
