### PR TITLE
podman container cleanup: ignore common errors

### DIFF
--- a/test/e2e/cleanup_test.go
+++ b/test/e2e/cleanup_test.go
@@ -12,10 +12,10 @@ var _ = Describe("Podman container cleanup", func() {
 		SkipIfRemote("podman container cleanup is not supported in remote")
 	})
 
-	It("podman cleanup bogus container", func() {
+	It("podman cleanup bogus container should not error", func() {
 		session := podmanTest.Podman([]string{"container", "cleanup", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(125, `no container with name or ID "foobar" found: no such container`))
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman cleanup container by id", func() {
@@ -86,7 +86,13 @@ var _ = Describe("Podman container cleanup", func() {
 		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"container", "cleanup", "running"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(125, "is running or paused, refusing to clean up: container state improper"))
+		Expect(session).Should(ExitCleanly())
+
+		// cleanup should be a NOP here, ctr must still be running
+		session = podmanTest.Podman([]string{"container", "inspect", "--format={{.State.Status}}", "running"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("running"))
 	})
 
 	It("podman cleanup paused container", func() {
@@ -99,7 +105,13 @@ var _ = Describe("Podman container cleanup", func() {
 		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"container", "cleanup", "paused"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(125, "is running or paused, refusing to clean up: container state improper"))
+		Expect(session).Should(ExitCleanly())
+
+		// cleanup should be a NOP here, ctr must still be paused
+		session = podmanTest.Podman([]string{"container", "inspect", "--format={{.State.Status}}", "paused"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("paused"))
 
 		// unpause so that the cleanup can stop the container,
 		// otherwise it fails with container state improper


### PR DESCRIPTION
The podman container cleanup command is not really intended for human use. Instead each conmon will spawn this command after the container exit to make sure we can cleanup resources asynchronously. However this command will always race against other foreground process such as podman rm -fa. Therefore it is possible that the ctr was already removed and we should not log errors in this case.

While these errors are normally not seen as the command is int he background you can see it if you enable syslog logging and then they just spam the log with useless errors so just ignore them.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman container cleanup command now ignore the error when the container does not exists 
```
