### PR TITLE
[skip-ci] Packit: switch to EPEL instead of centos-stream+epel-next

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -47,8 +47,8 @@ jobs:
     targets:
       - centos-stream+epel-next-8-x86_64
       - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-9-aarch64
+      - epel-9-x86_64
+      - epel-9-aarch64
     additional_repos:
       - "copr://rhcontainerbot/podman-next"
 


### PR DESCRIPTION
- EPEL is the recommended target for further testing with rpm builds.
- Fix EL9 builds.
- Do not change c8s for now as it will be removed soon anyway.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
