### PR TITLE
podman run use pod userns even with --pod-id-file

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"os"
-
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
 	commonFlag "github.com/containers/common/pkg/flag"
@@ -723,7 +721,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 
 		usernsFlagName := "userns"
 		createFlags.String(
-			usernsFlagName, os.Getenv("PODMAN_USERNS"),
+			usernsFlagName, "",
 			"User namespace to use",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(usernsFlagName, AutocompleteUserNamespace)

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -134,7 +134,7 @@ func playFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(logOptFlagName, common.AutocompleteLogOpt)
 
 	usernsFlagName := "userns"
-	flags.StringVar(&playOptions.Userns, usernsFlagName, os.Getenv("PODMAN_USERNS"),
+	flags.StringVar(&playOptions.Userns, usernsFlagName, "",
 		"User namespace to use",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(usernsFlagName, common.AutocompleteUserNamespace)


### PR DESCRIPTION
The pod was set after we checked the namespace and the namespace code only checked the --pod flag but didn't consider --pod-id-file option. As such fix the check to first set the pod option on the spec then use that for the namespace. Also make sure we always use an empty default otherwise it would be impossible in the backend to know if a user requested a specific userns or not, i.e. even in case of a set PODMAN_USERNS env a container should still get the userns from the pod and not use the var in this case. Therefore unset it from the default cli value.

There are more issues here around --pod-id-file and cli validation that does not consider the option as conflicting with --userns like --pod does but I decided to fix the bug at hand and don't try to fix the entire mess which most likely would take days.

Fixes #22931

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where using podman run/create --pod-id-file did not respect the pod's userns.  
```
