### PR TITLE
add `list` as an alias to list networks

### DIFF
--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -22,6 +22,7 @@ var (
 	networklistDescription = `List networks`
 	networklistCommand     = &cobra.Command{
 		Use:               "ls [options]",
+		Aliases:           []string{"list"},
 		Args:              validate.NoArgs,
 		Short:             "List networks",
 		Long:              networklistDescription,

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -10,6 +10,8 @@ load helpers.network
     heading="NETWORK *ID *NAME *DRIVER"
     run_podman network ls
     assert "${lines[0]}" =~ "^$heading\$" "network ls header missing"
+    run_podman network list
+    assert "${lines[0]}" =~ "^$heading\$" "network list header missing"
 
     run_podman network ls --noheading
     assert "$output" !~ "$heading" "network ls --noheading shows header anyway"


### PR DESCRIPTION
this makes it consistent with other commands (like image and container),
but also makes the example actually work

Signed-off-by: Evgeni Golov <evgeni@golov.de>

#### Does this PR introduce a user-facing change?

```release-note
None
```
