### PR TITLE
ExitWithError() - rest of the p files

### DIFF
--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman pause", func() {
@@ -37,13 +36,13 @@ var _ = Describe("Podman pause", func() {
 	It("podman pause bogus container", func() {
 		session := podmanTest.Podman([]string{"pause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman unpause bogus container", func() {
 		session := podmanTest.Podman([]string{"unpause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `no container with name or ID "foobar" found: no such container`))
 	})
 
 	It("podman pause a created container by id", func() {
@@ -55,7 +54,7 @@ var _ = Describe("Podman pause", func() {
 		result := podmanTest.Podman([]string{"pause", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, `"created" is not running, can't pause: container state improper`))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(strings.ToLower(podmanTest.GetContainerStatus())).To(ContainSubstring(createdState))
 
@@ -107,7 +106,7 @@ var _ = Describe("Podman pause", func() {
 		result := podmanTest.Podman([]string{"unpause", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(125))
+		Expect(result).Should(ExitWithError(125, fmt.Sprintf(`"%s" is not paused, can't unpause: container state improper`, cid)))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 	})
@@ -128,7 +127,7 @@ var _ = Describe("Podman pause", func() {
 		result = podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(2))
+		Expect(result).Should(ExitWithError(2, fmt.Sprintf("cannot remove container %s as it is paused - running or paused containers cannot be removed without force: container state improper", cid)))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(strings.ToLower(podmanTest.GetContainerStatus())).To(ContainSubstring(pausedState))
 
@@ -175,7 +174,7 @@ var _ = Describe("Podman pause", func() {
 		result = podmanTest.Podman([]string{"stop", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result).Should(Exit(125))
+		Expect(result).Should(ExitWithError(125, fmt.Sprintf("Error: container %s is running or paused, refusing to clean up: container state improper", cid)))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(strings.ToLower(podmanTest.GetContainerStatus())).To(ContainSubstring(pausedState))
 
@@ -186,7 +185,7 @@ var _ = Describe("Podman pause", func() {
 
 		result = podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(2))
+		Expect(result).Should(ExitWithError(2, fmt.Sprintf("cannot remove container %s as it is running - running or paused containers cannot be removed without force: container state improper", cid)))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-f", cid})
@@ -382,40 +381,38 @@ var _ = Describe("Podman pause", func() {
 		SkipIfRemote("--latest flag n/a")
 		result := podmanTest.Podman([]string{"pause", "--cidfile", "foobar", "--latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all, --latest, and --cidfile cannot be used together"))
+
 		result = podmanTest.Podman([]string{"pause", "--cidfile", "foobar", "--all"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all, --latest, and --cidfile cannot be used together"))
+
 		result = podmanTest.Podman([]string{"pause", "--cidfile", "foobar", "--all", "--latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all, --latest, and --cidfile cannot be used together"))
+
 		result = podmanTest.Podman([]string{"pause", "--latest", "--all"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all and --latest cannot be used together"))
 	})
 
 	It("podman unpause invalid --latest and --cidfile and --all", func() {
 		SkipIfRemote("--latest flag n/a")
 		result := podmanTest.Podman([]string{"unpause", "--cidfile", "foobar", "--latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all, --latest, and --cidfile cannot be used together"))
+
 		result = podmanTest.Podman([]string{"unpause", "--cidfile", "foobar", "--all"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all, --latest, and --cidfile cannot be used together"))
+
 		result = podmanTest.Podman([]string{"unpause", "--cidfile", "foobar", "--all", "--latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all, --latest, and --cidfile cannot be used together"))
+
 		result = podmanTest.Podman([]string{"unpause", "--latest", "--all"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
+		Expect(result).Should(ExitWithError(125, "--all and --latest cannot be used together"))
 	})
 
 	It("podman pause --filter", func() {
@@ -437,11 +434,11 @@ var _ = Describe("Podman pause", func() {
 
 		session1 = podmanTest.Podman([]string{"pause", cid1, "-f", "status=test"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(125))
+		Expect(session1).Should(ExitWithError(125, "--filter takes no arguments"))
 
 		session1 = podmanTest.Podman([]string{"unpause", cid1, "-f", "status=paused"})
 		session1.WaitWithDefaultTimeout()
-		Expect(session1).Should(Exit(125))
+		Expect(session1).Should(ExitWithError(125, "--filter takes no arguments"))
 
 		session1 = podmanTest.Podman([]string{"pause", "-a", "--filter", "label=test=with,comma"})
 		session1.WaitWithDefaultTimeout()

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman pod stats", func() {
@@ -25,7 +24,7 @@ var _ = Describe("Podman pod stats", func() {
 	It("podman pod stats with a bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "stats", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(ExitWithError(125, "unable to get list of pods: no pod with name or ID foobar found: no such pod"))
 	})
 
 	It("podman pod stats on a specific running pod", func() {
@@ -151,7 +150,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(session).Should(ExitCleanly())
 		stats := podmanTest.Podman([]string{"pod", "stats", "-a", "--no-reset", "--no-stream", "--format", "\"table {{.ID}} \""})
 		stats.WaitWithDefaultTimeout()
-		Expect(stats).To(ExitWithError())
+		Expect(stats).To(ExitWithError(125, `template: stats:1:20: executing "stats" at <.ID>: can't evaluate field ID in type *types.PodStatsReport`))
 	})
 
 	It("podman pod stats on net=host post", func() {

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -14,13 +14,17 @@ var _ = Describe("Podman port", func() {
 	It("podman port all and latest", func() {
 		result := podmanTest.Podman([]string{"port", "-a", "-l"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		if IsRemote() {
+			Expect(result).To(ExitWithError(125, "unknown shorthand flag: 'l' in -l"))
+		} else {
+			Expect(result).To(ExitWithError(125, "--all and --latest cannot be used together"))
+		}
 	})
 
 	It("podman port all and extra", func() {
 		result := podmanTest.Podman([]string{"port", "-a", "foobar"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, "no arguments are needed with --all"))
 	})
 
 	It("podman port -l nginx", func() {

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var pruneImage = fmt.Sprintf(`
@@ -492,8 +491,7 @@ var _ = Describe("Podman prune", func() {
 	It("podman system prune --all --external fails", func() {
 		prune := podmanTest.Podman([]string{"system", "prune", "--all", "--external"})
 		prune.WaitWithDefaultTimeout()
-		Expect(prune).Should(Exit(125))
-		Expect(prune.ErrorToString()).To(ContainSubstring("--external cannot be combined with other options"))
+		Expect(prune).Should(ExitWithError(125, "--external cannot be combined with other options"))
 	})
 
 	It("podman system prune --external leaves referenced containers", func() {

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -406,11 +406,11 @@ var _ = Describe("Podman ps", func() {
 	It("podman ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"ps", "-aqs"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "quiet conflicts with size and namespace"))
 
 		session = podmanTest.Podman([]string{"ps", "-a", "--ns", "-s"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "size and namespace options conflict"))
 	})
 
 	It("podman --format by size", func() {
@@ -540,8 +540,7 @@ var _ = Describe("Podman ps", func() {
 			"run", "-p", "1000-2000:2000-3000", "-p", "1999-2999:3001-4001", ALPINE,
 		})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		Expect(session.ErrorToString()).To(ContainSubstring("conflicting port mappings for host port 1999"))
+		Expect(session).Should(ExitWithError(125, "conflicting port mappings for host port 1999 (protocol tcp)"))
 	})
 
 	It("podman ps test with multiple port range", func() {
@@ -666,7 +665,7 @@ var _ = Describe("Podman ps", func() {
 		session = podmanTest.Podman([]string{"run", "--name", "test2", "--label", "foo=1",
 			ALPINE, "ls", "/fail"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, "ls: /fail: No such file or directory"))
 
 		session = podmanTest.Podman([]string{"create", "--name", "test3", ALPINE, cid1})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -21,9 +21,7 @@ var _ = Describe("Podman pull", func() {
 
 		session = podmanTest.Podman([]string{"pull", "busybox:latest", "docker.io/library/ibetthisdoesnotexistfr:random", "alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError := "initializing source docker://ibetthisdoesnotexistfr:random"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "initializing source docker://ibetthisdoesnotexistfr:random: reading manifest random in quay.io/libpod/ibetthisdoesnotexistfr:"))
 
 		session = podmanTest.Podman([]string{"rmi", "busybox:musl", "alpine", "quay.io/libpod/cirros", "testdigest_v2s2@sha256:755f4d90b3716e2bf57060d249e2cd61c9ac089b1233465c5c2cb2d7ee550fdb"})
 		session.WaitWithDefaultTimeout()
@@ -31,11 +29,16 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull bogus image", func() {
+		// This is a NOP in CI; but in a developer environment, if user
+		// has a valid login to quay.io, pull fails with "repository not found"
+		defer func() {
+			os.Unsetenv("REGISTRY_AUTH_FILE")
+		}()
+		os.Setenv("REGISTRY_AUTH_FILE", "/tmp/this/does/not/exist")
+
 		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/ibetthisdoesntexist:there"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		// "Not authorized", not "Not Found", because that's how registries roll??
-		Expect(session.ErrorToString()).To(ContainSubstring("unauthorized: access to the requested resource is not authorized"))
+		Expect(session).To(ExitWithError(125, "nitializing source docker://quay.io/libpod/ibetthisdoesntexist:there: reading manifest there in quay.io/libpod/ibetthisdoesntexist: unauthorized: access to the requested resource is not authorized"))
 	})
 
 	It("podman pull with tag --quiet", func() {
@@ -141,7 +144,7 @@ var _ = Describe("Podman pull", func() {
 		// Without a tag/digest the input is normalized with the "latest" tag, see #11964
 		session = podmanTest.Podman([]string{"rmi", "testdigest_v2s2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, "testdigest_v2s2: image not known"))
 
 		session = podmanTest.Podman([]string{"rmi", "testdigest_v2s2@sha256:755f4d90b3716e2bf57060d249e2cd61c9ac089b1233465c5c2cb2d7ee550fdb"})
 		session.WaitWithDefaultTimeout()
@@ -171,8 +174,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull from docker with nonexistent --authfile", func() {
 		session := podmanTest.Podman([]string{"pull", "-q", "--authfile", "/tmp/nonexistent", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(Equal("Error: credential file is not accessible: faccessat /tmp/nonexistent: no such file or directory"))
+		Expect(session).To(ExitWithError(125, "credential file is not accessible: faccessat /tmp/nonexistent: no such file or directory"))
 	})
 
 	It("podman pull by digest (image list)", func() {
@@ -222,14 +224,16 @@ var _ = Describe("Podman pull", func() {
 		session := podmanTest.Podman([]string{"pull", "-q", "--arch=arm64", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
+
 		// inspect using the digest of the list
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RepoTags}}", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, fmt.Sprintf(`no such object: "%s"`, ALPINELISTDIGEST)))
 		// inspect using the digest of the list
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RepoDigests}}", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, fmt.Sprintf(`no such object: "%s"`, ALPINELISTDIGEST)))
+
 		// inspect using the digest of the arch-specific image's manifest
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RepoTags}}", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
@@ -336,9 +340,7 @@ var _ = Describe("Podman pull", func() {
 		// image.
 		session = podmanTest.Podman([]string{"pull", "-q", "docker-archive:./testdata/docker-two-images.tar.xz"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError := "Unexpected tar manifest.json: expected 1 item, got 2"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "Unexpected tar manifest.json: expected 1 item, got 2"))
 
 		// Now pull _one_ image from a multi-image archive via the name
 		// and index syntax.
@@ -361,15 +363,11 @@ var _ = Describe("Podman pull", func() {
 		// Now check for some errors.
 		session = podmanTest.Podman([]string{"pull", "-q", "docker-archive:./testdata/docker-two-images.tar.xz:foo.com/does/not/exist:latest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError = "Tag \"foo.com/does/not/exist:latest\" not found"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, `Tag "foo.com/does/not/exist:latest" not found`))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "docker-archive:./testdata/docker-two-images.tar.xz:@2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError = "Invalid source index @2, only 2 manifest items available"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "Invalid source index @2, only 2 manifest items available"))
 	})
 
 	It("podman pull from oci-archive", func() {
@@ -544,15 +542,11 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull --platform", func() {
 		session := podmanTest.Podman([]string{"pull", "-q", "--platform=linux/bogus", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError := "no image found in manifest list for architecture bogus"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "no image found in manifest list for architecture bogus"))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "--platform=linux/arm64", "--os", "windows", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError = "--platform option can not be specified with --arch or --os"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "--platform option can not be specified with --arch or --os"))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "--platform=linux/arm64", ALPINE})
 		session.WaitWithDefaultTimeout()
@@ -571,15 +565,11 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull --arch", func() {
 		session := podmanTest.Podman([]string{"pull", "-q", "--arch=bogus", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError := "no image found in manifest list for architecture bogus"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "no image found in manifest list for architecture bogus"))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "--arch=arm64", "--os", "windows", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		expectedError = "no image found in manifest list for architecture"
-		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
+		Expect(session).Should(ExitWithError(125, "no image found in manifest list for architecture"))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "--arch=arm64", ALPINE})
 		session.WaitWithDefaultTimeout()
@@ -610,7 +600,7 @@ var _ = Describe("Podman pull", func() {
 
 	Describe("podman pull and decrypt", func() {
 
-		decryptionTestHelper := func(imgPath string) *PodmanSessionIntegration {
+		decryptionTestHelper := func(imgPath string, expectedError1 string) *PodmanSessionIntegration {
 			bitSize := 1024
 			keyFileName := filepath.Join(podmanTest.TempDir, "key,withcomma")
 			publicKeyFileName, privateKeyFileName, err := WriteRSAKeyPair(keyFileName, bitSize)
@@ -630,12 +620,12 @@ var _ = Describe("Podman pull", func() {
 			// Pulling encrypted image without key should fail
 			session = podmanTest.Podman([]string{"pull", imgPath})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(125))
+			Expect(session).Should(ExitWithError(125, expectedError1))
 
 			// Pulling encrypted image with wrong key should fail
 			session = podmanTest.Podman([]string{"pull", "-q", "--decryption-key", wrongPrivateKeyFileName, "--tls-verify=false", imgPath})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(125))
+			Expect(session).Should(ExitWithError(125, "no suitable key unwrapper found or none of the private keys could be used for decryption"))
 
 			// Pulling encrypted image with correct key should pass
 			session = podmanTest.Podman([]string{"pull", "-q", "--decryption-key", privateKeyFileName, "--tls-verify=false", imgPath})
@@ -657,7 +647,7 @@ var _ = Describe("Podman pull", func() {
 			imgName := "localhost/name:tag"
 			imgPath := fmt.Sprintf("oci:%s:%s", bbdir, imgName)
 
-			session := decryptionTestHelper(imgPath)
+			session := decryptionTestHelper(imgPath, "invalid tar header")
 
 			Expect(session.LineInOutputContainsTag("localhost/name", "tag")).To(BeTrue())
 		})
@@ -687,7 +677,7 @@ var _ = Describe("Podman pull", func() {
 
 			imgPath := "localhost:5012/my-alpine"
 
-			session = decryptionTestHelper(imgPath)
+			session = decryptionTestHelper(imgPath, `initializing source docker://localhost:5012/my-alpine:latest: pinging container registry localhost:5012: Get "https://localhost:5012/v2/": http: server gave HTTP response to HTTPS client`)
 
 			Expect(session.LineInOutputContainsTag(imgPath, "latest")).To(BeTrue())
 		})


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

This commit handles all remaining test/e2e/p*_test.go

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```