### PR TITLE
remote API: restore v4 payload in container inspect

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -144,6 +144,11 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
+	// if client request old v4 payload we should return v4 compatible json
+	if _, err := utils.SupportedVersion(r, ">=5.0.0"); err != nil {
+		data.Config.V4PodmanCompatMarshal = true
+	}
+
 	utils.WriteResponse(w, http.StatusOK, data)
 }
 

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -8,7 +8,7 @@ podman pull $IMAGE &>/dev/null
 # Ensure clean slate
 podman rm -a -f &>/dev/null
 
-podman run -d --name foo $IMAGE top
+podman run -d --name foo --entrypoint='["sh","-c"]' $IMAGE top
 
 # Check exists for none such
 t GET libpod/containers/nonesuch/exists 404
@@ -44,7 +44,15 @@ t GET libpod/containers/foo/json 200 \
   .State.Status=running \
   .ImageName=$IMAGE \
   .Config.Cmd[0]=top \
-  .Name=foo
+  .Name=foo \
+  .Config.StopSignal="SIGTERM" \
+  .Config.Entrypoint[0]="sh" \
+  .Config.Entrypoint[1]="-c"
+
+# now check v4 request return old compatible output
+t GET /v4.0.0/libpod/containers/foo/json 200 \
+  .Config.StopSignal=15 \
+  .Config.Entrypoint="sh -c"
 
 # List processes of the container
 t GET libpod/containers/foo/top 200 \

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -305,7 +305,7 @@ function t() {
         url=http://$HOST:$PORT
         case "$path" in
         /*) url="$url$path" ;;
-        libpod/*) url="$url/v4.0.0/$path" ;;
+        libpod/*) url="$url/v5.0.0/$path" ;;
         *)  url="$url/v1.41/$path" ;;
         esac
     fi


### PR DESCRIPTION
The v5 API made a breaking chnage for podman inspect, this means that old client could not longer parse the result from the new 5.X server. The other way around new client and old server were already fixed.

In order to keep the API working we now have a version check and return the old v4 compatiable payload so the old remote client can still work against a newer server.

Fixes #22657

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The remote API now return compatible v4.X container inspect output when a request with v4.0.0 is made. This makes old 4.X clients work with a new 5.X server. 
```
