### PR TITLE
Fix podman-remote support for `podman farm build`

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -119,11 +119,14 @@ func DefineBuildFlags(cmd *cobra.Command, buildOpts *BuildFlagsWrapper, isFarmBu
 		_ = flags.MarkHidden("disable-content-trust")
 		_ = flags.MarkHidden("sign-by")
 		_ = flags.MarkHidden("signature-policy")
-		_ = flags.MarkHidden("tls-verify")
 		_ = flags.MarkHidden("compress")
 		_ = flags.MarkHidden("output")
 		_ = flags.MarkHidden("logsplit")
 		_ = flags.MarkHidden("cw")
+		// Support for farm build in podman-remote
+		if !isFarmBuild {
+			_ = flags.MarkHidden("tls-verify")
+		}
 	}
 	if isFarmBuild {
 		for _, f := range FarmBuildHiddenFlags {

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -201,13 +201,13 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 
 // ManifestListClear clears out all instances from a manifest list
 func (ir *ImageEngine) ManifestListClear(ctx context.Context, name string) (string, error) {
-	listContents, err := manifests.InspectListData(ctx, name, &manifests.InspectOptions{})
+	listContents, err := manifests.InspectListData(ir.ClientCtx, name, &manifests.InspectOptions{})
 	if err != nil {
 		return "", err
 	}
 
 	for _, instance := range listContents.Manifests {
-		if _, err := manifests.Remove(ctx, name, instance.Digest.String(), &manifests.RemoveOptions{}); err != nil {
+		if _, err := manifests.Remove(ir.ClientCtx, name, instance.Digest.String(), &manifests.RemoveOptions{}); err != nil {
 			return "", err
 		}
 	}

--- a/test/farm/001-farm.bats
+++ b/test/farm/001-farm.bats
@@ -116,6 +116,13 @@ EOF
 
 @test "farm - build on farm node only (podman-remote)" {
     iname="test-image-5"
+    # ManifestAdd only
+    echo "Running test with ManifestAdd only..."
+    run_podman --remote farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname $FARM_TMPDIR
+    assert "$output" =~ "Farm \"$FARMNAME\" ready"
+
+    # ManifestListClear and ManifestAdd
+    echo "Running test with ManifestListClear and ManifestAdd..."
     run_podman --remote farm build --authfile $AUTHFILE --tls-verify=false -t $REGISTRY/$iname $FARM_TMPDIR
     assert "$output" =~ "Farm \"$FARMNAME\" ready"
 


### PR DESCRIPTION
Fix https://github.com/containers/podman/issues/22647

#### Does this PR introduce a user-facing change?

```release-note
Fixed a problem with `podman farm build` command in podman-remote not updating manifests on the registry that have already been pushed
```
