### PR TITLE
[skip-ci] GHA: Fix intermittent workflow error

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -2,7 +2,7 @@
 
 # Format ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 
-name: "Lock closed Issue/PR discussions"
+name: "Lock closed issues and PRs"
 
 on:
   schedule:
@@ -38,8 +38,7 @@ env:
   LOCKED_LABEL: 'locked - please file new issue/PR'
 
 jobs:
-  closed_issue_discussion_lock:
-    name: "Lock closed Issue/PR discussions"
+  manage_locking:
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -48,6 +47,7 @@ jobs:
       # Ref: https://github.com/dessant/lock-threads#usage
       - uses: dessant/lock-threads@v5
         with:
+          process-only: 'issues, prs'
           issue-inactive-days: '${{env.CLOSED_DAYS}}'
           pr-inactive-days: '${{env.CLOSED_DAYS}}'
           add-issue-labels: '${{env.LOCKED_LABEL}}'


### PR DESCRIPTION

Periodically, the discussion-lock workflow throws the error: `Resource
not accessible by integration`

This was identified in the [upstream](https://github.com/dessant/lock-threads) issue 47, as caused by a version-5 change that adds support for management of discussions but requires additional permissions and possibly settings.  Given the low notification traffic from discussions, old discussions may remain valid for a long while, and are a useful community-interface:  Disable management of discussions.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
