### PR TITLE
[v4.2.0-rhel] Gating-test fixes

### DIFF
--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -474,9 +474,8 @@ spec:
 
 @test "pod resource limits" {
     skip_if_remote "resource limits only implemented on non-remote"
-    if is_rootless; then
-        skip "only meaningful for rootful"
-    fi
+    skip_if_rootless "resource limits only work with root"
+    skip_if_cgroupsv1 "resource limits only meaningful on cgroups V2"
 
     local name1="resources1"
     run_podman --cgroup-manager=systemd pod create --name=$name1 --cpus=5 --memory=10m

--- a/test/system/251-system-service.bats
+++ b/test/system/251-system-service.bats
@@ -17,6 +17,10 @@ function teardown() {
 
 @test "podman-system-service containers survive service stop" {
     skip_if_remote "podman system service unavailable over remote"
+    local runtime=$(podman_runtime)
+    if [[ "$runtime" != "crun" ]]; then
+        skip "survival code only implemented in crun; you're using $runtime"
+    fi
 
     port=$(random_free_port)
     URL=tcp://127.0.0.1:$port

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -209,7 +209,7 @@ function check_label() {
 	# https://github.com/opencontainers/selinux/pull/148/commits/a5dc47f74c56922d58ead05d1fdcc5f7f52d5f4e
 	#   from failed to set /proc/self/attr/keycreate on procfs
 	#   to   write /proc/self/attr/keycreate: invalid argument
-	runc) expect="OCI runtime error: .*: \(failed to set|write\) /proc/self/attr/keycreate" ;;
+	runc) expect=".*: \(failed to set\|write\) /proc/self/attr/keycreate.*" ;;
 	*)    skip "Unknown runtime '$runtime'";;
     esac
 


### PR DESCRIPTION
Various fixes for gating tests on RHEL8.6: either skip tests that are N/A with runc, or adjust tests to expect the appropriate output. All of these changes are brought in from earlier fixes on `main`.

```release-note
None
```
