### PR TITLE
Change Windows installer MajorUpgrade Schedule

### DIFF
--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -12,7 +12,7 @@
 
 	<Package Name="podman" Manufacturer="Red Hat Inc." Version="$(VERSION)" UpgradeCode="a6a9dd9c-0732-44ba-9279-ffe22ea50671">
 		<Media Id="1" Cabinet="Podman.cab" EmbedCab="yes" />
-		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." RemoveFeatures="Complete" Schedule="afterInstallExecute" />
 		<Property Id="DiskPrompt" Value="Red Hat's Podman $(VERSION) Installation" />
 		<Property Id="MACHINE_PROVIDER" Value="wsl" />
 		<Property Id="MACHINE_PROVIDER_CONFIG_FILE_PATH">
@@ -93,10 +93,12 @@
 			<ComponentRef Id="GvProxyExecutable" />
 			<?endif?>
 			<ComponentRef Id="GuideHTMLComponent" />
-			<ComponentRef Id="MachineProviderConfigFile" />
 			<ComponentGroupRef Id="ManFiles" />
 			<ComponentGroupRef Id="WSLFeature" />
 			<ComponentGroupRef Id="HyperVFeature" />
+		</Feature>
+		<Feature Id="MachineProviderConfig" Level="1">
+			<ComponentRef Id="MachineProviderConfigFile" />
 		</Feature>
 
 		<Icon Id="podman.ico" SourceFile="resources/podman-logo.ico" />
@@ -152,7 +154,7 @@
 		<StandardDirectory Id="CommonAppDataFolder">
 			<Directory Id="CONFIGDIR" Name="containers">
 				<Directory Id="ContainersConfigSubDir" Name="containers.conf.d">
-					<Component Id="MachineProviderConfigFile" Guid="C32C0040-D9AF-4155-AC7E-465B63B6BE3B" Condition="CREATE_MACHINE_PROVIDER_CONFIG_FILE" NeverOverwrite="true">
+					<Component Id="MachineProviderConfigFile" Guid="C32C0040-D9AF-4155-AC7E-465B63B6BE3B" Condition="CREATE_MACHINE_PROVIDER_CONFIG_FILE">
 						<CreateFolder />
 						<IniFile Id="MachineProviderConfigFile" Action="createLine" Directory="ContainersConfigSubDir" Section="machine" Name="99-podman-machine-provider.conf" Key="provider" Value="&quot;[MACHINE_PROVIDER]&quot;" />
 					</Component>

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -293,7 +293,7 @@ switch ($scenario) {
         Start-Scenario-Installation-Skip-Config-Creation-Flag
         Start-Scenario-Installation-With-Pre-Existing-Podman-Exe
         Start-Scenario-Update-Without-User-Changes
-        # Start-Scenario-Update-With-User-Changed-Config-File
+        Start-Scenario-Update-With-User-Changed-Config-File
         Start-Scenario-Update-With-User-Removed-Config-File
     }
 }


### PR DESCRIPTION
Use Schedule "afterInstallExecute" (instead of the default "afterInstallValidate") in the Windows
installer MajorUpgrade element. With that upgrades don't override eventual users changes to the podman
machine configuration file.
- [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/msi/removeexistingproducts-action)
- [WiX MajorUpgrade documentation](https://wixtoolset.org/docs/schema/wxs/majorupgrade/#attributes)

Fixes #23502
Related to #23495

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
