### PR TITLE
Fix machine volumes with long path

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -96,19 +96,19 @@ func GenerateSystemDFilesForVirtiofsMounts(mounts []machine.VirtIoFs) ([]ignitio
 
 		virtiofsAutomount := ignition.Unit{
 			Enabled:  ignition.BoolToPtr(true),
-			Name:     fmt.Sprintf("%s.automount", mnt.Tag),
-			Contents: ignition.StrToPtr(fmt.Sprintf(autoMountUnitFile, mnt.Target, mnt.Target)),
+			Name:     fmt.Sprintf("%s.automount", parser.PathEscape(mnt.Target)),
+			Contents: ignition.StrToPtr(fmt.Sprintf(autoMountUnitFile, mnt.Tag, mnt.Target)),
 		}
 		virtiofsMount := ignition.Unit{
 			Enabled:  ignition.BoolToPtr(true),
-			Name:     fmt.Sprintf("%s.mount", mnt.Tag),
+			Name:     fmt.Sprintf("%s.mount", parser.PathEscape(mnt.Target)),
 			Contents: ignition.StrToPtr(fmt.Sprintf(mountUnitFile, mnt.Tag, mnt.Target)),
 		}
 
 		// This "unit" simulates something like systemctl enable virtiofs-mount-prepare@
 		enablePrep := ignition.Unit{
 			Enabled: ignition.BoolToPtr(true),
-			Name:    fmt.Sprintf("virtiofs-mount-prepare@%s.service", mnt.Tag),
+			Name:    fmt.Sprintf("virtiofs-mount-prepare@%s.service", parser.PathEscape(mnt.Target)),
 		}
 
 		unitFiles = append(unitFiles, virtiofsAutomount, virtiofsMount, enablePrep)

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -207,7 +207,8 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		_, err = os.CreateTemp(tmpDir, "example")
 		Expect(err).ToNot(HaveOccurred())
-		mount := tmpDir + ":/testmountdir"
+		// Test long target path, see https://github.com/containers/podman/issues/22226
+		mount := tmpDir + ":/very-long-test-mount-dir-path-more-than-thirty-six-bytes"
 		defer func() { _ = utils.GuardedRemoveAll(tmpDir) }()
 
 		name := randomString()
@@ -217,7 +218,7 @@ var _ = Describe("podman machine init", func() {
 		Expect(session).To(Exit(0))
 
 		ssh := sshMachine{}
-		sshSession, err := mb.setName(name).setCmd(ssh.withSSHCommand([]string{"ls /testmountdir"})).run()
+		sshSession, err := mb.setName(name).setCmd(ssh.withSSHCommand([]string{"ls /very-long-test-mount-dir-path-more-than-thirty-six-bytes"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sshSession).To(Exit(0))
 		Expect(sshSession.outputToString()).To(ContainSubstring("example"))

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -932,3 +932,9 @@ func (f *UnitFile) GetTemplateParts() (string, string) {
 	}
 	return parts[0] + "@" + ext, parts[1]
 }
+
+func PathEscape(path string) string {
+	var escaped strings.Builder
+	escapeString(&escaped, path, true)
+	return escaped.String()
+}


### PR DESCRIPTION
AppleHV accepts a max 36 bytes for mount tags. Instead of using the fully qualified path for the mount tag, use the sha256 of the path. 

Fixes: #22226
Fixes: https://github.com/containers/podman/issues/22505

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman machine start would fail if the machine had a volume with a long target path. 
Fixed a bug where  podman machine mounted paths that included dashes in the wrong location.
```
