### PR TITLE
cirrus: remove redundant skip logic and lower int timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -654,7 +654,7 @@ local_integration_test_task: &local_integration_test_task
     gce_instance: &fastvm
       <<: *standardvm
       cpu: 4
-    timeout_in: 50m
+    timeout_in: 30m
     env:
         TEST_FLAVOR: int
     clone_script: *get_gosrc
@@ -701,7 +701,7 @@ container_integration_test_task:
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
               CI_DESIRED_DATABASE: boltdb
     gce_instance: *fastvm
-    timeout_in: 50m
+    timeout_in: 30m
     env:
         TEST_FLAVOR: int
         TEST_ENVIRON: container
@@ -721,7 +721,7 @@ rootless_integration_test_task:
     depends_on: *build
     matrix: *platform_axis
     gce_instance: *fastvm
-    timeout_in: 50m
+    timeout_in: 30m
     env:
         TEST_FLAVOR: int
         PRIV_NAME: rootless

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -61,14 +61,10 @@ function _run_compose_v2() {
 }
 
 function _run_int() {
-    _bail_if_test_can_be_skipped test/e2e
-
     dotest integration
 }
 
 function _run_sys() {
-    _bail_if_test_can_be_skipped test/system
-
     dotest system
 }
 
@@ -79,8 +75,6 @@ function _run_upgrade_test() {
 }
 
 function _run_bud() {
-    _bail_if_test_can_be_skipped test/buildah-bud
-
     showrun ./test/buildah-bud/run-buildah-bud-tests |& logformatter
 }
 
@@ -429,8 +423,6 @@ dotest() {
 }
 
 _run_machine-linux() {
-    _bail_if_test_can_be_skipped pkg/machine/e2e
-
     showrun make localmachine |& logformatter
 }
 


### PR DESCRIPTION
cirrus: remove redundant skip logic

As of commit https://github.com/containers/podman/commit/d9183f0587950b8bdaebbc1ffe321965cb026397 we use the cirrus.yml skip logic to skip based
on source changes. As such the add hoc logic inside our test setup can
be removed. However as I did not yet implement the skip logic for all
tests task in cirrus.yml it must remain for the other tasks for now.
I plan to migrate the other in a week or two once we are confident that
the cirrus.yml logic works well for us.

--- 
cirrus: reduce int tests timeout

Integration tests run around 15-20 mins now. Lower the timeout to 30m,
if we hit this something is very wrong and needs to be looked at and
there is no point in waiting much longer in case of a hang.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
