### PR TITLE
restore: fix missing network setup

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1725,6 +1725,15 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 		}
 	}
 
+	// setup hosts/resolv.conf files
+	// Note this should normally be called after the container is created in the runtime but before it is started.
+	// However restore starts the container right away. This means that if we do the call afterwards there is a
+	// short interval where the file is still empty. Thus I decided to call it before which makes it not working
+	// with PostConfigureNetNS (userns) but as this does not work anyway today so I don't see it as problem.
+	if err := c.completeNetworkSetup(); err != nil {
+		return nil, 0, fmt.Errorf("complete network setup: %w", err)
+	}
+
 	runtimeRestoreDuration, err = c.ociRuntime.CreateContainer(c, &options)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
The restore code path never called completeNetworkSetup() and this means that hosts/resolv.conf files were not populated. This fix is simply to call this function. There is a big catch here. Technically this is suposed to be called after the container is created but before it is started. There is no such thing for restore, the container runs right away. This means that if we do the call afterwards there is a short interval where the file is still empty. Thus I decided to call it before which makes it not working with PostConfigureNetNS (userns) but as this does not work anyway today so  I don't see it as problem.

Fixes #22901

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where /etc/hosts and /etc/resolv.conf in the container were empty after checkpoint restore.
```
