### PR TITLE
libpod: remove UpdateContainerStatus()

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -29,8 +29,6 @@ type OCIRuntime interface { //nolint:interfacebloat
 	// the given container if it is a restore and if restoreOptions.PrintStats
 	// is true. In all other cases the returned int64 is 0.
 	CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) (int64, error)
-	// UpdateContainerStatus updates the status of the given container.
-	UpdateContainerStatus(ctr *Container) error
 	// StartContainer starts the given container.
 	StartContainer(ctr *Container) error
 	// KillContainer sends the given signal to the given container.

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -76,11 +76,6 @@ func (r *MissingRuntime) CreateContainer(ctr *Container, restoreOptions *Contain
 	return 0, r.printError()
 }
 
-// UpdateContainerStatus is not available as the runtime is missing
-func (r *MissingRuntime) UpdateContainerStatus(ctr *Container) error {
-	return r.printError()
-}
-
 // StartContainer is not available as the runtime is missing
 func (r *MissingRuntime) StartContainer(ctr *Container) error {
 	return r.printError()


### PR DESCRIPTION
There are two major problems with UpdateContainerStatus() First, it can deadlock when the the state json is to big as it tries to read stderr until EOF but it will never hit EOF as long as the runtime process is alive. This means if the runtime json is to big to git into the pipe buffer we deadlock ourselves.
Second, the function modifies the container state struct and even adds and exit code to the db however when it is called from the stop() code path we will be unlocked here.

While the first problem is easy to fix the second one not so much. And when we cannot update the state there is no point in reading the from runtime in the first place as such remove the function as it does more harm then good.

And add some warnings the the functions that might be called unlocked.

Fixes #22246

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a possible deadlock in the container stop code path when using big annotations 
```
