### PR TITLE
System test fixes

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1010,6 +1010,7 @@ EOF
     run_podman rm $output
 }
 
+# bats file_tags=distro-integration
 @test "podman run --device-read-bps" {
     skip_if_rootless "cannot use this flag in rootless mode"
     # this test is a triple check on blkio flags since they seem to sneak by the tests

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -305,6 +305,7 @@ EOF
     is "$output" "bar1.*bar2.*bar3" "Should match multiple source files on single destination directory"
 }
 
+# bats test_tags=distro-integration
 @test "podman mount noswap memory mounts" {
     # tmpfs+noswap new in kernel 6.x, mid-2023; likely not in RHEL for a while
     if ! is_rootless; then

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -299,7 +299,7 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
 }
 
 # https://github.com/containers/podman/issues/13153
-@test "podman rootless-netns pasta processes should be in different cgroup" {
+@test "podman rootless-netns processes should be in different cgroup" {
     is_rootless || skip "only meaningful for rootless"
 
     cname=$(random_string)

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -176,6 +176,7 @@ function wait_for_journal() {
     die "Timed out waiting for '$expect_str' in journalctl output"
 }
 
+# bats test_tags=distro-integration
 @test "quadlet - basic" {
     # Network=none is to work around a Pasta bug, can be removed once a patched Pasta is available.
     # Ref https://github.com/containers/podman/pull/21563#issuecomment-1965145324

--- a/test/system/280-update.bats
+++ b/test/system/280-update.bats
@@ -117,6 +117,7 @@ device-write-iops   = /dev/zero:4000 | - | -                                    
     run_podman update "${opts[@]}" $cid
 
     # ...and check one by one
+    defer-assertion-failures
     for opt in "${opts[@]}"; do
         read path op expect <<<"${check[$opt]}"
         run_podman exec $cid cat /sys/fs/cgroup/$path
@@ -126,6 +127,7 @@ device-write-iops   = /dev/zero:4000 | - | -                                    
         updated="$(echo $output)"
         assert "$updated" $op "$expect" "$opt ($path)"
     done
+    immediate-assertion-failures
 
     # Clean up
     run_podman rm -f -t0 $cid

--- a/test/system/420-cgroups.bats
+++ b/test/system/420-cgroups.bats
@@ -37,6 +37,7 @@ load helpers
     run_podman rm myc
 }
 
+# bats test_tags=distro-integration
 @test "podman run --cgroups=disabled keeps the current cgroup" {
     skip_if_remote "podman-remote does not support --cgroups=disabled"
     skip_if_rootless_cgroupsv1

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -398,6 +398,8 @@ _EOF
 
     _write_test_yaml command=id image=quay.io/libpod/userimage
     run_podman 125 play kube --build --start=false $PODMAN_TMPDIR/test.yaml
+    assert "$output" =~ "initializing source docker://quay.io/libpod/userimage:latest: reading manifest latest in "
+
     run_podman play kube --replace --context-dir=$PODMAN_TMPDIR --build --start=false $PODMAN_TMPDIR/test.yaml
     run_podman inspect --format "{{ .Config.User }}" test_pod-test
     is "$output" bin "expect container within pod to run as the bin user"


### PR DESCRIPTION
 - fix test name to reflect that it's not pasta-only
   (followup from #21563)

 - in one podman-update test run in OpenQA, defer assertion
   failures so we can gather better data on regressions.
   This would've been helpful in diagnosing bz2281805.

 - add an error-message check to one test that needed it
   (found by accident)

 - add distro-integration test tag to a handful of new tests,
   so they run in OpenQA. Found via 'git diff 33891e8 test/system'
   and scanning for '^\+@test '. I only added tests that IMO
   have some risk of interacting poorly with kernel or systemd
   updates, e.g. quadlet, modules, tmpfs+noswap.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```