### PR TITLE
test/e2e: fixes to make test pass locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -625,15 +625,15 @@ ginkgo-run: .install.ginkgo
 	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts $(GINKGO_FLAKE_ATTEMPTS) \
 		--trace $(if $(findstring y,$(GINKGO_NO_COLOR)),--no-color,) \
 		$(GINKGO_JSON) $(if $(findstring y,$(GINKGO_PARALLEL)),-p,) $(if $(FOCUS),--focus "$(FOCUS)",) \
-		$(if $(FOCUS_FILE),--focus-file "$(FOCUS_FILE)",) $(GINKGOWHAT) $(HACK)
+		$(if $(FOCUS_FILE),--focus-file "$(FOCUS_FILE)",) $(GINKGOWHAT)
 
 .PHONY: ginkgo
 ginkgo:
-	$(MAKE) ginkgo-run TAGS="$(BUILDTAGS)" HACK=hack/.
+	$(MAKE) ginkgo-run TAGS="$(BUILDTAGS)"
 
 .PHONY: ginkgo-remote
 ginkgo-remote:
-	$(MAKE) ginkgo-run TAGS="$(REMOTETAGS) remote_testing" HACK=
+	$(MAKE) ginkgo-run TAGS="$(REMOTETAGS) remote_testing"
 
 .PHONY: testbindings
 testbindings: .install.ginkgo
@@ -649,7 +649,7 @@ remoteintegration: test-binaries ginkgo-remote
 localmachine:
 	# gitCommit needed by logformatter, to link to sources
 	@echo /define.gitCommit=$(GIT_COMMIT)
-	$(MAKE) ginkgo-run GINKGO_PARALLEL=n TAGS="$(REMOTETAGS)" GINKGO_FLAKE_ATTEMPTS=0 FOCUS_FILE=$(FOCUS_FILE) GINKGOWHAT=pkg/machine/e2e/. HACK=
+	$(MAKE) ginkgo-run GINKGO_PARALLEL=n TAGS="$(REMOTETAGS)" GINKGO_FLAKE_ATTEMPTS=0 FOCUS_FILE=$(FOCUS_FILE) GINKGOWHAT=pkg/machine/e2e/.
 
 .PHONY: localsystem
 localsystem:

--- a/Makefile
+++ b/Makefile
@@ -620,6 +620,8 @@ localunit: test/goecho/goecho test/version/version
 test: localunit localintegration remoteintegration localsystem remotesystem  ## Run unit, integration, and system tests.
 
 .PHONY: ginkgo-run
+# e2e tests need access to podman-registry
+ginkgo-run: PATH := $(PATH):$(CURDIR)/hack
 ginkgo-run: .install.ginkgo
 	$(GINKGO) version
 	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts $(GINKGO_FLAKE_ATTEMPTS) \
@@ -636,6 +638,8 @@ ginkgo-remote:
 	$(MAKE) ginkgo-run TAGS="$(REMOTETAGS) remote_testing"
 
 .PHONY: testbindings
+# bindings tests need access to podman-registry
+testbindings: PATH := $(PATH):$(CURDIR)/hack
 testbindings: .install.ginkgo
 	$(GINKGO) -v $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --trace --no-color --timeout 30m  -v -r ./pkg/bindings/test
 

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -88,9 +88,6 @@ function _run_bindings() {
     # install ginkgo
     showrun make .install.ginkgo
 
-    # shellcheck disable=SC2155
-    export PATH=$PATH:$GOSRC/hack:$GOSRC/test/tools/build
-
     # if logformatter sees this, it can link directly to failing source lines
     local gitcommit_magic=
     if [[ -n "$GIT_COMMIT" ]]; then

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -38,8 +38,6 @@ do
     fi
 done
 
-cp hack/podman-registry /bin
-
 # Bypass git safety/security checks when operating in a throwaway environment
 showrun git config --global --add safe.directory $GOSRC
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -274,9 +274,6 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	}
 
 	cgroupManager := CGROUP_MANAGER
-	if isRootless() {
-		cgroupManager = "cgroupfs"
-	}
 	if os.Getenv("CGROUP_MANAGER") != "" {
 		cgroupManager = os.Getenv("CGROUP_MANAGER")
 	}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -718,10 +718,10 @@ USER bin`, BB)
 			Expect(session).Should(ExitCleanly())
 		}
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--oom-score-adj=111", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
+		session = podmanTest.Podman([]string{"run", "--rm", "--oom-score-adj=999", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal("111"))
+		Expect(session.OutputToString()).To(Equal("999"))
 
 		currentOOMScoreAdj, err := os.ReadFile("/proc/self/oom_score_adj")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -173,7 +173,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with volumes and suid/dev/exec options", func() {
-		SkipIfRemote("podman-remote does not support --volumes")
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err := os.Mkdir(mountPath, 0755)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
see commits
Fixes #22474

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
