### PR TITLE
Drop APIv2 CNI configuration

### DIFF
--- a/test/apiv2/python/rest_api/fixtures/podman.py
+++ b/test/apiv2/python/rest_api/fixtures/podman.py
@@ -38,42 +38,6 @@ class Podman:
         with open(os.environ["CONTAINERS_REGISTRIES_CONF"], "w") as w:
             p.write(w)
 
-        os.environ["CNI_CONFIG_PATH"] = os.path.join(self.anchor_directory, "cni", "net.d")
-        os.makedirs(os.environ["CNI_CONFIG_PATH"], exist_ok=True)
-        self.cmd.append("--network-config-dir=" + os.environ["CNI_CONFIG_PATH"])
-        cni_cfg = os.path.join(os.environ["CNI_CONFIG_PATH"], "87-podman-bridge.conflist")
-        # json decoded and encoded to ensure legal json
-        buf = json.loads(
-            """
-            {
-              "cniVersion": "0.3.0",
-              "name": "podman",
-              "plugins": [{
-                  "type": "bridge",
-                  "bridge": "cni0",
-                  "isGateway": true,
-                  "ipMasq": true,
-                  "ipam": {
-                    "type": "host-local",
-                    "subnet": "10.88.0.0/16",
-                    "routes": [{
-                      "dst": "0.0.0.0/0"
-                    }]
-                  }
-                },
-                {
-                  "type": "portmap",
-                  "capabilities": {
-                    "portMappings": true
-                  }
-                }
-              ]
-            }
-            """
-        )
-        with open(cni_cfg, "w") as w:
-            json.dump(buf, w)
-
     def open(self, command, *args, **kwargs):
         """Podman initialized instance to run a given command
 

--- a/test/python/docker/__init__.py
+++ b/test/python/docker/__init__.py
@@ -68,42 +68,6 @@ location = "mirror.localhost:5000"
         with open(os.environ["CONTAINERS_REGISTRIES_CONF"], "w") as file:
             file.write(conf)
 
-        os.environ["CNI_CONFIG_PATH"] = os.path.join(self.anchor_directory, "cni", "net.d")
-        os.makedirs(os.environ["CNI_CONFIG_PATH"], exist_ok=True)
-        self.cmd.append("--network-config-dir=" + os.environ["CNI_CONFIG_PATH"])
-        cni_cfg = os.path.join(os.environ["CNI_CONFIG_PATH"], "87-podman-bridge.conflist")
-        # json decoded and encoded to ensure legal json
-        buf = json.loads(
-            """
-            {
-              "cniVersion": "0.3.0",
-              "name": "default",
-              "plugins": [{
-                  "type": "bridge",
-                  "bridge": "cni0",
-                  "isGateway": true,
-                  "ipMasq": true,
-                  "ipam": {
-                    "type": "host-local",
-                    "subnet": "10.88.0.0/16",
-                    "routes": [{
-                      "dst": "0.0.0.0/0"
-                    }]
-                  }
-                },
-                {
-                  "type": "portmap",
-                  "capabilities": {
-                    "portMappings": true
-                  }
-                }
-              ]
-            }
-            """
-        )
-        with open(cni_cfg, "w") as file:
-            json.dump(buf, file)
-
     def open(self, command, *args, **kwargs):
         """Podman initialized instance to run a given command
 


### PR DESCRIPTION
**Depends on PR #23538**

CNI is no longer needed/supported.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
