### PR TITLE
test/e2e: more fixes to not leak tmp files/dirs

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -441,7 +441,7 @@ RUN find /test`, CITEST_IMAGE)
 	It("podman remote build must not allow symlink for ignore files", func() {
 		// Create a random file where symlink must be resolved
 		// but build should not be able to access it.
-		privateFile := filepath.Join("/tmp", "private_file")
+		privateFile := filepath.Join(podmanTest.TempDir, "private_file")
 		f, err := os.Create(privateFile)
 		Expect(err).ToNot(HaveOccurred())
 		// Mark hello to be ignored in outerfile, but it should not be ignored.
@@ -449,16 +449,14 @@ RUN find /test`, CITEST_IMAGE)
 		Expect(err).ToNot(HaveOccurred())
 		defer f.Close()
 
-		// Create .dockerignore which is a symlink to /tmp/private_file.
+		// Create .dockerignore which is a symlink to /tmp/.../private_file outside of the context dir.
 		currentDir, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 		ignoreFile := filepath.Join(currentDir, "build/containerignore-symlink/.dockerignore")
 		err = os.Symlink(privateFile, ignoreFile)
 		Expect(err).ToNot(HaveOccurred())
 		// Remove created .dockerignore for this test when test ends.
-		defer func() {
-			os.Remove(ignoreFile)
-		}()
+		defer os.Remove(ignoreFile)
 
 		if IsRemote() {
 			podmanTest.StopRemoteService()

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"slices"
+
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,5 +65,14 @@ var _ = Describe("Podman mount", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(ContainSubstring(podmanTest.TempDir))
+
+		// We have to unmount the image again otherwise we leak the tmpdir
+		// as active mount points cannot be removed.
+		index := slices.Index(args, "mount")
+		Expect(index).To(BeNumerically(">", 0), "index should be found")
+		args[index] = "unmount"
+		session = podmanTest.Podman(args)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 	})
 })

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4093,7 +4093,7 @@ o: {{ .Options.o }}`})
 	It("persistentVolumeClaim with source", func() {
 		fileName := "data"
 		expectedFileContent := "Test"
-		tarFilePath := filepath.Join(os.TempDir(), "podmanVolumeSource.tgz")
+		tarFilePath := filepath.Join(podmanTest.TempDir, "podmanVolumeSource.tgz")
 		err := createSourceTarFile(fileName, expectedFileContent, tarFilePath)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
see commits

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
