### PR TITLE
fix(diff): do not suggest `--latest` when runs on remote with no args

### DIFF
--- a/cmd/podman/diff/diff.go
+++ b/cmd/podman/diff/diff.go
@@ -73,6 +73,9 @@ func ValidateContainerDiffArgs(cmd *cobra.Command, args []string) error {
 		return errors.New("--latest and containers cannot be used together")
 	}
 	if len(args) == 0 && !given {
+		if registry.IsRemote() {
+			return fmt.Errorf("%q requires a name or id", cmd.CommandPath())
+		}
 		return fmt.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
 	}
 	return nil

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -165,4 +165,13 @@ RUN touch %s`, ALPINE, imagefile)
 		Expect(session.OutputToString()).To(ContainSubstring(confile))
 	})
 
+	It("podman diff without args", func() {
+		session := podmanTest.Podman([]string{"diff"})
+		session.WaitWithDefaultTimeout()
+		if IsRemote() {
+			Expect(session).Should(ExitWithError(125, " requires a name or id"))
+		} else {
+			Expect(session).Should(ExitWithError(125, " requires a name, id, or the \"--latest\" flag"))
+		}
+	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
When running `diff` with no args in `podman-remote`, the error message suggested the `--latest` flag.
However, this flag does not exist in `podman-remote`, so the error message was modified to improve usability.

Closes: https://github.com/containers/podman/issues/23038

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve error message in `podman-remote diff`. No longer suggesting flags that are not provided.
```
