### PR TITLE
Implement publishing API UNIX socket on Windows platforms

### DIFF
--- a/pkg/machine/e2e/api_test.go
+++ b/pkg/machine/e2e/api_test.go
@@ -1,0 +1,96 @@
+package e2e_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/docker/docker/client"
+	jsoniter "github.com/json-iterator/go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+const (
+	NamedPipeProto = "npipe://"
+)
+
+var _ = Describe("run podman API test calls", func() {
+
+	It("client connect to machine socket", func() {
+		if runtime.GOOS == "windows" {
+			Skip("Go docker client doesn't support unix socket on Windows")
+		}
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		inspectJSON := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+
+		var inspectInfo []machine.InspectInfo
+		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
+		Expect(err).ToNot(HaveOccurred())
+		sockPath := inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()
+
+		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + sockPath))
+		Expect(err).ToNot(HaveOccurred())
+		_, err = cli.Ping(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("client connect to machine named pipe", func() {
+		if runtime.GOOS != "windows" {
+			Skip("test is only supported on Windows")
+		}
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		inspectJSON := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+
+		var inspectInfo []machine.InspectInfo
+		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
+		Expect(err).ToNot(HaveOccurred())
+		pipePath := inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath()
+
+		cli, err := client.NewClientWithOpts(client.WithHost(NamedPipeProto + filepath.ToSlash(pipePath)))
+		Expect(err).ToNot(HaveOccurred())
+		_, err = cli.Ping(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("curl connect to machine socket", func() {
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		inspectJSON := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+
+		var inspectInfo []machine.InspectInfo
+		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
+		Expect(err).ToNot(HaveOccurred())
+		sockPath := inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()
+
+		cmd := exec.Command("curl", "--unix-socket", sockPath, "http://d/v5.0.0/libpod/info")
+		err = cmd.Run()
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -80,9 +80,6 @@ var _ = Describe("podman inspect stop", func() {
 	})
 
 	It("inspect shows a unique socket name per machine", func() {
-		skipIfVmtype(define.WSLVirt, "test is only relevant for Unix based providers")
-		skipIfVmtype(define.HyperVVirt, "test is only relevant for Unix based machines")
-
 		var socks []string
 		for c := 0; c < 2; c++ {
 			name := randomString()

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -18,6 +18,7 @@ import (
 	winio "github.com/Microsoft/go-winio"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
+	"github.com/containers/podman/v5/pkg/machine/sockets"
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/sirupsen/logrus"
 )
@@ -45,6 +46,7 @@ type WinProxyOpts struct {
 	RemoteUsername string
 	Rootful        bool
 	VMType         define.VMType
+	Socket         *define.VMFile
 }
 
 func GetProcessState(pid int) (active bool, exitCode int) {
@@ -159,6 +161,12 @@ func launchWinProxy(opts WinProxyOpts) (bool, string, error) {
 		args = append(args, NamedPipePrefix+GlobalNamedPipe, dest, opts.IdentityPath)
 		waitPipe = GlobalNamedPipe
 	}
+
+	hostURL, err := sockets.ToUnixURL(opts.Socket)
+	if err != nil {
+		return false, "", err
+	}
+	args = append(args, hostURL.String(), dest, opts.IdentityPath)
 
 	cmd := exec.Command(command, args...)
 	logrus.Debugf("winssh command: %s %v", command, args)

--- a/pkg/machine/shim/networking_windows.go
+++ b/pkg/machine/shim/networking_windows.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
+	sc "github.com/containers/podman/v5/pkg/machine/sockets"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 )
 
@@ -22,5 +23,16 @@ func setupMachineSockets(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) 
 		state = machine.DockerGlobal
 	}
 
-	return sockets, sockets[len(sockets)-1], state, nil
+	hostSocket, err := mc.APISocket()
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	hostURL, err := sc.ToUnixURL(hostSocket)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	sockets = append(sockets, hostURL.String())
+
+	return sockets, sockets[len(sockets)-2], state, nil
 }

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/podman/v5/pkg/errorhandling"
 	"github.com/containers/podman/v5/pkg/machine/connection"
 	"github.com/containers/podman/v5/pkg/machine/define"
-	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/lock"
 	"github.com/containers/podman/v5/pkg/machine/ports"
 	"github.com/containers/storage/pkg/fileutils"
@@ -331,19 +330,8 @@ func (mc *MachineConfig) IsFirstBoot() (bool, error) {
 }
 
 func (mc *MachineConfig) ConnectionInfo(vmtype define.VMType) (*define.VMFile, *define.VMFile, error) {
-	var (
-		socket *define.VMFile
-		pipe   *define.VMFile
-	)
-
-	if vmtype == define.HyperVVirt || vmtype == define.WSLVirt {
-		pipeName := env.WithPodmanPrefix(mc.Name)
-		pipe = &define.VMFile{Path: `\\.\pipe\` + pipeName}
-		return nil, pipe, nil
-	}
-
 	socket, err := mc.APISocket()
-	return socket, nil, err
+	return socket, getPipe(mc.Name), err
 }
 
 // LoadMachineByName returns a machine config based on the vm name and provider

--- a/pkg/machine/vmconfigs/machine_unix.go
+++ b/pkg/machine/vmconfigs/machine_unix.go
@@ -1,0 +1,11 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package vmconfigs
+
+import (
+	"github.com/containers/podman/v5/pkg/machine/define"
+)
+
+func getPipe(name string) *define.VMFile {
+	return nil
+}

--- a/pkg/machine/vmconfigs/machine_windows.go
+++ b/pkg/machine/vmconfigs/machine_windows.go
@@ -1,0 +1,11 @@
+package vmconfigs
+
+import (
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/env"
+)
+
+func getPipe(name string) *define.VMFile {
+	pipeName := env.WithPodmanPrefix(name)
+	return &define.VMFile{Path: `\\.\pipe\` + pipeName}
+}

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -191,6 +191,10 @@ func (w WSLStubber) RequireExclusiveActive() bool {
 }
 
 func (w WSLStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool) error {
+	socket, err := mc.APISocket()
+	if err != nil {
+		return err
+	}
 	winProxyOpts := machine.WinProxyOpts{
 		Name:           mc.Name,
 		IdentityPath:   mc.SSH.IdentityPath,
@@ -198,6 +202,7 @@ func (w WSLStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool
 		RemoteUsername: mc.SSH.RemoteUsername,
 		Rootful:        mc.HostUser.Rootful,
 		VMType:         w.VMType(),
+		Socket:         socket,
 	}
 	machine.LaunchWinProxy(winProxyOpts, noInfo)
 


### PR DESCRIPTION
Fixes #23408

gvproxy and win-sshproxy have capabilities to serve this type of enpoint. This change only adds one additional API enpoint publishing by appending proxy command lines.

Originally developed within https://github.com/containers/podman/issues/13006 but could be generalized to any VM using `gvproxy` or `win-sshproxy`.  This has been verified to work for Hyper-V and WSL machines.

Example how it looks for WSL machine.
commands
* podman machine list (to show what kind of machine it is)
* podman machine inspect (to demo published endpoint in info)
* where curl (to verify it will use Windows one)
* curl to call the enpoint

```
C:\qcw-utils\shells>podman machine list
NAME                     VM TYPE     CREATED         LAST UP            CPUS        MEMORY      DISK SIZE
podman-machine-default*  wsl         43 seconds ago  Currently running  2           2GiB        100GiB

C:\qcw-utils\shells>podman machine inspect
[
     {
          "ConfigDir": {
               "Path": "C:\\Users\\User\\.config\\containers\\podman\\machine\\wsl"
          },
          "ConnectionInfo": {
               "PodmanSocket": {
                    "Path": "C:\\Users\\User\\AppData\\Local\\Temp\\podman\\podman-machine-default-api.sock"
               },
               "PodmanPipe": {
                    "Path": "\\\\.\\pipe\\podman-machine-default"
               }
          },
          "Created": "2024-07-26T12:57:29.14137+03:00",
          "LastUp": "0001-01-01T00:00:00Z",
          "Name": "podman-machine-default",
          "Resources": {
               "CPUs": 2,
               "DiskSize": 100,
               "Memory": 2048,
               "USBs": []
          },
          "SSHConfig": {
               "IdentityPath": "C:\\Users\\User\\.local\\share\\containers\\podman\\machine\\machine",
               "Port": 50239,
               "RemoteUsername": "user"
          },
          "State": "running",
          "UserModeNetworking": false,
          "Rootful": false,
          "Rosetta": false
     }
]

C:\qcw-utils\shells>where curl
C:\Windows\System32\curl.exe

C:\qcw-utils\shells>curl --unix-socket C:\\Users\\User\\AppData\\Local\\Temp\\podman\\podman-machine-default-api.sock h
ttp://d/v5.0.0/libpod/info
{"host":{"arch":"amd64","buildahVersion":"1.36.0","cgroupManager":"cgroupfs","cgroupVersion":"v1","cgroupControllers":[],"conmon":{"package":"conmon-2.1.10-1.fc40.x86_64","path":"/usr/bin/conmon","version":"conmon version 2.1.10, commit: "},"cpus":4,"cpuUtilization":{"userPercent":0.86,"systemPercent":1.54,"idlePercent":97.6},"databaseBackend":"sqlite","distribution":{"distribution":"fedora","variant":"container","version":"40"},"eventLogger":"journald","freeLocks":2048,"hostname":"glider-mk2","idMappings":{"gidmap":[{"container_id":0,"host_id":1000,"size":1},{"container_id":1,"host_id":524288,"size":65536}],"uidmap":[{"container_id":0,"host_id":1000,"size":1},{"container_id":1,"host_id":524288,"size":65536}]},"kernel":"5.15.153.1-microsoft-standard-WSL2","logDriver":"journald","memFree":16180596736,"memTotal":16773939200,"networkBackend":"netavark","networkBackendInfo":{"backend":"netavark","version":"netavark 1.11.0","package":"netavark-1.11.0-1.fc40.x86_64","path":"/usr/libexec/podman/netavark","dns":{"version":"aardvark-dns 1.11.0","package":"aardvark-dns-1.11.0-1.fc40.x86_64","path":"/usr/libexec/podman/aardvark-dns"}},"ociRuntime":{"name":"crun","package":"crun-1.15-1.fc40.x86_64","path":"/usr/bin/crun","version":"crun version 1.15\ncommit: e6eacaf4034e84185fd8780ac9262bbf57082278\nrundir: /run/user/1000/crun\nspec: 1.0.0\n+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +LIBKRUN +WASM:wasmedge +YAJL"},"os":"linux","remoteSocket":{"path":"/run/user/1000/podman/podman.sock","exists":true},"rootlessNetworkCmd":"pasta","serviceIsRemote":false,"security":{"apparmorEnabled":false,"capabilities":"CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_NET_BIND_SERVICE,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT","rootless":true,"seccompEnabled":true,"seccompProfilePath":"/usr/share/containers/seccomp.json","selinuxEnabled":false},"slirp4netns":{"executable":"","package":"","version":""},"pasta":{"executable":"/usr/bin/pasta","package":"passt-0^20240624.g1ee2eca-1.fc40.x86_64","version":"pasta 0^20240624.g1ee2eca-1.fc40.x86_64\nCopyright Red Hat\nGNU General Public License, version 2 or later\n  \u003chttps://www.gnu.org/licenses/old-licenses/gpl-2.0.html\u003e\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n"},"swapFree":4294967296,"swapTotal":4294967296,"uptime":"0h 1m 29.00s","variant":"","linkmode":"dynamic"},"store":{"configFile":"/home/user/.config/containers/storage.conf","containerStore":{"number":0,"paused":0,"running":0,"stopped":0},"graphDriverName":"overlay","graphOptions":{},"graphRoot":"/home/user/.local/share/containers/storage","graphRootAllocated":1081101176832,"graphRootUsed":790700032,"graphStatus":{"Backing Filesystem":"extfs","Native Overlay Diff":"true","Supports d_type":"true","Supports shifting":"false","Supports volatile":"true","Using metacopy":"false"},"imageCopyTmpDir":"/var/tmp","imageStore":{"number":0},"runRoot":"/run/user/1000/containers","volumePath":"/home/user/.local/share/containers/storage/volumes","transientStore":false},"registries":{"search":["docker.io"]},"plugins":{"volume":["local"],"network":["bridge","macvlan","ipvlan"],"log":["k8s-file","none","passthrough","journald"],"authorization":null},"version":{"APIVersion":"5.1.2","Version":"5.1.2","GoVersion":"go1.22.5","GitCommit":"","BuiltTime":"Wed Jul 10 03:00:00 2024","Built":1720569600,"OsArch":"linux/amd64","Os":"linux"}}
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Additionally provide API access via UNIX sockets to Podman running in Podman Machine on Windows
```
