### PR TITLE
applehv: Print vfkit logs in --log-level debug

### DIFF
--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -195,6 +196,10 @@ func (a AppleHVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func
 	cmd, err := vm.Cmd(vfkitBinaryPath)
 	if err != nil {
 		return nil, nil, err
+	}
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 	}
 
 	vfkitEndpointArgs, err := getVfKitEndpointCMDArgs(mc.AppleHypervisor.Vfkit.Endpoint)


### PR DESCRIPTION
There has been various issues with vfkit exiting with
"Error: vfkit exited unexpectedly with exit code 1"

Among other reasons, this can be caused by vfkit being
built without the com.apple.security.virtualization
entitlement, and this can also happen when running
vfkit.x86_64 on Apple silicon hardware.

At the moment, the vfkit logs are not available, so there is no easy way
to know what's happening. This PR redirects vfkit stdout/stderr to
podman's log when --log-level debug is used.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```