### PR TITLE
Fix known_hosts file clogging and remote host id

### DIFF
--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -116,7 +116,10 @@ func commonNativeSSH(username, identityPath, name string, sshPort int, inputArgs
 
 	args := []string{"-i", identityPath, "-p", port, sshDestination,
 		"-o", "IdentitiesOnly=yes",
-		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=" + os.DevNull,
+		"-o", "CheckHostIP=no",
+		"-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
 	if len(inputArgs) > 0 {
 		interactive = false
 		args = append(args, inputArgs...)


### PR DESCRIPTION
By enabling UserKnownHostsFile=/dev/null option to the defaults in podman machine ssh we prevent the user from adding the host key multiple times.

Resolves: https://github.com/containers/podman/issues/23505

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
