### PR TITLE
Use faster gzip for compression for 3x build speedup for large context send to remote 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hugelgupf/p9 v0.3.1-0.20230822151754-54f5c5530921
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/pgzip v1.2.6
 	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-sqlite3 v1.14.22
@@ -149,7 +150,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
-	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20230907030200-6d76a0f91e1e // indirect

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -31,6 +30,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/hashicorp/go-multierror"
 	jsoniter "github.com/json-iterator/go"
+	gzip "github.com/klauspost/pgzip"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
# Speed up podman build context compression when talking to a remote.

This switches the gzip implementation over to using a faster version for context compression which gives a 3x speed up for a largish context

For a build context of around 3GiB send to a remote over Unix socket.

## Before:
```
 time podman build  ...
...
real	3m19.866s
user	2m31.238s
sys	0m16.211s
```

## After
```
 time podman-patched build  ...
...
real	1m8.367s
user	0m56.179s
sys	0m1.099s

```

This matches docker performance on my machine.

## Notes of interest

So I initially started this investigation by stracing the podman process on the client side. I noticed a large amount of `write` calls with a small  buffer (246bytes). It seems that the gzip module in GoLang seems to aggressively call flush for every block that is encoded causing a much large syscall overhead. I tried adding buffers but the flush propagates down. So in searching for "GoLang gzip slow" I found the replacement that podman is using nearly everywhere. 

Although I don't have time for a full investigation I suspect some of the slowness of the GoLang gzip is the excessive flushes. I'll leave this and a later exercise for anyone interested.

I suspect this reduction of syscalls (~40 times for this case) will really help on all platforms especially windows.

Comparing 

## Before:
```
$ strace -f -o ../podman-orig.strace podman build  ...
$ grep write  podman-orig.strace  | wc
8747448 52957275 763345879
```

## After
```
$ strace -f -o ../podman-patched.strace podman-patched build  ...
$ grep write  podman-patched.strace  | wc
 211700 1277848 15521249
```

#### Does this PR introduce a user-facing change?

```release-note
Faster podman builds with large context when communicating with remote podman 
```
