### PR TITLE
libpod: first delete container then cidfile

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -991,12 +991,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, opts ctrRmO
 		reportErrorf("cleaning up storage: %w", err)
 	}
 
-	// Remove the container's CID file on container removal.
-	if cidFile, ok := c.config.Spec.Annotations[define.InspectAnnotationCIDFile]; ok {
-		if err := os.Remove(cidFile); err != nil && !errors.Is(err, os.ErrNotExist) {
-			reportErrorf("cleaning up CID file: %w", err)
-		}
-	}
 	// Remove the container from the state
 	if c.config.Pod != "" {
 		// If we're removing the pod, the container will be evicted
@@ -1010,6 +1004,13 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, opts ctrRmO
 		}
 	}
 	removedCtrs[c.ID()] = nil
+
+	// Remove the container's CID file on container removal.
+	if cidFile, ok := c.config.Spec.Annotations[define.InspectAnnotationCIDFile]; ok {
+		if err := os.Remove(cidFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+			reportErrorf("cleaning up CID file: %w", err)
+		}
+	}
 
 	// Deallocate the container's lock
 	if err := c.lock.Free(); err != nil && !errors.Is(err, fs.ErrNotExist) {


### PR DESCRIPTION
I am seeing a weird flake in my parallel system test PR. The issue is that system units generated by podman systemd generate leave a container in the Removing state behind.

As far as I can tell the porblems seems to be that the cleanup process is killed while it tries to remove the container from the db. Because the cidfile was removed before the ExecStopPost=podman rm ... process no longer had access to the cidfile and reported no error because it runs with --ignore.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a race condition where containers run in systemd units would not be removed correctly on exit when they were using a cidfile.
```
