### PR TITLE
libpod: inhibit SIGTERM during cleanup()

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2046,6 +2046,11 @@ func (c *Container) cleanup(ctx context.Context) error {
 
 	logrus.Debugf("Cleaning up container %s", c.ID())
 
+	// Ensure we are not killed half way through cleanup
+	// which can leave us in a bad state.
+	shutdown.Inhibit()
+	defer shutdown.Uninhibit()
+
 	// Remove healthcheck unit/timer file if it execs
 	if c.config.HealthCheckConfig != nil {
 		if err := c.removeTransientFiles(ctx,


### PR DESCRIPTION
The network cleanup can handle it when it is killed half way through as it spits out a bunch of error in that case on the next cleanup attempt. Try to avoid getting into such a state and ignore sigterm during this section.

Of course we stil can get SIGKILL so we should work on fixing the underlying problems in network cleanup but let's see if this helps us with the CI flakes in the meantime.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
