### PR TITLE
De-duplicate docker-py testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -723,10 +723,6 @@ localapiv2-bash:
 localapiv2-python:
 	env CONTAINERS_CONF=$(CURDIR)/test/apiv2/containers.conf PODMAN=./bin/podman \
 		pytest --verbose --disable-warnings ./test/apiv2/python
-	touch test/__init__.py
-	env CONTAINERS_CONF=$(CURDIR)/test/apiv2/containers.conf PODMAN=./bin/podman \
-		pytest --verbose --disable-warnings ./test/python/docker
-	rm -f test/__init__.py
 
 # Order is important running python tests first causes the bash tests
 # to fail, see 12-imagesMore.  FIXME order of tests should not matter

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -393,7 +393,6 @@ case "$TEST_FLAVOR" in
         ;& # Continue with next item
     apiv2)
         msg "Installing previously downloaded/cached packages"
-        showrun dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm
         virtualenv .venv/requests
         source .venv/requests/bin/activate
         showrun pip install --upgrade pip

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,8 +1,1 @@
-docker~=6.1.0
-requests-mock~=1.12.1
-requests~=2.32.3
-setuptools~=72.1.0
-python-dateutil~=2.9.0
-PyYAML~=6.0.0
-openapi-schema-validator~=0.6.2
-pytest==8.1.2
+../apiv2/python/requirements.txt


### PR DESCRIPTION
Previously there were two CI tasks that ended up both testing docker-py compatibility.  Remove the duplicate from the `localapiv2-python` make target, and symlink the identical requirements file.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
