### PR TITLE
ExitWithError() - pod_xxx tests

### DIFF
--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -11,7 +11,11 @@ var _ = Describe("Podman pod inspect", func() {
 	It("podman inspect bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "inspect", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError())
+		expect := "no such pod foobar"
+		if IsRemote() {
+			expect = `no such pod "foobar"`
+		}
+		Expect(session).Should(ExitWithError(125, expect))
 	})
 
 	It("podman inspect a pod", func() {

--- a/test/e2e/pod_kill_test.go
+++ b/test/e2e/pod_kill_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman pod kill", func() {
@@ -12,7 +11,11 @@ var _ = Describe("Podman pod kill", func() {
 	It("podman pod kill bogus", func() {
 		session := podmanTest.Podman([]string{"pod", "kill", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		expect := "no pod with name or ID foobar found: no such pod"
+		if IsRemote() {
+			expect = `unable to find pod "foobar": no such pod`
+		}
+		Expect(session).To(ExitWithError(125, expect))
 	})
 
 	It("podman pod kill a pod by id", func() {
@@ -71,7 +74,7 @@ var _ = Describe("Podman pod kill", func() {
 
 		result := podmanTest.Podman([]string{"pod", "kill", "-s", "bogus", "test1"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
+		Expect(result).Should(ExitWithError(125, "invalid signal: bogus"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
 

--- a/test/e2e/pod_pause_test.go
+++ b/test/e2e/pod_pause_test.go
@@ -16,13 +16,21 @@ var _ = Describe("Podman pod pause", func() {
 	It("podman pod pause bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "pause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		expect := "no pod with name or ID foobar found: no such pod"
+		if IsRemote() {
+			expect = `unable to find pod "foobar": no such pod`
+		}
+		Expect(session).To(ExitWithError(125, expect))
 	})
 
 	It("podman unpause bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "unpause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		expect := "no pod with name or ID foobar found: no such pod"
+		if IsRemote() {
+			expect = `unable to find pod "foobar": no such pod`
+		}
+		Expect(session).To(ExitWithError(125, expect))
 	})
 
 	It("podman pod pause a created pod by id", func() {

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Podman ps", func() {
 	It("podman pod ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"pod", "ps", "-q", "--format", "{{.ID}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "quiet and format cannot be used together"))
 
 	})
 


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

This commit handles a subset of test/e2e/pod_xxxx_test.go
(I stopped before this grew too huge for review)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```