### PR TITLE
Quote systemd DefaultEnvironment Proxy values

### DIFF
--- a/pkg/machine/e2e/proxy_test.go
+++ b/pkg/machine/e2e/proxy_test.go
@@ -76,10 +76,12 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 		Expect(stopSession).To(Exit(0))
 
 		// Now update proxy env, lets use some special vars to make sure our scripts can handle it
-		proxy1 := "http:// some special @;\" here"
-		proxy2 := "https://abc :£$%6 : |\"\""
+		proxy1 := "http://foo:b%%40r@example.com:8080"
+		proxy2 := "https://foo:bar%%3F@example.com:8080"
+		noproxy := "noproxy1.example.com,noproxy2.example.com"
 		os.Setenv("HTTP_PROXY", proxy1)
 		os.Setenv("HTTPS_PROXY", proxy2)
+		os.Setenv("NO_PROXY", noproxy)
 
 		// changing SSL_CERT vars should not have an effect
 		os.Setenv("SSL_CERT_FILE", "/tmp/1")
@@ -90,10 +92,10 @@ var _ = Describe("podman machine proxy settings propagation", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(startSession).To(Exit(0))
 
-		sshSession, err = mb.setName(name).setCmd(sshProxy.withSSHCommand([]string{"printenv", "HTTP_PROXY", "HTTPS_PROXY"})).run()
+		sshSession, err = mb.setName(name).setCmd(sshProxy.withSSHCommand([]string{"printenv", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sshSession).To(Exit(0))
-		Expect(string(sshSession.Out.Contents())).To(Equal(proxy1 + "\n" + proxy2 + "\n"))
+		Expect(string(sshSession.Out.Contents())).To(Equal(proxy1 + "\n" + proxy2 + "\n" + noproxy + "\n"))
 
 		// SSL_CERT not implemented for WSL
 		if !isVmtype(define.WSLVirt) {

--- a/pkg/machine/proxyenv/env.go
+++ b/pkg/machine/proxyenv/env.go
@@ -24,7 +24,7 @@ rm -f $SYSTEMD_CONF $ENVD_CONF $PROFILE_CONF
 
 echo "[Manager]" >> $SYSTEMD_CONF
 for proxy in %s; do
-	printf "DefaultEnvironment=%%q\n" "$proxy"  >> $SYSTEMD_CONF
+	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_CONF
 	printf "%%q\n" "$proxy"  >> $ENVD_CONF
 	printf "export %%q\n" "$proxy" >> $PROFILE_CONF
 done

--- a/pkg/machine/proxyenv/env_test.go
+++ b/pkg/machine/proxyenv/env_test.go
@@ -1,0 +1,76 @@
+package proxyenv
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getProxyScript(t *testing.T) {
+	type env struct {
+		name  string
+		value string
+	}
+	type args struct {
+		isWSL bool
+		envs  []env
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "all vars set",
+			args: args{
+				isWSL: false,
+				envs: []env{
+					{
+						name:  "http_proxy",
+						value: "proxy1",
+					},
+					{
+						name:  "https_proxy",
+						value: "sproxy1",
+					},
+					{
+						name:  "no_proxy",
+						value: "no1,no2",
+					},
+				},
+			},
+			want: `#!/bin/bash
+
+SYSTEMD_CONF=/etc/systemd/system.conf.d/default-env.conf
+ENVD_CONF=/etc/environment.d/default-env.conf
+PROFILE_CONF=/etc/profile.d/default-env.sh
+
+mkdir -p /etc/profile.d /etc/environment.d /etc/systemd/system.conf.d/
+rm -f $SYSTEMD_CONF $ENVD_CONF $PROFILE_CONF
+
+echo "[Manager]" >> $SYSTEMD_CONF
+for proxy in "http_proxy=proxy1" "https_proxy=sproxy1" "no_proxy=no1,no2"; do
+	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_CONF
+	printf "%q\n" "$proxy"  >> $ENVD_CONF
+	printf "export %q\n" "$proxy" >> $PROFILE_CONF
+done
+
+systemctl daemon-reload
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, e := range tt.args.envs {
+				t.Setenv(e.name, e.value)
+			}
+			got := getProxyScript(tt.args.isWSL)
+			buf := new(bytes.Buffer)
+			_, err := buf.ReadFrom(got)
+			assert.NoError(t, err)
+			str := buf.String()
+			assert.Equal(t, tt.want, str)
+		})
+	}
+}


### PR DESCRIPTION
Quote systemd DefaultEnvironment Proxy values, as documented in systemd.conf man page:

```
Example:
DefaultEnvironment="VAR1=word1 word2" VAR2=word3 "VAR3=word 5 6" Sets three variables "VAR1", "VAR2", "VAR3".
```

Double quote is not escaped, as there is no chance it appears in a proxy value. User can still espace it if really necessary

Fixes #23277 
Fixes https://github.com/containers/podman-desktop/issues/7894

#### How to test 

1. Declare proxy env vars in `containers.conf` file, with comma special character in `no_proxy`, for example (please replace proxy IP/port with your own):

```
env = [
	'https_proxy=http://192.168.1.21:3128',
	'http_proxy=http://192.168.1.21:3128',
	'no_proxy=localhost,quay.io',
]
```

2. Create and start a new podman machine, and ssh to it

3. Check that no_proxy and NO_PROXY values are not escaped:

```
$ cat /etc/systemd/system.conf.d/default-env.conf 
[Manager]
DefaultEnvironment="http_proxy=http://192.168.1.21:3128"
DefaultEnvironment="https_proxy=http://192.168.1.21:3128"
DefaultEnvironment="no_proxy=host.containers.internal,quay.io"
DefaultEnvironment="HTTP_PROXY=http://192.168.1.21:3128"
DefaultEnvironment="HTTPS_PROXY=http://192.168.1.21:3128"
DefaultEnvironment="NO_PROXY=host.containers.internal,quay.io"
```

4. Restart podman machine so podman process takes these values into consideration

5. Check that proxy env vars are passed to podman process:

```
$ ps eww `pidof podman`
    PID TTY      STAT   TIME COMMAND
   1282 ?        Ssl    0:00 /usr/bin/podman --log-level=info system service HTTPS_PROXY=http://192.168.1.21:3128 HTTP_PROXY=http://192.168.1.21:3128 NO_PROXY=host.containers.internal,quay.io http_proxy=http://192.168.1.21:3128 https_proxy=http://192.168.1.21:3128 no_proxy=host.containers.internal,quay.io [...]
```

6. From a client (podman outside of VM or podman-desktop):
  - pull an image from docker.io: proxy should log requests
  - pull an image from quay.io: proxy should not log any request
  
#### Does this PR introduce a user-facing change?

Values for proxy env variables won't be escaped anymore. 

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed the way the proxy environment variables are defined in the systemd configuration file. These values were previously escaped for shell input reuse (%q), they are now not escaped.
```
