### PR TITLE
CI: flake workaround: ignore socat waitpid warnings

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -252,6 +252,10 @@ function pasta_test_do() {
     # Get server output, --follow is used to wait for the container to exit,
     run_podman logs --follow $cname
     # which should give us the expected output back.
+    # ...except, sigh, #23482: seems to be a bug in socat, issues spurious warning
+    if [[ "$recv" =~ EXEC ]]; then
+        output=$(grep -vE 'socat.*waitpid.*No child process' <<<"$output")
+    fi
     assert "${output}" = "${expect}" "Mismatch between data sent and received"
 
     run_podman rm $cname


### PR DESCRIPTION
Workaround (NOT A FIX) for pasta issue #23482, wherein
podman logs includes a waitpid: ESRCH warning. Consensus
seems to be that this is a bug in socat.

I have not seen the flake in my || PR since adding this, but now the flake is [in the wild](https://api.cirrus-ci.com/v1/artifact/task/4981562419183616/html/sys-podman-rawhide-rootless-host-sqlite.log.html#t--00611) so am filing a small PR.

I hate this, because there's no timebomb or other mechanism to know if the socat bug is ever fixed, so this little workaround will stick around forever, annoying future maintainers.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```