### PR TITLE
podman pod stats: fix race when ctr process exits

### DIFF
--- a/pkg/domain/infra/abi/pods_stats.go
+++ b/pkg/domain/infra/abi/pods_stats.go
@@ -38,7 +38,7 @@ func (ic *ContainerEngine) PodStats(ctx context.Context, namesOrIds []string, op
 func (ic *ContainerEngine) podsToStatsReport(pods []*libpod.Pod) ([]*entities.PodStatsReport, error) {
 	reports := []*entities.PodStatsReport{}
 	for i := range pods { // Access by index to prevent potential loop-variable leaks.
-		podStats, err := pods[i].GetPodStats(nil)
+		podStats, err := pods[i].GetPodStats()
 		if err != nil {
 			// pod was removed, skip it
 			if errors.Is(err, define.ErrNoSuchPod) {


### PR DESCRIPTION
Like commit 55749af0c7 but for podman *pod* stats not the normal podman stats. We must ignore ErrCtrStopped here as well as this will happen when the container process exited.

While at it remove a useless argument from the function as it was always nil and restructure the logic flow to make it easier to read.

Fixes #23334

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a race in podman pod stats that could cause it to exit with a "container is stopped" error when showing all pod containers.
```
