### PR TITLE
Add missing user-facing part to allow volume subpath mounts

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -37,6 +37,8 @@ Options specific to type=**volume**:
   Multiple ranges are separated with #.  If the specified mapping is prepended with a '@' then the mapping is considered relative to the container
   user namespace. The host ID for the mapping is changed to account for the relative position of the container user in the container user namespace.
 
+- *subpath*: If specified, mount specific file or directory from volume into the container.
+
 Options specific to type=**image**:
 
 - *rw*, *readwrite*: *true* or *false* (default if unspecified: *false*).

--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -28,6 +28,7 @@ The _OPTIONS_ is a comma-separated list and can be one or more of:
 * [**r**]**bind**
 * [**r**]**shared**|[**r**]**slave**|[**r**]**private**[**r**]**unbindable** <sup>[[1]](#Footnote1)</sup>
 * **idmap**[=**options**]
+* **subpath**[=**/path/inside/volume**]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The volume
 is mounted into the container at this directory.
@@ -204,3 +205,8 @@ For each triplet, the first value is the start of the backing file
 system IDs that are mapped to the second value on the host.  The
 length of this mapping is given in the third value.
 Multiple ranges are separated with #.
+
+`Volume sub-path mount`
+
+If `subpath` is specified, mount only specified file or directory from the volume
+into the container.

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -254,7 +254,7 @@ func Mounts(mountFlag []string, configMounts []string) (map[string]spec.Mount, m
 }
 
 func parseMountOptions(mountType string, args []string) (*spec.Mount, error) {
-	var setTmpcopyup, setRORW, setSuid, setDev, setExec, setRelabel, setOwnership, setSwap bool
+	var setTmpcopyup, setRORW, setSuid, setDev, setExec, setRelabel, setOwnership, setSubpath, setSwap bool
 
 	mnt := spec.Mount{}
 	for _, arg := range args {
@@ -371,6 +371,19 @@ func parseMountOptions(mountType string, args []string) (*spec.Mount, error) {
 				return nil, fmt.Errorf("host directory cannot be empty: %w", errOptionArg)
 			}
 			mnt.Source = value
+		case "subpath":
+			if setSubpath {
+				return nil, fmt.Errorf("cannot pass %q option more than once: %w", name, errOptionArg)
+			}
+			setSubpath = true
+			if mountType != define.TypeVolume {
+				return nil, fmt.Errorf("%q option not supported for %q mount types", name, mountType)
+			}
+			if hasValue {
+				mnt.Options = append(mnt.Options, fmt.Sprintf("subpath=%s", value))
+			} else {
+				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
+			}
 		case "target", "dst", "destination":
 			if mnt.Destination != "" {
 				return nil, fmt.Errorf("cannot pass %q option more than once: %w", name, errOptionArg)

--- a/vendor/github.com/containers/common/pkg/parse/parse.go
+++ b/vendor/github.com/containers/common/pkg/parse/parse.go
@@ -14,7 +14,7 @@ import (
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown, foundUpperDir, foundWorkDir, foundCopy, foundCopySymlink int
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown, foundUpperDir, foundWorkDir, foundCopy, foundCopySymlink, foundVolumeSubpath int
 	finalOpts := make([]string, 0, len(options))
 	for _, opt := range options {
 		// support advanced options like upperdir=/path, workdir=/path
@@ -35,6 +35,14 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			continue
 		}
 		if strings.HasPrefix(opt, "idmap") {
+			finalOpts = append(finalOpts, opt)
+			continue
+		}
+		if strings.HasPrefix(opt, "subpath") {
+			foundVolumeSubpath++
+			if foundVolumeSubpath > 1 {
+				return nil, fmt.Errorf("invalid options %q, can only specify 1 subpath per mount", strings.Join(options, ", "))
+			}
 			finalOpts = append(finalOpts, opt)
 			continue
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Add missing user-facing "subpath" option to mount subpaths of named volumes.

#### Does this PR introduce a user-facing change?

Yes, adding "subpath" as valid mount and volume option in podman-container-create(1), podman-run(1).

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow users to mount subpaths of named volumes via 'subpath' mount option.
```
