### PR TITLE
Ignore missing containers when calling GetExternalContainerLists

### DIFF
--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -122,6 +122,9 @@ func GetExternalContainerLists(runtime *libpod.Runtime) ([]entities.ListContaine
 		switch {
 		case errors.Is(err, types.ErrLoadError):
 			continue
+		// Container could have been removed since listing
+		case errors.Is(err, types.ErrContainerUnknown):
+			continue
 		case err != nil:
 			return nil, err
 		default:


### PR DESCRIPTION
Race condition between listing containers and figuring out if it is a buildah container.

Fixe: https://github.com/containers/podman/issues/23492

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
