### PR TITLE
ExitWithError() - s files

### DIFF
--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Podman save", func() {
 
 		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, "FOOBAR"})
 		save.WaitWithDefaultTimeout()
-		Expect(save).To(ExitWithError())
+		Expect(save).To(ExitWithError(125, "repository name must be lowercase"))
 	})
 
 	It("podman save to directory with oci format", func() {
@@ -102,13 +102,11 @@ var _ = Describe("Podman save", func() {
 
 		save := podmanTest.Podman([]string{"save", "-q", "--compress", "--format", "docker-archive", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
-		// should not be 0
-		Expect(save).To(ExitWithError())
+		Expect(save).To(ExitWithError(125, "--compress can only be set when --format is 'docker-dir'"))
 
 		save = podmanTest.Podman([]string{"save", "-q", "--compress", "--format", "oci-archive", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
-		// should not be 0
-		Expect(save).To(ExitWithError())
+		Expect(save).To(ExitWithError(125, "--compress can only be set when --format is 'docker-dir'"))
 
 	})
 
@@ -117,7 +115,7 @@ var _ = Describe("Podman save", func() {
 
 		save := podmanTest.Podman([]string{"save", "-q", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
-		Expect(save).To(ExitWithError())
+		Expect(save).To(ExitWithError(125, fmt.Sprintf(`invalid filename (should not contain ':') "%s"`, outdir)))
 	})
 
 	It("podman save remove signature", func() {
@@ -199,7 +197,7 @@ default-docker:
 			outfile := filepath.Join(podmanTest.TempDir, "temp.tar")
 			save := podmanTest.Podman([]string{"save", "-q", "remove-signatures=true", "-o", outfile, pushedImage})
 			save.WaitWithDefaultTimeout()
-			Expect(save).To(ExitWithError())
+			Expect(save).To(ExitWithError(125, "invalid reference format"))
 		}
 	})
 

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -39,8 +39,7 @@ var _ = Describe("Podman secret", func() {
 
 		session = podmanTest.Podman([]string{"secret", "create", "-d", "file", "--driver-opts", "opt1=val1", "a", secretFilePath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(Equal("Error: a: secret name in use"))
+		Expect(session).Should(ExitWithError(125, "Error: a: secret name in use"))
 
 		session = podmanTest.Podman([]string{"secret", "create", "-d", "file", "--driver-opts", "opt1=val1", "--replace", "a", secretFilePath})
 		session.WaitWithDefaultTimeout()
@@ -49,8 +48,7 @@ var _ = Describe("Podman secret", func() {
 
 		inspect = podmanTest.Podman([]string{"secret", "inspect", "-f", "{{.Spec.Driver.Options}}", secrID})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).To(ExitWithError())
-		Expect(inspect.ErrorToString()).To(ContainSubstring(fmt.Sprintf("Error: inspecting secret: no secret with name or id %q: no such secret", secrID)))
+		Expect(inspect).To(ExitWithError(125, fmt.Sprintf("Error: inspecting secret: no secret with name or id %q: no such secret", secrID)))
 
 		inspect = podmanTest.Podman([]string{"secret", "inspect", "-f", "{{.Spec.Driver.Options}}", "a"})
 		inspect.WaitWithDefaultTimeout()
@@ -66,14 +64,12 @@ var _ = Describe("Podman secret", func() {
 		badName := "foo/bar"
 		session := podmanTest.Podman([]string{"secret", "create", badName, secretFilePath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(Equal(fmt.Sprintf("Error: secret name %q can not include '=', '/', ',', or the '\\0' (NULL) and be between 1 and 253 characters: invalid secret name", badName)))
+		Expect(session).To(ExitWithError(125, fmt.Sprintf("Error: secret name %q can not include '=', '/', ',', or the '\\0' (NULL) and be between 1 and 253 characters: invalid secret name", badName)))
 
 		badName = "foo=bar"
 		session = podmanTest.Podman([]string{"secret", "create", badName, secretFilePath})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(Equal(fmt.Sprintf("Error: secret name %q can not include '=', '/', ',', or the '\\0' (NULL) and be between 1 and 253 characters: invalid secret name", badName)))
+		Expect(session).To(ExitWithError(125, fmt.Sprintf("Error: secret name %q can not include '=', '/', ',', or the '\\0' (NULL) and be between 1 and 253 characters: invalid secret name", badName)))
 	})
 
 	It("podman secret inspect", func() {
@@ -164,7 +160,7 @@ var _ = Describe("Podman secret", func() {
 
 		inspect := podmanTest.Podman([]string{"secret", "inspect", "bogus"})
 		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).To(ExitWithError())
+		Expect(inspect).To(ExitWithError(125, `inspecting secret: no secret with name or id "bogus": no such secret`))
 	})
 
 	It("podman secret ls", func() {
@@ -352,7 +348,7 @@ var _ = Describe("Podman secret", func() {
 		// no env variable set, should fail
 		session := podmanTest.Podman([]string{"secret", "create", "--env", "a", "MYENVVAR"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "cannot create store secret data: environment variable MYENVVAR is not set"))
 
 		os.Setenv("MYENVVAR", "somedata")
 		if IsRemote() {

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // TODO: we need to check the output. Currently, we only check the exit codes
@@ -25,7 +24,12 @@ var _ = Describe("Podman stats", func() {
 	It("podman stats with bogus container", func() {
 		session := podmanTest.Podman([]string{"stats", "--no-stream", "123"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		expect := `unable to get list of containers: unable to look up container 123: no container with name or ID "123" found: no such container`
+		// FIXME: #22612
+		if IsRemote() {
+			expect = "types.ContainerStatsReport.Error: decode non empty interface: can not unmarshal into nil, error found in #9 byte"
+		}
+		Expect(session).Should(ExitWithError(125, expect))
 	})
 
 	It("podman stats on a running container", func() {
@@ -81,7 +85,7 @@ var _ = Describe("Podman stats", func() {
 		Expect(session).Should(ExitCleanly())
 		stats := podmanTest.Podman([]string{"stats", "-a", "--no-reset", "--no-stream", "--format", "\"table {{.ID}} {{.NoSuchField}} \""})
 		stats.WaitWithDefaultTimeout()
-		Expect(stats).To(ExitWithError())
+		Expect(stats).To(ExitWithError(125, `template: stats:1:28: executing "stats" at <.NoSuchField>: can't evaluate field NoSuchField in type containers.containerStats`))
 	})
 
 	It("podman stats with negative interval", func() {
@@ -90,7 +94,7 @@ var _ = Describe("Podman stats", func() {
 		Expect(session).Should(ExitCleanly())
 		stats := podmanTest.Podman([]string{"stats", "-a", "--no-reset", "--no-stream", "--interval=-1"})
 		stats.WaitWithDefaultTimeout()
-		Expect(stats).To(ExitWithError())
+		Expect(stats).To(ExitWithError(125, "invalid interval, must be a positive number greater zero"))
 	})
 
 	It("podman stats with zero interval", func() {
@@ -99,7 +103,7 @@ var _ = Describe("Podman stats", func() {
 		Expect(session).Should(ExitCleanly())
 		stats := podmanTest.Podman([]string{"stats", "-a", "--no-reset", "--no-stream", "--interval=0"})
 		stats.WaitWithDefaultTimeout()
-		Expect(stats).To(ExitWithError())
+		Expect(stats).To(ExitWithError(125, "invalid interval, must be a positive number greater zero"))
 	})
 
 	It("podman stats with interval", func() {

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -95,8 +95,7 @@ var _ = Describe("podman system df", func() {
 	It("podman system df --format with --verbose", func() {
 		session := podmanTest.Podman([]string{"system", "df", "--format", "json", "--verbose"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(Equal("Error: cannot combine --format and --verbose flags"))
+		Expect(session).To(ExitWithError(125, "Error: cannot combine --format and --verbose flags"))
 	})
 
 	It("podman system df --format json", func() {


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

This commit handles test/e2e/s*_test.go

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```