### PR TITLE
Improve platform specific URL handling in `podman compose` for machines

### DIFF
--- a/cmd/podman/compose_machine.go
+++ b/cmd/podman/compose_machine.go
@@ -3,11 +3,9 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
@@ -55,16 +53,7 @@ func getMachineConn(connectionURI string, parsedConnection *url.URL) (string, er
 		if err != nil {
 			return "", err
 		}
-		if machineProvider.VMType() == define.WSLVirt || machineProvider.VMType() == define.HyperVVirt {
-			if podmanPipe == nil {
-				return "", errors.New("pipe of machine is not set")
-			}
-			return strings.Replace(podmanPipe.Path, `\\.\pipe\`, "npipe:////./pipe/", 1), nil
-		}
-		if podmanSocket == nil {
-			return "", errors.New("socket of machine is not set")
-		}
-		return "unix://" + podmanSocket.Path, nil
+		return extractConnectionString(podmanSocket, podmanPipe)
 	}
 	return "", fmt.Errorf("could not find a matching machine for connection %q", connectionURI)
 }

--- a/cmd/podman/compose_machine_unix.go
+++ b/cmd/podman/compose_machine_unix.go
@@ -1,0 +1,16 @@
+//go:build (amd64 || arm64) && !windows
+
+package main
+
+import (
+	"errors"
+
+	"github.com/containers/podman/v5/pkg/machine/define"
+)
+
+func extractConnectionString(podmanSocket *define.VMFile, podmanPipe *define.VMFile) (string, error) {
+	if podmanSocket == nil {
+		return "", errors.New("socket of machine is not set")
+	}
+	return "unix://" + podmanSocket.Path, nil
+}

--- a/cmd/podman/compose_machine_windows.go
+++ b/cmd/podman/compose_machine_windows.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/containers/podman/v5/pkg/machine/define"
+)
+
+func extractConnectionString(podmanSocket *define.VMFile, podmanPipe *define.VMFile) (string, error) {
+	if podmanPipe == nil {
+		return "", errors.New("pipe of machine is not set")
+	}
+	return "npipe://" + filepath.ToSlash(podmanPipe.Path), nil
+}

--- a/pkg/machine/e2e/compose_test.go
+++ b/pkg/machine/e2e/compose_test.go
@@ -1,0 +1,48 @@
+package e2e_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/containers/podman/v5/pkg/machine"
+	jsoniter "github.com/json-iterator/go"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("podman machine compose", func() {
+
+	It("compose test environment variable setup", func() {
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		inspectJSON := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+
+		var inspectInfo []machine.InspectInfo
+		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
+		Expect(err).ToNot(HaveOccurred())
+
+		compose := new(fakeCompose)
+		composeSession, err := mb.setName(name).setCmd(compose).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(composeSession).To(Exit(0))
+
+		lines := composeSession.outputToStringSlice()
+		if runtime.GOOS != "windows" {
+			Expect(lines[0]).To(Equal("unix://" + inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath()))
+		} else {
+			Expect(strings.TrimSuffix(lines[0], "\r")).To(Equal("npipe://" + filepath.ToSlash(inspectInfo[0].ConnectionInfo.PodmanPipe.GetPath())))
+		}
+		Expect(strings.TrimSuffix(lines[1], "\r")).To(Equal("0"))
+	})
+
+})

--- a/pkg/machine/e2e/config_compose_test.go
+++ b/pkg/machine/e2e/config_compose_test.go
@@ -1,0 +1,12 @@
+package e2e_test
+
+type fakeCompose struct {
+	cmd []string
+}
+
+func (f *fakeCompose) buildCmd(m *machineTestBuilder) []string {
+	cmd := []string{"compose"}
+	cmd = append(cmd, "env")
+	f.cmd = cmd
+	return cmd
+}

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -154,6 +154,22 @@ func setup() (string, *machineTestBuilder) {
 	if err := os.Setenv("PODMAN_CONNECTIONS_CONF", filepath.Join(homeDir, "connections.json")); err != nil {
 		Fail("failed to set PODMAN_CONNECTIONS_CONF")
 	}
+	if err := os.Setenv("PODMAN_COMPOSE_WARNING_LOGS", "false"); err != nil {
+		Fail("failed to set PODMAN_COMPOSE_WARNING_LOGS")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		Fail("unable to get working directory")
+	}
+	var fakeComposeBin string
+	if runtime.GOOS != "windows" {
+		fakeComposeBin = "fake_compose"
+	} else {
+		fakeComposeBin = "fake_compose.bat"
+	}
+	if err := os.Setenv("PODMAN_COMPOSE_PROVIDER", filepath.Join(cwd, "scripts", fakeComposeBin)); err != nil {
+		Fail("failed to set PODMAN_COMPOSE_PROVIDER")
+	}
 	mb, err := newMB()
 	if err != nil {
 		Fail(fmt.Sprintf("failed to create machine test: %q", err))

--- a/pkg/machine/e2e/scripts/fake_compose
+++ b/pkg/machine/e2e/scripts/fake_compose
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ "$@" == "env" ]]; then
+    printenv DOCKER_HOST DOCKER_BUILDKIT
+    exit 0
+fi
+echo "arguments: $@"

--- a/pkg/machine/e2e/scripts/fake_compose.bat
+++ b/pkg/machine/e2e/scripts/fake_compose.bat
@@ -1,0 +1,18 @@
+@ECHO off
+
+IF "%1"=="env" (
+    goto procenv
+)
+
+echo arguments: %*
+exit
+
+:procenv
+
+if NOT "%DOCKER_HOST%" == "" (
+    echo %DOCKER_HOST%
+)
+
+if NOT "%DOCKER_BUILDKIT%" == "" (
+    echo %DOCKER_BUILDKIT%
+)


### PR DESCRIPTION
Use filepath utility instead of generic string replace to convert path on Windows. This also separates OS specific implementations to separate compilation sources and removes redundant check for virtualization provider on Windows platform.

Decision to use transport protocol is based on platform, not virtualization provider. `podman-compose` and `docker-compose` are external tools, which are virtualization provider agnostic. It is logical to separate the implementation into exclusive compilation units.

filepath transformation with prepend of the protocol looks more in line with how the thing is implemented for Unix sockets,

There should be no functional changes, so, no new tests provided. It should be regression tested if `podman compose` for machines was previously covered by e2e tests.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
