### PR TITLE
podman run: ignore image rm error

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/podman/v5/pkg/rootless"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/containers/podman/v5/pkg/specgenutil"
-	"github.com/containers/storage/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -243,13 +242,9 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if runRmi {
-		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{imageName}, entities.ImageRemoveOptions{})
+		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{imageName}, entities.ImageRemoveOptions{Ignore: true})
 		for _, err := range rmErrors {
-			// ImageUnknown would be a super-unlikely race
-			if !errors.Is(err, types.ErrImageUnknown) {
-				// Typical case: ErrImageUsedByContainer
-				logrus.Warn(err)
-			}
+			logrus.Warnf("Failed to remove image: %v", err)
 		}
 	}
 	return nil

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -237,8 +237,10 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if runOpts.Detach && !passthrough {
-		fmt.Println(report.Id)
+	if runOpts.Detach {
+		if !passthrough {
+			fmt.Println(report.Id)
+		}
 		return nil
 	}
 	if runRmi {


### PR DESCRIPTION
Since commit 458ba5a8af the cleanup process now removes the image as well, thus the removal is racy and it will cause an error here.

The code tried to ignore the error with errors.Is() but this never works across the remote API. However the API already has a ignore option so juts use that and fix the error message so that we can easily find the root cause and I do not have to guess where the log was written.

Fixes #23719

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
