### PR TITLE
libpod: use original IDs if idmap is provided

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2819,6 +2819,15 @@ func (c *Container) createSecretMountDir(runPath string) error {
 	return err
 }
 
+func hasIdmapOption(options []string) bool {
+	for _, o := range options {
+		if o == "idmap" || strings.HasPrefix(o, "idmap=") {
+			return true
+		}
+	}
+	return false
+}
+
 // Fix ownership and permissions of the specified volume if necessary.
 func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 	vol, err := c.runtime.state.Volume(v.Name)
@@ -2842,7 +2851,8 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 		uid := int(c.config.Spec.Process.User.UID)
 		gid := int(c.config.Spec.Process.User.GID)
 
-		if c.config.IDMappings.UIDMap != nil {
+		// if the volume is mounted with "idmap", leave the IDs in from the current environment.
+		if c.config.IDMappings.UIDMap != nil && !hasIdmapOption(v.Options) {
 			p := idtools.IDPair{
 				UID: uid,
 				GID: gid,

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1252,8 +1252,15 @@ EOF
 
     touch $romount/testfile
     chown 2000:2000 $romount/testfile
-    run_podman run --uidmap=0:1000:2 --rm --rootfs "$romount:idmap=uids=@2000-1-1;gids=@2000-1-1" stat -c %u:%g /testfile
+    run_podman run --uidmap=0:1000:200 --rm --rootfs "$romount:idmap=uids=@2000-1-1;gids=@2000-1-1" stat -c %u:%g /testfile
     is "$output" "1:1"
+
+    myvolume=my-volume-$(random_string)
+    run_podman volume create $myvolume
+    mkdir $romount/volume
+    run_podman run --rm --uidmap=0:1000:10000 -v volume:/volume:idmap --rootfs $romount stat -c %u:%g /volume
+    is "$output" "0:0"
+    run_podman volume rm $myvolume
 
     rm -rf $romount
 }


### PR DESCRIPTION
if the volume is mounted with "idmap", there should not be any mapping using the user namespace mappings since this is done at runtime using the "idmap" kernel feature.

Closes: https://github.com/containers/podman/issues/22228

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If a volume is used with `:idmap`, do not map the volume owner to the mappings inside the user namespace
```
