### PR TITLE
ExitWithError() - yet more low-hanging fruit

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -29,8 +29,7 @@ var _ = Describe("Podman logs", func() {
 	It("podman logs on not existent container", func() {
 		results := podmanTest.Podman([]string{"logs", "notexist"})
 		results.WaitWithDefaultTimeout()
-		Expect(results).To(Exit(125))
-		Expect(results.ErrorToString()).To(Equal(`Error: no container with name or ID "notexist" found: no such container`))
+		Expect(results).To(ExitWithError(125, `no container with name or ID "notexist" found: no such container`))
 	})
 
 	for _, log := range []string{"k8s-file", "journald", "json-file"} {
@@ -270,7 +269,11 @@ var _ = Describe("Podman logs", func() {
 
 			results := podmanTest.Podman([]string{"logs", "-l", "foobar"})
 			results.WaitWithDefaultTimeout()
-			Expect(results).To(ExitWithError())
+			if IsRemote() {
+				Expect(results).To(ExitWithError(125, "unknown shorthand flag: 'l' in -l"))
+			} else {
+				Expect(results).To(ExitWithError(125, "--latest and containers cannot be used together"))
+			}
 		})
 
 		It("two containers showing short container IDs: "+log, func() {
@@ -326,8 +329,7 @@ var _ = Describe("Podman logs", func() {
 
 			if log == "journald" && !isEventBackendJournald(podmanTest) {
 				// --follow + journald log-driver is only supported with journald events-backend(PR #10431)
-				Expect(results).To(Exit(125))
-				Expect(results.ErrorToString()).To(ContainSubstring("using --follow with the journald --log-driver but without the journald --events-backend"))
+				Expect(results).To(ExitWithError(125, "using --follow with the journald --log-driver but without the journald --events-backend"))
 				return
 			}
 
@@ -366,8 +368,7 @@ var _ = Describe("Podman logs", func() {
 			results.WaitWithDefaultTimeout()
 			if log == "journald" && !isEventBackendJournald(podmanTest) {
 				// --follow + journald log-driver is only supported with journald events-backend(PR #10431)
-				Expect(results).To(Exit(125))
-				Expect(results.ErrorToString()).To(ContainSubstring("using --follow with the journald --log-driver but without the journald --events-backend"))
+				Expect(results).To(ExitWithError(125, "using --follow with the journald --log-driver but without the journald --events-backend"))
 				return
 			}
 			Expect(results).To(ExitCleanly())
@@ -581,8 +582,7 @@ var _ = Describe("Podman logs", func() {
 
 		logs := podmanTest.Podman([]string{"logs", "-f", ctrName})
 		logs.WaitWithDefaultTimeout()
-		Expect(logs).To(Exit(125))
-		Expect(logs.ErrorToString()).To(ContainSubstring("this container is using the 'none' log driver, cannot read logs: this container is not logging output"))
+		Expect(logs).To(ExitWithError(125, "this container is using the 'none' log driver, cannot read logs: this container is not logging output"))
 	})
 
 	It("podman logs with non ASCII log tag fails without correct LANG", func() {
@@ -595,14 +595,10 @@ var _ = Describe("Podman logs", func() {
 		defer cleanup()
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "--log-opt", "tag=äöüß", ALPINE, "echo", "podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc).To(Exit(126))
-		// FIXME-2023-09-26: conmon <2.1.8 logs to stdout; clean this up once >=2.1.8 is universal
-		errmsg := logc.ErrorToString() + logc.OutputToString()
+		Expect(logc).To(ExitWithError(126, "conmon failed: exit status 1"))
 		if !IsRemote() {
-			// Error is only seen on local client
-			Expect(errmsg).To(ContainSubstring("conmon: option parsing failed: Invalid byte sequence in conversion input"))
+			Expect(logc.ErrorToString()).To(ContainSubstring("conmon: option parsing failed: Invalid byte sequence in conversion input"))
 		}
-		Expect(errmsg).To(ContainSubstring("conmon failed: exit status 1"))
 	})
 
 	It("podman logs with non ASCII log tag succeeds with proper env", func() {

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -21,8 +21,7 @@ var _ = Describe("Podman mount", func() {
 
 		mount := podmanTest.Podman([]string{"mount", cid})
 		mount.WaitWithDefaultTimeout()
-		Expect(mount).To(ExitWithError())
-		Expect(mount.ErrorToString()).To(ContainSubstring("podman unshare"))
+		Expect(mount).To(ExitWithError(125, "must execute `podman unshare` first"))
 	})
 
 	It("podman unshare podman mount", func() {
@@ -48,8 +47,7 @@ var _ = Describe("Podman mount", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 		mount := podmanTest.Podman([]string{"image", "mount", ALPINE})
 		mount.WaitWithDefaultTimeout()
-		Expect(mount).To(ExitWithError())
-		Expect(mount.ErrorToString()).To(ContainSubstring("podman unshare"))
+		Expect(mount).To(ExitWithError(125, "must execute `podman unshare` first"))
 	})
 
 	It("podman unshare image podman mount", func() {

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -59,10 +59,9 @@ var _ = Describe("Podman mount", func() {
 		Expect(j).Should(ExitCleanly())
 		Expect(j.OutputToString()).To(BeValidJSON())
 
-		j = podmanTest.Podman([]string{"mount", "--format='{{.foobar}}'"})
+		j = podmanTest.Podman([]string{"mount", "--format={{.foobar}}"})
 		j.WaitWithDefaultTimeout()
-		Expect(j).To(ExitWithError())
-		Expect(j.ErrorToString()).To(ContainSubstring("unknown --format"))
+		Expect(j).To(ExitWithError(125, `unknown --format argument: "{{.foobar}}"`))
 
 		umount := podmanTest.Podman([]string{"umount", cid})
 		umount.WaitWithDefaultTimeout()

--- a/test/e2e/negative_test.go
+++ b/test/e2e/negative_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"fmt"
+
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -11,6 +13,10 @@ var _ = Describe("Podman negative command-line", func() {
 	It("podman snuffleupagus exits non-zero", func() {
 		session := podmanTest.Podman([]string{"snuffleupagus"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		cmdName := "podman"
+		if IsRemote() {
+			cmdName += "-remote"
+		}
+		Expect(session).To(ExitWithError(125, fmt.Sprintf("unrecognized command `%s snuffleupagus`", cmdName)))
 	})
 })


### PR DESCRIPTION
Followup to [1]#22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

Just trying to shrink down #22346 to a manageable, reviewable size.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```