### PR TITLE
pkg/rootless: simplify reexec for container code

### DIFF
--- a/pkg/domain/infra/abi/system_linux.go
+++ b/pkg/domain/infra/abi/system_linux.go
@@ -88,7 +88,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool, 
 	}
 
 	if len(paths) > 0 {
-		became, ret, err = rootless.TryJoinFromFilePaths(pausePidPath, true, paths)
+		became, ret, err = rootless.TryJoinFromFilePaths(pausePidPath, paths)
 	} else {
 		became, ret, err = rootless.BecomeRootInUserNS(pausePidPath)
 		if err == nil {

--- a/pkg/domain/infra/abi/system_linux.go
+++ b/pkg/domain/infra/abi/system_linux.go
@@ -30,15 +30,16 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool, 
 		}
 	}
 
-	configureCgroup := cgroupMode != "disabled"
-	if configureCgroup {
+	hasCapSysAdmin, err := unshare.HasCapSysAdmin()
+	if err != nil {
+		return err
+	}
+
+	// check for both euid == 0 and CAP_SYS_ADMIN because we may be running in a container with CAP_SYS_ADMIN set.
+	if os.Geteuid() == 0 && hasCapSysAdmin {
 		// do it only after podman has already re-execed and running with uid==0.
-		hasCapSysAdmin, err := unshare.HasCapSysAdmin()
-		if err != nil {
-			return err
-		}
-		// check for both euid == 0 and CAP_SYS_ADMIN because we may be running in a container with CAP_SYS_ADMIN set.
-		if os.Geteuid() == 0 && hasCapSysAdmin {
+		configureCgroup := cgroupMode != "disabled"
+		if configureCgroup {
 			ownsCgroup, err := cgroups.UserOwnsCurrentSystemdCgroup()
 			if err != nil {
 				logrus.Infof("Failed to detect the owner for the current cgroup: %v", err)
@@ -55,8 +56,8 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool, 
 					}
 				}
 			}
-			return nil
 		}
+		return nil
 	}
 
 	pausePidPath, err := util.GetRootlessPauseProcessPidPath()

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -24,7 +24,7 @@ func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
 		return false, -1, err
 	}
 
-	became, ret, err := TryJoinFromFilePaths("", false, []string{pausePidPath})
+	became, ret, err := TryJoinFromFilePaths("", []string{pausePidPath})
 	if err == nil {
 		return became, ret, nil
 	}
@@ -45,7 +45,7 @@ func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
 	}()
 
 	// Now the pause PID file is locked.  Try to join once again in case it changed while it was not locked.
-	became, ret, err = TryJoinFromFilePaths("", false, []string{pausePidPath})
+	became, ret, err = TryJoinFromFilePaths("", []string{pausePidPath})
 	if err != nil {
 		// It is still failing.  We can safely remove it.
 		os.Remove(pausePidPath)

--- a/pkg/rootless/rootless_freebsd.go
+++ b/pkg/rootless/rootless_freebsd.go
@@ -38,11 +38,7 @@ func GetRootlessGID() int {
 // This is useful when there are already running containers and we
 // don't have a pause process yet.  We can use the paths to the conmon
 // processes to attempt joining their namespaces.
-// If needNewNamespace is set, the file is read from a temporary user
-// namespace, this is useful for containers that are running with a
-// different uidmap and the unprivileged user has no way to read the
-// file owned by the root in the container.
-func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []string) (bool, int, error) {
+func TryJoinFromFilePaths(pausePidPath string, paths []string) (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
 }
 

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -41,11 +41,7 @@ func GetRootlessGID() int {
 // This is useful when there are already running containers and we
 // don't have a pause process yet.  We can use the paths to the conmon
 // processes to attempt joining their namespaces.
-// If needNewNamespace is set, the file is read from a temporary user
-// namespace, this is useful for containers that are running with a
-// different uidmap and the unprivileged user has no way to read the
-// file owned by the root in the container.
-func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []string) (bool, int, error) {
+func TryJoinFromFilePaths(pausePidPath string, paths []string) (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
 }
 

--- a/test/system/550-pause-process.bats
+++ b/test/system/550-pause-process.bats
@@ -119,7 +119,7 @@ function _check_pause_process() {
 
     # First let's run a container in the background to keep the userns active
     local cname1=c1_$(random_string)
-    run_podman run -d --name $cname1 $IMAGE top
+    run_podman run -d --name $cname1 --uidmap 0:100:100 $IMAGE top
 
     run_podman unshare readlink /proc/self/ns/user
     userns="$output"
@@ -135,6 +135,9 @@ function _check_pause_process() {
     local kidpid=$!
 
     _test_sigproxy $cname2 $kidpid
+
+    # check pause process again
+    _check_pause_process
 
     # our container exits 0 so podman should too
     wait $kidpid || die "podman run exited $? instead of zero"


### PR DESCRIPTION
The code currently tried to avoid joining the userns from conmon directly and rather joined to only read the pid file and then send this back to use so we could join the userns. From the comment this was done because we could not read the pid file. However this is no longer true as of commit 49eb5af301 and file is no always owned by the real user.

This means we can just remove this special logic and join the namespace directly there. A test has been added to check the rejoin logic with a custom uidmapping.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
