### PR TITLE
Enable libkrun provider to open a debug console

### DIFF
--- a/pkg/machine/apple/vfkit.go
+++ b/pkg/machine/apple/vfkit.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	vfConfig "github.com/crc-org/vfkit/pkg/config"
 	"github.com/crc-org/vfkit/pkg/rest"
+	"github.com/sirupsen/logrus"
 )
 
 func GetDefaultDevices(mc *vmconfigs.MachineConfig) ([]vfConfig.VirtioDevice, *define.VMFile, error) {
@@ -41,7 +42,12 @@ func GetDefaultDevices(mc *vmconfigs.MachineConfig) ([]vfConfig.VirtioDevice, *d
 	if err != nil {
 		return nil, nil, err
 	}
-	devices = append(devices, disk, rng, serial, readyDevice)
+	devices = append(devices, disk, rng, readyDevice)
+	if mc.LibKrunHypervisor == nil || !logrus.IsLevelEnabled(logrus.DebugLevel) {
+		// If libkrun is the provider and we want to show the debug console,
+		// don't add a virtio serial device to avoid redirecting the output.
+		devices = append(devices, serial)
+	}
 
 	if mc.AppleHypervisor != nil && mc.AppleHypervisor.Vfkit.Rosetta {
 		rosetta := &vfConfig.RosettaShare{


### PR DESCRIPTION
When running with "log-level=debug" and libkrun as machine provider, spawn a Terminal to execute "krunkit" to enable users to have full access to the VMs console for debugging purposes.

Users obtain an interactive, text console with scrollback. It's possible to interact with both the kernel and GRUB2. To obtain even additional debugging information, users can add "console=hvc0" to the linux kernel command line through GRUB2 (it may be worth considering extending the initial configuration of the VM to add that argument by default).

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
