### PR TITLE
Should not force conversion of manifest type to DockerV2ListMediaType

### DIFF
--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/containers/common/pkg/auth"
@@ -55,10 +56,14 @@ func inspect(cmd *cobra.Command, args []string) error {
 		insecure, _ := cmd.Flags().GetBool("insecure")
 		inspectOptions.SkipTLSVerify = types.NewOptionalBool(insecure)
 	}
-	buf, err := registry.ImageEngine().ManifestInspect(registry.Context(), args[0], inspectOptions)
+	list, err := registry.ImageEngine().ManifestInspect(registry.Context(), args[0], inspectOptions)
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(buf))
+	prettyJSON, err := json.MarshalIndent(list, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(prettyJSON))
 	return nil
 }

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containers/common/libimage/define"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/libpod"
@@ -190,19 +189,13 @@ func ManifestInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
-	rawManifest, err := imageEngine.ManifestInspect(r.Context(), name, opts)
+	manifest, err := imageEngine.ManifestInspect(r.Context(), name, opts)
 	if err != nil {
 		utils.Error(w, http.StatusNotFound, err)
 		return
 	}
 
-	var schema2List define.ManifestListData
-	if err := json.Unmarshal(rawManifest, &schema2List); err != nil {
-		utils.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-
-	utils.WriteResponse(w, http.StatusOK, schema2List)
+	utils.WriteResponse(w, http.StatusOK, manifest)
 }
 
 // ManifestAddV3 remove digest from manifest list

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"context"
 
+	"github.com/containers/common/libimage/define"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/podman/v5/pkg/domain/entities/reports"
@@ -34,7 +35,7 @@ type ImageEngine interface { //nolint:interfacebloat
 	Untag(ctx context.Context, nameOrID string, tags []string, options ImageUntagOptions) error
 	ManifestCreate(ctx context.Context, name string, images []string, opts ManifestCreateOptions) (string, error)
 	ManifestExists(ctx context.Context, name string) (*BoolReport, error)
-	ManifestInspect(ctx context.Context, name string, opts ManifestInspectOptions) ([]byte, error)
+	ManifestInspect(ctx context.Context, name string, opts ManifestInspectOptions) (*define.ManifestListData, error)
 	ManifestAdd(ctx context.Context, listName string, imageNames []string, opts ManifestAddOptions) (string, error)
 	ManifestAddArtifact(ctx context.Context, name string, files []string, opts ManifestAddArtifactOptions) (string, error)
 	ManifestAnnotate(ctx context.Context, names, image string, opts ManifestAnnotateOptions) (string, error)

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -2,11 +2,11 @@ package tunnel
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
 
+	"github.com/containers/common/libimage/define"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/pkg/bindings/images"
 	"github.com/containers/podman/v5/pkg/bindings/manifests"
@@ -34,7 +34,7 @@ func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entiti
 }
 
 // ManifestInspect returns contents of manifest list with given name
-func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts entities.ManifestInspectOptions) ([]byte, error) {
+func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts entities.ManifestInspectOptions) (*define.ManifestListData, error) {
 	options := new(manifests.InspectOptions).WithAuthfile(opts.Authfile)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
@@ -49,11 +49,7 @@ func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts en
 		return nil, fmt.Errorf("getting content of manifest list or image %s: %w", name, err)
 	}
 
-	buf, err := json.MarshalIndent(list, "", "    ")
-	if err != nil {
-		return buf, fmt.Errorf("rendering manifest for display: %w", err)
-	}
-	return buf, err
+	return list, err
 }
 
 // ManifestAdd adds images to the manifest list


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/23163

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman manifest inspect now includes annoations.
```
