### PR TITLE
[skip-ci] Packit: update targets for propose-downstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -99,8 +99,7 @@ jobs:
     update_release: false
     packages: [podman-fedora]
     dist_git_branches:
-      - fedora-development
-      - fedora-latest
+      - fedora-all
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
When a new Fedora target (41 currently), is branched from rawhide, `fedora-latest` packit target will point to fedora-41, while `fedora-latest-stable` will point to `fedora-40`. Once fedora-41 has released, `fedora-latest` and `fedora-latest-stable` will both point to fedora-41.

So, to have Packit continue to create PRs for Fedora 40 once Fedora 41 has released, it's best to set the target back to `fedora-all`.

Caution: `fedora-all` will create v5.x PRs for Fedora-39 until it goes EOL. Since dist-git PRs need to be merged manually, we can just manually close F39 PRs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
