### PR TITLE
Switch to 5.x WSL machine os stream using new automation

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -103,6 +103,14 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 		return "", fmt.Errorf("package permissions restore of shadow-utils on guest OS failed: %w", err)
 	}
 
+	if err = wslInvoke(dist, "mkdir", "-p", "/usr/local/bin"); err != nil {
+		return "", fmt.Errorf("could not create /usr/local/bin: %w", err)
+	}
+
+	if err = wslInvoke(dist, "ln", "-f", "-s", gvForwarderPath, "/usr/local/bin/vm"); err != nil {
+		return "", fmt.Errorf("could not setup compatibility link: %w", err)
+	}
+
 	return dist, nil
 }
 


### PR DESCRIPTION
- Switches from the current wsl-fedora images used by the 4.x stream to a 5.x WSL machine os stream produced by https://github.com/containers/podman-machine-wsl-os
- Adds subscription-manager and qemu-user-static
- Also Includes a switch from XZ to ZSTD for significantly improved fetch performance 
   + The increase in packages brought  xz extraction to almost 10 minutes (the xz golang is significantly less efficient than xz utils) , now 10 secs with zstd

The ultimate goal is to move from http to an oci pull, but this is targeted for 5.1

```release-note
none
```