### PR TITLE
CI: remove compose v1 tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -619,19 +619,12 @@ compose_test_task:
     gce_instance: *standardvm
     matrix:
       - env:
-            TEST_FLAVOR: compose
             PRIV_NAME: root
       - env:
-            TEST_FLAVOR: compose
-            PRIV_NAME: rootless
-      - env:
-            TEST_FLAVOR: compose_v2
-            PRIV_NAME: root
-      - env:
-            TEST_FLAVOR: compose_v2
             PRIV_NAME: rootless
     env:
         <<: *stdenvars
+        TEST_FLAVOR: compose_v2
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -54,12 +54,6 @@ function _run_apiv2() {
     ) |& logformatter
 }
 
-function _run_compose() {
-    _bail_if_test_can_be_skipped test/compose
-
-    showrun ./test/compose/test-compose |& logformatter
-}
-
 function _run_compose_v2() {
     _bail_if_test_can_be_skipped test/compose
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -367,11 +367,6 @@ case "$TEST_FLAVOR" in
         showrun pip install --upgrade pip
         showrun pip install --requirement $GOSRC/test/apiv2/python/requirements.txt
         ;&  # continue with next item
-    compose)
-        showrun make install.tools
-        showrun dnf remove -y gvisor-tap-vsock
-        showrun dnf install -y podman-docker*
-        ;&  # continue with next item
     int)
         showrun make .install.ginkgo
         ;&

--- a/test/compose/README.md
+++ b/test/compose/README.md
@@ -1,7 +1,8 @@
-Tests for docker-compose
-========================
+Tests for docker-compose v2
+===========================
 
-This directory contains tests for docker-compose under podman.
+This directory contains tests for docker-compose v2 under podman.
+docker-compose v1 is no longer supported upstream so we no longer test with it.
 
 Each subdirectory must contain one docker-compose.yml file along with
 all necessary infrastructure for it (e.g. Containerfile, any files

--- a/test/compose/etc_hosts/tests.sh
+++ b/test/compose/etc_hosts/tests.sh
@@ -1,9 +1,6 @@
 # -*- bash -*-
 
-ctr_name="etc_hosts_test_1"
-if [ "$TEST_FLAVOR" = "compose_v2" ]; then
-    ctr_name="etc_hosts-test-1"
-fi
+ctr_name="etc_hosts-test-1"
 
 podman exec "$ctr_name" sh -c 'grep "foobar" /etc/hosts'
 like "$output" "10\.123\.0\." "$testname : no entries are copied from the host"

--- a/test/compose/ipam_set_ip/tests.sh
+++ b/test/compose/ipam_set_ip/tests.sh
@@ -1,9 +1,6 @@
 # -*- bash -*-
 
-ctr_name="ipam_set_ip_test_1"
-if [ "$TEST_FLAVOR" = "compose_v2" ]; then
-    ctr_name="ipam_set_ip-test-1"
-fi
+ctr_name="ipam_set_ip-test-1"
 podman container inspect "$ctr_name" --format '{{ .NetworkSettings.Networks.ipam_set_ip_net1.IPAddress }}'
 is "$output" "10.123.0.253" "$testname : ip address is set"
 podman container inspect "$ctr_name" --format '{{ .NetworkSettings.Networks.ipam_set_ip_net1.MacAddress }}'

--- a/test/compose/two_networks/tests.sh
+++ b/test/compose/two_networks/tests.sh
@@ -1,9 +1,6 @@
 # -*- bash -*-
 
-ctr_name="two_networks_con1_1"
-if [ "$TEST_FLAVOR" = "compose_v2" ]; then
-    ctr_name="two_networks-con1-1"
-fi
+ctr_name="two_networks-con1-1"
 podman container inspect "$ctr_name" --format '{{len .NetworkSettings.Networks}}'
 is "$output" "2" "$testname : Container is connected to both networks"
 podman container inspect "$ctr_name" --format '{{.NetworkSettings.Networks}}'

--- a/test/compose/uptwice/tests.sh
+++ b/test/compose/uptwice/tests.sh
@@ -10,8 +10,5 @@ output=$(podman_compose up -d 2>&1)
 # Horrible output check here but we really want to make sure that there are
 # no unexpected warning/errors and the normal messages are send on stderr as
 # well so we cannot check for an empty stderr.
-expected="Recreating uptwice_app_1 ... ${CR}${NL}Recreating uptwice_app_1 ... done$CR"
-if [ "$TEST_FLAVOR" = "compose_v2" ]; then
-    expected="Container uptwice-app-1  Recreate${NL}Container uptwice-app-1  Recreated${NL}Container uptwice-app-1  Starting${NL}Container uptwice-app-1  Started"
-fi
+expected="Container uptwice-app-1  Recreate${NL}Container uptwice-app-1  Recreated${NL}Container uptwice-app-1  Starting${NL}Container uptwice-app-1  Started"
 is "$output" "$expected" "no error output in compose up (#15580)"


### PR DESCRIPTION
compose v1 has been deprecated for some time now, since July 2023 it no
longer receives any updates[1]. As such testing it on every PR is
pointless, it also does not provide any more coverage then compose v2.
At least I never saw only compose v1 test fails (except for flakes) so
it doesn't help us to catch regressions.
We tried to remove it before but decided against it at that time[2].

[1] https://docs.docker.com/compose/migrate/
[2] https://github.com/containers/podman/issues/18688

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
