### PR TITLE
Fix CI: misc parallel flakes 

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -324,7 +324,7 @@ function _log_test_follow_since() {
 
     # Now do the same with a running container to check #16950.
     run_podman ${events_backend} run --log-driver=$driver --name $cname -d $IMAGE \
-        sh -c "sleep 1; while :; do echo $content && sleep 5; done"
+        sh -c "sleep 1; while :; do echo $content && sleep 1; done"
 
     # sleep is required to make sure the podman event backend no longer sees the start event in the log
     # This value must be greater or equal than the value given in --since below
@@ -332,7 +332,7 @@ function _log_test_follow_since() {
 
     # Make sure podman logs actually follows by giving a low timeout and check that the command times out
     PODMAN_TIMEOUT=3 run_podman 124 ${events_backend} logs --since 0.1s -f $cname
-    assert "$output" =~ "^$content
+    assert "$output" =~ "${content}
 timeout: sending signal TERM to command.*" "logs --since -f on running container works"
 
     run_podman ${events_backend} rm -t 0 -f $cname

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -363,16 +363,17 @@ function _log_test_follow_until() {
     run_podman ${events_backend} run --log-driver=$driver --name $cname -d $IMAGE \
         sh -c "n=1;while :; do echo $content--\$n; n=\$((n+1));sleep 0.1; done"
 
-    t0=$SECONDS
+    t0=$(date +%s%3N)
     # The logs command should exit after the until time even when follow is set
     PODMAN_TIMEOUT=10 run_podman ${events_backend} logs --until 3s -f $cname
-    t1=$SECONDS
+    t1=$(date +%s%3N)
+
     logs_seen="$output"
 
     # The delta should be 3 but because it could be a bit longer on a slow system such as CI we also accept 4.
-    delta_t=$(( $t1 - $t0 ))
-    assert $delta_t -gt 2 "podman logs --until: exited too early!"
-    assert $delta_t -lt 5 "podman logs --until: exited too late!"
+    delta_t_ms=$(($t1 - $t0))
+    assert $delta_t_ms -gt 2000 "podman logs --until: exited too early!"
+    assert $delta_t_ms -lt 5000 "podman logs --until: exited too late!"
 
     # Impossible to know how many lines we'll see, but require at least two
     assert "$logs_seen" =~ "$content--1


### PR DESCRIPTION
This PR fixes parallel flakes. 

- `|035| podman logs - --until --follow journald`  The bash `$SECONDS` are not accurate because the time is rounded to whole seconds. So if the t0 is 1856ms, but the $SECONDS is still 1, this inaccuracy causes the command to be at most only about 150ms late which is less variation than I observed between test runs (the time was around 3150-3650ms). At higher workloads, this delay can be larger. Measuring time in `ms` should solve the problem. 

- `[035] podman logs - multi k8s-file test`:  issue: https://github.com/containers/podman/issues/21914

- `[035] podman logs - --since --follow journald` I would say that when running in parallel the journald is used by multiple containers, so it will be necessary to increase the timeout time to give the container more time to write to the journald, and also perform a check, end of journald content.


Fixes: #23682

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
