### PR TITLE
[CI:DOCS] Fix artifact action

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -48,6 +48,10 @@ jobs:
           echo "dryrun=${{ inputs.dryrun }}" >> $GITHUB_OUTPUT
         fi
 
+    - name: Dry Run Status
+      run: |
+        echo "::notice::This workflow execution will be a dry-run: ${{ steps.actual_dryrun.outputs.dryrun }}"
+
     - name: Check uploads
       id: check
       run: |
@@ -61,10 +65,11 @@ jobs:
             set -- $artifact # Convert the "tuple" into the param args $1 $2...
             status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${1:?}")
             if [[ "$status" == "404" ]] ; then
+              echo "${1:?} will be built"
               needsbuild=true
-              echo "${2:?}=true"
+              echo "${2:?}=true" >> $GITHUB_OUTPUT
             else
-              echo "::warning::${artifact} already exists, skipping"
+              echo "::warning::${1:?} already exists, skipping"
             fi
           done
 


### PR DESCRIPTION
Fix a bug where the check uploads section didn't actually mark the os/arch to be built.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
