### PR TITLE
Small fixes for testing libkrun

### DIFF
--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -62,10 +62,16 @@ var _ = BeforeSuite(func() {
 	if testProvider.VMType() == define.WSLVirt {
 		pullError = pullWSLDisk()
 	} else {
-		pullError = pullOCITestDisk(tmpDir, testProvider.VMType())
+		// This is a one-off and a little messy but once WSL switches
+		// to use OCI disk artifacts, we can make all the conditionals cleaner.
+		testDiskProvider := testProvider.VMType()
+		if testDiskProvider == define.LibKrun {
+			testDiskProvider = define.AppleHvVirt // libkrun uses the applehv image for testing
+		}
+		pullError = pullOCITestDisk(tmpDir, testDiskProvider)
 	}
 	if pullError != nil {
-		Fail(fmt.Sprintf("failed to pull wsl disk: %q", pullError))
+		Fail(fmt.Sprintf("failed to pull disk: %q", pullError))
 	}
 })
 

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -126,12 +126,14 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 	switch mp.VMType() {
 	case machineDefine.QemuVirt:
 		imageExtension = ".qcow2"
-	case machineDefine.AppleHvVirt:
+	case machineDefine.AppleHvVirt, machineDefine.LibKrun:
 		imageExtension = ".raw"
 	case machineDefine.HyperVVirt:
 		imageExtension = ".vhdx"
+	case machineDefine.WSLVirt:
+		imageExtension = ""
 	default:
-		// do nothing
+		return fmt.Errorf("unknown VM type: %s", mp.VMType())
 	}
 
 	imagePath, err = dirs.DataDir.AppendToNewVMFile(fmt.Sprintf("%s-%s%s", opts.Name, runtime.GOARCH, imageExtension), nil)


### PR DESCRIPTION
This PR is a couple of small fixes so that our CI would be capable of running the machine test suite on the libkrun provider.

RUN-2172

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
