### PR TITLE
remote: fix invalid --cidfile + --ignore

### DIFF
--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -405,6 +405,9 @@ func Stop(ctx context.Context, nameOrID string, options *StopOptions) error {
 		return err
 	}
 	defer response.Body.Close()
+	if options.GetIgnore() && response.StatusCode == http.StatusNotFound {
+		return nil
+	}
 
 	return response.Process(nil)
 }

--- a/pkg/domain/infra/tunnel/helpers.go
+++ b/pkg/domain/infra/tunnel/helpers.go
@@ -24,6 +24,13 @@ func getContainersAndInputByContext(contextWithConnection context.Context, all, 
 	if all && len(namesOrIDs) > 0 {
 		return nil, nil, errors.New("cannot look up containers and all")
 	}
+	// short cut if not all, not filters and no names are given. This can happen with
+	// --ignore and --cidfile, https://github.com/containers/podman/issues/23554.
+	// In this case we have to do nothting and not even have to do a request
+	if !all && len(filters) == 0 && len(namesOrIDs) == 0 {
+		return nil, nil, nil
+	}
+
 	options := new(containers.ListOptions).WithAll(true).WithSync(true).WithFilters(filters)
 	allContainers, err := containers.List(contextWithConnection, options)
 	if err != nil {

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -110,8 +110,15 @@ load helpers
     run_podman 125 stop --cidfile=$nosuchfile
     is "$output" "Error: reading CIDFile: open $nosuchfile: no such file or directory" "podman stop with missing cidfile, without --ignore"
 
+    # create a container to reproduce (#23554)
+    run_podman run -d $IMAGE sleep inf
+    cid="$output"
+
+    # Important for (#23554) that there is no output here
     run_podman stop --cidfile=$nosuchfile --ignore
-    is "$output" "" "podman stop with missing cidfile, with --ignore"
+    is "$output" "" "podman stop with missing cidfile, with --ignore (empty output)"
+
+    run_podman rm -f -t0 $cid
 }
 
 


### PR DESCRIPTION
When the cidfile does not exists and ignore is set the cli parser skips
the file without error and we call into the backend code without any
names at all. This should logically be a NOP but on remote it caused all
containers to be returned which caused podman stop to stop everything in
this case.

Fixes https://github.com/containers/podman/issues/23554

---

pkg/bindings/containers: handle ignore for stop

When the client gets a 404 back we know the container does not exists,
if ignore is set as well we should just ignore the error client side.

seen in https://github.com/containers/podman/issues/23554
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that causes podman-remote --cidfile doesnotexists --ignore to stop all containers.
```
