### PR TITLE
Remove duplicate `IsRemote`  call

### DIFF
--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -122,15 +122,14 @@ func pullFlags(cmd *cobra.Command) {
 
 	if registry.IsRemote() {
 		_ = flags.MarkHidden(decryptionKeysFlagName)
-	}
-	if !registry.IsRemote() {
+	} else {
 		certDirFlagName := "cert-dir"
 		flags.StringVar(&pullOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")
 		_ = cmd.RegisterFlagCompletionFunc(certDirFlagName, completion.AutocompleteDefault)
-	}
-	if !registry.IsRemote() {
-		flags.StringVar(&pullOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
-		_ = flags.MarkHidden("signature-policy")
+
+		signaturePolicyFlagName := "signature-policy"
+		flags.StringVar(&pullOptions.SignaturePolicy, signaturePolicyFlagName, "", "`Pathname` of signature policy file (not usually used)")
+		_ = flags.MarkHidden(signaturePolicyFlagName)
 	}
 }
 

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -162,10 +162,10 @@ func pushFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden(signPassphraseFileFlagName)
 		_ = flags.MarkHidden(encryptionKeysFlagName)
 		_ = flags.MarkHidden(encryptLayersFlagName)
-	}
-	if !registry.IsRemote() {
-		flags.StringVar(&pushOptions.SignaturePolicy, "signature-policy", "", "Path to a signature-policy file")
-		_ = flags.MarkHidden("signature-policy")
+	} else {
+		signaturePolicyFlagName := "signature-policy"
+		flags.StringVar(&pushOptions.SignaturePolicy, signaturePolicyFlagName, "", "Path to a signature-policy file")
+		_ = flags.MarkHidden(signaturePolicyFlagName)
 	}
 }
 
@@ -257,7 +257,7 @@ func imagePush(cmd *cobra.Command, args []string) error {
 	}
 
 	if pushOptions.DigestFile != "" {
-		if err := os.WriteFile(pushOptions.DigestFile, []byte(report.ManifestDigest), 0644); err != nil {
+		if err := os.WriteFile(pushOptions.DigestFile, []byte(report.ManifestDigest), 0o644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Remove unnecessary IsRemote calls and replace them with the else syntax.
