### PR TITLE
docs: update read the docs changes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,15 @@ import re
 import os
 import subprocess
 
+# Define the canonical URL for our custom docs.podman.io domain configured on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # We have to run the preprocessor to create the actual markdown files from .in files.
 # Do it here so the it can work on readthedocs as well.
 path = os.path.join(os.path.abspath(os.path.dirname(


### PR DESCRIPTION
Read the Docs does some update by October 7, 2024 which will effect our builds per[1]. As such apply the recommended changes from there to our conf.py file so we do not get broken builds after that date hopefully.

[1] https://about.readthedocs.com/blog/2024/07/addons-by-default/#how-does-it-affect-my-projects

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
