### PR TITLE
Fix race condition when listing /dev

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -84,7 +84,7 @@ func ParseDockerignore(containerfiles []string, root string) ([]string, string, 
 		// does not attempts to re-resolve it
 		ignoreFile = path
 		ignore, dockerIgnoreErr = os.ReadFile(path)
-		if os.IsNotExist(dockerIgnoreErr) {
+		if errors.Is(dockerIgnoreErr, fs.ErrNotExist) {
 			// In this case either ignorefile was not found
 			// or it is a symlink to unexpected file in such
 			// case manually set ignorefile to `/dev/null` so

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -191,6 +191,9 @@ func getDevices(path string) ([]spec.LinuxDevice, error) {
 			default:
 				sub, err := getDevices(filepath.Join(path, f.Name()))
 				if err != nil {
+					if errors.Is(err, fs.ErrNotExist) {
+						continue
+					}
 					return nil, err
 				}
 				if sub != nil {
@@ -209,7 +212,7 @@ func getDevices(path string) ([]spec.LinuxDevice, error) {
 			if err == errNotADevice {
 				continue
 			}
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
Also replace os.IsNotExist(err) with errors.Is(err, fs.ErrNotExist)

Fixes: https://github.com/containers/podman/issues/23582

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
