### PR TITLE
[v4.4.1-rhel] Fix artifacts task failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -974,12 +974,6 @@ artifacts_task:
         - tar xjf repo.tbz
         - mv ./podman-remote-release-darwin_*.zip $CIRRUS_WORKING_DIR/
         - mv ./contrib/pkginstaller/out/podman-installer-macos-*.pkg $CIRRUS_WORKING_DIR/
-    benchmarks_script:
-        - mkdir -p /tmp/benchmarks
-        - cd /tmp/benchmarks
-        - $ARTCURL/podman_machine/benchmark.zip
-        - unzip benchmark.zip
-        - mv ./data/benchmarks.{env,csv} $CIRRUS_WORKING_DIR/
     always:
       contents_script: ls -la $CIRRUS_WORKING_DIR
       # Produce downloadable files and an automatic zip-file accessible


### PR DESCRIPTION
PR https://github.com/containers/podman/pull/22540 removed the job that generated the (useless) benchmark data
generation.  However it neglected to stop addition of the data to the
output artifacts.  Fix this.

Ref: [Example of failing cirrus-cron job](https://cirrus-ci.com/task/5937026929786880).

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
