### PR TITLE
[skip-ci] Remove unncessary lines at the end of specfile summary

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -123,8 +123,6 @@ additional privileges.
 Both tools share image (not container) storage, hence each can use or
 manipulate images (but not containers) created by the other.
 
-%{summary}
-%{repo} Simple management tool for pods, containers and images
 
 %package docker
 Summary: Emulate Docker CLI using %{name}


### PR DESCRIPTION
The package summary for builds like [podman-5.0.2-1.fc40](https://koji.fedoraproject.org/koji/buildinfo?buildID=2440335) currently includes the following line:

```
%{repo} Simple management tool for pods, containers and images
```

Older package builds like [podman-3.0.1-1.fc33](https://koji.fedoraproject.org/koji/buildinfo?buildID=1712552) have the following:

```
podman Simple management tool for pods, containers and images
```


The `%{repo}` macro seems to be fairly common across Containers projects:

https://github.com/search?q=org%3Acontainers%20%25%7Brepo%7D&type=code

I don't see this macro defined anywhere in the podman repo anymore though.

It appears that `%{repo}` was once defined as a synonym of `%{name}` when looking at an older spec file:

https://src.fedoraproject.org/rpms/podman/blob/894150af40d787d9fb3ab53d2e879ff9ef53797a/f/podman.spec#_27

I think using `%{name}` directly would be a sensible fix.

Edit:

This change will actually delete the last two lines of the specfile summary at @lsm5's suggestion.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove unncessary lines at the end of specfile summary
```
