### PR TITLE
Clearly indicate names w/ URLencoded duplicates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,7 @@ validate-source_task:
 # otherwise duplicative effort in most tasks.
 build_task:
     alias: 'build'
-    name: 'Build for $DISTRO_NV'
+    name: 'Build for $DISTRO_NV' # N/B: Referenced by URLencoded strings elsewhere
     gce_instance: &standardvm
         image_project: libpod-218412
         zone: "us-central1-a"
@@ -237,17 +237,17 @@ alt_build_task:
       - env:
             # TODO: Replace with task using `winmake` to build
             # binary and archive installation zip file.
-            ALT_NAME: 'Windows Cross'
+            ALT_NAME: 'Windows Cross' # N/B: Referenced by URLencoded strings elsewhere
       - env:
-            ALT_NAME: 'Alt Arch. x86 Cross'
+            ALT_NAME: 'Alt Arch. x86 Cross' # N/B: Referenced by URLencoded strings elsewhere
       - env:
-            ALT_NAME: 'Alt Arch. ARM Cross'
+            ALT_NAME: 'Alt Arch. ARM Cross' # N/B: Referenced by URLencoded strings elsewhere
       - env:
-            ALT_NAME: 'Alt Arch. MIPS Cross'
+            ALT_NAME: 'Alt Arch. MIPS Cross' # N/B: Referenced by URLencoded strings elsewhere
       - env:
-            ALT_NAME: 'Alt Arch. MIPS64 Cross'
+            ALT_NAME: 'Alt Arch. MIPS64 Cross' # N/B: Referenced by URLencoded strings elsewhere
       - env:
-            ALT_NAME: 'Alt Arch. Other Cross'
+            ALT_NAME: 'Alt Arch. Other Cross' # N/B: Referenced by URLencoded strings elsewhere
     # This task cannot make use of the shared repo.tbz artifact.
     clone_script: *full_clone
     setup_script: *setup
@@ -260,7 +260,7 @@ alt_build_task:
 
 # Confirm building the remote client, natively on a Mac OS-X VM.
 osx_alt_build_task:
-    name: "Build for MacOS amd64+arm64"
+    name: "Build for MacOS amd64+arm64" # N/B: Referenced by URLencoded strings elsewhere
     alias: osx_alt_build
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: *no_rhel_release  # RHEL never releases podman mac installer binary


### PR DESCRIPTION
Previously it was easy for a maintainer to change a Cirrus-CI task name w/o realizing it would (later) cause a downstream task or the `artifacts` task to fail.  This is due to duplication of task names in URLencoded format.  Worse, `artifacts` task failures are inconsequential in PRs, and not all tasks are executed for every PR context (i.e. due to `skip` or `only_if` exclusions).  So induced name change failures may not be noticed until after a PR merges.

Improve the visibility of the situation by adding comments to all consequential names.  That is, task names where there is a URLencoded duplicate reference elsewhere.

Ref: https://github.com/containers/podman/pull/23105#issuecomment-2194270973

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
