### PR TITLE
Fix name for builder in farm connection

### DIFF
--- a/pkg/farm/farm.go
+++ b/pkg/farm/farm.go
@@ -61,7 +61,7 @@ func newFarmWithBuilders(_ context.Context, name string, cons []config.Connectio
 			defer fmt.Printf("Builder %q ready\n", con.Name)
 			builderMutex.Lock()
 			defer builderMutex.Unlock()
-			farm.builders[name] = engine
+			farm.builders[con.Name] = engine
 			return nil
 		})
 	}


### PR DESCRIPTION
Ensure that the map of builders we create links the builder name and not the farm name to the image engine of that node. This was a regression introduced during the farm conf rework.

There is no way to add a test for this as we will have to emulate remote nodes of different architectures.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
