### PR TITLE
add podman-clean-transient.service service to rootless mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -949,6 +949,7 @@ install.systemd: $(PODMAN_UNIT_FILES)
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman.service $(DESTDIR)${USERSYSTEMDDIR}/podman.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-restart.service $(DESTDIR)${USERSYSTEMDDIR}/podman-restart.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-kube@.service $(DESTDIR)${USERSYSTEMDDIR}/podman-kube@.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-clean-transient.service $(DESTDIR)${USERSYSTEMDDIR}/podman-clean-transient.service
 	# System services
 	install ${SELINUXOPT} -m 644 contrib/systemd/auto-update/podman-auto-update.service $(DESTDIR)${SYSTEMDDIR}/podman-auto-update.service
 	install ${SELINUXOPT} -m 644 contrib/systemd/auto-update/podman-auto-update.timer $(DESTDIR)${SYSTEMDDIR}/podman-auto-update.timer


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

This PR adds the podman-clean-transient.service to the list of installed user services. According to the issue #22317 there should be no reason this would not work in user mode. This seems like it was just forgotten in the original PR: https://github.com/containers/podman/pull/16892

```release-note
- Add podman-clean-transient.service as a user service.
```

Closes #22317 