### PR TITLE
containers/attach: Note bug around goroutine leak

### DIFF
--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -29,7 +29,13 @@ type CloseWriter interface {
 	CloseWrite() error
 }
 
-// Attach attaches to a running container
+// Attach attaches to a running container.
+//
+// NOTE: When stdin is provided, this function currently leaks a goroutine reading from that stream
+// even if the ctx is cancelled. The goroutine will only exit if the input stream is closed. For example,
+// if stdin is `os.Stdin` attached to a tty, the goroutine will consume a chunk of user input from the
+// terminal even after the container has exited. In this scenario the os.Stdin stream will not be expected
+// to be closed.
 func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Writer, stderr io.Writer, attachReady chan bool, options *AttachOptions) error {
 	if options == nil {
 		options = new(AttachOptions)


### PR DESCRIPTION
See:

- https://github.com/containers/podman-bootc/pull/59#issuecomment-2216051946
- https://github.com/containers/podman-bootc/pull/61

Sorry for not trying to fix this, but I am not aware of a remotely straightforward way to do so.

```release-note
None
```
