### PR TITLE
machine: Add provider detection API

### DIFF
--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -1,8 +1,13 @@
 package provider
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v5/pkg/machine/applehv"
@@ -35,4 +40,46 @@ func Get() (vmconfigs.VMProvider, error) {
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}
+}
+
+// SupportedProviders returns the providers that are supported on the host operating system
+func SupportedProviders() []define.VMType {
+	return []define.VMType{define.AppleHvVirt}
+}
+
+// InstalledProviders returns the supported providers that are installed on the host
+func InstalledProviders() ([]define.VMType, error) {
+	var outBuf bytes.Buffer
+	// Apple's Virtualization.Framework is only supported on MacOS 11.0+
+	const SupportedMacOSVersion = 11
+
+	cmd := exec.Command("sw_vers", "--productVersion")
+	cmd.Stdout = &outBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("unable to check current macOS version using `sw_vers --productVersion`: %s", err)
+	}
+
+	// the output will be in the format of MAJOR.MINOR.PATCH
+	output := outBuf.String()
+	idx := strings.Index(output, ".")
+	if idx < 0 {
+		return nil, errors.New("invalid output provided by sw_vers --productVersion")
+	}
+	majorString := output[:idx]
+	majorInt, err := strconv.Atoi(majorString)
+	if err != nil {
+		return nil, err
+	}
+
+	if majorInt >= SupportedMacOSVersion {
+		return []define.VMType{define.AppleHvVirt}, nil
+	}
+
+	return []define.VMType{}, nil
+}
+
+// HasPermsForProvider returns whether the host operating system has the proper permissions to use the given provider
+func HasPermsForProvider(provider define.VMType) bool {
+	// there are no permissions required for AppleHV
+	return provider == define.AppleHvVirt
 }

--- a/pkg/machine/provider/platform_test.go
+++ b/pkg/machine/provider/platform_test.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSupportedProviders(t *testing.T) {
+	switch runtime.GOOS {
+	case "darwin":
+		assert.Equal(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
+	case "windows":
+		assert.Equal(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
+	case "linux":
+		assert.Equal(t, []define.VMType{define.QemuVirt}, SupportedProviders())
+	}
+}
+
+func TestInstalledProviders(t *testing.T) {
+	installed, err := InstalledProviders()
+	assert.Nil(t, err)
+	switch runtime.GOOS {
+	case "darwin":
+		assert.Equal(t, []define.VMType{define.AppleHvVirt}, installed)
+	case "windows":
+		provider, err := Get()
+		assert.Nil(t, err)
+		assert.Contains(t, installed, provider)
+	case "linux":
+		assert.Equal(t, []define.VMType{define.QemuVirt}, installed)
+	}
+}
+
+func TestHasPermsForProvider(t *testing.T) {
+	provider, err := Get()
+	assert.Nil(t, err)
+	assert.True(t, HasPermsForProvider(provider.VMType()))
+}
+
+func TestHasBadPerms(t *testing.T) {
+	switch runtime.GOOS {
+	case "darwin":
+		assert.False(t, HasPermsForProvider(define.QemuVirt))
+	case "windows":
+		assert.False(t, HasPermsForProvider(define.QemuVirt))
+	case "linux":
+		assert.False(t, HasPermsForProvider(define.AppleHvVirt))
+	}
+}
+
+func TestBadSupportedProviders(t *testing.T) {
+	switch runtime.GOOS {
+	case "darwin":
+		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
+	case "windows":
+		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
+	case "linux":
+		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
+	}
+}
+
+func TestBadInstalledProviders(t *testing.T) {
+	installed, err := InstalledProviders()
+	assert.Nil(t, err)
+	switch runtime.GOOS {
+	case "darwin":
+		assert.NotEqual(t, []define.VMType{define.QemuVirt}, installed)
+	case "windows":
+		assert.NotContains(t, installed, define.QemuVirt)
+	case "linux":
+		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, installed)
+	}
+}


### PR DESCRIPTION
Extends the `pkg/machine/provider` package to add an API which includes provider detection based on the host operating system.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
