### PR TITLE
libpod: simplify WaitForExit()

### DIFF
--- a/docs/source/markdown/podman-wait.1.md.in
+++ b/docs/source/markdown/podman-wait.1.md.in
@@ -16,10 +16,13 @@ separated by newline in the same order as they were given to the command.  An
 exit code of -1 is emitted for all conditions other than "stopped" and
 "exited".
 
-NOTE: there is an inherent race condition when waiting for containers with a
-restart policy of `always` or `on-failure`, such as those created by `podman
-kube play`. Such containers may be repeatedly exiting and restarting, possibly
-with different exit codes, but `podman wait` can only display and detect one.
+When waiting for containers with a restart policy of `always` or `on-failure`,
+such as those created by `podman kube play`, the containers may be repeatedly
+exiting and restarting, possibly with different exit codes. `podman wait` will
+only display and detect the first exit after the wait command was started.
+
+When running a container with podman run --rm wait should wait for the
+container to be fully removed as well before it returns.
 
 ## OPTIONS
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2163,6 +2163,11 @@ func (c *Container) stopPodIfNeeded(ctx context.Context) error {
 		return nil
 	}
 
+	// Never try to stop the pod when a init container stopped
+	if c.IsInitCtr() {
+		return nil
+	}
+
 	pod, err := c.runtime.state.Pod(c.config.Pod)
 	if err != nil {
 		return fmt.Errorf("container %s is in pod %s, but pod cannot be retrieved: %w", c.ID(), c.config.Pod, err)

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -694,16 +694,14 @@ func (c *Container) makePlatformBindMounts() error {
 }
 
 func (c *Container) getConmonPidFd() int {
-	if c.state.ConmonPID != 0 {
-		// Track lifetime of conmon precisely using pidfd_open + poll.
-		// There are many cases for this to fail, for instance conmon is dead
-		// or pidfd_open is not supported (pre linux 5.3), so fall back to the
-		// traditional loop with poll + sleep
-		if fd, err := unix.PidfdOpen(c.state.ConmonPID, 0); err == nil {
-			return fd
-		} else if err != unix.ENOSYS && err != unix.ESRCH {
-			logrus.Debugf("PidfdOpen(%d) failed: %v", c.state.ConmonPID, err)
-		}
+	// Track lifetime of conmon precisely using pidfd_open + poll.
+	// There are many cases for this to fail, for instance conmon is dead
+	// or pidfd_open is not supported (pre linux 5.3), so fall back to the
+	// traditional loop with poll + sleep
+	if fd, err := unix.PidfdOpen(c.state.ConmonPID, 0); err == nil {
+		return fd
+	} else if err != unix.ENOSYS && err != unix.ESRCH {
+		logrus.Debugf("PidfdOpen(%d) failed: %v", c.state.ConmonPID, err)
 	}
 	return -1
 }

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -28,13 +28,6 @@ func (r *Runtime) RemoveVolume(ctx context.Context, v *Volume, force bool, timeo
 		return define.ErrRuntimeStopped
 	}
 
-	if !v.valid {
-		if ok, _ := r.state.HasVolume(v.Name()); !ok {
-			// Volume probably already removed
-			// Or was never in the runtime to begin with
-			return nil
-		}
-	}
 	return r.removeVolume(ctx, v, force, timeout, false)
 }
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1289,13 +1289,15 @@ EOF
     rm -rf $romount
 }
 
-@test "podman run --restart=always -- wait" {
+@test "podman run --restart=always/on-failure -- wait" {
     # regression test for #18572 to make sure Podman waits less than 20 seconds
     ctr=c_$(safename)
-    run_podman run -d --restart=always --name=$ctr $IMAGE false
-    PODMAN_TIMEOUT=20 run_podman wait $ctr
-    is "$output" "1" "container should exit 1"
-    run_podman rm -f -t0 $ctr
+    for policy in always on-failure; do
+        run_podman run -d --restart=$policy --name=$ctr $IMAGE false
+        PODMAN_TIMEOUT=20 run_podman wait $ctr
+        is "$output" "1" "container should exit 1 (policy: $policy)"
+        run_podman rm -f -t0 $ctr
+    done
 }
 
 @test "podman run - custom static_dir" {


### PR DESCRIPTION
The current code did several complicated state checks that simply do not work properly on a fast restarting container. It uses a special case for --restart=always but forgot to take care of --restart=on-failure which always hang for 20s until it run into the timeout.

The old logic also used to call CheckConmonRunning() but synced the state before which means it may check a new conmon every time and thus misses exits.

To fix the new the code is much simpler. Check the conmon pid, if it is no longer running then get then check exit file and get exit code.

This is related to #23473 but I am not sure if this fixes it because we cannot reproduce.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a bug where `podman wait` would exit only after 20s on a fast restarting container with a restart policy of on-failure.  
```
