### PR TITLE
package e2e tests in rpm

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -1430,11 +1429,6 @@ func CopyDirectory(srcDir, dest string) error {
 			return err
 		}
 
-		stat, ok := fileInfo.Sys().(*syscall.Stat_t)
-		if !ok {
-			return fmt.Errorf("failed to get raw syscall.Stat_t data for %q", sourcePath)
-		}
-
 		switch fileInfo.Mode() & os.ModeType {
 		case os.ModeDir:
 			if err := os.MkdirAll(destPath, 0755); err != nil {
@@ -1451,10 +1445,6 @@ func CopyDirectory(srcDir, dest string) error {
 			if err := Copy(sourcePath, destPath); err != nil {
 				return err
 			}
-		}
-
-		if err := os.Lchown(destPath, int(stat.Uid), int(stat.Gid)); err != nil {
-			return err
 		}
 
 		fInfo, err := entry.Info()

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -155,9 +155,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.MkdirAll(ImageCacheDir, 0700)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Cache images
-	cwd, _ := os.Getwd()
-	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
 	podman := PodmanTestSetup(filepath.Join(globalTmpDir, "image-init"))
 
 	// Pull cirros but don't put it into the cache
@@ -202,8 +199,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 func (p *PodmanTestIntegration) Setup() {
-	cwd, _ := os.Getwd()
-	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
 }
 
 var _ = SynchronizedAfterSuite(func() {
@@ -310,6 +305,12 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		}
 	}
 
+	INTEGRATION_ROOT = os.Getenv("PODMAN_INTEGRATION_ROOT")
+	if INTEGRATION_ROOT == "" {
+		cwd, _ := os.Getwd()
+		INTEGRATION_ROOT = filepath.Join(cwd, "../")
+	}
+
 	if err := os.MkdirAll(root, 0755); err != nil {
 		panic(err)
 	}
@@ -346,7 +347,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		OCIRuntime:          ociRuntime,
 		RunRoot:             filepath.Join(tempDir, "runroot"),
 		StorageOptions:      storageOptions,
-		SignaturePolicyPath: filepath.Join(INTEGRATION_ROOT, "test/policy.json"),
+		SignaturePolicyPath: filepath.Join(INTEGRATION_ROOT, "policy.json"),
 		CgroupManager:       cgroupManager,
 		Host:                host,
 	}

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -97,6 +97,14 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd --files --name", func() {
+		// We need to cd to a writable directory
+		cwd, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.Chdir(podmanTest.TempDir)).To(Succeed())
+		defer func() {
+			Expect(os.Chdir(cwd)).To(Succeed())
+		}()
+
 		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", NGINX_IMAGE})
 		n.WaitWithDefaultTimeout()
 		Expect(n).Should(Exit(0))
@@ -105,9 +113,6 @@ var _ = Describe("Podman generate systemd", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		for _, file := range session.OutputToStringArray() {
-			os.Remove(file)
-		}
 		Expect(session.OutputToString()).To(ContainSubstring("/container-nginx.service"))
 	})
 
@@ -228,6 +233,14 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd pod --name --files", func() {
+		// We need to cd to a writable directory
+		cwd, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.Chdir(podmanTest.TempDir)).To(Succeed())
+		defer func() {
+			Expect(os.Chdir(cwd)).To(Succeed())
+		}()
+
 		n := podmanTest.Podman([]string{"pod", "create", "--name", "foo"})
 		n.WaitWithDefaultTimeout()
 		Expect(n).Should(Exit(0))
@@ -239,10 +252,6 @@ var _ = Describe("Podman generate systemd", func() {
 		session := podmanTest.Podman([]string{"generate", "systemd", "--name", "--files", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-
-		for _, file := range session.OutputToStringArray() {
-			os.Remove(file)
-		}
 
 		Expect(session.OutputToString()).To(ContainSubstring("/pod-foo.service"))
 		Expect(session.OutputToString()).To(ContainSubstring("/container-foo-1.service"))

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -49,7 +49,7 @@ func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os
 }
 
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
-	defaultFile := filepath.Join(INTEGRATION_ROOT, "test/registries.conf")
+	defaultFile := filepath.Join(INTEGRATION_ROOT, "registries.conf")
 	os.Setenv("CONTAINERS_REGISTRIES_CONF", defaultFile)
 }
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -37,7 +37,7 @@ func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os
 }
 
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
-	defaultFile := filepath.Join(INTEGRATION_ROOT, "test/registries.conf")
+	defaultFile := filepath.Join(INTEGRATION_ROOT, "registries.conf")
 	err := os.Setenv("CONTAINERS_REGISTRIES_CONF", defaultFile)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Podman login and logout", func() {
 			"-e", strings.Join([]string{"REGISTRY_HTTP_ADDR=0.0.0.0", strconv.Itoa(port)}, ":"), "--name", "registry", "-v",
 			strings.Join([]string{authPath, "/auth:Z"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
 			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
-			"-v", strings.Join([]string{certPath, "/certs:Z"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
+			"-v", strings.Join([]string{certDirPath, "/certs:Z"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
 			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", REGISTRY_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -48,11 +48,10 @@ var _ = Describe("Podman login and logout", func() {
 
 		testImg = strings.Join([]string{server, "test-alpine"}, "/")
 
-		certDirPath = filepath.Join(os.Getenv("HOME"), ".config/containers/certs.d", server)
+		certDirPath = filepath.Join(podmanTest.TempDir, "certs")
 		err = os.MkdirAll(certDirPath, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
-		cwd, _ := os.Getwd()
-		certPath = filepath.Join(cwd, "../", "certs")
+		certPath = filepath.Join(INTEGRATION_ROOT, "certs")
 
 		setup := SystemExec("cp", []string{filepath.Join(certPath, "domain.crt"), filepath.Join(certDirPath, "ca.crt")})
 		setup.WaitWithDefaultTimeout()
@@ -296,8 +295,7 @@ var _ = Describe("Podman login and logout", func() {
 		err = os.MkdirAll(certDir, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
-		cwd, _ := os.Getwd()
-		certPath = filepath.Join(cwd, "../", "certs")
+		certPath = filepath.Join(INTEGRATION_ROOT, "certs")
 
 		setup := SystemExec("cp", []string{filepath.Join(certPath, "domain.crt"), filepath.Join(certDir, "ca.crt")})
 		setup.WaitWithDefaultTimeout()

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Podman push", func() {
 
 	It("podman push from local storage with nothing-allowed signature policy", func() {
 		SkipIfRemote("Remote push does not support dir transport")
-		denyAllPolicy := filepath.Join(INTEGRATION_ROOT, "test/deny.json")
+		denyAllPolicy := filepath.Join(INTEGRATION_ROOT, "deny.json")
 
 		inspect := podmanTest.Podman([]string{"inspect", "--format={{.ID}}", ALPINE})
 		inspect.WaitWithDefaultTimeout()

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -279,8 +279,7 @@ var _ = Describe("Podman push", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll("/etc/containers/certs.d/localhost:5004")
 
-		cwd, _ := os.Getwd()
-		certPath := filepath.Join(cwd, "../", "certs")
+		certPath := filepath.Join(INTEGRATION_ROOT, "certs")
 
 		lock := GetPortLock("5004")
 		defer lock.Unlock()

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -638,7 +638,7 @@ VOLUME /test/`, ALPINE)
 
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", ".:/app:O", ALPINE, "ls", "/app"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.OutputToString()).To(ContainSubstring(filepath.Base(CurrentSpecReport().FileName())))
+		Expect(session.OutputToString()).To(ContainSubstring(" quadlet "))
 		Expect(session).Should(ExitCleanly())
 
 		// Make sure modifications in container do not show up on host

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Podman trust", Ordered, func() {
 	})
 
 	It("podman image trust show", func() {
-		session := podmanTest.Podman([]string{"image", "trust", "show", "-n", "--registrypath", filepath.Join(INTEGRATION_ROOT, "test"), "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json")})
+		session := podmanTest.Podman([]string{"image", "trust", "show", "-n", "--registrypath", INTEGRATION_ROOT, "--policypath", filepath.Join(INTEGRATION_ROOT, "policy.json")})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		outArray := session.OutputToStringArray()
@@ -49,7 +49,7 @@ var _ = Describe("Podman trust", Ordered, func() {
 	})
 
 	It("podman image trust show --json", func() {
-		session := podmanTest.Podman([]string{"image", "trust", "show", "--registrypath", filepath.Join(INTEGRATION_ROOT, "test"), "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json"), "--json"})
+		session := podmanTest.Podman([]string{"image", "trust", "show", "--registrypath", INTEGRATION_ROOT, "--policypath", filepath.Join(INTEGRATION_ROOT, "policy.json"), "--json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(BeValidJSON())
@@ -88,10 +88,10 @@ var _ = Describe("Podman trust", Ordered, func() {
 	})
 
 	It("podman image trust show --raw", func() {
-		session := podmanTest.Podman([]string{"image", "trust", "show", "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json"), "--raw"})
+		session := podmanTest.Podman([]string{"image", "trust", "show", "--policypath", filepath.Join(INTEGRATION_ROOT, "policy.json"), "--raw"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		contents, err := os.ReadFile(filepath.Join(INTEGRATION_ROOT, "test/policy.json"))
+		contents, err := os.ReadFile(filepath.Join(INTEGRATION_ROOT, "policy.json"))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(session.OutputToString()).To(BeValidJSON())
 		Expect(string(session.Out.Contents())).To(Equal(string(contents) + "\n"))


### PR DESCRIPTION
Allow other parties to run e2e tests against an rpm-installed podman.

Much trickier than I'd predicted. Split into three commits. Please review those separately for your sanity.

Judgment call: I'm shoehorning these into the existing `podman-tests` rpm which until now has only had system tests. If there's any objection, or any strong argument for breaking out yet another new subpackage, please speak now.
```release-note
e2e tests are now included in the podman-tests rpm
```