### PR TITLE
Use HTTP path prefix of TCP connections to match Docker context behavior

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -276,7 +276,12 @@ func (c *Connection) DoRequest(ctx context.Context, httpBody io.Reader, httpMeth
 		params[i+1] = url.PathEscape(pv)
 	}
 
-	uri := fmt.Sprintf("http://d/v%s/libpod"+endpoint, params...)
+	baseURL := "http://d"
+	if c.URI.Scheme == "tcp" {
+		// Allow path prefixes for tcp connections to match Docker behavior
+		baseURL = "http://" + c.URI.Host + c.URI.Path
+	}
+	uri := fmt.Sprintf(baseURL+"/v%s/libpod"+endpoint, params...)
 	logrus.Debugf("DoRequest Method: %s URI: %v", httpMethod, uri)
 
 	req, err := http.NewRequestWithContext(ctx, httpMethod, uri, httpBody)


### PR DESCRIPTION
Currently `podman system connection add` allows providing TCP connections with paths. However, these paths are not actually used.

```
➤ podman system connection list
Name        URI         Identity    Default     ReadWrite
➤ podman system connection add foo tcp://localhost:8080/some/prefix
➤ podman system connection list
Name        URI                               Identity    Default     ReadWrite
foo         tcp://localhost:8080/some/prefix              true        true
➤ podman --log-level debug --connection foo ps
INFO[0000] podman filtering at log level debug
DEBU[0000] Called ps.PersistentPreRunE(podman --log-level debug --connection foo ps)
DEBU[0000] DoRequest Method: GET URI: http://d/v5.1.2/libpod/_ping
...
```

_NB: The `d` value for host is an ignored placeholder value, because the client uses an `*http.Transport` that dials the correct host with the correct scheme (not necessarily TCP)._

The docker client, however, does respect this path prefix. Upon parsing the connection/context URI, it saves the path as `basePath`: https://github.com/moby/moby/blob/ddea6b0fa8f816377b59e3f7d7b3c32fef629022/client/client.go#L401-L423

This PR introduces the same behavior:

```
➤ ./bin/podman --log-level=debug --connection foo ps
INFO[0000] ./bin/podman filtering at log level debug
DEBU[0000] Called ps.PersistentPreRunE(./bin/podman --log-level=debug --connection foo ps)
DEBU[0000] DoRequest Method: GET URI: http://localhost:8080/some/prefix/v5.2.0/libpod/_ping
...
```

#### Release Note

```release-note
Changed TCP connections with paths in their URI to use the path as an HTTP path prefix to all API requests, matching the behavior of docker context.
```
