### PR TITLE
Use custom image for make validatepr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,12 +315,17 @@ codespell:
 .PHONY: validate
 validate: lint .gitvalidation validate.completions man-page-check swagger-check tests-expect-exit pr-removes-fixed-skips
 
+
+# The image used below is generated manually from contrib/validatepr/Containerfile in this podman repo.  The builds are
+# not automated right now.  The hope is that eventually the quay.io/libpod/fedora_podman is multiarch and can replace this
+# image in the future.
 .PHONY: validatepr
 validatepr:
-	$(PODMANCMD) run --rm --env HOME=/root \
-		-v $(CURDIR):/var/tmp/go/src/github.com/containers/podman \
+	$(PODMANCMD) run --rm \
+		-v $(CURDIR):/go/src/github.com/containers/podman \
 		--security-opt label=disable \
-		quay.io/libpod/fedora_podman:latest  \
+		-w /go/src/github.com/containers/podman \
+		quay.io/libpod/validatepr:latest  \
 		make .validatepr
 
 .PHONY: .validatepr


### PR DESCRIPTION
The fedora image reviewers wanted to use for make validatepr is not being being built as a multiarch image.  Use quay.io/libpod/validatepr instead.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
