### PR TITLE
[CI:DOCS]Initial PR validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,18 @@ codespell:
 .PHONY: validate
 validate: lint .gitvalidation validate.completions man-page-check swagger-check tests-expect-exit pr-removes-fixed-skips
 
+.PHONY: validatepr
+validatepr:
+	$(PODMANCMD) run --rm --env HOME=/root \
+		-v $(CURDIR):/var/tmp/go/src/github.com/containers/podman \
+		--security-opt label=disable \
+		quay.io/libpod/fedora_podman:latest  \
+		make .validatepr
+
+.PHONY: .validatepr
+.validatepr:
+	env BUILDTAGS="$(BUILDTAGS)" REMOTETAGS="$(REMOTETAGS)" contrib/validatepr/validatepr.sh
+
 .PHONY: build-all-new-commits
 build-all-new-commits:
 	# Validate that all the commits build on top of $(GIT_BASE_BRANCH)

--- a/contrib/validatepr/Containerfile
+++ b/contrib/validatepr/Containerfile
@@ -1,0 +1,17 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+WORKDIR /go/src/github.com/containers/podman
+
+RUN dnf install -y systemd-devel \
+	libassuan-devel \
+	libseccomp-devel \
+	gpgme-devel \
+	device-mapper-devel \
+	btrfs-progs-devel \
+	golang \
+	make \
+	man-db \
+	git \
+	perl-Clone \
+	perl-FindBin \
+	pre-commit  && dnf clean all

--- a/contrib/validatepr/validatepr.sh
+++ b/contrib/validatepr/validatepr.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+
+#
+# This script is intended to help developers contribute to the podman project. It
+# checks various pre-CI checks like building, linting, man-pages, etc.  It is meant
+# to be run in a specific container environment.
+#
+
+# build all require incantations of podman
+echo "Building windows ..."
+GOOS=windows CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/test.windows ./cmd/podman
+echo "Building darwin..."
+GOOS=darwin CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/test.darwin ./cmd/podman
+
+# build podman
+echo "Building podman binaries ..."
+make binaries
+
+
+echo "Running validation tooling ..."
+make validate


### PR DESCRIPTION
This PR is only a first step towards being able to validate developer code locally prior to pushing a PR and using CI.  Right now, we have a prepared image in a temporary spot (will change when done).  That image can be used to exercise various podman builds, make validate, and DCO check.

The idea here is we have a make target that spins a podman container (or machine) and then execute a small script to perform the actual builds. Note, these builds are to verify code, not make production binaries so corners are cut.  As of now, we choose to not build cross-arch binaries because most of our problems thus far have been operating system builds and not arch.

Of course this can be expanded in the future.  This is just step one to start getting some of it in place.  The rest of the work is tracked in JIRA under two cards.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
