### PR TITLE
machine: Add LibKrun provider detection

### DIFF
--- a/pkg/machine/provider/platform_test.go
+++ b/pkg/machine/provider/platform_test.go
@@ -11,7 +11,11 @@ import (
 func TestSupportedProviders(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
-		assert.Equal(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
+		if runtime.GOARCH == "arm64" {
+			assert.Equal(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
+		} else {
+			assert.Equal(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
+		}
 	case "windows":
 		assert.Equal(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
 	case "linux":
@@ -24,6 +28,7 @@ func TestInstalledProviders(t *testing.T) {
 	assert.Nil(t, err)
 	switch runtime.GOOS {
 	case "darwin":
+		// TODO: need to verify if an arm64 machine reports {applehv, libkrun}
 		assert.Equal(t, []define.VMType{define.AppleHvVirt}, installed)
 	case "windows":
 		provider, err := Get()
@@ -55,6 +60,9 @@ func TestBadSupportedProviders(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
+		if runtime.GOARCH != "arm64" {
+			assert.NotEqual(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
+		}
 	case "windows":
 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
 	case "linux":
@@ -68,6 +76,9 @@ func TestBadInstalledProviders(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, installed)
+		if runtime.GOARCH != "arm64" {
+			assert.NotEqual(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, installed)
+		}
 	case "windows":
 		assert.NotContains(t, installed, define.QemuVirt)
 	case "linux":


### PR DESCRIPTION
Adds provider detection for LibKrun in `pkg/provider/platform_darwin.go`.

Changes the macOS version check to 13 instead of 11, and now uses the `semver` package to verify current version.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
