### PR TITLE
Quadlet: Add support for .build files

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -6,7 +6,7 @@ podman\-systemd.unit - systemd units using Podman Quadlet
 
 ## SYNOPSIS
 
-*name*.container, *name*.volume, *name*.network, *name*.kube *name*.image, *name*.pod
+*name*.container, *name*.volume, *name*.network, *name*.kube *name*.image, *name*.build *name*.pod
 
 ### Podman rootful unit search path
 
@@ -30,7 +30,7 @@ Symbolic links below the search paths are not supported.
 
 ## DESCRIPTION
 
-Podman supports starting containers (and creating volumes) via systemd by using a
+Podman supports building, and starting containers (and creating volumes) via systemd by using a
 [systemd generator](https://www.freedesktop.org/software/systemd/man/systemd.generator.html).
 These files are read during boot (and when `systemctl daemon-reload` is run) and generate
 corresponding regular systemd service unit files. Both system and user systemd units are supported.
@@ -39,7 +39,7 @@ the [Service] table and [Install] tables pass directly to systemd and are handle
 See systemd.unit(5) man page for more information.
 
 The Podman generator reads the search paths above and reads files with the extensions `.container`
-`.volume`, `.network`, `.pod` and `.kube`, and for each file generates a similarly named `.service` file. Be aware that
+`.volume`, `.network`, `.build`, `.pod` and `.kube`, and for each file generates a similarly named `.service` file. Be aware that
 existing vendor services (i.e., in `/usr/`) are replaced if they have the same name. The generated unit files can
 be started and managed with `systemctl` like any other systemd service. `systemctl {--user} list-unit-files`
 lists existing unit files on the system.
@@ -65,7 +65,7 @@ session gets started. For unit files placed in subdirectories within
 /etc/containers/systemd/user/${UID}/ and the other user unit search paths,
 Quadlet will recursively search and run the unit files present in these subdirectories.
 
-Note: When a Quadlet is starting, Podman often pulls one more container images which may take a considerable amount of time.
+Note: When a Quadlet is starting, Podman often pulls or builds one more container images which may take a considerable amount of time.
 Systemd defaults service start time to 90 seconds, or fails the service. Pre-pulling the image or extending
 the systemd timeout time for the service using the *TimeoutStartSec* Service option can fix the problem.
 
@@ -82,7 +82,7 @@ Quadlet requires the use of cgroup v2, use `podman info --format {{.Host.Cgroups
 
 By default, the `Type` field of the `Service` section of the Quadlet file does not need to be set.
 Quadlet will set it to `notify` for `.container` and `.kube` files,
-`forking` for `.pod` files, and `oneshot` for `.volume`, `.network` and `.image` files.
+`forking` for `.pod` files, and `oneshot` for `.volume`, `.network`, `.build`, and `.image` files.
 
 However, `Type` may be explicitly set to `oneshot` for `.container` and `.kube` files when no containers are expected
 to run once `podman` exits.
@@ -1324,6 +1324,251 @@ The (optional) name of the Podman volume. If this is not specified, the default 
 `systemd-%N` is used, which is the same as the unit name but with a `systemd-` prefix to avoid
 conflicts with user-managed volumes.
 
+## Build units [Build]
+
+Build files are named with a `.build` extension and contain a section `[Build]` describing the image
+build command. The generated service is a one-time command that ensures that the image is built on
+the host from a supplied Containerfile and context directory. Subsequent (re-)starts of the
+generated built service will usually finish quickly, as image layer caching will skip unchanged
+build steps.
+
+A minimal `.build` unit needs at least the `ImageTag=` key, and either of `File=` or
+`SetWorkingDirectory=` keys.
+
+Using build units allows containers and volumes to depend on images being built locally. This can be
+interesting for creating container images not available on container registries, or for local
+testing and development.
+
+Valid options for `[Build]` are listed below:
+
+| **[Build] options**                 | **podman build equivalent**                 |
+|-------------------------------------|---------------------------------------------|
+| Annotation=annotation=value         | --annotation=annotation=value               |
+| Arch=aarch64                        | --arch=aarch64                              |
+| AuthFile=/etc/registry/auth\.json   | --authfile=/etc/registry/auth\.json         |
+| ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                     |
+| DNS=192.168.55.1                    | --dns=192.168.55.1                          |
+| DNSOption=ndots:1                   | --dns-option=ndots:1                        |
+| DNSSearch=foo.com                   | --dns-search=foo.com                        |
+| Environment=foo=bar                 | --env foo=bar                               |
+| File=/path/to/Containerfile         | --file=/path/to/Containerfile               |
+| ForceRM=false                       | --force-rm=false                            |
+| GlobalArgs=--log-level=debug        | --log-level=debug                           |
+| GroupAdd=keep-groups                | --group-add=keep-groups                     |
+| ImageTag=localhost/imagename        | --tag=localhost/imagename                   |
+| Label=label                         | --label=label                               |
+| Network=host                        | --network=host                              |
+| PodmanArgs=--add-host foobar        | --add-host foobar                           |
+| Pull=never                          | --pull=never                                |
+| Secret=secret                       | --secret=id=mysecret,src=path               |
+| SetWorkingDirectory=unit            | Set `WorkingDirectory` of systemd unit file |
+| Target=my-app                       | --target=my-app                             |
+| TLSVerify=false                     | --tls-verify=false                          |
+| Variant=arm/v7                      | --variant=arm/v7                            |
+| Volume=/source:/dest                | --volume /source:/dest                      |
+
+### `Annotation=`
+
+Add an image *annotation* (e.g. annotation=*value*) to the image metadata. Can be used multiple
+times.
+
+This is equivalant to the `--annotation` option of `podman build`.
+
+### `Arch=`
+
+Override the architecture, defaults to hosts', of the image to be built.
+
+This is equivalent to the `--arch` option of `podman build`.
+
+### `AuthFile=`
+
+Path of the authentication file.
+
+This is equivalent to the `--authfile` option of `podman build`.
+
+### `ContainersConfModule=`
+
+Load the specified containers.conf(5) module. Equivalent to the Podman `--module` option.
+
+This key can be listed multiple times.
+
+### `DNS=`
+
+Set network-scoped DNS resolver/nameserver for the build container.
+
+This key can be listed multiple times.
+
+This is equivalent to the `--dns` option of `podman build`.
+
+### `DNSOption=`
+
+Set custom DNS options.
+
+This key can be listed multiple times.
+
+This is equivalent to the `--dns-option` option of `podman build`.
+
+### `DNSSearch=`
+
+Set custom DNS search domains. Use **DNSSearch=.** to remove the search domain.
+
+This key can be listed multiple times.
+
+This is equivalent to the `--dns-search` option of `podman build`.
+
+### `Environment=`
+
+Add a value (e.g. env=*value*) to the built image. This uses the same format as [services in
+systemd](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment=) and can be
+listed multiple times.
+
+### `File=`
+
+Specifies a Containerfile which contains instructions for building the image. A URL starting with
+`http(s)://` allows you to specify a remote Containerfile to be downloaded. Note that for a given
+relative path to a Containerfile, or when using a `http(s)://` URL, you also must set
+`SetWorkingDirectory=` in order for `podman build` to find a valid context directory for the
+resources specified in the Containerfile.
+
+Note that setting a `File=` field is mandatory for a `.build` file, unless `SetWorkingDirectory` (or
+a `WorkingDirectory` in the `Service` group) has also been set.
+
+This is equivalent to the `--file` option of `podman build`.
+
+### `ForceRM=`
+
+Always remove intermediate containers after a build, even if the build fails (default true).
+
+This is equivalent to the `--force-rm` option of `podman build`.
+
+### `GlobalArgs=`
+
+This key contains a list of arguments passed directly between `podman` and `build` in the generated
+file. It can be used to access Podman features otherwise unsupported by the generator. Since the
+generator is unaware of what unexpected interactions can be caused by these arguments, it is not
+recommended to use this option.
+
+The format of this is a space separated list of arguments, which can optionally be individually
+escaped to allow inclusion of whitespace and other control characters.
+
+This key can be listed multiple times.
+
+### `GroupAdd=`
+
+Assign additional groups to the primary user running within the container process. Also supports the
+`keep-groups` special flag.
+
+This is equivalent to the `--group-add` option of `podman build`.
+
+### `ImageTag=`
+
+Specifies the name which is assigned to the resulting image if the build process completes
+successfully.
+
+This is equivalent to the `--tag` option of `podman build`.
+
+### `Label=`
+
+Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
+
+This is equivalent to the `--label` option of `podman build`.
+
+### `Network=`
+
+Sets the configuration for network namespaces when handling RUN instructions. This has the same
+format as the `--network` option to `podman build`. For example, use `host` to use the host network,
+or `none` to not set up networking.
+
+As a special case, if the `name` of the network ends with `.network`, Quadlet will look for the
+corresponding `.network` Quadlet unit. If found, Quadlet will use the name of the Network set in the
+Unit, otherwise, `systemd-$name` is used. The generated systemd service contains a dependency on the
+service unit generated for that `.network` unit, or on `$name-network.service` if the `.network`
+unit is not found.
+
+This key can be listed multiple times.
+
+### `PodmanArgs=`
+
+This key contains a list of arguments passed directly to the end of the `podman build` command
+in the generated file (right before the image name in the command line). It can be used to
+access Podman features otherwise unsupported by the generator. Since the generator is unaware
+of what unexpected interactions can be caused by these arguments, it is not recommended to use
+this option.
+
+The format of this is a space separated list of arguments, which can optionally be individually
+escaped to allow inclusion of whitespace and other control characters.
+
+This key can be listed multiple times.
+
+### `Pull=`
+
+Set the image pull policy.
+
+This is equivalent to the `--pull` option of `podman build`.
+
+### `Secret=`
+
+Pass secret information used in Containerfile build stages in a safe way.
+
+This is equivalent to the `--secret` option of `podman build` and generally has the form
+`secret[,opt=opt ...]`.
+
+### `SetWorkingDirectory=`
+
+Provide context (a working directory) to `podman build`. Supported values are a path, a URL, or the
+special keys `file` or `unit` to set the context directory to the parent directory of the file from
+the `File=` key or to that of the Quadlet `.build` unit file, respectively. This allows Quadlet to
+resolve relative paths.
+
+When using one of the special keys (`file` or `unit`), the `WorkingDirectory` field of the `Service`
+group of the Systemd service unit will also be set to accordingly. Alternatively, users can
+explicitly set the `WorkingDirectory` field of the `Service` group in the `.build` file. Please note
+that if the `WorkingDirectory` field of the `Service` group is set by the user, Quadlet will not
+overwrite it even if `SetWorkingDirectory` is set to `file` or `unit`.
+
+By providing a URL to `SetWorkingDirectory=` you can instruct `podman build` to clone a Git
+repository or download an archive file extracted to a temporary location by `podman build` as build
+context. Note that in this case, the `WorkingDirectory` of the Systemd service unit is left
+untouched by Quadlet.
+
+Note that providing context directory is mandatory for a `.build` file, unless a `File=` key has
+also been provided.
+
+### `Target=`
+
+Set the target build stage to build. Commands in the Containerfile after the target stage are
+skipped.
+
+This is equivalent to the `--target` option of `podman build`.
+
+### `TLSVerify=`
+
+Require HTTPS and verification of certificates when contacting registries.
+
+This is equivalent to the `--tls-verify` option of `podman build`.
+
+### `Variant=`
+
+Override the default architecture variant of the container image to be built.
+
+This is equivalent to the `--variant` option of `podman build`.
+
+### `Volume=`
+
+Mount a volume to containers when executing RUN instructions during the build. This is equivalent to
+the `--volume` option of `podman build`, and generally has the form
+`[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]`.
+
+If `SOURCE-VOLUME` starts with `.`, Quadlet resolves the path relative to the location of the unit file.
+
+As a special case, if `SOURCE-VOLUME` ends with `.volume`, Quadlet will look for the corresponding
+`.volume` Quadlet unit. If found, Quadlet will use the name of the Volume set in the Unit,
+otherwise, `systemd-$name` is used. The generated systemd service contains a dependency on the
+service unit generated for that `.volume` unit, or on `$name-volume.service` if the `.volume` unit
+is not found
+
+This key can be listed multiple times.
+
 ## Image units [Image]
 
 Image files are named with a `.image` extension and contain a section `[Image]` describing the
@@ -1508,6 +1753,26 @@ Yaml=/opt/k8s/deployment.yml
 [Install]
 # Start by default on boot
 WantedBy=multi-user.target default.target
+```
+
+Example for locally built image to be used in a container:
+
+`test.build`
+```
+[Build]
+# Tag the image to be built
+ImageTag=localhost/imagename
+
+# Set the working directory to the path of the unit file,
+# expecting to find a Containerfile/Dockerfile
+# + other files needed to build the image
+SetWorkingDirectory=unit
+```
+
+`test.container`
+```
+[Container]
+Image=test.build
 ```
 
 Example `test.volume`:

--- a/test/e2e/quadlet/annotation.build
+++ b/test/e2e/quadlet/annotation.build
@@ -1,0 +1,14 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args "--annotation" "org.foo.Arg0=arg0"
+## assert-podman-args "--annotation" "org.foo.Arg1=arg1"
+## assert-podman-args "--annotation" "org.foo.Arg2=arg 2"
+## assert-podman-args "--annotation" "org.foo.Arg3=arg3"
+## assert-podman-args --tag=localhost/imagename
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Annotation=org.foo.Arg1=arg1 "org.foo.Arg2=arg 2" \
+  org.foo.Arg3=arg3
+
+Annotation=org.foo.Arg0=arg0

--- a/test/e2e/quadlet/arch.build
+++ b/test/e2e/quadlet/arch.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --arch=aarch64
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Arch=aarch64

--- a/test/e2e/quadlet/authfile.build
+++ b/test/e2e/quadlet/authfile.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --authfile=/etc/certs/auth.json
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+AuthFile=/etc/certs/auth.json

--- a/test/e2e/quadlet/basic.build
+++ b/test/e2e/quadlet/basic.build
@@ -1,0 +1,13 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-key-is "Unit" "After" "network-online.target"
+## assert-key-is "Unit" "Wants" "network-online.target"
+## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
+## assert-key-is-regex "Service" "WorkingDirectory" "/.*/podman-e2e-.*/subtest-.*/quadlet"
+## assert-key-is "Service" "Type" "oneshot"
+## assert-key-is "Service" "RemainAfterExit" "yes"
+## assert-key-is "Service" "SyslogIdentifier" "%N"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit

--- a/test/e2e/quadlet/build-not-found.quadlet.volume
+++ b/test/e2e/quadlet/build-not-found.quadlet.volume
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "requested Quadlet image not-found.build was not found"
+
+[Volume]
+Driver=image
+Image=not-found.build

--- a/test/e2e/quadlet/build.quadlet.volume
+++ b/test/e2e/quadlet/build.quadlet.volume
@@ -1,0 +1,8 @@
+## assert-podman-args --driver=image
+## assert-podman-args --opt image=localhost/imagename
+## assert-key-is "Unit" "Requires" "basic-build.service"
+## assert-key-is "Unit" "After" "basic-build.service"
+
+[Volume]
+Driver=image
+Image=basic.build

--- a/test/e2e/quadlet/containersconfmodule.build
+++ b/test/e2e/quadlet/containersconfmodule.build
@@ -1,0 +1,8 @@
+## assert-podman-global-args "build" "--module=/etc/container/1.conf"
+## assert-podman-global-args "build" "--module=/etc/container/2.conf"
+
+[Build]
+ImageTag=image:latest
+SetWorkingDirectory=unit
+ContainersConfModule=/etc/container/1.conf
+ContainersConfModule=/etc/container/2.conf

--- a/test/e2e/quadlet/dns-options.build
+++ b/test/e2e/quadlet/dns-options.build
@@ -1,0 +1,10 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--dns-option=ndots:1"
+## assert-podman-args "--dns-option=color:blue"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+DNSOption=ndots:1
+DNSOption=color:blue

--- a/test/e2e/quadlet/dns-search.build
+++ b/test/e2e/quadlet/dns-search.build
@@ -1,0 +1,10 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--dns-search=foo.com"
+## assert-podman-args "--dns-search=bar.com"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+DNSSearch=foo.com
+DNSSearch=bar.com

--- a/test/e2e/quadlet/dns.build
+++ b/test/e2e/quadlet/dns.build
@@ -1,0 +1,10 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--dns=8.7.7.7"
+## assert-podman-args "--dns=8.8.8.8"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+DNS=8.7.7.7
+DNS=8.8.8.8

--- a/test/e2e/quadlet/env.build
+++ b/test/e2e/quadlet/env.build
@@ -1,0 +1,14 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --env "FOO1=foo1"
+## assert-podman-args --env "FOO2=foo2 "
+## assert-podman-args --env "FOO3=foo3"
+## assert-podman-args --env "REPLACE=replaced"
+## assert-podman-args --env "FOO4=foo\\nfoo"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Environment=FOO1=foo1 "FOO2=foo2 " \
+                     FOO3=foo3 REPLACE=replace
+Environment=REPLACE=replaced 'FOO4=foo\nfoo'

--- a/test/e2e/quadlet/file-abs.build
+++ b/test/e2e/quadlet/file-abs.build
@@ -1,0 +1,5 @@
+## assert-podman-final-args --file=/etc/containers/systemd/Containerfile
+
+[Build]
+File=/etc/containers/systemd/Containerfile
+ImageTag=localhost/imagename

--- a/test/e2e/quadlet/file-https.build
+++ b/test/e2e/quadlet/file-https.build
@@ -1,0 +1,6 @@
+## assert-podman-args --tag=localhost/podman-hello
+## assert-podman-args --file=https://raw.githubusercontent.com/containers/PodmanHello/main/Containerfile
+
+[Build]
+File=https://raw.githubusercontent.com/containers/PodmanHello/main/Containerfile
+ImageTag=localhost/podman-hello

--- a/test/e2e/quadlet/file-rel-no-wd.build
+++ b/test/e2e/quadlet/file-rel-no-wd.build
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "relative path in File key requires SetWorkingDirectory key to be set"
+
+[Build]
+ImageTag=localhost/imagename
+File=Containerfile

--- a/test/e2e/quadlet/file-rel.build
+++ b/test/e2e/quadlet/file-rel.build
@@ -1,0 +1,7 @@
+## assert-podman-final-args .
+## assert-podman-args-regex "--file=Containerfile"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=.
+File=Containerfile

--- a/test/e2e/quadlet/force-rm.build
+++ b/test/e2e/quadlet/force-rm.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --force-rm=false
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+ForceRM=no

--- a/test/e2e/quadlet/globalargs.build
+++ b/test/e2e/quadlet/globalargs.build
@@ -1,0 +1,9 @@
+## assert-podman-global-args "build" "--identity=path=/etc/identity"
+## assert-podman-global-args "build" "--syslog"
+## assert-podman-global-args "build" "--log-level=debug"
+
+[Build]
+ImageTag=image:latest
+SetWorkingDirectory=unit
+GlobalArgs=--identity=path=/etc/identity
+GlobalArgs=--syslog --log-level=debug

--- a/test/e2e/quadlet/group-add.build
+++ b/test/e2e/quadlet/group-add.build
@@ -1,0 +1,8 @@
+## assert-podman-args "--group-add=keep-groups"
+## assert-podman-args "--group-add=users"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+GroupAdd=keep-groups
+GroupAdd=users

--- a/test/e2e/quadlet/image-not-found.quadlet.volume
+++ b/test/e2e/quadlet/image-not-found.quadlet.volume
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "requested Quadlet image not-found.image was not found"
+
+[Volume]
+Driver=image
+Image=not-found.image

--- a/test/e2e/quadlet/image.quadlet.volume
+++ b/test/e2e/quadlet/image.quadlet.volume
@@ -1,0 +1,8 @@
+## assert-podman-args --driver=image
+## assert-podman-args --opt image=localhost/imagename
+## assert-key-is "Unit" "Requires" "basic-image.service"
+## assert-key-is "Unit" "After" "basic-image.service"
+
+[Volume]
+Driver=image
+Image=basic.image

--- a/test/e2e/quadlet/label.build
+++ b/test/e2e/quadlet/label.build
@@ -1,0 +1,14 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--label" "org.foo.Arg0=arg0"
+## assert-podman-args "--label" "org.foo.Arg1=arg1"
+## assert-podman-args "--label" "org.foo.Arg2=arg 2"
+## assert-podman-args "--label" "org.foo.Arg3=arg3"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Label=org.foo.Arg1=arg1 "org.foo.Arg2=arg 2" \
+  org.foo.Arg3=arg3
+
+Label=org.foo.Arg0=arg0

--- a/test/e2e/quadlet/neither-workingdirectory-nor-file.build
+++ b/test/e2e/quadlet/neither-workingdirectory-nor-file.build
@@ -1,0 +1,5 @@
+## assert-failed
+## assert-stderr-contains "neither SetWorkingDirectory, nor File key specified"
+
+[Build]
+ImageTag=localhost/imagename

--- a/test/e2e/quadlet/network.build
+++ b/test/e2e/quadlet/network.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--network=host"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Network=host

--- a/test/e2e/quadlet/network.quadlet.build
+++ b/test/e2e/quadlet/network.quadlet.build
@@ -1,0 +1,8 @@
+## assert-podman-args "--network=systemd-basic"
+## assert-key-is "Unit" "Requires" "basic-network.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic-network.service"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Network=basic.network

--- a/test/e2e/quadlet/no-imagetag.build
+++ b/test/e2e/quadlet/no-imagetag.build
@@ -1,0 +1,5 @@
+## assert-failed
+## assert-stderr-contains "no ImageTag key specified"
+
+[Build]
+SetWorkingDirectory=unit

--- a/test/e2e/quadlet/podmanargs.build
+++ b/test/e2e/quadlet/podmanargs.build
@@ -1,0 +1,14 @@
+## assert-podman-args "--foo"
+## assert-podman-args "--bar"
+## assert-podman-args "--also"
+## assert-podman-args "--with-key=value"
+## assert-podman-args "--with-space" "yes"
+
+[Build]
+ImageTag=image:latest
+SetWorkingDirectory=unit
+PodmanArgs="--foo" \
+  --bar
+PodmanArgs=--also
+PodmanArgs=--with-key=value
+PodmanArgs=--with-space yes

--- a/test/e2e/quadlet/pull.build
+++ b/test/e2e/quadlet/pull.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --pull=never
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Pull=never

--- a/test/e2e/quadlet/secrets.build
+++ b/test/e2e/quadlet/secrets.build
@@ -1,0 +1,8 @@
+## assert-podman-args "--secret" "mysecret"
+## assert-podman-args "--secret" "id=mysecret,src=mysecret.txt"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Secret=mysecret
+Secret=id=mysecret,src=mysecret.txt

--- a/test/e2e/quadlet/setworkingdirectory-is-abs.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-abs.build
@@ -1,0 +1,5 @@
+## assert-podman-final-args /etc/containers/systemd
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=/etc/containers/systemd

--- a/test/e2e/quadlet/setworkingdirectory-is-archive.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-archive.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args https://github.com/containers/PodmanHello/archive/refs/heads/main.tar.gz
+## assert-podman-args --tag=localhost/podman-hello-archive
+## assert-podman-args --file=PodmanHello-main/Containerfile
+
+[Build]
+ImageTag=localhost/podman-hello-archive
+File=PodmanHello-main/Containerfile
+SetWorkingDirectory=https://github.com/containers/PodmanHello/archive/refs/heads/main.tar.gz

--- a/test/e2e/quadlet/setworkingdirectory-is-file-abs.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-file-abs.build
@@ -1,0 +1,7 @@
+## assert-podman-args --file=/etc/containers/systemd/Containerfile
+## assert-key-is "Service" "WorkingDirectory" "/etc/containers/systemd"
+
+[Build]
+File=/etc/containers/systemd/Containerfile
+ImageTag=localhost/imagename
+SetWorkingDirectory=file

--- a/test/e2e/quadlet/setworkingdirectory-is-file-rel.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-file-rel.build
@@ -1,0 +1,7 @@
+## assert-podman-args --file=Containerfile
+## assert-key-is-regex "Service" "WorkingDirectory" "/.*/podman-e2e-.*/subtest-.*/quadlet"
+
+[Build]
+ImageTag=localhost/imagename
+File=Containerfile
+SetWorkingDirectory=file

--- a/test/e2e/quadlet/setworkingdirectory-is-git.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-git.build
@@ -1,0 +1,6 @@
+## assert-podman-final-args git://git@git.sr.ht/~emersion/sr.ht-container-compose
+## assert-podman-args --tag=localhost/podman-hello
+
+[Build]
+ImageTag=localhost/podman-hello
+SetWorkingDirectory=git://git@git.sr.ht/~emersion/sr.ht-container-compose

--- a/test/e2e/quadlet/setworkingdirectory-is-github.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-github.build
@@ -1,0 +1,6 @@
+## assert-podman-final-args github.com/containers/PodmanHello.git
+## assert-podman-args --tag=localhost/podman-hello
+
+[Build]
+ImageTag=localhost/podman-hello
+SetWorkingDirectory=github.com/containers/PodmanHello.git

--- a/test/e2e/quadlet/setworkingdirectory-is-https-git.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-https-git.build
@@ -1,0 +1,6 @@
+## assert-podman-final-args https://github.com/containers/PodmanHello.git
+## assert-podman-args --tag=localhost/podman-hello
+
+[Build]
+ImageTag=localhost/podman-hello
+SetWorkingDirectory=https://github.com/containers/PodmanHello.git

--- a/test/e2e/quadlet/setworkingdirectory-is-rel.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-rel.build
@@ -1,0 +1,6 @@
+## assert-podman-final-args .
+## assert-key-is-regex "Service" "WorkingDirectory" "/.*/podman-e2e-.*/subtest-.*/quadlet"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=.

--- a/test/e2e/quadlet/target.build
+++ b/test/e2e/quadlet/target.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --target=my-app
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Target=my-app

--- a/test/e2e/quadlet/tls-verify.build
+++ b/test/e2e/quadlet/tls-verify.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --tls-verify=false
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+TLSVerify=no

--- a/test/e2e/quadlet/variant.build
+++ b/test/e2e/quadlet/variant.build
@@ -1,0 +1,8 @@
+## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
+## assert-podman-args --tag=localhost/imagename
+## assert-podman-args --variant=arm/v7
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Variant=arm/v7

--- a/test/e2e/quadlet/volume.build
+++ b/test/e2e/quadlet/volume.build
@@ -1,0 +1,17 @@
+## assert-podman-args -v /host/dir:/container/volume
+## assert-podman-args -v /host/dir2:/container/volume2:Z
+## assert-podman-args-regex -v .*/podman-e2e-.*/subtest-.*/quadlet/host/dir3:/container/volume3
+## assert-podman-args -v named:/container/named
+## assert-podman-args -v systemd-quadlet:/container/quadlet
+## assert-podman-args -v %h/container:/container/volume4
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Volume=/host/dir:/container/volume
+Volume=/host/dir2:/container/volume2:Z
+Volume=./host/dir3:/container/volume3
+Volume=/container/empty
+Volume=named:/container/named
+Volume=quadlet.volume:/container/quadlet
+Volume=%h/container:/container/volume4

--- a/test/e2e/quadlet/volume.quadlet.build
+++ b/test/e2e/quadlet/volume.quadlet.build
@@ -1,0 +1,8 @@
+## assert-podman-args "-v" "systemd-basic:/volume/basic"
+## assert-key-is "Unit" "Requires" "basic-volume.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic-volume.service"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Volume=basic.volume:/volume/basic


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet: Add support for .build files
```

This adds support for `.build` Quadlet units, as per discussion in https://github.com/containers/podman/discussions/17043#discussioncomment-9347329, basically by mapping Key/Value pairs inside a `.build` file to `podman build` command line arguments.

You depend on a container image built by a `.build` file, by adding `Image=name.build` to your `.container` file, similar to how you can depend on an `.image` file.

Mandatory keys in a `.build` file under the `[Build]` group are so far:

```
[Build]
# Tag the image you intend to build so that container service files can use this name in their command lines 
ImageTag=localhost/imagename
# Either of
File=/path/to/a/Containerfile
# or
SetWorkingDirectory=unit
# to add a build context to `podman build`
```

Not every single `podman build` command line argument is being handled, yet. There might be more which would be nice to have before merging (please let me know if you think I missed an important one!), but since adding a new Key/Value pair is a rather cumbersome and boring process, I decided to stop after adding the following:

- all `KeyXYZ` I found already defined, and which I also found in `podman builds` supported arguments (notable exceptions from this rule are those I did never use before myself, or those where I found more complicated parsing code in the current quadlet code base)
- a few mandatory things which were missing so far, like `KeyFile` (`podman build`'s `--file`, i.e. the Containerfile path), or `KeyTarget`

I have added e2e tests, and documentation for all currently supported keys/args, closely following what I found for the already existing Quadlet file types.

This is my first contribution to a Go project, so please let me know in case I did not follow best practice or used unidiomatic constructs. I used `go fmt` on all Go files I touched (except for `quadlet_test.go`, as I only added single lines here, and wasn't sure if `go fmt` would alter parts of the file I did not touch), and generally tried to follow naming conventions I found in surrounding code.

I have tested this with a few toy projects locally, and there it did it's job. Apart from adding more command line args if deemed necessary, I consider the implementation ready functionality wise.

Happy to hear what the maintainers think about this!