### PR TITLE
Add key CgroupsMode in Quadlet container unit

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -259,6 +259,7 @@ Valid options for `[Container]` are listed below:
 | AddDevice=/dev/foo                   | --device /dev/foo                                    |
 | Annotation="XYZ"                     | --annotation "XYZ"                                   |
 | AutoUpdate=registry                  | --label "io.containers.autoupdate=registry"          |
+| CgroupsMode=no-conmon                | --cgroups=no-conmon                                  |
 | ContainerName=name                   | --name name                                          |
 | ContainersConfModule=/etc/nvd\.conf  | --module=/etc/nvd\.conf                              |
 | DNS=192.168.55.1                     | --dns=192.168.55.1                                   |
@@ -369,6 +370,16 @@ Indicates whether the container will be auto-updated ([podman-auto-update(1)](po
 * `registry`: Requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container. This enforcement is necessary to know which image to actually check and pull. If an image ID was used, Podman does not know which image to check/pull anymore.
 
 * `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the container.
+
+### `CgroupsMode=`
+
+The cgroups mode of the Podman container. Equivalent to the Podman `--cgroups` option.
+
+By default, the cgroups mode of the container created by Quadlet is `split`,
+which differs from the default (`enabled`) used by the Podman CLI.
+
+If the container joins a pod (i.e. `Pod=` is specified), you may want to change this to
+`no-conmon` or `enabled` so that pod level cgroup resource limits can take effect.
 
 ### `ContainerName=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -62,6 +62,7 @@ const (
 	KeyAuthFile              = "AuthFile"
 	KeyAutoUpdate            = "AutoUpdate"
 	KeyCertDir               = "CertDir"
+	KeyCgroupsMode           = "CgroupsMode"
 	KeyConfigMap             = "ConfigMap"
 	KeyContainerName         = "ContainerName"
 	KeyContainersConfModule  = "ContainersConfModule"
@@ -191,6 +192,7 @@ var (
 		KeyAddDevice:             true,
 		KeyAnnotation:            true,
 		KeyAutoUpdate:            true,
+		KeyCgroupsMode:           true,
 		KeyContainerName:         true,
 		KeyContainersConfModule:  true,
 		KeyDNS:                   true,
@@ -581,7 +583,12 @@ func ConvertContainer(container *parser.UnitFile, isUser bool, unitsInfoMap map[
 
 	// We delegate groups to the runtime
 	service.Add(ServiceGroup, "Delegate", "yes")
-	podman.add("--cgroups=split")
+
+	if cgroupsMode, ok := container.Lookup(ContainerGroup, KeyCgroupsMode); ok && len(cgroupsMode) > 0 {
+		podman.addf("--cgroups=%s", cgroupsMode)
+	} else {
+		podman.add("--cgroups=split")
+	}
 
 	timezone, ok := container.Lookup(ContainerGroup, KeyTimezone)
 	if ok && len(timezone) > 0 {

--- a/test/e2e/quadlet/cgroups-mode.container
+++ b/test/e2e/quadlet/cgroups-mode.container
@@ -1,0 +1,5 @@
+## assert-podman-args --cgroups=no-conmon
+
+[Container]
+Image=localhost/imagename
+CgroupsMode=no-conmon

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -897,6 +897,7 @@ BOGUS=foo
 		Entry("template@instance.container", "template@instance.container"),
 		Entry("Unit After Override", "unit-after-override.container"),
 		Entry("NetworkAlias", "network-alias.container"),
+		Entry("CgroupMode", "cgroups-mode.container"),
 
 		Entry("basic.volume", "basic.volume"),
 		Entry("device-copy.volume", "device-copy.volume"),


### PR DESCRIPTION
Fixes #23664.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a new key `CgroupsMode` to Quadlet container unit file.
```
