### PR TITLE
libpod: do not chmod bind mounts

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -544,16 +544,6 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	c.config.StaticDir = containerInfo.Dir
 	c.state.RunDir = containerInfo.RunDir
 
-	if len(c.config.IDMappings.UIDMap) != 0 || len(c.config.IDMappings.GIDMap) != 0 {
-		if err := idtools.SafeChown(containerInfo.RunDir, c.RootUID(), c.RootGID()); err != nil {
-			return err
-		}
-
-		if err := idtools.SafeChown(containerInfo.Dir, c.RootUID(), c.RootGID()); err != nil {
-			return err
-		}
-	}
-
 	// Set the default Entrypoint and Command
 	if containerInfo.Config != nil {
 		// Set CMD in the container to the default configuration only if ENTRYPOINT is not set by the user.

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1917,15 +1917,6 @@ func (c *Container) makeBindMounts() error {
 					return fmt.Errorf("assigning mounts to container %s: %w", c.ID(), err)
 				}
 			}
-
-			if !hasCurrentUserMapped(c) {
-				if err := makeAccessible(resolvPath, c.RootUID(), c.RootGID()); err != nil {
-					return err
-				}
-				if err := makeAccessible(hostsPath, c.RootUID(), c.RootGID()); err != nil {
-					return err
-				}
-			}
 		} else {
 			if !c.config.UseImageResolvConf {
 				if err := c.createResolvConf(); err != nil {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -565,7 +565,11 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		return nil, nil, err
 	}
 
-	g.SetRootPath(c.state.Mountpoint)
+	rootPath, err := c.getRootPathForOCI()
+	if err != nil {
+		return nil, nil, err
+	}
+	g.SetRootPath(rootPath)
 	g.AddAnnotation("org.opencontainers.image.stopSignal", strconv.FormatUint(uint64(c.config.StopSignal), 10))
 
 	if _, exists := g.Config.Annotations[annotations.ContainerManager]; !exists {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1834,10 +1834,6 @@ func (c *Container) mountIntoRootDirs(mountName string, mountPath string) error 
 
 // Make standard bind mounts to include in the container
 func (c *Container) makeBindMounts() error {
-	if err := idtools.SafeChown(c.state.RunDir, c.RootUID(), c.RootGID()); err != nil {
-		return fmt.Errorf("cannot chown run directory: %w", err)
-	}
-
 	if c.state.BindMounts == nil {
 		c.state.BindMounts = make(map[string]string)
 	}

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -183,16 +183,14 @@ func hasCurrentUserMapped(ctr *Container) bool {
 
 // CreateContainer creates a container.
 func (r *ConmonOCIRuntime) CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) (int64, error) {
-	// always make the run dir accessible to the current user so that the PID files can be read without
+	// always make the container directory accessible to the current user so that the PID files can be read without
 	// being in the rootless user namespace.
 	if err := makeAccessible(ctr.state.RunDir, 0, 0); err != nil {
 		return 0, err
 	}
 	if !hasCurrentUserMapped(ctr) {
-		for _, i := range []string{ctr.state.RunDir, ctr.runtime.config.Engine.TmpDir, ctr.config.StaticDir, ctr.state.Mountpoint, ctr.runtime.config.Engine.VolumePath} {
-			if err := makeAccessible(i, ctr.RootUID(), ctr.RootGID()); err != nil {
-				return 0, err
-			}
+		if err := makeAccessible(ctr.state.Mountpoint, ctr.RootUID(), ctr.RootGID()); err != nil {
+			return 0, err
 		}
 
 		// if we are running a non privileged container, be sure to umount some kernel paths so they are not

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -183,11 +183,6 @@ func hasCurrentUserMapped(ctr *Container) bool {
 
 // CreateContainer creates a container.
 func (r *ConmonOCIRuntime) CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) (int64, error) {
-	// always make the container directory accessible to the current user so that the PID files can be read without
-	// being in the rootless user namespace.
-	if err := makeAccessible(ctr.state.RunDir, 0, 0); err != nil {
-		return 0, err
-	}
 	if !hasCurrentUserMapped(ctr) {
 		if err := makeAccessible(ctr.state.Mountpoint, ctr.RootUID(), ctr.RootGID()); err != nil {
 			return 0, err

--- a/libpod/oci_conmon_freebsd.go
+++ b/libpod/oci_conmon_freebsd.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) (int64, error) {
+func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions, hideFiles bool) (int64, error) {
 	return -1, errors.New("unsupported (*ConmonOCIRuntime) createRootlessContainer")
 }
 

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -3,7 +3,9 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,7 +27,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) (int64, error) {
+func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions, hideFiles bool) (int64, error) {
 	type result struct {
 		restoreDuration int64
 		err             error
@@ -39,6 +41,11 @@ func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOption
 				return 0, err
 			}
 			defer errorhandling.CloseQuiet(fd)
+
+			rootPath, err := ctr.getRootPathForOCI()
+			if err != nil {
+				return 0, err
+			}
 
 			// create a new mountns on the current thread
 			if err = unix.Unshare(unix.CLONE_NEWNS); err != nil {
@@ -54,26 +61,69 @@ func (r *ConmonOCIRuntime) createRootlessContainer(ctr *Container, restoreOption
 					logrus.Errorf("Unable to reset the previous mount namespace: %q", err)
 				}
 			}()
-
-			// don't spread our mounts around.  We are setting only /sys to be slave
-			// so that the cleanup process is still able to umount the storage and the
-			// changes are propagated to the host.
-			err = unix.Mount("/sys", "/sys", "none", unix.MS_REC|unix.MS_SLAVE, "")
-			if err != nil {
-				return 0, fmt.Errorf("cannot make /sys slave: %w", err)
-			}
-
 			mounts, err := pmount.GetMounts()
 			if err != nil {
 				return 0, err
 			}
-			for _, m := range mounts {
-				if !strings.HasPrefix(m.Mountpoint, "/sys/kernel") {
-					continue
+			if rootPath != "" {
+				byMountpoint := make(map[string]*pmount.Info)
+				for _, m := range mounts {
+					byMountpoint[m.Mountpoint] = m
 				}
-				err = unix.Unmount(m.Mountpoint, 0)
-				if err != nil && !os.IsNotExist(err) {
-					return 0, fmt.Errorf("cannot unmount %s: %w", m.Mountpoint, err)
+				isShared := false
+				var parentMount string
+				for dir := filepath.Dir(rootPath); ; dir = filepath.Dir(dir) {
+					if m, found := byMountpoint[dir]; found {
+						parentMount = dir
+						for _, o := range strings.Split(m.Optional, ",") {
+							opt := strings.Split(o, ":")
+							if opt[0] == "shared" {
+								isShared = true
+								break
+							}
+						}
+						break
+					}
+					if dir == "/" {
+						return 0, fmt.Errorf("cannot find mountpoint for the root path")
+					}
+				}
+
+				// do not propagate the bind mount on the parent mount namespace
+				if err := unix.Mount("", parentMount, "", unix.MS_SLAVE, ""); err != nil {
+					return 0, fmt.Errorf("failed to make %s slave: %w", parentMount, err)
+				}
+
+				// bind mount the containers' mount path to the path where the OCI runtime expects it to be
+				if err := unix.Mount(ctr.state.Mountpoint, rootPath, "", unix.MS_BIND, ""); err != nil {
+					return 0, fmt.Errorf("failed to bind mount %s to %s: %w", ctr.state.Mountpoint, rootPath, err)
+				}
+
+				if isShared {
+					// we need to restore the shared propagation of the parent mount so that we don't break -v $SRC:$DST:shared in the container
+					// if $SRC is on the same mount as the root path
+					if err := unix.Mount("", parentMount, "", unix.MS_SHARED, ""); err != nil {
+						return 0, fmt.Errorf("failed to restore MS_SHARED propagation for %s: %w", parentMount, err)
+					}
+				}
+			}
+
+			if hideFiles {
+				// don't spread our mounts around.  We are setting only /sys to be slave
+				// so that the cleanup process is still able to umount the storage and the
+				// changes are propagated to the host.
+				err = unix.Mount("/sys", "/sys", "none", unix.MS_REC|unix.MS_SLAVE, "")
+				if err != nil {
+					return 0, fmt.Errorf("cannot make /sys slave: %w", err)
+				}
+				for _, m := range mounts {
+					if !strings.HasPrefix(m.Mountpoint, "/sys/kernel") {
+						continue
+					}
+					err = unix.Unmount(m.Mountpoint, 0)
+					if err != nil && !errors.Is(err, fs.ErrNotExist) {
+						return 0, fmt.Errorf("cannot unmount %s: %w", m.Mountpoint, err)
+					}
 				}
 			}
 			return r.createOCIContainer(ctr, restoreOptions)


### PR DESCRIPTION
with the new mount API is available, the OCI runtime doesn't require that each parent directory for a bind mount must be accessible. Instead it is opened in the initial user namespace and passed down to the container init process.

This requires that the kernel supports the new mount API and that the OCI runtime uses it.

Closes: https://github.com/containers/podman/issues/23028

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now Podman requires the new kernel mount API (available since Linux 5.2) to configure containers in a new user namespace where the current user is not part of the mapping
```
