### PR TITLE
[CI:DOCS] build deps: make-validate needs docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,7 @@ podman-remote-%-docs: podman-remote
 		$(if $(findstring windows,$*),docs/source/markdown,docs/build/man)
 
 .PHONY: man-page-check
-man-page-check: bin/podman
+man-page-check: bin/podman docs
 	hack/man-page-checker
 	hack/xref-helpmsgs-manpages
 	hack/man-page-table-check


### PR DESCRIPTION
The man-page-check target requires up-to-date man pages.

Closes: #22025

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
`make validate` was not rebuilding or requiring `docs`, possibly leading to inaccurate/misleading errors
```