### PR TITLE
e2e tests: remove requirement for fuse-overlayfs

### DIFF
--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -83,10 +83,11 @@ var _ = Describe("Podman Info", func() {
 
 		rootlessStoragePath := `"/tmp/$HOME/$USER/$UID/storage"`
 		driver := `"overlay"`
-		storageOpt := `"/usr/bin/fuse-overlayfs"`
-		storageConf := []byte(fmt.Sprintf("[storage]\ndriver=%s\nrootless_storage_path=%s\n[storage.options]\nmount_program=%s", driver, rootlessStoragePath, storageOpt))
+		storageConf := []byte(fmt.Sprintf("[storage]\ndriver=%s\nrootless_storage_path=%s\n[storage.options]\n", driver, rootlessStoragePath))
 		err = os.WriteFile(configPath, storageConf, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
+		// Failures in this test are impossible to debug without breadcrumbs
+		GinkgoWriter.Printf("CONTAINERS_STORAGE_CONF=%s:\n%s\n", configPath, storageConf)
 
 		u, err := user.Current()
 		Expect(err).ToNot(HaveOccurred())
@@ -96,8 +97,9 @@ var _ = Describe("Podman Info", func() {
 		podmanPath := podmanTest.PodmanTest.PodmanBinary
 		cmd := exec.Command(podmanPath, "info", "--format", "{{.Store.GraphRoot -}}")
 		out, err := cmd.CombinedOutput()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(out)).To(Equal(expect))
+		GinkgoWriter.Printf("Running: podman info --format {{.Store.GraphRoot -}}\nOutput: %s\n", string(out))
+		Expect(err).ToNot(HaveOccurred(), "podman info")
+		Expect(string(out)).To(Equal(expect), "output from podman info")
 	})
 
 	It("check RemoteSocket ", func() {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -201,11 +201,6 @@ var _ = Describe("Podman run with volumes", func() {
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}
-		if isRootless() {
-			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
-				Skip("Fuse-Overlayfs required for rootless overlay mount test")
-			}
-		}
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err := os.Mkdir(mountPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
@@ -220,11 +215,6 @@ var _ = Describe("Podman run with volumes", func() {
 		SkipIfRemote("Overlay volumes only work locally")
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
-		}
-		if isRootless() {
-			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
-				Skip("Fuse-Overlayfs required for rootless overlay mount test")
-			}
 		}
 		session := podmanTest.Podman([]string{"volume", "create", "myvolume"})
 		session.WaitWithDefaultTimeout()
@@ -253,11 +243,6 @@ var _ = Describe("Podman run with volumes", func() {
 		SkipIfRemote("Overlay volumes only work locally")
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
-		}
-		if isRootless() {
-			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
-				Skip("Fuse-Overlayfs required for rootless overlay mount test")
-			}
 		}
 
 		// create persistent upperdir on host
@@ -307,11 +292,6 @@ var _ = Describe("Podman run with volumes", func() {
 		SkipIfRemote("Overlay volumes only work locally")
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
-		}
-		if isRootless() {
-			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
-				Skip("Fuse-Overlayfs required for rootless overlay mount test")
-			}
 		}
 
 		// Use bindsource instead of named volume
@@ -625,11 +605,6 @@ VOLUME /test/`, ALPINE)
 		SkipIfRemote("Overlay volumes only work locally")
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
-		}
-		if isRootless() {
-			if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
-				Skip("Fuse-Overlayfs required for rootless overlay mount test")
-			}
 		}
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err := os.Mkdir(mountPath, 0755)


### PR DESCRIPTION
As of April 2024, it's no longer included in rawhide by default.
We could force-install it, but it's 2024 and it seems likely
that all systems on which Podman 5 will run will have kernels
that support native overlay.

I also added two debugging printfs to the 'podman info' test
that initially failed on an (unpublished) rawhide VM. Without
these printfs it was impossible to diagnose the failure.

Updating docs is left as a future exercise.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```