### PR TITLE
[skip-ci] Packit: use only one value for `packages` key for `trigger: commit` copr builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,6 +55,7 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [podman-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."


### PR DESCRIPTION
Without this key, there are duplicate copr jobs being created on podman-next copr for `podman-fedora` and `podman-centos`.

Picking just one of `podman-fedora` / `podman-centos` should trigger builds for all targets specified on the podman-next copr.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
