### PR TITLE
Support idmap for image volume mounts

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -39,6 +39,13 @@ Options specific to type=**volume**:
 
 Options specific to type=**image**:
 
+- *idmap*: If specified, create an idmapped mount to the target user namespace in the container.
+  The idmap option supports a custom mapping that can be different than the user namespace used by the container.
+  The mapping can be specified after the idmap option like: `idmap=uids=0-1-10#10-11-10;gids=0-100-10`.  For each triplet, the first value is the
+  start of the backing file system IDs that are mapped to the second value on the host.  The length of this mapping is given in the third value.
+  Multiple ranges are separated with #.  If the specified mapping is prepended with a '@' then the mapping is considered relative to the container
+  user namespace. The host ID for the mapping is changed to account for the relative position of the container user in the container user namespace.
+
 - *rw*, *readwrite*: *true* or *false* (default if unspecified: *false*).
 
 - *subpath*: Mount only a specific path within the image, instead of the whole image.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -280,6 +280,8 @@ type ContainerImageVolume struct {
 	ReadWrite bool `json:"rw"`
 	// SubPath determines which part of the image will be mounted into the container.
 	SubPath string `json:"subPath,omitempty"`
+	// Options holds image volume options.
+	Options []string `json:"options,omitempty"`
 }
 
 // ContainerSecret is a secret that is mounted in a container

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -449,7 +449,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		if err != nil {
 			return nil, nil, fmt.Errorf("creating image volume %q:%q: %w", volume.Source, volume.Dest, err)
 		}
-		mountPoint, err := img.Mount(ctx, nil, "")
+		mountPoint, err := img.Mount(ctx, volume.Options, "")
 		if err != nil {
 			return nil, nil, fmt.Errorf("mounting image volume %q:%q: %w", volume.Source, volume.Dest, err)
 		}

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -470,6 +470,7 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 				Source:      v.Source,
 				Destination: v.Dest,
 				ReadWrite:   v.ReadWrite,
+				Options:     v.Options,
 			})
 		}
 	}

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -56,6 +56,8 @@ type ImageVolume struct {
 	// SubPath mounts a particular path within the image.
 	// If empty, the whole image is mounted.
 	SubPath string `json:"subPath,omitempty"`
+	// Options for image volume mounts
+	Options []string `json:"options,omitempty"`
 }
 
 // GenVolumeMounts parses user input into mounts, volumes and overlay volumes

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -611,6 +611,12 @@ func getImageVolume(args []string) (*specgen.ImageVolume, error) {
 			default:
 				return nil, fmt.Errorf("invalid rw value %q: %w", value, util.ErrBadMntOption)
 			}
+		case "idmap":
+			if hasValue {
+				newVolume.Options = append(newVolume.Options, fmt.Sprintf("idmap=%s", value))
+			} else {
+				newVolume.Options = append(newVolume.Options, "idmap")
+			}
 		case "subpath":
 			if !hasValue {
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -110,6 +110,17 @@ load helpers
     done
 }
 
+@test "podman run - image volume mounts with idmapped mounts" {
+    skip_if_rootless "idmapped mounts work only with root for now"
+
+    skip_if_remote "userns=auto is set on the server"
+
+    grep -E -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
+
+    run_podman run --rm --userns=auto --mount type=image,src=$IMAGE,dst=/image-mount,idmap $IMAGE ls -ld /image-mount
+    is "$output" "dr-xr-xr-x    1 root     root.*"
+}
+
 @test "podman run --mount image" {
     skip_if_rootless "too hard to test rootless"
 


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/23211

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman run --mount type=image now supports idmap mounts for rootful containers.
```
