### PR TITLE
[CI:BUILD] Add golang 1.21 update warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,21 @@
 module github.com/containers/podman/v5
 
-go 1.20
+// Minimum required golang version
+go 1.20 // *****  ATTENTION  WARNING  CAUTION  DANGER  ******
+
+//         Go versions 1.21 and later will AUTO-UPDATE based
+//         on currently running tools and the (new) `toolchain`
+//         value (when also increasing the `go` value above).
+//         ref: https://go.dev/doc/toolchain  Because several
+//         different distros and distro-versions build from
+//         this code, golang version consistency is
+//         desireable.  After manually updating to 1.21, a
+//         `toolchain` specificication should be added to pin
+//         the version and block auto-updates.  This does not
+//         block any future changes to the `go` value.
+//         Ref: Upstream discussion:
+//         https://github.com/golang/go/issues/65847
+//         *****  ATTENTION  WARNING  CAUTION  DANGER  ******
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
This is needed on the off-chance that some tool or a human suggests updating the minimum version to 1.21 or later. Since doing so would cause Fedora and Debian to start behaving differently WRT builds.

Ref: https://github.com/containers/automation/pull/187

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
