### PR TITLE
pkg/util: FindDeviceNodes() ignore ENOENT errors

### DIFF
--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -37,7 +37,9 @@ func FindDeviceNodes() (map[string]string, error) {
 	nodes := make(map[string]string)
 	err := filepath.WalkDir("/dev", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			logrus.Warnf("Error descending into path %s: %v", path, err)
+			if !errors.Is(err, fs.ErrNotExist) {
+				logrus.Warnf("Error descending into path %s: %v", path, err)
+			}
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
This is racy by design, if you walk a tree and the directory was removed between listing and then opening we get an ENOENT error. Simply ignore that case and do not log it.

Fixes #21782

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
