### PR TITLE
libpod: don't warn about cgroupsv1 on FreeBSD

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -15,8 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/libnetwork/network"
@@ -392,32 +390,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 
 	runtime.mergeDBConfig(dbConfig)
 
-	unified, _ := cgroups.IsCgroup2UnifiedMode()
-	// DELETE ON RHEL9
-	if !unified {
-		_, ok := os.LookupEnv("PODMAN_IGNORE_CGROUPSV1_WARNING")
-		if !ok {
-			logrus.Warn("Using cgroups-v1 which is deprecated in favor of cgroups-v2 with Podman v5 and will be removed in a future version. Set environment variable `PODMAN_IGNORE_CGROUPSV1_WARNING` to hide this warning.")
-		}
-	}
-	// DELETE ON RHEL9
-
-	if unified && rootless.IsRootless() && !systemd.IsSystemdSessionValid(rootless.GetRootlessUID()) {
-		// If user is rootless and XDG_RUNTIME_DIR is found, podman will not proceed with /tmp directory
-		// it will try to use existing XDG_RUNTIME_DIR
-		// if current user has no write access to XDG_RUNTIME_DIR we will fail later
-		if err := unix.Access(runtime.storageConfig.RunRoot, unix.W_OK); err != nil {
-			msg := fmt.Sprintf("RunRoot is pointing to a path (%s) which is not writable. Most likely podman will fail.", runtime.storageConfig.RunRoot)
-			if errors.Is(err, os.ErrNotExist) {
-				// if dir does not exist, try to create it
-				if err := os.MkdirAll(runtime.storageConfig.RunRoot, 0700); err != nil {
-					logrus.Warn(msg)
-				}
-			} else {
-				logrus.Warnf("%s: %v", msg, err)
-			}
-		}
-	}
+	checkCgroups2UnifiedMode(runtime)
 
 	logrus.Debugf("Using graph driver %s", runtime.storageConfig.GraphDriverName)
 	logrus.Debugf("Using graph root %s", runtime.storageConfig.GraphRoot)

--- a/libpod/runtime_freebsd.go
+++ b/libpod/runtime_freebsd.go
@@ -1,0 +1,6 @@
+//go:build !remote
+
+package libpod
+
+func checkCgroups2UnifiedMode(runtime *Runtime) {
+}

--- a/libpod/runtime_linux.go
+++ b/libpod/runtime_linux.go
@@ -1,0 +1,45 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/containers/common/pkg/cgroups"
+	"github.com/containers/podman/v5/pkg/rootless"
+	"github.com/containers/podman/v5/pkg/systemd"
+	"github.com/sirupsen/logrus"
+)
+
+func checkCgroups2UnifiedMode(runtime *Runtime) {
+	unified, _ := cgroups.IsCgroup2UnifiedMode()
+	// DELETE ON RHEL9
+	if !unified {
+		_, ok := os.LookupEnv("PODMAN_IGNORE_CGROUPSV1_WARNING")
+		if !ok {
+			logrus.Warn("Using cgroups-v1 which is deprecated in favor of cgroups-v2 with Podman v5 and will be removed in a future version. Set environment variable `PODMAN_IGNORE_CGROUPSV1_WARNING` to hide this warning.")
+		}
+	}
+	// DELETE ON RHEL9
+
+	if unified && rootless.IsRootless() && !systemd.IsSystemdSessionValid(rootless.GetRootlessUID()) {
+		// If user is rootless and XDG_RUNTIME_DIR is found, podman will not proceed with /tmp directory
+		// it will try to use existing XDG_RUNTIME_DIR
+		// if current user has no write access to XDG_RUNTIME_DIR we will fail later
+		if err := unix.Access(runtime.storageConfig.RunRoot, unix.W_OK); err != nil {
+			msg := fmt.Sprintf("RunRoot is pointing to a path (%s) which is not writable. Most likely podman will fail.", runtime.storageConfig.RunRoot)
+			if errors.Is(err, os.ErrNotExist) {
+				// if dir does not exist, try to create it
+				if err := os.MkdirAll(runtime.storageConfig.RunRoot, 0700); err != nil {
+					logrus.Warn(msg)
+				}
+			} else {
+				logrus.Warnf("%s: %v", msg, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This factors out the check for cgroupsv2 unified mode into a platform-specific file and stops podman from generating a (harmless) warning every time it is run on FreeBSD.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
