### PR TITLE
[CI:DOCS] Fix typos in podman-build

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -604,7 +604,7 @@ $ podman build https://10.10.10.1/podman/Containerfile
 #### Building an image using a Git repository
 
   Podman clones the specified GitHub repository to a temporary location and
-use it as the context. The Containerfile at the root of the repository is used
+uses it as the context. The Containerfile at the root of the repository is used
 and it only works if the GitHub repository is a dedicated repository.
 
 Build image from specified git repository downloaded into temporary location used as the build context:
@@ -617,7 +617,7 @@ $ podman run hello
 
 #### Building an image using a URL to an archive
 
-  Podman fetches the archive file, decompress it, and use its contents as the
+  Podman fetches the archive file, decompresses it, and uses its contents as the
 build context. The Containerfile at the root of the archive and the rest of the
 archive are used as the context of the build. Passing the
 `-f PATH/Containerfile` option as well tells the system to look for that file


### PR DESCRIPTION
Fix two typos in podman build as reported by #22946

FIXES: #22946

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
