### PR TITLE
Remove references to --pull=true and --pull=false 

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -75,7 +75,7 @@ func DefineBuildFlags(cmd *cobra.Command, buildOpts *BuildFlagsWrapper, isFarmBu
 	if err := flag.Value.Set("missing"); err != nil {
 		logrus.Errorf("Unable to set --pull to 'missing': %v", err)
 	}
-	flag.Usage = `Pull image policy ("always/true"|"missing"|"never/false"|"newer")`
+	flag.Usage = `Pull image policy ("always"|"missing"|"never"|"newer")`
 	flags.AddFlagSet(&budFlags)
 
 	// Add the completion functions

--- a/docs/source/markdown/options/pull.image.md
+++ b/docs/source/markdown/options/pull.image.md
@@ -4,9 +4,9 @@
 ####> are applicable to all of those.
 #### **--pull**=*policy*
 
-Pull image policy. The default is **always**.
+Pull image policy. The default is **missing**.
 
-- **always**, **true**: Always pull the image and throw an error if the pull fails.
+- **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
-- **never**, **false**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
+- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
 - **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -313,8 +313,6 @@ the help of emulation provided by packages like `qemu-user-static`.
 
 @@option pull.image
 
-Pull image policy. The default is **missing**.
-
 @@option quiet
 
 @@option retry

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -1168,4 +1168,9 @@ function teardown() {
     basic_teardown
 }
 
+@test "podman build --help defaults" {
+    run_podman build --help
+    assert "$output" =~ "--pull.*(default \"missing\")" "pull should default to missing"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix documentation on default --pull value for podman build.
```
