### PR TITLE
ExitWithError() - more r files

### DIFF
--- a/test/e2e/rename_test.go
+++ b/test/e2e/rename_test.go
@@ -13,7 +13,7 @@ var _ = Describe("podman rename", func() {
 	It("podman rename on non-existent container", func() {
 		session := podmanTest.Podman([]string{"rename", "doesNotExist", "aNewName"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, `no container with name or ID "doesNotExist" found: no such container`))
 	})
 
 	It("Podman rename on existing container with bad name", func() {
@@ -25,7 +25,7 @@ var _ = Describe("podman rename", func() {
 		newName := "invalid<>:char"
 		rename := podmanTest.Podman([]string{"rename", ctrName, newName})
 		rename.WaitWithDefaultTimeout()
-		Expect(rename).To(ExitWithError())
+		Expect(rename).To(ExitWithError(125, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument"))
 
 		ps := podmanTest.Podman([]string{"ps", "-aq", "--filter", fmt.Sprintf("name=%s", ctrName), "--format", "{{ .Names }}"})
 		ps.WaitWithDefaultTimeout()

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		Expect(killSession).Should(ExitCleanly())
 
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(2, "SIGFPE: floating-point exception"))
 		Expect(session.OutputToString()).To(Not(ContainSubstring("Received")))
 	})
 

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -20,19 +20,19 @@ var _ = Describe("Podman run with --ip flag", func() {
 	It("Podman run --ip with garbage address", func() {
 		result := podmanTest.Podman([]string{"run", "--ip", "114232346", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, `"114232346" is not an ip address`))
 	})
 
 	It("Podman run --ip with v6 address", func() {
 		result := podmanTest.Podman([]string{"run", "--ip", "2001:db8:bad:beef::1", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(126, "requested static ip 2001:db8:bad:beef::1 not in any subnet on network podman"))
 	})
 
 	It("Podman run --ip with non-allocatable IP", func() {
 		result := podmanTest.Podman([]string{"run", "--ip", "203.0.113.124", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(126, "requested static ip 203.0.113.124 not in any subnet on network podman"))
 	})
 
 	It("Podman run with specified static IP has correct IP", func() {


### PR DESCRIPTION
Followup to #22270: wherever possible/practical, extend command
error checks to include explicit exit status codes and error strings.

This commit handles all remaining test/e2e/r*_test.go

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```