### PR TITLE
Add virtiofsd to rpm spec

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -93,6 +93,7 @@ BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: catatonit
 Requires: conmon >= 2:2.1.7-2
+Requires: virtiofsd
 %if %{defined fedora} && 0%{?fedora} >= 40
 # TODO: Remove the f40 conditional after a few releases to keep conditionals to
 # a minimum


### PR DESCRIPTION
With the merge of #22920, we now require virtiofsd on Linux for machine mounts.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add virtiofsd to required package for Linux
```
