### PR TITLE
Quadlet - use specifier for unescaped values for templated container name

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -488,7 +488,7 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	if !ok || len(containerName) == 0 {
 		// By default, We want to name the container by the service name
 		if strings.Contains(container.Filename, "@") {
-			containerName = "systemd-%P_%I"
+			containerName = "systemd-%p_%i"
 		} else {
 			containerName = "systemd-%N"
 		}

--- a/test/e2e/quadlet/template@.container
+++ b/test/e2e/quadlet/template@.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--name=systemd-%P_%I"
+## assert-podman-args "--name=systemd-%p_%i"
 ## assert-symlink want.service.wants/template@default.service ../template@.service
 ## assert-podman-args --env "FOO=bar"
 

--- a/test/e2e/quadlet/template@instance.container
+++ b/test/e2e/quadlet/template@instance.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/changed-image
-## assert-podman-args "--name=systemd-%P_%I"
+## assert-podman-args "--name=systemd-%p_%i"
 ## assert-symlink want.service.wants/template@instance.service ../template@instance.service
 ## assert-podman-args --env "FOO=bar"
 


### PR DESCRIPTION
<!--
#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - use un-escaped prefix and instance names for container name in a template
```
