### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = bin,vendor,.git,go.sum,.cirrus.yml,"*.fish,RELEASE_NOTES.md,*.xz,*.gz,*.ps1,*.tar,swagger.yaml,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go
+check-hidden = true
+ignore-regex = \b(Not|assert)In\b
+ignore-words-list = ddress,secon,passt,bu,hastable,te,clos,ans,pullrequest,uint,iff,od,seeked,splitted,marge,erro,hist,ether,specif,whit

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 /*
 
-Validate this file before commiting with (from repository root):
+Validate this file before committing with (from repository root):
 
     podman run -it \
         -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
@@ -17,7 +17,7 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
    ****** Global/general configuration options *****
    *************************************************/
 
-  // Re-use predefined sets of configuration options to DRY
+  // Reuse predefined sets of configuration options to DRY
   "extends": [
     // https://github.com/containers/automation/blob/main/renovate/defaults.json5
     "github>containers/automation//renovate/defaults.json5"

--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -14,7 +14,7 @@ on:
         - cron:  '03 03 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
-    # Allow re-use of this workflow by other repositories
+    # Allow reuse of this workflow by other repositories
     # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
     workflow_call:
       secrets:

--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -11,7 +11,7 @@ name: "Lock closed issues and PRs"
 on:
   schedule:
     - cron: '0 0 * * *'
-  # Allow re-use of this workflow by other repositories
+  # Allow reuse of this workflow by other repositories
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   workflow_call:
     secrets:

--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -13,7 +13,7 @@ on:
         - cron:  '01 01 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
-    # Allow re-use of this workflow by other repositories
+    # Allow reuse of this workflow by other repositories
     # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
     workflow_call:
       secrets:

--- a/.github/workflows/update-podmanio.yml
+++ b/.github/workflows/update-podmanio.yml
@@ -101,7 +101,7 @@ jobs:
             steps.checkversion.outputs.needsUpdate == 'true' &&
             steps.checkpr.outputs.prexists == 'false'
         run: |
-          # Make commiter the user who triggered the action, either through cutting a release or manual trigger
+          # Make committer the user who triggered the action, either through cutting a release or manual trigger
           # GitHub gives everyone a noreply email associated with their account, use that email for the sign-off
           git config --local user.name ${{ github.actor }}
           git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-yaml
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .codespellrc
+    rev: v2.2.6
+    hooks:
+    - id: codespell

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,8 @@ test/version/version: version/version.go
 
 .PHONY: codespell
 codespell:
-	codespell -S bin,vendor,.git,go.sum,.cirrus.yml,"*.fish,RELEASE_NOTES.md,*.xz,*.gz,*.ps1,*.tar,swagger.yaml,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L ddress,secon,passt,bu,hastable,te,clos,ans,pullrequest,uint,iff,od,seeked,splitted,marge,erro,hist,ether,specif -w
+	# Configuration for codespell is in .codespellrc
+	codespell -w
 
 # Code validation target that **DOES NOT** require building podman binaries
 .PHONY: validate-source

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -253,7 +253,7 @@ spelled with complete minutiae.
       event states triggered, but this can be ignored, as any duplicates
       will gracefully back-off. The job takes 5-6 minutes to complete.
 
-      Please note that the Windows action depends onthe artifact action, and will be
+      Please note that the Windows action depends on the artifact action, and will be
       triggered after the artifact action succeeds.
 
       If any of these actions are somehow not triggered, you can manually trigger them

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -147,7 +147,7 @@ podman manifest add mylist:v1.11 docker://fedora
 71c201d10fffdcac52968a000d85a0a016ca1c7d5473948000d3131c1773d965
 ```
 
-Add all images from source manfest list to destination manifest list:
+Add all images from source manifest list to destination manifest list:
 ```
 podman manifest add --all mylist:v1.11 docker://fedora
 71c201d10fffdcac52968a000d85a0a016ca1c7d5473948000d3131c1773d965

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -213,11 +213,11 @@ type ContainerBasicConfig struct {
 	// container.
 	// Optional.
 	EnvMerge []string `json:"envmerge,omitempty"`
-	// UnsetEnv unsets the specified default environment variables from the image or from buildin or containers.conf
+	// UnsetEnv unsets the specified default environment variables from the image or from built-in or containers.conf
 	// Optional.
 	UnsetEnv []string `json:"unsetenv,omitempty"`
-	// UnsetEnvAll unsetall default environment variables from the image or from buildin or containers.conf
-	// UnsetEnvAll unsets all default environment variables from the image or from buildin
+	// UnsetEnvAll unsetall default environment variables from the image or from built-in or containers.conf
+	// UnsetEnvAll unsets all default environment variables from the image or from built-in
 	// Optional.
 	UnsetEnvAll *bool `json:"unsetenvall,omitempty"`
 	// Passwd is a container run option that determines if we are validating users/groups before running the container

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -92,7 +92,7 @@ t POST libpod/containers/create name=test1 image=$IMAGE privileged=true 201
 t GET libpod/containers/test1/json 200 \
   .HostConfig.Annotations.'"io.podman.annotations.privileged"'="TRUE"
 
-# now the same without privileged it should not inhert the privileged from before
+# now the same without privileged it should not inherit the privileged from before
 t POST libpod/containers/create name=test2 image=$IMAGE 201
 t GET libpod/containers/test2/json 200 \
   .HostConfig.Annotations=null


### PR DESCRIPTION
codespell is not new to this project but not really part of the automated workflow(s) (precommit, CI).

There is `Makefile` rule but had hardcoded settings into it, so people had to use `make` and could not `pre-commit` or directly -- I moved configuration into `pyproject.yaml` so now if you have codespell (and tomli) installed - you can just codespell. 

CI workflow has 'permissions' set only to 'read' so also should be safe.

Also added pre-commit hook for it so no new typos would sneak in.

attn @rhatdan as I believe the codespell user ;)