### PR TITLE
Fix relabeling failures with Z/z volumes on Mac

### DIFF
--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -120,7 +120,7 @@ func generateSystemDFilesForVirtiofsMounts(mounts []machine.VirtIoFs) []ignition
 		mountUnit.Add("Mount", "What", "%s")
 		mountUnit.Add("Mount", "Where", "%s")
 		mountUnit.Add("Mount", "Type", "virtiofs")
-		mountUnit.Add("Mount", "Options", "defcontext=\"system_u:object_r:nfs_t:s0\"")
+		mountUnit.Add("Mount", "Options", "context=\"system_u:object_r:nfs_t:s0\"")
 		mountUnit.Add("Install", "WantedBy", "multi-user.target")
 		mountUnitFile, err := mountUnit.ToString()
 		if err != nil {


### PR DESCRIPTION
Fixes #19852

Non-Linux systems, such as BSD derived kernels, constrain selinux xatter updates according to file permissions. This is in contrast to Linux selinux attr writes, which are governed by an selinux policy. By dafault this policy apllows users to relabel files owned by themselves even if file perms would otherwise disallow write.

This results in robust container relabeling results on Linux, and fragile results everywhere else. Therefore, change the mac policy to force the nfs_t context on all files, and ignore all relabel events.

As a side-effect, this will disallow any ability to store custom selinux contexts on files. However, this is of limited use in a machine context with host volumes, since files in these volumes are externally managed on systems which do not support SELinux.

```release-note
Fixes EACCESS failures on Mac volumes when using Z/z options on a directory with read only files (#19852)
```
