### PR TITLE
Skip machine tests if they don't need to be run

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -412,7 +412,8 @@ dotest() {
 }
 
 _run_machine-linux() {
-    # N/B: Can't use _bail_if_test_can_be_skipped here b/c content isn't under test/
+    _bail_if_test_can_be_skipped pkg/machine/e2e
+
     showrun make localmachine |& logformatter
 }
 


### PR DESCRIPTION
Followup to #13936 : add an exclusion to localmachine tests
so we can avoid running those on test- or doc-only PRs.
Reason: #22551, the machine-start-timeout flake, is causing
hours of wasted time.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```