### PR TITLE
[skip-ci] Packit: enable CentOS 10 Stream build jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,6 +49,8 @@ jobs:
       - centos-stream+epel-next-8-aarch64
       - epel-9-x86_64
       - epel-9-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
     additional_repos:
       - "copr://rhcontainerbot/podman-next"
 


### PR DESCRIPTION
CentOS 10 Stream rpm builds are now active, so we should add jobs for
those on PRs.
    
These have to be centos-stream for now and not epel as epel will be
created only after RHEL-10 is released AFAIK, while the centos-stream-10
targets are available in copr now.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
