### PR TITLE
command is not optional to podman exec

### DIFF
--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -24,7 +24,7 @@ var (
 	execDescription = `Execute the specified command inside a running container.
 `
 	execCommand = &cobra.Command{
-		Use:               "exec [options] CONTAINER [COMMAND [ARG...]]",
+		Use:               "exec [options] CONTAINER COMMAND [ARG...]",
 		Short:             "Run a process in a running container",
 		Long:              execDescription,
 		RunE:              exec,

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -4,9 +4,9 @@
 podman\-exec - Execute a command in a running container
 
 ## SYNOPSIS
-**podman exec** [*options*] *container* [*command* [*arg* ...]]
+**podman exec** [*options*] *container* *command* [*arg* ...]
 
-**podman container exec** [*options*] *container* [*command* [*arg* ...]]
+**podman container exec** [*options*] *container* *command* [*arg* ...]
 
 ## DESCRIPTION
 **podman exec** executes a command in a running container.


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/22849

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
