### PR TITLE
build API: accept platform comma separated

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -738,7 +738,12 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		UnsetLabels:                    query.UnsetLabels,
 	}
 
-	for _, platformSpec := range query.Platform {
+	platforms := query.Platform
+	if len(platforms) == 1 {
+		// Docker API uses comma sperated platform arg so match this here
+		platforms = strings.Split(query.Platform[0], ",")
+	}
+	for _, platformSpec := range platforms {
 		os, arch, variant, err := parse.Platform(platformSpec)
 		if err != nil {
 			utils.BadRequest(w, "platform", platformSpec, err)

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -667,6 +667,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    default:
 	//    description: |
 	//      Platform format os[/arch[/variant]]
+	//      Can be comma separated list for multi arch builds.
 	//      (As of version 1.xx)
 	//  - in: query
 	//    name: target

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -274,6 +274,12 @@ else
     _show_ok 1 "compat quiet build"
 fi
 
+# Do not try a real build here to tests the comma separated syntax as emulation
+# is slow and may not work everywhere, checking the error is good enough to know
+# we parsed it correctly on the server I would say
+t POST "/build?q=1&dockerfile=containerfile&platform=linux/amd64,test" $CONTAINERFILE_WITH_ERR_TAR 400 \
+  .message="failed to parse query parameter 'platform': \"test\": invalid platform syntax for --platform=\"test\": \"test\": unknown operating system or architecture: invalid argument"
+
 cleanBuildTest
 
 # compat API vs libpod API event differences:


### PR DESCRIPTION
The docker API uses only a single arg for platform and multiple platforms are given as comma separated list.

Fixes #22071

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The build API now accepts platform values comma separated to better match docker.
```
