### PR TITLE
[CI:DOCS] Use checkout@v4 in GH Actions

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             # This is where the scripts live
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - uses: actions/checkout@v4
               with:
                   repository: containers/podman
                   ref: 'main'

--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -98,7 +98,7 @@ jobs:
         steps.check.outputs.buildarm == 'true' ||
         steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
       with:
         ref: ${{steps.getversion.outputs.version}}
     - name: Set up Go

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       if: >-
         steps.check.outputs.buildartifacts == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
       with:
         repository: containers/podman
         ref: ${{steps.getversion.outputs.version}}

--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -42,7 +42,7 @@ jobs:
     cron_rerun:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - uses: actions/checkout@v4
               with:
                   # All scripts used by this workflow live in podman repo.
                   repository: "containers/podman"

--- a/.github/workflows/upload-win-installer.yml
+++ b/.github/workflows/upload-win-installer.yml
@@ -53,7 +53,7 @@ jobs:
     # Note this purposefully checks out the same branch the action runs in, as the
     # installer build script is designed to support older releases (uses the archives
     # on the release tag).
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+    - uses: actions/checkout@v4
     # This step is super-duper critical for the built/signed windows installer .exe file.
     # It ensures the referenced $version github release page does NOT already contain
     # this file.  Windows assigns a UUID to the installer at build time, it's assumed


### PR DESCRIPTION
This change will minimize renovate PR's.
Checkout is an action maintained by GitHub, so using the latest v4 action shouldn't have stability consequences.

Replaces: https://github.com/containers/podman/pull/22456

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
