### PR TITLE
Do not segfault on hard stop

### DIFF
--- a/pkg/machine/apple/vfkit/helper.go
+++ b/pkg/machine/apple/vfkit/helper.go
@@ -83,7 +83,9 @@ func (vf *Helper) stateChange(newState rest.StateChange) error {
 	}
 	payload := bytes.NewReader(b)
 	serverResponse, err := vf.post(vf.Endpoint+state, payload)
-	_ = serverResponse.Body.Close()
+	if err == nil {
+		_ = serverResponse.Body.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
Podman machine on MAC can segfault on hard stop.

Fixes: #23654

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
