### PR TITLE
CI: system tests: make random_free_port() parallel-safe

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -41,6 +41,9 @@ if [ $(id -u) -eq 0 ]; then
     _LOG_PROMPT='#'
 fi
 
+# Used in helpers.network, needed here in teardown
+PORT_LOCK_DIR=$BATS_SUITE_TMPDIR/reserved-ports
+
 ###############################################################################
 # BEGIN tools for fetching & caching test images
 #
@@ -204,6 +207,14 @@ function defer-assertion-failures() {
 # Basic teardown: remove all pods and containers
 function basic_teardown() {
     echo "# [teardown]" >&2
+
+    # Free any ports reserved by our test
+    if [[ -d $PORT_LOCK_DIR ]]; then
+        mylocks=$(grep -wlr $BATS_SUITE_TEST_NUMBER $PORT_LOCK_DIR || true)
+        if [[ -n "$mylocks" ]]; then
+            rm -f $mylocks
+        fi
+    fi
 
     immediate-assertion-failures
     # Unlike normal tests teardown will not exit on first command failure

--- a/test/system/helpers.t
+++ b/test/system/helpers.t
@@ -22,6 +22,9 @@ rc=0
 PODMAN_TMPDIR=$(mktemp -d --tmpdir=${TMPDIR:-/tmp} podman_helper_tests.XXXXXX)
 trap 'rm -rf $PODMAN_TMPDIR' 0
 
+# Used by random_free_port.
+PORT_LOCK_DIR=$PODMAN_TMPDIR/reserved-ports
+
 ###############################################################################
 # BEGIN test the parse_table helper
 


### PR DESCRIPTION
...by using a crude port lock-and-reserve mechanism. This is
a small cherrypick from code that has been working in #23275
over dozens of CI runs. Am separating out into a small PR
because it's stable, harmless to serial runs, and will
simplify the eventual review of #23275.

Closes: #23488

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```