### PR TITLE
[CI:DOCS] Fix windows installer action

### DIFF
--- a/.github/workflows/upload-win-installer.yml
+++ b/.github/workflows/upload-win-installer.yml
@@ -40,8 +40,6 @@ jobs:
     - name: Dry Run Status
       run: |
         Write-Output "::notice::This workflow execution will be a dry-run: ${{ steps.actual_dryrun.outputs.dryrun }}"
-    - name: Install Wix
-      run: choco install wixtoolset --version=3.14.0
     - name: Determine version
       id: getversion
       run: |


### PR DESCRIPTION
We temporarily installed wixtoolset using chocolatey, when 3.14 wasn't in GHA yet. Now it's there by default, so remove the install. This prevents the downgrade error. Note: If we change the minir version of WiX that we use, then we may need to install wix again. But for now, removing this step will allow us to use the latest 3.14 patch.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
