### PR TITLE
Draft: Prevent 'podman kube play' on a daemonset/deployment from dropping pod labels

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -967,6 +967,15 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			labels[k] = v
 		}
 
+		if labels == nil {
+			labels = podYAML.Annotations
+		} else {
+			// if it already exists add the yaml annotations
+			for k, v := range podYAML.Annotations { // add podYAML labels
+				labels[k] = v
+			}
+		}
+
 		automountImages, err := ic.prepareAutomountImages(ctx, container.Name, annotations)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

This PR ensures that the labels for the pods are retained when using `podman kube play` on either a deployment or daemonset.


### Testing

```
make binaries
./bin/podman container create --name autoupdate-test --replace --label io.containers.autoupdate=registry quay.io/quay/busybox echo foobar
./bin/podman kube generate -t deployment autoupdate-test > /tmp/kube.yml
./bin/podman kube play /tmp/kube.yml
./bin/podman inspect  autoupdate-test-pod-deployment-pod-autoupdate-test | grep -A 10 Labels
```

Verify that Config.Labels contains the following entry:
`"io.containers.autoupdate/autoupdate-test": "registry"`

#### Before:
```
"Labels": {
      "app": "autoupdate-test-pod"
 },
```

#### After:
```
"Labels": {
    "app": "autoupdate-test-pod",
    "io.containers.autoupdate/autoupdate-test": "registry"
 },
```


```release-note
`podman kube play` on a deployment will no longer drop labels. 
```

Closes #22801 