### PR TITLE
test/e2e: remove toolbox image

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -161,7 +161,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	podman := PodmanTestSetup(filepath.Join(globalTmpDir, "image-init"))
 
 	// Pull cirros but don't put it into the cache
-	pullImages := []string{CIRROS_IMAGE, fedoraToolbox, volumeTest}
+	pullImages := []string{CIRROS_IMAGE, volumeTest}
 	pullImages = append(pullImages, CACHE_IMAGES...)
 	for _, image := range pullImages {
 		podman.createArtifact(image)

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -13,7 +13,6 @@ var (
 	INFRA_IMAGE       = "quay.io/libpod/k8s-pause:3.5" //nolint:revive,stylecheck
 	BB                = "quay.io/libpod/busybox:latest"
 	HEALTHCHECK_IMAGE = "quay.io/libpod/alpine_healthcheck:latest" //nolint:revive,stylecheck
-	fedoraToolbox     = "registry.fedoraproject.org/fedora-toolbox:36"
 	volumeTest        = "quay.io/libpod/volume-plugin-test-img:20220623"
 
 	// This image has seccomp profiles that blocks all syscalls.

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -1,15 +1,15 @@
 package integration
 
 var (
-	STORAGE_FS               = "overlay"                                                                                                                                  //nolint:revive,stylecheck
-	STORAGE_OPTIONS          = "--storage-driver overlay"                                                                                                                 //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_FS      = "overlay"                                                                                                                                  //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_OPTIONS = "--storage-driver overlay"                                                                                                                 //nolint:revive,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
-	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                                       //nolint:revive,stylecheck
-	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                          //nolint:revive,stylecheck
-	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                            //nolint:revive,stylecheck
-	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"                                                                                                        //nolint:revive,stylecheck
-	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20240124"                                                                                                    //nolint:revive,stylecheck
-	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                             //nolint:revive,stylecheck
+	STORAGE_FS               = "overlay"                                                                                                                   //nolint:revive,stylecheck
+	STORAGE_OPTIONS          = "--storage-driver overlay"                                                                                                  //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_FS      = "overlay"                                                                                                                   //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_OPTIONS = "--storage-driver overlay"                                                                                                  //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE} //nolint:revive,stylecheck
+	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                        //nolint:revive,stylecheck
+	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                           //nolint:revive,stylecheck
+	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                             //nolint:revive,stylecheck
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"                                                                                         //nolint:revive,stylecheck
+	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20240124"                                                                                     //nolint:revive,stylecheck
+	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                              //nolint:revive,stylecheck
 )

--- a/test/e2e/config_arm64.go
+++ b/test/e2e/config_arm64.go
@@ -1,15 +1,15 @@
 package integration
 
 var (
-	STORAGE_FS               = "overlay"                                                                                                                                                 //nolint:revive,stylecheck
-	STORAGE_OPTIONS          = "--storage-driver overlay"                                                                                                                                //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_FS      = "overlay"                                                                                                                                                 //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_OPTIONS = "--storage-driver overlay"                                                                                                                                //nolint:revive,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE, fedoraToolbox} //nolint:revive,stylecheck
-	NGINX_IMAGE              = "quay.io/lsm5/alpine_nginx-aarch64:latest"                                                                                                                //nolint:revive,stylecheck
-	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                         //nolint:revive,stylecheck
-	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                                           //nolint:revive,stylecheck
-	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"                                                                                                                       //nolint:revive,stylecheck
-	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20240124"                                                                                                                   //nolint:revive,stylecheck
-	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                            //nolint:revive,stylecheck
+	STORAGE_FS               = "overlay"                                                                                                                                  //nolint:revive,stylecheck
+	STORAGE_OPTIONS          = "--storage-driver overlay"                                                                                                                 //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_FS      = "overlay"                                                                                                                                  //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_OPTIONS = "--storage-driver overlay"                                                                                                                 //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE} //nolint:revive,stylecheck
+	NGINX_IMAGE              = "quay.io/lsm5/alpine_nginx-aarch64:latest"                                                                                                 //nolint:revive,stylecheck
+	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                          //nolint:revive,stylecheck
+	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.8.2"                                                                                                            //nolint:revive,stylecheck
+	CITEST_IMAGE             = "quay.io/libpod/testimage:20240123"                                                                                                        //nolint:revive,stylecheck
+	SYSTEMD_IMAGE            = "quay.io/libpod/systemd-image:20240124"                                                                                                    //nolint:revive,stylecheck
+	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                             //nolint:revive,stylecheck
 )


### PR DESCRIPTION
The image is way to big (over 800MB) that slows tests down as we always have to pull this, the tests itself are also super slow due the entrypoint logic that we don't care about. We should be testing for features needed and not specific tools.

I think the current changes should have a similar coverage in terms of podman features, it no longer tests toolbox but IMO this never was a task for podman CI tests.

The main driver for this is to make the tests run entirely based on tmpfs and this image is just to much[1].

[1] https://github.com/containers/podman/pull/22533

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
