### PR TITLE
[skip-ci] Packit: specify fedora-latest in propose-downstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -67,7 +67,8 @@ jobs:
     trigger: release
     update_release: false
     dist_git_branches:
-      - fedora-development # Implies fedora-rawhide and any branched but unreleased version, will include f40 before f40 is marked stable.
+      - fedora-development
+      - fedora-latest
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
The packit alias `fedora-latest` points to the latest branched version (regardless if released or not).

So, this configuration should work without issues through Fedora 40 release and should account for all branches until Fedora 41 release.

Ref: https://packit.dev/docs/configuration#aliases

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
