### PR TITLE
rm --force work for more than one arg

### DIFF
--- a/cmd/podman/pods/rm.go
+++ b/cmd/podman/pods/rm.go
@@ -83,6 +83,10 @@ func rm(cmd *cobra.Command, args []string) error {
 		rmOptions.Timeout = &timeout
 	}
 
+	if rmOptions.Force {
+		rmOptions.Ignore = true
+	}
+
 	errs = append(errs, removePods(args, rmOptions.PodRmOptions, true)...)
 
 	for _, idFile := range rmOptions.PodIDFiles {
@@ -110,9 +114,6 @@ func removePods(namesOrIDs []string, rmOptions entities.PodRmOptions, printIDs b
 
 	responses, err := registry.ContainerEngine().PodRm(context.Background(), namesOrIDs, rmOptions)
 	if err != nil {
-		if rmOptions.Force && strings.Contains(err.Error(), define.ErrNoSuchPod.Error()) {
-			return nil
-		}
 		setExitCode(err)
 		errs = append(errs, err)
 		if !strings.Contains(err.Error(), define.ErrRemovingCtrs.Error()) {
@@ -127,9 +128,6 @@ func removePods(namesOrIDs []string, rmOptions entities.PodRmOptions, printIDs b
 				fmt.Println(r.Id)
 			}
 		} else {
-			if rmOptions.Force && strings.Contains(r.Err.Error(), define.ErrNoSuchPod.Error()) {
-				continue
-			}
 			setExitCode(r.Err)
 			errs = append(errs, r.Err)
 			for ctr, err := range r.RemovedCtrs {

--- a/pkg/domain/infra/tunnel/helpers.go
+++ b/pkg/domain/infra/tunnel/helpers.go
@@ -81,7 +81,7 @@ func getContainersAndInputByContext(contextWithConnection context.Context, all, 
 	return filtered, rawInputs, nil
 }
 
-func getPodsByContext(contextWithConnection context.Context, all bool, namesOrIDs []string) ([]*entities.ListPodsReport, error) {
+func getPodsByContext(contextWithConnection context.Context, all bool, ignore bool, namesOrIDs []string) ([]*entities.ListPodsReport, error) {
 	if all && len(namesOrIDs) > 0 {
 		return nil, errors.New("cannot look up specific pods and all")
 	}
@@ -108,6 +108,9 @@ func getPodsByContext(contextWithConnection context.Context, all bool, namesOrID
 		inspectData, err := pods.Inspect(contextWithConnection, nameOrID, nil)
 		if err != nil {
 			if errorhandling.Contains(err, define.ErrNoSuchPod) {
+				if ignore {
+					continue
+				}
 				return nil, fmt.Errorf("unable to find pod %q: %w", nameOrID, define.ErrNoSuchPod)
 			}
 			return nil, err
@@ -126,6 +129,9 @@ func getPodsByContext(contextWithConnection context.Context, all bool, namesOrID
 		}
 
 		if !found {
+			if ignore {
+				continue
+			}
 			return nil, fmt.Errorf("unable to find pod %q: %w", nameOrID, define.ErrNoSuchPod)
 		}
 	}

--- a/pkg/domain/infra/tunnel/pods.go
+++ b/pkg/domain/infra/tunnel/pods.go
@@ -23,7 +23,7 @@ func (ic *ContainerEngine) PodKill(ctx context.Context, namesOrIds []string, opt
 		return nil, err
 	}
 
-	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, namesOrIds)
+	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (ic *ContainerEngine) PodLogs(ctx context.Context, nameOrIDs string, option
 }
 
 func (ic *ContainerEngine) PodPause(ctx context.Context, namesOrIds []string, options entities.PodPauseOptions) ([]*entities.PodPauseReport, error) {
-	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, namesOrIds)
+	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (ic *ContainerEngine) PodPause(ctx context.Context, namesOrIds []string, op
 }
 
 func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, options entities.PodunpauseOptions) ([]*entities.PodUnpauseReport, error) {
-	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, namesOrIds)
+	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 
 func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opts entities.PodStopOptions) ([]*entities.PodStopReport, error) {
 	timeout := -1
-	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, namesOrIds)
-	if err != nil && !(opts.Ignore && errors.Is(err, define.ErrNoSuchPod)) {
+	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
+	if err != nil {
 		return nil, err
 	}
 	if opts.Timeout != -1 {
@@ -127,7 +127,7 @@ func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opt
 }
 
 func (ic *ContainerEngine) PodRestart(ctx context.Context, namesOrIds []string, options entities.PodRestartOptions) ([]*entities.PodRestartReport, error) {
-	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, namesOrIds)
+	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (ic *ContainerEngine) PodRestart(ctx context.Context, namesOrIds []string, 
 }
 
 func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, options entities.PodStartOptions) ([]*entities.PodStartReport, error) {
-	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, namesOrIds)
+	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, op
 }
 
 func (ic *ContainerEngine) PodRm(ctx context.Context, namesOrIds []string, opts entities.PodRmOptions) ([]*entities.PodRmReport, error) {
-	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, namesOrIds)
-	if err != nil && !(opts.Ignore && errors.Is(err, define.ErrNoSuchPod)) {
+	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
+	if err != nil {
 		return nil, err
 	}
 	reports := make([]*entities.PodRmReport, 0, len(foundPods))

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -312,6 +312,15 @@ Deleted: $pauseID"
     is "$output" "Error: bogus: image not known" "Should print error"
     run_podman image rm --force bogus
     is "$output" "" "Should print no output"
+
+    random_image_name=$(random_string)
+    random_image_name=${random_image_name,,} # name must be lowercase
+    run_podman image tag $IMAGE $random_image_name
+    run_podman image rm --force bogus $random_image_name
+    assert "$output" = "Untagged: localhost/$random_image_name:latest" "removed image"
+
+    run_podman images
+    assert "$output" !~ "$random_image_name" "image must be removed"
 }
 
 @test "podman images - commit docker with comment" {

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -111,6 +111,13 @@ load helpers
     is "$output" "Error: no container with ID or name \"bogus\" found: no such container" "Should print error"
     run_podman container rm --force bogus
     is "$output" "" "Should print no output"
+
+    run_podman create --name test $IMAGE
+    run_podman container rm --force bogus test
+    assert "$output" = "test" "should delete test"
+
+    run_podman ps -a -q
+    assert "$output" = "" "container should be removed"
 }
 
 function __run_healthcheck_container() {

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -550,6 +550,13 @@ EOF
     is "$output" "Error: no volume with name \"bogus\" found: no such volume" "Should print error"
     run_podman volume rm --force bogus
     is "$output" "" "Should print no output"
+
+    run_podman volume create testvol
+    run_podman volume rm --force bogus testvol
+    assert "$output" = "testvol" "removed volume"
+
+    run_podman volume ls -q
+    assert "$output" = "" "no volumes"
 }
 
 @test "podman ps -f" {

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -579,6 +579,12 @@ io.max          | $lomajmin rbps=1048576 wbps=1048576 riops=max wiops=max
     is "$output" "Error: .*bogus.*: no such pod" "Should print error"
     run_podman pod rm -t -1 --force bogus
     is "$output" "" "Should print no output"
+
+    run_podman pod create --name testpod
+    run_podman pod rm --force bogus testpod
+    assert "$output" =~ "[0-9a-f]{64}" "rm pod"
+    run_podman pod ps -q
+    assert "$output" = "" "no pods listed"
 }
 
 @test "podman pod create on failure" {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -848,6 +848,12 @@ EOF
     is "$output" "Error: unable to find network with name or ID bogus: network not found" "Should print error"
     run_podman network rm -t -1 --force bogus
     is "$output" "" "Should print no output"
+
+    run_podman network create testnet
+    run_podman network rm --force bogus testnet
+    assert "$output" = "testnet" "rm network"
+    run_podman network ls -q
+    assert "$output" = "podman" "only podman network listed"
 }
 
 @test "podman network rm --dns-option " {


### PR DESCRIPTION
When we remove with --force we do not return a error if the input does not exists, however if we get more than on input we must try to remove all and not just NOP out and not remove anything just because one arg did not exists.

Also make the code simpler for commands that do have the --ignore option and just make --force imply --ignore which reduces the ugly error handling.

Fixes #21529

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where removing multiple container/image/pod with --force did not work when multiple args where given to the command and one of them did not exists.
```
