### PR TITLE
[CI:DOCS] Trigger windows installer action properly

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -180,5 +180,7 @@ jobs:
       if: >-
           steps.check.outputs.windows_amd == 'true' ||
           steps.actual_dryrun.outputs.dryrun == 'false'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh workflow run upload-win-installer.yml -f ${{steps.getversion.outputs.version}} -f dryrun=false
+        gh workflow run upload-win-installer.yml -f version=${{steps.getversion.outputs.version}} -f dryrun=false


### PR DESCRIPTION
Add the needed GH_TOKEN for the windows action.

See: https://github.com/containers/podman/actions/runs/9036143646/job/24832415217#step:17:1
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
