### PR TITLE
restore: fix container restore into pod

### DIFF
--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -102,16 +102,17 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		if !crutils.CRRuntimeSupportsPodCheckpointRestore(runtime.GetOCIRuntimePath()) {
 			return nil, fmt.Errorf("runtime %s does not support pod restore", runtime.GetOCIRuntimePath())
 		}
-		// Restoring into an existing Pod
-		ctrConfig.Pod = restoreOptions.Pod
 
 		// According to podman pod create a pod can share the following namespaces:
 		// cgroup, ipc, net, pid, uts
 		// Let's make sure we are restoring into a pod with the same shared namespaces.
-		pod, err := runtime.LookupPod(ctrConfig.Pod)
+		pod, err := runtime.LookupPod(restoreOptions.Pod)
 		if err != nil {
 			return nil, fmt.Errorf("pod %q cannot be retrieved: %w", ctrConfig.Pod, err)
 		}
+
+		// Restoring into an existing Pod
+		ctrConfig.Pod = pod.ID()
 
 		infraContainer, err := pod.InfraContainer()
 		if err != nil {


### PR DESCRIPTION
Currently, when Podman restores a container into a Pod, it always fails with the following error:

    Error: cannot add container f96670b26e53e70f7f451191ea39a093c940c6c48b47218aeeef1396cb860042 to pod h2-pod: no such pod

#### Steps to reproduce this error:

```console
podman pod create --name=test
podman run -d --pod=test --name looper busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
podman container checkpoint -l --export=/tmp/test.tar.gz
podman rm -a
podman pod rm -a

podman pod create --name=test
podman container restore --pod=test --import=/tmp/test.tar.gz
```

This error occurs because [`r.state.Pod()`](https://github.com/containers/podman/blob/b8d95a5893572b37c8257407e964ad06ba87ade6/libpod/boltdb_state.go#L2087) is called in [`setupContainer()`](https://github.com/containers/podman/blob/b8d95a5893572b37c8257407e964ad06ba87ade6/libpod/runtime_ctr.go#L354) with the Pod *name* instead of *ID*. This problem is fixed by setting `ctrConfig.Pod` to `pod.ID()`.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed container restore into Pod.
```
