### PR TITLE
[v5.0] Bump Buildah to v1.35.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.1.0
 	github.com/checkpoint-restore/go-criu/v7 v7.0.0
 	github.com/containernetworking/plugins v1.4.0
-	github.com/containers/buildah v1.35.1
-	github.com/containers/common v0.58.0
+	github.com/containers/buildah v1.35.3
+	github.com/containers/common v0.58.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.3
 	github.com/containers/image/v5 v5.30.0

--- a/go.sum
+++ b/go.sum
@@ -74,10 +74,10 @@ github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl3
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v1.4.0 h1:+w22VPYgk7nQHw7KT92lsRmuToHvb7wwSv9iTbXzzic=
 github.com/containernetworking/plugins v1.4.0/go.mod h1:UYhcOyjefnrQvKvmmyEKsUA+M9Nfn7tqULPpH0Pkcj0=
-github.com/containers/buildah v1.35.1 h1:m4TF6V8b06cS4jH9/t39PUsUIjzDQg/P14FLpwjr40Y=
-github.com/containers/buildah v1.35.1/go.mod h1:vVSVUlTu8+99H5j43gBJscpkb/quZvdJg78+6X1HeTM=
-github.com/containers/common v0.58.0 h1:iQuwMxDD4ubZ9s1tmgdsiaHxMU4TdVBpV6kctJc6Bk8=
-github.com/containers/common v0.58.0/go.mod h1:l3vMqanJGj7tZ3W/i76gEJ128VXgFUO1tLaohJXPvdk=
+github.com/containers/buildah v1.35.3 h1:Dn8Krwm2PemBNNOMwp7uiMK2e5cW2ZjTdLRzKM789pc=
+github.com/containers/buildah v1.35.3/go.mod h1:kYi6vTHdbr1gnRo3B/RhTHsY2if/w398+/RvCxAXqkQ=
+github.com/containers/common v0.58.1 h1:E1DN9Lr7kgMVQy7AXLv1CYQCiqnweklMiYWbf0KOnqY=
+github.com/containers/common v0.58.1/go.mod h1:l3vMqanJGj7tZ3W/i76gEJ128VXgFUO1tLaohJXPvdk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.3 h1:yORnf15sP+sLFhxLNLgmB5/lOhldn9dRMHx/tmYtSOQ=

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/common/libnetwork/pasta"
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/secrets"
@@ -127,6 +128,7 @@ type Container struct {
 	restoreFromCheckpoint bool
 
 	slirp4netnsSubnet *net.IPNet
+	pastaResult       *pasta.SetupResult
 }
 
 // ContainerState contains the current state of the container

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -279,7 +279,7 @@ func (c *Container) setCgroupsPath(g *generate.Generator) error {
 	return nil
 }
 
-func (c *Container) addSlirp4netnsDNS(nameservers []string) []string {
+func (c *Container) addSpecialDNS(nameservers []string) []string {
 	return nameservers
 }
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -413,27 +413,6 @@ func (c *Container) getOCICgroupPath() (string, error) {
 	}
 }
 
-// If the container is rootless, set up the slirp4netns network
-func (c *Container) setupRootlessNetwork() error {
-	// set up slirp4netns again because slirp4netns will die when conmon exits
-	if c.config.NetMode.IsSlirp4netns() {
-		err := c.runtime.setupSlirp4netns(c, c.state.NetNS)
-		if err != nil {
-			return err
-		}
-	}
-
-	// set up rootlesskit port forwarder again since it dies when conmon exits
-	// we use rootlesskit port forwarder only as rootless and when bridge network is used
-	if rootless.IsRootless() && c.config.NetMode.IsBridge() && len(c.config.PortMappings) > 0 {
-		err := c.runtime.setupRootlessPortMappingViaRLK(c, c.state.NetNS, c.state.NetworkStatus)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func openDirectory(path string) (fd int, err error) {
 	return unix.Open(path, unix.O_RDONLY|unix.O_PATH, 0)
 }

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -616,7 +616,12 @@ func (c *Container) setCgroupsPath(g *generate.Generator) error {
 	return nil
 }
 
-func (c *Container) addSlirp4netnsDNS(nameservers []string) []string {
+// addSpecialDNS adds special dns servers for slirp4netns and pasta
+func (c *Container) addSpecialDNS(nameservers []string) []string {
+	if c.pastaResult != nil {
+		nameservers = append(nameservers, c.pastaResult.DNSForwardIPs...)
+	}
+
 	// slirp4netns has a built in DNS forwarder.
 	if c.config.NetMode.IsSlirp4netns() {
 		slirp4netnsDNS, err := slirp4netns.GetDNS(c.slirp4netnsSubnet)

--- a/libpod/networking_freebsd.go
+++ b/libpod/networking_freebsd.go
@@ -268,7 +268,3 @@ func (c *Container) reloadRootlessRLKPortMapping() error {
 func (c *Container) setupRootlessNetwork() error {
 	return nil
 }
-
-func getPastaIP(state *ContainerState) (net.IP, error) {
-	return nil, fmt.Errorf("pasta networking is Linux only")
-}

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containers/common/libnetwork/types"
-	netUtil "github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/netns"
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/rootless"
@@ -299,14 +298,4 @@ func (c *Container) inspectJoinedNetworkNS(networkns string) (q types.StatusBloc
 		return nil
 	})
 	return result, err
-}
-
-func getPastaIP(state *ContainerState) (net.IP, error) {
-	var ip string
-	err := ns.WithNetNSPath(state.NetNS, func(_ ns.NetNS) error {
-		// get the first ip in the netns
-		ip = netUtil.GetLocalIP()
-		return nil
-	})
-	return net.ParseIP(ip), err
 }

--- a/libpod/networking_pasta_linux.go
+++ b/libpod/networking_pasta_linux.go
@@ -12,10 +12,15 @@ package libpod
 import "github.com/containers/common/libnetwork/pasta"
 
 func (r *Runtime) setupPasta(ctr *Container, netns string) error {
-	return pasta.Setup(&pasta.SetupOptions{
+	res, err := pasta.Setup2(&pasta.SetupOptions{
 		Config:       r.config,
 		Netns:        netns,
 		Ports:        ctr.convertPortMappings(),
 		ExtraOptions: ctr.config.NetworkOptions[pasta.BinaryName],
 	})
+	if err != nil {
+		return err
+	}
+	ctr.pastaResult = res
+	return nil
 }

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -431,9 +431,12 @@ function pasta_test_do() {
 @test "Local forwarder, IPv4" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
-    run_podman run --dns 198.51.100.1 \
-        --net=pasta:--dns-forward,198.51.100.1 $IMAGE nslookup 127.0.0.1 || :
+    # pasta is the default now so no need to set it
+    run_podman run --rm $IMAGE grep nameserver /etc/resolv.conf
+    assert "${lines[0]}" == "nameserver 169.254.0.1" "default dns forward server"
 
+    run_podman run --rm --net=pasta:--dns-forward,198.51.100.1 \
+        $IMAGE nslookup 127.0.0.1 || :
     assert "$output" =~ "1.0.0.127.in-addr.arpa" "No answer from resolver"
 }
 

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # Changelog
 
+## v1.35.3 (2024-03-28)
+
+    [release-1.35] Bump c/common to v0.58.1
+
+## v1.35.2 (2024-03-22)
+
+    [release-1.35] CVE-2024-24786 protobuf to 1.33
+    [release-1.35] Bump to v1.35.2-dev
+
 ## v1.35.1 (2024-03-18)
 
     [release-1.35] CVE-2024-1753 container escape fix

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.35.3 (2024-03-28)
+  * [release-1.35] Bump c/common to v0.58.1
+
+- Changelog for v1.35.2 (2024-03-22)
+  * [release-1.35] CVE-2024-24786 protobuf to 1.33
+  * [release-1.35] Bump to v1.35.2-dev
+
 - Changelog for v1.35.1 (2024-03-18)
   * [release-1.35] CVE-2024-1753 container escape fix
 

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.35.1"
+	Version = "1.35.3"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/run.go
+++ b/vendor/github.com/containers/buildah/run.go
@@ -3,10 +3,12 @@ package buildah
 import (
 	"fmt"
 	"io"
+	"net"
 
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	"github.com/containers/buildah/pkg/sshagent"
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -206,4 +208,13 @@ type IDMaps struct {
 	rootGID    int
 	processUID int
 	processGID int
+}
+
+// netResult type to hold network info for hosts/resolv.conf
+type netResult struct {
+	entries           etchosts.HostEntries
+	dnsServers        []string
+	excludeIPs        []net.IP
+	ipv6              bool
+	keepHostResolvers bool
 }

--- a/vendor/github.com/containers/buildah/run_common.go
+++ b/vendor/github.com/containers/buildah/run_common.go
@@ -55,50 +55,13 @@ import (
 	"golang.org/x/term"
 )
 
-// addResolvConf copies files from host and sets them up to bind mount into container
-func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServers, dnsSearch, dnsOptions []string, namespaces []specs.LinuxNamespace) (string, error) {
-	defaultConfig, err := config.Default()
-	if err != nil {
-		return "", fmt.Errorf("failed to get config: %w", err)
-	}
-
-	nameservers := make([]string, 0, len(defaultConfig.Containers.DNSServers.Get())+len(dnsServers))
-	nameservers = append(nameservers, defaultConfig.Containers.DNSServers.Get()...)
-	nameservers = append(nameservers, dnsServers...)
-
-	keepHostServers := false
-	// special check for slirp ip
-	if len(nameservers) == 0 && b.Isolation == IsolationOCIRootless {
-		for _, ns := range namespaces {
-			if ns.Type == specs.NetworkNamespace && ns.Path == "" {
-				keepHostServers = true
-				// if we are using slirp4netns, also add the built-in DNS server.
-				logrus.Debugf("adding slirp4netns 10.0.2.3 built-in DNS server")
-				nameservers = append([]string{"10.0.2.3"}, nameservers...)
-			}
-		}
-	}
-
-	searches := make([]string, 0, len(defaultConfig.Containers.DNSSearches.Get())+len(dnsSearch))
-	searches = append(searches, defaultConfig.Containers.DNSSearches.Get()...)
-	searches = append(searches, dnsSearch...)
-
-	options := make([]string, 0, len(defaultConfig.Containers.DNSOptions.Get())+len(dnsOptions))
-	options = append(options, defaultConfig.Containers.DNSOptions.Get()...)
-	options = append(options, dnsOptions...)
-
+func (b *Builder) createResolvConf(rdir string, chownOpts *idtools.IDPair) (string, error) {
 	cfile := filepath.Join(rdir, "resolv.conf")
-	if err := resolvconf.New(&resolvconf.Params{
-		Path:            cfile,
-		Namespaces:      namespaces,
-		IPv6Enabled:     true, // TODO we should check if we have ipv6
-		KeepHostServers: keepHostServers,
-		Nameservers:     nameservers,
-		Searches:        searches,
-		Options:         options,
-	}); err != nil {
-		return "", fmt.Errorf("building resolv.conf for container %s: %w", b.ContainerID, err)
+	f, err := os.Create(cfile)
+	if err != nil {
+		return "", err
 	}
+	defer f.Close()
 
 	uid := 0
 	gid := 0
@@ -106,7 +69,7 @@ func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServe
 		uid = chownOpts.UID
 		gid = chownOpts.GID
 	}
-	if err = os.Chown(cfile, uid, gid); err != nil {
+	if err = f.Chown(uid, gid); err != nil {
 		return "", err
 	}
 
@@ -116,57 +79,61 @@ func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServe
 	return cfile, nil
 }
 
-// generateHosts creates a containers hosts file
-func (b *Builder) generateHosts(rdir string, chownOpts *idtools.IDPair, imageRoot string, spec *specs.Spec) (string, error) {
-	conf, err := config.Default()
+// addResolvConf copies files from host and sets them up to bind mount into container
+func (b *Builder) addResolvConfEntries(file string, networkNameServer []string,
+	namespaces []specs.LinuxNamespace, keepHostServers, ipv6 bool) error {
+	defaultConfig, err := config.Default()
 	if err != nil {
-		return "", err
+		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	path, err := etchosts.GetBaseHostFile(conf.Containers.BaseHostsFile, imageRoot)
-	if err != nil {
-		return "", err
+	dnsServers, dnsSearch, dnsOptions := b.CommonBuildOpts.DNSServers, b.CommonBuildOpts.DNSSearch, b.CommonBuildOpts.DNSOptions
+	nameservers := make([]string, 0, len(defaultConfig.Containers.DNSServers.Get())+len(dnsServers))
+	nameservers = append(nameservers, defaultConfig.Containers.DNSServers.Get()...)
+	nameservers = append(nameservers, dnsServers...)
+
+	searches := make([]string, 0, len(defaultConfig.Containers.DNSSearches.Get())+len(dnsSearch))
+	searches = append(searches, defaultConfig.Containers.DNSSearches.Get()...)
+	searches = append(searches, dnsSearch...)
+
+	options := make([]string, 0, len(defaultConfig.Containers.DNSOptions.Get())+len(dnsOptions))
+	options = append(options, defaultConfig.Containers.DNSOptions.Get()...)
+	options = append(options, dnsOptions...)
+
+	if len(nameservers) == 0 {
+		nameservers = networkNameServer
 	}
 
-	var entries etchosts.HostEntries
-	isHost := true
-	if spec.Linux != nil {
-		for _, ns := range spec.Linux.Namespaces {
-			if ns.Type == specs.NetworkNamespace {
-				isHost = false
-				break
-			}
-		}
-	}
-	// add host entry for local ip when running in host network
-	if spec.Hostname != "" && isHost {
-		ip := netUtil.GetLocalIP()
-		if ip != "" {
-			entries = append(entries, etchosts.HostEntry{
-				Names: []string{spec.Hostname},
-				IP:    ip,
-			})
-		}
-	}
-
-	targetfile := filepath.Join(rdir, "hosts")
-	if err := etchosts.New(&etchosts.Params{
-		BaseFile:                 path,
-		ExtraHosts:               b.CommonBuildOpts.AddHost,
-		HostContainersInternalIP: etchosts.GetHostContainersInternalIP(conf, nil, nil),
-		TargetFile:               targetfile,
-		ContainerIPs:             entries,
+	if err := resolvconf.New(&resolvconf.Params{
+		Path:            file,
+		Namespaces:      namespaces,
+		IPv6Enabled:     ipv6,
+		KeepHostServers: keepHostServers,
+		Nameservers:     nameservers,
+		Searches:        searches,
+		Options:         options,
 	}); err != nil {
-		return "", err
+		return fmt.Errorf("building resolv.conf for container %s: %w", b.ContainerID, err)
 	}
 
+	return nil
+}
+
+// createHostsFile creates a containers hosts file
+func (b *Builder) createHostsFile(rdir string, chownOpts *idtools.IDPair) (string, error) {
+	targetfile := filepath.Join(rdir, "hosts")
+	f, err := os.Create(targetfile)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
 	uid := 0
 	gid := 0
 	if chownOpts != nil {
 		uid = chownOpts.UID
 		gid = chownOpts.GID
 	}
-	if err = os.Chown(targetfile, uid, gid); err != nil {
+	if err := f.Chown(uid, gid); err != nil {
 		return "", err
 	}
 	if err := relabel(targetfile, b.MountLabel, false); err != nil {
@@ -174,6 +141,25 @@ func (b *Builder) generateHosts(rdir string, chownOpts *idtools.IDPair, imageRoo
 	}
 
 	return targetfile, nil
+}
+
+func (b *Builder) addHostsEntries(file, imageRoot string, entries etchosts.HostEntries, exculde []net.IP) error {
+	conf, err := config.Default()
+	if err != nil {
+		return err
+	}
+
+	base, err := etchosts.GetBaseHostFile(conf.Containers.BaseHostsFile, imageRoot)
+	if err != nil {
+		return err
+	}
+	return etchosts.New(&etchosts.Params{
+		BaseFile:                 base,
+		ExtraHosts:               b.CommonBuildOpts.AddHost,
+		HostContainersInternalIP: etchosts.GetHostContainersInternalIPExcluding(conf, nil, nil, exculde),
+		TargetFile:               file,
+		ContainerIPs:             entries,
+	})
 }
 
 // generateHostname creates a containers /etc/hostname file
@@ -352,6 +338,27 @@ func getNetworkInterface(store storage.Store, cniConfDir, cniPluginPath string) 
 		return nil, err
 	}
 	return netInt, nil
+}
+
+func netStatusToNetResult(netStatus map[string]netTypes.StatusBlock, hostnames []string) *netResult {
+	result := &netResult{
+		keepHostResolvers: false,
+	}
+	for _, status := range netStatus {
+		for _, dns := range status.DNSServerIPs {
+			result.dnsServers = append(result.dnsServers, dns.String())
+		}
+		for _, netInt := range status.Interfaces {
+			for _, netAddress := range netInt.Subnets {
+				e := etchosts.HostEntry{IP: netAddress.IPNet.IP.String(), Names: hostnames}
+				result.entries = append(result.entries, e)
+				if !result.ipv6 && netUtil.IsIPv6(netAddress.IPNet.IP) {
+					result.ipv6 = true
+				}
+			}
+		}
+	}
+	return result
 }
 
 // DefaultNamespaceOptions returns the default namespace settings from the
@@ -1122,7 +1129,7 @@ func runUsingRuntimeMain() {
 }
 
 func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string,
-	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile string) (err error) {
+	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string) (err error) {
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -1227,7 +1234,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 				return fmt.Errorf("parsing pid %s as a number: %w", string(pidValue), err)
 			}
 
-			teardown, netstatus, err := b.runConfigureNetwork(pid, isolation, options, networkString, containerName)
+			teardown, netResult, err := b.runConfigureNetwork(pid, isolation, options, networkString, containerName, []string{spec.Hostname, buildContainerName})
 			if teardown != nil {
 				defer teardown()
 			}
@@ -1237,9 +1244,14 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 
 			// only add hosts if we manage the hosts file
 			if hostsFile != "" {
-				entries := etchosts.GetNetworkHostEntries(netstatus, spec.Hostname, buildContainerName)
-				// make sure to sync this with (b *Builder) generateHosts()
-				err = etchosts.Add(hostsFile, entries)
+				err = b.addHostsEntries(hostsFile, rootPath, netResult.entries, netResult.excludeIPs)
+				if err != nil {
+					return err
+				}
+			}
+
+			if resolvFile != "" {
+				err = b.addResolvConfEntries(resolvFile, netResult.dnsServers, spec.Linux.Namespaces, netResult.keepHostResolvers, netResult.ipv6)
 				if err != nil {
 					return err
 				}

--- a/vendor/github.com/containers/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/vendor/github.com/containers/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -158,7 +158,8 @@ func (n *Netns) setupPasta(nsPath string) error {
 		Netns:        nsPath,
 		ExtraOptions: []string{"--pid", pidPath},
 	}
-	if err := pasta.Setup(&pastaOpts); err != nil {
+	res, err := pasta.Setup2(&pastaOpts)
+	if err != nil {
 		return fmt.Errorf("setting up Pasta: %w", err)
 	}
 
@@ -185,11 +186,9 @@ func (n *Netns) setupPasta(nsPath string) error {
 		Namespaces: []specs.LinuxNamespace{
 			{Type: specs.NetworkNamespace},
 		},
-		// TODO: Need a way to determine if there is a valid v6 address on any
-		// external interface of the system.
-		IPv6Enabled:     false,
+		IPv6Enabled:     res.IPv6,
 		KeepHostServers: true,
-		Nameservers:     []string{},
+		Nameservers:     res.DNSForwardIPs,
 	}); err != nil {
 		return wrapError("create resolv.conf", err)
 	}

--- a/vendor/github.com/containers/common/libnetwork/pasta/types.go
+++ b/vendor/github.com/containers/common/libnetwork/pasta/types.go
@@ -1,0 +1,15 @@
+package pasta
+
+import "net"
+
+const BinaryName = "pasta"
+
+type SetupResult struct {
+	// IpAddresses configured by pasta
+	IPAddresses []net.IP
+	// DNSForwardIP is the ip used in --dns-forward, it should be added as first
+	// entry to resolv.conf in the container.
+	DNSForwardIPs []string
+	// IPv6 says whenever pasta run with ipv6 support
+	IPv6 bool
+}

--- a/vendor/github.com/containers/common/libnetwork/slirp4netns/const.go
+++ b/vendor/github.com/containers/common/libnetwork/slirp4netns/const.go
@@ -1,5 +1,7 @@
 package slirp4netns
 
+import "net"
+
 const (
 	ipv6ConfDefaultAcceptDadSysctl = "/proc/sys/net/ipv6/conf/default/accept_dad"
 	BinaryName                     = "slirp4netns"
@@ -10,3 +12,13 @@ const (
 	// default slirp4ns subnet
 	defaultSubnet = "10.0.2.0/24"
 )
+
+// SetupResult return type from Setup()
+type SetupResult struct {
+	// Pid of the created slirp4netns process
+	Pid int
+	// Subnet which is used by slirp4netns
+	Subnet *net.IPNet
+	// IPv6 whenever Ipv6 is enabled in slirp4netns
+	IPv6 bool
+}

--- a/vendor/github.com/containers/common/libnetwork/slirp4netns/slirp4netns.go
+++ b/vendor/github.com/containers/common/libnetwork/slirp4netns/slirp4netns.go
@@ -86,16 +86,6 @@ type SetupOptions struct {
 	Pdeathsig syscall.Signal
 }
 
-// SetupResult return type from Setup()
-type SetupResult struct {
-	// Pid of the created slirp4netns process
-	Pid int
-	// Subnet which is used by slirp4netns
-	Subnet *net.IPNet
-	// IPv6 whenever Ipv6 is enabled in slirp4netns
-	IPv6 bool
-}
-
 type logrusDebugWriter struct {
 	prefix string
 }

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.58.0"
+const Version = "0.58.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,7 +141,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.4.0
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.35.1
+# github.com/containers/buildah v1.35.3
 ## explicit; go 1.20
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -171,7 +171,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.58.0
+# github.com/containers/common v0.58.1
 ## explicit; go 1.20
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
As the title says, bumping to Buildah v1.35.3 in preparation of Podman v5.0.1

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
