### PR TITLE
Quadlet - Support multiple image tags in .build files

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1621,6 +1621,8 @@ successfully.
 
 This is equivalent to the `--tag` option of `podman build`.
 
+This key can be listed multiple times. The first instance will be used as the name of the created artifact when the `.build` file is referenced by another Quadlet unit.
+
 ### `Label=`
 
 Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1494,7 +1494,10 @@ func ConvertBuild(build *parser.UnitFile, unitsInfoMap map[string]*UnitInfo) (*p
 	labels := build.LookupAllKeyVal(BuildGroup, KeyLabel)
 	podman.addLabels(labels)
 
-	podman.addf("--tag=%s", unitInfo.ResourceName)
+	imageTags := build.LookupAll(BuildGroup, KeyImageTag)
+	for _, imageTag := range imageTags {
+		podman.addf("--tag=%s", imageTag)
+	}
 
 	if err := addNetworks(build, BuildGroup, service, unitsInfoMap, podman); err != nil {
 		return nil, err
@@ -1555,8 +1558,9 @@ func ConvertBuild(build *parser.UnitFile, unitsInfoMap map[string]*UnitInfo) (*p
 }
 
 func GetBuiltImageName(buildUnit *parser.UnitFile) string {
-	if builtImageName, ok := buildUnit.Lookup(BuildGroup, KeyImageTag); ok {
-		return builtImageName
+	imageTags := buildUnit.LookupAll(BuildGroup, KeyImageTag)
+	if len(imageTags) > 0 {
+		return imageTags[0]
 	}
 	return ""
 }

--- a/test/e2e/quadlet/build.multiple-tags.container
+++ b/test/e2e/quadlet/build.multiple-tags.container
@@ -1,0 +1,4 @@
+## assert-podman-final-args localhost/imagename:v1
+
+[Container]
+Image=multiple-tags.build

--- a/test/e2e/quadlet/multiple-tags.build
+++ b/test/e2e/quadlet/multiple-tags.build
@@ -1,0 +1,7 @@
+## assert-podman-args --tag=localhost/imagename:v1
+## assert-podman-args --tag=localhost/imagename:latest
+
+[Build]
+ImageTag=localhost/imagename:v1
+ImageTag=localhost/imagename:latest
+SetWorkingDirectory=unit

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -984,6 +984,7 @@ BOGUS=foo
 		Entry("Build - GroupAdd Key", "group-add.build"),
 		Entry("Build - Containers Conf Modules", "containersconfmodule.build"),
 		Entry("Build - Label Key", "label.build"),
+		Entry("Build - Multiple Tags", "multiple-tags.build"),
 		Entry("Build - Network Key host", "network.build"),
 		Entry("Build - PodmanArgs", "podmanargs.build"),
 		Entry("Build - Pull Key", "pull.build"),
@@ -1075,6 +1076,7 @@ BOGUS=foo
 		Entry("Container - Mount overriding service name", "mount.servicename.container", []string{"service-name.volume"}),
 		Entry("Container - Quadlet Network overriding service name", "network.quadlet.servicename.container", []string{"service-name.network"}),
 		Entry("Container - Quadlet Volume overriding service name", "volume.servicename.container", []string{"service-name.volume"}),
+		Entry("Container - Quadlet build with multiple tags", "build.multiple-tags.container", []string{"multiple-tags.build"}),
 
 		Entry("Volume - Quadlet image (.build)", "build.quadlet.volume", []string{"basic.build"}),
 		Entry("Volume - Quadlet image (.image)", "image.quadlet.volume", []string{"basic.image"}),


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - support multiple image tags for .build files
```

Resolves: #23781
