### PR TITLE
[skip-ci] Add big warning to GHA workflow

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -1,5 +1,9 @@
 ---
 
+# WARNING ALERT DANGER CAUTION ATTENTION: This file is re-used from the
+# `main` branch, by workflows in (at least) the Buildah and Skopeo repos.
+# Please think twice before making large changes, renaming, or moving the file.
+
 # Format ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 
 name: "Lock closed issues and PRs"


### PR DESCRIPTION
A simple file rename quickly broke the same workflow in both the Buildah and Skopeo repos.  Add a big-fat warning comment to prevent this from happening again.

#### Does this PR introduce a user-facing change?

```release-note
None
```
