### PR TITLE
podman exec CID without command should exit 125

### DIFF
--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -29,6 +29,10 @@ func TranslateExecErrorToExitCode(originalEC int, err error) int {
 	if errors.Is(err, ErrOCIRuntimeNotFound) {
 		return ExecErrorCodeNotFound
 	}
+	if errors.Is(err, ErrInvalidArg) {
+		return ExecErrorCodeGeneric
+	}
+
 	return originalEC
 }
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -32,11 +32,7 @@ var _ = Describe("Podman exec", func() {
 		// With no command
 		session = podmanTest.Podman([]string{"exec", "test1"})
 		session.WaitWithDefaultTimeout()
-		expectedStatus := 255
-		if IsRemote() {
-			expectedStatus = 125
-		}
-		Expect(session).Should(ExitWithError(expectedStatus, "must provide a non-empty command to start an exec session: invalid argument"))
+		Expect(session).Should(ExitWithError(125, "must provide a non-empty command to start an exec session: invalid argument"))
 	})
 
 	It("podman container exec simple command", func() {

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -33,6 +33,9 @@ load helpers
     run_podman 127 exec $cid /no/such/command
     is "$output" ".*such file or dir"   "podman exec /no/such/command"
 
+    run_podman 125 exec $cid
+    is "$output" ".*must provide a non-empty command to start an exec session"   "podman exec must include a command"
+
     # Done. Tell the container to stop.
     # The '-d' is because container exit is racy: the exec process itself
     # could get caught and killed by cleanup, causing this step to exit 137


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Fixes: 
```release-note
None
```
