### PR TITLE
[skip-ci] RPM: podman-iptables.conf only on Fedora

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -264,9 +264,11 @@ PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} ETCDI
        install.docker \
        install.docker-docs \
        install.remote \
-       install.testing \
-%if %{defined _modulesloaddir}
-       install.modules-load
+       install.testing
+
+# Only need this on Fedora until nftables becomes the default
+%if %{defined fedora}
+%{__make} DESTDIR=%{buildroot} MODULESLOADDIR=%{_modulesloaddir} install.modules-load
 %endif
 
 sed -i 's;%{buildroot};;g' %{buildroot}%{_bindir}/docker
@@ -305,7 +307,7 @@ ln -s ../virtiofsd %{buildroot}%{_libexecdir}/%{name}
 %{_tmpfilesdir}/%{name}.conf
 %{_systemdgeneratordir}/%{name}-system-generator
 %{_systemdusergeneratordir}/%{name}-user-generator
-%if %{defined _modulesloaddir}
+%if %{defined fedora}
 %{_modulesloaddir}/%{name}-iptables.conf
 %endif
 


### PR DESCRIPTION
RHEL10 defaults to nftables and doesn't need
/usr/lib/modules-load.d/podman-iptables.conf so this should be Fedora only.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
