### PR TITLE
[CI:DOCS] Swap out javascript engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -974,7 +974,7 @@ install.tools: .install.golangci-lint ## Install needed tools
 
 .PHONY: .install.swagger
 .install.swagger:
-	env VERSION=0.30.3 \
+	env VERSION=0.30.5 \
 		BINDIR=$(BINDIR) \
 		GOOS=$(GOOS) \
 		GOARCH=$(GOARCH) \

--- a/pkg/api/Makefile
+++ b/pkg/api/Makefile
@@ -4,7 +4,7 @@ validate: ${SWAGGER_OUT}
 	swagger validate ${SWAGGER_OUT}
 
 serve: ${SWAGGER_OUT}
-	swagger serve -F redoc -p=8080 swagger.yaml
+	swagger serve -F swagger -p=8080 swagger.yaml
 
 .PHONY: ${SWAGGER_OUT}
 ${SWAGGER_OUT}:


### PR DESCRIPTION
* Replace redoc with swagger javascript engine. redoc was causing an error. Only used when debugging swagger output.


Reported-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
