### PR TITLE
New VMs again

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240821t171500z-f40f39d13"
+    IMAGE_SUFFIX: "c20240826t190000z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"


### PR DESCRIPTION
Most important change is removing the RPM IMA workaround (#18543).
Let's see if podman still works on rawhide.

Also: pasta bumped to 08-21 (from 08-14)

Source: https://github.com/containers/automation_images/pull/384

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```