### PR TITLE
Remove the unused machine volume-driver

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -123,6 +123,13 @@ func init() {
 		"USB Host passthrough: bus=$1,devnum=$2 or vendor=$1,product=$2")
 	_ = initCmd.RegisterFlagCompletionFunc(USBFlagName, completion.AutocompleteDefault)
 
+	VolumeDriverFlagName := "volume-driver"
+	flags.String(VolumeDriverFlagName, "", "Optional volume driver")
+	_ = initCmd.RegisterFlagCompletionFunc(VolumeDriverFlagName, completion.AutocompleteDefault)
+	if err := flags.MarkDeprecated(VolumeDriverFlagName, "will be ignored"); err != nil {
+		logrus.Error("unable to mark volume-driver flag deprecated")
+	}
+
 	IgnitionPathFlagName := "ignition-path"
 	flags.StringVar(&initOpts.IgnitionPath, IgnitionPathFlagName, "", "Path to ignition file")
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -123,10 +123,6 @@ func init() {
 		"USB Host passthrough: bus=$1,devnum=$2 or vendor=$1,product=$2")
 	_ = initCmd.RegisterFlagCompletionFunc(USBFlagName, completion.AutocompleteDefault)
 
-	VolumeDriverFlagName := "volume-driver"
-	flags.StringVar(&initOpts.VolumeDriver, VolumeDriverFlagName, "", "Optional volume driver")
-	_ = initCmd.RegisterFlagCompletionFunc(VolumeDriverFlagName, completion.AutocompleteDefault)
-
 	IgnitionPathFlagName := "ignition-path"
 	flags.StringVar(&initOpts.IgnitionPath, IgnitionPathFlagName, "", "Path to ignition file")
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -160,10 +160,6 @@ Example: `-v "$HOME/git:$HOME/git:ro,security_model=none"`
 Default volume mounts are defined in *containers.conf*.  Unless changed, the default values
 is `$HOME:$HOME`.
 
-#### **--volume-driver**
-
-Driver to use for mounting volumes from the host, such as `virtfs`.
-
 ## EXAMPLES
 
 Initialize the default Podman machine, pulling the content from the internet.

--- a/pkg/machine/define/initopts.go
+++ b/pkg/machine/define/initopts.go
@@ -8,7 +8,6 @@ type InitOptions struct {
 	IgnitionPath       string
 	Image              string
 	Volumes            []string
-	VolumeDriver       string
 	IsDefault          bool
 	Memory             uint64
 	Name               string


### PR DESCRIPTION
The driver is now hardcoded again, and there can only be one type of mounts at a time (which one changes over time)

Revert "Make it possible to select the volume driver" This reverts commit 6630e5cf66cf76aefcfe9caebe5df4f37dd0bdd5.

The driver is now always virtiofs(d).

Previously it was always virtfs (9p).

#### Does this PR introduce a user-facing change?

```release-note
Remove the --volume-driver flag from podman machine init.
```

/cc @baude 

----

The flag was introduced, so that users could choose between sshfs and virtfs drivers:

* https://github.com/containers/podman/pull/12584

Mostly because some operating systems do not support 9p filesystems, such as RHEL

The real name should have been "reverse-sshfs", since it is calling back (to sftp on host)