### PR TITLE
Fix windows installer deleting machine provider config file

### DIFF
--- a/build_windows.md
+++ b/build_windows.md
@@ -362,11 +362,19 @@ set the bundle variables `MachineProvider` (`wsl` or `hyperv`), `WSLCheckbox`
 otherwise):
 
 ```pwsh
-contrib\win-installer\podman-5.1.0-dev-setup.exe /install /log podman-setup.log /quiet MachineProvider=wsl WSLCheckbox=0 HyperVCheckbox=0
+contrib\win-installer\podman-5.1.0-dev-setup.exe /install `
+                      /log podman-setup.log /quiet `
+                      MachineProvider=wsl WSLCheckbox=0 HyperVCheckbox=0
 ```
 
-:information_source: The `winmake.ps1` target `installertest` automatically
-tests installing and uninstalling Podman.
+#### Run the Windows installer automated tests
+
+The following command executes a number of tests of the windows installer. Running
+it requires an administrator terminal.
+
+```pwsh
+.\winmake.ps1 installertest
+```
 
 ### Build and test the standalone `podman.msi` file
 

--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -23,10 +23,7 @@ Pop-Location
 # Run the installer silently and WSL/HyperV install options disabled (prevent reboots)
 # We need -skipWinVersionCheck for server 2019 (cirrus image), can be dropped after server 2022
 $command = "$WIN_INST_FOLDER\test-installer.ps1 "
-$command += "-operation all "
+$command += "-scenario all "
 $command += "-provider $ENV:CONTAINERS_MACHINE_PROVIDER "
-$command += "-setupExePath `"$WIN_INST_FOLDER\podman-$ENV:WIN_INST_VER-dev-setup.exe`" "
-$command += "-installWSL:`$false "
-$command += "-installHyperV:`$false "
-$command += "-skipWinVersionCheck:`$true"
+$command += "-setupExePath `"$WIN_INST_FOLDER\podman-$ENV:WIN_INST_VER-dev-setup.exe`""
 Run-Command "${command}"

--- a/contrib/win-installer/README.md
+++ b/contrib/win-installer/README.md
@@ -1,28 +1,3 @@
 # Windows Installer Build
 
-## Requirements
-
-1. Win 10+
-2. Golang
-3. MingW
-4. Dotnet SDK (if AzureSignTool)
-5. AzureSignTool (optional)
-6. WiX Toolset
-
-## Usage
-
-```
-.\build.ps1 <version> [prod|dev] [release_dir]
-```
-
-## One off build (-dev output (default), unsigned (default))
-
-```
-.\build.ps1 4.2.0
-```
-
-## Build with a pre-downloaded win release zip in my-download dir
-
-```
-.\build.ps1 4.2.0 dev my-download
-```
+Instructions [have moved here](Build and test the Podman Windows installer](#build-and-test-the-podman-windows-installer)).

--- a/contrib/win-installer/burn.wxs
+++ b/contrib/win-installer/burn.wxs
@@ -14,7 +14,7 @@
     <Variable Name="AllowOldWin" Type="numeric" Value="0" bal:Overridable="yes" />
     <Variable Name="LaunchTarget" Value="explorer.exe" />
     <Variable Name="LaunchArguments" Value="&quot;[InstallFolder]\podman-for-windows.html&quot;" />
-    <Variable Name="SkipConfigFileCreation" Value="0" />
+    <Variable Name="SkipConfigFileCreation" Value="0" bal:Overridable="yes" />
 
     <util:RegistrySearch Id="PreviousVersionSearch" Variable="PreviousVersion" Result="value" Root="HKLM" Key="SOFTWARE\[WixBundleManufacturer]\Updates\[WixBundleName]" Value="PackageVersion" />
     <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="SOFTWARE\[WixBundleManufacturer]\[WixBundleName]" Value="InstallDir" Variable="PreviousInstallFolder" Bitness="always64" />

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -25,7 +25,7 @@
 			</DirectorySearch>
 		</Property>
 		<Property Id="MAIN_EXECUTABLE_FILE_PATH">
-			<DirectorySearch Id="ProgramFiles6432FolderSearch" Path="[ProgramFiles6432Folder]">
+			<DirectorySearch Id="ProgramFiles64FolderSearch" Path="[ProgramFiles64Folder]">
 				<DirectorySearch Id="RedHatFolderSearch" Path="RedHat">
 					<DirectorySearch Id="PodmanFolderSearch" Path="Podman">
 						<FileSearch Name="podman.exe" />
@@ -52,12 +52,11 @@
 		<SetProperty Id="HYPERV_INSTALL" Before="AppSearch" Value="1" Sequence="first" Condition="(HAS_HYPERVFEATURE = 0) AND (MACHINE_PROVIDER = &quot;hyperv&quot;) AND (NOT (WITH_HYPERV = 0))" />
 		<!--
       Property CREATE_MACHINE_PROVIDER_CONFIG_FILE is set at runtime and used as the condition to run the `MachineProviderConfigFile` Component:
-      The machine provider config file is created only if all these conditions are met:
+      The machine provider config file is created (or is not deleted if it already exist) if these conditions are met:
         - The user hasn't set property `SKIP_CONFIG_FILE_CREATION` to 1
-        - The machine provider config file ($PROGRAMDATA/containers/containers.conf.d/99-podman-machine-provider.conf) doesn't exist
-        - The main executable file ($PROGRAMDATA/RedHat/Podman/podman.exe) doesn't exist
+        - The main executable file ($PROGRAMDATA/RedHat/Podman/podman.exe) doesn't exist or, if it exists, the machine provider config file exists
      -->
-		<SetProperty Id="CREATE_MACHINE_PROVIDER_CONFIG_FILE" After="AppSearch" Value="1" Sequence="first" Condition="(NOT (SKIP_CONFIG_FILE_CREATION = 1)) AND (NOT MACHINE_PROVIDER_CONFIG_FILE_PATH) AND (NOT MAIN_EXECUTABLE_FILE_PATH)" />
+		<SetProperty Id="CREATE_MACHINE_PROVIDER_CONFIG_FILE" After="AppSearch" Value="1" Sequence="first" Condition="(NOT (SKIP_CONFIG_FILE_CREATION = 1)) AND ((NOT MAIN_EXECUTABLE_FILE_PATH) OR (MACHINE_PROVIDER_CONFIG_FILE_PATH))" />
 		<!--
       Property HIDE_PROVIDER_CHOICE is set at runtime and used as the condition to hide the Machine Provider
       choice from the MSI GUI (the Radio Button Group and other related controls):
@@ -153,10 +152,9 @@
 		<StandardDirectory Id="CommonAppDataFolder">
 			<Directory Id="CONFIGDIR" Name="containers">
 				<Directory Id="ContainersConfigSubDir" Name="containers.conf.d">
-					<Component Id="MachineProviderConfigFile" Guid="C32C0040-D9AF-4155-AC7E-465B63B6BE3B" Condition="CREATE_MACHINE_PROVIDER_CONFIG_FILE">
+					<Component Id="MachineProviderConfigFile" Guid="C32C0040-D9AF-4155-AC7E-465B63B6BE3B" Condition="CREATE_MACHINE_PROVIDER_CONFIG_FILE" NeverOverwrite="true">
 						<CreateFolder />
 						<IniFile Id="MachineProviderConfigFile" Action="createLine" Directory="ContainersConfigSubDir" Section="machine" Name="99-podman-machine-provider.conf" Key="provider" Value="&quot;[MACHINE_PROVIDER]&quot;" />
-
 					</Component>
 				</Directory>
 			</Directory>

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -3,62 +3,103 @@
 # The Param statement must be the first statement, except for comments and any #Require statements.
 param (
     [Parameter(Mandatory)]
-    [ValidateSet("install", "uninstall", "all")]
-    [string]$operation,
-    [Parameter(Mandatory)]
+    [ValidateSet("installation-green-field", "installation-skip-config-creation-flag", "installation-with-pre-existing-podman-exe", "update-without-user-changes", "update-with-user-changed-config-file", "update-with-user-removed-config-file", "all")]
+    [string]$scenario,
     [ValidateScript({Test-Path $_ -PathType Leaf})]
     [string]$setupExePath,
+    [ValidateScript({Test-Path $_ -PathType Leaf})]
+    [string]$previousSetupExePath,
     [ValidateSet("wsl", "hyperv")]
     [string]$provider="wsl",
     [switch]$installWSL=$false,
     [switch]$installHyperV=$false,
-    [switch]$skipWinVersionCheck=$false
+    [switch]$skipWinVersionCheck=$false,
+    [switch]$skipConfigFileCreation=$false
 )
 
-$ConfFilePath = "$env:ProgramData\containers\containers.conf.d\99-podman-machine-provider.conf"
-$WindowsPathsToTest = @("C:\Program Files\RedHat\Podman\podman.exe",
-                        "C:\Program Files\RedHat\Podman\win-sshproxy.exe",
-                        "$ConfFilePath",
+$MachineConfPath = "$env:ProgramData\containers\containers.conf.d\99-podman-machine-provider.conf"
+$PodmanFolderPath = "$env:ProgramFiles\RedHat\Podman"
+$PodmanExePath = "$PodmanFolderPath\podman.exe"
+$WindowsPathsToTest = @($PodmanExePath,
+                        "$PodmanFolderPath\win-sshproxy.exe",
                         "HKLM:\SOFTWARE\Red Hat\Podman")
 
-function Test-Installation {
+function Install-Podman {
+    param (
+        # [Parameter(Mandatory)]
+        [ValidateScript({Test-Path $_ -PathType Leaf})]
+        [string]$setupExePath
+    )
     if ($installWSL) {$wslCheckboxVar = "1"} else {$wslCheckboxVar = "0"}
     if ($installHyperV) {$hypervCheckboxVar = "1"} else {$hypervCheckboxVar = "0"}
     if ($skipWinVersionCheck) {$allowOldWinVar = "1"} else {$allowOldWinVar = "0"}
+    if ($skipConfigFileCreation) {$skipConfigFileCreationVar = "1"} else {$skipConfigFileCreationVar = "0"}
 
-    Write-Host "Running the installer (provider=`"$provider`")..."
+    Write-Host "Running the installer ($setupExePath)..."
+    Write-Host "(provider=`"$provider`", WSLCheckbox=`"$wslCheckboxVar`", HyperVCheckbox=`"$hypervCheckboxVar`", AllowOldWin=`"$allowOldWinVar`", SkipConfigFileCreation=`"$skipConfigFileCreationVar`")"
     $ret = Start-Process -Wait `
-                         -PassThru "$setupExePath" `
-                         -ArgumentList "/install /quiet `
+                            -PassThru "$setupExePath" `
+                            -ArgumentList "/install /quiet `
                                 MachineProvider=${provider} `
                                 WSLCheckbox=${wslCheckboxVar} `
                                 HyperVCheckbox=${hypervCheckboxVar} `
                                 AllowOldWin=${allowOldWinVar} `
+                                SkipConfigFileCreation=${skipConfigFileCreationVar} `
                                 /log $PSScriptRoot\podman-setup.log"
     if ($ret.ExitCode -ne 0) {
         Write-Host "Install failed, dumping log"
         Get-Content $PSScriptRoot\podman-setup.log
         throw "Exit code is $($ret.ExitCode)"
     }
-
-    Write-Host "Verifying that the installer has created the expected files, folders and registry entries..."
-    $WindowsPathsToTest | ForEach-Object {
-        if (! (Test-Path -Path $_) ) {
-            throw "Expected $_ but it's not present after uninstall"
-        }
-    }
-
-    Write-Host "Verifying that the machine provider configuration is correct..."
-    $machineProvider = Get-Content $ConfFilePath | Select-Object -Skip 1 | ConvertFrom-StringData | ForEach-Object { $_.provider }
-    if ( $machineProvider -ne "`"$provider`"" ) {
-        throw "Expected `"$provider`" as default machine provider but got $machineProvider"
-    }
-
-    Write-Host "The installation verification was successful!`n"
+    Write-Host "Installation completed successfully!`n"
 }
 
-function Test-Uninstallation {
-    Write-Host "Running the uninstaller"
+function Install-Previous-Podman {
+    Install-Podman -setupExePath $previousSetupExePath
+}
+
+function Install-Current-Podman {
+    Install-Podman -setupExePath $setupExePath
+}
+
+function Test-Podman-Objects-Exist {
+    Write-Host "Verifying that podman files, folders and registry entries exist..."
+    $WindowsPathsToTest | ForEach-Object {
+        if (! (Test-Path -Path $_) ) {
+            throw "Expected $_ but doesn't exist"
+        }
+    }
+    Write-Host "Verification was successful!`n"
+}
+
+function Test-Podman-Machine-Conf-Exist {
+    Write-Host "Verifying that $MachineConfPath exist..."
+    if (! (Test-Path -Path $MachineConfPath) ) {
+        throw "Expected $MachineConfPath but doesn't exist"
+    }
+    Write-Host "Verification was successful!`n"
+}
+
+function Test-Podman-Machine-Conf-Content {
+    param (
+        [ValidateSet("wsl", "hyperv")]
+        [string]$expected=$provider
+    )
+    Write-Host "Verifying that the machine provider configuration is correct..."
+    $machineProvider = Get-Content $MachineConfPath | Select-Object -Skip 1 | ConvertFrom-StringData | ForEach-Object { $_.provider }
+    if ( $machineProvider -ne "`"$expected`"" ) {
+        throw "Expected `"$expected`" as default machine provider but got $machineProvider"
+    }
+    Write-Host "Verification was successful!`n"
+}
+
+function Uninstall-Podman {
+    param (
+        # [Parameter(Mandatory)]
+        [ValidateScript({Test-Path $_ -PathType Leaf})]
+        [string]$setupExePath
+    )
+    Write-Host "Running the uninstaller ($setupExePath)..."
     $ret = Start-Process -Wait `
                          -PassThru "$setupExePath" `
                          -ArgumentList "/uninstall `
@@ -68,26 +109,191 @@ function Test-Uninstallation {
         Get-Content $PSScriptRoot\podman-setup-uninstall.log
         throw "Exit code is $($ret.ExitCode)"
     }
-
-    Write-Host "Verifying that the uninstaller has removed files, folders and registry entries as expected..."
-    $WindowsPathsToTest | ForEach-Object {
-        if ( Test-Path -Path $_ ) {
-            throw "Path $_ is still present after uninstall"
-        }
-    }
-
-    Write-Host "The uninstallation verification was successful!`n"
+    Write-Host "The uninstallation completed successfully!`n"
 }
 
-switch ($operation) {
-    'install' {
-        Test-Installation
+function Uninstall-Current-Podman {
+    Uninstall-Podman -setupExePath $setupExePath
+}
+
+function Uninstall-Previous-Podman {
+    Uninstall-Podman -setupExePath $previousSetupExePath
+}
+
+function Test-Podman-Objects-Exist-Not {
+    Write-Host "Verifying that podman files, folders and registry entries don't exist..."
+    $WindowsPathsToTest | ForEach-Object {
+        if ( Test-Path -Path $_ ) {
+            throw "Path $_ is present"
+        }
     }
-    'uninstall' {
-        Test-Uninstallation
+    Write-Host "Verification was successful!`n"
+}
+
+function Test-Podman-Machine-Conf-Exist-Not {
+    Write-Host "Verifying that $MachineConfPath doesn't exist..."
+    if ( Test-Path -Path $MachineConfPath ) {
+        throw "Path $MachineConfPath is present"
+    }
+    Write-Host "Verification was successful!`n"
+}
+
+function New-Fake-Podman-Exe {
+    Write-Host "Creating a fake $PodmanExePath..."
+    New-Item -ItemType Directory -Path $PodmanFolderPath -Force -ErrorAction Stop | out-null
+    New-Item -ItemType File -Path $PodmanExePath -ErrorAction Stop | out-null
+    Write-Host "Creation successful!`n"
+}
+
+function Switch-Podman-Machine-Conf-Content {
+    $currentProvider = $provider
+    if ( $currentProvider -eq "wsl" ) { $newProvider = "hyperv" } else { $newProvider = "wsl" }
+    Write-Host "Editing $MachineConfPath content (was $currentProvider, will be $newProvider)..."
+    "[machine]`nprovider=`"$newProvider`"" | Out-File -FilePath $MachineConfPath -ErrorAction Stop
+    Write-Host "Edit successful!`n"
+    return $newProvider
+}
+
+function Remove-Podman-Machine-Conf {
+    Write-Host "Deleting $MachineConfPath..."
+    Remove-Item -Path $MachineConfPath -ErrorAction Stop | out-null
+    Write-Host "Deletion successful!`n"
+}
+
+function Get-Latest-Podman-Setup-From-GitHub {
+    Write-Host "Downloading the latest Podman windows setup from GitHub..."
+    $apiUrl = "https://api.github.com/repos/containers/podman/releases/latest"
+    $response = Invoke-RestMethod -Uri $apiUrl -Headers @{"User-Agent"="PowerShell"} -ErrorAction Stop
+    $downloadUrl = $response.assets[0].browser_download_url
+    Write-Host "Downloading URL: $downloadUrl"
+    $latestTag = $response.tag_name
+    $destinationPath = "$PSScriptRoot\podman-$latestTag-setup.exe"
+    Write-Host "Destination Path: $destinationPath"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $destinationPath
+    Write-Host "Command completed successfully!`n"
+    return $destinationPath
+}
+
+# SCENARIOS
+function Start-Scenario-Installation-Green-Field {
+    Write-Host "`n==========================================="
+    Write-Host " Running scenario: Installation-Green-Field"
+    Write-Host "==========================================="
+    Install-Current-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    Test-Podman-Machine-Conf-Content
+    Uninstall-Current-Podman
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+function Start-Scenario-Installation-Skip-Config-Creation-Flag {
+    Write-Host "`n========================================================="
+    Write-Host " Running scenario: Installation-Skip-Config-Creation-Flag"
+    Write-Host "========================================================="
+    $skipConfigFileCreation = $true
+    Install-Current-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist-Not
+    Uninstall-Current-Podman
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+function Start-Scenario-Installation-With-Pre-Existing-Podman-Exe {
+    Write-Host "`n============================================================"
+    Write-Host " Running scenario: Installation-With-Pre-Existing-Podman-Exe"
+    Write-Host "============================================================"
+    New-Fake-Podman-Exe
+    Install-Current-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist-Not
+    Uninstall-Current-Podman
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+function Start-Scenario-Update-Without-User-Changes {
+    Write-Host "`n=============================================="
+    Write-Host " Running scenario: Update-Without-User-Changes"
+    Write-Host "=============================================="
+    Install-Previous-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    Test-Podman-Machine-Conf-Content
+    Install-Current-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    Test-Podman-Machine-Conf-Content
+    Uninstall-Current-Podman
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+function Start-Scenario-Update-With-User-Changed-Config-File {
+    Write-Host "`n======================================================="
+    Write-Host " Running scenario: Update-With-User-Changed-Config-File"
+    Write-Host "======================================================="
+    Install-Previous-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    Test-Podman-Machine-Conf-Content
+    $newProvider = Switch-Podman-Machine-Conf-Content
+    Install-Current-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    Test-Podman-Machine-Conf-Content -expected $newProvider
+    Uninstall-Current-Podman
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+function Start-Scenario-Update-With-User-Removed-Config-File {
+    Write-Host "`n======================================================="
+    Write-Host " Running scenario: Update-With-User-Removed-Config-File"
+    Write-Host "======================================================="
+    Install-Previous-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    Test-Podman-Machine-Conf-Content
+    Remove-Podman-Machine-Conf
+    Install-Current-Podman
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist-Not
+    Uninstall-Current-Podman
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+switch ($scenario) {
+    'installation-green-field' {
+        Start-Scenario-Installation-Green-Field
+    }
+    'installation-skip-config-creation-flag' {
+        Start-Scenario-Installation-Skip-Config-Creation-Flag
+    }
+    'installation-with-pre-existing-podman-exe' {
+        Start-Scenario-Installation-With-Pre-Existing-Podman-Exe
+    }
+    'update-without-user-changes' {
+        Start-Scenario-Update-Without-User-Changes
+    }
+    'update-with-user-changed-config-file' {
+        Start-Scenario-Update-With-User-Changed-Config-File
+    }
+    'update-with-user-removed-config-file' {
+        Start-Scenario-Update-With-User-Removed-Config-File
     }
     'all' {
-        Test-Installation
-        Test-Uninstallation
+        if (!$previousSetupExePath) {
+            $previousSetupExePath = Get-Latest-Podman-Setup-From-GitHub
+        }
+        Start-Scenario-Installation-Green-Field
+        Start-Scenario-Installation-Skip-Config-Creation-Flag
+        Start-Scenario-Installation-With-Pre-Existing-Podman-Exe
+        Start-Scenario-Update-Without-User-Changes
+        Start-Scenario-Update-With-User-Changed-Config-File
+        Start-Scenario-Update-With-User-Removed-Config-File
     }
 }

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -114,12 +114,9 @@ function Test-Installer{
     }
 
     $command = "$PSScriptRoot\contrib\win-installer\test-installer.ps1"
-    $command += " -operation all"
+    $command += " -scenario all"
     $command += " -provider $provider"
     $command += " -setupExePath $setupExePath"
-    $command += " -installWSL:`$false"
-    $command += " -installHyperV:`$false"
-    $command += " -skipWinVersionCheck:`$true"
     Run-Command "${command}"
 }
 
@@ -205,7 +202,7 @@ function Build-Ginkgo{
 function Git-Commit{
     # git is not installed by default on windows,
     # so if we can't get the commit, we don't include this info
-    Get-Command git  -ErrorAction SilentlyContinue  | out-null
+    Get-Command git  -ErrorAction SilentlyContinue | out-null
     if(!$?){
         return
     }
@@ -285,7 +282,11 @@ switch ($target) {
         Win-SSHProxy -Ref $ref
     }
     'installer' {
-        Installer
+        if ($args.Count -gt 1) {
+            Installer -version $args[1]
+        } else {
+            Installer
+        }
     }
     'installertest' {
         if ($args.Count -gt 1) {


### PR DESCRIPTION
This PR fixes #23244

A few things are included in this PR:
- The fix for [#23244](#23244) by changing the condition for setting the property `CREATE_MACHINE_PROVIDER_CONFIG_FILE` in `contrib/win-installer/podman.wxs`
- The fix for a regression in `contrib/win-installer/podman.wxs` that prevented finding a pre-existing `podman.exe` due to the check in the wrong folder (`ProgramFiles6432FolderSearch` instead of `ProgramFiles64FolderSearch`)
- The fix for a regression in `contrib/win-installer/burn.wxs` that made the Variable `SkipConfigFileCreation` not overridable
- A big refactoring of `contrib/win-installer/test-installer.ps1` to add automated tests of the scenarios that got broken above and more  

#### Does this PR introduce a user-facing change?

```release-note
None
```
