### PR TITLE
[skip-ci] Packit: split rhel and centos-stream jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,8 @@ packages:
   podman-centos:
     pkg_tool: centpkg
     specfile_path: rpm/podman.spec
+  podman-rhel:
+    specfile_path: rpm/podman.spec
 
 srpm_build_deps:
   - git-archive-all
@@ -25,32 +27,39 @@ jobs:
   - job: copr_build
     trigger: pull_request
     packages: [podman-fedora]
-    notifications:
+    notifications: &packit_build_failure_notification
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-      - fedora-eln-x86_64
-      - fedora-eln-aarch64
-    additional_repos:
-      - "copr://rhcontainerbot/podman-next"
+      fedora-all-x86_64: {}
+      fedora-all-aarch64: {}
+      fedora-eln-x86_64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
+      fedora-eln-aarch64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
 
   - job: copr_build
     trigger: pull_request
     packages: [podman-centos]
-    notifications:
-      failure_comment:
-        message: "Ephemeral COPR build failed. @containers/packit-build please check."
+    notifications: *packit_build_failure_notification
+    enable_net: true
+    targets:
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [podman-rhel]
+    notifications: *packit_build_failure_notification
     enable_net: true
     targets:
       - epel-9-x86_64
       - epel-9-aarch64
-      - centos-stream-10-x86_64
-      - centos-stream-10-aarch64
-    additional_repos:
-      - "copr://rhcontainerbot/podman-next"
 
   # Run on commit to main branch
   - job: copr_build


### PR DESCRIPTION
This allows centos stream builds to run for outside contributors without write access to the repos.

This commit also include centos-stream-9 build jobs so we can compare both centos-stream-9 and rhel-9 builds if required. This will also be useful when we want to run tests on both centos stream and rhel envs using their respective builds.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
