### PR TITLE
[skip-ci] Maintain renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,32 +1,13 @@
 /*
-   Renovate is a service similar to GitHub Dependabot, but with
-   (fantastically) more configuration options.  So many options
-   in fact, if you're new I recommend glossing over this cheat-sheet
-   prior to the official documentation:
 
-   https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet
+Validate this file before commiting with (from repository root):
 
-   Configuration Update/Change Procedure:
-     1. Make changes
-     2. Manually validate changes (from repo-root):
+    podman run -it \
+        -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
+        ghcr.io/renovatebot/renovate:latest \
+        renovate-config-validator
 
-        podman run -it \
-            -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
-            docker.io/renovate/renovate:latest \
-            renovate-config-validator
-     3. Commit.
-
-   Configuration Reference:
-   https://docs.renovatebot.com/configuration-options/
-
-   Monitoring Dashboard:
-   https://app.renovatebot.com/dashboard#github/containers
-
-   Note: The Renovate bot will create/manage it's business on
-         branches named 'renovate/*'.  Otherwise, and by
-         default, the only the copy of this file that matters
-         is the one on the `main` branch.  No other branches
-         will be monitored or touched in any way.
+and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
 */
 
 {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,25 +53,26 @@
 
   "addLabels": ["release-note-none"],
 
-  "golang": {
-    // N/B: LAST matching rule wins
-    "packageRules": [
-      // Updates for `github.com/containers/*` should be checked hourly.
-      {
-        "matchPackagePrefixes": ["github.com/containers"],
-        "schedule": "before 11am",  // UTC
-      },
+  // N/B: LAST matching rule wins
+  "packageRules": [
+    // Updates for `github.com/containers/*` should be checked more frequently than other deps.
+    {
+      "matchCategories": ["golang"],
+      "schedule": "before 11am",
+      "matchPackageNames": ["github.com/containers{/,}**"]
+    },
 
-      // Updates for c/common, c/image, and c/storage should be grouped into a single PR
-      {
-        "matchPackagePatterns": [
-          "^github.com/containers/common",
-          "^github.com/containers/image",
-          "^github.com/containers/storage",
-        ],
-        "groupName": "common, image, and storage deps",
-        "schedule": "before 11am",  // UTC
-      }
-    ],
+    // Updates for c/common, c/image, and c/storage should be grouped into a single PR.
+    {
+      "matchCategories": ["golang"],
+      "groupName": "common, image, and storage deps",
+      "schedule": "before 11am",
+      "matchPackageNames": [
+        "/^github.com/containers/common/",
+        "/^github.com/containers/image/",
+        "/^github.com/containers/storage/"
+      ]
+    }
+  ],
   }
 }


### PR DESCRIPTION
* The main change is a global "packageRules" config that encompasses all
rules instead of configuring them as options to a manager. [This is
a recommended change by the config-validation tool].

* The previous [header] comment included way too many details.  It also referenced
a docker-hub container image which is not accessible under all
circumstances.  Switch to the GitHub container registry and include
mention of the pre-commit hook that's available.

**N/B:** There's no good way to test this configuration other than running it through the validator (which I did).  If the python management needs adjusting, it can be done in a followup PR.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
