### PR TITLE
remote: fix incorrect CONTAINER_CONNECTION parsing

### DIFF
--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -48,6 +48,7 @@ type PodmanConfig struct {
 	Trace                    bool     // Hidden: Trace execution
 	URI                      string   // URI to RESTful API Service
 	FarmNodeName             string   // Name of farm node
+	ConnectionError          error    // Error when looking up the connection in setupRemoteConnection()
 
 	Runroot        string
 	ImageStore     string


### PR DESCRIPTION
When a user specifies a invalid connection in CONTAINER_CONNECTION then podman should return a proper error saying so. Currently it ignored the error and in rootFlags() just exited early with defining any flags. This caused a panic then when trying to use the flags later.

In order to address this first store the connection error in the PodmanConfig struct and not abort right away during flag setup. This is important as the user might have specified a flag with a valid remote connection. As such we check all flags and only when none were given we return the connection error.

Also while at it I noticed that the default connection reported via podman --help was wrong as it only used the old containers.conf field for it and did not consider the podman-connections.json default.

New regression tests have been added to make sure it behaves correctly.

This fixes the problem reported in the PR #22997.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in podman-remote where specifying a invalid connection in the CONTAINER_CONNECTION env lead to a panic. 
```
