### PR TITLE
podman wait: allow waiting for removal of containers

### DIFF
--- a/docs/source/markdown/podman-wait.1.md.in
+++ b/docs/source/markdown/podman-wait.1.md.in
@@ -21,8 +21,9 @@ such as those created by `podman kube play`, the containers may be repeatedly
 exiting and restarting, possibly with different exit codes. `podman wait` will
 only display and detect the first exit after the wait command was started.
 
-When running a container with podman run --rm wait should wait for the
-container to be fully removed as well before it returns.
+When running a container with podman run --rm wait does not wait for the
+container to be fully removed. To wait for the removal of a container use
+`--condition=removing`.
 
 ## OPTIONS
 

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -66,7 +66,7 @@ EOF
     # container completes fast, and the cleanup *did* happen properly
     # the container is now gone.  So, we need to ignore "no such
     # container" errors from podman wait.
-    CONTAINERS_CONF="$conf_tmp" run_podman '?' wait "$cid"
+    CONTAINERS_CONF="$conf_tmp" run_podman '?' wait --condition=removing "$cid"
     if [[ $status != 0 ]]; then
         is "$output" "Error:.*no such container" "unexpected error from podman wait"
     fi


### PR DESCRIPTION
By default wait only waits for the exit of a container, there is really no way to make it wait for the removal too when the container was created with --rm. I though I found a clever way in 8a943311db but this is not working race free. While it works most of the time any other parallel process might call syncContainer() before the cleanup process holds the lock until it removes it. As such the wait hack to only update the state and not sync the exit file did not work so we can drop that.

However the test wants to wait for the removal to happen by the cleanup process and we can already say --condition=removing to do this but this will throw an error if the ctr was removed instead of counting this as success so fix that as well.

Fixes #23640

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman wait --condition=removing will no longer throw an error when the container is removed as this is expected.
```
