### PR TITLE
cirrus: use faster VM's for integration tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -639,7 +639,11 @@ local_integration_test_task: &local_integration_test_task
     only_if: *not_tag_branch_build_docs_machine
     depends_on: *build
     matrix: *platform_axis
-    gce_instance: *standardvm
+    # integration tests scale well with cpu as they are parallelized
+    # so we give these tests 4 cores to make them faster
+    gce_instance: &fastvm
+      <<: *standardvm
+      cpu: 4
     timeout_in: 50m
     env:
         TEST_FLAVOR: int
@@ -687,7 +691,7 @@ container_integration_test_task:
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
               CI_DESIRED_RUNTIME: crun
               CI_DESIRED_DATABASE: boltdb
-    gce_instance: *standardvm
+    gce_instance: *fastvm
     timeout_in: 50m
     env:
         TEST_FLAVOR: int
@@ -706,7 +710,7 @@ rootless_integration_test_task:
     only_if: *not_tag_branch_build_docs_machine
     depends_on: *build
     matrix: *platform_axis
-    gce_instance: *standardvm
+    gce_instance: *fastvm
     timeout_in: 50m
     env:
         TEST_FLAVOR: int


### PR DESCRIPTION
Use 4 core VM vompred to the standard 2 cores, integration tests scale
 almost linear with extra cores, as such doubling the cores makes the
 tests almost twice as fast. This brings the test time down to 15-17 min
 in CI.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
