### PR TITLE
[CI:DOCS] golangci-lint: update deprecated flags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,6 @@
 run:
   concurrency: 6
   deadline: 5m
-  skip-dirs-use-default: true
-  skip-dirs:
-    - contrib
-    - dependencies
-  skip-files:
-    - swagger.go
   modules-download-mode: readonly
 linters:
   enable-all: true
@@ -97,3 +91,9 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
+  exclude-dirs-use-default: true
+  exclude-dirs:
+    - contrib
+    - dependencies
+  exclude-files:
+    - swagger.go

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -40,6 +40,6 @@ for to_lint in "${to_lint[@]}"; do
     # Make it really easy for a developer to copy-paste the command-line
     # to focus or debug a single, specific linting category.
     set -x
-    ./bin/golangci-lint run --timeout=10m --build-tags="${!tags_var}" --skip-dirs="${!skip_var}" "$@"
+    ./bin/golangci-lint run --timeout=10m --build-tags="${!tags_var}" --exclude-dirs="${!skip_var}" "$@"
   )
 done


### PR DESCRIPTION
Per https://golangci-lint.run/product/changelog/#v1570
  - Replace run.skip-xxx options by issues.exclude-xxx options

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```