### PR TITLE
Fix hang boot podman

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -613,6 +613,11 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	// refresh runs.
 	runtime.valid = true
 
+	// Setup the worker channel early to start accepting jobs from refresh,
+	// but do not start to execute the jobs right away. The runtime is not
+	// ready at this point.
+	runtime.setupWorkerQueue()
+
 	// If we need to refresh the state, do it now - things are guaranteed to
 	// be set up by now.
 	if doRefresh {

--- a/libpod/runtime_worker.go
+++ b/libpod/runtime_worker.go
@@ -2,8 +2,11 @@
 
 package libpod
 
-func (r *Runtime) startWorker() {
+func (r *Runtime) setupWorkerQueue() {
 	r.workerChannel = make(chan func(), 10)
+}
+
+func (r *Runtime) startWorker() {
 	go func() {
 		for w := range r.workerChannel {
 			w()


### PR DESCRIPTION
This is an attempt at fixing #22984.

It seems that if some background tasks are queued in libpod's `Runtime` **before** the [worker's channel](https://github.com/containers/podman/blob/4e9486dbc63c24bfe109066abbb54d5d8dc2489e/libpod/runtime_worker.go#L6) is set up (eg. in the refresh phase), they are not executed later on, but the workerGroup's counter is still ticked up. This leads podman to hang when the imageEngine is shutdown, since it [waits](https://github.com/containers/podman/blob/4e9486dbc63c24bfe109066abbb54d5d8dc2489e/libpod/runtime.go#L758) for the workerGroup to be done.

I'm not really sure why the function to queue a job works, as the queue object shouldn't exist, but I think that might be caused by my very sparse Go knowledge.

I would probably need some guidance to write a test for that one, as my test workflow has been:
1. Make a change to podman
2. `reboot -f`
3. Login and run `journalctl list-jobs`  to monitor the boot process

And I'm honestly a bit confused at how do the reboot part in the tests.

```release-note
Fixed a bug that could cause a the first podman command after boot to hang when using transient mode.
```