### PR TITLE
podman mount: fix storage/libpod ctr race

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1392,7 +1392,11 @@ func (ic *ContainerEngine) ContainerMount(ctx context.Context, nameOrIDs []strin
 	for _, sctr := range storageCtrs {
 		mounted, path, err := ic.Libpod.IsStorageContainerMounted(sctr.ID)
 		if err != nil {
-			if errors.Is(err, types.ErrContainerUnknown) {
+			// ErrCtrExists means this is a libpod container, we handle that below.
+			// This can only happen in a narrow race because we first create the storage
+			// container and then the libpod container so the StorageContainers() call
+			// above would need to happen in that interval.
+			if errors.Is(err, types.ErrContainerUnknown) || errors.Is(err, define.ErrCtrExists) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
When we create a container we first create it in the storage then in the libpod db so there is a tiny window where it is seen as storage ctr but then by the time we mount it we see it was a libpod container.

Fixes #23637

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
