### PR TITLE
Add NetworkAlias= support for quadlet .container and .pod files

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -282,6 +282,7 @@ Valid options for `[Container]` are listed below:
 | Mask=/proc/sys/foo\:/proc/sys/bar    | --security-opt mask=/proc/sys/foo:/proc/sys/bar      |
 | Mount=type=...                       | --mount type=...                                     |
 | Network=host                         | --net host                                           |
+| NetworkAlias=name                    | --network-alias name                                 |
 | NoNewPrivileges=true                 | --security-opt no-new-privileges                     |
 | Notify=true                          | --sdnotify container                                 |
 | PidsLimit=10000                      | --pids-limit 10000                                   |
@@ -594,6 +595,15 @@ created by using a `$name.network` Quadlet file.
 
 This key can be listed multiple times.
 
+### `NetworkAlias=`
+
+Add a network-scoped alias for the container. This has the same format as the `--network-alias`
+option to `podman run`. Aliases can be used to group containers together in DNS resolution: for
+example, setting `NetworkAlias=web` on multiple containers will make a DNS query for `web` resolve
+to all the containers with that alias.
+
+This key can be listed multiple times.
+
 ### `NoNewPrivileges=` (defaults to `false`)
 
 If enabled, this disables the container processes from gaining additional privileges via things like
@@ -828,6 +838,7 @@ Valid options for `[Pod]` are listed below:
 | ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                |
 | GlobalArgs=--log-level=debug        | --log-level=debug                      |
 | Network=host                        | --network host                         |
+| NetworkAlias=name                   | --network-alias name                   |
 | PodmanArgs=\-\-cpus=2               | --cpus=2                               |
 | PodName=name                        | --name=name                            |
 | PublishPort=50-59                   | --publish 50-59                        |
@@ -863,6 +874,15 @@ As a special case, if the `name` of the network ends with `.network`, Quadlet wi
 If found, Quadlet will use the name of the Network set in the Unit, otherwise, `systemd-$name` is used.
 The generated systemd service contains a dependency on the service unit generated for that `.network` unit,
 or on `$name-network.service` if the `.network` unit is not found
+
+This key can be listed multiple times.
+
+### `NetworkAlias=`
+
+Add a network-scoped alias for the pod. This has the same format as the `--network-alias` option to
+`podman pod create`. Aliases can be used to group containers together in DNS resolution: for
+example, setting `NetworkAlias=web` on multiple containers will make a DNS query for `web` resolve
+to all the containers with that alias.
 
 This key can be listed multiple times.
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -114,6 +114,7 @@ const (
 	KeyMask                  = "Mask"
 	KeyMount                 = "Mount"
 	KeyNetwork               = "Network"
+	KeyNetworkAlias          = "NetworkAlias"
 	KeyNetworkName           = "NetworkName"
 	KeyNoNewPrivileges       = "NoNewPrivileges"
 	KeyNotify                = "Notify"
@@ -217,6 +218,7 @@ var (
 		KeyMask:                  true,
 		KeyMount:                 true,
 		KeyNetwork:               true,
+		KeyNetworkAlias:          true,
 		KeyNoNewPrivileges:       true,
 		KeyNotify:                true,
 		KeyPidsLimit:             true,
@@ -363,6 +365,7 @@ var (
 		KeyContainersConfModule: true,
 		KeyGlobalArgs:           true,
 		KeyNetwork:              true,
+		KeyNetworkAlias:         true,
 		KeyPodName:              true,
 		KeyPodmanArgs:           true,
 		KeyPublishPort:          true,
@@ -559,6 +562,11 @@ func ConvertContainer(container *parser.UnitFile, names map[string]string, isUse
 	}
 
 	addNetworks(container, ContainerGroup, service, names, podman)
+
+	networkAliases := container.LookupAll(ContainerGroup, KeyNetworkAlias)
+	for _, networkAlias := range networkAliases {
+		podman.add("--network-alias", networkAlias)
+	}
 
 	// Run with a pid1 init to reap zombies by default (as most apps don't do that)
 	runInit, ok := container.LookupBoolean(ContainerGroup, KeyRunInit)
@@ -1535,6 +1543,11 @@ func ConvertPod(podUnit *parser.UnitFile, name string, podsInfoMap map[string]*P
 	}
 
 	addNetworks(podUnit, PodGroup, service, names, execStartPre)
+
+	networkAliases := podUnit.LookupAll(PodGroup, KeyNetworkAlias)
+	for _, networkAlias := range networkAliases {
+		execStartPre.add("--network-alias", networkAlias)
+	}
 
 	if err := addVolumes(podUnit, service, PodGroup, names, execStartPre); err != nil {
 		return nil, err

--- a/test/e2e/quadlet/network-alias.container
+++ b/test/e2e/quadlet/network-alias.container
@@ -1,0 +1,6 @@
+[Container]
+Image=localhost/imagename
+## assert-podman-args-key-val "--network-alias" "," "name"
+NetworkAlias=name
+## assert-podman-args-key-val "--network-alias" "," "othername"
+NetworkAlias=othername

--- a/test/e2e/quadlet/network-alias.pod
+++ b/test/e2e/quadlet/network-alias.pod
@@ -1,0 +1,6 @@
+## assert-podman-pre-args --network-alias name
+## assert-podman-pre-args --network-alias othername
+
+[Pod]
+NetworkAlias=name
+NetworkAlias=othername

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -873,6 +873,7 @@ BOGUS=foo
 		Entry("template@.container", "template@.container", 0, ""),
 		Entry("template@instance.container", "template@instance.container", 0, ""),
 		Entry("Unit After Override", "unit-after-override.container", 0, ""),
+		Entry("NetworkAlias", "network-alias.container", 0, ""),
 
 		Entry("basic.volume", "basic.volume", 0, ""),
 		Entry("device-copy.volume", "device-copy.volume", 0, ""),
@@ -996,6 +997,7 @@ BOGUS=foo
 		Entry("network-quadlet.pod", "network.quadlet.pod", 0, ""),
 		Entry("podmanargs.pod", "podmanargs.pod", 0, ""),
 		Entry("volume.pod", "volume.pod", 0, ""),
+		Entry("Pod - NetworkAlias", "network-alias.pod", 0, ""),
 	)
 
 	DescribeTable("Running quadlet test case with dependencies",


### PR DESCRIPTION
Noticed this was missing while porting a compose file to a quadlet system.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add NetworkAlias= support for quadlet .container and .pod files.
```
