### PR TITLE
CI: podman-machine: do not use cache registry

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -195,9 +195,20 @@ setup_rootless() {
 }
 
 install_test_configs() {
-    msg "Installing ./test/registries.conf system-wide."
+    # Which registries.conf to use. By default we always want the cached one...
+    cached="-cached"
+    # ...except for podman-machine, where it's antihelpful
+    if [[ -n "$1" ]]; then
+        if [[ "$1" = "nocache" ]]; then
+            cached=""
+        else
+            die "Internal error: install_test_configs(): unknown arg '$*'"
+        fi
+    fi
+
+    msg "Installing ./test/registries$cached.conf system-wide."
     # All CI VMs run with a local registry
-    install -v -D -m 644 ./test/registries-cached.conf /etc/containers/registries.conf
+    install -v -D -m 644 ./test/registries$cached.conf /etc/containers/registries.conf
 }
 
 # Remove all files provided by the distro version of podman.

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -450,11 +450,8 @@ case "$TEST_FLAVOR" in
         fi
         remove_packaged_podman_files
         showrun make install PREFIX=/usr ETCDIR=/etc
-        # machine-os image changes too frequently, can't be precached
-        # FIXME: I don't think we can use version.go, because of chicken-egg
-        # problem when that gets bumped. Ideas welcome.
-        $LCR cache podman/machine-os:5.3
-        install_test_configs
+        # machine-os image changes too frequently, can't use image cache
+        install_test_configs nocache
         ;;
     swagger)
         showrun make .install.swagger


### PR DESCRIPTION
It's too difficult to keep the podman-machine image up-to-date.
And, we can't use the cache on Mac/Windows, so if quay is down
we're hosed no matter what.

Add a "nocache" mechanism to install_test_configs() and use that
in machine test setup.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```