### PR TITLE
Graceful shutdown during podman kube down 

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1504,6 +1504,7 @@ func sortKubeKinds(documentList [][]byte) ([][]byte, error) {
 
 	return sortedDocumentList, nil
 }
+
 func imageNamePrefix(imageName string) string {
 	prefix := imageName
 	s := strings.Split(prefix, ":")
@@ -1663,7 +1664,10 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 	}
 
 	// Add the reports
-	reports.StopReport, err = ic.PodStop(ctx, podNames, entities.PodStopOptions{Ignore: true})
+	reports.StopReport, err = ic.PodStop(ctx, podNames, entities.PodStopOptions{
+		Ignore:  true,
+		Timeout: -1,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -273,14 +273,41 @@ spec:
     - name: testctr
       image: ` + CITEST_IMAGE + `
       command:
-        - sleep
-        - inf
+      - /bin/sh
+      - -c
+      - |
+        trap exit SIGTERM
+        while :; do sleep 0.1; done
       volumeMounts:
       - mountPath: /var
         name: testing
         subPath: testing/onlythis
     volumes:
     - name: testing
+      persistentVolumeClaim:
+        claimName: testvol
+`
+
+var signalTest = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testpod
+spec:
+    containers:
+    - name: testctr
+      image: ` + CITEST_IMAGE + `
+      command:
+        - /bin/sh
+        - -c
+        - |
+          trap 'echo TERMINATED > /testvol/termfile; exit' SIGTERM
+          while true; do sleep 0.1; done
+      volumeMounts:
+      - mountPath: /testvol
+        name: testvol
+    volumes:
+    - name: testvol
       persistentVolumeClaim:
         claimName: testvol
 `
@@ -5566,6 +5593,28 @@ spec:
 		checkVol.WaitWithDefaultTimeout()
 		Expect(checkVol).Should(ExitCleanly())
 		Expect(checkVol.OutputToString()).To(Equal("testvol1"))
+	})
+
+	It("with graceful shutdown", func() {
+
+		volumeCreate := podmanTest.Podman([]string{"volume", "create", "testvol"})
+		volumeCreate.WaitWithDefaultTimeout()
+		Expect(volumeCreate).Should(ExitCleanly())
+
+		err = writeYaml(signalTest, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		playKube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		playKube.WaitWithDefaultTimeout()
+		Expect(playKube).Should(ExitCleanly())
+
+		teardown := podmanTest.Podman([]string{"kube", "down", kubeYaml})
+		teardown.WaitWithDefaultTimeout()
+		Expect(teardown).Should(ExitCleanly())
+
+		session := podmanTest.Podman([]string{"run", "--volume", "testvol:/testvol", CITEST_IMAGE, "sh", "-c", "cat /testvol/termfile"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).Should(ContainSubstring("TERMINATED"))
 	})
 
 	It("with hostPath subpaths", func() {


### PR DESCRIPTION
Fixes #22397
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where `podman kube down` would not respect the StopTimeout and StopSignal of containers that it stopped
```
