### PR TITLE
test/e2e: fix ncat tests

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -3,10 +3,12 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -543,56 +545,58 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		}
 	})
 
-	It("podman run network bind to 127.0.0.1", func() {
-		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
-		Expect(slirp4netnsHelp).Should(ExitCleanly())
-		networkConfiguration := "slirp4netns:outbound_addr=127.0.0.1,allow_host_loopback=true"
-		port := strconv.Itoa(GetPort())
-
-		if strings.Contains(slirp4netnsHelp.OutputToString(), "outbound-addr") {
-			ncListener := StartSystemExec("nc", []string{"-v", "-n", "-l", "-p", port})
-			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, "-dt", ALPINE, "nc", "-w", "2", "10.0.2.2", port})
-			session.WaitWithDefaultTimeout()
-			ncListener.WaitWithDefaultTimeout()
-
-			Expect(session).Should(ExitCleanly())
-			Expect(ncListener).Should(Exit(0))
-			Expect(ncListener.ErrorToString()).To(ContainSubstring("Connection from 127.0.0.1"))
-		} else {
-			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, "-dt", ALPINE, "nc", "-w", "2", "10.0.2.2", port})
-			session.WaitWithDefaultTimeout()
-			Expect(session).To(ExitWithError(125, "outbound_addr not supported"))
+	for _, local := range []bool{true, false} {
+		local := local
+		testName := "HostIP"
+		if local {
+			testName = "127.0.0.1"
 		}
-	})
+		It(fmt.Sprintf("podman run network slirp4netns bind to %s", testName), func() {
+			ip := "127.0.0.1"
+			if !local {
+				// Determine our likeliest outgoing IP address
+				conn, err := net.Dial("udp", "8.8.8.8:80")
+				Expect(err).ToNot(HaveOccurred())
 
-	It("podman run network bind to HostIP", func() {
-		// Determine our likeliest outgoing IP address
-		conn, err := net.Dial("udp", "8.8.8.8:80")
-		Expect(err).ToNot(HaveOccurred())
+				defer conn.Close()
+				ip = conn.LocalAddr().(*net.UDPAddr).IP.String()
+			}
+			port := strconv.Itoa(GetPort())
 
-		defer conn.Close()
-		ip := conn.LocalAddr().(*net.UDPAddr).IP
-		port := strconv.Itoa(GetPort())
+			networkConfiguration := fmt.Sprintf("slirp4netns:outbound_addr=%s,allow_host_loopback=true", ip)
 
-		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
-		Expect(slirp4netnsHelp).Should(ExitCleanly())
-		networkConfiguration := fmt.Sprintf("slirp4netns:outbound_addr=%s,allow_host_loopback=true", ip.String())
+			listener, err := net.Listen("tcp", ":"+port)
+			Expect(err).ToNot(HaveOccurred())
+			defer listener.Close()
 
-		if strings.Contains(slirp4netnsHelp.OutputToString(), "outbound-addr") {
-			ncListener := StartSystemExec("nc", []string{"-v", "-n", "-l", "-p", port})
-			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, ALPINE, "nc", "-w", "2", "10.0.2.2", port})
-			session.Wait(30)
-			ncListener.Wait(30)
+			msg := RandomString(10)
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			// now use a new goroutine to start accepting connection in the background and make the checks there
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				conn, err := listener.Accept()
+				Expect(err).ToNot(HaveOccurred(), "accept new connection")
+				defer conn.Close()
+				addr := conn.RemoteAddr()
+				// addr will be in the form ip:port, we don't care about the port as it is random
+				Expect(addr.String()).To(HavePrefix(ip+":"), "remote address")
+				gotBytes, err := io.ReadAll(conn)
+				Expect(err).ToNot(HaveOccurred(), "read from connection")
+				Expect(string(gotBytes)).To(Equal(msg), "received correct message from container")
+			}()
 
+			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, ALPINE, "sh", "-c", "echo -n " + msg + " | nc -w 30 10.0.2.2 " + port})
+			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
-			Expect(ncListener).Should(Exit(0))
-			Expect(ncListener.ErrorToString()).To(ContainSubstring("Connection from " + ip.String()))
-		} else {
-			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, ALPINE, "nc", "-w", "2", "10.0.2.2", port})
-			session.Wait(30)
-			Expect(session).To(ExitWithError(125, "outbound_addr not supported"))
-		}
-	})
+
+			// explicitly close the socket here before we wait to unlock Accept() calls in case of hangs
+			listener.Close()
+			// wait for the checks in the goroutine to be done
+			wg.Wait()
+		})
+	}
 
 	It("podman run network expose ports in image metadata", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "test", "-t", "-P", NGINX_IMAGE})


### PR DESCRIPTION
These tests are flaking for unknown reasons. One problem could be ncat did not bound the port before we connect to it. Simple fix do not use ncat and just use the golang API to listen on the port without the extra ncat process. This should be race free in theory. Also do not run the nc container in the background, we want to see the errors from the ncat process in the container.

And because both tests do the same thing deduplicate them into one that just uses a loop to create both tests.

Fixes #23263

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
