### PR TITLE
libpod: fix HostConfig.Devices output from 'podman inspect' on FreeBSD

### DIFF
--- a/libpod/container_inspect_freebsd.go
+++ b/libpod/container_inspect_freebsd.go
@@ -15,5 +15,14 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 	// UTS namespace mode
 	hostConfig.UTSMode = c.NamespaceMode(spec.UTSNamespace, ctrSpec)
 
+	// Devices
+	// Do not include if privileged - assumed that all devices will be
+	// included.
+	var err error
+	hostConfig.Devices, err = c.GetDevices(hostConfig.Privileged, *ctrSpec, map[string]string{})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
This changes the value emitted for HostConfig.Devices from 'null' to '[]'. The 'null' value was preventing ansible's podman module from working correctly on FreeBSD.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
On FreeBSD hosts, fix the 'HostConfig.Device' value emitted by 'podman inspect'. This makes Ansible's podman module usable on FreeBSD.
```
