### PR TITLE
e2e: redefine ExitWithError() to require exit code

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -110,7 +110,7 @@ file itself. Consider the following actual test:
 It("podman inspect bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "inspect", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "no such pod foobar"))
 	})
 ```
 

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman attach", func() {
@@ -15,7 +14,7 @@ var _ = Describe("Podman attach", func() {
 	It("podman attach to bogus container", func() {
 		session := podmanTest.Podman([]string{"attach", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(ExitWithError(125, `no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman attach to non-running container", func() {
@@ -25,7 +24,7 @@ var _ = Describe("Podman attach", func() {
 
 		results := podmanTest.Podman([]string{"attach", "test1"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(125))
+		Expect(results).Should(ExitWithError(125, "you can only attach to running containers"))
 	})
 
 	It("podman container attach to non-running container", func() {
@@ -36,7 +35,7 @@ var _ = Describe("Podman attach", func() {
 
 		results := podmanTest.Podman([]string{"container", "attach", "test1"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(125))
+		Expect(results).Should(ExitWithError(125, "you can only attach to running containers"))
 	})
 
 	It("podman attach to multiple containers", func() {
@@ -50,7 +49,7 @@ var _ = Describe("Podman attach", func() {
 
 		results := podmanTest.Podman([]string{"attach", "test1", "test2"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).Should(Exit(125))
+		Expect(results).Should(ExitWithError(125, " attach` accepts at most one argument"))
 	})
 
 	It("podman attach to a running container", func() {

--- a/test/e2e/checkpoint_image_test.go
+++ b/test/e2e/checkpoint_image_test.go
@@ -35,8 +35,7 @@ var _ = Describe("Podman checkpoint", func() {
 		checkpointImage := "foobar-checkpoint"
 		session := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("no container with name or ID \"foobar\" found"))
+		Expect(session).To(ExitWithError(125, `no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman checkpoint --create-image with running container", func() {

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -20,8 +20,7 @@ var _ = Describe("Podman commit", func() {
 
 		session := podmanTest.Podman([]string{"commit", "test1", "--change", "BOGUS=foo", "foobar.com/test1-image:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(HaveSuffix(`applying changes: processing change "BOGUS foo": did not understand change instruction "BOGUS foo"`))
+		Expect(session).Should(ExitWithError(125, `applying changes: processing change "BOGUS foo": did not understand change instruction "BOGUS foo"`))
 
 		session = podmanTest.Podman([]string{"commit", "test1", "foobar.com/test1-image:latest"})
 		session.WaitWithDefaultTimeout()
@@ -47,8 +46,7 @@ var _ = Describe("Podman commit", func() {
 		// commit second time with --quiet, should not write to stderr
 		session = podmanTest.Podman([]string{"commit", "--quiet", "bogus", "foobar.com/test1-image:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(Equal("Error: no container with name or ID \"bogus\" found: no such container"))
+		Expect(session).Should(ExitWithError(125, `no container with name or ID "bogus" found: no such container`))
 	})
 
 	It("podman commit single letter container", func() {
@@ -346,7 +344,7 @@ var _ = Describe("Podman commit", func() {
 
 		session = podmanTest.Podman([]string{"run", "foobar.com/test1-image:latest", "cat", "/run/secrets/mysecret"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(1, "can't open '/run/secrets/mysecret': No such file or directory"))
 
 	})
 

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -441,8 +441,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 	It("--add-host and no-hosts=true fails", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--add-host", "test1:127.0.0.1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("--no-hosts and --add-host cannot be set together"))
+		Expect(session).To(ExitWithError(125, "--no-hosts and --add-host cannot be set together"))
 
 		session = podmanTest.Podman([]string{"run", "-dt", "--add-host", "test1:127.0.0.1", "--no-hosts=false", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
@@ -533,8 +532,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		if !IsRemote() {
 			session = podmanTest.Podman([]string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(125))
-			Expect(session.ErrorToString()).To(ContainSubstring("invalid image_copy_tmp_dir value \"storage1\" (relative paths are not accepted)"))
+			Expect(session).Should(ExitWithError(125, `invalid image_copy_tmp_dir value "storage1" (relative paths are not accepted)`))
 
 			os.Setenv("TMPDIR", "/hoge")
 			session = podmanTest.Podman([]string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"})
@@ -573,18 +571,15 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		result := podmanTest.Podman([]string{"pod", "create", "--infra-image", infra2})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring(error2String))
+		Expect(result).Should(ExitWithError(125, error2String))
 
 		result = podmanTest.Podman([]string{"pod", "create"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring(errorString))
+		Expect(result).Should(ExitWithError(125, errorString))
 
 		result = podmanTest.Podman([]string{"create", "--pod", "new:pod1", ALPINE})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring(errorString))
+		Expect(result).Should(ExitWithError(125, errorString))
 	})
 
 	It("set .engine.remote=true", func() {
@@ -679,8 +674,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 			podman.WaitWithDefaultTimeout()
 
 			if mode == "invalid" {
-				Expect(podman).Should(Exit(125))
-				Expect(podman.ErrorToString()).Should(ContainSubstring("invalid default_rootless_network_cmd option \"invalid\""))
+				Expect(podman).Should(ExitWithError(125, `invalid default_rootless_network_cmd option "invalid"`))
 				continue
 			}
 			Expect(podman).Should(ExitCleanly())

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman cp", func() {
 		// Cannot copy to a nonexistent path (note the trailing "/").
 		session = podmanTest.Podman([]string{"cp", srcFile.Name(), name + ":foo/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `"foo/" could not be found on container`))
 
 		// The file will now be created (and written to).
 		session = podmanTest.Podman([]string{"cp", srcFile.Name(), name + ":foo"})

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -48,6 +48,6 @@ var _ = Describe("Podman export", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "container:with:colon.tar")
 		result := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, "invalid filename (should not contain ':')"))
 	})
 })

--- a/test/e2e/farm_test.go
+++ b/test/e2e/farm_test.go
@@ -180,13 +180,13 @@ farm2 [QA] false true
 			cmd = []string{"farm", "update", "--add", "no-node", "farm1"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitWithError())
+			Expect(session).Should(ExitWithError(125, `cannot add to farm, "no-node" is not a system connection`))
 
 			// update farm2 to remove node not in farm connections from it
 			cmd = []string{"farm", "update", "--remove", "QB", "farm2"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitWithError())
+			Expect(session).Should(ExitWithError(125, `cannot remove from farm, "QB" is not a connection in the farm`))
 
 			// check again to ensure that nothing has changed
 			session = podmanTest.Podman(farmListCmd)
@@ -209,13 +209,13 @@ farm2 [QA] false true
 			cmd = []string{"farm", "update", "--add", "no-node", "non-existent"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitWithError())
+			Expect(session).Should(ExitWithError(125, `cannot update farm, "non-existent" farm doesn't exist`))
 
 			// update non-existent farm to default
 			cmd = []string{"farm", "update", "--default", "non-existent"}
 			session = podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitWithError())
+			Expect(session).Should(ExitWithError(125, `cannot update farm, "non-existent" farm doesn't exist`))
 
 			session = podmanTest.Podman(farmListCmd)
 			session.WaitWithDefaultTimeout()

--- a/test/e2e/generate_spec_test.go
+++ b/test/e2e/generate_spec_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Podman generate spec", func() {
 	It("podman generate spec bogus should fail", func() {
 		session := podmanTest.Podman([]string{"generate", "spec", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError())
+		Expect(session).Should(ExitWithError(125, "could not find a pod or container with the id foobar"))
 	})
 
 	It("podman generate spec basic usage", func() {

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -15,19 +15,13 @@ var _ = Describe("Podman generate systemd", func() {
 	It("podman generate systemd on bogus container/pod", func() {
 		session := podmanTest.Podman([]string{"generate", "systemd", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-	})
-
-	It("podman generate systemd bad restart policy", func() {
-		session := podmanTest.Podman([]string{"generate", "systemd", "--restart-policy", "never", "foobar"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `foobar does not refer to a container or pod: no pod with name or ID foobar found: no such pod: no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman generate systemd bad timeout value", func() {
 		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "-1", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `invalid argument "-1" for "-t, --time" flag: strconv.ParseUint: parsing "-1": invalid syntax`))
 	})
 
 	It("podman generate systemd bad restart-policy value", func() {
@@ -37,8 +31,7 @@ var _ = Describe("Podman generate systemd", func() {
 
 		session = podmanTest.Podman([]string{"generate", "systemd", "--restart-policy", "bogus", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("bogus is not a valid restart policy"))
+		Expect(session).To(ExitWithError(125, "bogus is not a valid restart policy"))
 	})
 
 	It("podman generate systemd with --no-header=true", func() {
@@ -628,8 +621,7 @@ var _ = Describe("Podman generate systemd", func() {
 
 		session = podmanTest.Podman([]string{"generate", "systemd", "--env", "=bar", "-e", "hoge=fuga", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(ContainSubstring("invalid variable"))
+		Expect(session).Should(ExitWithError(125, "invalid variable"))
 
 		// Use -e/--env option with --new option
 		session = podmanTest.Podman([]string{"generate", "systemd", "--env", "foo=bar", "-e", "hoge=fuga", "--new", "test"})
@@ -640,8 +632,7 @@ var _ = Describe("Podman generate systemd", func() {
 
 		session = podmanTest.Podman([]string{"generate", "systemd", "--env", "foo=bar", "-e", "=fuga", "--new", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(ContainSubstring("invalid variable"))
+		Expect(session).Should(ExitWithError(125, "invalid variable"))
 
 		// Escape systemd arguments
 		session = podmanTest.Podman([]string{"generate", "systemd", "--env", "BAR=my test", "-e", "USER=%a", "test"})

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck run bogus container", func() {
 		session := podmanTest.Podman([]string{"healthcheck", "run", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `unable to look up foobar to perform a health check: no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman disable healthcheck with --no-healthcheck on valid container", func() {
@@ -27,7 +27,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(125))
+		Expect(hc).Should(ExitWithError(125, "has no defined healthcheck"))
 	})
 
 	It("podman disable healthcheck with --no-healthcheck must not show starting on status", func() {
@@ -80,7 +80,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(session).Should(ExitCleanly())
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(125))
+		Expect(hc).Should(ExitWithError(125, "has no defined healthcheck"))
 	})
 
 	It("podman healthcheck on valid container", func() {
@@ -126,7 +126,7 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(125))
+		Expect(hc).Should(ExitWithError(125, "is not running"))
 	})
 
 	It("podman healthcheck on container without healthcheck", func() {
@@ -136,7 +136,7 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(125))
+		Expect(hc).Should(ExitWithError(125, "has no defined healthcheck"))
 	})
 
 	It("podman healthcheck should be starting", func() {

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -3,57 +3,97 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/types"
 )
 
+type podmanSession interface {
+	ExitCode() int
+	ErrorToString() string
+}
+
 type ExitMatcher struct {
 	types.GomegaMatcher
-	Expected int
-	Actual   int
+	ExpectedExitCode int
+	ExitCode         int
+	ExpectedStderr   string
+	msg              string
 }
 
 // ExitWithError matches when assertion is > argument.  Default 0
 // Modeled after the gomega Exit() matcher and also operates on sessions.
-func ExitWithError(optionalExitCode ...int) *ExitMatcher {
+func ExitWithError(expectations ...interface{}) *ExitMatcher {
 	exitCode := 0
-	if len(optionalExitCode) > 0 {
-		exitCode = optionalExitCode[0]
+	expectStderr := ""
+	// FIXME: once all ExitWithError()s have been migrated to new form,
+	//        change interface to (int, ...string)
+	if len(expectations) > 0 {
+		var ok bool
+		exitCode, ok = expectations[0].(int)
+		if !ok {
+			panic("ExitWithError(): first arg, if present, must be an int")
+		}
+
+		if len(expectations) > 1 {
+			expectStderr, ok = expectations[1].(string)
+			if !ok {
+				panic("ExitWithError(): second arg, if present, must be a string")
+			}
+		}
 	}
-	return &ExitMatcher{Expected: exitCode}
+
+	return &ExitMatcher{ExpectedExitCode: exitCode, ExpectedStderr: expectStderr}
 }
 
 // Match follows gexec.Matcher interface.
 func (matcher *ExitMatcher) Match(actual interface{}) (success bool, err error) {
-	exiter, ok := actual.(gexec.Exiter)
+	session, ok := actual.(podmanSession)
 	if !ok {
 		return false, fmt.Errorf("ExitWithError must be passed a gexec.Exiter (Missing method ExitCode() int) Got:\n#{format.Object(actual, 1)}")
 	}
 
-	matcher.Actual = exiter.ExitCode()
-	if matcher.Actual == -1 {
+	matcher.ExitCode = session.ExitCode()
+	if matcher.ExitCode == -1 {
+		matcher.msg = "Expected process to exit. It did not."
 		return false, nil
 	}
-	return matcher.Actual > matcher.Expected, nil
+
+	// FIXME: temporary until all ExitWithError()s are migrated
+	//        to new mandatory-int form.
+	if matcher.ExpectedExitCode == 0 {
+		if matcher.ExitCode == 0 {
+			matcher.msg = "Expected process to exit nonzero. It did not."
+			return false, nil
+		}
+		return true, nil
+	}
+
+	// Check exit code first. If it's not what we want, there's no point
+	// in checking error substrings
+	if matcher.ExitCode != matcher.ExpectedExitCode {
+		matcher.msg = fmt.Sprintf("Command exited with status %d (expected %d)", matcher.ExitCode, matcher.ExpectedExitCode)
+		return false, nil
+	}
+
+	if matcher.ExpectedStderr != "" {
+		if !strings.Contains(session.ErrorToString(), matcher.ExpectedStderr) {
+			matcher.msg = fmt.Sprintf("Command exited %d as expected, but did not emit '%s'", matcher.ExitCode, matcher.ExpectedStderr)
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func (matcher *ExitMatcher) FailureMessage(_ interface{}) (message string) {
-	if matcher.Actual == -1 {
-		return "Expected process to exit.  It did not."
-	}
-	return format.Message(matcher.Actual, "to be greater than exit code: ", matcher.Expected)
+	return matcher.msg
 }
 
 func (matcher *ExitMatcher) NegatedFailureMessage(_ interface{}) (message string) {
-	switch {
-	case matcher.Actual == -1:
-		return "you really shouldn't be able to see this!"
-	case matcher.Expected == -1:
-		return "Expected process not to exit.  It did."
-	}
-	return format.Message(matcher.Actual, "is less than or equal to exit code: ", matcher.Expected)
+	panic("There is no conceivable reason to call Not(ExitWithError) !")
 }
 
 func (matcher *ExitMatcher) MatchMayChangeInTheFuture(actual interface{}) bool {
@@ -71,11 +111,6 @@ func ExitCleanly() types.GomegaMatcher {
 
 type exitCleanlyMatcher struct {
 	msg string
-}
-
-type podmanSession interface {
-	ExitCode() int
-	ErrorToString() string
 }
 
 func (matcher *exitCleanlyMatcher) Match(actual interface{}) (success bool, err error) {


### PR DESCRIPTION
...and an optional error-message string, to be checked against stderr.

This is a starting point and baby-steps progress toward #18188. There are 249 ExitWithError() checks in test/e2e. It will take weeks to fix them all. This commit enables new functionality:

    Expect(ExitWithError(125, "expected substring"))

...while also allowing the current empty-args form. Once all 249 empty-args uses are modernized, the matcher code will be cleaned up.

I expect it will take several months of light effort to get all e2e tests transitioned to the new form. I am choosing to do so in pieces, for (relative) ease of review. This PR:

  1) makes the initial changes described above; and
  2) updates a small subset of e2e _test.go files such that:
     a) ExitWithError() is given an exit code and error string; and
     b) Exit(Nonzero) is changed to ExitWithError(Nonzero, "string") (when possible)

```release-note
None
```
