### PR TITLE
Podman machine resets all providers

### DIFF
--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -38,6 +38,10 @@ func Get() (vmconfigs.VMProvider, error) {
 	}
 }
 
+func GetAll(_ bool) ([]vmconfigs.VMProvider, error) {
+	return []vmconfigs.VMProvider{new(qemu.QEMUStubber)}, nil
+}
+
 // SupportedProviders returns the providers that are supported on the host operating system
 func SupportedProviders() []define.VMType {
 	return []define.VMType{define.QemuVirt}

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -42,6 +42,13 @@ func Get() (vmconfigs.VMProvider, error) {
 	}
 }
 
+func GetAll(_ bool) ([]vmconfigs.VMProvider, error) {
+	return []vmconfigs.VMProvider{
+		new(applehv.AppleHVStubber),
+		new(libkrun.LibKrunStubber),
+	}, nil
+}
+
 // SupportedProviders returns the providers that are supported on the host operating system
 func SupportedProviders() []define.VMType {
 	supported := []define.VMType{define.AppleHvVirt}

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -43,6 +43,18 @@ func Get() (vmconfigs.VMProvider, error) {
 	}
 }
 
+func GetAll(force bool) ([]vmconfigs.VMProvider, error) {
+	providers := []vmconfigs.VMProvider{
+		new(wsl.WSLStubber),
+	}
+	if !wsl.HasAdminRights() && !force {
+		logrus.Warn("managing hyperv machines require admin authority.")
+	} else {
+		providers = append(providers, new(hyperv.HyperVStubber))
+	}
+	return providers, nil
+}
+
 // SupportedProviders returns the providers that are supported on the host operating system
 func SupportedProviders() []define.VMType {
 	return []define.VMType{define.HyperVVirt, define.WSLVirt}


### PR DESCRIPTION
Podman machine reset now removes and resets machines from all providers availabe on the platform.

On windows, if the user is does not have admin privs, machine will only reset WSL, but will emit a warning that it is unable to remove hyperV machines without elevated privs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman machine reset` command now removes machines from all providers. 
```
