### PR TITLE
[CI:DOCS] Update kube docs

### DIFF
--- a/docs/source/markdown/podman-kube.1.md
+++ b/docs/source/markdown/podman-kube.1.md
@@ -10,6 +10,10 @@ podman\-kube - Play containers, pods or volumes based on a structured input file
 The kube command recreates containers, pods or volumes based on the input from a structured (like YAML)
 file input.  Containers are automatically started.
 
+Note: The kube commands in podman focus on simplifying the process of moving containers from podman to a Kubernetes
+environment and from a Kubernetes environment back to podman. Podman is not replicating the kubectl CLI. Once containers
+are deployed to a Kubernetes cluster from podman, please use `kubectl` to manage the workloads in the cluster.
+
 ## COMMANDS
 
 | Command  | Man Page                                             | Description                                                                   |


### PR DESCRIPTION
Update kube docs stating the support of moving to and from k8s in podman and explicitly stating that we are not replicating the kubectl cli.

Fixes https://github.com/containers/podman/issues/21076.
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
