### PR TITLE
[CI:DOCS] kubernetes_support.md: Mark volumeMounts.subPath as supported

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -104,7 +104,7 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | volumeMounts\.name                                  | ✅      |
 | volumeMounts\.mountPropagation                      | no      |
 | volumeMounts\.readOnly                              | ✅      |
-| volumeMounts\.subPath                               | no      |
+| volumeMounts\.subPath                               | ✅      |
 | volumeMounts\.subPathExpr                           | no      |
 | volumeDevices\.devicePath                           | no      |
 | volumeDevices\.name                                 | no      |


### PR DESCRIPTION
It seems like podman kube play already supports the field since version 4.4.0 but the documentation was not yet updated.

#### Does this PR introduce a user-facing change?

```release-note
None
```
