### PR TITLE
Always chown volumes when mounting into a container

### DIFF
--- a/docs/source/markdown/podman-volume-inspect.1.md
+++ b/docs/source/markdown/podman-volume-inspect.1.md
@@ -26,25 +26,25 @@ Format volume output using Go template
 
 Valid placeholders for the Go template are listed below:
 
-| **Placeholder**     | **Description**                                        |
-| ------------------- | ------------------------------------------------------ |
-| .Anonymous          | Indicates whether volume is anonymous                  |
-| .CreatedAt ...      | Volume creation time                                   |
-| .Driver             | Volume driver                                          |
-| .GID                | GID the volume was created with                        |
-| .Labels ...         | Label information associated with the volume           |
-| .LockNumber         | Number of the volume's Libpod lock                     |
-| .MountCount         | Number of times the volume is mounted                  |
-| .Mountpoint         | Source of volume mount point                           |
-| .Name               | Volume name                                            |
-| .NeedsChown         | Indicates volume needs to be chowned on first use      |
-| .NeedsCopyUp        | Indicates volume needs dest data copied up on first use|
-| .Options ...        | Volume options                                         |
-| .Scope              | Volume scope                                           |
-| .Status ...         | Status of the volume                                   |
-| .StorageID          | StorageID of the volume                                |
-| .Timeout            | Timeout of the volume                                  |
-| .UID                | UID the volume was created with                        |
+| **Placeholder**     | **Description**                                                             |
+| ------------------- | --------------------------------------------------------------------------- |
+| .Anonymous          | Indicates whether volume is anonymous                                       |
+| .CreatedAt ...      | Volume creation time                                                        |
+| .Driver             | Volume driver                                                               |
+| .GID                | GID the volume was created with                                             |
+| .Labels ...         | Label information associated with the volume                                |
+| .LockNumber         | Number of the volume's Libpod lock                                          |
+| .MountCount         | Number of times the volume is mounted                                       |
+| .Mountpoint         | Source of volume mount point                                                |
+| .Name               | Volume name                                                                 |
+| .NeedsChown         | Indicates volume will be chowned on next use                                |
+| .NeedsCopyUp        | Indicates data at the destination will be copied into the volume on next use|
+| .Options ...        | Volume options                                                              |
+| .Scope              | Volume scope                                                                |
+| .Status ...         | Status of the volume                                                        |
+| .StorageID          | StorageID of the volume                                                     |
+| .Timeout            | Timeout of the volume                                                       |
+| .UID                | UID the volume was created with                                             |
 
 #### **--help**
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1901,6 +1901,7 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 		// Set NeedsCopyUp to false since we are about to do first copy
 		// Do not copy second time.
 		vol.state.NeedsCopyUp = false
+		vol.state.CopiedUp = true
 		if err := vol.save(); err != nil {
 			return nil, err
 		}

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -98,6 +98,10 @@ type VolumeState struct {
 	// a container, the container will chown the volume to the container process
 	// UID/GID.
 	NeedsChown bool `json:"notYetChowned,omitempty"`
+	// Indicates that a copy-up event occurred during the current mount of
+	// the volume into a container.
+	// We use this to determine if a chown is appropriate.
+	CopiedUp bool `json:"copiedUp,omitempty"`
 	// UIDChowned is the UID the volume was chowned to.
 	UIDChowned int `json:"uidChowned,omitempty"`
 	// GIDChowned is the GID the volume was chowned to.

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -110,4 +110,5 @@ func (v *Volume) refresh() error {
 func resetVolumeState(state *VolumeState) {
 	state.MountCount = 0
 	state.MountPoint = ""
+	state.CopiedUp = false
 }

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -467,11 +467,13 @@ NeedsChown    | true
     run_podman volume inspect --format '{{ .NeedsCopyUp }}' $myvolume
     is "${output}" "true" "If content in dest '/vol' empty NeedsCopyUP should still be true"
     run_podman volume inspect --format '{{ .NeedsChown }}' $myvolume
-    is "${output}" "false" "After first use within a container NeedsChown should still be false"
+    is "${output}" "true" "No copy up occurred so the NeedsChown will still be true"
 
     run_podman run --rm --volume $myvolume:/etc $IMAGE ls /etc/passwd
     run_podman volume inspect --format '{{ .NeedsCopyUp }}' $myvolume
     is "${output}" "false" "If content in dest '/etc' non-empty NeedsCopyUP should still have happened and be false"
+    run_podman volume inspect --format '{{ .NeedsChown }}' $myvolume
+    is "${output}" "false" "Content has been copied up into volume, needschown will be false"
 
     run_podman volume inspect --format '{{.Mountpoint}}' $myvolume
     mountpoint="$output"


### PR DESCRIPTION
This is done to better match Docker's behavior. Our current behavior is to only chown a volume once, the first time it is mounted into a container; that doesn't match what Docker does. Docker chowns every time a container mounts a volume, to ensure it is always accessible to the last container to mount it.

Fortunately, this is a relatively easy fix. We have a bool in volume state as to whether a volume needs to be chowned, which we set to false when the volume was first chowned; so just stop doing that.

I was really hoping to eliminate the NeedsChown bool entirely, but things are a bit of a mess. There are some cases where we do want to completely inhibit chowning, like when the user explicitly requests that a volume be a specific UID and GID. Unfortunately, those are both ints, not *int, so we can't tell whether they were actually set, and the solution we were using was to force the NeedsChown bool to false - so we really need to keep it around. And even if we could change volume UID/GID to pointers, we're setting them in places we really shouldn't be - for example, container anonymous volumes set UID/GID to current container UID/GID, despite the fact that the volume will immediately chown itself from that to match the directory it's mounting over? In short, the current code's a mess and I don't see a way to fix it without breaking changes.

Fixes #22571

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now changes volume ownership every time a volume is mounted into a container, not just the first time.
```
