### PR TITLE
podman.spec: `Requires: composefs`

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -93,6 +93,9 @@ BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: catatonit
 Requires: conmon >= 2:2.1.7-2
+# Not a strict requirement yet, but we expect it to potentially
+# become one.
+Requires: composefs
 %if %{defined fedora} && 0%{?fedora} >= 40
 # TODO: Remove the f40 conditional after a few releases to keep conditionals to
 # a minimum


### PR DESCRIPTION
This has come up multiple times, most recently in
https://issues.redhat.com/browse/RHELMISC-4891

But also previously when we tried to enable composefs by default in rawhide for a while it was belatedly realized that we were missing this implicit runtime dependency.

Since composefs is tiny, and we want to promote it and make it easier to use, and we consider it a core target for RHEL10, let's add a hard requirement by default.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
