### PR TITLE
Mac PM test: Require pre-installed rosetta

### DIFF
--- a/contrib/cirrus/mac_setup.sh
+++ b/contrib/cirrus/mac_setup.sh
@@ -7,6 +7,14 @@
 
 set -euo pipefail
 
+# Confirm rosetta is installed/enabled and working
+if ! arch -arch x86_64 /usr/bin/uname -m; then
+    # This likely means whatever script used to prepare this mac failed
+    # and/or did not execute `sudo softwareupdate --install-rosetta --agree-to-license`
+    echo "Rosetta doesn't appear to be installed, or is non-functional."
+    exit 1
+fi
+
 # The otherwise standard `/etc/ci_environment` file cannot be used in this
 # context, because the system is shared for multiple tasks.  Instead, persist
 # env. vars required during /subsequent/ testing steps via a "magic" Cirrus-CI

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -69,13 +68,6 @@ var _ = BeforeSuite(func() {
 	}
 	if pullError != nil {
 		Fail(fmt.Sprintf("failed to pull wsl disk: %q", pullError))
-	}
-	if testProvider.VMType() == define.AppleHvVirt {
-		cmd := exec.Command("softwareupdate", "--install-rosetta", "--agree-to-license")
-		err := cmd.Run()
-		if err != nil {
-			Fail(fmt.Sprintf("Command failed with error: %q", err))
-		}
 	}
 })
 


### PR DESCRIPTION
Previously, the mac podman-machine tests installed rosetta before
executing any tests.  As a best-practice (and because the Macs in CI are
shared) tests should never permanently modify the system.  As of this
commit, the system setup script used for the CI Macs does the rosetta
installation.  Remove the test setup code that installed rosetta and
add a CI-level confirmation that it's been pre-installed.

Ref:
- https://github.com/containers/podman/pull/21670
- https://github.com/containers/automation/pull/196

TODO:

- [x] Confirm tests fail on mac w/o rosetta [result](https://cirrus-ci.com/task/6334672685236224)
- [X] Confirm mac setup script fails on mac w/o rosetta [result](https://cirrus-ci.com/task/4912824634310656)
- [x] Confirm tests pass on mac already setup with rosetta [result](https://cirrus-ci.com/task/6159379097976832)
- [x] Confirm tests pass on mac pre-setup (https://github.com/containers/automation/pull/196) with rosetta [result](https://cirrus-ci.com/task/6564662479683584)
- [x] Confirm reosetta is installed on entire CI mac worker pool.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
