### PR TITLE
util: specify a not empty pause dir for root too

### DIFF
--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -28,7 +28,7 @@ func GetRootlessConfigHomeDir() (string, error) {
 // GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
 // the pause process.
 func GetRootlessPauseProcessPidPath() (string, error) {
-	runtimeDir, err := GetRootlessRuntimeDir()
+	runtimeDir, err := homedir.GetRuntimeDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -764,3 +764,9 @@ func TestProcessOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRootlessPauseProcessPidPath(t *testing.T) {
+	dir, err := GetRootlessPauseProcessPidPath()
+	assert.NoError(t, err)
+	assert.NotEqual(t, dir, "libpod/tmp/pause.pid")
+}


### PR DESCRIPTION
commit b3014c1c69d5870104aa45f7caae7af041094171 changed GetRootlessRuntimeDir() to return an empty string for root, so that its value is not exported as XDG_RUNTIME_DIR, and other programs like crun can use a better default.

Now GetRootlessPauseProcessPidPath() uses homedir.GetRuntimeDir(). The homedir.GetRuntimeDir() function returns a value also when running as root so it can be used inside a nested Podman.

Closes: https://github.com/containers/podman/issues/22327

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
