### PR TITLE
pkg/machine/wsl: wrap command errors

### DIFF
--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -266,7 +266,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 	}
 
 	if err = cmd.Wait(); err != nil {
-		return fmt.Errorf("wait for systemd to exit: %w (%s)", err, strings.TrimSpace(out.String()))
+		logrus.Warnf("Failed to wait for systemd to exit: (%s)", strings.TrimSpace(out.String()))
 	}
 
 	return terminateDist(dist)

--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -4,6 +4,7 @@ package wutil
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -74,7 +75,10 @@ func SilentExec(command string, args ...string) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000}
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command %s %v failed: %w", command, args, err)
+	}
+	return nil
 }
 
 func SilentExecCmd(command string, args ...string) *exec.Cmd {


### PR DESCRIPTION
First of some commands ignored cmd.Wait() error which means it was impossible to notice any command errors. And other just returned the wait error as it which is when a command fails just `exit status <code>` which is not helpful at all.

This commit should add proper error wrapping with stderr to get useful strings back hopefully.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
