### PR TITLE
[CI:DOCS] Add GitHub action to update version on Podman.io

### DIFF
--- a/.github/workflows/update-podmanio.yml
+++ b/.github/workflows/update-podmanio.yml
@@ -1,0 +1,121 @@
+name: Update Podman version on Podman.io
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to build and upload (e.g. "v9.8.7")'
+        required: true
+
+jobs:
+  bump:
+    name: Bump
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get version
+        id: getversion
+        run: |
+
+          if [[ -z "${{ inputs.version }}" ]]
+          then
+                VERSION=${{ github.event.release.tag_name }}
+          else
+                VERSION=${{ inputs.version }}
+          fi
+
+          # strip out the prefix v if it's there
+          if [[ $VERSION == v* ]]; then
+            VERSION="${VERSION:1}"
+          fi
+          echo "Bump to ${VERSION}"
+
+          if [[ $VERSION != *-rc* ]] && [[ $VERSION != *-dev ]]; then
+            echo "notRC=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "SKIPPING: Version is a RC or a dev, no need to update."
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check open PRs
+        if: steps.getversion.outputs.notRC == 'true'
+        id: checkpr
+        run: |
+          prs=$(gh pr list \
+            --repo containers/podman.io \
+            --head bump-podmanv${{ steps.getversion.outputs.version }} \
+            --state open \
+            --json title \
+            --jq 'length')
+          if ((prs > 0)); then
+            echo "SKIPPING: PR already exists to update to v${{ steps.getversion.outputs.version }}."
+          else
+            echo "prexists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+
+      - uses: actions/checkout@v4
+        if: >-
+            steps.getversion.outputs.notRC == 'true' &&
+            steps.checkpr.outputs.prexists == 'false'
+        with:
+          repository: containers/podman.io
+          ref: refs/heads/main
+          token: ${{ secrets.PODMANBOT_TOKEN }}
+
+      - name: Check version
+        if: >-
+            steps.getversion.outputs.notRC == 'true' &&
+            steps.checkpr.outputs.prexists == 'false'
+        id: checkversion
+        run: |
+          # Check if version is actually higher than one on podman.io
+          prevversion=`grep -P "(?<=export const LATEST_VERSION = ')(\d.\d.\d)" -o static/data/global.ts`
+          echo "Version currently on site: ${prevversion}"
+          echo "Version to update to: ${{ steps.getversion.outputs.version }}"
+          # sort -V -C returns 0 if args are ascending version order
+          if echo "${prevversion},${{ steps.getversion.outputs.version }}" | tr ',' '\n' | sort -V -C && [[ ${prevversion} != ${{ steps.getversion.outputs.version }} ]]
+          then
+            echo "needsUpdate=true" >> $GITHUB_OUTPUT
+            echo "This release is a higher version, so we need to update podman.io"
+          else
+            echo "SKIPPING: This release is not a higher version, no need to update."
+          fi
+
+      - name: Bump version
+        if: >-
+          steps.getversion.outputs.notRC == 'true' &&
+          steps.checkversion.outputs.needsUpdate == 'true' &&
+          steps.checkpr.outputs.prexists == 'false'
+        run: |
+          # Replace the version in static/data/global.ts file
+          sed -i "s/export const LATEST_VERSION = '.*';/export const LATEST_VERSION = '${{ steps.getversion.outputs.version }}';/g" static/data/global.ts
+          echo "Updated file:"
+          cat static/data/global.ts
+
+      - name: Open PR
+        if: >-
+            steps.getversion.outputs.notRC == 'true' &&
+            steps.checkversion.outputs.needsUpdate == 'true' &&
+            steps.checkpr.outputs.prexists == 'false'
+        run: |
+          # Make commiter the user who triggered the action, either through cutting a release or manual trigger
+          # GitHub gives everyone a noreply email associated with their account, use that email for the sign-off
+          git config --local user.name ${{ github.actor }}
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          bumpbranch="bump-podmanv${{ steps.getversion.outputs.version }}"
+          git checkout -b $bumpbranch
+          git add static/data/global.ts
+          git commit --signoff -m "Bump Podman to v${{ steps.getversion.outputs.version }}"
+          git remote -v
+          git remote add podmanbot https://github.com/podmanbot/podman.io
+          git push podmanbot "+$bumpbranch"
+          gh pr create \
+            --title "Bump Podman to v${{ steps.getversion.outputs.version }}" \
+            --body  "Bump Podman to v${{ steps.getversion.outputs.version }}" \
+            --head "podmanbot:$bumpbranch" \
+            --base "main" -R "containers/podman.io"
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}


### PR DESCRIPTION
Introduce a new GitHub action that will update Podman.io to the newest version of Podman. This action will run on a release being published to GitHub, or by clicking the run workflow button on GitHub. The action will check if the release version is higher than the current version on the website, and open a PR to update the version if a PR does not already exist. The commit will be signed off by the user who triggered the action, so whoever creates the release or presses the run workflow button. The PR will be opened by the podmanbot GitHub account.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
