### PR TITLE
Add utility to convert VMFile to URL for UNIX sockets

### DIFF
--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -319,11 +318,15 @@ func (q *QEMUStubber) StartNetworking(mc *vmconfigs.MachineConfig, cmd *gvproxy.
 	if err != nil {
 		return err
 	}
+	socketURL, err := sockets.ToUnixURL(gvProxySock)
+	if err != nil {
+		return err
+	}
 	// make sure it does not exist before gvproxy is called
 	if err := gvProxySock.Delete(); err != nil {
 		logrus.Error(err)
 	}
-	cmd.AddQemuSocket(fmt.Sprintf("unix://%s", filepath.ToSlash(gvProxySock.GetPath())))
+	cmd.AddQemuSocket(socketURL.String())
 	return nil
 }
 

--- a/pkg/machine/sockets/sockets.go
+++ b/pkg/machine/sockets/sockets.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"net/url"
 	"path/filepath"
 	"time"
 
@@ -109,4 +110,18 @@ func WaitForSocketWithBackoffs(maxBackoffs int, backoff time.Duration, socketPat
 		backoffWait *= 2
 	}
 	return fmt.Errorf("unable to connect to %q socket at %q", name, socketPath)
+}
+
+// ToUnixURL converts `socketLoc` into URL representation
+func ToUnixURL(socketLoc *define.VMFile) (*url.URL, error) {
+	p := socketLoc.GetPath()
+	if !filepath.IsAbs(p) {
+		return nil, fmt.Errorf("socket path must be absolute %q", p)
+	}
+	s, err := url.Parse("unix:///")
+	if err != nil {
+		return nil, err
+	}
+	s = s.JoinPath(filepath.ToSlash(p))
+	return s, nil
 }


### PR DESCRIPTION
This adds generic utility to convert file system path into URL structure. Instead of string manipulation it uses URL parsing and building routines. Appending absolute path to `unix:///` URL out of the box correctly handles URL format on Windows platform, where filepath should be prepended by additional `/` before drive letter.

Example that it works correctly on Unix platforms https://go.dev/play/p/OgiwK3E_-KM

This utility could be reused in the future if Hyper-V Podman machine (or generally speaking any Podman machine on Windows platform, which utilizes `gvproxy` for networking) would publish AF_UNIX socket for API access in addition to npipe:// API access points.

Comparing to the old implementation it mandates that the Path should be absolute, but using relative paths for creating socket URLs is a road to disaster. 

It adds public API method under `sockets` package, but these sorts of API are considered application internal, so ,there is no user facing changes.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
