### PR TITLE
Quadlet add support for --add-host --ip and --ip6

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -880,6 +880,8 @@ Valid options for `[Pod]` are listed below:
 | ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                |
 | GIDMap=0:10000:10                   | --gidmap=0:10000:10                   |
 | GlobalArgs=--log-level=debug        | --log-level=debug                      |
+| IP=192.5.0.1                        | --ip 192.5.0.1                         |
+| IP6=2001:db8::1                     | --ip6 2001:db8::1                      |
 | Network=host                        | --network host                         |
 | NetworkAlias=name                   | --network-alias name                   |
 | PodmanArgs=\-\-cpus=2               | --cpus=2                               |
@@ -918,6 +920,16 @@ The format of this is a space separated list of arguments, which can optionally 
 escaped to allow inclusion of whitespace and other control characters.
 
 This key can be listed multiple times.
+
+### `IP=`
+
+Specify a static IPv4 address for the pod, for example **10.88.64.128**.
+Equivalent to the Podman `--ip` option.
+
+### `IP6=`
+
+Specify a static IPv6 address for the pod, for example **fd46:db93:aa76:ac37::10**.
+Equivalent to the Podman `--ip6` option.
 
 ### `Network=`
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -257,6 +257,7 @@ Valid options for `[Container]` are listed below:
 |--------------------------------------|------------------------------------------------------|
 | AddCapability=CAP                    | --cap-add CAP                                        |
 | AddDevice=/dev/foo                   | --device /dev/foo                                    |
+| AddHost=hostname:192.168.10.11       | --add-host=hostname:192.168.10.11                    |
 | Annotation="XYZ"                     | --annotation "XYZ"                                   |
 | AutoUpdate=registry                  | --label "io.containers.autoupdate=registry"          |
 | CgroupsMode=no-conmon                | --cgroups=no-conmon                                  |
@@ -354,6 +355,14 @@ the container, and `PERMISSIONS` is a list of permissions combining 'r' for read
 'w' for write, and 'm' for mknod(2). The `-` prefix tells Quadlet to add the device
 only if it exists on the host.
 
+This key can be listed multiple times.
+
+### `AddHost=`
+
+Add  host-to-IP mapping to /etc/hosts.
+The format is `hostname:ip`.
+
+Equivalent to the Podman `--add-host` option.
 This key can be listed multiple times.
 
 ### `Annotation=`
@@ -877,6 +886,7 @@ Valid options for `[Pod]` are listed below:
 
 | **[Pod] options**                   | **podman container create equivalent** |
 |-------------------------------------|----------------------------------------|
+| AddHost=hostname:192.168.10.11      | --add-host=hostname:192.168.10.11      |
 | ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                |
 | GIDMap=0:10000:10                   | --gidmap=0:10000:10                   |
 | GlobalArgs=--log-level=debug        | --log-level=debug                      |
@@ -895,6 +905,14 @@ Valid options for `[Pod]` are listed below:
 | Volume=/source:/dest                | --volume /source:/dest                 |
 
 Supported keys in the `[Pod]` section are:
+
+### `AddHost=`
+
+Add  host-to-IP mapping to /etc/hosts.
+The format is `hostname:ip`.
+
+Equivalent to the Podman `--add-host` option.
+This key can be listed multiple times.
 
 ### `ContainersConfModule=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -56,6 +56,7 @@ const (
 const (
 	KeyAddCapability         = "AddCapability"
 	KeyAddDevice             = "AddDevice"
+	KeyAddHost               = "AddHost"
 	KeyAllTags               = "AllTags"
 	KeyAnnotation            = "Annotation"
 	KeyArch                  = "Arch"
@@ -190,6 +191,7 @@ var (
 	supportedContainerKeys = map[string]bool{
 		KeyAddCapability:         true,
 		KeyAddDevice:             true,
+		KeyAddHost:               true,
 		KeyAnnotation:            true,
 		KeyAutoUpdate:            true,
 		KeyCgroupsMode:           true,
@@ -381,6 +383,7 @@ var (
 	}
 
 	supportedPodKeys = map[string]bool{
+		KeyAddHost:              true,
 		KeyContainersConfModule: true,
 		KeyGIDMap:               true,
 		KeyGlobalArgs:           true,
@@ -830,6 +833,11 @@ func ConvertContainer(container *parser.UnitFile, isUser bool, unitsInfoMap map[
 	ip6, ok := container.Lookup(ContainerGroup, KeyIP6)
 	if ok && len(ip6) > 0 {
 		podman.add("--ip6", ip6)
+	}
+
+	addHosts := container.LookupAll(ContainerGroup, KeyAddHost)
+	for _, addHost := range addHosts {
+		podman.addf("--add-host=%s", addHost)
 	}
 
 	labels := container.LookupAllKeyVal(ContainerGroup, KeyLabel)
@@ -1689,6 +1697,11 @@ func ConvertPod(podUnit *parser.UnitFile, name string, unitsInfoMap map[string]*
 	ip6, ok := podUnit.Lookup(PodGroup, KeyIP6)
 	if ok && len(ip6) > 0 {
 		execStartPre.addf("--ip6=%s", ip6)
+	}
+
+	addHosts := podUnit.LookupAll(PodGroup, KeyAddHost)
+	for _, addHost := range addHosts {
+		execStartPre.addf("--add-host=%s", addHost)
 	}
 
 	handlePodmanArgs(podUnit, PodGroup, execStartPre)

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -384,6 +384,8 @@ var (
 		KeyContainersConfModule: true,
 		KeyGIDMap:               true,
 		KeyGlobalArgs:           true,
+		KeyIP:                   true,
+		KeyIP6:                  true,
 		KeyNetwork:              true,
 		KeyNetworkAlias:         true,
 		KeyPodName:              true,
@@ -1678,6 +1680,16 @@ func ConvertPod(podUnit *parser.UnitFile, name string, unitsInfoMap map[string]*
 
 	execStartPre.addf("--infra-name=%s-infra", podName)
 	execStartPre.addf("--name=%s", podName)
+
+	ip, ok := podUnit.Lookup(PodGroup, KeyIP)
+	if ok && len(ip) > 0 {
+		execStartPre.addf("--ip=%s", ip)
+	}
+
+	ip6, ok := podUnit.Lookup(PodGroup, KeyIP6)
+	if ok && len(ip6) > 0 {
+		execStartPre.addf("--ip6=%s", ip6)
+	}
 
 	handlePodmanArgs(podUnit, PodGroup, execStartPre)
 

--- a/test/e2e/quadlet/host.container
+++ b/test/e2e/quadlet/host.container
@@ -1,0 +1,6 @@
+[Container]
+Image=localhost/imagename
+## assert-podman-args "--add-host=my-host-name:192.168.10.10"
+AddHost=my-host-name:192.168.10.10
+## assert-podman-args "--add-host=my-second-host-name:192.168.10.11"
+AddHost=my-second-host-name:192.168.10.11

--- a/test/e2e/quadlet/host.pod
+++ b/test/e2e/quadlet/host.pod
@@ -1,0 +1,5 @@
+[Pod]
+## assert-podman-pre-args "--add-host=my-host-name:192.168.10.10"
+AddHost=my-host-name:192.168.10.10
+## assert-podman-pre-args "--add-host=my-second-host-name:192.168.10.11"
+AddHost=my-second-host-name:192.168.10.11

--- a/test/e2e/quadlet/ip.pod
+++ b/test/e2e/quadlet/ip.pod
@@ -1,0 +1,6 @@
+## assert-podman-pre-args "--ip=10.88.64.128"
+## assert-podman-pre-args "--ip6=fd46:db93:aa76:ac37::10"
+
+[Pod]
+IP=10.88.64.128
+IP6=fd46:db93:aa76:ac37::10

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1000,6 +1000,7 @@ BOGUS=foo
 		Entry("Build - Variant Key", "variant.build"),
 
 		Entry("Pod - Basic", "basic.pod"),
+		Entry("Pod - IP", "ip.pod"),
 		Entry("Pod - Name", "name.pod"),
 		Entry("Pod - Network", "network.pod"),
 		Entry("Pod - PodmanArgs", "podmanargs.pod"),

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -841,6 +841,7 @@ BOGUS=foo
 		Entry("exec.container", "exec.container"),
 		Entry("group-add.container", "group-add.container"),
 		Entry("health.container", "health.container"),
+		Entry("host.container", "host.container"),
 		Entry("hostname.container", "hostname.container"),
 		Entry("idmapping.container", "idmapping.container"),
 		Entry("image.container", "image.container"),
@@ -1000,6 +1001,7 @@ BOGUS=foo
 		Entry("Build - Variant Key", "variant.build"),
 
 		Entry("Pod - Basic", "basic.pod"),
+		Entry("Pod - Host", "host.pod"),
 		Entry("Pod - IP", "ip.pod"),
 		Entry("Pod - Name", "name.pod"),
 		Entry("Pod - Network", "network.pod"),


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/23692

- Add support for --add-host for Pod and Container units. It is possible to specify multiple hosts for a single IP. 
- Add support for IP and IP6 for Pod units.

#### Does this PR introduce a user-facing change?

```release-note
Podman Quadlet Pod and Containers now supports AddHost
Podman Quadlet Pod now supports  IP and IP6
```
