### PR TITLE
systests: conditionalize slirp4netns tests

### DIFF
--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -255,11 +255,13 @@ EOF
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod
 
-    run_podman kube play --network slirp4netns:port_handler=slirp4netns $PODMAN_TMPDIR/test.yaml
-    run_podman pod inspect --format {{.InfraContainerID}} "${lines[1]}"
-    infraID="$output"
-    run_podman container inspect --format "{{.HostConfig.NetworkMode}}" $infraID
-    is "$output" "slirp4netns" "network mode slirp4netns is set for the container"
+    if has_slirp4netns; then
+        run_podman kube play --network slirp4netns:port_handler=slirp4netns $PODMAN_TMPDIR/test.yaml
+        run_podman pod inspect --format {{.InfraContainerID}} "${lines[1]}"
+        infraID="$output"
+        run_podman container inspect --format "{{.HostConfig.NetworkMode}}" $infraID
+        is "$output" "slirp4netns" "network mode slirp4netns is set for the container"
+    fi
 
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -1,5 +1,7 @@
 # -*- bash -*-
 
+_cached_has_pasta=
+_cached_has_slirp4netns=
 
 ### Feature Checks #############################################################
 
@@ -31,9 +33,28 @@ function skip_if_no_ipv6() {
     fi
 }
 
+# has_slirp4netns - Check if the slirp4netns(1) command is available
+function has_slirp4netns() {
+    if [[ -z "$_cached_has_slirp4netns" ]]; then
+        _cached_has_slirp4netns=n
+        run_podman info --format '{{.Host.Slirp4NetNS.Executable}}'
+        if [[ -n "$output" ]]; then
+            _cached_has_slirp4netns=y
+        fi
+    fi
+    test "$_cached_has_slirp4netns" = "y"
+}
+
 # has_pasta() - Check if the pasta(1) command is available
 function has_pasta() {
-    command -v pasta >/dev/null
+    if [[ -z "$_cached_has_pasta" ]]; then
+        _cached_has_pasta=n
+        run_podman info --format '{{.Host.Pasta.Executable}}'
+        if [[ -n "$output" ]]; then
+            _cached_has_pasta=y
+        fi
+    fi
+    test "$_cached_has_pasta" = "y"
 }
 
 # skip_if_no_pasta() - Skip current test if pasta(1) is not available


### PR DESCRIPTION
As of podman 5.0, slirp4netns is a soft dependency. It might
not be installed on a host (and, in gating tests, is not).
Deal with it.

Use podman itself, not 'which', to tell us if slirp4netns
is available. We don't want to duplicate podman's path-check
logic. Since this check is expensive, cache the result.
    
(Change the has_pasta check similarly)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```