### PR TITLE
[CI:DOCS] fix swagger doc for manifest create

### DIFF
--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -103,14 +103,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/internalError"
 	v4.Handle("/{name:.*}/registry/{destination:.*}", s.APIHandler(libpod.ManifestPush)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/manifests manifests ManifestCreateLibpod
+	// swagger:operation POST /libpod/manifests/{name} manifests ManifestCreateLibpod
 	// ---
 	// summary: Create
 	// description: Create a manifest list
 	// produces:
 	// - application/json
 	// parameters:
-	// - in: query
+	// - in: path
 	//   name: name
 	//   type: string
 	//   description: manifest list or index name to create


### PR DESCRIPTION
The manifest name is part of the path in the URL.

Fixes #22255

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
