### PR TITLE
test: podman system service doesn't leak mount on termination

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
 	"github.com/containers/podman/v5/libpod/define"
+	"github.com/containers/podman/v5/libpod/shutdown"
 	"github.com/containers/podman/v5/pkg/bindings"
 	"github.com/containers/podman/v5/pkg/checkpoint/crutils"
 	"github.com/containers/podman/v5/pkg/domain/entities"
@@ -124,9 +125,11 @@ func Execute() {
 		fmt.Fprintln(os.Stderr, formatError(err))
 	}
 
+	_ = shutdown.Stop()
+
 	if requireCleanup {
 		// The cobra post-run is not being executed in case of
-		// a previous error , so make sure that the engine(s)
+		// a previous error, so make sure that the engine(s)
 		// are correctly shutdown.
 		//
 		// See https://github.com/spf13/cobra/issues/914

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -91,6 +91,11 @@ func Stop() error {
 		return nil
 	}
 
+	// if the signal handler is running, wait that it terminates
+	handlerLock.Lock()
+	defer handlerLock.Unlock()
+	// it doesn't need to be in the critical section, but staticcheck complains if
+	// the critical section is empty.
 	cancelChan <- true
 
 	return nil

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -33,7 +33,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -1057,16 +1056,6 @@ func rmAll(podmanBin string, path string) {
 			GinkgoWriter.Printf("%v\n", err)
 		}
 	} else {
-		// When using overlay as root, podman leaves a stray mount behind.
-		// This leak causes remote tests to take a loooooong time, which
-		// then causes Cirrus to time out. Unmount that stray.
-		overlayPath := path + "/root/overlay"
-		if _, err := os.Stat(overlayPath); err == nil {
-			if err = unix.Unmount(overlayPath, unix.MNT_DETACH); err != nil {
-				GinkgoWriter.Printf("Error unmounting %s: %v\n", overlayPath, err)
-			}
-		}
-
 		if err = os.RemoveAll(path); err != nil {
 			GinkgoWriter.Printf("%q\n", err)
 		}

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -103,7 +103,7 @@ func (p *PodmanTestIntegration) StartRemoteService() {
 }
 
 func (p *PodmanTestIntegration) StopRemoteService() {
-	if err := p.RemoteSession.Kill(); err != nil {
+	if err := p.RemoteSession.Signal(syscall.SIGTERM); err != nil {
 		GinkgoWriter.Printf("unable to clean up service %d, %v\n", p.RemoteSession.Pid, err)
 	}
 	if _, err := p.RemoteSession.Wait(); err != nil {

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -277,7 +277,7 @@ run_podman --noout system connection ls
     run_podman --log-level=debug run --rm $IMAGE true
     is "$output" ".*Shutting down engines.*"
     run_podman 125 --log-level=debug run dockah://rien.de/rien:latest
-    is "${lines[-1]}" ".*Shutting down engines"
+    is "$output" ".*Shutting down engines.*"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now "podman system service" does not leak a mount when it is terminated
```
