### PR TITLE
New CI VMs, to give us pasta 2024-04-05

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240328t140922z-f39f38d13"
+    IMAGE_SUFFIX: "c20240409t192511z-f39f38d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"


### PR DESCRIPTION
Source: https://github.com/containers/automation_images/pull/345

@mheon yesterday in standup you mentioned that you needed new aardvark-dns packages for (something). Are those packages available anywhere? If so, this VM build didn't get them.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```