### PR TITLE
[v4.0-rhel] CI maintenance mode

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,19 +34,13 @@ env:
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
     FEDORA_NAME: "fedora-35"
-    PRIOR_FEDORA_NAME: "fedora-34"
-    UBUNTU_NAME: "ubuntu-2110"
 
     # Google-cloud VM Images
     IMAGE_SUFFIX: "c5814666029957120"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
 
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
-    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
 
     ####
     #### Control variables that determine what to run and how to run it.
@@ -157,16 +151,6 @@ build_task:
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        #- env: &priorfedora_envvars
-        #      DISTRO_NV: ${PRIOR_FEDORA_NAME}
-        #      VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-        #      CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-        #      _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        - env: &ubuntu_envvars
-              DISTRO_NV: ${UBUNTU_NAME}
-              VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
-              _BUILD_CACHE_HANDLE: ${UBUNTU_NAME}-build-${CIRRUS_BUILD_ID}
     env:
         TEST_FLAVOR: build
     # Ref: https://cirrus-ci.org/guide/writing-tasks/#cache-instruction
@@ -192,68 +176,34 @@ build_task:
 # Confirm the result of building on at least one platform appears sane.
 # This confirms the binaries can be executed, checks --help vs docs, and
 # other essential post-build validation checks.
-# validate_task:
-#     name: "Validate $DISTRO_NV Build"
-#     alias: validate
-#     # This task is primarily intended to catch human-errors early on, in a
-#     # PR.  Skip it for branch-push, branch-create, and tag-push to improve
-#     # automation reliability/speed in those contexts.  Any missed errors due
-#     # to nonsequential PR merging practices, will be caught on a future PR,
-#     # build or test task failures.
-#     skip: *branches_and_tags
-#     depends_on:
-#         - ext_svc_check
-#         - automation
-#         - build
-#     # golangci-lint is a very, very hungry beast.
-#     gce_instance: &bigvm
-#         <<: *standardvm
-#         cpu: 8
-#         memory: "16Gb"
-#     env:
-#         <<: *stdenvars
-#         TEST_FLAVOR: validate
-#     gopath_cache: &ro_gopath_cache
-#         <<: *gopath_cache
-#         reupload_on_changes: false
-#     clone_script: *noop
-#     setup_script: *setup
-#     main_script: *main
-#     always: *runner_stats
-
-
-# Exercise the "libpod" API with a small set of common
-# operations to ensure they are functional.
-bindings_task:
-    name: "Test Bindings"
-    alias: bindings
-    # Don't run for [CI:DOCS] or [CI:BUILD]
-    only_if: &not_build $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' && $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
+validate_task:
+    name: "Validate $DISTRO_NV Build"
+    alias: validate
+    # This task is primarily intended to catch human-errors early on, in a
+    # PR.  Skip it for branch-push, branch-create, and tag-push to improve
+    # automation reliability/speed in those contexts.  Any missed errors due
+    # to nonsequential PR merging practices, will be caught on a future PR,
+    # build or test task failures.
     skip: *branches_and_tags
     depends_on:
+        - ext_svc_check
+        - automation
         - build
-    gce_instance: *standardvm
+    # golangci-lint is a very, very hungry beast.
+    gce_instance: &bigvm
+        <<: *standardvm
+        cpu: 8
+        memory: "16Gb"
     env:
         <<: *stdenvars
-        TEST_FLAVOR: bindings
+        TEST_FLAVOR: validate
     gopath_cache: &ro_gopath_cache
         <<: *gopath_cache
         reupload_on_changes: false
-    clone_script: *noop  # Comes from cache
+    clone_script: *noop
     setup_script: *setup
     main_script: *main
-    always: &logs_artifacts
-        <<: *runner_stats
-        # Required for `contrib/cirrus/logformatter` to work properly
-        html_artifacts:
-            path: ./*.html
-            type: text/html
-        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
-        df_script: '$SCRIPT_BASE/logcollector.sh df'
-        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
-        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
-        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
-        time_script: '$SCRIPT_BASE/logcollector.sh time'
+    always: *runner_stats
 
 
 # Build the "libpod" API documentation `swagger.yaml` and
@@ -282,28 +232,6 @@ swagger_task:
     always: *binary_artifacts
 
 
-# Check that all included go modules from other sources match
-# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
-# make sure that the generated bindings in pkg/bindings/...
-# are in sync with the code.
-# consistency_task:
-#     name: "Test Code Consistency"
-#     alias: consistency
-#     skip: *tags
-#     depends_on:
-#         - build
-#     container: *smallcontainer
-#     env:
-#         <<: *stdenvars
-#         TEST_FLAVOR: consistency
-#         TEST_ENVIRON: container
-#         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-#     clone_script: *full_clone  # build-cache not available to container tasks
-#     setup_script: *setup
-#     main_script: *main
-#     always: *runner_stats
-
-
 # There are several other important variations of podman which
 # must always build successfully.  Most of them are handled in
 # this task, though a few need dedicated tasks which follow.
@@ -320,10 +248,6 @@ alt_build_task:
     gce_instance: *standardvm
     matrix:
       - env:
-            ALT_NAME: 'Windows Cross'
-      - env:
-            ALT_NAME: 'Build Without CGO'
-      - env:
             ALT_NAME: 'Test build RPM'
       - env:
             ALT_NAME: 'Alt Arch. Cross'
@@ -334,39 +258,17 @@ alt_build_task:
     always: *binary_artifacts
 
 
-# Verify podman is compatible with the docker python-module.
-docker-py_test_task:
-    name: Docker-py Compat.
-    alias: docker-py_test
-    skip: *tags
-    only_if: *not_build
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: docker-py
-        TEST_ENVIRON: container
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
 # Does exactly what it says, execute the podman unit-tests on all primary
 # platforms and release versions.
 unit_test_task:
     name: "Unit tests on $DISTRO_NV"
     alias: unit_test
     skip: *tags
-    only_if: *not_build
+    only_if: &not_build $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' && $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
     depends_on:
         - build
     matrix:
         - env: *stdenvars
-        #- env: *priorfedora_envvars
-        - env: *ubuntu_envvars
         # Special-case: Rootless on latest Fedora (standard) VM
         - name: "Rootless unit on $DISTRO_NV"
           env:
@@ -379,278 +281,18 @@ unit_test_task:
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
     main_script: *main
-    always: *logs_artifacts
-
-
-apiv2_test_task:
-    name: "APIv2 test on $DISTRO_NV"
-    alias: apiv2_test
-    only_if: *not_build
-    skip: *tags
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    # Test is normally pretty quick, about 10-minutes.  If it hangs,
-    # don't make developers wait the full 1-hour timeout.
-    timeout_in: 20m
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: apiv2
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-compose_test_task:
-    name: "compose test on $DISTRO_NV ($PRIV_NAME)"
-    alias: compose_test
-    only_if: *not_build
-    skip: *tags
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: compose
-    matrix:
-      - env:
-            PRIV_NAME: root
-      - env:
-            PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-# Execute the podman integration tests on all primary platforms and release
-# versions, as root, without involving the podman-remote client.
-local_integration_test_task: &local_integration_test_task
-    # Integration-test task name convention:
-    # <int.|sys.> <podman|remote> <Distro NV> <root|rootless>
-    name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
-    alias: local_integration_test
-    only_if: *not_build
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    timeout_in: 90m
-    env:
-        TEST_FLAVOR: int
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: &int_logs_artifacts
-        <<: *logs_artifacts
-        ginkgo_node_logs_artifacts:
-            path: ./test/e2e/ginkgo-node-*.log
-            type: text/plain
-
-
-# Nearly identical to `local_integration_test` except all operations
-# are performed through the podman-remote client vs a podman "server"
-# running on the same host.
-remote_integration_test_task:
-    <<: *local_integration_test_task
-    alias: remote_integration_test
-    env:
-        TEST_FLAVOR: int
-        PODBIN_NAME: remote
-
-
-# Run the complete set of integration tests from inside a container.
-# This verifies all/most operations function with "podman-in-podman".
-container_integration_test_task:
-    name: *std_name_fmt
-    alias: container_integration_test
-    only_if: *not_build
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    matrix: &fedora_vm_axis
-        - env:
-              DISTRO_NV: ${FEDORA_NAME}
-              _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        #- env:
-        #      DISTRO_NV: ${PRIOR_FEDORA_NAME}
-        #      _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        #      VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-        #      CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-    gce_instance: *standardvm
-    timeout_in: 90m
-    env:
-        TEST_FLAVOR: int
-        TEST_ENVIRON: container
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *int_logs_artifacts
-
-
-# Execute most integration tests as a regular (non-root) user.
-rootless_integration_test_task:
-    name: *std_name_fmt
-    alias: rootless_integration_test
-    only_if: *not_build
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    timeout_in: 90m
-    env:
-        TEST_FLAVOR: int
-        PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *int_logs_artifacts
-
-
-# Run various scenarios using upstream netavark/aardvark-dns binaries
-netavark_task:
-    name: "Netavark $TEST_FLAVOR $PODBIN_NAME $PRIV_NAME"
-    alias: netavark
-    only_if: *not_build
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    gce_instance: *standardvm
-    matrix:
-        - env: &nenv
-            DISTRO_NV: ${FEDORA_NAME}
-            _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-            VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-            CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-            TEST_FLAVOR: int
-            TEST_ENVIRON: host-netavark
-        - env:
-            <<: *nenv
-            TEST_FLAVOR: int
-            PRIV_NAME: rootless
-        - env:
-            <<: *nenv
-            TEST_FLAVOR: sys
-        - env:
-            <<: *nenv
-            TEST_FLAVOR: sys
-            PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *int_logs_artifacts
-
-
-# Always run subsequent to integration tests.  While parallelism is lost
-# with runtime, debugging system-test failures can be more challenging
-# for some golang developers.  Otherwise the following tasks run across
-# the same matrix as the integration-tests (above).
-local_system_test_task: &local_system_test_task
-    name: *std_name_fmt
-    alias: local_system_test
-    skip: *tags
-    only_if: *not_build
-    depends_on:
-      - local_integration_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-remote_system_test_task:
-    <<: *local_system_test_task
-    alias: remote_system_test
-    depends_on:
-      - remote_integration_test
-    env:
-        TEST_FLAVOR: sys
-        PODBIN_NAME: remote
-
-
-rootless_remote_system_test_task:
-    <<: *local_system_test_task
-    alias: rootless_remote_system_test
-    depends_on:
-      - remote_integration_test
-    matrix:
-      # Minimal sanity testing: only the latest Fedora
-      - env:
-          DISTRO_NV: ${FEDORA_NAME}
-          # Not used here, is used in other tasks
-          VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-          CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-          # ID for re-use of build output
-          _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-        PODBIN_NAME: remote
-        PRIV_NAME: rootless
-
-
-buildah_bud_test_task:
-    name: *std_name_fmt
-    alias: buildah_bud_test
-    skip: *tags
-    only_if: *not_build
-    depends_on:
-      - local_integration_test
-    env:
-        TEST_FLAVOR: bud
-        DISTRO_NV: ${FEDORA_NAME}
-        # Not used here, is used in other tasks
-        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        # ID for re-use of build output
-        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-    matrix:
-        - env:
-            PODBIN_NAME: podman
-        - env:
-            PODBIN_NAME: remote
-    gce_instance: *standardvm
-    timeout_in: 45m
-    clone_script: *noop
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *int_logs_artifacts
-
-
-rootless_system_test_task:
-    name: *std_name_fmt
-    alias: rootless_system_test
-    skip: *tags
-    only_if: *not_build
-    depends_on:
-      - rootless_integration_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-        PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
+    always: &logs_artifacts
+        <<: *runner_stats
+        # Required for `contrib/cirrus/logformatter` to work properly
+        html_artifacts:
+            path: ./*.html
+            type: text/html
+        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
+        df_script: '$SCRIPT_BASE/logcollector.sh df'
+        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
+        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
+        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
+        time_script: '$SCRIPT_BASE/logcollector.sh time'
 
 
 upgrade_test_task:
@@ -659,7 +301,7 @@ upgrade_test_task:
     skip: *tags
     only_if: *not_build
     depends_on:
-      - local_system_test
+      - build
     matrix:
         - env:
               PODMAN_UPGRADE_FROM: v1.9.0
@@ -697,8 +339,6 @@ meta_task:
         # Space-separated list of images used by this repository state
         IMGNAMES: >-
             ${FEDORA_CACHE_IMAGE_NAME}
-            ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-            ${UBUNTU_CACHE_IMAGE_NAME}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_REPO_NAME}"
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]
@@ -717,26 +357,13 @@ success_task:
     # N/B: ALL tasks must be listed here, minus their '_task' suffix.
     depends_on:
         - ext_svc_check
+        - validate
         - automation
         - build
-        - bindings
         - swagger
         - alt_build
-        - docker-py_test
         - unit_test
-        - apiv2_test
-        - compose_test
-        - local_integration_test
-        - remote_integration_test
-        - container_integration_test
-        - rootless_integration_test
-        - netavark
-        - local_system_test
-        - remote_system_test
-        - rootless_system_test
-        - rootless_remote_system_test
         - upgrade_test
-        - buildah_bud_test
         - meta
     container: *smallcontainer
     env:
@@ -744,49 +371,3 @@ success_task:
         TEST_ENVIRON: container
     clone_script: *noop
     script: /bin/true
-
-
-# When a new tag is pushed, confirm that the code and commits
-# meet criteria for an official release.
-release_task:
-    name: "Verify Release"
-    alias: release
-    only_if: *tags
-    depends_on:
-        - success
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: release
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# When preparing to release a new version, this task may be manually
-# activated at the PR stage to verify the build is proper for a potential
-# podman release.
-#
-# Note: This cannot use a YAML alias on 'release_task' as of this
-# comment, it is incompatible with 'trigger_type: manual'
-release_test_task:
-    name: "Optional Release Test"
-    alias: release_test
-    # Release-PRs always include "release" or "Bump" in the title
-    only_if: $CIRRUS_CHANGE_TITLE =~ '.*((release)|(bump)).*'
-    # Allow running manually only as part of release-related builds
-    # see RELEASE_PROCESS.md
-    trigger_type: manual
-    depends_on:
-        - success
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: release
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts


### PR DESCRIPTION
This release was originally built around Fedora 35 and golang 1.16.
However the RHEL platform this branch feeds has since moved on to golang
1.17 out of necessity to support security backports.  Given the
difficulty/complexity of updating the CI platform to F36 (golang 1.18),
and the age of this branch, place it into a slimmed-down
"maintenance-only" mode.

Note: This implies a heavier reliance on downstream QE/QA.

Ref: https://github.com/containers/podman/pull/22269

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
