### PR TITLE
`podman events`: check for an error after we finish reading events

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -162,8 +162,7 @@ func eventsCmd(cmd *cobra.Command, _ []string) error {
 	}
 
 	go func() {
-		err := registry.ContainerEngine().Events(context.Background(), eventOptions)
-		errChannel <- err
+		errChannel <- registry.ContainerEngine().Events(context.Background(), eventOptions)
 	}()
 
 	for {
@@ -171,6 +170,13 @@ func eventsCmd(cmd *cobra.Command, _ []string) error {
 		case event, ok := <-eventChannel:
 			if !ok {
 				// channel was closed we can exit
+				select {
+				case err := <-errChannel:
+					if err != nil {
+						return err
+					}
+				default:
+				}
 				return nil
 			}
 			switch {

--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -42,6 +42,10 @@ func Events(ctx context.Context, eventChan chan types.Event, cancelChan chan boo
 		}()
 	}
 
+	if response.StatusCode != http.StatusOK {
+		return response.Process(nil)
+	}
+
 	dec := json.NewDecoder(response.Body)
 	for err = (error)(nil); err == nil; {
 		var e = types.Event{}

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -406,3 +406,8 @@ EOF
     run_podman events --since=1m --stream=false --filter volume=${vname:0:5}
     assert "$output" = "$notrunc_results"
 }
+
+@test "events - invalid filter" {
+    run_podman 125 events --since="the dawn of time...ish"
+    assert "$output" =~ "failed to parse event filters"
+}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
`podman events` should be able to diagnose invalid values being passed as arguments to its `--since` and `--until` flags.
```
