### PR TITLE
[v5.1] Drop minikube CI test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -930,23 +930,6 @@ rootless_system_test_task:
     main_script: *main
     always: *logs_artifacts
 
-
-minikube_test_task:
-    name: *std_name_fmt
-    alias: minikube_test
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_tag_magic
-    depends_on: *build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: minikube
-        PRIV_NAME: rootless
-    clone_script: *get_gosrc
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
 farm_test_task:
     name: *std_name_fmt
     alias: farm_test
@@ -1079,7 +1062,6 @@ success_task:
         - remote_system_test
         - rootless_remote_system_test
         - rootless_system_test
-        - minikube_test
         - farm_test
         - buildah_bud_test
         - upgrade_test

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -326,7 +326,6 @@ esac
 showrun echo "about to set up for TEST_FLAVOR [=$TEST_FLAVOR]"
 case "$TEST_FLAVOR" in
     validate)
-        showrun dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm
         # For some reason, this is also needed for validation
         showrun make .install.pre-commit .install.gitvalidation
         ;;


### PR DESCRIPTION
I'm happy to hear arguments for keeping this (and perhaps the one on main also?) and/or pointer at someone who is willing to debug and maintain it.  Otherwise IMO this task is just a waste of resources.

---
--**_OR_**--

---


At the time of this commit, on main this task includes:

```yaml
    # 2024-05-21: flaking almost constantly since March.
    skip: $CI == $CI
```

Disable the test entirely on this branch due to multiple failures, difficulty debugging, lack of team expertise, and willpower to care.

Ref: https://cirrus-ci.com/task/4712403315720192

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
