### PR TITLE
libpod API: fix two pod remote error messages

### DIFF
--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -202,7 +202,7 @@ func PodStart(w http.ResponseWriter, r *http.Request) {
 	}
 	status, err := pod.GetPodStatus()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, err)
+		utils.InternalServerError(w, err)
 		return
 	}
 	if status == define.PodStateRunning {
@@ -212,13 +212,13 @@ func PodStart(w http.ResponseWriter, r *http.Request) {
 
 	responses, err := pod.Start(r.Context())
 	if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
-		utils.Error(w, http.StatusConflict, err)
+		utils.InternalServerError(w, err)
 		return
 	}
 
 	cfg, err := pod.Config()
 	if err != nil {
-		utils.Error(w, http.StatusConflict, err)
+		utils.InternalServerError(w, err)
 		return
 	}
 	report := entities.PodStartReport{

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -29,12 +29,7 @@ var _ = Describe("Podman pod start", func() {
 
 		session := podmanTest.Podman([]string{"pod", "start", podid})
 		session.WaitWithDefaultTimeout()
-		expect := fmt.Sprintf("no containers in pod %s have no dependencies, cannot start pod: no such container", podid)
-		if IsRemote() {
-			// FIXME: #22989 no error message
-			expect = "Error:"
-		}
-		Expect(session).Should(ExitWithError(125, expect))
+		Expect(session).Should(ExitWithError(125, fmt.Sprintf("no containers in pod %s have no dependencies, cannot start pod: no such container", podid)))
 	})
 
 	It("podman pod start single pod by name", func() {

--- a/test/e2e/pod_top_test.go
+++ b/test/e2e/pod_top_test.go
@@ -85,12 +85,7 @@ var _ = Describe("Podman top", func() {
 		// the wrong input and still print the -ef output instead.
 		result := podmanTest.Podman([]string{"pod", "top", podid, "-eo", "invalid"})
 		result.WaitWithDefaultTimeout()
-		if IsRemote() {
-			// FIXME: #22986
-			Expect(result).Should(ExitWithError(125, "unmarshalling into &handlers.PodTopOKBody{ContainerTopOKBody:container.ContainerTopOKBody"))
-		} else {
-			Expect(result).Should(ExitWithError(125, "Error: '-eo': unknown descriptor"))
-		}
+		Expect(result).Should(ExitWithError(125, "Error: '-eo': unknown descriptor"))
 	})
 
 	It("podman pod top on pod with containers in same pid namespace", func() {


### PR DESCRIPTION
libpod API: return proper error status code for pod start

When we failed to do anything we should return 500, the 409 code has a
special meaing to the client as it uses a different error format. As
such the remote client was not able to unmarshal the error correctly and
just returned an empty string.

Fixes https://github.com/containers/podman/issues/22989

---

remote API: fix pod top error reporting

Do not return 200 status code before we know if there will be an error.
Delay writing the status code until we send the first response. That way
we can set an error code inside the loop when we get a error on the
first try, i.e. because an invalid descriptor was used.

Fixes https://github.com/containers/podman/issues/22986

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed an incorrect error status code in the libpod pod start REST API.
Fixed a missing error message when using the libpod pod top REST API.
```
