### PR TITLE
[CI:DOCS] Switch back to checking out the same branch the action script runs in

### DIFF
--- a/.github/workflows/upload-win-installer.yml
+++ b/.github/workflows/upload-win-installer.yml
@@ -54,9 +54,10 @@ jobs:
           }
         }
         Write-Output "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    # Note this purposefully checks out the same branch the action runs in, as the
+    # installer build script is designed to support older releases (uses the archives
+    # on the release tag).
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      with:
-        ref: ${{steps.getversion.outputs.version}}
     # This step is super-duper critical for the built/signed windows installer .exe file.
     # It ensures the referenced $version github release page does NOT already contain
     # this file.  Windows assigns a UUID to the installer at build time, it's assumed


### PR DESCRIPTION
This restores the checkout to use the installer build at the same branch version as the action. This allows us to update the installer process for releases that have already tagged (sometimes necessary to adapt / adjust to toolchain changes). As an example v4.9.4 is using wix 3.11 but we need to use 3.14.

```release-note
none
```
