### PR TITLE
libpod: fix 'podman kube generate' on FreeBSD

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -1308,7 +1308,7 @@ func generateKubeSecurityContext(c *Container) (*v1.SecurityContext, bool, error
 		scHasData = true
 		sc.ReadOnlyRootFilesystem = &ro
 	}
-	if c.config.Spec.Linux.MaskedPaths == nil {
+	if c.config.Spec.Linux != nil && c.config.Spec.Linux.MaskedPaths == nil {
 		scHasData = true
 		unmask := v1.UnmaskedProcMount
 		sc.ProcMount = &unmask


### PR DESCRIPTION
This avoids dereferencing c.config.Spec.Linux if it is nil, which is the case on FreeBSD.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
