### PR TITLE
quadlet: support container network reusing

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -638,6 +638,10 @@ As a special case, if the `name` of the network ends with `.network`, a Podman n
 a dependency on the `$name-network.service`. Such a network can be automatically
 created by using a `$name.network` Quadlet file.
 
+Another special case is that if the `name` ends with `.container`,
+the container will reuse the network stack of another container created by `$name.container`.
+The generated systemd service contains a dependency on `$name.service`.
+
 This key can be listed multiple times.
 
 ### `NetworkAlias=`

--- a/test/e2e/quadlet/network.reuse.container
+++ b/test/e2e/quadlet/network.reuse.container
@@ -1,0 +1,7 @@
+## assert-podman-args "--network=container:systemd-basic"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is "Unit" "After" "network-online.target" "basic.service"
+
+[Container]
+Image=localhost/imagename
+Network=basic.container

--- a/test/e2e/quadlet/network.reuse.name.container
+++ b/test/e2e/quadlet/network.reuse.name.container
@@ -1,0 +1,7 @@
+## assert-podman-args "--network=container:foobar"
+## assert-key-is "Unit" "Requires" "name.service"
+## assert-key-is "Unit" "After" "network-online.target" "name.service"
+
+[Container]
+Image=localhost/imagename
+Network=name.container

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1077,6 +1077,8 @@ BOGUS=foo
 		Entry("Container - Quadlet Network overriding service name", "network.quadlet.servicename.container", []string{"service-name.network"}),
 		Entry("Container - Quadlet Volume overriding service name", "volume.servicename.container", []string{"service-name.volume"}),
 		Entry("Container - Quadlet build with multiple tags", "build.multiple-tags.container", []string{"multiple-tags.build"}),
+		Entry("Container - Reuse another container's network", "network.reuse.container", []string{"basic.container"}),
+		Entry("Container - Reuse another named container's network", "network.reuse.name.container", []string{"name.container"}),
 
 		Entry("Volume - Quadlet image (.build)", "build.quadlet.volume", []string{"basic.build"}),
 		Entry("Volume - Quadlet image (.image)", "image.quadlet.volume", []string{"basic.image"}),


### PR DESCRIPTION

```release-note
A container created by Quadlet can now reuse the network of another container by setting `Network=another.container`
```
