### PR TITLE
podman top: join the container userns

### DIFF
--- a/libpod/container_top_linux.c
+++ b/libpod/container_top_linux.c
@@ -3,6 +3,7 @@
 
 #define _GNU_SOURCE
 #include <errno.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mount.h>
@@ -11,6 +12,7 @@
 
 /* keep special_exit_code in sync with container_top_linux.go */
 int special_exit_code = 255;
+int join_userns = 0;
 char **argv = NULL;
 
 void
@@ -31,6 +33,12 @@ void
 set_argv (int pos, char *arg)
 {
   argv[pos] = arg;
+}
+
+void
+set_userns ()
+{
+  join_userns = 1;
 }
 
 /*
@@ -64,6 +72,23 @@ fork_exec_ps ()
           fprintf (stderr, "mount proc: %m");
           exit (special_exit_code);
         }
+      if (join_userns)
+        {
+          // join the userns to make sure uid mapping match
+          // we are already part of the pidns so so pid 1 is the main container process
+          r = open ("/proc/1/ns/user", O_CLOEXEC | O_RDONLY);
+          if (r < 0)
+            {
+              fprintf (stderr, "open /proc/1/ns/user: %m");
+              exit (special_exit_code);
+            }
+          if ((status = setns (r, CLONE_NEWUSER)) < 0)
+            {
+              fprintf (stderr, "setns NEWUSER: %m");
+              exit (special_exit_code);
+            }
+        }
+
       /* use execve to unset all env vars, we do not want to leak anything into the container */
       execve (argv[0], argv, NULL);
       fprintf (stderr, "execve: %m");

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -119,6 +119,18 @@ var _ = Describe("Podman top", func() {
 		exec := podmanTest.Podman([]string{"top", session.OutputToString(), "aux"})
 		exec.WaitWithDefaultTimeout()
 		Expect(exec).Should(ExitWithError(125, "OCI runtime attempted to invoke a command that was not found"))
+
+		session = podmanTest.Podman([]string{"run", "-d", "--uidmap=0:1000:1000", "--user", "9", fedoraMinimal, "sleep", "inf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		result = podmanTest.Podman([]string{"top", session.OutputToString(), "-ef", "hn"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+		output := result.OutputToString()
+		Expect(output).To(ContainSubstring("sleep inf"))
+		// check for https://github.com/containers/podman/issues/22293
+		Expect(output).To(HavePrefix("9 "), "user id of process")
 	})
 
 	It("podman top with comma-separated options", func() {


### PR DESCRIPTION
When we execute ps(1) in the container and the container uses a userns with a different id mapping the user id field will be wrong.

To fix this we must join the userns in such case.

Fixes #22293

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix cases where podman top would show the incorrect uid for the processes when the container is using a user namespace.
```
