### PR TITLE
Sigh, new VMs again

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240528t194313z-f40f39d13"
+    IMAGE_SUFFIX: "c20240529t141726z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"


### PR DESCRIPTION
Another new-VM import from

   https://github.com/containers/automation_images/pull/338

...because the usual conflict dealio in that repo. This
should mostly be a NOP. All the major work was done in #22706.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```