### PR TITLE
logformatter: tweaks to pass html tidy

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -33,7 +33,7 @@ $| = 1;
 # Stylesheet for highlighting or de-highlighting parts of lines
 our $CSS = <<'END_CSS';
 /* wrap long lines - don't require user to scroll right */
-pre        { line-break: normal; overflow-wrap: normal; white-space: pre-wrap; }
+.tt           { font-family: monospace; line-break: normal; overflow-wrap: normal; white-space: pre-wrap; }
 
 /* synopsis table at top */
 table.synopsis { border: none; border-collapse: collapse; margin-left: 2em; margin-top: 2ex; }
@@ -246,7 +246,7 @@ END_HTML
     # When running in cirrus, we have the commit SHA
     $git_commit = $ENV{CIRRUS_CHANGE_IN_REPO};
 
-    print { $out_fh } "<pre> <!-- begin processed output -->\n";
+    print { $out_fh } "<div class='tt'> <!-- begin processed output -->\n";
 
     # Assume rootful prompt, check for rootless (here and in log itself, below)
     my $Prompt = '#';
@@ -581,7 +581,7 @@ END_HTML
             $subtest_status = 'passed';         # until proven otherwise
             $subtest_name = '';
 
-            print { $out_fh } "</pre>\n<hr />\n<pre>\n";
+            print { $out_fh } "</div>\n<hr />\n<div class='tt'>\n";
             # Always show timestamp at start of each new test
             $previous_timestamp = '';
             next LINE;
@@ -595,8 +595,6 @@ END_HTML
                 my ($full_path, $remote, $options, $args) = ($1, $2||'', $3, $6);
 
                 $options =~ s/^\s+//;
-                # July 2024: "" in composefs pull-option confuses hovertext
-                $options =~ s/\&quot;//g;
                 # Separate each '--foo bar' with newlines for readability
                 $options =~ s/ --/\n--/g;
                 qq{<span title="$full_path"><b>podman$remote</b></span> <span class=\"boring\" title=\"$options\">[options]</span><b>$args</b>};
@@ -683,7 +681,7 @@ END_HTML
                 $subtest_name .= " " if $subtest_name;
                 $subtest_name .= $2;
                 my $id = make_id($subtest_name, 'anchor');
-                $line = "<a name='t--$id'><h2 class=\"log-$subtest_status\">$line</h2></a>";
+                $line = "<a name='t--$id' /><h2 class=\"log-$subtest_status\">$line</h2>";
 
                 # Special case for tests that fail outside of a Describe()
                 # block, e.g., global After/BeforeEach. We still want to
@@ -741,7 +739,7 @@ END_HTML
             print { $out_fh } "</span>\n";
         }
 
-        print { $out_fh } "</pre>  <!-- end processed output -->\n";
+        print { $out_fh } "</div>  <!-- end processed output -->\n";
 
         # Did we find a cirrus task? Link back.
         if ($cirrus_task) {


### PR DESCRIPTION
Plus, I think my ampersand-quot change earlier this month
caused problems for firefox. We no longer need it (pull-option
does not need the funky double-quoted curly-brace string),
so, remove it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```