### PR TITLE
CI: Bump VMs to 2024-03-28

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240227t125812z-f39f38d13"
+    IMAGE_SUFFIX: "c20240328t140922z-f39f38d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -38,7 +38,8 @@ var _ = Describe("Podman run device", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		if !isRootless() {
-			session = podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", "--cap-add", "SYS_ADMIN", ALPINE, "head", "-n", "1", "/dev/kmsg"})
+			// Kernel 6.9.0 (2024-03) requires SYSLOG
+			session = podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", "--cap-add", "SYS_ADMIN,SYSLOG", ALPINE, "head", "-n", "1", "/dev/kmsg"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
 		}

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -66,7 +66,8 @@ WantedBy=default.target
 
 		checkAvailableJournald()
 		if !journald.journaldSkip {
-			logs := SystemExec("journalctl", []string{dashWhat, "-n", "20", "-u", serviceName})
+			// "-q" needed on fc40+ because something creates /run/log/journal/XXX 2750
+			logs := SystemExec("journalctl", []string{dashWhat, "-q", "-n", "20", "-u", serviceName})
 			Expect(logs).Should(ExitCleanly())
 		}
 


### PR DESCRIPTION
Emergency update to get pasta 03-26. Also gives us crun 1.14.4.

One unexplained difference: fc39 and rawhide now create:

    /run/log/journal/SOMETHING/system.journal

...and the SOMETHING is o-rwx. This triggers journalctl to spit out a warning:

    Hint: You are currently not seeing messages from the system.
          Users in groups 'adm', 'systemd-journal', 'wheel' can see all messages.
          Pass -q to turn off this notice.

...which in turn causes ExitCleanly() to fail.

It is not clear who/what is creating this journal directory, or
why it allofasudden started just now. Workaround is to add -q
to journalctl in one test.

One more difference, another test now requires SYSLOG capability.

VM package info:
    https://github.com/containers/automation_images/pull/342

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```