### PR TITLE
Convert additional build context paths on Windows

### DIFF
--- a/build_windows.md
+++ b/build_windows.md
@@ -24,8 +24,8 @@ Windows.
   - [Create and start a podman machine](#create-and-start-a-podman-machine)
   - [Run a container using podman](#run-a-container-using-podman)
 - [Build and test the Podman Windows installer](#build-and-test-the-podman-windows-installer)
-  - [Build the installer](#build-the-installer)
-  - [Test the installer](#test-the-installer)
+  - [Build the Windows installer](#build-the-windows-installer)
+  - [Test the Windows installer](#test-the-windows-installer)
   - [Build and test the standalone `podman.msi` file](#build-and-test-the-standalone-podmanmsi-file)
   - [Verify the installation](#verify-the-installation)
   - [Uninstall and clean-up](#uninstall-and-clean-up)
@@ -480,7 +480,7 @@ $foldersToCheck = @(
     "$env:USERPROFILE.config\containers\"
     "$env:USERPROFILE.local\share\containers\"
     "$ENV:LOCALAPPDATA\containers\"
-    "$ENV:APPDATA\containers\containers.conf.d\99-podman-machine-provider.conf"
+    "$ENV:PROGRAMDATA\containers\containers.conf.d\99-podman-machine-provider.conf"
 )
 $foldersToCheck | ForEach-Object {Test-Path -Path $PSItem}
 ```

--- a/pkg/bindings/images/build_test.go
+++ b/pkg/bindings/images/build_test.go
@@ -3,6 +3,7 @@ package images
 import (
 	"testing"
 
+	"github.com/containers/buildah/define"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,4 +15,46 @@ func TestBuildMatchIID(t *testing.T) {
 
 func TestBuildNotMatchStatusMessage(t *testing.T) {
 	assert.False(t, iidRegex.MatchString("Copying config a883dafc480d466ee04e0d6da986bd78eb1fdd2178d04693723da3a8f95d42f4"))
+}
+
+func TestConvertAdditionalBuildContexts(t *testing.T) {
+	additionalBuildContexts := map[string]*define.AdditionalBuildContext{
+		"context1": {
+			IsURL:           false,
+			IsImage:         false,
+			Value:           "C:\\test",
+			DownloadedCache: "",
+		},
+		"context2": {
+			IsURL:           false,
+			IsImage:         false,
+			Value:           "/test",
+			DownloadedCache: "",
+		},
+		"context3": {
+			IsURL:           true,
+			IsImage:         false,
+			Value:           "https://a.com/b.tar",
+			DownloadedCache: "",
+		},
+		"context4": {
+			IsURL:           false,
+			IsImage:         true,
+			Value:           "quay.io/a/b:c",
+			DownloadedCache: "",
+		},
+	}
+
+	convertAdditionalBuildContexts(additionalBuildContexts)
+
+	expectedGuestValues := map[string]string{
+		"context1": "/mnt/c/test",
+		"context2": "/test",
+		"context3": "https://a.com/b.tar",
+		"context4": "quay.io/a/b:c",
+	}
+
+	for key, value := range additionalBuildContexts {
+		assert.Equal(t, expectedGuestValues[key], value.Value)
+	}
 }

--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -1,49 +1,86 @@
 # Running the machine tests
 
-This document is a quick how-to run machine tests.  Not all dependencies, like
-`gvproxy` are documented. You must install `gvproxy` in all cases described below.
+This document is a quick how-to run machine tests. Not all dependencies, like
+`gvproxy` are documented. You must install `gvproxy` in all cases described
+below.
 
 ## General notes
 
 ### Environment must be clean
-You must not have any machines defined before running tests.  Consider running `podman machine reset` prior to running tests.
+
+You must not have any machines defined before running tests. Consider running
+`podman machine reset` prior to running tests.
+
+###
 
 ### Scoping tests
-You can scope tests in the machine suite by adding various incantations of `FOCUS=`.  For example, add `FOCUS_FILE=basic_test.go` to only run basic test. Or add `FOCUS="simple init with start"` to only run one test case. For windows, the syntax differs slightly.  In windows, executing something like following achieves the same result:
+
+You can scope tests in the machine suite by adding various incantations of
+`FOCUS=`. For example, add `FOCUS_FILE=basic_test.go` to only run basic test. Or
+add `FOCUS="simple init with start"` to only run one test case. For windows, the
+syntax differs slightly. In windows, executing something like following achieves
+the same result:
 
 `./winmake localmachine "basic_test.go start_test.go"`
+
+To focus on one specific test on windows, run `ginkgo` manually:
+
+```pwsh
+$remotetags = "remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp"
+$focus_file = "basic_test.go"
+$focus_test = "podman build contexts"
+./test/tools/build/ginkgo.exe `
+     -v --tags "$remotetags" -timeout=90m --trace --no-color `
+     --focus-file  $focus_file `
+     --focus "$focus_test" `
+     ./pkg/machine/e2e/.
+```
+
+Note that ginkgo.exe is built when running the command
+`winmake.ps1 localmachine` so make sure to run it before trying the command
+above.
 
 ## Linux
 
 ### QEMU
-1. `make localmachine`
 
+1. `make localmachine`
 
 ## Microsoft Windows
 
 ### Hyper-V
-1. Open a powershell as admin
-1. `$env:CONTAINERS_MACHINE_PROVIDER="hyperv"`
-1. `./winmake localmachine`
 
+1. Open a powershell as admin
+1. `.\winmake.ps1 podman-remote && .\winmake.ps1 win-gvproxy`
+1. `$env:CONTAINERS_HELPER_BINARY_DIR="$pwd\bin\windows"`
+1. `$env:CONTAINERS_MACHINE_PROVIDER="hyperv"`
+1. `.\winmake localmachine`
 
 ### WSL
+
 1. Open a powershell as a regular user
-1. Build and copy win-sshproxy into bin/
-1. `./winmake localmachine`
+1. `.\winmake.ps1 podman-remote && .\winmake.ps1 win-gvproxy`
+1. `$env:CONTAINERS_HELPER_BINARY_DIR="$pwd\bin\windows"`
+1. `$env:CONTAINERS_MACHINE_PROVIDER="wsl"`
+1. `.\winmake localmachine`
 
 ## MacOS
-Macs now support two different machine providers: `applehv` and `libkrun`.  The `applehv` provider is the default.
 
-Note: On macOS, an error will occur if the path length of `$TMPDIR` is longer than 22 characters. Please set the appropriate path to `$TMPDIR`. Also, if `$TMPDIR` is empty, `/private/tmp` will be set.
+Macs now support two different machine providers: `applehv` and `libkrun`. The
+`applehv` provider is the default.
+
+Note: On macOS, an error will occur if the path length of `$TMPDIR` is longer
+than 22 characters. Please set the appropriate path to `$TMPDIR`. Also, if
+`$TMPDIR` is empty, `/private/tmp` will be set.
 
 ### Apple Hypervisor
+
 1. `brew install vfkit`
 1. `make podman-remote`
 1. `make localmachine`
 
-
 ### [Libkrun](https://github.com/containers/libkrun)
+
 1. `brew install krunkit`
 1. `make podman-remote`
 1. `export CONTAINERS_MACHINE_PROVIDER="libkrun"`


### PR DESCRIPTION
This PR partially fixes issues with the option `--build-context <label>=<path>` of `podman build`. 

This is enough to fix https://github.com/containers/podman/issues/17313 on macOS and Windows WSL with the default machine mounts. 

A complete fix of the option `--build-context` would require packaging the additional build contexts in some additional tars and update the `/libpod/build` endpoint to accept multi-part HTTP requests. But that's outside the scope of this PR.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix VisualStudio Dev Containers Features on Windows
```
