### PR TITLE
hyperv: error if not admin

### DIFF
--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -32,6 +32,9 @@ func Get() (vmconfigs.VMProvider, error) {
 	case define.WSLVirt:
 		return new(wsl.WSLStubber), nil
 	case define.HyperVVirt:
+		if !wsl.HasAdminRights() {
+			return nil, fmt.Errorf("hyperv machines require admin authority")
+		}
 		return new(hyperv.HyperVStubber), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -308,7 +308,7 @@ func checkAndInstallWSL(reExec bool) (bool, error) {
 		return true, nil
 	}
 
-	admin := hasAdminRights()
+	admin := HasAdminRights()
 
 	if !IsWSLFeatureEnabled() {
 		return false, attemptFeatureInstall(reExec, admin)

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -96,7 +96,7 @@ func winVersionAtLeast(major uint, minor uint, build uint) bool {
 	return true
 }
 
-func hasAdminRights() bool {
+func HasAdminRights() bool {
 	var sid *windows.SID
 
 	// See: https://coolaj86.com/articles/golang-and-windows-and-admins-oh-my/


### PR DESCRIPTION
creating vsocks in windows requires admin privileges.  there could be some workarounds made in the future,but the general deal has always been, you need to be admin.  lets enforce this with an error until those work-arounds can be implemented.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Hard error when using podman machine with hyperv and user is not admin
```
