### PR TITLE
[skip-ci] GHA: Attempt fix exceeded a secondary rate limit

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -15,6 +15,8 @@ on:
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   workflow_call:
     secrets:
+      STALE_LOCKING_APP_PRIVATE_KEY:
+        required: true
       ACTION_MAIL_SERVER:
         required: true
       ACTION_MAIL_USERNAME:
@@ -48,9 +50,20 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # Use dedicated github app to workaround API rate limiting
+      # Ref: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow
+      - name: Obtain Stale Locking App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          # N/B: These are both defined at the containers-org level
+          app-id: ${{ vars.STALE_LOCKING_APP_ID }}
+          private-key: ${{ secrets.STALE_LOCKING_APP_PRIVATE_KEY }}
+
       # Ref: https://github.com/dessant/lock-threads#usage
       - uses: dessant/lock-threads@v5
         with:
+          github-token: '${{ steps.generate-token.outputs.token }}'
           process-only: 'issues, prs'
           issue-inactive-days: '${{env.CLOSED_DAYS}}'
           pr-inactive-days: '${{env.CLOSED_DAYS}}'


### PR DESCRIPTION
Frequent but intermittently, the stale issue and PR locking workflow generates the error:

```
You have exceeded a secondary rate limit. Please wait a few minutes
before you try again. If you reach out to GitHub Support for help,
please include the request ID XYZ
```

According to [upstream `dessant/lock-threads` issue 48](https://github.com/dessant/lock-threads/issues/48), this seems to be coming from the GitHub side (bug/feature/limitation), since the action uses an official github API rate-limiting library.  It's unlikely related to which style/syntax of github token is used, nor if the action is executed concurrently across multiple repos.

According to the rate-limiting docs:
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits it's possible the issue is caused due to an unknown aspect of the clause:

```
These secondary rate limits are subject to change without notice. You
may also encounter a secondary rate limit for undisclosed reasons.
```

The same docs indicate Github Apps have enhanced rate-limits which scale with the org's repo count.  Attempt to fix the intermittent failures by making use of a new, dedicated, org-specific, private "Stale Locking App" I recently created.  This requires the addition of a new action to the workflow that obtains a short-lived token for passing to lock-threads.

Note: Because both `vars.STALE_LOCKING_APP_ID` and `secrets.STALE_LOCKING_APP_PRIVATE_KEY` are defined at the containers-organization level, the Buildah and Skopeo re-use of this workflow should continue to function normally w/o change.


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
