### PR TITLE
libpod: wrap store setup error message

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -438,7 +438,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 			}
 		}
 
-		return err
+		return fmt.Errorf("configure storage: %w", err)
 	}
 	defer func() {
 		if retErr != nil && store != nil {
@@ -616,7 +616,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		// Ensure we have a store before refresh occurs
 		if runtime.store == nil {
 			if err := runtime.configureStore(); err != nil {
-				return err
+				return fmt.Errorf("configure storage: %w", err)
 			}
 		}
 


### PR DESCRIPTION
In cases where we fail to configure the error is returned as it and may be missing useful context. Make sure we know the error happened as part of the storage setup.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
