### PR TITLE
pkg/machine/compression: skip decompress bar for empty file

### DIFF
--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -149,7 +149,7 @@ function check_subcommand() {
     # ...or machine. But podman machine is ultra-finicky, it fails as root
     # or if qemu is missing. Instead of checking for all the possible ways
     # to skip it, just try running init. If it works, we can test it.
-    run_podman '?' machine init --image-path=/dev/null mymachine
+    run_podman '?' machine init --image=/dev/null mymachine
     if [[ $status -eq 0 ]]; then
         can_run_podman_machine=true
         extra_args_table+="


### PR DESCRIPTION
When the file is empty it is possible our code panics as bar.ProxyReader returns nil when the bar is finished which is the case for 0 size as it doesn't have to read anything from there. However as this happens on different goroutines it is race and most of the time still works.

To fix this simply skip the progress bar setup for empty files.

While at it fix the deprecated argument in the tests.

Fixes #23281

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
