### PR TITLE
specgen: parse devices even with privileged set

### DIFF
--- a/docs/source/markdown/options/network.md
+++ b/docs/source/markdown/options/network.md
@@ -17,7 +17,7 @@ Valid _mode_ values are:
 
     For example, to set a static ipv4 address and a static mac address, use `--network bridge:ip=10.88.0.10,mac=44:33:22:11:00:99`.
 
-- _\<network name or ID\>_**[:OPTIONS,...]**: Connect to a user-defined network; this is the network name or ID from a network created by **[podman network create](podman-network-create.1.md)**. Using the network name implies the bridge network mode. It is possible to specify the same options described under the bridge mode above. Use the **--network** option multiple times to specify additional networks. \
+- _\<network name or ID\>_**[:OPTIONS,...]**: Connect to a user-defined network; this is the network name or ID from a network created by **[podman network create](podman-network-create.1.md)**. It is possible to specify the same options described under the bridge mode above. Use the **--network** option multiple times to specify additional networks. \
   For backwards compatibility it is also possible to specify comma-separated networks on the first **--network** argument, however this prevents you from using the options described under the bridge section above.
 
 - **none**: Create a network namespace for the container but do not configure network interfaces for it, thus the container has no network connectivity.

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -254,24 +254,21 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	var userDevices []spec.LinuxDevice
-
-	if !s.IsPrivileged() {
-		// add default devices from containers.conf
-		for _, device := range rtc.Containers.Devices.Get() {
-			if err = DevicesFromPath(&g, device); err != nil {
-				return nil, err
-			}
+	// add default devices from containers.conf
+	for _, device := range rtc.Containers.Devices.Get() {
+		if err = DevicesFromPath(&g, device); err != nil {
+			return nil, err
 		}
-		if len(compatibleOptions.HostDeviceList) > 0 && len(s.Devices) == 0 {
-			userDevices = compatibleOptions.HostDeviceList
-		} else {
-			userDevices = s.Devices
-		}
-		// add default devices specified by caller
-		for _, device := range userDevices {
-			if err = DevicesFromPath(&g, device.Path); err != nil {
-				return nil, err
-			}
+	}
+	if len(compatibleOptions.HostDeviceList) > 0 && len(s.Devices) == 0 {
+		userDevices = compatibleOptions.HostDeviceList
+	} else {
+		userDevices = s.Devices
+	}
+	// add default devices specified by caller
+	for _, device := range userDevices {
+		if err = DevicesFromPath(&g, device.Path); err != nil {
+			return nil, err
 		}
 	}
 	s.HostDeviceList = userDevices

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -106,7 +106,6 @@ func AddPrivilegedDevices(g *generate.Generator, systemdMode bool) error {
 	if err != nil {
 		return err
 	}
-	g.ClearLinuxDevices()
 
 	if rootless.IsRootless() {
 		mounts := make(map[string]interface{})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1687,6 +1687,19 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		Expect(session).Should(ExitCleanly())
 	})
 
+	It("podman run --device and --privileged", func() {
+		session := podmanTest.Podman([]string{"run", "--device", "/dev/null:/dev/testdevice", "--privileged", ALPINE, "ls", "/dev"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(ContainSubstring(" testdevice "), "our custom device")
+		// assumes that /dev/mem always exists
+		Expect(session.OutputToString()).To(ContainSubstring(" mem "), "privileged device")
+
+		session = podmanTest.Podman([]string{"run", "--device", "invalid-device", "--privileged", ALPINE, "ls", "/dev"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "stat invalid-device: no such file or directory"))
+	})
+
 	It("podman run --replace", func() {
 		// Make sure we error out with --name.
 		session := podmanTest.Podman([]string{"create", "--replace", ALPINE, "/bin/sh"})


### PR DESCRIPTION
When a users asks for specific devices we should still add them and not
ignore them just because privileged adds all of them.

Most notably if you set --device /dev/null:/dev/test you expect
/dev/test in the container, however as we ignored them this was not the
case. Another side effect is that the input was not validated at at all.
This leads to confusion as descriped in the issue.

Fixes https://github.com/containers/podman/issues/23132

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The podman create/run `--device` option is no longer ignored when `--privileged` is used.
```
