### PR TITLE
vendor: update go-criu to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/goterm v1.0.4
 	github.com/checkpoint-restore/checkpointctl v1.2.1
-	github.com/checkpoint-restore/go-criu/v7 v7.1.0
+	github.com/checkpoint-restore/go-criu/v7 v7.1.1-0.20240728160228-a9064d7e053c
 	github.com/containernetworking/plugins v1.5.1
 	github.com/containers/buildah v1.37.0
 	github.com/containers/common v0.60.1-0.20240808214705-d93f74f43223

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/checkpointctl v1.2.1 h1:aYFl2CEk95bPLDvNDgif4ZLx3pjCZMJm6td+A0X1+xs=
 github.com/checkpoint-restore/checkpointctl v1.2.1/go.mod h1:8oF+AtNUFJAI13ETcbB3clnjiwvviX0QzVBhYzQ8yBA=
-github.com/checkpoint-restore/go-criu/v7 v7.1.0 h1:JbQyO4o+P8ycNTMLPiiDqXg49bAcy4WljWCzYQho35A=
-github.com/checkpoint-restore/go-criu/v7 v7.1.0/go.mod h1:1svAtmbtvX4BKI45OFzgoTTLG7oYFKdColv/Vcsb2A8=
+github.com/checkpoint-restore/go-criu/v7 v7.1.1-0.20240728160228-a9064d7e053c h1:/LNWuEZICKO96wvlLRam53lp7inbzwR1zE/YuoUUV/k=
+github.com/checkpoint-restore/go-criu/v7 v7.1.1-0.20240728160228-a9064d7e053c/go.mod h1:FTB8VSlcpwignNNaAXXzNlKBIf+DcZw8urnXKCkpeB4=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0=

--- a/vendor/github.com/checkpoint-restore/go-criu/v7/.gitignore
+++ b/vendor/github.com/checkpoint-restore/go-criu/v7/.gitignore
@@ -15,3 +15,4 @@ scripts/magic-gen/expected.go
 scripts/magic-gen/output.go
 crit/bin
 crit/test-imgs/
+__pycache__

--- a/vendor/github.com/checkpoint-restore/go-criu/v7/Makefile
+++ b/vendor/github.com/checkpoint-restore/go-criu/v7/Makefile
@@ -18,9 +18,6 @@ test: build
 coverage:
 	$(MAKE) -C test coverage
 
-codecov:
-	$(MAKE) -C test codecov
-
 rpc/rpc.proto:
 	curl -sSL https://raw.githubusercontent.com/checkpoint-restore/criu/master/images/rpc.proto -o $@
 
@@ -42,4 +39,4 @@ clean:
 	$(MAKE) -C crit/ clean
 	$(MAKE) -C test/ clean
 
-.PHONY: build test lint vendor coverage codecov clean
+.PHONY: build test lint vendor coverage clean

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,8 +89,8 @@ github.com/bytedance/sonic/utf8
 # github.com/checkpoint-restore/checkpointctl v1.2.1
 ## explicit; go 1.21
 github.com/checkpoint-restore/checkpointctl/lib
-# github.com/checkpoint-restore/go-criu/v7 v7.1.0
-## explicit; go 1.18
+# github.com/checkpoint-restore/go-criu/v7 v7.1.1-0.20240728160228-a9064d7e053c
+## explicit; go 1.20
 github.com/checkpoint-restore/go-criu/v7
 github.com/checkpoint-restore/go-criu/v7/rpc
 github.com/checkpoint-restore/go-criu/v7/stats


### PR DESCRIPTION
There is no new version yet but we like to use the new code[1] to debug a flake[2] in the podman CI. It will not fix it but the new error might give us a better idea what is going on.

[1] https://github.com/checkpoint-restore/go-criu/pull/175
[2] https://github.com/containers/podman/issues/18856

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
