### PR TITLE
[v4.9-rhel] libpod: cleanup default cache on system reset 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containers/common v0.57.6
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.2
-	github.com/containers/image/v5 v5.29.4
+	github.com/containers/image/v5 v5.29.5
 	github.com/containers/libhvee v0.5.0
 	github.com/containers/ocicrypt v1.1.10
 	github.com/containers/psgo v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.2 h1:6CyU5D85C0/DciRRd7W0bPljK4FAS+DPrrHEQMHfZKY=
 github.com/containers/gvisor-tap-vsock v0.7.2/go.mod h1:6NiTxh2GCVxZQLPzfuEB78/Osp2Usd9uf6nLdd6PiUY=
-github.com/containers/image/v5 v5.29.4 h1:EbYrwOscTvzeCXt4149OtU74T/ZuohEottcs/hz47O4=
-github.com/containers/image/v5 v5.29.4/go.mod h1:kQ7qcDsps424ZAz24thD+x7+dJw1vgur3A9tTDsj97E=
+github.com/containers/image/v5 v5.29.5 h1:hMA9TBrk/tpXX7tYHTjbuyJ6L04Hm+m97+CZaU0VGwI=
+github.com/containers/image/v5 v5.29.5/go.mod h1:kQ7qcDsps424ZAz24thD+x7+dJw1vgur3A9tTDsj97E=
 github.com/containers/libhvee v0.5.0 h1:rDhfG2NI8Q+VgeXht2dXezanxEdpj9pHqYX3vWfOGUw=
 github.com/containers/libhvee v0.5.0/go.mod h1:yvU3Em2u1ZLl2VLd2glMIBWriBwfhWsDaRJsvixUIB0=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/libnetwork/types"
+	blobinfocache "github.com/containers/image/v5/pkg/blobinfocache"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/pkg/rootless"
@@ -259,6 +260,14 @@ func (r *Runtime) Reset(ctx context.Context) error {
 			prevError = err
 		}
 	}
+
+	if err := blobinfocache.CleanupDefaultCache(nil); err != nil {
+		if prevError != nil {
+			logrus.Error(prevError)
+		}
+		prevError = err
+	}
+
 	if storageConfPath, err := storage.DefaultConfigFile(rootless.IsRootless()); err == nil {
 		switch storageConfPath {
 		case stypes.SystemConfigFile:

--- a/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go
+++ b/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go
@@ -74,3 +74,15 @@ func DefaultCache(sys *types.SystemContext) types.BlobInfoCache {
 	logrus.Debugf("Using SQLite blob info cache at %s", path)
 	return cache
 }
+
+// CleanupDefaultCache removes the blob info cache directory.
+// It deletes the cache directory but it does not affect any file or memory buffer currently
+// in use.
+func CleanupDefaultCache(sys *types.SystemContext) error {
+	dir, err := blobInfoCacheDir(sys, rootless.GetRootlessEUID())
+	if err != nil {
+		// Mirror the DefaultCache behavior that does not fail in this case
+		return nil
+	}
+	return os.RemoveAll(dir)
+}

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 29
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 4
+	VersionPatch = 5
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,7 +243,7 @@ github.com/containers/conmon/runner/config
 # github.com/containers/gvisor-tap-vsock v0.7.2
 ## explicit; go 1.20
 github.com/containers/gvisor-tap-vsock/pkg/types
-# github.com/containers/image/v5 v5.29.4
+# github.com/containers/image/v5 v5.29.5
 ## explicit; go 1.19
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
Cherry-picks #22830 into the Podman v4.9-rhel branch

Addresses:  https://issues.redhat.com/browse/ACCELFIX-267

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
