### PR TITLE
Update CI images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240708t152000z-f40f39d13"
+    IMAGE_SUFFIX: "c20240805t173227z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -212,6 +212,7 @@ var _ = Describe("run basic podman commands", func() {
 	It("podman build contexts", func() {
 		skipIfVmtype(define.HyperVVirt, "FIXME: #23429 - Error running podman build with option --build-context on Hyper-V")
 		skipIfVmtype(define.QemuVirt, "FIXME: #23433 - Additional build contexts should be sent as additional tar files")
+		skipIfVmtype(define.LibKrun, "FIXME: #23296 - Fails on MacOS when libkrun in use.")
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -667,7 +667,8 @@ var _ = Describe("Podman pull", func() {
 			}
 			lock := GetPortLock("5012")
 			defer lock.Unlock()
-			session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5012:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+			// FIXME: #23517: using network slirp4netns as work around
+			session := podmanTest.Podman([]string{"run", "-d", "--network", "slirp4netns", "--name", "registry", "-p", "5012:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -611,6 +611,7 @@ var _ = Describe("Podman pull", func() {
 
 			session := podmanTest.Podman([]string{"push", "-q", "--encryption-key", "jwe:" + publicKeyFileName, "--tls-verify=false", "--remove-signatures", ALPINE, imgPath})
 			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitCleanly())
 
 			session = podmanTest.Podman([]string{"rmi", ALPINE})
 			session.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2160,7 +2160,8 @@ WORKDIR /madethis`, BB)
 
 		lock := GetPortLock("5006")
 		defer lock.Unlock()
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5006:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		// FIXME: #23517: using network slirp4netns as work around
+		session := podmanTest.Podman([]string{"run", "-d", "--network", "slirp4netns", "--name", "registry", "-p", "5006:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2176,6 +2176,8 @@ WORKDIR /madethis`, BB)
 		imgPath := "localhost:5006/my-alpine-podman-run-and-decrypt"
 		session = podmanTest.Podman([]string{"push", "--encryption-key", "jwe:" + publicKeyFileName, "--tls-verify=false", "--remove-signatures", ALPINE, imgPath})
 		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("Writing manifest to image destination"))
 
 		session = podmanTest.Podman([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Source: https://github.com/containers/automation_images/pull/371

Also fix some small test bug where the exit code was not checked and add a work around for a new pasta issue.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
