### PR TITLE
CI: do not install python packages at runtime

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -326,7 +326,6 @@ esac
 showrun echo "about to set up for TEST_FLAVOR [=$TEST_FLAVOR]"
 case "$TEST_FLAVOR" in
     validate)
-        showrun dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm
         # For some reason, this is also needed for validation
         showrun make .install.pre-commit .install.gitvalidation
         ;;
@@ -341,8 +340,6 @@ case "$TEST_FLAVOR" in
         remove_packaged_podman_files
         showrun make install PREFIX=/usr ETCDIR=/etc
 
-        msg "Installing previously downloaded/cached packages"
-        showrun dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm
         virtualenv .venv/docker-py
         source .venv/docker-py/bin/activate
         showrun pip install --upgrade pip


### PR DESCRIPTION
No idea why we need them, it passes without them so I just remove them.
Currently CI is broken as this install is failing on rawhide for some
reason. I don't know what changed there but this is working and unblocks
CI so I like to get this in.

#### Does this PR introduce a user-facing change?


```release-note
None
```
