### PR TITLE
(minor) prefetch systemd image before use

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -506,6 +506,8 @@ json-file | f
 }
 
 @test "podman run --tz with zoneinfo" {
+    _prefetch $SYSTEMD_IMAGE
+
     # First make sure that zoneinfo is actually in the image otherwise the test is pointless
     run_podman run --rm $SYSTEMD_IMAGE ls /usr/share/zoneinfo
 
@@ -1395,6 +1397,8 @@ search               | $IMAGE           |
 
 # https://issues.redhat.com/browse/RHEL-14469
 @test "podman run - /run must not be world-writable in systemd containers" {
+    _prefetch $SYSTEMD_IMAGE
+
     run_podman run -d --rm $SYSTEMD_IMAGE /usr/sbin/init
     cid=$output
 


### PR DESCRIPTION
Two system tests were relying on $SYSTEMD_IMAGE but were not
running _prefetch. This led to baffling flakes that wasted
my time. (Quay flakes, of course. New manifestation.)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```