### PR TITLE
Allow --debug/--trace options for pasta

### DIFF
--- a/vendor/github.com/containers/common/libnetwork/pasta/pasta_linux.go
+++ b/vendor/github.com/containers/common/libnetwork/pasta/pasta_linux.go
@@ -217,8 +217,12 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, error) {
 		cmdArgs = append(cmdArgs, "--no-map-gw")
 	}
 
-	// always pass --quiet to silence the info output from pasta
-	cmdArgs = append(cmdArgs, "--quiet", "--netns", opts.Netns)
+	if !slices.Contains(cmdArgs, "--trace") && !slices.Contains(cmdArgs, "--debug")) {
+		// pass --quiet to silence the info output from pasta if verbose/trace pasta is not required
+		cmdArgs = append(cmdArgs, "--quiet")
+	}
+
+	cmdArgs = append(cmdArgs, "--netns", opts.Netns)
 
 	return cmdArgs, dnsForwardIPs, nil
 }


### PR DESCRIPTION
The user is allowed to pass --debug/--trace option to pasta in order to get logs on pasta failure.

Example :
--network=pasta:--map-gw,--debug,--log-file=/tmp/log,--trace 

#### Does this PR introduce a user-facing change?

```release-note
None
```
