### PR TITLE
Ignore ERROR_SHARING_VIOLATION error on windows

### DIFF
--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -27,5 +27,5 @@ func CleanupGVProxy(f define.VMFile) error {
 	if err := waitOnProcess(proxyPid); err != nil {
 		return err
 	}
-	return f.Delete()
+	return removeGVProxyPIDFile(f)
 }

--- a/pkg/machine/gvproxy_unix.go
+++ b/pkg/machine/gvproxy_unix.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/podman/v5/pkg/machine/define"
 	psutil "github.com/shirou/gopsutil/v3/process"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -71,4 +72,10 @@ func waitOnProcess(processID int) error {
 		return err
 	}
 	return backoffForProcess(p)
+}
+
+// removeGVProxyPIDFile is just a wrapper to vmfile delete so we handle differently
+// on windows
+func removeGVProxyPIDFile(f define.VMFile) error {
+	return f.Delete()
 }

--- a/pkg/machine/gvproxy_windows.go
+++ b/pkg/machine/gvproxy_windows.go
@@ -1,11 +1,14 @@
 package machine
 
 import (
+	"errors"
 	"os"
 	"time"
 
+	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/winquit/pkg/winquit"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 func waitOnProcess(processID int) error {
@@ -42,5 +45,15 @@ func waitOnProcess(processID int) error {
 		logrus.Errorf("was not able to kill gvproxy (PID %d)", processID)
 	}
 
+	return nil
+}
+
+// removeGVProxyPIDFile special wrapper for deleting the GVProxyPIDFile on windows in case
+// the file has an open handle which we will ignore.  unix does not have this problem
+func removeGVProxyPIDFile(f define.VMFile) error {
+	err := f.Delete()
+	if err != nil && !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
When removing the gvproxy pid file, under CI conditions we could hit a case where the PID file being removed seemed to have an open handle on it still.  I could not find anything in podman that left an open handle and gvproxy would have quit before this, so we think it is likely another process holding it.  I could not find root cause with CI because I could not trip the flake.

this new code allows windows (specifically hyperv bc WSL does not use GVProxy) to ignore an ERROR_SHARING_VIOLATION.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
