### PR TITLE
CI: quadlet tests: make parallel-safe

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -3,6 +3,8 @@
 # Tests generated configurations for systemd.
 #
 
+# bats file_tags=ci:parallel
+
 load helpers
 load helpers.network
 load helpers.registry
@@ -184,7 +186,7 @@ function wait_for_journal() {
 @test "quadlet - basic" {
     # Network=none is to work around a Pasta bug, can be removed once a patched Pasta is available.
     # Ref https://github.com/containers/podman/pull/21563#issuecomment-1965145324
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -223,7 +225,7 @@ EOF
     # only process the first name
     dir1=$PODMAN_TMPDIR/$(random_string)
     dir2=$PODMAN_TMPDIR/$(random_string)
-    local quadlet_file=basic_$(random_string).container
+    local quadlet_file=basic_$(safename).container
     mkdir -p $dir1 $dir2
 
     cat > $dir1/$quadlet_file <<EOF
@@ -245,7 +247,7 @@ EOF
 }
 
 @test "quadlet - envvar" {
-    local quadlet_file=$PODMAN_TMPDIR/envvar_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/envvar_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -269,7 +271,7 @@ EOF
 }
 
 @test "quadlet - ContainerName and journal output check" {
-    local quadlet_file=$PODMAN_TMPDIR/containername_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/containername_$(safename).container
     local token_out="STDOUT$(random_string 10)"
     local token_err="STDERR$(random_string 10)"
     cat > $quadlet_file <<EOF
@@ -302,7 +304,7 @@ EOF
 }
 
 @test "quadlet - labels" {
-    local quadlet_file=$PODMAN_TMPDIR/labels_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/labels_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -328,7 +330,7 @@ EOF
 }
 
 @test "quadlet - oneshot" {
-    local quadlet_file=$PODMAN_TMPDIR/oneshot_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/oneshot_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -351,7 +353,7 @@ EOF
 }
 
 @test "quadlet - volume" {
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).volume
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).volume
     cat > $quadlet_file <<EOF
 [Volume]
 Label=foo=bar other="with space"
@@ -377,7 +379,7 @@ EOF
 # A quadlet container depends on a quadlet volume
 @test "quadlet - volume dependency" {
     # Save the unit name to use as the volume for the container
-    local quadlet_vol_unit=dep_$(random_string).volume
+    local quadlet_vol_unit=dep_$(safename).volume
     local quadlet_vol_file=$PODMAN_TMPDIR/${quadlet_vol_unit}
     cat > $quadlet_vol_file <<EOF
 [Volume]
@@ -391,7 +393,7 @@ EOF
     local vol_service=$QUADLET_SERVICE_NAME
     local volume_name=systemd-$(basename $quadlet_vol_file .volume)
 
-    local quadlet_file=$PODMAN_TMPDIR/user_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/user_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -427,7 +429,7 @@ EOF
 # A quadlet container depends on a named quadlet volume
 @test "quadlet - named volume dependency" {
     # Save the unit name to use as the volume for the container
-    local quadlet_vol_unit=dep_$(random_string).volume
+    local quadlet_vol_unit=dep_$(safename).volume
     local quadlet_vol_file=$PODMAN_TMPDIR/${quadlet_vol_unit}
     cat > $quadlet_vol_file <<EOF
 [Volume]
@@ -442,7 +444,7 @@ EOF
     local vol_service=$QUADLET_SERVICE_NAME
     local volume_name="foo"
 
-    local quadlet_file=$PODMAN_TMPDIR/user_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/user_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -480,7 +482,7 @@ EOF
 }
 
 @test "quadlet - network" {
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).network
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).network
     cat > $quadlet_file <<EOF
 [Network]
 Label=foo=bar other="with space"
@@ -505,7 +507,7 @@ EOF
 # A quadlet container depends on a quadlet network
 @test "quadlet - network dependency" {
     # Save the unit name to use as the network for the container
-    local quadlet_network_unit=dep_$(random_string).network
+    local quadlet_network_unit=dep_$(safename).network
     local quadlet_network_file=$PODMAN_TMPDIR/${quadlet_network_unit}
     cat > $quadlet_network_file <<EOF
 [Network]
@@ -519,7 +521,7 @@ EOF
     local network_service=$QUADLET_SERVICE_NAME
     local network_name=systemd-$(basename $quadlet_network_file .network)
 
-    local quadlet_file=$PODMAN_TMPDIR/user_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/user_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -552,7 +554,7 @@ EOF
 # A quadlet container depends on a named quadlet network
 @test "quadlet - named network dependency" {
     # Save the unit name to use as the network for the container
-    local quadlet_network_unit=dep_$(random_string).network
+    local quadlet_network_unit=dep_$(safename).network
     local quadlet_network_file=$PODMAN_TMPDIR/${quadlet_network_unit}
     cat > $quadlet_network_file <<EOF
 [Network]
@@ -567,7 +569,7 @@ EOF
     local network_service=$QUADLET_SERVICE_NAME
     local network_name="foo"
 
-    local quadlet_file=$PODMAN_TMPDIR/user_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/user_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -603,9 +605,9 @@ EOF
 
 @test "quadlet kube - basic" {
     # Create the YAMl file
-    pod_name="test_pod"
-    container_name="test"
-    yaml_source="$PODMAN_TMPDIR/basic_$(random_string).yaml"
+    pod_name="p-$(safename)"
+    container_name="c-$(safename)"
+    yaml_source="$PODMAN_TMPDIR/basic_$(safename).yaml"
     cat >$yaml_source <<EOF
 apiVersion: v1
 kind: Pod
@@ -625,7 +627,7 @@ spec:
 EOF
 
     # Create the Quadlet file
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).kube
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).kube
     cat > $quadlet_file <<EOF
 [Kube]
 Yaml=${yaml_source}
@@ -637,21 +639,20 @@ EOF
     # Ensure we have output.
     wait_for_output "STARTED CONTAINER" $pod_name-$container_name
 
-    run_podman container inspect  --format "{{.State.Status}}" test_pod-test
+    run_podman container inspect  --format "{{.State.Status}}" $pod_name-$container_name
     is "$output" "running" "container should be started by systemd and hence be running"
 
     service_cleanup $QUADLET_SERVICE_NAME inactive
-    run_podman rmi $(pause_image)
-    run_podman network rm podman-default-kube-network
 }
 
 @test "quadlet kube - named network dependency" {
     # Save the unit name to use as the network for the container
-    local quadlet_network_unit=dep_$(random_string).network
+    local quadlet_network_unit=dep_$(safename).network
     local quadlet_network_file=$PODMAN_TMPDIR/${quadlet_network_unit}
+    local network_name="n-$(safename)"
     cat > $quadlet_network_file <<EOF
 [Network]
-NetworkName=foo
+NetworkName=${network_name}
 EOF
 
     # Have quadlet create the systemd unit file for the network unit
@@ -660,12 +661,11 @@ EOF
 
     # Save the network service name since the variable will be overwritten
     local network_service=$QUADLET_SERVICE_NAME
-    local network_name="foo"
 
     # Create the YAMl file
-    pod_name="test_pod"
-    container_name="test"
-    yaml_source="$PODMAN_TMPDIR/basic_$(random_string).yaml"
+    pod_name="p-$(safename)"
+    container_name="c-$(safename)"
+    yaml_source="$PODMAN_TMPDIR/basic_$(safename).yaml"
     cat >$yaml_source <<EOF
 apiVersion: v1
 kind: Pod
@@ -685,7 +685,7 @@ spec:
 EOF
 
     # Create the Quadlet file
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).kube
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).kube
     cat > $quadlet_file <<EOF
 [Kube]
 Yaml=${yaml_source}
@@ -708,22 +708,21 @@ EOF
     # Ensure we have output.
     wait_for_output "STARTED CONTAINER" $pod_name-$container_name
 
-    run_podman container inspect  --format "{{.State.Status}}" test_pod-test
+    run_podman container inspect  --format "{{.State.Status}}" $pod_name-$container_name
     assert "$output" =~ "running" "container should be started by systemd and hence be running"
 
     # Container should be attached to defined network
-    run_podman container inspect --format "{{index .NetworkSettings.Networks \"$network_name\"}}" test_pod-test
+    run_podman container inspect --format "{{index .NetworkSettings.Networks \"$network_name\"}}" $pod_name-$container_name
     assert "$output" != "<nil>" "container should be attached to network $network_name"
 
     service_cleanup $QUADLET_SERVICE_NAME inactive
     run_podman network rm $network_name
-    run_podman rmi $(pause_image)
 }
 
 @test "quadlet - rootfs" {
     skip_if_no_selinux
     skip_if_rootless
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Rootfs=/:O
@@ -739,7 +738,7 @@ EOF
 
 @test "quadlet - selinux disable" {
     skip_if_no_selinux
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -761,8 +760,8 @@ EOF
 
 @test "quadlet - selinux labels" {
     skip_if_no_selinux
-    NAME=$(random_string)
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    NAME=name$(safename)
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 ContainerName=$NAME
@@ -791,7 +790,7 @@ EOF
 @test "quadlet - secret as environment variable" {
     create_secret
 
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 ContainerName=$NAME
@@ -817,7 +816,7 @@ EOF
 @test "quadlet - secret as a file" {
     create_secret
 
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 ContainerName=$NAME
@@ -846,7 +845,7 @@ EOF
     # Step 1: determine what systemd is using for %T. There does not
     # seem to be any systemctly way to find this.
     percent_t_file="${PODMAN_TMPDIR}/foo"
-    local service=get-percent-t.$(random_string 10).service
+    local service=get-percent-t.$(safename).service
     local unitfile=${UNIT_DIR}/$service
     cat >$unitfile <<EOF
 [Unit]
@@ -872,7 +871,7 @@ EOF
     local file_content="data_$(random_string 15)"
     echo $file_content > $tmp_path/$file_name
 
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -891,7 +890,7 @@ EOF
 }
 
 @test "quadlet - tmpfs" {
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -916,7 +915,7 @@ EOF
 }
 
 @test "quadlet - userns" {
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).container
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
 [Container]
 Image=$IMAGE
@@ -934,15 +933,15 @@ EOF
 }
 
 @test "quadlet - exit-code propagation" {
-   pod_name="test_pod"
-   container_name="ctr"
+   pod_name="p-$(safename)"
+   container_name="c-$(safename)"
    exit_tests="
 all  | true  | 0   | inactive
 all  | false | 137 | failed
 none | false | 0   | inactive
 "
    while read exit_code_prop cmd exit_code service_state; do
-      local basename=propagate-${exit_code_prop}-${cmd}-$(random_string)
+      local basename=propagate-${exit_code_prop}-${cmd}_$(safename)
       local quadlet_file=$PODMAN_TMPDIR/$basename.kube
       local yaml_file=$PODMAN_TMPDIR/$basename.yaml
 
@@ -1007,19 +1006,17 @@ EOF
 
       # This is the actual propagation check
       service_cleanup $QUADLET_SERVICE_NAME $service_state
-      run_podman ps -aq
-      is "$output" "" "all containers are cleaned up even in case of errors"
+      run_podman ps -a
+      assert "$output" !~ "$(safename)" \
+             "all containers are cleaned up even in case of errors"
    done < <(parse_table "$exit_tests")
-
-   run_podman rmi $(pause_image)
-   run_podman network rm podman-default-kube-network
 }
 
 @test "quadlet kube - Working Directory" {
-    yaml_source="$PODMAN_TMPDIR/basic_$(random_string).yaml"
+    yaml_source="$PODMAN_TMPDIR/basic_$(safename).yaml"
     local_path=local_path$(random_string)
-    pod_name=test_pod
-    container_name=test
+    pod_name="p-$(safename)"
+    container_name="c-$(safename)"
 
     cat >$yaml_source <<EOF
 apiVersion: v1
@@ -1050,7 +1047,7 @@ spec:
 EOF
 
     # Create the Quadlet file
-    local quadlet_file=$PODMAN_TMPDIR/basic_$(random_string).kube
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).kube
     cat > $quadlet_file <<EOF
 [Kube]
 Yaml=${yaml_source}
@@ -1072,8 +1069,6 @@ EOF
     is $(cat $PODMAN_TMPDIR/$local_path/test.txt) "hello"
 
     service_cleanup $QUADLET_SERVICE_NAME inactive
-    run_podman rmi $(pause_image)
-    run_podman network rm podman-default-kube-network
 }
 
 @test "quadlet - image files" {
@@ -1083,7 +1078,7 @@ EOF
     local image_for_test=$registry/quadlet_image_test:$(random_string)
     local authfile=$PODMAN_TMPDIR/authfile.json
 
-    local quadlet_image_unit=image_test_$(random_string).image
+    local quadlet_image_unit=image_test_$(safename).image
     local quadlet_image_file=$PODMAN_TMPDIR/$quadlet_image_unit
     cat > $quadlet_image_file <<EOF
 [Image]
@@ -1092,7 +1087,7 @@ AuthFile=$authfile
 TLSVerify=false
 EOF
 
-    local quadlet_volume_unit=image_test_$(random_string).volume
+    local quadlet_volume_unit=image_test_$(safename).volume
     local quadlet_volume_file=$PODMAN_TMPDIR/$quadlet_volume_unit
     local volume_name=systemd-$(basename $quadlet_volume_file .volume)
     cat > $quadlet_volume_file <<EOF
@@ -1101,7 +1096,7 @@ Driver=image
 Image=$quadlet_image_unit
 EOF
 
-    local quadlet_container_unit=image_test_$(random_string).container
+    local quadlet_container_unit=image_test_$(safename).container
     local quadlet_container_file=$PODMAN_TMPDIR/$quadlet_container_unit
     cat > $quadlet_container_file <<EOF
 [Container]
@@ -1202,7 +1197,7 @@ EOF
 
 @test "quadlet - kube oneshot" {
     local quadlet_tmpdir=$PODMAN_TMPDIR/quadlets
-    local test_random_string=$(random_string)
+    local test_random_string=r_$(safename)
 
     local quadlet_kube_volume_name=test-volume_$test_random_string
     local quadlet_kube_volume_yaml_file=$PODMAN_TMPDIR/volume_$test_random_string.yaml
@@ -1230,8 +1225,8 @@ Type=oneshot
 RemainAfterExit=yes
 EOF
 
-    local pod_name="test_pod_$test_random_string"
-    local container_name="test"
+    local pod_name="p-$(safename)"
+    local container_name="c-$(safename)"
     local quadlet_kube_pod_yaml_file=$PODMAN_TMPDIR/pod_$test_random_string.yaml
     cat > $quadlet_kube_pod_yaml_file <<EOF
 apiVersion: v1
@@ -1304,16 +1299,14 @@ EOF
     # Shutdown the service and remove the volume
     service_cleanup $pod_service inactive
     run_podman volume rm $quadlet_kube_volume_name
-    run_podman rmi --ignore $(pause_image)
-    run_podman network rm podman-default-kube-network
 }
 
 @test "quadlet - kube down force" {
     local test_random_string=$(random_string)
 
     local quadlet_kube_volume_name=test-volume_$test_random_string
-    local pod_name="test_pod_$test_random_string"
-    local container_name="test"
+    local pod_name="p-$(safename)"
+    local container_name="c-$(safename)"
     local quadlet_kube_pod_yaml_file=$PODMAN_TMPDIR/pod_$test_random_string.yaml
     cat > $quadlet_kube_pod_yaml_file <<EOF
 ---
@@ -1384,8 +1377,6 @@ EOF
 
     # Volume should not exist
     run_podman 1 volume exists ${quadlet_kube_volume_name}
-    run_podman rmi --ignore $(pause_image)
-    run_podman network rm podman-default-kube-network
 }
 
 @test "quadlet - image tag" {
@@ -1393,7 +1384,7 @@ EOF
     local archive_file=$PODMAN_TMPDIR/archive-file.tar
     local image_for_test=localhost/quadlet_image_test:$(random_string)
 
-    local quadlet_image_unit=image_test_$(random_string).image
+    local quadlet_image_unit=image_test_$(safename).image
     local quadlet_image_file=$PODMAN_TMPDIR/$quadlet_image_unit
     cat > $quadlet_image_file <<EOF
 [Image]
@@ -1401,7 +1392,7 @@ Image=docker-archive:$archive_file
 ImageTag=$image_for_test
 EOF
 
-    local quadlet_volume_unit=image_test_$(random_string).volume
+    local quadlet_volume_unit=image_test_$(safename).volume
     local quadlet_volume_file=$PODMAN_TMPDIR/$quadlet_volume_unit
     local volume_name=systemd-$(basename $quadlet_volume_file .volume)
     cat > $quadlet_volume_file <<EOF
@@ -1410,7 +1401,7 @@ Driver=image
 Image=$quadlet_image_unit
 EOF
 
-    local quadlet_container_unit=image_test_$(random_string).container
+    local quadlet_container_unit=image_test_$(safename).container
     local quadlet_container_file=$PODMAN_TMPDIR/$quadlet_container_unit
     cat > $quadlet_container_file <<EOF
 [Container]
@@ -1472,14 +1463,13 @@ EOF
     # Shutdown the service and remove the image
     service_cleanup $container_service failed
     run_podman image rm --ignore $image_for_test
-    run_podman rmi --ignore $(pause_image)
     run_podman volume rm $volume_name
 }
 
 @test "quadlet - pod simple" {
     local quadlet_tmpdir=$PODMAN_TMPDIR/quadlets
 
-    local test_pod_name=pod_test_$(random_string)
+    local test_pod_name=pod_test_$(safename)
     local quadlet_pod_unit=$test_pod_name.pod
     local quadlet_pod_file=$PODMAN_TMPDIR/$quadlet_pod_unit
     cat > $quadlet_pod_file <<EOF
@@ -1487,7 +1477,7 @@ EOF
 PodName=$test_pod_name
 EOF
 
-    local quadlet_container_unit=pod_test_$(random_string).container
+    local quadlet_container_unit=pod_test_$(safename).container
     local quadlet_container_file=$PODMAN_TMPDIR/$quadlet_container_unit
     cat > $quadlet_container_file <<EOF
 [Container]
@@ -1534,8 +1524,6 @@ EOF
 
     # Container should not exist
     run_podman 1 container exists ${container_name}
-
-    run_podman rmi $(pause_image)
 }
 
 # This test reproduces https://github.com/containers/podman/issues/20432
@@ -1545,8 +1533,9 @@ EOF
 @test "quadlet - kube build from unavailable image with no tag" {
     local quadlet_tmpdir=$PODMAN_TMPDIR/quadlets
 
+    # FIXME: how to make this parallel-safe? Can we?
     local untagged_image=quay.io/libpod/busybox
-    local built_image=test_image
+    local built_image="built-$(safename)"
     local yaml_dir=$quadlet_tmpdir/$built_image
     local build_dir=$yaml_dir/$built_image
 
@@ -1559,9 +1548,9 @@ FROM $untagged_image
 EOF
 
     # Create the YAMl file
-    pod_name="test_pod"
-    container_name="test"
-    yaml_source="$yaml_dir/build_$(random_string).yaml"
+    pod_name="p-$(safename)"
+    container_name="c-$(safename)"
+    yaml_source="$yaml_dir/build_$(safename).yaml"
     cat >$yaml_source <<EOF
 apiVersion: v1
 kind: Pod
@@ -1581,7 +1570,7 @@ spec:
 EOF
 
     # Create the Quadlet file
-    local quadlet_file=$quadlet_tmpdir/build_$(random_string).kube
+    local quadlet_file=$quadlet_tmpdir/build_$(safename).kube
     cat > $quadlet_file <<EOF
 [Kube]
 Yaml=${yaml_source}
@@ -1598,18 +1587,17 @@ EOF
     # Ensure we have output.
     wait_for_output "STARTED CONTAINER" $pod_name-$container_name
 
-    run_podman container inspect  --format "{{.State.Status}}" test_pod-test
+    run_podman container inspect  --format "{{.State.Status}}" $pod_name-$container_name
     is "$output" "running" "container should be started by systemd and hence be running"
 
     service_cleanup $QUADLET_SERVICE_NAME inactive
-    run_podman rmi $untagged_image:latest $built_image $(pause_image)
-    run_podman network rm podman-default-kube-network
+    run_podman rmi $untagged_image:latest $built_image
 }
 
 @test "quadlet - drop-in files" {
     local quadlet_tmpdir="${PODMAN_TMPDIR}/dropins"
 
-    local quadlet_file="truncated-$(random_string).container"
+    local quadlet_file="truncated-$(safename).container"
 
     local -A dropin_dirs=(
         [toplevel]=container.d


### PR DESCRIPTION
The usual, safename instead of hardcoded names or random_string.
And remove some rmi statements: we no longer clean up pause_image.

Been working great in #23275 all week.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```