### PR TITLE
[CI:DOCS] update golangci-lint to 1.58

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     - dupword # too many false positives (e.g., in tests)
     - gocognit
     - testpackage
-    - goerr113
+    - err113
     - exhaustivestruct
     - errorlint
     - wrapcheck
@@ -50,10 +50,12 @@ linters:
     - gosec
     - maligned
     - musttag # way to many warnings to fix for now, also some false positives
+    - mnd # way to many false positives
     - gomoddirectives
     - containedctx
     - contextcheck
     - cyclop
+    - canonicalheader # our current header values are fixed and should not be changed
     - errname
     - forcetypeassert
     - ireturn
@@ -69,6 +71,7 @@ linters:
     - deadcode    # deprecated since v1.49.0, replaced by unused
     - structcheck # deprecated since v1.49.0, replaced by unused
     - varcheck    # deprecated since v1.49.0, replaced by unused
+    - execinquery
 linters-settings:
   errcheck:
     check-blank: false

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 1.57.2
+GOLANGCI_LINT_VERSION := 1.58.0
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems


### PR DESCRIPTION
disable linters:
- mnd (magic number checker): it seems to complain about almost anything, while there might be a few valid findings most of them are useless
- canonicalheader: HTTP header syntax, most of the header are given by docker and are stable so we cannot change them anyway
- execinquery: it has been deprecated

goerr113 was renamed to err113

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
