### PR TITLE
[CI:DOCS] fix podman-pod-restart.1.md typo

### DIFF
--- a/docs/source/markdown/podman-pod-restart.1.md
+++ b/docs/source/markdown/podman-pod-restart.1.md
@@ -7,7 +7,7 @@ podman\-pod\-restart - Restart one or more pods
 **podman pod restart** [*options*] *pod* ...
 
 ## DESCRIPTION
-Restart containers in one or more pods. Running containers are stopped an restarted.
+Restart containers in one or more pods. Running containers are stopped and restarted.
 Stopped containers are started. You may use pod IDs or names as input.
 The pod ID is printed upon successful restart.
 When restarting multiple pods, an error from restarting one pod does not effect restarting other pods.


### PR DESCRIPTION
Small typographical error:
"an restarted" -> "and restarted"

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
