### PR TITLE
[v5.0] Bump c/common to v0.58.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.0.0
 	github.com/containernetworking/plugins v1.4.0
 	github.com/containers/buildah v1.35.3
-	github.com/containers/common v0.58.1
+	github.com/containers/common v0.58.2
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.3
 	github.com/containers/image/v5 v5.30.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/containernetworking/plugins v1.4.0 h1:+w22VPYgk7nQHw7KT92lsRmuToHvb7w
 github.com/containernetworking/plugins v1.4.0/go.mod h1:UYhcOyjefnrQvKvmmyEKsUA+M9Nfn7tqULPpH0Pkcj0=
 github.com/containers/buildah v1.35.3 h1:Dn8Krwm2PemBNNOMwp7uiMK2e5cW2ZjTdLRzKM789pc=
 github.com/containers/buildah v1.35.3/go.mod h1:kYi6vTHdbr1gnRo3B/RhTHsY2if/w398+/RvCxAXqkQ=
-github.com/containers/common v0.58.1 h1:E1DN9Lr7kgMVQy7AXLv1CYQCiqnweklMiYWbf0KOnqY=
-github.com/containers/common v0.58.1/go.mod h1:l3vMqanJGj7tZ3W/i76gEJ128VXgFUO1tLaohJXPvdk=
+github.com/containers/common v0.58.2 h1:5nu9lQz4QNSgovNk7NRk33SkqkVNKYoXh7L6gXmACow=
+github.com/containers/common v0.58.2/go.mod h1:l3vMqanJGj7tZ3W/i76gEJ128VXgFUO1tLaohJXPvdk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.3 h1:yORnf15sP+sLFhxLNLgmB5/lOhldn9dRMHx/tmYtSOQ=

--- a/vendor/github.com/containers/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/vendor/github.com/containers/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -100,18 +100,37 @@ func (n *Netns) getOrCreateNetns() (ns.NetNS, bool, error) {
 	nsPath := n.getPath(rootlessNetnsDir)
 	nsRef, err := ns.GetNS(nsPath)
 	if err == nil {
-		// TODO check if slirp4netns is alive
-		return nsRef, false, nil
-	}
-	logrus.Debugf("Creating rootless network namespace at %q", nsPath)
-	// We have to create the netns dir again here because it is possible
-	// that cleanup() removed it.
-	if err := os.MkdirAll(n.dir, 0o700); err != nil {
-		return nil, false, wrapError("", err)
-	}
-	netns, err := netns.NewNSAtPath(nsPath)
-	if err != nil {
-		return nil, false, wrapError("create netns", err)
+		pidPath := n.getPath(rootlessNetNsConnPidFile)
+		pid, err := readPidFile(pidPath)
+		if err == nil {
+			// quick check if pasta/slirp4netns are still running
+			err := unix.Kill(pid, 0)
+			if err == nil {
+				// All good, return the netns.
+				return nsRef, false, nil
+			}
+			// Print warnings in case things went wrong, we might be able to recover
+			// but maybe not so make sure to leave some hints so we can figure out what went wrong.
+			if errors.Is(err, unix.ESRCH) {
+				logrus.Warn("rootless netns program no longer running, trying to start it again")
+			} else {
+				logrus.Warnf("failed to check if rootless netns program is running: %v, trying to start it again", err)
+			}
+		} else {
+			logrus.Warnf("failed to read rootless netns program pid: %v", err)
+		}
+		// In case of errors continue and setup the network cmd again.
+	} else {
+		logrus.Debugf("Creating rootless network namespace at %q", nsPath)
+		// We have to create the netns dir again here because it is possible
+		// that cleanup() removed it.
+		if err := os.MkdirAll(n.dir, 0o700); err != nil {
+			return nil, false, wrapError("", err)
+		}
+		nsRef, err = netns.NewNSAtPath(nsPath)
+		if err != nil {
+			return nil, false, wrapError("create netns", err)
+		}
 	}
 	switch strings.ToLower(n.config.Network.DefaultRootlessNetworkCmd) {
 	case "", slirp4netns.BinaryName:
@@ -121,7 +140,17 @@ func (n *Netns) getOrCreateNetns() (ns.NetNS, bool, error) {
 	default:
 		err = fmt.Errorf("invalid rootless network command %q", n.config.Network.DefaultRootlessNetworkCmd)
 	}
-	return netns, true, err
+	// If pasta or slirp4netns fail here we need to get rid of the netns again to not leak it,
+	// otherwise the next command thinks the netns was successfully setup.
+	if err != nil {
+		if nerr := netns.UnmountNS(nsPath); nerr != nil {
+			logrus.Error(nerr)
+		}
+		_ = nsRef.Close()
+		return nil, false, err
+	}
+
+	return nsRef, true, nil
 }
 
 func (n *Netns) cleanup() error {
@@ -165,11 +194,7 @@ func (n *Netns) setupPasta(nsPath string) error {
 
 	if systemd.RunsOnSystemd() {
 		// Treat these as fatal - if pasta failed to write a PID file something is probably wrong.
-		pidfile, err := os.ReadFile(pidPath)
-		if err != nil {
-			return fmt.Errorf("unable to open pasta PID file: %w", err)
-		}
-		pid, err := strconv.Atoi(strings.TrimSpace(string(pidfile)))
+		pid, err := readPidFile(pidPath)
 		if err != nil {
 			return fmt.Errorf("unable to decode pasta PID: %w", err)
 		}
@@ -245,16 +270,12 @@ func (n *Netns) setupSlirp4netns(nsPath string) error {
 
 func (n *Netns) cleanupRootlessNetns() error {
 	pidFile := n.getPath(rootlessNetNsConnPidFile)
-	b, err := os.ReadFile(pidFile)
+	pid, err := readPidFile(pidFile)
 	if err == nil {
-		var i int
-		i, err = strconv.Atoi(strings.TrimSpace(string(b)))
-		if err == nil {
-			// kill the slirp process so we do not leak it
-			err = unix.Kill(i, unix.SIGTERM)
-			if err == unix.ESRCH {
-				err = nil
-			}
+		// kill the slirp/pasta process so we do not leak it
+		err = unix.Kill(pid, unix.SIGTERM)
+		if err == unix.ESRCH {
+			err = nil
 		}
 	}
 	return err
@@ -294,6 +315,13 @@ func (n *Netns) setupMounts() error {
 		return wrapError("create new mount namespace", err)
 	}
 
+	// Ensure we mount private in our mountns to prevent accidentally
+	// overwriting the host mounts in case the default propagation is shared.
+	err = unix.Mount("", "/", "", unix.MS_PRIVATE|unix.MS_REC, "")
+	if err != nil {
+		return wrapError("make tree private in new mount namespace", err)
+	}
+
 	xdgRuntimeDir, err := homedir.GetRuntimeDir()
 	if err != nil {
 		return fmt.Errorf("could not get runtime directory: %w", err)
@@ -301,7 +329,7 @@ func (n *Netns) setupMounts() error {
 	newXDGRuntimeDir := n.getPath(xdgRuntimeDir)
 	// 1. Mount the netns into the new run to keep them accessible.
 	// Otherwise cni setup will fail because it cannot access the netns files.
-	err = mountAndMkdirDest(xdgRuntimeDir, newXDGRuntimeDir, none, unix.MS_BIND|unix.MS_SHARED|unix.MS_REC)
+	err = mountAndMkdirDest(xdgRuntimeDir, newXDGRuntimeDir, none, unix.MS_BIND|unix.MS_REC)
 	if err != nil {
 		return err
 	}
@@ -556,15 +584,12 @@ func (n *Netns) Run(lock *lockfile.LockFile, toRun func() error) error {
 		logrus.Errorf("Failed to decrement ref count: %v", err)
 		return inErr
 	}
-	if count == 0 {
+	// runInner() already cleans up the netns when it created a new one on errors
+	// so we only need to do that if there was no error.
+	if inErr == nil && count == 0 {
 		err = n.cleanup()
 		if err != nil {
-			err = wrapError("cleanup", err)
-			if inErr == nil {
-				return err
-			}
-			logrus.Errorf("Failed to cleanup rootless netns: %v", err)
-			return inErr
+			return wrapError("cleanup", err)
 		}
 	}
 
@@ -598,4 +623,12 @@ func refCount(dir string, inc int) (int, error) {
 	}
 
 	return currentCount, nil
+}
+
+func readPidFile(path string) (int, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(b)))
 }

--- a/vendor/github.com/containers/common/libnetwork/netavark/config.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/config.go
@@ -376,6 +376,11 @@ func (n *netavarkNetwork) NetworkRemove(nameOrID string) error {
 		return fmt.Errorf("default network %s cannot be removed", n.defaultNetwork)
 	}
 
+	// remove the ipam bucket for this network
+	if err := n.removeNetworkIPAMBucket(network); err != nil {
+		return err
+	}
+
 	file := filepath.Join(n.networkConfigDir, network.Name+".json")
 	// make sure to not error for ErrNotExist
 	if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/vendor/github.com/containers/common/libnetwork/netavark/network.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/network.go
@@ -135,7 +135,11 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	}
 
 	var netns *rootlessnetns.Netns
-	if unshare.IsRootless() {
+	// Do not use unshare.IsRootless() here. We only care if we are running re-exec in the userns,
+	// IsRootless() also returns true if we are root in a userns which is not what we care about and
+	// causes issues as this slower more complicated rootless-netns logic should not be used as root.
+	_, useRootlessNetns := os.LookupEnv(unshare.UsernsEnvName)
+	if useRootlessNetns {
 		netns, err = rootlessnetns.New(conf.NetworkRunDir, rootlessnetns.Netavark, conf.Config)
 		if err != nil {
 			return nil, err
@@ -147,7 +151,7 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		networkRunDir:      conf.NetworkRunDir,
 		netavarkBinary:     conf.NetavarkBinary,
 		aardvarkBinary:     conf.AardvarkBinary,
-		networkRootless:    unshare.IsRootless(),
+		networkRootless:    useRootlessNetns,
 		ipamDBPath:         filepath.Join(conf.NetworkRunDir, "ipam.db"),
 		firewallDriver:     conf.Config.Network.FirewallDriver,
 		defaultNetwork:     defaultNetworkName,

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.58.1"
+const Version = "0.58.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.58.1
+# github.com/containers/common v0.58.2
 ## explicit; go 1.20
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
Bumping c/common to v0.58.2 in preparation for
Podman v5.0.2

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that leaked ipam entries when the network was removed. [#22034](https://github.com/containers/podman/issues/22034)
Fixed a bug which caused the rootless-netns to not be cleaned up on setup errors resulting in a weird resolv.conf missing error message later.  [#22168](https://github.com/containers/podman/issues/22168)
Fixed a bug to no longer use the rootless-netns logic in nested containers [#22218](https://github.com/containers/podman/issues/22218)
```
