### PR TITLE
ExitWithError() - final push to strict mode

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2396,7 +2396,7 @@ var _ = Describe("Podman kube play", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", ctrName})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(ExitWithError(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		exec := podmanTest.Podman([]string{"exec", ctrName, "sh", "-c", "echo 'startup probe success' > /testfile"})
 		exec.WaitWithDefaultTimeout()
@@ -5737,7 +5737,7 @@ spec:
 
 		curlTest := podmanTest.Podman([]string{"run", "--network", "host", NGINX_IMAGE, "curl", "-s", "localhost:19000"})
 		curlTest.WaitWithDefaultTimeout()
-		Expect(curlTest).Should(ExitWithError(7))
+		Expect(curlTest).Should(ExitWithError(7, ""))
 	})
 
 	It("without Ports, publish in command line - curl should succeed", func() {

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Podman run device", func() {
 	It("podman run bad device test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/baddevice", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+		Expect(session).To(ExitWithError(125, "stat /dev/baddevice: no such file or directory"))
 	})
 
 	It("podman run device test", func() {

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Podman run memory", func() {
 		// create a container that gets oomkilled
 		session := podmanTest.Podman([]string{"run", "--name", ctrName, "--read-only", "--memory-swap=20m", "--memory=20m", "--oom-score-adj=1000", ALPINE, "sort", "/dev/urandom"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(137))
+		Expect(session).Should(ExitWithError(137, ""))
 
 		inspect := podmanTest.Podman(([]string{"inspect", "--format", "{{.State.OOMKilled}} {{.State.ExitCode}}", ctrName}))
 		inspect.WaitWithDefaultTimeout()

--- a/test/e2e/run_seccomp_test.go
+++ b/test/e2e/run_seccomp_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman run", func() {
 			// TODO: worse than that. With runc, we get two alternating failures:
 			//   126 + cannot start a container that has stopped
 			//   127 + failed to connect to container's attach socket ... ENOENT
-			Expect(session).To(ExitWithError())
+			Expect(session.ExitCode()).To(BeNumerically(">=", 126), "Exit status using runc")
 		} else {
 			expect := "OCI runtime error: crun: read from the init process"
 			if IsRemote() {

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		result := podmanTest.Podman([]string{"run", "-d", "--name", "nginx", "--ip", ip, NGINX_IMAGE})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
+		cid := result.OutputToString()
 
 		// This test should not use a proxy
 		client := &http.Client{
@@ -112,7 +113,6 @@ var _ = Describe("Podman run with --ip flag", func() {
 		}
 		result = podmanTest.Podman([]string{"run", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
-		Expect(result.ErrorToString()).To(ContainSubstring(" address %s ", ip))
+		Expect(result).To(ExitWithError(126, fmt.Sprintf("IPAM error: requested ip address %s is already allocated to container ID %s", ip, cid)))
 	})
 })

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -64,17 +64,20 @@ var _ = Describe("podman container runlabel", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
 	})
+
 	It("podman container runlabel bogus label should result in non-zero exit code", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", ALPINE})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, fmt.Sprintf("cannot find the value of label: RUN in image: %s", ALPINE)))
 		// should not panic when label missing the value or don't have the label
 		Expect(result.OutputToString()).To(Not(ContainSubstring("panic")))
 	})
+
 	It("podman container runlabel bogus label in remote image should result in non-zero exit", func() {
-		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", "docker.io/library/ubuntu:latest"})
+		remoteImage := "quay.io/libpod/testimage:00000000"
+		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", remoteImage})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, fmt.Sprintf("cannot find the value of label: RUN in image: %s", remoteImage)))
 		// should not panic when label missing the value or don't have the label
 		Expect(result.OutputToString()).To(Not(ContainSubstring("panic")))
 	})
@@ -86,7 +89,7 @@ var _ = Describe("podman container runlabel", func() {
 		// runlabel should fail with nonexistent authfile
 		result := podmanTest.Podman([]string{"container", "runlabel", "--authfile", "/tmp/nonexistent", "RUN", image})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).To(ExitWithError(125, "credential file is not accessible: faccessat /tmp/nonexistent: no such file or directory"))
 
 		result = podmanTest.Podman([]string{"rmi", image})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Podman start", func() {
 		Expect(session).Should(ExitWithError(125, "not found in $PATH"))
 		session = podmanTest.Podman([]string{"container", "exists", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(1))
+		Expect(session).To(ExitWithError(1, ""))
 	})
 
 	It("podman start --rm --attach removed on failure", func() {
@@ -52,7 +52,7 @@ var _ = Describe("Podman start", func() {
 		Expect(session).Should(ExitWithError(125, "not found in $PATH"))
 		session = podmanTest.Podman([]string{"container", "exists", cid})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(1))
+		Expect(session).To(ExitWithError(1, ""))
 	})
 
 	It("podman container start single container by id", func() {
@@ -97,7 +97,7 @@ var _ = Describe("Podman start", func() {
 		session = podmanTest.Podman([]string{"start", "--attach", cid})
 		session.WaitWithDefaultTimeout()
 		// It should forward the signal
-		Expect(session).Should(ExitWithError(1))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 
 	It("podman start multiple containers", func() {


### PR DESCRIPTION
Final followup to #22270. That PR added a temporary convention
allowing a new form of ExitWithError(), one with an exit code
and stderr substring. In order to allow bite-size progress,
the old no-args form was still allowed. This PR removes
support for no-args ExitWithError().

This PR also adds one piece of new functionality: passing ""
(empty string) as the stderr arg means "expect exit code
but fail if there's anything at all in stderr".

And, one small commit because I seem to have missed a few.
```release-note
None
```