### PR TITLE
Check AppleHypervisor before accessing it

### DIFF
--- a/pkg/machine/apple/vfkit.go
+++ b/pkg/machine/apple/vfkit.go
@@ -43,8 +43,7 @@ func GetDefaultDevices(mc *vmconfigs.MachineConfig) ([]vfConfig.VirtioDevice, *d
 	}
 	devices = append(devices, disk, rng, serial, readyDevice)
 
-	rosettaCfg := mc.AppleHypervisor.Vfkit.Rosetta
-	if rosettaCfg {
+	if mc.AppleHypervisor != nil && mc.AppleHypervisor.Vfkit.Rosetta {
 		rosetta := &vfConfig.RosettaShare{
 			DirectorySharingConfig: vfConfig.DirectorySharingConfig{
 				MountTag: define.MountTag,


### PR DESCRIPTION
In GetDefaultDevices(), make sure MachineConfig has an AppleHypervisor instance before attempting to access it. This fixes a SIGSEGV when running with libkrun as machine provider.

#### Does this PR introduce a user-facing change?

```release-note
None
```
