### PR TITLE
cirrus: skip windows/macos machine task on RHEL branches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -439,10 +439,7 @@ win_installer_task:
       - env:
             CONTAINERS_MACHINE_PROVIDER: 'hyperv'
     alias: win_installer
-    only_if:  # RHEL never releases podman windows installer binary
-      $CIRRUS_TAG == '' &&
-      $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
-      $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
+    only_if: *no_rhel_release
     depends_on: *build
     ec2_instance: &windows
         image: "${WINDOWS_AMI}"
@@ -762,6 +759,14 @@ podman_machine_windows_task:
     alias: podman_machine_windows
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: *only_if_machine_test
+    # Special case, we do not run macos/windows builds on rhel branches.
+    # Thus the machine task should not be run too, while we use only_if
+    # everywhere to do so here it would mean we would need duplicate the
+    # full big only_if condition which is more difficult to maintain so
+    # use the skip here.
+    skip: &skip_rhel_release |
+        $CIRRUS_BRANCH =~ 'v[0-9\.]+-rhel' ||
+        $CIRRUS_BASE_BRANCH =~ 'v[0-9\.]+-rhel'
     depends_on: *build
     ec2_instance:
         <<: *windows
@@ -786,6 +791,7 @@ podman_machine_mac_task:
     name: *std_name_fmt
     alias: podman_machine_mac
     only_if: *only_if_machine_test
+    skip: *skip_rhel_release
     depends_on: *build
     persistent_worker: *mac_pw
     env:
@@ -1092,9 +1098,7 @@ artifacts_task:
     name: "Artifacts"
     alias: artifacts
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: >-
-        $CIRRUS_BRANCH !=~ 'v[0-9\.]+-rhel' &&
-        $CIRRUS_BASE_BRANCH !=~ 'v[0-9\.]+-rhel'
+    only_if: *no_rhel_release
     depends_on:
         - success
     # This task is a secondary/convenience for downstream consumers, don't


### PR DESCRIPTION
We already exclude the build jobs this is causing the machine tasks to fail as noticed in #23764. Given we do not need windows/macos testing for RHEL we have to skip them there.

While we try to only use only_if the problem here is that we would need to duplicate the big only_if_machine_test string and work the rhel condition into it which doesn't work with the current logic either so we would need to change the logic flow there which then doesn't work with our cirrus_yaml_test.py selftest. Therefore I think using skip here is easier.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
