### PR TITLE
pkg/machine/e2e: run debug command only for macos

### DIFF
--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -172,7 +173,9 @@ func (m *machineTestBuilder) runWithoutWait() (*machineSession, error) {
 
 func (m *machineTestBuilder) run() (*machineSession, error) {
 	s, err := runWrapper(m.podmanBinary, m.cmd, m.timeout, true)
-	if m.isInit {
+	// debug for the slow init on macos
+	// The image file is not consistent, sometimes it is sparse sometimes not.
+	if m.isInit && runtime.GOOS == "darwin" {
 		c := exec.Command("du", "-ah", filepath.Join(os.Getenv("HOME"), ".local/share/containers/podman/machine/applehv"))
 		c.Stderr = os.Stderr
 		c.Stdout = os.Stdout


### PR DESCRIPTION
The commands only make sense on macos so do not clutter the logs on linux/windows with the output.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
