### PR TITLE
Quadlet override service name

### DIFF
--- a/test/e2e/quadlet/build.quadlet.servicename.volume
+++ b/test/e2e/quadlet/build.quadlet.servicename.volume
@@ -1,0 +1,8 @@
+## assert-podman-args --driver=image
+## assert-podman-args --opt image=localhost/imagename
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "basic.service"
+
+[Volume]
+Driver=image
+Image=service-name.build

--- a/test/e2e/quadlet/image.quadlet.servicename.volume
+++ b/test/e2e/quadlet/image.quadlet.servicename.volume
@@ -1,0 +1,8 @@
+## assert-podman-args --driver=image
+## assert-podman-args --opt image=localhost/imagename
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "basic.service"
+
+[Volume]
+Driver=image
+Image=service-name.image

--- a/test/e2e/quadlet/mount.container
+++ b/test/e2e/quadlet/mount.container
@@ -8,10 +8,10 @@ Mount=type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
 Mount=type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
 ## assert-podman-args-key-val "--mount" "," "type=volume,source=vol1,destination=/path/in/container,ro=true"
 Mount=type=volume,source=vol1,destination=/path/in/container,ro=true
-## assert-podman-args-key-val "--mount" "," "type=volume,source=systemd-vol2,destination=/path/in/container,ro=true"
-## assert-key-is "Unit" "Requires" "vol2-volume.service"
-## assert-key-is "Unit" "After" "network-online.target" "vol2-volume.service"
-Mount=type=volume,source=vol2.volume,destination=/path/in/container,ro=true
+## assert-podman-args-key-val "--mount" "," "type=volume,source=systemd-basic,destination=/path/in/container,ro=true"
+## assert-key-is "Unit" "Requires" "basic-volume.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic-volume.service"
+Mount=type=volume,source=basic.volume,destination=/path/in/container,ro=true
 ## assert-podman-args-key-val "--mount" "," "type=tmpfs,tmpfs-size=512M,destination=/path/in/container"
 Mount=type=tmpfs,tmpfs-size=512M,destination=/path/in/container
 ## assert-podman-args-key-val "--mount" "," "type=image,source=fedora,destination=/fedora-image,rw=true"

--- a/test/e2e/quadlet/mount.servicename.container
+++ b/test/e2e/quadlet/mount.servicename.container
@@ -1,0 +1,6 @@
+[Container]
+Image=localhost/imagename
+## assert-podman-args-key-val "--mount" "," "type=volume,source=test-volume,destination=/path/in/container,ro=true"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic.service"
+Mount=type=volume,source=service-name.volume,destination=/path/in/container,ro=true

--- a/test/e2e/quadlet/network.quadlet.servicename.build
+++ b/test/e2e/quadlet/network.quadlet.servicename.build
@@ -1,0 +1,8 @@
+## assert-podman-args "--network=test-network"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic.service"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Network=service-name.network

--- a/test/e2e/quadlet/network.quadlet.servicename.container
+++ b/test/e2e/quadlet/network.quadlet.servicename.container
@@ -1,0 +1,7 @@
+## assert-podman-args "--network=test-network"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic.service"
+
+[Container]
+Image=localhost/imagename
+Network=service-name.network

--- a/test/e2e/quadlet/network.quadlet.servicename.kube
+++ b/test/e2e/quadlet/network.quadlet.servicename.kube
@@ -1,0 +1,8 @@
+## assert-podman-args "--network=test-network"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "basic.service"
+
+
+[Kube]
+Yaml=deployment.yml
+Network=service-name.network

--- a/test/e2e/quadlet/network.servicename.quadlet.pod
+++ b/test/e2e/quadlet/network.servicename.quadlet.pod
@@ -1,0 +1,6 @@
+## assert-podman-pre-args "--network=test-network"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "basic.service"
+
+[Pod]
+Network=service-name.network

--- a/test/e2e/quadlet/service-name.build
+++ b/test/e2e/quadlet/service-name.build
@@ -1,0 +1,6 @@
+## assert-podman-args --tag=localhost/imagename
+
+[Build]
+ServiceName=basic
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit

--- a/test/e2e/quadlet/service-name.container
+++ b/test/e2e/quadlet/service-name.container
@@ -1,0 +1,5 @@
+## assert-podman-final-args localhost/imagename
+
+[Container]
+ServiceName=basic
+Image=localhost/imagename

--- a/test/e2e/quadlet/service-name.image
+++ b/test/e2e/quadlet/service-name.image
@@ -1,0 +1,5 @@
+## assert-podman-final-args localhost/imagename
+
+[Image]
+ServiceName=basic
+Image=localhost/imagename

--- a/test/e2e/quadlet/service-name.kube
+++ b/test/e2e/quadlet/service-name.kube
@@ -1,0 +1,5 @@
+## assert-podman-final-args-regex .*/podman-e2e-.*/subtest-.*/quadlet/deployment.yml
+
+[Kube]
+ServiceName=basic
+Yaml=deployment.yml

--- a/test/e2e/quadlet/service-name.network
+++ b/test/e2e/quadlet/service-name.network
@@ -1,0 +1,5 @@
+## assert-podman-final-args "test-network"
+
+[Network]
+ServiceName=basic
+NetworkName=test-network

--- a/test/e2e/quadlet/service-name.pod
+++ b/test/e2e/quadlet/service-name.pod
@@ -1,5 +1,5 @@
 ## assert-podman-pre-args "--name=test-pod"
 
 [Pod]
+ServiceName=basic
 PodName=test-pod
-ServiceName=test-pod

--- a/test/e2e/quadlet/service-name.volume
+++ b/test/e2e/quadlet/service-name.volume
@@ -1,0 +1,5 @@
+## assert-podman-final-args "test-volume"
+
+[Volume]
+ServiceName=basic
+VolumeName=test-volume

--- a/test/e2e/quadlet/volume.build
+++ b/test/e2e/quadlet/volume.build
@@ -2,7 +2,7 @@
 ## assert-podman-args -v /host/dir2:/container/volume2:Z
 ## assert-podman-args-regex -v .*/podman-e2e-.*/subtest-.*/quadlet/host/dir3:/container/volume3
 ## assert-podman-args -v named:/container/named
-## assert-podman-args -v systemd-quadlet:/container/quadlet
+## assert-podman-args -v systemd-basic:/container/quadlet
 ## assert-podman-args -v %h/container:/container/volume4
 
 [Build]
@@ -13,5 +13,5 @@ Volume=/host/dir2:/container/volume2:Z
 Volume=./host/dir3:/container/volume3
 Volume=/container/empty
 Volume=named:/container/named
-Volume=quadlet.volume:/container/quadlet
+Volume=basic.volume:/container/quadlet
 Volume=%h/container:/container/volume4

--- a/test/e2e/quadlet/volume.container
+++ b/test/e2e/quadlet/volume.container
@@ -2,7 +2,7 @@
 ## assert-podman-args -v /host/dir2:/container/volume2:Z
 ## assert-podman-args-regex -v .*/podman-e2e-.*/subtest-.*/quadlet/host/dir3:/container/volume3
 ## assert-podman-args -v named:/container/named
-## assert-podman-args -v systemd-quadlet:/container/quadlet
+## assert-podman-args -v systemd-basic:/container/quadlet
 ## assert-podman-args -v %h/container:/container/volume4
 
 [Container]
@@ -12,5 +12,5 @@ Volume=/host/dir2:/container/volume2:Z
 Volume=./host/dir3:/container/volume3
 Volume=/container/empty
 Volume=named:/container/named
-Volume=quadlet.volume:/container/quadlet
+Volume=basic.volume:/container/quadlet
 Volume=%h/container:/container/volume4

--- a/test/e2e/quadlet/volume.pod
+++ b/test/e2e/quadlet/volume.pod
@@ -2,7 +2,7 @@
 ## assert-podman-pre-args -v /host/dir2:/container/volume2:Z
 ## assert-podman-pre-args-regex -v .*/podman-e2e-.*/subtest-.*/quadlet/host/dir3:/container/volume3
 ## assert-podman-pre-args -v named:/container/named
-## assert-podman-pre-args -v systemd-quadlet:/container/quadlet
+## assert-podman-pre-args -v systemd-basic:/container/quadlet
 ## assert-podman-pre-args -v %h/container:/container/volume4
 
 [Pod]
@@ -11,5 +11,5 @@ Volume=/host/dir2:/container/volume2:Z
 Volume=./host/dir3:/container/volume3
 Volume=/container/empty
 Volume=named:/container/named
-Volume=quadlet.volume:/container/quadlet
+Volume=basic.volume:/container/quadlet
 Volume=%h/container:/container/volume4

--- a/test/e2e/quadlet/volume.quadlet.servicename.build
+++ b/test/e2e/quadlet/volume.quadlet.servicename.build
@@ -1,0 +1,8 @@
+## assert-podman-args "-v" "test-volume:/volume/basic"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic.service"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+Volume=service-name.volume:/volume/basic

--- a/test/e2e/quadlet/volume.servicename.container
+++ b/test/e2e/quadlet/volume.servicename.container
@@ -1,0 +1,6 @@
+[Container]
+Image=localhost/imagename
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic.service"
+## assert-podman-args -v test-volume:/container/quadlet
+Volume=service-name.volume:/container/quadlet

--- a/test/e2e/quadlet/volume.servicename.pod
+++ b/test/e2e/quadlet/volume.servicename.pod
@@ -1,0 +1,6 @@
+## assert-podman-pre-args -v test-volume:/container/quadlet
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "basic.service"
+
+[Pod]
+Volume=service-name.volume:/container/quadlet

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -383,8 +383,9 @@ EOF
 [Volume]
 EOF
 
+    local quadlet_tmpdir=$(mktemp -d --tmpdir=$PODMAN_TMPDIR quadlet.XXXXXX)
     # Have quadlet create the systemd unit file for the volume unit
-    run_quadlet "$quadlet_vol_file"
+    run_quadlet "$quadlet_vol_file" "$quadlet_tmpdir"
 
     # Save the volume service name since the variable will be overwritten
     local vol_service=$QUADLET_SERVICE_NAME
@@ -399,7 +400,7 @@ Volume=$quadlet_vol_unit:/tmp
 EOF
 
     # Have quadlet create the systemd unit file for the container unit
-    run_quadlet "$quadlet_file"
+    run_quadlet "$quadlet_file" "$quadlet_tmpdir"
 
     # Save the container service name for readability
     local container_service=$QUADLET_SERVICE_NAME
@@ -510,8 +511,9 @@ EOF
 [Network]
 EOF
 
+    local quadlet_tmpdir=$(mktemp -d --tmpdir=$PODMAN_TMPDIR quadlet.XXXXXX)
     # Have quadlet create the systemd unit file for the network unit
-    run_quadlet "$quadlet_network_file"
+    run_quadlet "$quadlet_network_file" "$quadlet_tmpdir"
 
     # Save the volume service name since the variable will be overwritten
     local network_service=$QUADLET_SERVICE_NAME
@@ -525,7 +527,7 @@ Exec=top
 Network=$quadlet_network_unit
 EOF
 
-    run_quadlet "$quadlet_file"
+    run_quadlet "$quadlet_file" "$quadlet_tmpdir"
 
     # Save the container service name for readability
     local container_service=$QUADLET_SERVICE_NAME


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Allow overriding the service name on all Quadlet unit types
Due to dependency enforcement, all referenced Quadlet files must exist even on dryrun 
```
