### PR TITLE
Emergency fix (well, skip) for failing bud tests

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -291,6 +291,10 @@ skip_if_rootless_remote "FIXME: not sure if 17788 or some other bug" \
 skip "FIXME: 2023-06-13 buildah PR 4746 broke this test" \
      "bud with encrypted FROM image"
 
+# 2024-04-16 test needs to be fixed in buildah repo, to use another registry
+skip "FIXME: 2024-04-16 nixery is down" \
+     "bud-implicit-no-history"
+
 # END   temporary workarounds that must be reevaluated periodically
 ###############################################################################
 


### PR DESCRIPTION
nixery registry has been down all day. Disable test.

Someone will need to fix this on the buildah end.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```