### PR TITLE
Add `kube play` support for volumes of type image 

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -28,11 +28,12 @@ Currently, the supported Kubernetes kinds are:
 
 `Kubernetes Pods or Deployments`
 
-Only three volume types are supported by kube play, the *hostPath*, *emptyDir*, and *persistentVolumeClaim* volume types.
+Only four volume types are supported by kube play, the *hostPath*, *emptyDir*, *persistentVolumeClaim*, and *image* volume types.
 
 - When using the *hostPath* volume type, only the  *default (empty)*, *DirectoryOrCreate*, *Directory*, *FileOrCreate*, *File*, *Socket*, *CharDevice* and *BlockDevice* subtypes are supported. Podman interprets the value of *hostPath* *path* as a file path when it contains at least one forward slash, otherwise Podman treats the value as the name of a named volume.
 - When using a *persistentVolumeClaim*, the value for *claimName* is the name for the Podman named volume.
 - When using an *emptyDir* volume, Podman creates an anonymous volume that is attached the containers running inside the pod and is deleted once the pod is removed.
+- When using an *image* volume, Podman creates a read-only image volume with an empty subpath (the whole image is mounted). The image must already exist locally. It is supported in rootful mode only.
 
 Note: The default restart policy for containers is `always`.  You can change the default by setting the `restartPolicy` field in the spec.
 
@@ -159,7 +160,9 @@ spec:
 
 and as a result environment variable `FOO` is set to `bar` for container `container-1`.
 
-`Automounting Volumes`
+`Automounting Volumes (deprecated)`
+
+Note: The automounting annotation is deprecated. Kubernetes has [native support for image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/) and that should be used rather than this podman-specific annotation.
 
 An image can be automatically mounted into a container if the annotation `io.podman.annotations.kube.image.automount/$ctrname` is given. The following rules apply:
 

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -567,6 +567,14 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 				Source:      define.TypeTmpfs,
 			}
 			s.Mounts = append(s.Mounts, memVolume)
+		case KubeVolumeTypeImage:
+			imageVolume := specgen.ImageVolume{
+				Destination: volume.MountPath,
+				ReadWrite:   false,
+				Source:      volumeSource.Source,
+				SubPath:     "",
+			}
+			s.ImageVolumes = append(s.ImageVolumes, &imageVolume)
 		default:
 			return nil, errors.New("unsupported volume source type")
 		}

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -14,7 +14,7 @@ one and only one (standard) image, and no running containers.
 * `parse_table` - you can define tables of inputs and expected results,
 then read those in a `while` loop. This makes it easy to add new tests.
 Because bash is not a programming language, the caller of `parse_table`
-sometimes needs to massage the returned values; `015-run.bats` offers
+sometimes needs to massage the returned values; `030-run.bats` offers
 examples of how to deal with the more typical such issues.
 
 * `run_podman` - runs command defined in `$PODMAN` (default: 'podman'


### PR DESCRIPTION
Add the support for [Kubernetes volumes of type image](https://kubernetes.io/blog/2024/08/16/kubernetes-1-31-image-volume-source/). 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kube play supports Kubernetes volumes of type image, introduced as an alpha feature in v1.31 
```

Resolves: https://github.com/containers/podman/issues/23775