### PR TITLE
[skip-ci] Packit: Enable CentOS Stream 10 update job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,8 +2,16 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-specfile_path: rpm/podman.spec
+downstream_package_name: podman
 upstream_tag_template: v{version}
+
+packages:
+  podman-fedora:
+    pkg_tool: fedpkg
+    specfile_path: rpm/podman.spec
+  podman-centos:
+    pkg_tool: centpkg
+    specfile_path: rpm/podman.spec
 
 srpm_build_deps:
   - git-archive-all
@@ -16,6 +24,7 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
+    packages: [podman-fedora]
     notifications:
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
@@ -25,6 +34,17 @@ jobs:
       - fedora-all-aarch64
       - fedora-eln-x86_64
       - fedora-eln-aarch64
+    additional_repos:
+      - "copr://rhcontainerbot/podman-next"
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [podman-centos]
+    notifications:
+      failure_comment:
+        message: "Ephemeral COPR build failed. @containers/packit-build please check."
+    enable_net: true
+    targets:
       - centos-stream+epel-next-8-x86_64
       - centos-stream+epel-next-8-aarch64
       - centos-stream+epel-next-9-x86_64
@@ -46,6 +66,7 @@ jobs:
   - job: tests
     identifier: cockpit-revdeps
     trigger: pull_request
+    packages: [podman-fedora]
     notifications:
       failure_comment:
         message: "Cockpit tests failed for commit {commit_sha}. @martinpitt, @jelly, @mvollmer please check."
@@ -66,15 +87,25 @@ jobs:
   - job: propose_downstream
     trigger: release
     update_release: false
+    packages: [podman-fedora]
     dist_git_branches:
       - fedora-development # Implies fedora-rawhide and any branched but unreleased version, will include f40 before f40 is marked stable.
 
+  - job: propose_downstream
+    trigger: release
+    update_release: false
+    packages: [podman-centos]
+    dist_git_branches:
+      - c10s
+
   - job: koji_build
     trigger: commit
+    packages: [podman-fedora]
     dist_git_branches:
       - fedora-all
 
   - job: bodhi_update
     trigger: commit
+    packages: [podman-fedora]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
Packit now has recently added support to enable downstream PR updates to CentOS Stream packages.
Ref:
https://packit.dev/docs/configuration/upstream/propose_downstream#syncing-the-release-to-centos-stream

CentOS Stream support is still in its early stages but this change should be safe to add to upstream packit config.

Whenever there's a new Podman release, the rpm maintainer would need to run `packit propose-downstream` using the packit CLI (not github comment) to actually create the downstream update PR.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
