### PR TITLE
[CI:DOCS]Add missing option 'healthy' to output of `podman run --help`

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -418,7 +418,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.StringVar(
 			&cf.SdNotifyMode,
 			sdnotifyFlagName, cf.SdNotifyMode,
-			`control sd-notify behavior ("container"|"conmon"|"ignore")`,
+			`control sd-notify behavior ("container"|"conmon"|"healthy"|"ignore")`,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(sdnotifyFlagName, AutocompleteSDNotify)
 


### PR DESCRIPTION
The `podman run --sdnotify=healthy` option was implemented some time ago. It's correctly mentioned in the documentation but was missing in the usage text of `podman run --help`.
 
I'm not sure if this is a valid `[CI:DOCS]` PR or not because it's technically in the code but it's also just a single line usage text change.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
