### PR TITLE
Prepare tests for better reuse with zstd:chunked pulls

### DIFF
--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -670,7 +670,7 @@ var _ = Describe("Podman pull", func() {
 				Skip("Cannot start docker registry.")
 			}
 
-			imgPath := "localhost:5012/my-alpine"
+			imgPath := "localhost:5012/my-alpine-pull-and-decrypt"
 
 			session = decryptionTestHelper(imgPath, `initializing source docker://localhost:5012/my-alpine:latest: pinging container registry localhost:5012: Get "https://localhost:5012/v2/": http: server gave HTTP response to HTTPS client`)
 

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -595,7 +595,7 @@ var _ = Describe("Podman pull", func() {
 
 	Describe("podman pull and decrypt", func() {
 
-		decryptionTestHelper := func(imgPath string, expectedError1 string) *PodmanSessionIntegration {
+		decryptionTestHelper := func(imgPath string) *PodmanSessionIntegration {
 			bitSize := 1024
 			keyFileName := filepath.Join(podmanTest.TempDir, "key,withcomma")
 			publicKeyFileName, privateKeyFileName, err := WriteRSAKeyPair(keyFileName, bitSize)
@@ -613,9 +613,9 @@ var _ = Describe("Podman pull", func() {
 			Expect(session).Should(ExitCleanly())
 
 			// Pulling encrypted image without key should fail
-			session = podmanTest.Podman([]string{"pull", imgPath})
+			session = podmanTest.Podman([]string{"pull", "--tls-verify=false", imgPath})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitWithError(125, expectedError1))
+			Expect(session).Should(ExitWithError(125, "invalid tar header"))
 
 			// Pulling encrypted image with wrong key should fail
 			session = podmanTest.Podman([]string{"pull", "-q", "--decryption-key", wrongPrivateKeyFileName, "--tls-verify=false", imgPath})
@@ -642,7 +642,7 @@ var _ = Describe("Podman pull", func() {
 			imgName := "localhost/name:tag"
 			imgPath := fmt.Sprintf("oci:%s:%s", bbdir, imgName)
 
-			session := decryptionTestHelper(imgPath, "invalid tar header")
+			session := decryptionTestHelper(imgPath)
 
 			Expect(session.LineInOutputContainsTag("localhost/name", "tag")).To(BeTrue())
 		})
@@ -672,7 +672,7 @@ var _ = Describe("Podman pull", func() {
 
 			imgPath := "localhost:5012/my-alpine-pull-and-decrypt"
 
-			session = decryptionTestHelper(imgPath, `initializing source docker://localhost:5012/my-alpine:latest: pinging container registry localhost:5012: Get "https://localhost:5012/v2/": http: server gave HTTP response to HTTPS client`)
+			session = decryptionTestHelper(imgPath)
 
 			Expect(session.LineInOutputContainsTag(imgPath, "latest")).To(BeTrue())
 		})

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -175,7 +175,9 @@ var _ = Describe("Podman push", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		if !IsRemote() { // Remote does not support --encryption-key
-			push = podmanTest.Podman([]string{"push", "-q", "--encryption-key", "jwe:" + publicKeyFileName, "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5003/my-alpine"})
+			// Explicitly specify compression-format because encryption and zstd:chunked together triggers a warning:
+			//	Compression using zstd:chunked is not beneficial for encrypted layers, using plain zstd instead
+			push = podmanTest.Podman([]string{"push", "-q", "--encryption-key", "jwe:" + publicKeyFileName, "--tls-verify=false", "--remove-signatures", "--compression-format=zstd", ALPINE, "localhost:5003/my-alpine"})
 			push.WaitWithDefaultTimeout()
 			Expect(push).Should(ExitCleanly())
 		}
@@ -352,7 +354,9 @@ var _ = Describe("Podman push", func() {
 		publicKeyFileName, _, err := WriteRSAKeyPair(keyFileName, bitSize)
 		Expect(err).ToNot(HaveOccurred())
 
-		session := podmanTest.Podman([]string{"push", "-q", "--encryption-key", "jwe:" + publicKeyFileName, ALPINE, fmt.Sprintf("oci:%s", bbdir)})
+		// Explicitly specify compression-format because encryption and zstd:chunked together triggers a warning:
+		//	Compression using zstd:chunked is not beneficial for encrypted layers, using plain zstd instead
+		session := podmanTest.Podman([]string{"push", "-q", "--encryption-key", "jwe:" + publicKeyFileName, "--compression-format=zstd", ALPINE, fmt.Sprintf("oci:%s", bbdir)})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2173,7 +2173,7 @@ WORKDIR /madethis`, BB)
 		publicKeyFileName, privateKeyFileName, err := WriteRSAKeyPair(keyFileName, bitSize)
 		Expect(err).ToNot(HaveOccurred())
 
-		imgPath := "localhost:5006/my-alpine"
+		imgPath := "localhost:5006/my-alpine-podman-run-and-decrypt"
 		session = podmanTest.Podman([]string{"push", "--encryption-key", "jwe:" + publicKeyFileName, "--tls-verify=false", "--remove-signatures", ALPINE, imgPath})
 		session.WaitWithDefaultTimeout()
 


### PR DESCRIPTION
- Fix a test of encrypted pulls to actually test the right thing
- Update tests to be ready for future https://github.com/containers/image/pull/2321 , so that we can later vendor c/image without seeing test failures.

#### Does this PR introduce a user-facing change?

```release-note
None
```
