### PR TITLE
[CI:DOCS] Update troubleshooting.md

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -733,8 +733,30 @@ file `/etc/systemd/system/user@.service.d/delegate.conf` with the contents:
 Delegate=memory pids cpu cpuset
 ```
 
+Then `sudo systemctl daemon-reload` to Reload systemd configuration.
+
 After logging out and logging back in, you should have permission to set
 CPU and CPUSET limits.
+
+##### Auto shell scripts
+
+Here is a shell script that combines the above operations:
+
+```sh
+cat "/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers" \
+| grep cpu || ( \
+sudo mkdir -p /etc/systemd/system/user@.service.d/ && \
+ 
+sudo bash -c "cat > /etc/systemd/system/user@.service.d/delegate.conf << EOF
+[Service]
+Delegate=memory pids cpu cpuset
+EOF" && \
+ 
+sudo systemctl daemon-reload
+)
+```
+
+After logging out and logging back in, check it again by `cat "/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers"`
 
 ### 27) `exec container process '/bin/sh': Exec format error` (or another binary than `bin/sh`)
 


### PR DESCRIPTION
Add one more step `sudo systemctl daemon-reload` before re-login. Only with reloading systemd config fixing `--cpus` error on my situation.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add one more step `sudo systemctl daemon-reload` before re-login.
```
