### PR TITLE
nc -p considered harmful

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -760,7 +760,7 @@ nameserver 8.8.8.8" "nameserver order is correct"
         cid="$output"
 
         # make sure binding the same port fails
-        run timeout 5 nc -l -p $port 127.0.0.1
+        run timeout 5 nc -l 127.0.0.1 $port
         assert "$status" -eq 2 "ncat unexpected exit code"
         assert "$output" =~ "127.0.0.1:$port: Address already in use" "ncat error message"
 


### PR DESCRIPTION
nmap-ncat has been downgraded on Fedora, to 7.92.
nc -l -p PORT requires 7.95. Switch to nc -l ADDR PORT.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```