### PR TITLE
rootless: fix reexec to use /proc/self/exe

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -922,8 +922,8 @@ reexec_userns_join (int pid_to_join, char *pause_pid_file_path)
       _exit (EXIT_FAILURE);
     }
 
-  execvp (argv[0], argv);
-  fprintf (stderr, "failed to execvp %s: %m\n", argv[0]);
+  execvp ("/proc/self/exe", argv);
+  fprintf (stderr, "failed to reexec: %m\n");
 
   _exit (EXIT_FAILURE);
 }
@@ -1145,7 +1145,8 @@ reexec_in_user_namespace (int ready, char *pause_pid_file_path, char *file_to_re
       _exit (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
     }
 
-  execvp (argv[0], argv);
+  execvp ("/proc/self/exe", argv);
+  fprintf (stderr, "failed to reexec: %m\n");
 
   _exit (EXIT_FAILURE);
 }

--- a/test/system/550-pause-process.bats
+++ b/test/system/550-pause-process.bats
@@ -94,7 +94,9 @@ function _check_pause_process() {
     run_podman system migrate
 
     # We're forced to use $PODMAN because run_podman cannot be backgrounded
-    $PODMAN run -i --name c_run $IMAGE sh -c "$SLEEPLOOP" &
+    # Also special logic to set a different argv0 to make sure the reexec still works:
+    # https://github.com/containers/podman/issues/22672
+    bash -c "exec -a argv0-podman $PODMAN run -i --name c_run $IMAGE sh -c '$SLEEPLOOP'" &
     local kidpid=$!
 
     _test_sigproxy c_run $kidpid


### PR DESCRIPTION
Under some circumstances podman might be executed with a different argv0 than the actual path to the podman binary. This breaks the reexec logic as it tried to exec argv0 which failed.

This is visible when using podmansh as login shell which get's the special -podmansh on argv0 to signal the shell it is a login shell.

To fix this we can simply use /proc/self/exe as command path which is much more robust and the argv array is still passed correctly.

Fixes #22672

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where rootless podman could fail to reexeute itself when run with a custom argv0 that is not a valid command path.
```
