### PR TITLE
container: pass StopTimeout to the systemd slice

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -349,7 +349,7 @@ type ContainerMiscConfig struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// StopSignal is the signal that will be used to stop the container
 	StopSignal uint `json:"stopSignal,omitempty"`
-	// StopTimeout is the signal that will be used to stop the container
+	// StopTimeout is maximum time a container is allowed to run after getting the stop signal
 	StopTimeout uint `json:"stopTimeout,omitempty"`
 	// Timeout is maximum time a container will run before getting the kill signal
 	Timeout uint `json:"timeout,omitempty"`

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -568,6 +568,15 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	g.SetRootPath(c.state.Mountpoint)
 	g.AddAnnotation("org.opencontainers.image.stopSignal", strconv.FormatUint(uint64(c.config.StopSignal), 10))
 
+	if c.config.StopSignal != 0 {
+		g.AddAnnotation("org.systemd.property.KillSignal", strconv.FormatUint(uint64(c.config.StopSignal), 10))
+	}
+
+	if c.config.StopTimeout != 0 {
+		annotation := fmt.Sprintf("uint64 %d", c.config.StopTimeout*1000000) // sec to usec
+		g.AddAnnotation("org.systemd.property.TimeoutStopUSec", annotation)
+	}
+
 	if _, exists := g.Config.Annotations[annotations.ContainerManager]; !exists {
 		g.AddAnnotation(annotations.ContainerManager, annotations.ContainerManagerLibpod)
 	}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?


```release-note
Now Podman specifies the StopTimeout to systemd, so that it is honored when systemd stops the scope
```
