### PR TITLE
test: improve test for powercap presence

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v5/libpod/define"
 	. "github.com/containers/podman/v5/test/utils"
+	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -455,8 +456,8 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run powercap is masked", func() {
-		if os.Getenv("CI") != "" {
-			Skip("CI VMs do not have access to powercap")
+		if err := fileutils.Exists("/sys/devices/virtual/powercap"); err != nil {
+			Skip("/sys/devices/virtual/powercap is not present")
 		}
 
 		testCtr1 := "testctr"


### PR DESCRIPTION
check if the file path exists instead of using the env variable.

I hit the problem in the crun CI: https://github.com/containers/crun/actions/runs/8986352255/job/24682255111?pr=1465

```release-note
None
```
