### PR TITLE
container: do not chown to dest target with U

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2882,8 +2882,13 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 			return err
 		}
 
-		// Make sure the new volume matches the permissions of the target directory.
+		// Make sure the new volume matches the permissions of the target directory unless 'U' is
+		// provided (since the volume was already chowned in this case).
 		// https://github.com/containers/podman/issues/10188
+		if slices.Contains(v.Options, "U") {
+			return nil
+		}
+
 		st, err := os.Lstat(filepath.Join(c.state.Mountpoint, v.Dest))
 		if err == nil {
 			if stat, ok := st.Sys().(*syscall.Stat_t); ok {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -750,6 +750,12 @@ VOLUME /test/`, ALPINE)
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring("888:888"))
 
+		// test with an existing directory in the image
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "881:882", "-v", "NAMED-VOLUME:/mnt:U", ALPINE, "stat", "-c", "%u:%g", "/mnt"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(ContainSubstring("881:882"))
+
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--userns", "auto", "-v", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -740,15 +740,6 @@ VOLUME /test/`, ALPINE)
 			Skip("cannot find mappings for the current user")
 		}
 
-		if os.Getenv("container") != "" {
-			Skip("Overlay mounts not supported when running in a container")
-		}
-		if isRootless() {
-			if _, err := exec.LookPath("fuse_overlay"); err != nil {
-				Skip("Fuse-Overlayfs required for rootless overlay mount test")
-			}
-		}
-
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err = os.Mkdir(mountPath, 0755)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When the 'U' option is provided, the mount destination is not chown to the destination target in the image
```

Closes: https://github.com/containers/podman/issues/22224
