### PR TITLE
Error when machine memory exceeds system memory

### DIFF
--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -111,6 +111,9 @@ func setMachine(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("memory") {
 		newMemory := strongunits.MiB(setFlags.Memory)
+		if err := checkMaxMemory(newMemory); err != nil {
+			return err
+		}
 		setOpts.Memory = &newMemory
 	}
 	if cmd.Flags().Changed("disk-size") {

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -33,6 +33,11 @@ var _ = Describe("podman machine set", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
+		setMem := setMachine{}
+		SetMemSession, err := mb.setName(name).setCmd(setMem.withMemory(524288)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(SetMemSession).To(Exit(125))
+
 		set := setMachine{}
 		setSession, err := mb.setName(name).setCmd(set.withCPUs(2).withDiskSize(102).withMemory(4096)).run()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Close loophole that would allow you to assign more memory than the system has to a podman machine

Fixes: #18206

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where user could assign more memory to a Podman machine than existed on the host.
```
