### PR TITLE
fix "concurrent map writes" in network ls compat endpoint

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/infra/abi"
 	"github.com/containers/podman/v5/pkg/util"
 	"github.com/docker/docker/api/types"
+	"golang.org/x/exp/maps"
 
 	dockerNetwork "github.com/docker/docker/api/types/network"
 	"github.com/sirupsen/logrus"
@@ -118,7 +119,9 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi
 	if changeDefaultName && name == runtime.Network().DefaultNetworkName() {
 		name = nettypes.BridgeNetworkDriver
 	}
-	options := network.Options
+	// Make sure to clone the map as we have access to the map stored in
+	// the network backend and will overwrite it which is not good.
+	options := maps.Clone(network.Options)
 	// bridge always has isolate set in the compat API but we should not return it to not confuse callers
 	// https://github.com/containers/podman/issues/15580
 	delete(options, nettypes.IsolateOption)

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -192,6 +192,22 @@ t DELETE libpod/networks/macvlan1 200 \
   .[0].Name~macvlan1 \
   .[0].Err=null
 
+
+# create network with isolate option and make sure it is not shown in docker compat endpoint
+podman network create --opt isolate=true isolate-test
+# Note the order of both list calls is important to test for https://github.com/containers/podman/issues/22330
+# First call the compat endpoint, then the libpod one. Previously this would have removed
+# the internal option for the libpod endpoint as well.
+t GET networks?filters='{"name":["isolate-test"]}' 200 \
+  .[0].Name=isolate-test \
+  .[0].Options="{}"
+
+t GET libpod/networks/json?filters='{"name":["isolate-test"]}' 200 \
+  .[0].name=isolate-test \
+  .[0].options.isolate="true"
+
+t DELETE libpod/networks/isolate-test 200
+
 #
 # test networks with containers
 #


### PR DESCRIPTION
Not sure why this only triggers now but this code was broken for a while. It is racy as reported on the issue but because it changes the actual map part of the network backend it means it can also alter the behavior of the network which is very bad.

Fixes #22330

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in the compat network list endpoint that could crash the server with "concurrent map writes".
```
