### PR TITLE
test/system: two networking test fixes

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -319,7 +319,8 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     # stop systemd container
     service_cleanup
 
-    pasta_iface=$(default_ifname)
+    pasta_iface=$(default_ifname 4)
+    assert "$pasta_iface" != "" "pasta_iface is set"
 
     # now check that the rootless netns slirp4netns process is still alive and working
     run_podman unshare --rootless-netns ip addr

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -802,7 +802,10 @@ EOF
     pasta_ip="$(default_addr 4)"
     host_ips=$(ip -4 -j addr | jq -r '.[] | select(.ifname != "lo") | .addr_info[].local')
 
-    for network in "pasta" "bridge"; do
+    netname=n_$(safename)
+    run_podman network create $netname
+
+    for network in "pasta" "$netname"; do
         # special exit code logic needed here, it is possible that there is no host.containers.internal
         # when there is only one ip one the host and that one is used by pasta.
         # As such we have to deal with both cases.
@@ -818,6 +821,8 @@ EOF
             die "unexpected exit code '$status' from grep or podman ($network)"
         fi
     done
+
+    run_podman network rm $netname
 
     first_host_ip=$(head -n 1 <<<"$host_ips")
     run_podman run --rm --network=pasta:-a,169.254.0.2,-g,169.254.0.1,-n,24 $IMAGE grep host.containers.internal /etc/hosts

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -784,7 +784,8 @@ EOF
 @test "Podman unshare --rootless-netns with Pasta" {
     skip_if_remote "unshare is local-only"
 
-    pasta_iface=$(default_ifname)
+    pasta_iface=$(default_ifname 4)
+    assert "$pasta_iface" != "" "pasta_iface is set"
 
     # First let's force a setup error by making pasta be "false".
     ln -s /usr/bin/false $PODMAN_TMPDIR/pasta


### PR DESCRIPTION
see the commits

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
