### PR TITLE
Fix an improperly ignored error in SQLite

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -2157,6 +2157,7 @@ func (s *SQLiteState) Volume(name string) (*Volume, error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, define.ErrNoSuchVolume
 		}
+		return nil, fmt.Errorf("querying volume %s: %w", name, err)
 	}
 
 	vol := new(Volume)


### PR DESCRIPTION
This looks like a case of boilerplate error handling making it too easy to miss a legitimately ignored error, which is annoying. In a more featureful language most of the SQL code here could be macros (at the very least, Rust would have forced us to handle all error cases, not just the one seen here).

Found while looking through the Libpod DB code, no actual bug I can think of associated with this.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
