### PR TITLE
test netavark nftables driver

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -147,6 +147,11 @@ case "$OS_RELEASE_ID" in
             msg "Enabling container_manage_cgroup"
             showrun setsebool container_manage_cgroup true
         fi
+
+        # Test nftables driver, https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault
+        # We can drop this once this implemented and pushed into fedora stable. We cannot test it on
+        # debian because the netavark version there is way to old for nftables support.
+        printf "[network]\nfirewall_driver=\"nftables\"\n" > /etc/containers/containers.conf.d/90-nftables.conf
         ;;
     *) die_unknown OS_RELEASE_ID
 esac

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -48,6 +48,11 @@ setup() {
     # skip_mount_home=true is required so we can share the storage mounts between host and container,
     # the default c/storage behavior is to make the mount propagation private.
     export _PODMAN_TEST_OPTS="--storage-opt=skip_mount_home=true --cgroup-manager=cgroupfs --root=$PODMAN_UPGRADE_WORKDIR/root --runroot=$PODMAN_UPGRADE_WORKDIR/runroot --tmpdir=$PODMAN_UPGRADE_WORKDIR/tmp"
+
+    # Old netavark used iptables but newer versions might uses nftables.
+    # Networking can only work correctly if both use the same firewall driver so force iptables.
+    printf "[network]\nfirewall_driver=\"iptables\"\n" > $PODMAN_UPGRADE_WORKDIR/containers.conf
+    export CONTAINERS_CONF_OVERRIDE=$PODMAN_UPGRADE_WORKDIR/containers.conf
 }
 
 ###############################################################################
@@ -180,6 +185,7 @@ EOF
             --net=host \
             --cgroupns=host \
             --pid=host \
+            --env CONTAINERS_CONF_OVERRIDE \
             $v_sconf \
             -v /dev/fuse:/dev/fuse \
             -v /run/crun:/run/crun \


### PR DESCRIPTION
Make sure this passes podman CI before push out a default change.

ref: https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
