### PR TITLE
Add os, arch, and ismanifest to libpod image list

### DIFF
--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -52,7 +52,7 @@ my $Format_Exceptions = <<'END_EXCEPTIONS';
 # Deep internal structs; pretty sure these are permanent exceptions
 events       .Details
 history      .ImageHistoryLayer
-images       .ImageSummary
+images       .Arch .ImageSummary .Os .IsManifestList
 network-ls   .Network
 
 # FIXME: this one, maybe? But someone needs to write the text

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -483,7 +483,7 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
-	listOptions := entities.ImageListOptions{All: query.All, Filter: filterList}
+	listOptions := entities.ImageListOptions{All: query.All, Filter: filterList, ExtendedAttributes: utils.IsLibpodRequest(r)}
 	summaries, err := imageEngine.List(r.Context(), listOptions)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -242,8 +242,11 @@ type ImageSearchReport = entitiesTypes.ImageSearchReport
 
 // Image List Options
 type ImageListOptions struct {
-	All    bool     `json:"all" schema:"all"`
-	Filter []string `json:"Filter,omitempty"`
+	All bool
+	// ExtendedAttributes is used by the libpod endpoint only to deliver extra information
+	// that the compat endpoint does not
+	ExtendedAttributes bool
+	Filter             []string
 }
 
 type ImagePruneOptions struct {

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -23,9 +23,15 @@ type ImageSummary struct {
 	Dangling    bool `json:",omitempty"`
 
 	// Podman extensions
-	Names   []string `json:",omitempty"`
+	Arch    string   `json:",omitempty"`
 	Digest  string   `json:",omitempty"`
 	History []string `json:",omitempty"`
+	// IsManifestList is a ptr so we can distinguish between a true
+	// json empty response and false.  the docker compat side needs to return
+	// empty; where as the libpod side needs a value of true or false
+	IsManifestList *bool    `json:",omitempty"`
+	Names          []string `json:",omitempty"`
+	Os             string   `json:",omitempty"`
 }
 
 func (i *ImageSummary) Id() string { //nolint:revive,stylecheck

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -57,6 +57,21 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 				RepoTags:    img.Names(), // may include tags and digests
 				ParentId:    parentID,
 			}
+			if opts.ExtendedAttributes {
+				iml, err := img.IsManifestList(ctx)
+				if err != nil {
+					return nil, err
+				}
+				s.IsManifestList = &iml
+				if !iml {
+					imgData, err := img.Inspect(ctx, nil)
+					if err != nil {
+						return nil, err
+					}
+					s.Arch = imgData.Architecture
+					s.Os = imgData.Os
+				}
+			}
 			s.Labels, err = img.Labels(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("retrieving label for image %q: you may need to remove the image to resolve the error: %w", img.ID(), err)

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -90,3 +90,41 @@ t DELETE libpod/images/$IMAGE 200 \
 podman system connection rm $conn
 
 stop_registry
+
+# if an image is a manifest list, it should not have
+# anything for arch or os
+podman manifest create foobar
+t GET libpod/images/json 200  \ .[0].IsManifestList=true \
+                                .[0].Arch=null \
+                                .[0].Os=null
+
+
+# list images through the libpod endpoint should return
+# IsManifestList (bool), Arch (string), and Os (string)
+podman pull -q $IMAGE
+t GET libpod/images/json 200  \ .[0].IsManifestList=true\
+                                .[0].Arch=null \
+                                .[0].Os=null \
+                                '.[0].RepoDigests | length=1' \
+                                .[1].IsManifestList=false \
+                                .[1].Arch=amd64 \
+                                .[1].Os=linux
+
+# if a manifest list and an image are returned with libpod images
+# endpoint, then one should be a manifest with IsManifest only; and
+# the other image should have IsManifestList, Arch, and Os.
+podman manifest add --arch amd64 foobar $IMAGE
+t GET libpod/images/json 200    .[0].IsManifestList=true\
+                                .[0].Arch=null \
+                                .[0].Os=null \
+                                '.[0].RepoDigests | length=2' \
+                                .[1].IsManifestList=false \
+                                .[1].Arch=amd64 \
+                                .[1].Os=linux
+
+t GET images/json 200    .[0].IsManifestList=null \
+                                .[0].Arch=null \
+                                .[0].Os=null \
+                                .[1].IsManifestList=null \
+                                .[1].Arch=null \
+                                .[1].Os=null \


### PR DESCRIPTION
when listing images through the restful service, consumers want to know if the image they are listing is a manifest or not because the libpod endpoint returns both images and manifest lists.

in addition, we now add `arch` and `os` as fields in the libpod endpoint for image listing as well.

Fixes: #22184
Fixes: #22185

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
on libpod/images/json endpoint, added isManifestList(string) to all returned entries.  If the item is an image (not a manifest list), then we also added Arch (string) and Os (string)
```
