### PR TITLE
Add support for annotations

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -506,6 +506,10 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 
 	// Annotations
 	if ctrSpec.Annotations != nil {
+		if len(ctrSpec.Annotations) != 0 {
+			hostConfig.Annotations = ctrSpec.Annotations
+		}
+
 		hostConfig.ContainerIDFile = ctrSpec.Annotations[define.InspectAnnotationCIDFile]
 		if ctrSpec.Annotations[define.InspectAnnotationAutoremove] == define.InspectResponseTrue {
 			hostConfig.AutoRemove = true

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -364,6 +364,9 @@ type InspectContainerHostConfig struct {
 	// It is not handled directly within libpod and is stored in an
 	// annotation.
 	AutoRemove bool `json:"AutoRemove"`
+	// Annotations are provided to the runtime when the container is
+	// started.
+	Annotations map[string]string `json:"Annotations"`
 	// VolumeDriver is presently unused and is retained for Docker
 	// compatibility.
 	VolumeDriver string `json:"VolumeDriver"`

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -451,6 +451,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		ReadOnly:          cc.HostConfig.ReadonlyRootfs,
 		ReadWriteTmpFS:    true, // podman default
 		Rm:                cc.HostConfig.AutoRemove,
+		Annotation:        stringMaptoArray(cc.HostConfig.Annotations),
 		SecurityOpt:       cc.HostConfig.SecurityOpt,
 		StopSignal:        cc.Config.StopSignal,
 		StopTimeout:       rtc.Engine.StopTimeout, // podman default

--- a/test/apiv2/28-containersAnnotations.at
+++ b/test/apiv2/28-containersAnnotations.at
@@ -1,0 +1,8 @@
+# -*- sh -*-
+
+podman pull $IMAGE &>/dev/null
+t POST containers/create Image=$IMAGE HostConfig='{"annotations":{"foo":"bar","zoo":"boo"}}' 201 .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+    .HostConfig.Annotations.foo=bar \
+    .HostConfig.Annotations.zoo=boo \


### PR DESCRIPTION
In addition to the issue in docker-compose and the corresponding CL:
https://github.com/docker/compose/issues/11644
https://github.com/docker/compose/pull/11645

Compose doesn't send Annotations as part of the HostConfig to the docker/podman socket.

On the other hand, podman also ignores Annotations received from the create container API handle.

This CL fix that.

```release-note
None
```