### PR TITLE
libpod: correctly capture healthcheck output

### DIFF
--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -59,7 +59,7 @@ function _check_health {
 Status           | \"healthy\"
 FailingStreak    | 0
 Log[-1].ExitCode | 0
-Log[-1].Output   | \"Life is Good on stdout\\\nLife is Good on stderr\"
+Log[-1].Output   | \"Life is Good on stdout\\\nLife is Good on stderr\\\n\"
 " "$current_time" "healthy"
 
     current_time=$(date --iso-8601=seconds)
@@ -71,7 +71,7 @@ Log[-1].Output   | \"Life is Good on stdout\\\nLife is Good on stderr\"
 Status           | \"healthy\"
 FailingStreak    | [123]
 Log[-1].ExitCode | 1
-Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
+Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
 " "$current_time" "healthy"
 
     # Check that we now we do have valid podman units with this
@@ -85,7 +85,7 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
 Status           | \"unhealthy\"
 FailingStreak    | [3456]
 Log[-1].ExitCode | 1
-Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
+Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
 " "$current_time" "unhealthy"
 
     # now the on-failure should kick in and kill the container


### PR DESCRIPTION
Using the scanner is just unnecessary complicated an buggy as it will not read the final line with a newline. There is also the problem that it happens in a separate goroutine so it could loose output if we read the array before the scanner was done.

The API accepts a Writer so we can just directly use a bytes.Buffer which captures all output in memory without the need of another goroutine.

This also means that now we always include the final newline in the output. I checked with docker and they do the same so this is good.

Fixes #23332

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that resulted in the healtcheck output not being correctly captured when it didn't include a final newline.
```
