### PR TITLE
test/e2e: use local skopeo not image

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -233,12 +233,11 @@ var _ = Describe("Podman manifest", func() {
 		// 4 images must be pushed two for gzip and two for zstd
 		Expect(output).To(ContainSubstring("Copying 4 images generated from 2 images in list"))
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--net", "host", "quay.io/skopeo/stable", "inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		skopeo := SystemExec("skopeo", []string{"inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
+		Expect(skopeo).Should(ExitCleanly())
+		inspectData := []byte(skopeo.OutputToString())
 		var index imgspecv1.Index
-		inspectData := []byte(session.OutputToString())
-		err := json.Unmarshal(inspectData, &index)
+		err = json.Unmarshal(inspectData, &index)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(verifyInstanceCompression(index.Manifests, "zstd", "amd64")).Should(BeTrue())
@@ -254,10 +253,9 @@ var _ = Describe("Podman manifest", func() {
 		// 4 images must be pushed two for gzip and two for zstd
 		Expect(output).To(ContainSubstring("Copying 4 images generated from 2 images in list"))
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--net", "host", "quay.io/skopeo/stable", "inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-		inspectData = []byte(session.OutputToString())
+		skopeo = SystemExec("skopeo", []string{"inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
+		Expect(skopeo).Should(ExitCleanly())
+		inspectData = []byte(skopeo.OutputToString())
 		err = json.Unmarshal(inspectData, &index)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -280,10 +278,9 @@ add_compression = ["zstd"]`), 0o644)
 		// 4 images must be pushed two for gzip and two for zstd
 		Expect(output).To(ContainSubstring("Copying 4 images generated from 2 images in list"))
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--net", "host", "quay.io/skopeo/stable", "inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-		inspectData = []byte(session.OutputToString())
+		skopeo = SystemExec("skopeo", []string{"inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
+		Expect(skopeo).Should(ExitCleanly())
+		inspectData = []byte(skopeo.OutputToString())
 		err = json.Unmarshal(inspectData, &index)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -301,10 +298,9 @@ add_compression = ["zstd"]`), 0o644)
 		// 4 images must be pushed two for gzip and two for zstd
 		Expect(output).To(ContainSubstring("Copying 4 images generated from 2 images in list"))
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--net", "host", "quay.io/skopeo/stable", "inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-		inspectData = []byte(session.OutputToString())
+		skopeo = SystemExec("skopeo", []string{"inspect", "--tls-verify=false", "--raw", "docker://localhost:5007/list:latest"})
+		Expect(skopeo).Should(ExitCleanly())
+		inspectData = []byte(skopeo.OutputToString())
 		err = json.Unmarshal(inspectData, &index)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
The e2e tests already depend on skopeo anyway and pulling a over 300 MB image is not helpful for flakes but most importantly we see ENOSPC flakes. I see them around the skopeo test so I assume the big image is pushing the tmpfs limits so other tests running in parallel can start failing because of it.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
