### PR TITLE
Switch to named GCE VM types

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,8 +89,7 @@ validate-source_task:
         image_project: libpod-218412
         zone: "us-central1-a"
         # golangci-lint is a very, very hungry beast.
-        cpu: 8
-        memory: "16Gb"
+        type: n2-standard-8
         # Required to be 200gig, do not modify - has i/o performance impact
         # according to gcloud CLI tool warning messages.
         disk: 200
@@ -132,8 +131,7 @@ build_task:
     gce_instance: &standardvm
         image_project: libpod-218412
         zone: "us-central1-a"
-        cpu: 2
-        memory: "4Gb"
+        type: n2-standard-2
         # Required to be 200gig, do not modify - has i/o performance impact
         # according to gcloud CLI tool warning messages.
         disk: 200
@@ -630,7 +628,7 @@ local_integration_test_task: &local_integration_test_task
     # so we give these tests 4 cores to make them faster
     gce_instance: &fastvm
       <<: *standardvm
-      cpu: 4
+      type: n2-standard-4
     timeout_in: 30m
     env:
         TEST_FLAVOR: int


### PR DESCRIPTION
Fixes errors similar to:

```
Operation denied by custom org policy:
[customConstraints/custom.denyC2MachineTypes]:
This organization policy prevents creating instances with exotic
machine types. Contact the IT Public Cloud team at help.redhat.com
for an exception
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
