### PR TITLE
CI VMs: bump

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240529t141726z-f40f39d13"
+    IMAGE_SUFFIX: "c20240620t153000z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"


### PR DESCRIPTION
Built in: https://github.com/containers/automation_images/pull/361

Main changes:
 - lots of package bumps, see link above. Most important is debian systemd, which should fix the XDG bug in 256-rc3
 - workaround for rawhide IMA (signed rpms) issue
 - rawhide now includes composefs

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```