### PR TITLE
ExitWithError() - v files

### DIFF
--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Podman volume create", func() {
 
 		session = podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "volume with name myvol already exists: volume already exists"))
 	})
 
 	It("podman create volume --ignore", func() {
@@ -133,24 +133,21 @@ var _ = Describe("Podman volume create", func() {
 
 		session := podmanTest.Podman([]string{"volume", "import", "notfound", "notfound.tar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("open notfound.tar: no such file or directory"))
+		Expect(session).To(ExitWithError(125, "open notfound.tar: no such file or directory"))
 
 		session = podmanTest.Podman([]string{"volume", "import", "notfound", "-"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("no such volume notfound"))
+		Expect(session).To(ExitWithError(125, "no such volume notfound"))
 
 		session = podmanTest.Podman([]string{"volume", "export", "notfound"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("no such volume notfound"))
+		Expect(session).To(ExitWithError(125, "no such volume notfound"))
 	})
 
 	It("podman create volume with bad volume option", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--opt", "badOpt=bad"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "invalid mount option badOpt for driver 'local': invalid argument"))
 	})
 
 	It("podman create volume with o=uid,gid", func() {

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -27,13 +27,13 @@ var _ = Describe("Podman volume plugins", func() {
 	It("volume create with nonexistent plugin errors", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--driver", "notexist", "test_volume_name"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "volume test_volume_name uses volume plugin notexist but it could not be retrieved: no volume plugin with name notexist available: required plugin missing"))
 	})
 
 	It("volume create with not-running plugin does not error", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--driver", "testvol0", "test_volume_name"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `Error: volume test_volume_name uses volume plugin testvol0 but it could not be retrieved: cannot access plugin testvol0 socket "/run/docker/plugins/testvol0.sock": stat /run/docker/plugins/testvol0.sock: no such file or directory`))
 	})
 
 	It("volume create and remove with running plugin succeeds", func() {
@@ -145,7 +145,7 @@ var _ = Describe("Podman volume plugins", func() {
 		// Remove should exit non-zero because missing plugin
 		remove := podmanTest.Podman([]string{"volume", "rm", volName})
 		remove.WaitWithDefaultTimeout()
-		Expect(remove).To(ExitWithError())
+		Expect(remove).To(ExitWithError(125, "cannot remove volume testVolume1 from plugin testvol3, but it has been removed from Podman: required plugin missing"))
 
 		// But the volume should still be gone
 		ls2 := podmanTest.Podman([]string{"volume", "ls", "-q"})


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

This commit handles test/e2e/v*_test.go

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```