### PR TITLE
Fix several reliability problems with pasta DNS handling tests

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -452,12 +452,16 @@ function pasta_test_do() {
            "::1 not resolved"
 }
 
-@test "Local forwarder, IPv4" {
+@test "Default nameserver forwarding" {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     # pasta is the default now so no need to set it
     run_podman run --rm $IMAGE grep nameserver /etc/resolv.conf
     assert "${lines[0]}" == "nameserver 169.254.1.1" "default dns forward server"
+}
+
+@test "Local forwarder, IPv4" {
+    skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --rm --net=pasta:--dns-forward,198.51.100.1 \
         $IMAGE nslookup 127.0.0.1 || :

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -462,7 +462,12 @@ function pasta_test_do() {
 @test "Custom DNS forward address, IPv6" {
     skip_if_no_ipv6 "IPv6 not routable on the host"
 
-    # TODO: Two issues here:
+    # TODO: In fact, this requires not just IPv6 connectivity on the
+    #       host, but an IPv6 reachable nameserver which is harder to
+    #       test for.  We could remove that requirement if pasta could
+    #       forward between IPv4 and IPv6 addresses but as of
+    #       2024_09_06.6b38f07 that's unsupported.  Skip the test for
+    #       now.
     skip "Currently unsupported"
     # local addr=2001:db8::1
     #
@@ -471,6 +476,10 @@ function pasta_test_do() {
     # assert "${lines[0]}" == "nameserver $addr" "custom dns forward server"
     # run_podman run --rm --net=pasta:--dns-forward,$addr \
     #     $IMAGE nslookup l.root-servers.net $addr
+    #
+    # TODO: In addition to the IPv6 nameserver requirement above,
+    #       there seem to be two problems running this test.  It's
+    #       unclear if those are in busybox, musl or pasta.
     #
     # 1. With this, Podman writes "nameserver 2001:db8::1" to
     #    /etc/resolv.conf, without zone, and the query originates from ::1.

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -434,22 +434,11 @@ function pasta_test_do() {
 
 ### DNS ########################################################################
 
-@test "External resolver, IPv4" {
-    skip_if_no_ipv4 "IPv4 not routable on the host"
-
+@test "Basic nameserver lookup" {
     run_podman '?' run --rm --net=pasta $IMAGE nslookup 127.0.0.1
 
     assert "$output" =~ "1.0.0.127.in-addr.arpa" \
            "127.0.0.1 not resolved"
-}
-
-@test "External resolver, IPv6" {
-    skip_if_no_ipv6 "IPv6 not routable on the host"
-
-    run_podman '?' run --rm --net=pasta $IMAGE nslookup ::1
-
-    assert "$output" =~ "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa" \
-           "::1 not resolved"
 }
 
 @test "Default nameserver forwarding" {

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -435,10 +435,7 @@ function pasta_test_do() {
 ### DNS ########################################################################
 
 @test "Basic nameserver lookup" {
-    run_podman '?' run --rm --net=pasta $IMAGE nslookup 127.0.0.1
-
-    assert "$output" =~ "1.0.0.127.in-addr.arpa" \
-           "127.0.0.1 not resolved"
+    run_podman run --rm --net=pasta $IMAGE nslookup l.root-servers.net
 }
 
 @test "Default nameserver forwarding" {
@@ -453,8 +450,7 @@ function pasta_test_do() {
     skip_if_no_ipv4 "IPv4 not routable on the host"
 
     run_podman run --rm --net=pasta:--dns-forward,198.51.100.1 \
-        $IMAGE nslookup 127.0.0.1 || :
-    assert "$output" =~ "1.0.0.127.in-addr.arpa" "No answer from resolver"
+        $IMAGE nslookup l.root-servers.net
 }
 
 @test "Local forwarder, IPv6" {


### PR DESCRIPTION
I've had intermittent problems with the pasta DNS tests in podman.  Here are some fixes that address at least some of them.

/cc @sbrivio-rh @Luap99 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
