### PR TITLE
Do not use exit-dir, get exit status from perist_dir/ctr-id/exit

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -885,16 +885,16 @@ func (c *Container) execAttachSocketPath(sessionID string) (string, error) {
 	return c.ociRuntime.ExecAttachSocketPath(c, sessionID)
 }
 
-// execExitFileDir gets the path to the container's exit file
-func (c *Container) execExitFileDir(sessionID string) string {
-	return filepath.Join(c.execBundlePath(sessionID), "exit")
-}
-
 // execPersistDir gets the path to the container's persist directory
 // The persist directory container the exit file and oom file (if oomkilled)
 // of a container
 func (c *Container) execPersistDir(sessionID string) string {
 	return filepath.Join(c.execBundlePath(sessionID), "persist", c.ID())
+}
+
+// execExitFileDir gets the path to the container's exit file
+func (c *Container) execExitFileDir(sessionID string) string {
+	return filepath.Join(c.execPersistDir(sessionID), "exit")
 }
 
 // execOCILog returns the file path for the exec sessions oci log
@@ -918,12 +918,6 @@ func (c *Container) createExecBundle(sessionID string) (retErr error) {
 			}
 		}
 	}()
-	if err := os.MkdirAll(c.execExitFileDir(sessionID), execDirPermission); err != nil {
-		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return fmt.Errorf("creating OCI runtime exit file path %s: %w", c.execExitFileDir(sessionID), err)
-		}
-	}
 	if err := os.MkdirAll(c.execPersistDir(sessionID), execDirPermission); err != nil {
 		return fmt.Errorf("creating OCI runtime persist directory path %s: %w", c.execPersistDir(sessionID), err)
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -765,7 +765,7 @@ func (c *Container) removeConmonFiles() error {
 		return err
 	}
 	if err := os.RemoveAll(persistDir); err != nil {
-		return fmt.Errorf("removing container %s perist dir with exit & oom files %q: %w", c.ID(), persistDir, err)
+		return fmt.Errorf("removing container %s persist dir with exit & oom files %q: %w", c.ID(), persistDir, err)
 	}
 
 	return nil

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -206,6 +206,36 @@ func TestPostDeleteHooks(t *testing.T) {
 	assert.Equal(t, strings.TrimSuffix(string(content), "\n"), dir)
 }
 
+func TestRemoveConmonFiles(t *testing.T) {
+	c := &Container{
+		state: &ContainerState{
+			RunDir: t.TempDir(),
+		},
+	}
+
+	exitsFilePath := filepath.Join(c.state.RunDir, "exits")
+	randomFilePath := filepath.Join(c.state.RunDir, "random")
+
+	err := os.WriteFile(exitsFilePath, []byte{}, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(randomFilePath, []byte{}, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.FileExists(t, exitsFilePath)
+	assert.FileExists(t, randomFilePath)
+
+	err = c.removeConmonFiles()
+	assert.Nil(t, err)
+
+	assert.NoFileExists(t, exitsFilePath)
+	assert.NoFileExists(t, randomFilePath)
+}
+
 func init() {
 	if runtime.GOOS != "windows" {
 		hookPath = "/bin/sh"

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -141,6 +141,10 @@ type OCIRuntime interface { //nolint:interfacebloat
 	// exec session in the given container.
 	// TODO: Probably should be made internal.
 	ExecAttachSocketPath(ctr *Container, sessionID string) (string, error)
+
+	// PersistDir is the path to a container's dir for oom & exit files.
+	PersistDir(ctr *Container) (string, error)
+
 	// ExitFilePath is the path to a container's exit file.
 	// All runtime implementations must create an exit file when containers
 	// exit, containing the exit code of the container (as a string).

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -387,7 +387,7 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 	}
 	defer processFile.Close()
 
-	args, err := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), c.execPersistDir(sessionID), ociLog, define.NoLogging, c.config.LogTag)
+	args, err := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execPersistDir(sessionID), ociLog, define.NoLogging, c.config.LogTag)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note 
None
```

Currently podman calls `conmon` with `--exit-dir` & `--persist-dir` flags,  so conmon creates two exit files - one in the exit-dir and another one in the persist-dir and removes only the first file.  This MR changes this behaviour - podman will not use exit-dir at all and will remove whole persist-dir after calling `conmon`

Closes #23107
