### PR TITLE
[skip-ci] Packit: move downstream tests upstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,9 +9,26 @@ packages:
   podman-fedora:
     pkg_tool: fedpkg
     specfile_path: rpm/podman.spec
+    # Ref: https://packit.dev/docs/configuration#files_to_sync
+    files_to_sync:
+      - src: rpm/gating.yaml
+        dest: gating.yaml
+        delete: true
+      - src: rpm/fedora-tests/tests
+        dest: tests/
+        delete: true
+      - .packit.yaml
   podman-centos:
     pkg_tool: centpkg
     specfile_path: rpm/podman.spec
+    files_to_sync:
+      - src: rpm/gating.yaml
+        dest: gating.yaml
+        delete: true
+      - src: rpm/centos-tests/tests
+        dest: tests/
+        delete: true
+      - .packit.yaml
   podman-rhel:
     specfile_path: rpm/podman.spec
 

--- a/rpm/centos-tests/tests/main.fmf
+++ b/rpm/centos-tests/tests/main.fmf
@@ -1,0 +1,2 @@
+require:
+  - podman

--- a/rpm/centos-tests/tests/roles/bats_installed/tasks/main.yml
+++ b/rpm/centos-tests/tests/roles/bats_installed/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# Sigh; RHEL8 doesn't have BATS
+- name: bats | fetch and unpack tarball
+  unarchive:
+    src: https://github.com/bats-core/bats-core/archive/v1.11.0.tar.gz
+    dest: /root
+    remote_src: true
+
+- name: bats | install
+  command: ./install.sh /usr/local
+  args:
+    chdir: /root/bats-core-1.11.0

--- a/rpm/centos-tests/tests/roles/rootless_user/tasks/main.yml
+++ b/rpm/centos-tests/tests/roles/rootless_user/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: create rootless user
+  user:
+    name: testuser
+    shell: /bin/bash
+- name: enable linger
+  command: loginctl enable-linger testuser

--- a/rpm/centos-tests/tests/roles/run_bats_tests/files/run_bats_tests.sh
+++ b/rpm/centos-tests/tests/roles/run_bats_tests/files/run_bats_tests.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Run bats tests for a given $TEST_PACKAGE, e.g. buildah, podman
+#
+# This is invoked by the 'run_bats_tests' role; we assume that
+# the package foo has a foo-tests subpackage which provides the
+# directory /usr/share/foo/test/system, containing one or more .bats
+# test files.
+#
+
+export PATH=/usr/local/bin:/usr/sbin:/usr/bin
+
+FULL_LOG=/tmp/test.debug.log
+BATS_LOG=/tmp/test.bats.log
+rm -f $FULL_LOG $BATS_LOG
+touch $FULL_LOG $BATS_LOG
+
+exec &> $FULL_LOG
+
+# Log program versions
+echo "Packages:"
+rpm -q ${TEST_PACKAGE} ${TEST_PACKAGE}-tests
+
+echo "------------------------------"
+printenv | sort
+
+testdir=/usr/share/${TEST_PACKAGE}/test/system
+
+if ! cd $testdir; then
+    echo "FAIL ${TEST_NAME} : cd $testdir"      >> /tmp/test.log
+    exit 0
+fi
+
+if [ -e /tmp/helper.sh ]; then
+    echo "------------------------------"
+    echo ". /tmp/helper.sh"
+    . /tmp/helper.sh
+fi
+
+if [ "$(type -t setup)" = "function" ]; then
+    echo "------------------------------"
+    echo "\$ setup"
+    setup
+    if [ $? -ne 0 ]; then
+        echo "FAIL ${TEST_NAME} : setup"       >> /tmp/test.log
+        exit 0
+    fi
+fi
+
+echo "------------------------------"
+echo "\$ bats ."
+bats . &> $BATS_LOG
+rc=$?
+
+echo "------------------------------"
+echo "bats completed with status $rc"
+
+status=PASS
+if [ $rc -ne 0 ]; then
+    status=FAIL
+fi
+
+echo "${status} ${TEST_NAME}" >> /tmp/test.log
+
+if [ "$(type -t teardown)" = "function" ]; then
+    echo "------------------------------"
+    echo "\$ teardown"
+    teardown
+fi
+
+# FIXME: for CI purposes, always exit 0. This allows subsequent tests.
+exit 0

--- a/rpm/centos-tests/tests/roles/run_bats_tests/tasks/main.yml
+++ b/rpm/centos-tests/tests/roles/run_bats_tests/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# Create empty results file, world-writable
+- name: initialize test.log file
+  copy: dest=/tmp/test.log content='' force=yes mode=0666
+
+- name: execute tests
+  include: run_one_test.yml
+  with_items: "{{ tests }}"
+  loop_control:
+    loop_var: test
+
+- name: pull test.log results
+  fetch:
+    src: "/tmp/test.log"
+    dest: "{{ artifacts }}/test.log"
+    flat: yes
+
+# Copied from standard-test-basic
+- name: check results
+  shell: grep "^FAIL" /tmp/test.log
+  register: test_fails
+  # Never fail at this step. Just store result of tests.
+  failed_when: False
+
+- name: preserve results
+  set_fact:
+    role_result_failed: "{{ (test_fails.stdout|d|length > 0) or (test_fails.stderr|d|length > 0) }}"
+    role_result_msg: "{{ test_fails.stdout|d('tests failed.') }}"
+
+- name: display results
+  vars:
+    msg: |
+       Tests failed: {{ role_result_failed|d('Undefined') }}
+       Tests msg: {{ role_result_msg|d('None') }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  failed_when: "role_result_failed|bool"

--- a/rpm/centos-tests/tests/roles/run_bats_tests/tasks/run_one_test.yml
+++ b/rpm/centos-tests/tests/roles/run_bats_tests/tasks/run_one_test.yml
@@ -1,0 +1,52 @@
+---
+- name: "{{ test.name }} | install test packages"
+  dnf: name="{{ test.package }}-tests" state=installed
+
+- name: "{{ test.name }} | define helper variables"
+  set_fact:
+    test_name_oneword: "{{ test.name | replace(' ','-') }}"
+
+# UGH. This is necessary because our caller sets some environment variables
+# and we need to set a few more based on other caller variables; then we
+# need to combine the two dicts when running the test. This seems to be
+# the only way to do it in ansible.
+- name: "{{ test.name }} | define local environment"
+  set_fact:
+    local_environment:
+      TEST_NAME:    "{{ test.name }}"
+      TEST_PACKAGE: "{{ test.package }}"
+      TEST_ENV:     "{{ test.environment }}"
+
+- name: "{{ test.name }} | setup/teardown helper | see if exists"
+  local_action: stat path={{ role_path }}/files/helper.{{ test_name_oneword }}.sh
+  register: helper
+
+- name: "{{ test.name }} | setup/teardown helper | install"
+  copy: src=helper.{{ test_name_oneword }}.sh dest=/tmp/helper.sh
+  when: helper.stat.exists
+
+- name: "{{ test.name }} | run test"
+  script: ./run_bats_tests.sh
+  args:
+    chdir: /usr/share/{{ test.package }}/test/system
+  become: "{{ true if test.become is defined else false }}"
+  become_user: testuser
+  environment: "{{ local_environment | combine(test.environment) }}"
+
+- name: "{{ test.name }} | pull logs"
+  fetch:
+    src: "/tmp/test.{{ item }}.log"
+    dest: "{{ artifacts }}/test.{{ test_name_oneword }}.{{ item }}.log"
+    flat: yes
+  with_items:
+    - bats
+    - debug
+
+- name: "{{ test.name }} | remove remote logs and helpers"
+  file:
+    dest=/tmp/{{ item }}
+    state=absent
+  with_items:
+    - test.bats.log
+    - test.debug.log
+    - helper.sh

--- a/rpm/centos-tests/tests/smoke.fmf
+++ b/rpm/centos-tests/tests/smoke.fmf
@@ -1,0 +1,2 @@
+summary: Execute a simple command
+test: podman run -t --rm fedora cat /etc/os-release | grep 'Fedora Linux'

--- a/rpm/centos-tests/tests/tests.yml
+++ b/rpm/centos-tests/tests/tests.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  tags:  classic
+  vars:
+  - artifacts: ./artifacts
+  roles:
+  - role: bats_installed
+  - role: rootless_user
+  - role: run_bats_tests
+    tests:
+    - name:    podman root
+      package: podman
+      environment:
+        PODMAN: /usr/bin/podman
+        PODMAN_TESTING: /usr/bin/podman-testing
+        QUADLET: /usr/libexec/podman/quadlet
+
+    - name:    podman rootless
+      package: podman
+      environment:
+        PODMAN: /usr/bin/podman
+        PODMAN_TESTING: /usr/bin/podman-testing
+        QUADLET: /usr/libexec/podman/quadlet
+      become:  true
+
+      #- name:    podman-remote root
+      #package: podman
+      #environment:
+      #  PODMAN: /usr/bin/podman-remote
+      #  QUADLET: /usr/libexec/podman/quadlet

--- a/rpm/centos-tests/tests/tmt.fmf
+++ b/rpm/centos-tests/tests/tmt.fmf
@@ -1,0 +1,8 @@
+summary: Make sure that container provision works
+require:
+  - tmt-provision-container
+test:
+    tmt run --verbose --remove
+        provision --how container --image fedora
+        login --command 'cat /etc/os-release'
+        finish

--- a/rpm/fedora-tests/tests/README
+++ b/rpm/fedora-tests/tests/README
@@ -1,0 +1,18 @@
+I'm sorry. The playbooks here are a much-too-complicated way of saying:
+
+   - test podman (root and rootless)
+   - same, with podman-remote
+
+The starting point is tests.yml . From there:
+
+    tests.yml
+      \- test_podman.yml
+           |- roles/rootless_user_ready/
+           \- run_podman_tests.yml          (once for local, once for remote)
+                \- roles/run_bats_tests/    (runs tests: root, rootless)
+
+Principal result is the file 'artifacts/test.log'. It will contain
+one line for each test run, format will be '(PASS|FAIL|ERROR) <test name>'
+
+For each completed test there will also be a 'test.<name>.bats.log'
+containing some setup blurbs (RPMs, environment) and the full BATS log.

--- a/rpm/fedora-tests/tests/check_results.yml
+++ b/rpm/fedora-tests/tests/check_results.yml
@@ -1,0 +1,36 @@
+---
+# Copied from standard-test-basic
+# ...and, 2020-05-13, updated, looks like they changed the whole thing around
+- name: Check the results
+  local_action:
+    module: shell
+    cmd: |
+      log="{{ artifacts }}/test.log"
+      if [ ! -f "$log" ]; then
+          echo ERROR
+          echo "Test results not found." 1>&2
+      elif grep ^ERROR "$log" 1>&2; then
+          echo ERROR
+      elif grep ^FAIL "$log" 1>&2; then
+          echo FAIL
+      elif grep -q ^PASS "$log"; then
+          echo PASS
+      else
+          echo ERROR
+          echo "No test results found." 1>&2
+      fi
+  register: test_results
+
+- name: Set role result
+  set_fact:
+    role_result: "{{ test_results.stdout }}"
+    role_message: "{{ test_results.stderr|d('test execution error.') }}"
+
+- name: display results
+  vars:
+    msg: |
+       role_result:  {{ role_result|d('Undefined') }}
+       {{ role_message|d('[No error messages found]') }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  failed_when: role_message|d("") != ""

--- a/rpm/fedora-tests/tests/roles/disable_systemd_resolved/files/disable_systemd_resolved.sh
+++ b/rpm/fedora-tests/tests/roles/disable_systemd_resolved/files/disable_systemd_resolved.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Excerpted from https://github.com/containers/automation_images/blob/main/systemd_banish.sh
+#
+# Early 2023: https://github.com/containers/podman/issues/16973
+#
+# We see countless instances of "lookup cdn03.quay.io" flakes.
+# Disabling the systemd resolver has completely resolved those,
+# from multiple flakes per day to zero in a month.
+#
+# Opinions differ on the merits of systemd-resolve, but the fact is
+# it breaks our CI testing. Kill it.
+nsswitch=/etc/authselect/nsswitch.conf
+if [[ -e $nsswitch ]]; then
+    if grep -q -E 'hosts:.*resolve' $nsswitch; then
+        echo "Disabling systemd-resolved"
+        sed -i -e 's/^\(hosts: *\).*/\1files dns myhostname/' $nsswitch
+        systemctl disable --now systemd-resolved
+        rm -f /etc/resolv.conf
+
+        # NetworkManager may already be running, or it may not....
+        systemctl start NetworkManager
+        sleep 1
+        systemctl restart NetworkManager
+
+        # ...and it may create resolv.conf upon start/restart, or it
+        # may not. Keep restarting until it does. (Yes, I realize
+        # this is cargocult thinking. Don't care. Not worth the effort
+        # to diagnose and solve properly.)
+        retries=10
+        while ! test -e /etc/resolv.conf;do
+              retries=$((retries - 1))
+              if [[ $retries -eq 0 ]]; then
+                  echo "Timed out waiting for resolv.conf" >&2
+                  echo "...gonna try continuing. Expect failures." >&2
+              fi
+              systemctl restart NetworkManager
+              sleep 5
+        done
+    fi
+fi

--- a/rpm/fedora-tests/tests/roles/disable_systemd_resolved/tasks/main.yml
+++ b/rpm/fedora-tests/tests/roles/disable_systemd_resolved/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: disable systemd resolved
+  script: ./disable_systemd_resolved.sh

--- a/rpm/fedora-tests/tests/roles/rootless_user_ready/tasks/main.yml
+++ b/rpm/fedora-tests/tests/roles/rootless_user_ready/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: make sure rootless account exists
+  user: name={{ rootless_user }}
+
+- name: rootless account | enable linger
+  shell: loginctl enable-linger {{ rootless_user }}
+
+- name: rootless account | get uid
+  getent:
+    database: passwd
+    key: "{{ rootless_user }}"
+
+- name: rootless account | preserve uid
+  set_fact: rootless_uid="{{ getent_passwd[rootless_user][1] }}"

--- a/rpm/fedora-tests/tests/roles/run_bats_tests/files/run_bats_tests.sh
+++ b/rpm/fedora-tests/tests/roles/run_bats_tests/files/run_bats_tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Run bats tests for a given $TEST_PACKAGE, e.g. buildah, podman
+#
+# This is invoked by the 'run_bats_tests' role; we assume that
+# the package foo has a foo-tests subpackage which provides the
+# directory /usr/share/foo/test/system, containing one or more .bats
+# test files.
+#
+# We create two files:
+#
+#    /tmp/test.summary.log - one-liner with FAIL, PASS, ERROR and a blurb
+#    /tmp/test.bats.log    - full log of this script, plus the BATS run
+#
+export PATH=/usr/local/bin:/usr/sbin:/usr/bin
+
+FULL_LOG=/tmp/test.bats.log
+rm -f $FULL_LOG
+touch $FULL_LOG
+
+# Preserve output to a log file, but also emit on stdout. This covers
+# RHEL (which preserves logfiles but runs ansible without --verbose)
+# and Fedora (which hides logfiles but runs ansible --verbose).
+exec &> >(tee -a $FULL_LOG)
+
+# Log program versions
+echo "Packages:"
+echo "  Kernel: $(uname -r)"
+rpm -qa |\
+    grep -E 'toolbox|podman|conmon|containers-common|crun|runc|iptable|slirp|aardvark|netavark|containernetworking-plugins|systemd|container-selinux|passt' |\
+    sort |\
+    sed -e 's/^/  /'
+
+divider='------------------------------------------------------------------'
+echo $divider
+printenv | sort
+echo $divider
+echo "ip addr:"
+ip addr
+echo $divider
+
+testdir=/usr/share/${TEST_PACKAGE}/test/system
+
+if ! cd $testdir; then
+    echo "FAIL ${TEST_NAME} : cd $testdir"      > /tmp/test.summary.log
+    exit 0
+fi
+
+if [[ $PODMAN =~ remote ]]; then
+    ${PODMAN%%-remote} system service -t0 &>/dev/null &
+    PODMAN_SERVER_PID=$!
+fi
+
+echo "\$ bats ."
+bats .
+rc=$?
+
+if [[ -n "$PODMAN_SERVER_PID" ]]; then
+    kill $PODMAN_SERVER_PID
+fi
+
+echo $divider
+echo "bats completed with status $rc"
+
+status=PASS
+if [ $rc -ne 0 ]; then
+    status=FAIL
+fi
+
+echo "${status} ${TEST_NAME}" > /tmp/test.summary.log
+
+# FIXME: for CI purposes, always exit 0. This allows subsequent tests.
+exit 0

--- a/rpm/fedora-tests/tests/roles/run_bats_tests/tasks/main.yml
+++ b/rpm/fedora-tests/tests/roles/run_bats_tests/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Create empty results file, world-writable
+- name: initialize test.log file
+  copy: dest=/tmp/test.log content='' force=yes mode=0666
+
+- name: execute tests
+  include_tasks: run_one_test.yml
+  with_items: "{{ tests }}"
+  loop_control:
+    loop_var: test

--- a/rpm/fedora-tests/tests/roles/run_bats_tests/tasks/run_one_test.yml
+++ b/rpm/fedora-tests/tests/roles/run_bats_tests/tasks/run_one_test.yml
@@ -1,0 +1,87 @@
+---
+- name: "{{ test.name }} | install test packages"
+  dnf: name="{{ test.package }}-tests" state=installed
+
+- name: "{{ test.name }} | define helper variables"
+  set_fact:
+    test_name_oneword: "{{ test.name | replace(' ','-') }}"
+
+# UGH. This is necessary because our caller sets some environment variables
+# and we need to set a few more based on other caller variables; then we
+# need to combine the two dicts when running the test. This seems to be
+# the only way to do it in ansible.
+- name: "{{ test.name }} | define local environment"
+  set_fact:
+    local_environment:
+      TEST_NAME:    "{{ test.name }}"
+      TEST_PACKAGE: "{{ test.package }}"
+      TEST_ENV:     "{{ test.environment }}"
+
+- name: "{{ test.name }} | setup/teardown helper | see if exists"
+  local_action: stat path={{ role_path }}/files/helper.{{ test_name_oneword }}.sh
+  register: helper
+
+- name: "{{ test.name }} | setup/teardown helper | install"
+  copy: src=helper.{{ test_name_oneword }}.sh dest=/tmp/helper.sh
+  when: helper.stat.exists
+
+# This is what runs the BATS tests.
+- name: "{{ test.name }} | run test"
+  script: ./run_bats_tests.sh
+  args:
+    chdir: /usr/share/{{ test.package }}/test/system
+  become: "{{ true if test.become is defined else false }}"
+  become_user: "{{ rootless_user }}"
+  environment: "{{ local_environment | combine(test.environment) }}"
+
+# BATS tests will always exit zero and should leave behind two files:
+# a full log (test.bats.log) and a one-line PASS/FAIL file (.summary.log)
+- name: "{{ test.name }} | pull logs"
+  fetch:
+    src: "/tmp/test.{{ item }}.log"
+    dest: "{{ artifacts }}/test.{{ test_name_oneword }}.{{ item }}.log"
+    flat: yes
+  with_items:
+    - bats
+    - summary
+
+# Collect all the one-line PASS/FAIL results in one file, test.log
+# Write the same thing, in a different format, to results.yml
+#   https://docs.fedoraproject.org/en-US/ci/standard-test-interface/
+- name: "{{ test.name }} | keep running tally of test results"
+  local_action:
+    module: shell
+    cmd: |
+      cd {{ artifacts }}
+      cat "test.{{ test_name_oneword }}.summary.log" >>test.log
+
+      status=$(awk '{print $1}' <test.{{ test_name_oneword }}.summary.log | tr A-Z a-z)
+      echo "- test: {{ test.name }}"                        >>results.yml
+      echo "  result: $status"                              >>results.yml
+      echo "  logs: test.{{ test_name_oneword }}.bats.log"  >>results.yml
+
+      # delete the oneliner file, to keep artifacts dir clean
+      rm -f test.{{ test_name_oneword }}.summary.log
+
+- name: "{{ test.name }} | remove remote logs and helpers"
+  file:
+    dest=/tmp/{{ item }}
+    state=absent
+  with_items:
+    - test.bats.log
+    - test.summary.log
+    - helper.sh
+
+# AAAAARGH!
+#
+# Fedora gating tests are failing, because str-common-final/tasks/main.yml
+# tries to pull test.log and other logs from $remote_host:/tmp/artifacts .
+# Those don't exist, because I track status and artifacts locally, because
+# with the reboot I can't rely on /tmp being preserved.
+# I see no way to tell str-common-final to skip this step; so let's just
+# push logs over upon completion of each subtest.
+- name: keep remote artifacts synced
+  synchronize:
+    src:  "{{ artifacts }}/"
+    dest: "{{ remote_artifacts|d('/tmp/artifacts') }}/"
+    mode: push

--- a/rpm/fedora-tests/tests/run_podman_tests.yml
+++ b/rpm/fedora-tests/tests/run_podman_tests.yml
@@ -1,0 +1,29 @@
+---
+- name: "podman-remote | install"
+  dnf: name="podman-remote" state=installed
+  when: podman_bin == "podman-remote"
+
+# As of podman 5.0, slirp is a soft dependency. Until/unless it is
+# actually deprecated, we continue to test with it.
+- name: "slirp4netns | install"
+  dnf: name="slirp4netns" state=installed
+
+- include_role:
+    name: run_bats_tests
+  vars:
+    tests:
+    # Yes, this is horrible duplication, but trying to refactor in ansible
+    # yields even more horrible unreadable code. This is the lesser evil.
+    - name: "{{ podman_bin }} root"
+      package: podman
+      environment:
+        PODMAN: /usr/bin/{{ podman_bin }}
+        PODMAN_TESTING: /usr/bin/{{ podman_bin }}-testing
+        QUADLET: /usr/libexec/podman/quadlet
+    - name: "{{ podman_bin }} rootless"
+      package: podman
+      environment:
+        PODMAN: /usr/bin/{{ podman_bin }}
+        PODMAN_TESTING: /usr/bin/{{ podman_bin }}-testing
+        QUADLET: /usr/libexec/podman/quadlet
+      become: true

--- a/rpm/fedora-tests/tests/test_podman.yml
+++ b/rpm/fedora-tests/tests/test_podman.yml
@@ -1,0 +1,39 @@
+---
+- hosts: localhost
+  tags:
+    - classic
+    - container
+  vars:
+  - artifacts: ./artifacts
+    rootless_user: testuser
+  roles:
+  - role: disable_systemd_resolved
+  - role: rootless_user_ready
+
+  tasks:
+  # At the start of a run, clean up state. Useful for test reruns.
+  - name: local artifacts directory exists
+    local_action: file path="{{ artifacts }}" state=directory
+
+  - name: remove stale log files
+    local_action: shell rm -f {{ artifacts }}/test*.log
+
+  - name: clear test results (test.log)
+    local_action: command truncate --size=0 {{ artifacts }}/test.log
+
+  - name: clear test results (results.yml)
+    local_action: copy content="results:\n" dest={{ artifacts }}/results.yml
+
+  # These are the actual tests.
+  - name: test podman
+    include_tasks: run_podman_tests.yml
+    loop: [ podman, podman-remote ]
+    loop_control:
+      loop_var: podman_bin
+
+  - name: test toolbx
+    include_tasks: test_toolbx.yml
+
+  # Postprocessing: check for FAIL or ERROR in any test, exit 1 if so
+  - name: check results
+    include_tasks: check_results.yml

--- a/rpm/fedora-tests/tests/test_toolbx.yml
+++ b/rpm/fedora-tests/tests/test_toolbx.yml
@@ -1,0 +1,11 @@
+---
+- include_role:
+    name: run_bats_tests
+  vars:
+    tests:
+    - name: toolbx
+      package: toolbox
+      become: true
+      environment:
+        TMPDIR: /var/tmp
+        XDG_RUNTIME_DIR: /run/user/{{ rootless_uid }}

--- a/rpm/fedora-tests/tests/tests.yml
+++ b/rpm/fedora-tests/tests/tests.yml
@@ -1,0 +1,1 @@
+- import_playbook: test_podman.yml

--- a/rpm/gating.yaml
+++ b/rpm/gating.yaml
@@ -1,0 +1,16 @@
+--- !Policy
+product_versions:
+  - fedora-*
+decision_contexts:
+  - bodhi_update_push_stable
+  - bodhi_update_push_testing
+subject_type: koji_build
+rules:
+  - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
+
+--- !Policy
+product_versions:
+  - rhel-10
+decision_context: osci_compose_gate
+rules:
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}


### PR DESCRIPTION
This commit moves Fedora and CentOS Stream 10 tests upstream. The `files_to_sync` addition will sync all relevant files from upstream to downstream in the dist-git PR whenever there's a new upstream release.

Ideally, we should have a single set of tests that can run on both Fedora and CentOS Stream, but currently both dist-gits have slightly different tests so we can leave the merging of tests for when we actually move from STI to TMT.

Resolves: RUN-2204

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
