### PR TITLE
Never skip checkout step in release workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -101,9 +101,6 @@ jobs:
             fi
 
       - name: Checkout Version
-        if: >-
-          steps.check.outputs.buildartifacts == 'true' ||
-          steps.actual_dryrun.outputs.dryrun == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{steps.getversion.outputs.version}}


### PR DESCRIPTION
Step `Trigger Windows Installer` fails if checkout is skipped

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
