### PR TITLE
sqlite_state: Fix RewriteVolumeConfig

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -1310,7 +1310,7 @@ func (s *SQLiteState) RewriteVolumeConfig(volume *Volume, newCfg *VolumeConfig) 
 		}
 	}()
 
-	results, err := tx.Exec("UPDATE VolumeConfig SET Name=?, JSON=? WHERE ID=?;", newCfg.Name, json, volume.Name())
+	results, err := tx.Exec("UPDATE VolumeConfig SET Name=?, JSON=? WHERE Name=?;", newCfg.Name, json, volume.Name())
 	if err != nil {
 		return fmt.Errorf("updating volume config table with new configuration for volume %s: %w", volume.Name(), err)
 	}

--- a/test/system/760-system-renumber.bats
+++ b/test/system/760-system-renumber.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# tests for podman system renumber
+#
+
+load helpers
+
+function setup() {
+    basic_setup
+
+    skip_if_remote "podman system renumber is not available remote"
+}
+
+@test "podman system renumber - Basic test with a volume" {
+    run_podman volume create test
+    assert "$output" == "test" "podman volume create output"
+    run_podman system renumber
+    assert "$output" == "" "podman system renumber output"
+    run_podman volume rm test
+    assert "$output" == "test" "podman volume rm output"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
The `VolumeConfig` table does not have an `ID` column, thus use the `Name` column to update it. This will fix #23052.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed podman system renumber if a volume exists.
```
