### PR TITLE
system connection remove: use Args function to validate

### DIFF
--- a/cmd/podman/system/connection/remove.go
+++ b/cmd/podman/system/connection/remove.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"errors"
 	"slices"
 
 	"github.com/containers/common/pkg/config"
@@ -14,10 +13,16 @@ import (
 var (
 	// Skip creating engines since this command will obtain connection information to said engines.
 	rmCmd = &cobra.Command{
-		Use:               "remove [options] NAME",
-		Aliases:           []string{"rm"},
-		Long:              `Delete named destination from podman configuration`,
-		Short:             "Delete named destination",
+		Use:     "remove [options] NAME",
+		Aliases: []string{"rm"},
+		Long:    `Delete named destination from podman configuration`,
+		Short:   "Delete named destination",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if rmOpts.All {
+				return nil
+			}
+			return cobra.ExactArgs(1)(cmd, args)
+		},
 		ValidArgsFunction: common.AutocompleteSystemConnections,
 		RunE:              rm,
 		Example: `podman system connection remove devl
@@ -58,10 +63,6 @@ func rm(cmd *cobra.Command, args []string) error {
 				cfg.Farm.List[k] = []string{}
 			}
 			return nil
-		}
-
-		if len(args) != 1 {
-			return errors.New("accepts 1 arg(s), received 0")
 		}
 
 		delete(cfg.Connection.Connections, args[0])


### PR DESCRIPTION
Using the ExactArgs(1) function is better because we have less duplication of the error text and the ValidArgsFunction uses that to suggest shell completion. The command before this commit would suggest connection names even if there was already one arg on the cli set.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
