### PR TITLE
CI: disable minikube task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -935,6 +935,8 @@ minikube_test_task:
     alias: minikube_test
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: *not_tag_magic
+    # 2024-05-21: flaking almost constantly since March.
+    skip: $CI == $CI
     depends_on: *build
     gce_instance: *standardvm
     env:


### PR DESCRIPTION
It's been flaking heavily since March. I don't see any new
development going on in minikube-land. If anyone decides
to care about minikube again, they can reenable this.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```