### PR TITLE
pkg/api: do not leak config pointers into specgen

### DIFF
--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -27,14 +27,18 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// copy vars here and not leak config pointers into specgen
+	noHosts := conf.Containers.NoHosts
+	privileged := conf.Containers.Privileged
+
 	// we have to set the default before we decode to make sure the correct default is set when the field is unset
 	sg := specgen.SpecGenerator{
 		ContainerNetworkConfig: specgen.ContainerNetworkConfig{
-			UseImageHosts: &conf.Containers.NoHosts,
+			UseImageHosts: &noHosts,
 		},
 		ContainerSecurityConfig: specgen.ContainerSecurityConfig{
 			Umask:      conf.Containers.Umask,
-			Privileged: &conf.Containers.Privileged,
+			Privileged: &privileged,
 		},
 	}
 

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -86,4 +86,17 @@ podman run $IMAGE true
 t POST libpod/containers/prune 200
 t GET libpod/containers/json 200 \
   length=0
+
+# check the config options are not overwritten by acceident
+t POST libpod/containers/create name=test1 image=$IMAGE privileged=true 201
+t GET libpod/containers/test1/json 200 \
+  .HostConfig.Annotations.'"io.podman.annotations.privileged"'="TRUE"
+
+# now the same without privileged it should not inhert the privileged from before
+t POST libpod/containers/create name=test2 image=$IMAGE 201
+t GET libpod/containers/test2/json 200 \
+  .HostConfig.Annotations=null
+
+podman rm test1 test2
+
 # vim: filetype=sh


### PR DESCRIPTION
The value of the pointer might be changed while creating the container causing unexpected side effects.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
