### PR TITLE
podman: check for nil pointers in remote flags

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -160,7 +160,7 @@ func readRemoteCliFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig)
 		podmanConfig.URI = con.URI
 		podmanConfig.Identity = con.Identity
 		podmanConfig.MachineMode = con.IsMachine
-	case url.Changed:
+	case url != nil && url.Changed:
 		podmanConfig.URI = url.Value.String()
 	case contextConn != nil && contextConn.Changed:
 		service := contextConn.Value.String()
@@ -173,7 +173,7 @@ func readRemoteCliFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig)
 			podmanConfig.Identity = con.Identity
 			podmanConfig.MachineMode = con.IsMachine
 		}
-	case host.Changed:
+	case host != nil && host.Changed:
 		podmanConfig.URI = host.Value.String()
 	}
 	return nil

--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -230,6 +230,10 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true[ ]\+true" \
     CONTAINER_HOST=foo://124.com _run_podman_remote 125 --remote ps
     assert "$output" =~ "foo" "test env variable CONTAINER_HOST wrt config"
 
+    # Does not crash with invalid connection
+    CONTAINER_HOST=badvalue _run_podman_remote 125 ps
+    assert "$output" =~ "Error: unable to create connection." "test invalid CONTAINER_HOST gives Error and doesn't crash"
+
     # Clean up
     run_podman system connection rm defaultconnection
     run_podman system connection rm env-override


### PR DESCRIPTION
I'm hitting url being nil when I have
CONTAINER_CONNECTION=podman-machine-default-root, but the machine does
not exist.

```release-note
Fix nil pointer check in remote client flags 
```

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
