### PR TITLE
Expose uid/gid mapping in podman info when run inside a user namespace.

### DIFF
--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/common/pkg/version"
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/rootless"
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 )
@@ -90,7 +91,7 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 		info.Pasta = program
 	}
 
-	if rootless.IsRootless() {
+	if unshare.IsRootless() {
 		uidmappings, err := rootless.ReadMappingsProc("/proc/self/uid_map")
 		if err != nil {
 			return fmt.Errorf("reading uid mappings: %w", err)


### PR DESCRIPTION
This is a small "fix" that is needed on Amadeus side. I guess it's too late for the real podman 5.0 release, but if accepted I wish to have this backported in the RHEL 4.9 branch (since it's rather unrisky).

`unshare.IsRootless()` and `rootless.IsRootless()` are almost the same, except that `rootless.IsRootless()` will also check that podman runs as non-root. In the case where podman runs as root but inside a user namespace (for example, case of podman inside podman), then we have `unshare.IsRootless() == true ` but `rootless.IsRootless() == false`. What I am interested in on my side is not root vs non-root, but really the information wether or not we are running inside a user namespace or not (ie detect top level podman vs podman-inside-docker). By adopting the same logic as podman I can easily detect this using the uid map as seen by podman (see `hasFullUsersMappings` in `vendor/github.com/containers/storage/pkg/unshare/unshare_linux.go`).

Actually, should this uid/gid map always be printed, even when running a classical rootful podman ?

Or should we enrich `podman info` to directly expose a new `RunningInsideUserNamspace` field which would check if the uid_map contains `4294967295` ?

[NO NEW TESTS NEEDED]

```release-note
None
```