### PR TITLE
pkg/rootless: set _CONTAINERS_USERNS_CONFIGURED correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.1.0
 	github.com/containernetworking/plugins v1.5.0
 	github.com/containers/buildah v1.36.0
-	github.com/containers/common v0.59.0
+	github.com/containers/common v0.59.1-0.20240603155017-49ad520556e7
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.4-0.20240515153903-01a1a0cd3f70
 	github.com/containers/image/v5 v5.31.1-0.20240530141348-2343e812b95b

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/containernetworking/plugins v1.5.0 h1:P09DMlfvvsLSskDoftnuwXY7lwa7IAh
 github.com/containernetworking/plugins v1.5.0/go.mod h1:bcXMvG9gWGc6jVXeodmMzuXmXqpqMguZm6Zu/oIr7AA=
 github.com/containers/buildah v1.36.0 h1:e369nE9bx0yJtPVRDMsbr0OzkW59XCYAl+5poGhFjcs=
 github.com/containers/buildah v1.36.0/go.mod h1:qlEF4RuCnzEUTQhAnCyGr5WoYNZaU0k2mPcZscUR//c=
-github.com/containers/common v0.59.0 h1:fy9Jz0B7Qs1C030bm73YJtVddaiFSZD3558EV1tgN2g=
-github.com/containers/common v0.59.0/go.mod h1:53VicJCZ2AD0O+Br7VVoyrS7viXF4YmwlTIocWUT8XE=
+github.com/containers/common v0.59.1-0.20240603155017-49ad520556e7 h1:Vp0npRNqZJrtMrOeVPyLNDYojSPbkNm3pQVnuBULubs=
+github.com/containers/common v0.59.1-0.20240603155017-49ad520556e7/go.mod h1:G4vF3V1iWu+NxT/pquuJYBcWGsrVKibDhPu9h52nXyI=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.4-0.20240515153903-01a1a0cd3f70 h1:aACcXSIgcuPq5QdNZZ8B53BCdhqYvw33/8QmZWJATvg=

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -880,7 +880,7 @@ reexec_userns_join (int pid_to_join, char *pause_pid_file_path)
         setenv ("LISTEN_FDNAMES", saved_systemd_listen_fdnames, true);
     }
 
-  setenv ("_CONTAINERS_USERNS_CONFIGURED", "init", 1);
+  setenv ("_CONTAINERS_USERNS_CONFIGURED", "done", 1);
   setenv ("_CONTAINERS_ROOTLESS_UID", uid, 1);
   setenv ("_CONTAINERS_ROOTLESS_GID", gid, 1);
 
@@ -1081,7 +1081,7 @@ reexec_in_user_namespace (int ready, char *pause_pid_file_path, char *file_to_re
         setenv ("LISTEN_FDNAMES", saved_systemd_listen_fdnames, true);
     }
 
-  setenv ("_CONTAINERS_USERNS_CONFIGURED", "init", 1);
+  setenv ("_CONTAINERS_USERNS_CONFIGURED", "done", 1);
   setenv ("_CONTAINERS_ROOTLESS_UID", uid, 1);
   setenv ("_CONTAINERS_ROOTLESS_GID", gid, 1);
 

--- a/vendor/github.com/containers/common/libimage/manifests/manifests.go
+++ b/vendor/github.com/containers/common/libimage/manifests/manifests.go
@@ -663,6 +663,9 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 		if err != nil {
 			return "", fmt.Errorf("adding instance with digest %q: %w", *instanceInfo.instanceDigest, err)
 		}
+		if err := l.List.SetArtifactType(instanceInfo.instanceDigest, instanceInfo.ArtifactType); err != nil {
+			return "", fmt.Errorf("setting artifact manifest type for instance with digest %q: %w", *instanceInfo.instanceDigest, err)
+		}
 		if err = l.List.SetURLs(*instanceInfo.instanceDigest, instanceInfo.URLs); err != nil {
 			return "", fmt.Errorf("setting URLs for instance with digest %q: %w", *instanceInfo.instanceDigest, err)
 		}

--- a/vendor/github.com/containers/common/pkg/config/config_bsd.go
+++ b/vendor/github.com/containers/common/pkg/config/config_bsd.go
@@ -1,3 +1,5 @@
+//go:build (freebsd || netbsd || openbsd)
+
 package config
 
 const (

--- a/vendor/github.com/containers/common/pkg/config/config_windows.go
+++ b/vendor/github.com/containers/common/pkg/config/config_windows.go
@@ -5,7 +5,7 @@ import "os"
 const (
 	// _configPath is the path to the containers/containers.conf
 	// inside a given config directory.
-	_configPath = "containers\\containers.conf"
+	_configPath = "\\containers\\containers.conf"
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = ""

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -350,9 +350,9 @@ default_sysctls = [
 
 # The firewall driver to be used by netavark.
 # The default is empty which means netavark will pick one accordingly. Current supported
-# drivers are "iptables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
-# experimental at the moment and not recommend outside of testing). In the future we are
-# planning to add support for a "nftables" driver.
+# drivers are "iptables", "nftables", "none" (no firewall rules will be created) and "firewalld" (firewalld is
+# experimental at the moment and not recommend outside of testing).
+#
 #firewall_driver = ""
 
 
@@ -890,10 +890,10 @@ default_sysctls = [
 [podmansh]
 # Shell to spawn in container. Default: /bin/sh.
 #shell = "/bin/sh"
-# 
+#
 # Name of the container the podmansh user should join.
 #container = "podmansh"
-# 
+#
 # Default timeout in seconds for podmansh logins.
 # Favored over the deprecated "podmansh_timeout" field.
 #timeout = 30

--- a/vendor/github.com/containers/common/pkg/config/default_bsd.go
+++ b/vendor/github.com/containers/common/pkg/config/default_bsd.go
@@ -1,3 +1,5 @@
+//go:build (freebsd || netbsd || openbsd)
+
 package config
 
 // DefaultInitPath is the default path to the container-init binary.

--- a/vendor/github.com/containers/common/pkg/config/default_common.go
+++ b/vendor/github.com/containers/common/pkg/config/default_common.go
@@ -1,4 +1,4 @@
-//go:build !freebsd
+//go:build !freebsd && !netbsd
 
 package config
 

--- a/vendor/github.com/containers/common/pkg/password/password_supported.go
+++ b/vendor/github.com/containers/common/pkg/password/password_supported.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin || freebsd
+//go:build linux || darwin || freebsd || netbsd
 
 package password
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.59.0"
+const Version = "0.60.0-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.59.0
+# github.com/containers/common v0.59.1-0.20240603155017-49ad520556e7
 ## explicit; go 1.21
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
This is a bit weird and I admit I don't understand exactly how the init
value is used but this seems wrong. When podman reexec itself it then
gets the wrong init value and because rootless_uid() will be 0 the
init() function in rootless_linux.go will not set it either because of
that. Thus the first reexec has the wrong env.

Now that I make use of it in c/common[1] this turns out top be a real
issue and is failing all first podman commands. To reproduce make sure
to kill the pause process then just run any podman command with the new
c/common vendor and without this patch.

[1] https://github.com/containers/common/pull/2020

```release-note
None
```
