### PR TITLE
test, pasta: Ignore deprecated addresses in tests

### DIFF
--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -427,6 +427,6 @@ function default_addr() {
     local ip_ver="${1}"
     local ifname="${2:-$(default_ifname "${ip_ver}")}"
 
-    local expr='.[0] | .addr_info[0].local'
+    local expr='[.[0].addr_info[] | select(.deprecated != true)][0].local'
     ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}"
 }


### PR DESCRIPTION
The default_addr shell function in test/system/helpers.network is used to get the host's default address, which is used in a number of pasta networking tests.  However, in certain circumstances it can incorrectly pick a deprecated address as the primary address.  Correct it to exclude those.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
No
```
