### PR TITLE
CI: parallel-safe userns test

### DIFF
--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -15,6 +15,7 @@ function _require_crun() {
     fi
 }
 
+# bats test_tags=ci:parallel
 @test "podman --group-add keep-groups while in a userns" {
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
@@ -23,6 +24,7 @@ function _require_crun() {
     is "$output" ".*65534(nobody)" "Check group leaked into user namespace"
 }
 
+# bats test_tags=ci:parallel
 @test "podman --group-add keep-groups while not in a userns" {
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
@@ -31,6 +33,7 @@ function _require_crun() {
     is "$output" ".*1234" "Check group leaked into container"
 }
 
+# bats test_tags=ci:parallel
 @test "podman --group-add without keep-groups while in a userns" {
     skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "chroot is not allowed in rootless mode"
@@ -39,21 +42,22 @@ function _require_crun() {
     is "$output" ".*457" "Check group leaked into container"
 }
 
+# bats test_tags=ci:parallel
 @test "rootful pod with custom ID mapping" {
     skip_if_cgroupsv1 "run --uidmap fails on cgroups v1 (issue 15025, wontfix)"
     skip_if_rootless "does not work rootless - rootful feature"
-    random_pod_name=$(random_string 30)
+    random_pod_name=p_$(safename)
     run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name
     run_podman pod start $random_pod_name
     run_podman pod inspect --format '{{.InfraContainerID}}' $random_pod_name
     run_podman inspect --format '{{.HostConfig.IDMappings.UIDMap}}' $output
     is "$output" ".*0:200000:5000" "UID Map Successful"
 
-    # Remove the pod and the pause image
+    # Clean up
     run_podman pod rm $random_pod_name
-    run_podman rmi -f $(pause_image)
 }
 
+# bats test_tags=ci:parallel
 @test "podman --remote --group-add keep-groups " {
     if ! is_remote; then
         skip "this test only meaningful under podman-remote"
@@ -63,16 +67,19 @@ function _require_crun() {
     is "$output" ".*not supported in remote mode" "Remote check --group-add keep-groups"
 }
 
+# bats test_tags=ci:parallel
 @test "podman --group-add without keep-groups " {
     run_podman run --rm --group-add 457 $IMAGE id
     is "$output" ".*457" "Check group leaked into container"
 }
 
+# bats test_tags=ci:parallel
 @test "podman --group-add keep-groups plus added groups " {
     run_podman 125 run --rm --group-add keep-groups --group-add 457 $IMAGE id
     is "$output" ".*the '--group-add keep-groups' option is not allowed with any other --group-add options" "Check group leaked into container"
 }
 
+# CANNOT BE PARALLELIZED: userns=auto, rootless, => not enough unused IDs in user namespace
 @test "podman userns=auto in config file" {
     skip_if_remote "userns=auto is set on the server"
 
@@ -99,6 +106,7 @@ EOF
     CONTAINERS_CONF_OVERRIDE=$PODMAN_TMPDIR/userns_auto.conf run_podman 0 run --rm $IMAGE awk '{if($2 == "0"){exit 1}}' /proc/self/uid_map /proc/self/gid_map
 }
 
+# CANNOT BE PARALLELIZED: userns=auto, rootless, => not enough unused IDs in user namespace
 @test "podman userns=auto and secrets" {
     ns_user="containers"
     if is_rootless; then
@@ -115,6 +123,7 @@ EOF
     run_podman secret rm ${test_name}
 }
 
+# bats test_tags=ci:parallel
 @test "podman userns=nomap" {
     if is_rootless; then
         ns_user=$(id -un)
@@ -133,21 +142,24 @@ EOF
     fi
 }
 
+# bats test_tags=ci:parallel
 @test "podman userns=keep-id" {
     user=$(id -u)
     run_podman run --rm --userns=keep-id $IMAGE id -u
     is "${output}" "$user" "Container should run as the current user"
 }
 
+# bats test_tags=ci:parallel
 @test "podman userns=keep-id in a pod" {
     user=$(id -u)
-    run_podman pod create --userns keep-id
+    run_podman pod create --name p_$(safename) --userns keep-id
     pid=$output
     run_podman run --rm --pod $pid $IMAGE id -u
     is "${output}" "$user" "Container should run as the current user"
-    run_podman rmi -f $(pause_image)
+    run_podman pod rm $pid
 }
 
+# CANNOT BE PARALLELIZED: userns=auto, rootless, => not enough unused IDs in user namespace
 @test "podman userns=auto with id mapping" {
     skip_if_not_rootless
     skip_if_remote


### PR DESCRIPTION
- use safename
- add ci:parallel tags where possible
  - where not possible, document why

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```