### PR TITLE
libpod: do not reuse networking on start

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -71,6 +71,14 @@ func (c *Container) prepare() error {
 
 	go func() {
 		defer wg.Done()
+		if c.state.State == define.ContainerStateStopped {
+			// networking should not be reused after a stop
+			if err := c.cleanupNetwork(); err != nil {
+				createNetNSErr = err
+				return
+			}
+		}
+
 		// Set up network namespace if not already set up
 		noNetNS := c.state.NetNS == ""
 		if c.config.CreateNetNS && noNetNS && !c.config.PostConfigureNetNS {

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -193,12 +193,13 @@ var _ = Describe("Podman restart", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		testCmd := []string{"exec", "host-restart-test", "sh", "-c", "wc -l < /etc/hosts"}
+		testCmd := []string{"exec", "host-restart-test", "cat", "/etc/hosts"}
 
 		// before restart
 		beforeRestart := podmanTest.Podman(testCmd)
 		beforeRestart.WaitWithDefaultTimeout()
 		Expect(beforeRestart).Should(ExitCleanly())
+		nHostLines := len(beforeRestart.OutputToStringArray())
 
 		session = podmanTest.Podman([]string{"restart", "host-restart-test"})
 		session.WaitWithDefaultTimeout()
@@ -209,7 +210,8 @@ var _ = Describe("Podman restart", func() {
 		Expect(afterRestart).Should(ExitCleanly())
 
 		// line count should be equal
-		Expect(beforeRestart.OutputToString()).To(Equal(afterRestart.OutputToString()))
+		Expect(afterRestart.OutputToStringArray()).To(HaveLen(nHostLines),
+			"number of host lines post-restart == number of lines pre-restart")
 	})
 
 	It("podman restart all stopped containers with --all", func() {

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -58,6 +58,9 @@ load helpers
     is "$output" ".*$c1_id.*" "--filter finds container 1"
     is "$output" ".*$c3_id.*" "--filter finds container 3"
 
+    # start again, before this fix it could panic
+    run_podman start --filter restart-policy=always
+
     # Start via filtered names
     run_podman start --filter restart-policy=on-failure $c2 $c3
     is "$output" "$c2" "--filter finds container 2"


### PR DESCRIPTION
If a container was stopped and we try to start it before we called cleanup it tried to reuse the network which caused a panic as the pasta code cannot deal with that. It is also never correct as the netns must be created by the runtime in case of custom user namespaces used. As such the proper thing is to clean the netns up first.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a small race where podman start could panic when it tried to start a container in the stopped state.  
```
