### PR TITLE
CI: 050-stop.bats: make parallel-safe

### DIFF
--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -3,6 +3,7 @@
 load helpers
 
 # Very simple test
+# bats test_tags=ci:parallel
 @test "podman stop - basic test" {
     run_podman run -d $IMAGE sleep 60
     cid="$output"
@@ -36,6 +37,7 @@ load helpers
 }
 
 # #9051 : podman stop --all was not working with podman-remote
+# DO NOT PARALLELIZE! (due to stop -a)
 @test "podman stop --all" {
     # Start three containers, create (without running) a fourth
     run_podman run -d --name c1 $IMAGE sleep 20
@@ -79,6 +81,7 @@ load helpers
     run_podman rm $cid1 $cid2 $cid3 $cid4
 }
 
+# DO NOT PARALLELIZE! (due to stop -a)
 @test "podman stop print IDs or raw input" {
     # stop -a must print the IDs
     run_podman run -d $IMAGE top
@@ -96,6 +99,7 @@ load helpers
 }
 
 # #9051 : podman stop --ignore was not working with podman-remote
+# bats test_tags=ci:parallel
 @test "podman stop --ignore" {
     name=thiscontainerdoesnotexist
     run_podman 125 stop $name
@@ -122,10 +126,8 @@ load helpers
 }
 
 
-# Test fallback
-
-
 # Regression test for #2472
+# bats test_tags=ci:parallel
 @test "podman stop - can trap signal" {
     # Because the --time and --timeout options can be wonky, try three
     # different variations of this test.
@@ -158,6 +160,7 @@ load helpers
 }
 
 # Regression test for #8501
+# bats test_tags=ci:parallel
 @test "podman stop - unlock while waiting for timeout" {
     # Test that the container state transitions to "stopping" and that other
     # commands can get the container's lock.  To do that, run a container that
@@ -165,22 +168,23 @@ load helpers
     # to finish.  This gives us enough time to try some commands and inspect
     # the container's status.
 
-    run_podman run --name stopme -d $IMAGE sh -c \
+    ctrname="c-stopme-$(safename)"
+    run_podman run --name $ctrname -d $IMAGE sh -c \
         "trap 'echo Received SIGTERM, ignoring' SIGTERM; echo READY; while :; do sleep 0.2; done"
 
-    wait_for_ready stopme
+    wait_for_ready $ctrname
 
     local t0=$SECONDS
     # Stop the container, but do so in the background so we can inspect
     # the container status while it's stopping. Use $PODMAN because we
     # don't want the overhead and error checks of run_podman.
-    $PODMAN stop -t 20 stopme &
+    $PODMAN stop -t 20 $ctrname &
 
     # Wait for container to acknowledge the signal. We can't use wait_for_output
     # because that aborts if .State.Running != true
     local timeout=5
     while [[ $timeout -gt 0 ]]; do
-        run_podman logs stopme
+        run_podman logs $ctrname
         if [[ "$output" =~ "Received SIGTERM, ignoring" ]]; then
             break
         fi
@@ -193,7 +197,7 @@ load helpers
     run_podman ps -a
 
     # The container state transitioned to "stopping"
-    run_podman inspect --format '{{.State.Status}}' stopme
+    run_podman inspect --format '{{.State.Status}}' $ctrname
     is "$output" "stopping" "Status of container should be 'stopping'"
 
     # Time check: make sure we were able to run 'ps' before the container
@@ -201,36 +205,42 @@ load helpers
     local delta_t=$(( $SECONDS - t0 ))
     assert $delta_t -le 5 "Operations took too long"
 
-    run_podman kill stopme
-    run_podman wait stopme
+    run_podman kill $ctrname
+    run_podman wait $ctrname
 
     # Exit code should be 137 as it was killed
-    run_podman inspect --format '{{.State.ExitCode}}' stopme
+    run_podman inspect --format '{{.State.ExitCode}}' $ctrname
     is "$output" "137" "Exit code of killed container"
 
-    run_podman rm stopme
+    run_podman rm $ctrname
 }
 
+# bats test_tags=ci:parallel
 @test "podman stop -t 1 Generate warning" {
     skip_if_remote "warning only happens on server side"
-    run_podman run --rm --name stopme -d $IMAGE sleep 100
+
+    ctrname="c-stopme-$(safename)"
+    run_podman run --rm --name $ctrname -d $IMAGE sleep 100
 
     local plusw="+w"
     if is_remote; then
         plusw=
     fi
-    run_podman 0$plusw stop -t 1 stopme
+    run_podman 0$plusw stop -t 1 $ctrname
     if [[ -n "$plusw" ]]; then
-        require_warning ".*StopSignal SIGTERM failed to stop container stopme in 1 seconds, resorting to SIGKILL"
+        require_warning ".*StopSignal SIGTERM failed to stop container $ctrname in 1 seconds, resorting to SIGKILL"
     fi
 }
 
+# bats test_tags=ci:parallel
 @test "podman stop --noout" {
-    run_podman run --rm --name stopme -d $IMAGE top
-    run_podman --noout stop -t 0 stopme
+    ctrname="c-$(safename)"
+    run_podman run --rm --name $ctrname -d $IMAGE top
+    run_podman --noout stop -t 0 $ctrname
     is "$output" "" "output should be empty"
 }
 
+# bats test_tags=ci:parallel
 @test "podman stop, with --rm container" {
     OCIDir=/run/$(podman_runtime)
 
@@ -238,9 +248,10 @@ load helpers
         OCIDir=/run/user/$(id -u)/$(podman_runtime)
     fi
 
-    run_podman run --rm -d --name rmstop $IMAGE sleep infinity
+    ctrname="c-$(safename)"
+    run_podman run --rm -d --name $ctrname $IMAGE sleep infinity
     local cid="$output"
-    run_podman stop -t0 rmstop
+    run_podman stop -t0 $ctrname
 
     # Check the OCI runtime directory has removed.
     is "$(ls $OCIDir | grep $cid)" "" "The OCI runtime directory should have been removed"


### PR DESCRIPTION
Very few changes needed, all of them simple.

It is impossible to parallelize this entire file, because "stop -a".
Add tags to tests that can be parallelized, and comments to those
that can't.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```