### PR TITLE
--squash --layers=false should be allowed

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -136,9 +136,8 @@ func DefineBuildFlags(cmd *cobra.Command, buildOpts *BuildFlagsWrapper, isFarmBu
 }
 
 func ParseBuildOpts(cmd *cobra.Command, args []string, buildOpts *BuildFlagsWrapper) (*entities.BuildOptions, error) {
-	if (cmd.Flags().Changed("squash") && cmd.Flags().Changed("layers")) ||
-		(cmd.Flags().Changed("squash-all") && cmd.Flags().Changed("squash")) {
-		return nil, errors.New("cannot specify --squash with --layers and --squash-all with --squash")
+	if cmd.Flags().Changed("squash-all") && cmd.Flags().Changed("squash") {
+		return nil, errors.New("cannot specify --squash-all with --squash")
 	}
 
 	if cmd.Flag("output").Changed && registry.IsRemote() {

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -190,12 +190,11 @@ var _ = Describe("Podman build", func() {
 		// Test if entire build is used from cache
 		Expect(session.OutputToString()).To(ContainSubstring("Using cache"))
 
-		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test-squash-d"})
+		session = podmanTest.Podman([]string{"inspect", "--format", "{{.RootFS.Layers}}", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		// Check for one layers
 		Expect(strings.Fields(session.OutputToString())).To(HaveLen(1))
-
 	})
 
 	It("podman build Containerfile locations", func() {

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -1110,6 +1110,12 @@ EOF
     run_podman build -t build_test $tmpdir/link
 }
 
+@test "podman build --squash --squash-all should conflict" {
+    echo FROM scratch > $PODMAN_TMPDIR/Dockerfile
+    run_podman 125 build -t build_test --squash-all --squash $PODMAN_TMPDIR
+    is "$output" "Error: cannot specify --squash-all with --squash" "--squash and --sqaush-all should conflict"
+}
+
 @test "podman build --volumes-from conflict" {
     rand_content=$(random_string 50)
 


### PR DESCRIPTION
This is the same as what --squash-all is doing, and we already support --squash with --layers=true since this is the default.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
You can now use `podman build --squash --layers=false` at the same time.
```
