### PR TITLE
Add rootless network command to `podman info`

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -51,8 +51,10 @@ type HostInfo struct {
 	OCIRuntime         *OCIRuntimeInfo   `json:"ociRuntime"`
 	OS                 string            `json:"os"`
 	// RemoteSocket returns the UNIX domain socket the Podman service is listening on
-	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
-	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`
+	RemoteSocket *RemoteSocket `json:"remoteSocket,omitempty"`
+	// RootlessNetworkCmd returns the default rootless network command (slirp4netns or pasta)
+	RootlessNetworkCmd string                 `json:"rootlessNetworkCmd"`
+	RuntimeInfo        map[string]interface{} `json:"runtimeInfo,omitempty"`
 	// ServiceIsRemote is true when the podman/libpod service is remote to the client
 	ServiceIsRemote bool         `json:"serviceIsRemote"`
 	Security        SecurityInfo `json:"security"`

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -126,6 +126,7 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 		NetworkBackend:     r.config.Network.NetworkBackend,
 		NetworkBackendInfo: r.network.NetworkInfo(),
 		OS:                 runtime.GOOS,
+		RootlessNetworkCmd: r.config.Network.DefaultRootlessNetworkCmd,
 		SwapFree:           mi.SwapFree,
 		SwapTotal:          mi.SwapTotal,
 	}

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -47,6 +47,7 @@ host.cgroupVersion        | v[12]
 host.networkBackendInfo   | .*dns.*package.*
 host.ociRuntime.path      | $expr_path
 host.pasta                | .*executable.*package.*
+host.rootlessNetworkCmd   | pasta
 store.configFile          | $expr_path
 store.graphDriverName     | [a-z0-9]\\\+\\\$
 store.graphRoot           | $expr_path


### PR DESCRIPTION
Useful to tell whether containers are being made with pasta or slirp4netns by default. Info is bloated enough already that I don't really have concerns about shoving more into it.

Fixes #22172

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman info` command now reports the default rootless network command (Pasta or slirp4netns)
```
