### PR TITLE
Change podman.service.in to only log at notice level and above

### DIFF
--- a/contrib/systemd/system/podman.service.in
+++ b/contrib/systemd/system/podman.service.in
@@ -11,6 +11,7 @@ Type=exec
 KillMode=process
 Environment=LOGGING="--log-level=info"
 ExecStart=@@PODMAN@@ $LOGGING system service
+LogLevelMax=notice
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman.service will no longer log debug messages into the journal.
```
