### PR TITLE
Add the ability to automount images as volumes via play

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -41,6 +41,8 @@ Options specific to type=**image**:
 
 - *rw*, *readwrite*: *true* or *false* (default if unspecified: *false*).
 
+- *subpath*: Mount only a specific path within the image, instead of the whole image.
+
 Options specific to **bind** and **glob**:
 
 - *ro*, *readonly*: *true* or *false* (default if unspecified: *false*).

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -158,6 +158,17 @@ spec:
 
 and as a result environment variable `FOO` is set to `bar` for container `container-1`.
 
+`Automounting Volumes`
+
+An image can be automatically mounted into a container if the annotation `io.podman.annotations.kube.image.automount/$ctrname` is given. The following rules apply:
+
+- The image must already exist locally.
+- The image must have at least 1 volume directive.
+- The path given by the volume directive will be mounted from the image into the container. For example, an image with a volume at `/test/test_dir` will have `/test/test_dir` in the image mounted to `/test/test_dir` in the container.
+- Multiple images can be specified. If multiple images have a volume at a specific path, the last image specified trumps.
+- The images are always mounted read-only.
+- Images to mount are defined in the annotation "io.podman.annotations.kube.image.automount/$ctrname" as a semicolon-separated list. They are mounted into a single container in the pod, not the whole pod. The annotation can be specified for additional containers if additional mounts are required.
+
 ## OPTIONS
 
 @@option annotation.container

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -275,6 +275,8 @@ type ContainerImageVolume struct {
 	Dest string `json:"dest"`
 	// ReadWrite sets the volume writable.
 	ReadWrite bool `json:"rw"`
+	// SubPath determines which part of the image will be mounted into the container.
+	SubPath string `json:"subPath,omitempty"`
 }
 
 // ContainerSecret is a secret that is mounted in a container

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -160,6 +160,9 @@ const (
 	// the k8s behavior of waiting for the intialDelaySeconds to be over before updating the status
 	KubeHealthCheckAnnotation = "io.podman.annotations.kube.health.check"
 
+	// KubeImageAutomountAnnotation
+	KubeImageAutomountAnnotation = "io.podman.annotations.kube.image.volumes.mount"
+
 	// TotalAnnotationSizeLimitB is the max length of annotations allowed by Kubernetes.
 	TotalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
 )

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1474,6 +1474,7 @@ func WithImageVolumes(volumes []*ContainerImageVolume) CtrCreateOption {
 				Dest:      vol.Dest,
 				Source:    vol.Source,
 				ReadWrite: vol.ReadWrite,
+				SubPath:   vol.SubPath,
 			})
 		}
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -501,6 +501,7 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 				Dest:      v.Destination,
 				Source:    v.Source,
 				ReadWrite: v.ReadWrite,
+				SubPath:   v.SubPath,
 			})
 		}
 		options = append(options, libpod.WithImageVolumes(vols))

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -142,6 +142,8 @@ type CtrSpecGenOptions struct {
 	Volumes map[string]*KubeVolume
 	// VolumesFrom for all containers
 	VolumesFrom []string
+	// Image Volumes for this container
+	ImageVolumes []*specgen.ImageVolume
 	// PodID of the parent pod
 	PodID string
 	// PodName of the parent pod
@@ -222,6 +224,8 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	s.LogConfiguration = &specgen.LogConfig{
 		Driver: opts.LogDriver,
 	}
+
+	s.ImageVolumes = opts.ImageVolumes
 
 	s.LogConfiguration.Options = make(map[string]string)
 	for _, o := range opts.LogOptions {

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -53,6 +53,9 @@ type ImageVolume struct {
 	Destination string
 	// ReadWrite sets the volume writable.
 	ReadWrite bool
+	// SubPath mounts a particular path within the image.
+	// If empty, the whole image is mounted.
+	SubPath string `json:"subPath,omitempty"`
 }
 
 // GenVolumeMounts parses user input into mounts, volumes and overlay volumes

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -611,6 +611,14 @@ func getImageVolume(args []string) (*specgen.ImageVolume, error) {
 			default:
 				return nil, fmt.Errorf("invalid rw value %q: %w", value, util.ErrBadMntOption)
 			}
+		case "subpath":
+			if !hasValue {
+				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
+			}
+			if !filepath.IsAbs(value) {
+				return nil, fmt.Errorf("volume subpath %q must be an absolute path", value)
+			}
+			newVolume.SubPath = value
 		case "consistency":
 			// Often used on MACs and mistakenly on Linux platforms.
 			// Since Docker ignores this option so shall we.

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -936,14 +936,19 @@ USER testuser`, CITEST_IMAGE)
 	})
 
 	It("podman run --mount type=image with subpath", func() {
-		ctrCommand := []string{"run", "--mount", fmt.Sprintf("type=image,source=%s,dest=/mnt,subpath=/etc", ALPINE), ALPINE, "ls"}
+		podmanTest.AddImageToRWStore(ALPINE)
 
-		run1Cmd := append(ctrCommand, "/etc")
+		pathToCheck := "/sbin"
+		pathInCtr := "/mnt"
+
+		ctrCommand := []string{"run", "--mount", fmt.Sprintf("type=image,source=%s,dst=%s,subpath=%s", ALPINE, pathInCtr, pathToCheck), ALPINE, "ls"}
+
+		run1Cmd := append(ctrCommand, pathToCheck)
 		run1 := podmanTest.Podman(run1Cmd)
 		run1.WaitWithDefaultTimeout()
 		Expect(run1).Should(ExitCleanly())
 
-		run2Cmd := append(ctrCommand, "/mnt")
+		run2Cmd := append(ctrCommand, pathInCtr)
 		run2 := podmanTest.Podman(run2Cmd)
 		run2.WaitWithDefaultTimeout()
 		Expect(run2).Should(ExitCleanly())

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -934,4 +934,20 @@ USER testuser`, CITEST_IMAGE)
 		Expect(run).Should(ExitCleanly())
 		Expect(run.OutputToString()).Should(ContainSubstring(strings.TrimLeft("/vol/", f.Name())))
 	})
+
+	It("podman run --mount type=image with subpath", func() {
+		ctrCommand := []string{"run", "--mount", fmt.Sprintf("type=image,source=%s,dest=/mnt,subpath=/etc", ALPINE), ALPINE, "ls"}
+
+		run1Cmd := append(ctrCommand, "/etc")
+		run1 := podmanTest.Podman(run1Cmd)
+		run1.WaitWithDefaultTimeout()
+		Expect(run1).Should(ExitCleanly())
+
+		run2Cmd := append(ctrCommand, "/mnt")
+		run2 := podmanTest.Podman(run2Cmd)
+		run2.WaitWithDefaultTimeout()
+		Expect(run2).Should(ExitCleanly())
+
+		Expect(run1.OutputToString()).Should(Equal(run2.OutputToString()))
+	})
 })


### PR DESCRIPTION
Effectively, this is an ability to take an image already pulled to the system, and automatically mount it into one or more containers defined in Kubernetes YAML accepted by `podman play`.

Requirements:
- The image must already exist in storage.
- The image must have a single Volume directive. We will mount to the path defined in the Volume directive.
- More than one image can be specified, but the paths they mount to (the Volume directives) must be different for all images mounted into a single container.
- The images are always mounted read-only
- Images to mount are defined in the annotation "io.podman.annotations.kube.image.automount/$ctrname" as a semicolon-separated list. They are mounted into a single container in the pod, not the whole pod.

As we're using a nonstandard annotation, this is Podman only, any Kubernetes install will just ignore this.

Underneath, this compiles down to an image volume
(`podman run --mount type=image,...`).

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A list of images to automatically mount as volumes can now be specified in Kubernetes YAML via the "io.podman.annotations.kube.image.automount/$ctrname" annotation.
Image-based mounts using `podman run --mount type=image,...` now support a new option, `subpath`, to mount only part of the image into the container.
```
