### PR TITLE
Add ssh options to podman machine tests

### DIFF
--- a/pkg/machine/e2e/config_ssh_test.go
+++ b/pkg/machine/e2e/config_ssh_test.go
@@ -26,6 +26,12 @@ func (s *sshMachine) withUsername(name string) *sshMachine { //nolint:unused
 }
 
 func (s *sshMachine) withSSHCommand(sshCommand []string) *sshMachine {
-	s.sshCommand = sshCommand
+	sshOptions := []string{
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "CheckHostIP=no",
+    }
+    // Combine the options with the provided SSH command
+    s.sshCommand = append(sshOptions, sshCommand...)
 	return s
 }


### PR DESCRIPTION
Add options UserKnownHostsFile=/dev/null, StrictHostKeyChecking=no, and CheckHostIP=no to machine tests so we can share known_hosts files avoiding Remote Host Identification errors.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
