### PR TITLE
ExitWithError() - more run_xxx tests

### DIFF
--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -98,7 +98,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 		skipIfAppArmorDisabled()
 		session := podmanTest.Podman([]string{"run", "--security-opt", "apparmor=invalid", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(126, `AppArmor profile "invalid" specified but not loaded`))
 	})
 
 	It("podman run apparmor unconfined", func() {
@@ -118,7 +118,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 		// Should fail if user specifies apparmor on disabled system
 		session := podmanTest.Podman([]string{"create", "--security-opt", fmt.Sprintf("apparmor=%s", apparmor.Profile), ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, fmt.Sprintf(`apparmor profile "%s" specified, but Apparmor is not enabled on this system`, apparmor.Profile)))
 	})
 
 	It("podman run apparmor disabled no default", func() {

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -109,13 +109,13 @@ var _ = Describe("Podman run cpu", func() {
 	It("podman run cpus and cpu-period", func() {
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-period=5000", "--cpus=0.5", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, "--cpu-period and --cpus cannot be set together"))
 	})
 
 	It("podman run cpus and cpu-quota", func() {
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-quota=5000", "--cpus=0.5", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, "--cpu-quota and --cpus cannot be set together"))
 	})
 
 	It("podman run invalid cpu-rt-period with cgroupsv2", func() {

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Podman run device", func() {
 	It("podman run device rename and bad permission test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(ExitWithError(125, "invalid device mode: rd"))
 	})
 
 	It("podman run device host device and container device parameter are directories", func() {
@@ -96,6 +96,7 @@ var _ = Describe("Podman run device", func() {
 		session2 := podmanTest.Podman([]string{"run", ALPINE, "test", "-c", "/dev/kmsg"})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(Exit(1))
+		Expect(session2.OutputToString()).To(BeEmpty())
 	})
 
 	It("podman run CDI device test", func() {

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add bad dns server", func() {
 		session := podmanTest.Podman([]string{"run", "--dns=foobar", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "foobar is not an ip address"))
 	})
 
 	It("podman run add dns server", func() {
@@ -46,7 +46,7 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add bad host", func() {
 		session := podmanTest.Podman([]string{"run", "--add-host=foo:1.2", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `invalid IP address in add-host: "1.2"`))
 	})
 
 	It("podman run add host", func() {
@@ -78,15 +78,15 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run mutually excludes --dns* and --network", func() {
 		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "container:ALPINE", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: container"))
 
 		session = podmanTest.Podman([]string{"run", "--dns-opt=1.2.3.4", "--network", "container:ALPINE", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: container"))
 
 		session = podmanTest.Podman([]string{"run", "--dns-search=foobar.com", "--network", "none", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: none"))
 
 		session = podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -82,14 +82,13 @@ var _ = Describe("Podman run memory", func() {
 		// create a container that gets oomkilled
 		session := podmanTest.Podman([]string{"run", "--name", ctrName, "--read-only", "--memory-swap=20m", "--memory=20m", "--oom-score-adj=1000", ALPINE, "sort", "/dev/urandom"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError())
+		Expect(session).Should(ExitWithError(137))
 
 		inspect := podmanTest.Podman(([]string{"inspect", "--format", "{{.State.OOMKilled}} {{.State.ExitCode}}", ctrName}))
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(ExitCleanly())
 		// Check oomkilled and exit code values
-		Expect(inspect.OutputToString()).Should(ContainSubstring("true"))
-		Expect(inspect.OutputToString()).Should(ContainSubstring("137"))
+		Expect(inspect.OutputToString()).Should(Equal("true 137"))
 	})
 
 	It("podman run memory test on successfully exited container", func() {
@@ -102,7 +101,6 @@ var _ = Describe("Podman run memory", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(ExitCleanly())
 		// Check oomkilled and exit code values
-		Expect(inspect.OutputToString()).Should(ContainSubstring("false"))
-		Expect(inspect.OutputToString()).Should(ContainSubstring("0"))
+		Expect(inspect.OutputToString()).Should(Equal("false 0"))
 	})
 })

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run ns", func() {
 
 		session = podmanTest.Podman([]string{"run", "--pid=badpid", fedoraMinimal, "bash", "-c", "echo $$"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "unrecognized namespace mode badpid passed"))
 	})
 
 	It("podman run --cgroup private test", func() {
@@ -79,7 +79,7 @@ var _ = Describe("Podman run ns", func() {
 	It("podman run bad ipc pid test", func() {
 		session := podmanTest.Podman([]string{"run", "--ipc=badpid", fedoraMinimal, "bash", "-c", "echo $$"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "unrecognized namespace mode badpid passed"))
 	})
 
 	It("podman run mounts fresh cgroup", func() {

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -71,7 +71,7 @@ USER 1000`, ALPINE)
 	It("podman run non-numeric group not specified in container", func() {
 		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "root:doesnotexist", BB, "mount"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(126, "unable to find group doesnotexist: no matching entries in group file"))
 	})
 
 	It("podman run numeric group specified in container", func() {

--- a/test/e2e/run_seccomp_test.go
+++ b/test/e2e/run_seccomp_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman run", func() {
@@ -25,7 +24,7 @@ var _ = Describe("Podman run", func() {
 	It("podman run --seccomp-policy invalid", func() {
 		session := podmanTest.Podman([]string{"run", "--seccomp-policy", "invalid", alpineSeccomp, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `invalid seccomp policy "invalid": valid policies are ["default" "image"]`))
 	})
 
 	It("podman run --seccomp-policy image (block all syscalls)", func() {
@@ -34,12 +33,23 @@ var _ = Describe("Podman run", func() {
 		// TODO: we're getting a "cannot start a container that has
 		//       stopped" error which seems surprising.  Investigate
 		//       why that is so.
-		Expect(session).To(ExitWithError())
+		if podmanTest.OCIRuntime == "runc" {
+			// TODO: worse than that. With runc, we get two alternating failures:
+			//   126 + cannot start a container that has stopped
+			//   127 + failed to connect to container's attach socket ... ENOENT
+			Expect(session).To(ExitWithError())
+		} else {
+			expect := "OCI runtime error: crun: read from the init process"
+			if IsRemote() {
+				expect = "for attach: crun: read from the init process: OCI runtime error"
+			}
+			Expect(session).To(ExitWithError(126, expect))
+		}
 	})
 
 	It("podman run --seccomp-policy image (bogus profile)", func() {
 		session := podmanTest.Podman([]string{"run", "--seccomp-policy", "image", alpineBogusSeccomp, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(ExitWithError(125, "loading seccomp profile failed: decoding seccomp profile failed: invalid character 'B' looking for beginning of value"))
 	})
 })


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

This commit handles a subset of test/e2e/run_xxx_test.go

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```