### PR TITLE
test/e2e: rm systemd start test

### DIFF
--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -14,67 +14,6 @@ import (
 
 var _ = Describe("Podman systemd", func() {
 
-	var systemdUnitFile string
-
-	BeforeEach(func() {
-		podmanCmd := fmt.Sprintf("%s %s", podmanTest.PodmanBinary, strings.Join(podmanTest.MakeOptions(nil, false, false), " "))
-		systemdUnitFile = fmt.Sprintf(`[Unit]
-Description=redis container
-[Service]
-Restart=always
-ExecStart=%s start -a redis
-ExecStop=%s stop -t 10 redis
-KillMode=process
-[Install]
-WantedBy=default.target
-`, podmanCmd, podmanCmd)
-	})
-
-	It("podman start container by systemd", func() {
-		SkipIfRemote("cannot create unit file on remote host")
-		SkipIfContainerized("test does not have systemd as pid 1")
-
-		dashWhat := "--system"
-		unitDir := "/run/systemd/system"
-		if isRootless() {
-			dashWhat = "--user"
-			unitDir = fmt.Sprintf("%s/systemd/user", os.Getenv("XDG_RUNTIME_DIR"))
-		}
-		err := os.MkdirAll(unitDir, 0700)
-		Expect(err).ToNot(HaveOccurred())
-
-		serviceName := "redis-" + RandomString(10)
-		sysFilePath := filepath.Join(unitDir, serviceName+".service")
-		sysFile := os.WriteFile(sysFilePath, []byte(systemdUnitFile), 0644)
-		Expect(sysFile).ToNot(HaveOccurred())
-		defer func() {
-			stop := SystemExec("systemctl", []string{dashWhat, "stop", serviceName})
-			os.Remove(sysFilePath)
-			SystemExec("systemctl", []string{dashWhat, "daemon-reload"})
-			Expect(stop).Should(ExitCleanly())
-		}()
-
-		create := podmanTest.Podman([]string{"create", "--name", "redis", REDIS_IMAGE})
-		create.WaitWithDefaultTimeout()
-		Expect(create).Should(ExitCleanly())
-
-		enable := SystemExec("systemctl", []string{dashWhat, "daemon-reload"})
-		Expect(enable).Should(ExitCleanly())
-
-		start := SystemExec("systemctl", []string{dashWhat, "start", serviceName})
-		Expect(start).Should(ExitCleanly())
-
-		checkAvailableJournald()
-		if !journald.journaldSkip {
-			// "-q" needed on fc40+ because something creates /run/log/journal/XXX 2750
-			logs := SystemExec("journalctl", []string{dashWhat, "-q", "-n", "20", "-u", serviceName})
-			Expect(logs).Should(ExitCleanly())
-		}
-
-		status := SystemExec("systemctl", []string{dashWhat, "status", serviceName})
-		Expect(status.OutputToString()).To(ContainSubstring("active (running)"))
-	})
-
 	It("podman run container with systemd PID1", func() {
 		ctrName := "testSystemd"
 		run := podmanTest.Podman([]string{"run", "--name", ctrName, "-t", "-i", "-d", SYSTEMD_IMAGE, "/sbin/init"})


### PR DESCRIPTION
We have a lot of systemd and quadlet based tests in the system tests. This test doesn't seem very useful and it seems to flake so just remove it.

Fixes #23480

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
