### PR TITLE
[CI:DOCS] Remove redundant Prerequisite before build section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,28 +94,6 @@ Makefile allow you to install needed tools:
 $ make install.tools
 ```
 
-### Prerequisite before build
-
-You need install some dependencies before building a binary.
-
-#### Fedora
-
-  ```shell
-  $ sudo dnf install gpgme-devel libseccomp-devel.x86_64 systemd-devel
-  ```
-
-#### Debian / Ubuntu
-
-  ```shell
-  $ sudo apt-get install -y libsystemd-dev libgpgme-dev libseccomp-dev
-  ```
-
-#### openSUSE
-
-  ```shell
-  $ sudo zypper -n in libgpgme-devel libseccomp-devel systemd-devel
-  ```
-
 ### Building binaries and test your changes
 
 To test your changes do `make binaries` to generate your binaries.


### PR DESCRIPTION
The contents of the "Prerequisite before buil"d section are given already in a link in its "Prepare your environment" parent section and therefore redundant. Let's remove it.

This is a followup of https://github.com/containers/podman/pull/22464 as suggested in https://github.com/containers/podman/pull/22464#discussion_r1575990476

The "Prepare your environment" section already links to https://podman.io/getting-started/installation#build-and-run-dependencies, where the required dependencies are much better documented.

Following the previous suggestion from @Luap99, the whole "Prerequisite before build" section is redundant, likely will be outdated and should be removed in favor of the actual installation docs.

#### Does this PR introduce a user-facing change?

```release-note
None
```
