### PR TITLE
quadlet: support user mapping in pod unit

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -658,7 +658,7 @@ func process() error {
 		case strings.HasSuffix(unit.Filename, ".build"):
 			service, err = quadlet.ConvertBuild(unit, unitsInfoMap)
 		case strings.HasSuffix(unit.Filename, ".pod"):
-			service, err = quadlet.ConvertPod(unit, unit.Filename, unitsInfoMap)
+			service, err = quadlet.ConvertPod(unit, unit.Filename, unitsInfoMap, isUserFlag)
 		default:
 			Logf("Unsupported file type %q", unit.Filename)
 			continue

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -867,6 +867,7 @@ Valid options for `[Pod]` are listed below:
 | **[Pod] options**                   | **podman container create equivalent** |
 |-------------------------------------|----------------------------------------|
 | ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                |
+| GIDMap=0:10000:10                   | --gidmap=0:10000:10                   |
 | GlobalArgs=--log-level=debug        | --log-level=debug                      |
 | Network=host                        | --network host                         |
 | NetworkAlias=name                   | --network-alias name                   |
@@ -874,6 +875,10 @@ Valid options for `[Pod]` are listed below:
 | PodName=name                        | --name=name                            |
 | PublishPort=50-59                   | --publish 50-59                        |
 | ServiceName=name                    | Name the systemd unit `name.service`   |
+| SubGIDMap=gtest                     | --subgidname=gtest                     |
+| SubUIDMap=utest                     | --subuidname=utest                     |
+| UIDMap=0:10000:10                   | --uidmap=0:10000:10                    |
+| UserNS=keep-id:uid=200,gid=210      | --userns keep-id:uid=200,gid=210       |
 | Volume=/source:/dest                | --volume /source:/dest                 |
 
 Supported keys in the `[Pod]` section are:
@@ -881,6 +886,13 @@ Supported keys in the `[Pod]` section are:
 ### `ContainersConfModule=`
 
 Load the specified containers.conf(5) module. Equivalent to the Podman `--module` option.
+
+This key can be listed multiple times.
+
+### `GIDMap=`
+
+Create the pod in a new user namespace using the supplied GID mapping.
+Equivalent to the Podman `--gidmap` option.
 
 This key can be listed multiple times.
 
@@ -965,6 +977,28 @@ By default, Quadlet will name the systemd service unit by appending `-pod` to th
 Setting this key overrides this behavior by instructing Quadlet to use the provided name.
 
 Note, the name should not include the `.service` file extension
+
+### `SubGIDMap=`
+
+Create the pod in a new user namespace using the map with name in the /etc/subgid file.
+Equivalent to the Podman `--subgidname` option.
+
+### `SubUIDMap=`
+
+Create the pod in a new user namespace using the map with name in the /etc/subuid file.
+Equivalent to the Podman `--subuidname` option.
+
+### `UIDMap=`
+
+Create the pod in a new user namespace using the supplied UID mapping.
+Equivalent to the Podman `--uidmap` option.
+
+This key can be listed multiple times.
+
+### `UserNS=`
+
+Set the user namespace mode for the pod. This is equivalent to the Podman `--userns` option and
+generally has the form `MODE[:OPTIONS,...]`.
 
 ### `Volume=`
 

--- a/test/e2e/quadlet/remap-auto.pod
+++ b/test/e2e/quadlet/remap-auto.pod
@@ -1,0 +1,4 @@
+## assert-podman-pre-args --userns=auto
+
+[Pod]
+RemapUsers=auto

--- a/test/e2e/quadlet/remap-auto2.pod
+++ b/test/e2e/quadlet/remap-auto2.pod
@@ -1,0 +1,9 @@
+## assert-podman-pre-args "--userns=auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
+
+[Pod]
+RemapUsers=auto
+RemapUid=0:10000:10
+RemapUid=10:20000:10
+RemapGid=0:10000:10
+RemapGid=10:20000:10
+RemapUidSize=20

--- a/test/e2e/quadlet/remap-keep-id.pod
+++ b/test/e2e/quadlet/remap-keep-id.pod
@@ -1,0 +1,4 @@
+## assert-podman-pre-args --userns=keep-id
+
+[Pod]
+RemapUsers=keep-id

--- a/test/e2e/quadlet/remap-manual.pod
+++ b/test/e2e/quadlet/remap-manual.pod
@@ -1,0 +1,11 @@
+## assert-podman-pre-args "--uidmap=0:10000:10"
+## assert-podman-pre-args "--uidmap=10:20000:10"
+## assert-podman-pre-args "--gidmap=0:10000:10"
+## assert-podman-pre-args "--gidmap=10:20000:10"
+
+[Pod]
+RemapUsers=manual
+RemapUid=0:10000:10
+RemapUid=10:20000:10
+RemapGid=0:10000:10
+RemapGid=10:20000:10

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -998,11 +998,15 @@ BOGUS=foo
 		Entry("Build - TLSVerify Key", "tls-verify.build"),
 		Entry("Build - Variant Key", "variant.build"),
 
-		Entry("basic.pod", "basic.pod"),
-		Entry("name.pod", "name.pod"),
-		Entry("network.pod", "network.pod"),
-		Entry("podmanargs.pod", "podmanargs.pod"),
+		Entry("Pod - Basic", "basic.pod"),
+		Entry("Pod - Name", "name.pod"),
+		Entry("Pod - Network", "network.pod"),
+		Entry("Pod - PodmanArgs", "podmanargs.pod"),
 		Entry("Pod - NetworkAlias", "network-alias.pod"),
+		Entry("Pod - Remap auto", "remap-auto.pod"),
+		Entry("Pod - Remap auto2", "remap-auto2.pod"),
+		Entry("Pod - Remap keep-id", "remap-keep-id.pod"),
+		Entry("Pod - Remap manual", "remap-manual.pod"),
 	)
 
 	DescribeTable("Running expected warning quadlet test case",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added keys related to user mappings (e.g. `UserNS`) to Quadlet pod unit file.
```
