### PR TITLE
utils: do not generate duplicate range

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -195,7 +195,7 @@ func getRootlessKeepIDMapping(uid, gid int, uids, gids []idtools.IDMap) (*stypes
 
 	options.UIDMap, options.GIDMap = nil, nil
 
-	if len(uids) > 0 {
+	if len(uids) > 0 && uid != 0 {
 		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(uid, maxUID)})
 	}
 	options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid, HostID: 0, Size: 1})
@@ -203,7 +203,7 @@ func getRootlessKeepIDMapping(uid, gid int, uids, gids []idtools.IDMap) (*stypes
 		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid + 1, HostID: uid + 1, Size: maxUID - uid})
 	}
 
-	if len(gids) > 0 {
+	if len(gids) > 0 && gid != 0 {
 		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(gid, maxGID)})
 	}
 	options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid, HostID: 0, Size: 1})

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -180,14 +180,47 @@ func ParseSignal(rawSignal string) (syscall.Signal, error) {
 	return sig, nil
 }
 
-// GetKeepIDMapping returns the mappings and the user to use when keep-id is used
-func GetKeepIDMapping(opts *namespaces.KeepIDUserNsOptions) (*stypes.IDMappingOptions, int, int, error) {
+func getRootlessKeepIDMapping(uid, gid int, uids, gids []idtools.IDMap) (*stypes.IDMappingOptions, int, int, error) {
 	options := stypes.IDMappingOptions{
 		HostUIDMapping: false,
 		HostGIDMapping: false,
 	}
+	maxUID, maxGID := 0, 0
+	for _, u := range uids {
+		maxUID += u.Size
+	}
+	for _, g := range gids {
+		maxGID += g.Size
+	}
 
+	options.UIDMap, options.GIDMap = nil, nil
+
+	if len(uids) > 0 {
+		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(uid, maxUID)})
+	}
+	options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid, HostID: 0, Size: 1})
+	if maxUID > uid {
+		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid + 1, HostID: uid + 1, Size: maxUID - uid})
+	}
+
+	if len(gids) > 0 {
+		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(gid, maxGID)})
+	}
+	options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid, HostID: 0, Size: 1})
+	if maxGID > gid {
+		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid + 1, HostID: gid + 1, Size: maxGID - gid})
+	}
+
+	return &options, uid, gid, nil
+}
+
+// GetKeepIDMapping returns the mappings and the user to use when keep-id is used
+func GetKeepIDMapping(opts *namespaces.KeepIDUserNsOptions) (*stypes.IDMappingOptions, int, int, error) {
 	if !rootless.IsRootless() {
+		options := stypes.IDMappingOptions{
+			HostUIDMapping: false,
+			HostGIDMapping: false,
+		}
 		uids, err := rootless.ReadMappingsProc("/proc/self/uid_map")
 		if err != nil {
 			return nil, 0, 0, err
@@ -224,33 +257,7 @@ func GetKeepIDMapping(opts *namespaces.KeepIDUserNsOptions) (*stypes.IDMappingOp
 		return nil, -1, -1, fmt.Errorf("cannot read mappings: %w", err)
 	}
 
-	maxUID, maxGID := 0, 0
-	for _, u := range uids {
-		maxUID += u.Size
-	}
-	for _, g := range gids {
-		maxGID += g.Size
-	}
-
-	options.UIDMap, options.GIDMap = nil, nil
-
-	if len(uids) > 0 {
-		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(uid, maxUID)})
-	}
-	options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid, HostID: 0, Size: 1})
-	if maxUID > uid {
-		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid + 1, HostID: uid + 1, Size: maxUID - uid})
-	}
-
-	if len(gids) > 0 {
-		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(gid, maxGID)})
-	}
-	options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid, HostID: 0, Size: 1})
-	if maxGID > gid {
-		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid + 1, HostID: gid + 1, Size: maxGID - gid})
-	}
-
-	return &options, uid, gid, nil
+	return getRootlessKeepIDMapping(uid, gid, uids, gids)
 }
 
 // GetNoMapMapping returns the mappings and the user to use when nomap is used

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -612,6 +612,20 @@ func TestGetRootlessKeepIDMapping(t *testing.T) {
 			expectedUID: 1000,
 			expectedGID: 1000,
 		},
+		{
+			uid:  0,
+			gid:  0,
+			uids: []idtools.IDMap{{ContainerID: 0, HostID: 100000, Size: 65536}},
+			gids: []idtools.IDMap{{ContainerID: 0, HostID: 100000, Size: 65536}},
+			expectedOptions: &stypes.IDMappingOptions{
+				HostUIDMapping: false,
+				HostGIDMapping: false,
+				UIDMap:         []idtools.IDMap{{ContainerID: 0, HostID: 0, Size: 1}, {ContainerID: 1, HostID: 1, Size: 65536}},
+				GIDMap:         []idtools.IDMap{{ContainerID: 0, HostID: 0, Size: 1}, {ContainerID: 1, HostID: 1, Size: 65536}},
+			},
+			expectedUID: 0,
+			expectedGID: 0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
do not generate a duplicated range when --userns=keep-id:uid=0 or --userns=keep-id:gid=0 are used.
    
Closes: https://github.com/containers/podman/issues/22078


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Generate the correct mapping when --userns=keep-id:uid=0 is used 
```
