### PR TITLE
machine: Always use --log-file with gvproxy

### DIFF
--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -57,9 +57,7 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 	runDir := dirs.RuntimeDir
 	cmd.PidFile = filepath.Join(runDir.GetPath(), "gvproxy.pid")
 
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		cmd.LogFile = filepath.Join(runDir.GetPath(), "gvproxy.log")
-	}
+	cmd.LogFile = filepath.Join(runDir.GetPath(), "gvproxy.log")
 
 	cmd.SSHPort = mc.SSH.Port
 


### PR DESCRIPTION
The logs are not verbose if `--debug` is not set, and very useful to
have if gvproxy exits unexpectedly.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```