### PR TITLE
CM VMs: bump f39/f38 to f40/f39

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,14 +26,14 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-39"
+    FEDORA_NAME: "fedora-40"
     FEDORA_AARCH64_NAME: "${FEDORA_NAME}-aarch64"
-    PRIOR_FEDORA_NAME: "fedora-38"
+    PRIOR_FEDORA_NAME: "fedora-39"
     RAWHIDE_NAME: "rawhide"
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240411t124913z-f39f38d13"
+    IMAGE_SUFFIX: "c20240506t132946z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -147,6 +147,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		// a hotrod workstation. Assume they know what they're doing.
 		baseTmpDir = ""
 	}
+	// FIXME: #22533 (debian pasta apparmor bug): CHECK THIS AFTER 2024-05-30!
+	info := GetHostDistributionInfo()
+	if info.Distribution == "debian" {
+		baseTmpDir = "/tmp"
+	}
 	globalTmpDir, err := os.MkdirTemp(baseTmpDir, "podman-e2e-")
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Images built in https://github.com/containers/automation_images/pull/349

Include a **TEMPORARY** workaround for Debian Pasta Apparmor bug
that is preventing use of /var/tmp.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```