### PR TITLE
CI: disable ginkgo flake retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ GINKGO ?= ./test/tools/build/ginkgo
 GINKGO_JSON ?= $(if $(CI),--json-report ginkgo-e2e.json,)
 
 # Allow control over some Ginkgo parameters
-GINKGO_FLAKE_ATTEMPTS ?= 3
+GINKGO_FLAKE_ATTEMPTS ?= 0
 GINKGO_NO_COLOR ?= y
 
 # Conditional required to produce empty-output if binary not built yet.

--- a/test/README.md
+++ b/test/README.md
@@ -130,7 +130,7 @@ make localintegration FOCUS="podman inspect bogus pod"
 You can control some of the parameters passed to Ginkgo
 
 - Disable parallel tests by setting `GINKGO_PARALLEL=n`
-- Set flake retry count (default 3) to one by setting `GINKGO_FLAKE_ATTEMPTS=1`
+- Set flake retry count (default 0) to one by setting `GINKGO_FLAKE_ATTEMPTS=1`
 - Produce colorful tests report by setting `GINKGO_NO_COLOR=n`
 
 # System tests


### PR DESCRIPTION
As discussed in Aug 13 Cabal, we are almost at a point where
e2e tests are reliably passing on the first try. Let's try to
keep things that way, and not hide future flakes.

Closes: #17967

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```