### PR TITLE
Ignore result of EvalSymlinks on ENOENT

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -3,9 +3,7 @@
 package libpod
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -237,20 +235,18 @@ func readOnlyValidateConfig(bucket *bolt.Bucket, toCheck dbConfigValidation) (bo
 	// which is symlinked to /var/home.
 	if toCheck.isPath {
 		if dbValue != "" {
-			// Ignore ENOENT on both, on a fresh system some paths
-			// may not exist this early in Libpod init.
-			dbVal, err := filepath.EvalSymlinks(dbValue)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			checkedVal, err := evalSymlinksIfExists(dbValue)
+			if err != nil {
 				return false, fmt.Errorf("evaluating symlinks on DB %s path %q: %w", toCheck.name, dbValue, err)
 			}
-			dbValue = dbVal
+			dbValue = checkedVal
 		}
 		if ourValue != "" {
-			ourVal, err := filepath.EvalSymlinks(ourValue)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			checkedVal, err := evalSymlinksIfExists(ourValue)
+			if err != nil {
 				return false, fmt.Errorf("evaluating symlinks on configured %s path %q: %w", toCheck.name, ourValue, err)
 			}
-			ourValue = ourVal
+			ourValue = checkedVal
 		}
 	}
 


### PR DESCRIPTION
When the path does not exist, filepath.EvalSymlinks returns an empty string - so we can't just ignore ENOENT, we have to discard the result if an ENOENT is returned.

Should fix Jira issue [RHEL-37948](https://issues.redhat.com/browse/RHEL-37948)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where Podman could throw errors about a database configuration mismatch if certain paths did not yet exist on the host.
```
