### PR TITLE
[CI:DOCS] Improvements to make validatepr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,13 +291,7 @@ commit automatically with `git commit -s`.
 
 ### Go Format and lint
 
-All code changes must pass ``make validate`` and ``make lint``.
-
-```
-podman build -t gate -f contrib/gate/Dockerfile .
-```
-
-***N/B:*** **don't miss the dot (.) at the end, it's really important**
+All code changes must pass ``make validatepr``.
 
 ### Integration Tests
 

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ validatepr:
 	$(PODMANCMD) run --rm \
 		-v $(CURDIR):/go/src/github.com/containers/podman \
 		--security-opt label=disable \
+		-it \
 		-w /go/src/github.com/containers/podman \
 		quay.io/libpod/validatepr:latest  \
 		make .validatepr

--- a/contrib/validatepr/validatepr.sh
+++ b/contrib/validatepr/validatepr.sh
@@ -6,18 +6,46 @@ set -x
 # This script is intended to help developers contribute to the podman project. It
 # checks various pre-CI checks like building, linting, man-pages, etc.  It is meant
 # to be run in a specific container environment.
-#
 
-# build all require incantations of podman
-echo "Building windows ..."
-GOOS=windows CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/test.windows ./cmd/podman
-echo "Building darwin..."
-GOOS=darwin CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/test.darwin ./cmd/podman
+build() {
+    err=""
 
-# build podman
-echo "Building podman binaries ..."
-make binaries
+    echo "Building windows"
+    if ! GOOS=windows CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/podman-remote-windows ./cmd/podman; then
+        err+="\n - Windows "
+    fi
 
+    echo "Building darwin"
+    if ! GOOS=darwin CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/podman-remote-darwin ./cmd/podman; then
+        err+="\n - Darwin "
+    fi
 
-echo "Running validation tooling ..."
-make validate
+    echo "Building podman binaries"
+    if ! make binaries; then
+        err+="\n - Additional Binaries "
+    fi
+
+    if [ ! -z "$err" ]
+    then
+        echo -e "\033[31mFailed to build: ${err}\033[0m">&2
+        exit 1
+    fi
+}
+
+validate(){
+    echo "Running validation tooling"
+
+    # golangci-lint gobbles memory.
+    # By default, podman machines only have 2GB memory,
+    # often causing the linter be killed when run on Darwin/Windows
+    mem=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+    if (( $((mem)) < 3900000 )); then
+        echo -e "\033[33mWarning: Your machine may not have sufficient memory (< 4 GB)to run the linter. \
+If the process is killed, please allocate more memory.\033[0m">&2
+    fi
+
+    make validate
+}
+
+build
+validate


### PR DESCRIPTION
Small usability improvements for our containerized validate target.

- Responds to SIGINT
- Exits if build fails, only validate if builds succeed
- Warns about potential of insufficient memory
- Document `make validatepr`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
