### PR TITLE
Create volume path before state initialization

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -369,6 +369,14 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		return fmt.Errorf("creating runtime temporary files directory: %w", err)
 	}
 
+	// Create the volume path if needed.
+	// This is not strictly necessary at this point, but the path not
+	// existing can cause troubles with DB path validation on OSTree based
+	// systems. Ref: https://github.com/containers/podman/issues/23515
+	if err := os.MkdirAll(runtime.config.Engine.VolumePath, 0700); err != nil {
+		return fmt.Errorf("creating runtime volume path directory: %w", err)
+	}
+
 	// Set up the state.
 	runtime.state, err = getDBState(runtime)
 	if err != nil {

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -194,6 +194,13 @@ host.slirp4netns.executable | $expr_path
 
     ln -s /home $new_home
 
+    # Remove volume directory. This doesn't break Podman but can cause our DB
+    # validation to break if Podman misbehaves. Ref:
+    # https://github.com/containers/podman/issues/23515
+    # (Unfortunately, we can't just use a new directory, that will just trip DB
+    # validation that it doesn't match the path we were using before)
+    rm -rf $PODMAN_TMPDIR/$HOME/.local/share/containers/storage/volumes
+
     # Just need the command to run cleanly
     HOME=$PODMAN_TMPDIR/$HOME run_podman info
 


### PR DESCRIPTION
Strictly speaking we don't need the path yet, but it existing prevents a lot of strangeness in our path-checking logic to validate the current Podman configuration, as it was the only path that might not exist this early in init.

Fixes #23515

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where rootless Podman could fail to validate the runtime's volume path on systems with a symlinked `/home` ([#23515](https://github.com/containers/podman/issues/23515)).
```
