### PR TITLE
Make podman-compose refer to podman-compose(1) when using an external provider

### DIFF
--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -202,7 +202,7 @@ func composeProviderExec(args []string, stdout io.Writer, stderr io.Writer, warn
 	logrus.Debugf("Executing compose provider (%s %s) with additional env %s", provider, strings.Join(args, " "), strings.Join(env, " "))
 
 	if warn {
-		fmt.Fprint(os.Stderr, underline(fmt.Sprintf(">>>> Executing external compose provider %q. Please refer to the documentation for details. <<<<\n\n", provider)))
+		fmt.Fprint(os.Stderr, underline(fmt.Sprintf(">>>> Executing external compose provider %q. Please see podman-compose(1) for how to disable this message. <<<<\n\n", provider)))
 	}
 
 	if err := cmd.Run(); err != nil {

--- a/docs/source/markdown/podman-compose.1.md.in
+++ b/docs/source/markdown/podman-compose.1.md.in
@@ -13,6 +13,8 @@ The default compose providers are `docker-compose` and `podman-compose`.  If ins
 
 If you want to change the default behavior or have a custom installation path for your provider of choice, please change the `compose_provider` field in `containers.conf(5)`.  You may also set the `PODMAN_COMPOSE_PROVIDER` environment variable.
 
+By default, `podman compose` will emit a warning saying that it executes an external command. This warning can be disabled by setting `compose_warning_logs` to false in `containers.conf(5)` or setting the `PODMAN_COMPOSE_WARNING_LOGS` environment variable to false. See the man page for `containers.conf(5)` for more information.
+
 ## OPTIONS
 
 To see supported options of the installed compose provider, please run `podman compose --help`.


### PR DESCRIPTION
This PR is meant to fix https://github.com/containers/podman/issues/22904. It makes the warning message emitted by podman-compose when using an external provider point to podman-compose(1) which is also updated to include instructions on how to disable said message.

#### Does this PR introduce a user-facing change?

```release-note
Changed the warning message emitted by `podman-compose` when using an external compose provider. Instead of referring to "the documentation" it now refers to the man page of `podman-compose(1)` which is also updated to contain the relevant information.
```
