### PR TITLE
[CI:DOCS] Add contrib/podmanimage/stable path back in repo

### DIFF
--- a/contrib/podmanimage/stable/README.md
+++ b/contrib/podmanimage/stable/README.md
@@ -1,0 +1,2 @@
+The podman container image build context and automation have been
+moved to [https://github.com/containers/image_build/tree/main/podman](https://github.com/containers/image_build/tree/main/podman)


### PR DESCRIPTION
The path mentioned above is linked in the sysadmin article on running podman inside containers. The content has since been moved and users are getting a 404 there now. Add the path back with a readme pointing to the new location of the content.

Not sure if the article can be updated, but this seems like a good workaround for the time being. Link to article is https://www.redhat.com/sysadmin/podman-inside-container.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
