### PR TITLE
docs/podman-login: Give an example of writing the persistent path

### DIFF
--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -69,9 +69,22 @@ print detailed information about credential store
 
 ## EXAMPLES
 
-Add login credentials for specified registry to default authentication file.
+Add login credentials for specified registry to default authentication file;
+note that unlike the `docker` default, the default credentials are under `$XDG_RUNTIME_DIR`
+which is a subdirectory of `/run` (an emphemeral directory) and hence do not persist across reboot.
+
 ```
 $ podman login quay.io
+Username: umohnani
+Password:
+Login Succeeded!
+```
+
+To explicitly preserve credentials across reboot, you will need to specify
+the default persistent path:
+
+```
+$ podman login --authfile ~/.config/containers/auth.json quay.io
 Username: umohnani
 Password:
 Login Succeeded!


### PR DESCRIPTION
The way `podman login` works by default is fundamentally different from `docker login` and this causes a lot of confusion, and I have seen multiple bad suggestions for ways to address this such as setting `XDG_RUNTIME_DIR`.

Let's document up front how to write to the persistent path.

```release-note
None
```
