### PR TITLE
ExitWithError, continued

### DIFF
--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman healthcheck run", func() {
@@ -117,7 +116,7 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 	})
 
 	It("podman healthcheck on stopped container", func() {
@@ -155,15 +154,15 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		inspect := podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
@@ -178,14 +177,14 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		inspect := podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
 
 		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		inspect = podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckUnhealthy))
@@ -213,7 +212,7 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 	})
 
 	// Run this test with and without healthcheck events, even without events
@@ -240,14 +239,14 @@ var _ = Describe("Podman healthcheck run", func() {
 
 			hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 			hc.WaitWithDefaultTimeout()
-			Expect(hc).Should(Exit(1))
+			Expect(hc).Should(ExitWithError(1, ""))
 
 			inspect := podmanTest.InspectContainer("hc")
 			Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
 
 			hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 			hc.WaitWithDefaultTimeout()
-			Expect(hc).Should(Exit(1))
+			Expect(hc).Should(ExitWithError(1, ""))
 
 			inspect = podmanTest.InspectContainer("hc")
 			Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckUnhealthy))
@@ -366,7 +365,7 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", ctrName})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc).Should(Exit(1))
+		Expect(hc).Should(ExitWithError(1, ""))
 
 		exec := podmanTest.Podman([]string{"exec", ctrName, "sh", "-c", "touch /test && echo startup > /test"})
 		exec.WaitWithDefaultTimeout()

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -700,7 +700,7 @@ RUN touch /file
 
 		session = podmanTest.Podman([]string{"manifest", "exists", "no-manifest"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 
 	It("rm should not remove referenced images", func() {
@@ -753,6 +753,6 @@ RUN touch /file
 		// verify that manifest should not exist
 		session = podmanTest.Podman([]string{"manifest", "exists", manifestName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 })

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -428,8 +428,7 @@ var _ = Describe("Podman network", func() {
 		// check if pod is deleted
 		session = podmanTest.Podman([]string{"pod", "exists", podID})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
-		Expect(session.ErrorToString()).To(Equal(""))
+		Expect(session).Should(ExitWithError(1, ""))
 
 		// check if net is deleted
 		session = podmanTest.Podman([]string{"network", "ls"})
@@ -617,8 +616,7 @@ var _ = Describe("Podman network", func() {
 
 		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
-		Expect(session.ErrorToString()).To(Equal(""))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 
 	It("podman network create macvlan with network info and options", func() {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4538,7 +4538,7 @@ invalid kube kind
 		// volume should not be deleted on teardown
 		exists = podmanTest.Podman([]string{"volume", "exists", volName})
 		exists.WaitWithDefaultTimeout()
-		Expect(exists).To(Exit(1))
+		Expect(exists).To(ExitWithError(1, ""))
 	})
 
 	It("after teardown with volume reuse", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
@@ -68,7 +67,7 @@ var _ = Describe("Podman pod create", func() {
 		Expect(webserver).Should(ExitCleanly())
 
 		check := SystemExec("nc", []string{"-z", "localhost", "80"})
-		Expect(check).Should(Exit(1))
+		Expect(check).Should(ExitWithError(1, ""))
 	})
 
 	It("podman create pod with network portbindings", func() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -413,7 +413,7 @@ var _ = Describe("Podman pull", func() {
 		// Note that reference is not preserved in dir.
 		session = podmanTest.Podman([]string{"image", "exists", "cirros"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 
 	It("podman pull from local OCI directory", func() {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Podman run networking", func() {
 
 		session = podmanTest.Podman([]string{"exec", "con1", "nslookup", "google.com", aardvarkDNSGateway})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 		Expect(session.OutputToString()).To(ContainSubstring(";; connection timed out; no servers could be reached"))
 	})
 
@@ -118,7 +118,7 @@ var _ = Describe("Podman run networking", func() {
 
 		session = podmanTest.Podman([]string{"exec", "con1", "nslookup", "google.com", aardvarkDNSGateway})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 		Expect(session.OutputToString()).To(ContainSubstring(";; connection timed out; no servers could be reached"))
 	})
 
@@ -766,7 +766,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 		session = podmanTest.Podman([]string{"run", "--uidmap", "0:100000:1000", "--rm", "--hostname", "foohostname", "-v", "/etc/hosts:/etc/hosts", ALPINE, "grep", "foohostname", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 
 	It("podman run network in user created network namespace", func() {
@@ -1111,7 +1111,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 		session = podmanTest.Podman([]string{"run", "--name", "con3", "--pod", pod2, CITEST_IMAGE, "nslookup", "con1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 		Expect(session.OutputToString()).To(ContainSubstring("server can't find con1.dns.podman: NXDOMAIN"))
 
 		session = podmanTest.Podman([]string{"run", "--name", "con4", "--network", net, CITEST_IMAGE, "nslookup", pod2 + ".dns.podman"})

--- a/test/e2e/untag_test.go
+++ b/test/e2e/untag_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman untag", func() {
@@ -35,7 +34,7 @@ var _ = Describe("Podman untag", func() {
 		for _, t := range tags {
 			session = podmanTest.Podman([]string{"image", "exists", t})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(1))
+			Expect(session).Should(ExitWithError(1, ""))
 		}
 	})
 
@@ -68,7 +67,7 @@ var _ = Describe("Podman untag", func() {
 
 			session = podmanTest.Podman([]string{"image", "exists", tt.normalized})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(1))
+			Expect(session).Should(ExitWithError(1, ""))
 		}
 	})
 

--- a/test/e2e/volume_exists_test.go
+++ b/test/e2e/volume_exists_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman volume exists", func() {
@@ -26,6 +25,6 @@ var _ = Describe("Podman volume exists", func() {
 
 		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(1))
+		Expect(session).Should(ExitWithError(1, ""))
 	})
 })


### PR DESCRIPTION
Low-hanging fruit: Exit(X) with no error message
is now ExitWithError(X, "")

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```