### PR TITLE
machine/linux: Switch to virtiofs by default

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -410,7 +410,12 @@ case "$TEST_FLAVOR" in
         install_test_configs
         ;;
     machine-linux)
-        showrun dnf install -y podman-gvproxy*
+        showrun dnf install -y podman-gvproxy* virtiofsd
+        # Bootstrap this link if it isn't yet in the package; xref
+        # https://github.com/containers/podman/pull/22920
+        if ! test -L /usr/libexec/podman/virtiofsd; then
+            showrun ln -sfr /usr/libexec/virtiofsd /usr/libexec/podman/virtiofsd
+        fi
         remove_packaged_podman_files
         showrun make install PREFIX=/usr ETCDIR=/etc
         install_test_configs

--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -87,7 +87,7 @@ func GenerateSystemDFilesForVirtiofsMounts(mounts []machine.VirtIoFs) ([]ignitio
 		mountUnit.Add("Mount", "What", "%s")
 		mountUnit.Add("Mount", "Where", "%s")
 		mountUnit.Add("Mount", "Type", "virtiofs")
-		mountUnit.Add("Mount", "Options", "context=\"system_u:object_r:nfs_t:s0\"")
+		mountUnit.Add("Mount", "Options", fmt.Sprintf("context=\"%s\"", machine.NFSSELinuxContext))
 		mountUnit.Add("Install", "WantedBy", "multi-user.target")
 		mountUnitFile, err := mountUnit.ToString()
 		if err != nil {

--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -32,7 +32,7 @@ func Get() (vmconfigs.VMProvider, error) {
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
 	switch resolvedVMType {
 	case define.QemuVirt:
-		return new(qemu.QEMUStubber), nil
+		return qemu.NewStubber()
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -35,8 +35,10 @@ func NewQemuBuilder(binary string, options []string) QemuCmd {
 
 // SetMemory adds the specified amount of memory for the machine
 func (q *QemuCmd) SetMemory(m strongunits.MiB) {
-	// qemu accepts the memory in MiB
-	*q = append(*q, "-m", strconv.FormatUint(uint64(m), 10))
+	serializedMem := strconv.FormatUint(uint64(m), 10)
+	// In order to use virtiofsd, we must enable shared memory
+	*q = append(*q, "-object", fmt.Sprintf("memory-backend-memfd,id=mem,size=%sM,share=on", serializedMem))
+	*q = append(*q, "-m", serializedMem)
 }
 
 // SetCPUs adds the number of CPUs the machine will have

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -99,15 +99,6 @@ func (q *QemuCmd) SetSerialPort(readySocket, vmPidFile define.VMFile, name strin
 		"-pidfile", vmPidFile.GetPath())
 }
 
-// SetVirtfsMount adds a virtfs mount to the machine
-func (q *QemuCmd) SetVirtfsMount(source, tag, securityModel string, readonly bool) {
-	virtfsOptions := fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=%s", source, tag, securityModel)
-	if readonly {
-		virtfsOptions += ",readonly"
-	}
-	*q = append(*q, "-virtfs", virtfsOptions)
-}
-
 // SetBootableImage specifies the image the machine will use to boot
 func (q *QemuCmd) SetBootableImage(image string) {
 	*q = append(*q, "-drive", "if=virtio,file="+image)

--- a/pkg/machine/qemu/command/qemu_command_test.go
+++ b/pkg/machine/qemu/command/qemu_command_test.go
@@ -53,6 +53,8 @@ func TestQemuCmd(t *testing.T) {
 
 	expected := []string{
 		"/usr/bin/qemu-system-x86_64",
+		"-object",
+		"memory-backend-memfd,id=mem,size=2048M,share=on",
 		"-m", "2048",
 		"-smp", "4",
 		"-fw_cfg", fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignPath),

--- a/pkg/machine/qemu/command/qemu_command_test.go
+++ b/pkg/machine/qemu/command/qemu_command_test.go
@@ -47,7 +47,6 @@ func TestQemuCmd(t *testing.T) {
 	err = cmd.SetNetwork(vlanSocket)
 	assert.NoError(t, err)
 	cmd.SetSerialPort(*readySocket, *vmPidFile, "test-machine")
-	cmd.SetVirtfsMount("/tmp/path", "vol10", "none", true)
 	cmd.SetBootableImage(bootableImagePath)
 	cmd.SetDisplay("none")
 
@@ -65,7 +64,6 @@ func TestQemuCmd(t *testing.T) {
 		"-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=atest-machine_ready", readySocketPath),
 		"-device", "virtserialport,chardev=atest-machine_ready,name=org.fedoraproject.port.0",
 		"-pidfile", vmPidFilePath,
-		"-virtfs", "local,path=/tmp/path,mount_tag=vol10,security_model=none,readonly",
 		"-drive", fmt.Sprintf("if=virtio,file=%s", bootableImagePath),
 		"-display", "none"}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -25,8 +25,27 @@ import (
 )
 
 const (
-	MountType9p = "9p"
+	MountType9p       = "9p"
+	MountTypeVirtiofs = "virtiofs"
 )
+
+func NewStubber() (*QEMUStubber, error) {
+	var mountType string
+	if v, ok := os.LookupEnv("PODMAN_MACHINE_VIRTFS"); ok {
+		logrus.Debugf("using virtiofs %q", v)
+		switch v {
+		case MountType9p, MountTypeVirtiofs:
+			mountType = v
+		default:
+			return nil, fmt.Errorf("failed to parse PODMAN_MACHINE_VIRTFS=%s", v)
+		}
+	} else {
+		mountType = MountType9p
+	}
+	return &QEMUStubber{
+		mountType: mountType,
+	}, nil
+}
 
 // qemuPid returns -1 or the PID of the running QEMU instance.
 func qemuPid(pidFile *define.VMFile) (int, error) {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -24,27 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	MountType9p       = "9p"
-	MountTypeVirtiofs = "virtiofs"
-)
-
 func NewStubber() (*QEMUStubber, error) {
-	var mountType string
-	if v, ok := os.LookupEnv("PODMAN_MACHINE_VIRTFS"); ok {
-		logrus.Debugf("using virtiofs %q", v)
-		switch v {
-		case MountType9p, MountTypeVirtiofs:
-			mountType = v
-		default:
-			return nil, fmt.Errorf("failed to parse PODMAN_MACHINE_VIRTFS=%s", v)
-		}
-	} else {
-		mountType = MountType9p
-	}
-	return &QEMUStubber{
-		mountType: mountType,
-	}, nil
+	return &QEMUStubber{}, nil
 }
 
 // qemuPid returns -1 or the PID of the running QEMU instance.

--- a/pkg/machine/qemu/options_linux_amd64.go
+++ b/pkg/machine/qemu/options_linux_amd64.go
@@ -10,6 +10,7 @@ func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{
 		"-accel", "kvm",
 		"-cpu", "host",
+		"-M", "memory-backend=mem",
 	}
 	return opts
 }

--- a/pkg/machine/qemu/options_linux_arm64.go
+++ b/pkg/machine/qemu/options_linux_arm64.go
@@ -16,7 +16,7 @@ func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{
 		"-accel", "kvm",
 		"-cpu", "host",
-		"-M", "virt,gic-version=max",
+		"-M", "virt,gic-version=max,memory-backend=mem",
 		"-bios", getQemuUefiFile("QEMU_EFI.fd"),
 	}
 	return opts

--- a/pkg/machine/qemu/virtiofsd.go
+++ b/pkg/machine/qemu/virtiofsd.go
@@ -1,0 +1,99 @@
+//go:build linux || freebsd
+
+package qemu
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/containers/storage/pkg/fileutils"
+	"github.com/sirupsen/logrus"
+)
+
+// VirtiofsdSpawner spawns an instance of virtiofsd
+type virtiofsdSpawner struct {
+	runtimeDir *define.VMFile
+	binaryPath string
+	mountCount uint
+}
+
+func newVirtiofsdSpawner(runtimeDir *define.VMFile) (*virtiofsdSpawner, error) {
+	var binaryPath string
+	cfg, err := config.Default()
+	if err != nil {
+		return nil, err
+	}
+	binaryPath, err = cfg.FindHelperBinary("virtiofsd", true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find virtiofsd: %w", err)
+	}
+	return &virtiofsdSpawner{binaryPath: binaryPath, runtimeDir: runtimeDir}, nil
+}
+
+// createVirtiofsCmd returns a new command instance configured to launch virtiofsd.
+func (v *virtiofsdSpawner) createVirtiofsCmd(directory, socketPath string) *exec.Cmd {
+	args := []string{"--sandbox", "none", "--socket-path", socketPath, "--shared-dir", "."}
+	// We don't need seccomp filtering; we trust our workloads. This incidentally
+	// works around issues like https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/200.
+	args = append(args, "--seccomp=none")
+	cmd := exec.Command(v.binaryPath, args...)
+	// This sets things up so that the `.` we passed in the arguments is the target directory
+	cmd.Dir = directory
+	// Quiet the daemon by default
+	cmd.Env = append(cmd.Environ(), "RUST_LOG=ERROR")
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		cmd.Stderr = os.Stderr
+	}
+	return cmd
+}
+
+type virtiofsdHelperCmd struct {
+	command exec.Cmd
+	socket  *define.VMFile
+}
+
+// spawnForMount returns on success a combination of qemu commandline and child process for virtiofsd
+func (v *virtiofsdSpawner) spawnForMount(hostmnt *vmconfigs.Mount) ([]string, *virtiofsdHelperCmd, error) {
+	logrus.Debugf("Initializing virtiofsd mount for %s", hostmnt.Source)
+	// By far the most common failure to spawn virtiofsd will be a typo'd source directory,
+	// so let's synchronously check that ourselves here.
+	if err := fileutils.Exists(hostmnt.Source); err != nil {
+		return nil, nil, fmt.Errorf("failed to access virtiofs source directory %s", hostmnt.Source)
+	}
+	virtiofsChar := fmt.Sprintf("virtiofschar%d", v.mountCount)
+	virtiofsCharPath, err := v.runtimeDir.AppendToNewVMFile(virtiofsChar, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	qemuCommand := []string{}
+
+	qemuCommand = append(qemuCommand, "-chardev", fmt.Sprintf("socket,id=%s,path=%s", virtiofsChar, virtiofsCharPath.Path))
+	qemuCommand = append(qemuCommand, "-device", fmt.Sprintf("vhost-user-fs-pci,queue-size=1024,chardev=%s,tag=%s", virtiofsChar, hostmnt.Tag))
+	// TODO: Honor hostmnt.readonly somehow here (add an option to virtiofsd)
+	virtiofsdCmd := v.createVirtiofsCmd(hostmnt.Source, virtiofsCharPath.Path)
+	if err := virtiofsdCmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("failed to start virtiofsd")
+	}
+	// Wait for the socket
+	for {
+		if err := fileutils.Exists(virtiofsCharPath.Path); err == nil {
+			break
+		}
+		logrus.Debugf("waiting for virtiofsd socket %q", virtiofsCharPath.Path)
+		time.Sleep(time.Millisecond * 100)
+	}
+	// Increment our count of mounts which are used to create unique names for the devices
+	v.mountCount += 1
+	return qemuCommand, &virtiofsdHelperCmd{
+		command: *virtiofsdCmd,
+		socket:  virtiofsCharPath,
+	}, nil
+}

--- a/pkg/machine/volumes.go
+++ b/pkg/machine/volumes.go
@@ -7,6 +7,11 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 )
 
+// NFSSELinuxContext is what is used by NFS mounts, which is allowed
+// access by container_t.  We need to fix the Fedora selinux policy
+// to just allow access to virtiofs_t.
+const NFSSELinuxContext = "system_u:object_r:nfs_t:s0"
+
 type Volume interface {
 	Kind() VolumeKind
 }


### PR DESCRIPTION
machine/linux: Use memory-backend-memfd by default

This is prep for using virtiofsd; it has no real
impact otherwise.

Signed-off-by: Colin Walters <walters@verbum.org>

---

machine: Also initialize virtiofs mounts

I'm hitting a bug with 9p when trying to transfer large files.
In RHEL at least 9p isn't supported because it's known to have a
lot of design flaws; virtiofsd is the supported and recommended
way to share files between a host and guest.

This patch somewhat hackily sets up parallel virtiofsd mounts
alongside the 9p mounts (just on the host side, but one
can then easily mount in the guest).

This is allowing me to do some side-by-side comparisons
with the exact same machine.

I think what we can do in the short term is make
this a hidden option to enable (both "alongside" and also
fully replacing the 9p code).

Signed-off-by: Colin Walters <walters@verbum.org>

---

```release-note
On Linux, podman machine has switched to using virtiofs (instead of 9p) for mounting host filesystems.  This change will be transparently applied when a machine is stopped and restarted (e.g. "podman machine stop; podman machine start") or reinitializing the machine.  This change is intended to improve performance and reliability.
```
