### PR TITLE
ExitWithError() - low-hanging fruit

### DIFF
--- a/test/e2e/image_scp_test.go
+++ b/test/e2e/image_scp_test.go
@@ -17,7 +17,7 @@ var _ = Describe("podman image scp", func() {
 	It("podman image scp bogus image", func() {
 		scp := podmanTest.Podman([]string{"image", "scp", "FOOBAR"})
 		scp.WaitWithDefaultTimeout()
-		Expect(scp).Should(ExitWithError())
+		Expect(scp).Should(ExitWithError(125, "must specify a destination: invalid argument"))
 	})
 
 	It("podman image scp with proper connection", func() {
@@ -38,12 +38,7 @@ var _ = Describe("podman image scp", func() {
 		// exit with error because we cannot make an actual ssh connection
 		// This tests that the input we are given is validated and prepared correctly
 		// The error given should either be a missing image (due to testing suite complications) or a no such host timeout on ssh
-		Expect(scp).Should(ExitWithError())
-		// podman-remote exits with a different error
-		if !IsRemote() {
-			Expect(scp.ErrorToString()).Should(ContainSubstring("no such host"))
-		}
-
+		Expect(scp).Should(ExitWithError(125, "failed to connect: dial tcp: lookup "))
 	})
 
 })

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman kill", func() {
@@ -14,7 +13,7 @@ var _ = Describe("Podman kill", func() {
 	It("podman kill bogus container", func() {
 		session := podmanTest.Podman([]string{"kill", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman container kill a running container by id", func() {
@@ -87,7 +86,7 @@ var _ = Describe("Podman kill", func() {
 
 		result := podmanTest.Podman([]string{"kill", "-s", "foobar", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
+		Expect(result).Should(ExitWithError(125, "invalid signal: foobar"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
 

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -86,11 +86,7 @@ var _ = Describe("Podman load", func() {
 		result := podmanTest.Podman([]string{"load", "-q", "--signature-policy", "/etc/containers/policy.json", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		if IsRemote() {
-			Expect(result).To(ExitWithError())
-			Expect(result.ErrorToString()).To(ContainSubstring("unknown flag"))
-			result = podmanTest.Podman([]string{"load", "-i", outfile})
-			result.WaitWithDefaultTimeout()
-			Expect(result).Should(ExitCleanly())
+			Expect(result).To(ExitWithError(125, "unknown flag: --signature-policy"))
 		} else {
 			Expect(result).Should(ExitCleanly())
 		}
@@ -138,16 +134,13 @@ var _ = Describe("Podman load", func() {
 
 		result := podmanTest.Podman([]string{"load", "-i", podmanTest.TempDir})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-
-		errMsg := fmt.Sprintf("remote client supports archives only but %q is a directory", podmanTest.TempDir)
-		Expect(result.ErrorToString()).To(ContainSubstring(errMsg))
+		Expect(result).Should(ExitWithError(125, fmt.Sprintf("remote client supports archives only but %q is a directory", podmanTest.TempDir)))
 	})
 
 	It("podman load bogus file", func() {
 		save := podmanTest.Podman([]string{"load", "-i", "foobar.tar"})
 		save.WaitWithDefaultTimeout()
-		Expect(save).To(ExitWithError())
+		Expect(save).To(ExitWithError(125, "faccessat foobar.tar: no such file or directory"))
 	})
 
 	It("podman load multiple tags", func() {


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

Because #22346 is stalled, these are some trivial easy-to-review
changes that get us closer to the goal.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```