### PR TITLE
Use a compute-optimized VM for Linux builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,8 +90,7 @@ build_task:
     gce_instance: &standardvm
         image_project: libpod-218412
         zone: "us-central1-a"
-        cpu: 2
-        memory: "4Gb"
+        type: "c2d-highcpu-16"
         # Required to be 200gig, do not modify - has i/o performance impact
         # according to gcloud CLI tool warning messages.
         disk: 200
@@ -195,6 +194,7 @@ validate_task:
         TEST_FLAVOR: validate
     # N/B: This script depends on ${DISTRO_NV} being defined for the task.
     clone_script: &get_gosrc |
+        /bin/false  # FIXME: TESTING
         cd /tmp
         echo "$ARTCURL/Build%20for%20${DISTRO_NV}/repo/repo.tbz"
         time $ARTCURL/Build%20for%20${DISTRO_NV}/repo/repo.tbz
@@ -255,6 +255,7 @@ validate_aarch64_task:
         DISTRO_NV: ${FEDORA_AARCH64_NAME}
     # N/B: This script depends on ${DISTRO_NV} being defined for the task.
     clone_script: &get_gosrc_aarch64 |
+        /bin/false  # FIXME: TESTING
         cd /tmp
         echo "$ARTCURL/build_aarch64/repo/repo.tbz"
         time $ARTCURL/build_aarch64/repo/repo.tbz


### PR DESCRIPTION
Previously, the Linux build tasks made use of standard-issue custom-cpu/mem VMs with a completion time of around 10-15min. Attempt to significantly improve this by utilizing (on paper) faster, compute-optimized VMs w/ additional cores.  Since golang compilation is highly parallelized, the additional cores also benefit the build time (in addition to increased speed).

Ref: https://cloud.google.com/compute/docs/compute-optimized-machines

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
