### PR TITLE
podman: add new hidden flag --pull-option

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -580,6 +580,8 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 
 		pFlags.BoolVar(&podmanConfig.TransientStore, "transient-store", false, "Enable transient container storage")
 
+		pFlags.StringArrayVar(&podmanConfig.PullOptions, "pull-option", nil, "Specify an option to change how the image is pulled")
+
 		runtimeFlagName := "runtime"
 		pFlags.StringVar(&podmanConfig.RuntimePath, runtimeFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.OCIRuntime, "Path to the OCI-compatible binary used to run containers.")
 		_ = cmd.RegisterFlagCompletionFunc(runtimeFlagName, completion.AutocompleteDefault)
@@ -606,6 +608,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 			"default-mounts-file",
 			"max-workers",
 			"memory-profile",
+			"pull-option",
 			"registries-conf",
 			"trace",
 		} {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -83,6 +83,13 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 			copy(rt.storageConfig.GIDMap, config.GIDMap)
 		}
 
+		if config.PullOptions != nil {
+			rt.storageConfig.PullOptions = make(map[string]string)
+			for k, v := range config.PullOptions {
+				rt.storageConfig.PullOptions[k] = v
+			}
+		}
+
 		// If any one of runroot, graphroot, graphdrivername,
 		// or graphdriveroptions are set, then GraphRoot and RunRoot
 		// must be set

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -57,4 +57,5 @@ type PodmanConfig struct {
 	MachineMode    bool
 	TransientStore bool
 	GraphRoot      string
+	PullOptions    []string
 }

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -93,6 +94,20 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		storageSet = true
 		storageOpts.ImageStore = cfg.ImageStore
 		options = append(options, libpod.WithImageStore(cfg.ImageStore))
+	}
+	if fs.Changed("pull-option") {
+		storageSet = true
+		storageOpts.PullOptions = make(map[string]string)
+		for _, v := range cfg.PullOptions {
+			if v == "" {
+				continue
+			}
+			val := strings.SplitN(v, "=", 2)
+			if len(val) != 2 {
+				return nil, fmt.Errorf("invalid pull option: %s", v)
+			}
+			storageOpts.PullOptions[val[0]] = val[1]
+		}
 	}
 	if fs.Changed("storage-driver") {
 		storageSet = true

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -90,6 +90,7 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		storageOpts.RunRoot = cfg.Runroot
 	}
 	if fs.Changed("imagestore") {
+		storageSet = true
 		storageOpts.ImageStore = cfg.ImageStore
 		options = append(options, libpod.WithImageStore(cfg.ImageStore))
 	}


### PR DESCRIPTION
add a new flag that allows to override the pull options configured in the storage.conf file.
    
e.g.: --pull-option="enable_partial_images=false" can be specified to Podman to disable partial pulls even if enabled.
    
Leave it as a hidden configuration flag for now since the API itself is marked as experimental in c/storage.
    
Currently c/storage doesn't honor the overrides, being fixed with https://github.com/containers/storage/pull/1966

```release-note
None
```
