### PR TITLE
libimage: Add error context when parsing image reference

### DIFF
--- a/vendor/github.com/containers/common/libimage/normalize.go
+++ b/vendor/github.com/containers/common/libimage/normalize.go
@@ -107,7 +107,7 @@ func normalizeTaggedDigestedString(s string) (string, reference.Named, error) {
 	// return it verbatim in error cases.
 	ref, err := reference.Parse(s)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("parsing reference %q: %w", s, err)
 	}
 	named, ok := ref.(reference.Named)
 	if !ok {


### PR DESCRIPTION
Before, here's what happens if you forget a `-v` in your bind mount for example:

```
$ podman run /dev:/dev docker.io/busybox echo hello
Error: invalid reference format
$
```

After:

```
$ podman run /dev:/dev docker.io/busybox echo hello
Error: parsing reference "/dev:/dev": invalid reference format
```

This error prefixing is common in other callers.


```release-note
None
```
