### PR TITLE
Quadlet: add -list-images

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1223,6 +1223,21 @@ func ConvertKube(kube *parser.UnitFile, names map[string]string, isUser bool) (*
 	return service, nil
 }
 
+func ListImage(image *parser.UnitFile) (string, error) {
+	// Even if we're only interested in the Image= of the unit, it should
+	// still be valid.
+	if err := checkForUnknownKeys(image, ImageGroup, supportedImageKeys); err != nil {
+		return "", err
+	}
+
+	imageName, ok := image.Lookup(ImageGroup, KeyImage)
+	if !ok || len(imageName) == 0 {
+		return "", fmt.Errorf("no Image key specified")
+	}
+
+	return imageName, nil
+}
+
 func ConvertImage(image *parser.UnitFile) (*parser.UnitFile, string, error) {
 	service := image.Dup()
 	service.Filename = replaceExtension(image.Filename, ".service", "", "-image")

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1027,6 +1027,43 @@ EOF
     run_podman network rm podman-default-kube-network
 }
 
+@test "quadlet - list images" {
+    local quadlet_tmpdir=$PODMAN_TMPDIR/quadlets
+    mkdir -p $quadlet_tmpdir
+
+    local image_name_1=quay.io/quadlet/image:1
+    local image_name_2=quay.io/quadlet/image:2
+    local image_name_3=quay.io/quadlet/image:3
+
+    cat > $PODMAN_TMPDIR/1.image <<EOF
+[Image]
+Image=$image_name_1
+EOF
+    cat > $quadlet_tmpdir/2.image <<EOF
+[Image]
+Image=$image_name_2
+EOF
+    cat > $quadlet_tmpdir/3.image <<EOF
+[Image]
+Image=$image_name_3
+EOF
+    cat > $quadlet_tmpdir/1.container <<EOF
+[Image]
+Image=quay.io/do/not/parse:me
+EOF
+
+    local image_file=$quadlet_tmpdir/image_file
+    touch $image_file
+
+    QUADLET_UNIT_DIRS=$PODMAN_TMPDIR run \
+                    timeout --foreground -v --kill=10 $PODMAN_TIMEOUT \
+                    $QUADLET -list-images=$image_file
+
+    assert "$(< $image_file)" = "$image_name_1
+$image_name_2
+$image_name_3" "-list-images=FILE lists all images referenced in .image Quadlets"
+}
+
 @test "quadlet - image files" {
     local quadlet_tmpdir=$PODMAN_TMPDIR/quadlets
 


### PR DESCRIPTION
Add a new `-list-images` string flag Quadlet which will write a list of images mentioned in `.image` Quadlets to specified file.

In order to avoid disk bloat, many bootable containers do not embed application-container images.  Hence, those must be pulled in _some_ use-case dependent way.  Quadlet is perfectly capable of pulling the images on boot or on demand but that does not satisfy all use cases as it slows down boot or initialization of the workloads.  In those cases, we want a `bootc upgrade` to first pull down the bootable container image and then analyze its root FS to extract all referenced images in (rootful) `.image` Quadlets.  This change is a first step in this direction.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a `-list-images` flag to Quadlet to list images referenced in `.image` Quadlets.
```
