### PR TITLE
[skip-ci] RPM: `bats` required only on Fedora

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -143,7 +143,9 @@ pages and %{name}.
 Summary: Tests for %{name}
 
 Requires: %{name} = %{epoch}:%{version}-%{release}
+%if %{defined fedora}
 Requires: bats
+%endif
 Requires: jq
 Requires: skopeo
 Requires: nmap-ncat


### PR DESCRIPTION
The `bats` package is not present on RHEL environments. It should be conditionalized only for Fedora to avoid `installibility` test failures.

C9S Ref: https://gitlab.com/redhat/centos-stream/rpms/podman/-/blob/c9s/podman.spec?ref_type=heads#L130

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
