### PR TITLE
fix: disable compose_warning_logs if PODMAN_COMPOSE_WARNING_LOGS=false

### DIFF
--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -295,11 +295,7 @@ else
 fi
 
 # hide annoying podman compose warnings, some tests want to check compose stderr and this breaks it.
-CONTAINERS_CONF_OVERRIDE="$WORKDIR/containers.conf"
-echo '[engine]
-compose_warning_logs=false' > "$CONTAINERS_CONF_OVERRIDE"
-export CONTAINERS_CONF_OVERRIDE
-
+export PODMAN_COMPOSE_WARNING_LOGS=false
 
 # Identify the tests to run. If called with args, use those as globs.
 tests_to_run=()


### PR DESCRIPTION
- Fixes: #23441
- Related: #23074

Also adds an alias `COMPOSE_WARNING_LOGS`, which is parsed as fallback if `PODMAN_COMPOSE_WARNING_LOGS` is not defined.

If neither is defined, previous behavior is retained.

#### Does this PR introduce a user-facing change?

```release-note
Respect the PODMAN_COMPOSE_WARNING_LOGS environment variable, which is equivalent to engines.compose_warning_logs in containers.conf.
```
