### PR TITLE
[CI:ALL] Fix and validate renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,5 +55,4 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
       ]
     }
   ],
-  }
 }

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -62,6 +62,12 @@ if [[ "${DISTRO_NV}" == "$PRIOR_FEDORA_NAME" ]]; then
     # Tests for lib.sh
     showrun ${SCRIPT_BASE}/lib.sh.t
 
+    msg "Checking renovate config."
+    showrun podman run -it \
+            -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
+            ghcr.io/renovatebot/renovate:latest \
+            renovate-config-validator
+
     # Run this during daily cron job to prevent a GraphQL API change/breakage
     # from impacting every PR.  Down-side being if it does fail, a maintainer
     # will need to do some archaeology to find it.


### PR DESCRIPTION
Fix a syntax error, also perform renovate config validation during CI.

Fixes #23586

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
