### PR TITLE
CI: remove build-time quay check

### DIFF
--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -94,26 +94,3 @@ cat ${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/required_host_ports.txt | \
             err_retry 9 1000 1 nc -zv -w 13 $host $port
         fi
     done
-
-# Verify we can pull metadata from a few key testing images on quay.io
-# in the 'libpod' namespace.  This is mostly aimed at validating the
-# quay.io service is up and responsive.  Images were hand-picked with
-# grep -E -ro 'quay.io/libpod/.+:latest' test | sort -u
-TEST_IMGS=(\
-    alpine:latest
-    busybox:latest
-    alpine_labels:latest
-    alpine_nginx:latest
-    alpine_healthcheck:latest
-    badhealthcheck:latest
-    cirros:latest
-)
-
-msg "Checking quay.io test image accessibility"
-for testimg in "${TEST_IMGS[@]}"; do
-    fqin="quay.io/libpod/$testimg"
-    echo "    $fqin"
-    # Belt-and-suspenders: Catch skopeo (somehow) returning False or null
-    # in addition to "bad" (invalid) JSON.
-    skopeo inspect --retry-times 5 "docker://$fqin" | jq -e . > /dev/null
-done


### PR DESCRIPTION
CI will fail if quay is down, but a build-time check does not
help us in any way. It just introduces another pain point
where we have to hit the Rerun button.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```