### PR TITLE
test/system: podman play --service-container slog to syslog

### DIFF
--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -170,7 +170,7 @@ RELABEL="system_u:object_r:container_file_t:s0"
     # Run `play kube` in the background as it will wait for the service
     # container to exit.
     timeout --foreground -v --kill=10 60 \
-        $PODMAN play kube --service-container=true --log-driver journald $TESTYAML &>/dev/null &
+        $PODMAN --syslog play kube --service-container=true --log-driver journald $TESTYAML &>/dev/null &
 
     # Wait for the container to be running
     container_a=$PODCTRNAME
@@ -212,7 +212,7 @@ RELABEL="system_u:object_r:container_file_t:s0"
     is "$output" "true"
 
     # Restart the pod, make sure the service is running again
-    run_podman pod restart $PODNAME
+    run_podman --syslog pod restart $PODNAME
     run_podman container inspect $service_container --format "{{.State.Running}}"
     is "$output" "true"
 
@@ -223,11 +223,11 @@ RELABEL="system_u:object_r:container_file_t:s0"
     is "$output" "Error: container .* is the service container of pod(s) .* and cannot be removed without removing the pod(s)"
 
     # Kill the pod and make sure the service is not running
-    run_podman pod kill $PODNAME
+    run_podman --syslog pod kill $PODNAME
     _ensure_container_running $service_container false
 
     # Remove the pod and make sure the service is removed along with it
-    run_podman pod rm $PODNAME
+    run_podman --syslog pod rm $PODNAME
     run_podman 1 container exists $service_container
 }
 


### PR DESCRIPTION
In theory when syslog is set the cleanup process should log its errors to syslog (journald) so we can have a look at the errors in CI. Without it podman container cleanup errors will never be logged anywhere.

In order to rey to debug  #21569

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
