### PR TITLE
pr-should-include-tests: no more CI:DOCS override

### DIFF
--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -7,11 +7,6 @@ ME=$(basename $0)
 # Github label which allows overriding this check
 OVERRIDE_LABEL="No New Tests"
 
-# Docs-only changes are excused
-if [[ "${CIRRUS_CHANGE_TITLE}" =~ CI:DOCS ]]; then
-    exit 0
-fi
-
 # HEAD should be good enough, but the CIRRUS envariable allows us to test
 head=${CIRRUS_CHANGE_IN_REPO:-HEAD}
 # Base of this PR. Here we absolutely rely on cirrus.

--- a/contrib/cirrus/pr-should-include-tests.t
+++ b/contrib/cirrus/pr-should-include-tests.t
@@ -97,7 +97,7 @@ function run_test_script() {
             testnum=$(( testnum + 1 ))
 
             CIRRUS_CHANGE_TITLE="[CI:DOCS] hi there" $test_script &>/dev/null
-            if [[ $? -ne 0 ]]; then
+            if [[ $? -ne 1 ]]; then
                 echo "not ok $testnum $rest (override with CI:DOCS)"
                 rc=1
             else


### PR DESCRIPTION
CI:DOCS is no more.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```