### PR TITLE
Bump to v4.9.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 4.9.4
+### Security
+- Fixed [CVE-2024-1753](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-1753) in Buildah and `podman build` which allowed a user to write files to the `/` directory of the host machine if selinux was not enabled.
+
+### Bugfixes
+- Fixed a bug where health check status would be updated to "healthy" before the startup delay had expired.
+
 ## 4.9.3
 ### Features
 - The `podman container commit` command now features a `--config` option which accepts a filename containing a JSON-encoded container configuration to be merged in to the newly-created image.

--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "4.9.4-dev"
+const RawVersion = "4.9.4"

--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "4.9.4"
+const RawVersion = "4.9.5-dev"


### PR DESCRIPTION
Has the fix for CVE-2024-1753,

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
