### PR TITLE
rootless: drop function ReadMappingsProc

### DIFF
--- a/pkg/rootless/rootless_freebsd.go
+++ b/pkg/rootless/rootless_freebsd.go
@@ -57,11 +57,6 @@ func GetConfiguredMappings(quiet bool) ([]idtools.IDMap, []idtools.IDMap, error)
 	return nil, nil, errors.New("this function is not supported on this os")
 }
 
-// ReadMappingsProc returns the uid_map and gid_map
-func ReadMappingsProc(path string) ([]idtools.IDMap, error) {
-	return nil, nil
-}
-
 // IsFdInherited checks whether the fd is opened and valid to use
 func IsFdInherited(fd int) bool {
 	return int(C.is_fd_inherited(C.int(fd))) > 0

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -60,11 +60,6 @@ func GetConfiguredMappings(quiet bool) ([]idtools.IDMap, []idtools.IDMap, error)
 	return nil, nil, errors.New("this function is not supported on this os")
 }
 
-// ReadMappingsProc returns the uid_map and gid_map
-func ReadMappingsProc(path string) ([]idtools.IDMap, error) {
-	return nil, nil
-}
-
 // IsFdInherited checks whether the fd is opened and valid to use
 func IsFdInherited(fd int) bool {
 	return false

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containers/podman/v5/pkg/signal"
 	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/unshare"
 	stypes "github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	ruser "github.com/moby/sys/user"
@@ -221,16 +222,12 @@ func GetKeepIDMapping(opts *namespaces.KeepIDUserNsOptions) (*stypes.IDMappingOp
 			HostUIDMapping: false,
 			HostGIDMapping: false,
 		}
-		uids, err := rootless.ReadMappingsProc("/proc/self/uid_map")
+		uids, gids, err := unshare.GetHostIDMappings("")
 		if err != nil {
 			return nil, 0, 0, err
 		}
-		gids, err := rootless.ReadMappingsProc("/proc/self/gid_map")
-		if err != nil {
-			return nil, 0, 0, err
-		}
-		options.UIDMap = uids
-		options.GIDMap = gids
+		options.UIDMap = RuntimeSpecToIDtools(uids)
+		options.GIDMap = RuntimeSpecToIDtools(gids)
 
 		uid, gid := 0, 0
 		if opts.UID != nil {


### PR DESCRIPTION
use the equivalent GetHostIDMappings from the storage unshare package.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
