### PR TITLE
[CI:DOCS] Quadlet - add note about relative path resolution

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -185,6 +185,13 @@ create a drop-in file like `sleep@10.container.d/10-image.conf`:
 Image=quay.io/centos/centos
 ```
 
+### Relative paths
+
+In order to support Systemd specifiers, Quadlet does not resolve relative paths that start with `%`.
+To resolve such a path, prepend it with `./`.
+
+For example, instead of `EnvironmentFile=%n/env` use `EnvironmentFile=./%n/env`
+
 ### Debugging unit files
 
 After placing the unit file in one of the unit search paths (mentioned


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
No

```release-note
None
```
Resolves: #19125
