### PR TITLE
Implement disable default mounts via command line

### DIFF
--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -168,9 +168,13 @@ func (q *QEMUStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func()
 	if err != nil {
 		return nil, nil, err
 	}
-	spawner, err := newVirtiofsdSpawner(runtime)
-	if err != nil {
-		return nil, nil, err
+
+	var spawner *virtiofsdSpawner
+	if len(mc.Mounts) > 0 {
+		spawner, err = newVirtiofsdSpawner(runtime)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	for _, hostmnt := range mc.Mounts {

--- a/pkg/machine/shim/volume.go
+++ b/pkg/machine/shim/volume.go
@@ -8,6 +8,9 @@ import (
 func CmdLineVolumesToMounts(volumes []string, volumeType vmconfigs.VolumeMountType) []*vmconfigs.Mount {
 	mounts := []*vmconfigs.Mount{}
 	for i, volume := range volumes {
+		if volume == "" {
+			continue
+		}
 		var mount vmconfigs.Mount
 		tag, source, target, readOnly, _ := vmconfigs.SplitVolume(i, volume)
 		switch volumeType {


### PR DESCRIPTION
Fixes #22364 

This PR adds specific handling of the command line arguments `-v ""` - special handling for empty string. `-v` being present suppresses defaults from the config, so, it is sufficient to implement it as no-op to achieve empty mounts. This happens as early as possible (before any machine specific logic would be called).

Additional change is to allow using QEMU w/o virtiofsd binary if there are no mounts needed and the binary will not be used to run additional daemon.

And the final change is to disable default mounts for e2e tests, which are not supposed to have any mounts. Implementation is a bit hacky it checks if the command is `machine init` and then traverses args to see if there are mounts requested, if no mounts in the list it will inject empty mount arguments and continue.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow `podman machine init` w/o default mounts via command line arguments `-v ""`
```
