### PR TITLE
Makefile: fix annoying errors in docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,7 @@ pkg/api/swagger.yaml:
 $(MANPAGES_MD_GENERATED): %.md: %.md.in $(MANPAGES_SOURCE_DIR)/options/*.md
 	hack/markdown-preprocess
 
+$(MANPAGES): OUTFILE=$(subst source/markdown,build/man,$@)
 $(MANPAGES): %: %.md .install.md2man docdir
 
 # This does a bunch of filtering needed for man pages:
@@ -515,12 +516,12 @@ $(MANPAGES): %: %.md .install.md2man docdir
 	       -e 's/\[\([^]]*\)](http[^)]\+)/\1/g'         \
 	       -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g'    \
 	       -e 's/\\$$/  /g' $<                         |\
-	$(GOMD2MAN) -out $(subst source/markdown,build/man,$@)
-	@if grep 'included file options/' docs/build/man/*; then \
-		echo "FATAL: man pages must not contain ^^^^"; exit 1; \
+	$(GOMD2MAN) -out $(OUTFILE)
+	@if grep 'included file options/' $(OUTFILE); then \
+		echo "FATAL: man pages must not contain ^^^^ in $(OUTFILE)"; exit 1; \
 	fi
-	@if $(MAN_L) $(subst source/markdown,build/man,$@) | $(GREP) -Pazoq '│\s+│\n\s+├─+┼─+┤\n\s+│\s+│'; then  \
-		echo "FATAL: $< has a too-long table column; use 'man -l $(subst source/markdown,build/man,$@)' and look for empty table cells."; exit 1; \
+	@if $(MAN_L) $(OUTFILE)| $(GREP) -Pazoq '│\s+│\n\s+├─+┼─+┤\n\s+│\s+│'; then  \
+		echo "FATAL: $< has a too-long table column; use 'man -l $(OUTFILE)' and look for empty table cells."; exit 1; \
 	fi
 
 .PHONY: docdir


### PR DESCRIPTION
Currently when we run make docs we will see 100+ lines of `grep: docs/build/man/links: Is a directory` printed. This makes no sense as we should only try to validate the man page.

The manpage target is structured in a way that it runs the generation for each file individually. As such the current way of grep'ing the entire directory for each page is wrong. It should only validate the on page that was created by the command above.

To fix this first define a OUTFILE var for the target to not have to call the substitution every time we use the path and then only grep this one file and not everything in the dir.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
