### PR TITLE
[CI:DOCS] Add installation instructions for openSUSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,13 @@ You need install some dependencies before building a binary.
   $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
   ```
 
+#### openSUSE
+
+  ```shell
+  $ sudo zypper -n in libgpgme-devel libseccomp-devel systemd-devel
+  $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
+  ```
+
 ### Building binaries and test your changes
 
 To test your changes do `make binaries` to generate your binaries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,21 +102,18 @@ You need install some dependencies before building a binary.
 
   ```shell
   $ sudo dnf install gpgme-devel libseccomp-devel.x86_64 systemd-devel
-  $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
   ```
 
 #### Debian / Ubuntu
 
   ```shell
   $ sudo apt-get install -y libsystemd-dev libgpgme-dev libseccomp-dev
-  $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
   ```
 
 #### openSUSE
 
   ```shell
   $ sudo zypper -n in libgpgme-devel libseccomp-devel systemd-devel
-  $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
   ```
 
 ### Building binaries and test your changes


### PR DESCRIPTION
This PR consists of two commits:

* Adds the installation instructions for openSUSE, similar to the present ones for Fedora and Debian/Ubuntu (Tested on openSUSE Tumbleweed and Leap 15.6)
* Remove the `PKG_CONFIG_PATH` configuration, which appears to not be needed anymore

#### Does this PR introduce a user-facing change?

```release-note
None
```