### PR TITLE
chore(podmansnoop): explain why crun comm is 3

### DIFF
--- a/hack/podmansnoop
+++ b/hack/podmansnoop
@@ -125,7 +125,12 @@ def _print_event(cpu, data, size): # callback
 
     comm = e.comm.decode()
     if comm == "3":
-        # For absolutely unknown reasons, 'crun' appears as '3'.
+        # Because of CVE-2019-5736, crun copies itself on a memfd or temp file, add seals,
+        # then goes fexecve. The linux kernel will then set comm as the basename of
+        # /dev/fd/<fdnum>, which happens to be 3 being the first available file descriptor.
+        # runc implementation is slightly different, with multiple processes, and they also
+        # set the process name to make them intelligible (i.e. "runc:[0:PARENT]", "runc:[1:CHILD]")
+        # so it doesn't fall into this case.
         comm = "crun"
 
     if e.isArgv:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

While working on `crun` appearing as `3` and checking podman code too, I spotted this and wanted to clarify that.