### PR TITLE
kube generate/play restores the user namespace configuration

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -513,6 +513,10 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 
 	for _, ctr := range containers {
 		if ctr.IsInfra() {
+			// If there is an user namespace for the infra container, then register it for the entire pod.
+			if v, found := ctr.config.Spec.Annotations[define.UserNsAnnotation]; found {
+				podAnnotations[define.UserNsAnnotation] = v
+			}
 			_, _, infraDNS, _, err := containerToV1Container(ctx, ctr, getService)
 			if err != nil {
 				return nil, err

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -46,6 +46,9 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 		infraOptions.Net = &entities.NetOptions{}
 		infraOptions.Devices = psg.Devices
 		infraOptions.SecurityOpt = psg.SecurityOpt
+		if !psg.Userns.IsDefault() {
+			infraOptions.UserNS = psg.Userns.String()
+		}
 		if psg.ShareParent == nil {
 			t := true
 			psg.ShareParent = &t

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -603,11 +603,12 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	if options.Userns == "" {
 		if v, ok := annotations[define.UserNsAnnotation]; ok {
 			options.Userns = v
+		} else if v, ok := annotations[define.UserNsAnnotation+"/"+podName]; ok {
+			options.Userns = v
+		} else if podYAML.Spec.HostUsers != nil && !*podYAML.Spec.HostUsers {
+			options.Userns = "auto"
 		} else {
 			options.Userns = "host"
-		}
-		if podYAML.Spec.HostUsers != nil && !*podYAML.Spec.HostUsers {
-			options.Userns = "auto"
 		}
 	} else if podYAML.Spec.HostUsers != nil {
 		logrus.Info("overriding the user namespace mode in the pod spec")

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -610,6 +610,10 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		} else {
 			options.Userns = "host"
 		}
+		// FIXME: how to deal with explicit mappings?
+		if options.Userns == "private" {
+			options.Userns = "auto"
+		}
 	} else if podYAML.Spec.HostUsers != nil {
 		logrus.Info("overriding the user namespace mode in the pod spec")
 	}

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -516,6 +516,10 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if len(s.Annotations) == 0 {
 		s.Annotations = annotations
 	}
+	// Add the user namespace configuration to the annotations
+	if c.UserNS != "" {
+		s.Annotations[define.UserNsAnnotation] = c.UserNS
+	}
 
 	if len(c.StorageOpts) > 0 {
 		opts := make(map[string]string, len(c.StorageOpts))

--- a/pkg/specgenutil/specgenutil_test.go
+++ b/pkg/specgenutil/specgenutil_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/containers/common/pkg/machine"
+	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/stretchr/testify/assert"
@@ -215,4 +216,17 @@ func TestGenRlimits(t *testing.T) {
 
 	_, err = GenRlimits([]string{"nofile=bar:buzz"})
 	assert.Error(t, err, "err is not nil")
+}
+
+func TestFillOutSpecGenRecorsUserNs(t *testing.T) {
+	sg := specgen.NewSpecGenerator("nothing", false)
+	err := FillOutSpecGen(sg, &entities.ContainerCreateOptions{
+		ImageVolume: "ignore",
+		UserNS:      "keep-id",
+	}, []string{})
+	assert.NoError(t, err)
+
+	v, ok := sg.Annotations[define.UserNsAnnotation]
+	assert.True(t, ok, "UserNsAnnotation is set")
+	assert.Equal(t, "keep-id", v, "UserNsAnnotation is keep-id")
 }

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -1037,3 +1037,33 @@ spec:
     run_podman kube down $fname
     run_podman rmi $imgname
 }
+
+@test "podman kube restore user namespace" {
+    if ! is_rootless; then
+        grep -E -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
+    fi
+
+    run_podman pod create --userns auto --name usernspod
+    run_podman create --pod usernspod $IMAGE true
+
+    run_podman pod inspect --format {{.InfraContainerID}} usernspod
+    infraID="$output"
+
+    run_podman inspect --format '{{index .Config.Annotations "io.podman.annotations.userns"}}' $infraID
+    assert "$output" == "auto" "user namespace should be kept"
+
+    YAML=$PODMAN_TMPDIR/test.yml
+
+    # Make sure the same setting is restored if the pod is recreated from the yaml
+    run_podman kube generate usernspod -f $YAML
+    cat $YAML
+    run_podman kube play --replace $YAML
+
+    run_podman pod inspect --format {{.InfraContainerID}} usernspod
+    infraID="$output"
+
+    run_podman inspect --format '{{index .Config.Annotations "io.podman.annotations.userns"}}' $infraID
+    assert "$output" == "auto" "user namespace should be kept"
+
+    run_podman pod rm -f usernspod
+}


### PR DESCRIPTION
a few fixes to improve how "kube generate" and "kube apply" deal with user namespaces.

Now the yaml generated by "kube generate" stores the user namespace configuration for the pod, which is later used by "kube apply"

Closes: https://issues.redhat.com/browse/RHEL-13033

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now "kube generate" stores the user namespace configuration that is used by "kube apply"
```
