### PR TITLE
podman --runroot: remove 50 char length restriction

### DIFF
--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -93,9 +93,6 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		storageOpts.ImageStore = cfg.ImageStore
 		options = append(options, libpod.WithImageStore(cfg.ImageStore))
 	}
-	if len(storageOpts.RunRoot) > 50 {
-		return nil, errors.New("the specified runroot is longer than 50 characters")
-	}
 	if fs.Changed("storage-driver") {
 		storageSet = true
 		storageOpts.GraphDriverName = cfg.StorageDriver

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -17,9 +17,8 @@ function setup_suite() {
     IFS="
  	"
 
-    # Can't use $BATS_SUITE_TMPDIR because podman barfs:
-    #    Error: the specified runroot is longer than 50 characters
-    export PODMAN_LOGIN_WORKDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-${TMPDIR:-/tmp}} podman-bats-registry.XXXXXX)
+    export PODMAN_LOGIN_WORKDIR="$BATS_SUITE_TMPDIR/podman-bats-registry"
+    mkdir "$PODMAN_LOGIN_WORKDIR"
 
     export PODMAN_LOGIN_USER="user$(random_string 4)"
     export PODMAN_LOGIN_PASS="pw$(random_string 15)"


### PR DESCRIPTION
This was added ages ago in commit c65b3599cc, however in the meantime both podman and conmon can support longer socket paths as they use a workaround to open the path via /proc/self/fd, see openUnixSocket() in libpod/oci_conmon_attach_linux.go

Thus this restriction is not needed anymore and we can drop a workaround in the tests.

Fixes #22272

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The --runroot option now can use paths longer than 50 characters.
```
