### PR TITLE
Add disclaimer in `podman machine info` manpage

### DIFF
--- a/docs/source/markdown/podman-machine-info.1.md
+++ b/docs/source/markdown/podman-machine-info.1.md
@@ -11,6 +11,12 @@ podman\-machine\-info - Display machine host info
 Display information pertaining to the machine host.
 Rootless only, as all `podman machine` commands can be only be used with rootless Podman.
 
+*Note*: The `DefaultMachine` field in the `Host` output does not suggest that
+one can set a default podman machine via system connections. This value represents
+the current active system connection associated with a podman machine. Regardless
+of the default system connection, the default podman machine will always be
+`podman-machine-default`.
+
 ## OPTIONS
 
 #### **--format**, **-f**=*format*

--- a/pkg/domain/entities/machine.go
+++ b/pkg/domain/entities/machine.go
@@ -28,8 +28,14 @@ type MachineInfo struct {
 
 // MachineHostInfo contains info on the machine host
 type MachineHostInfo struct {
-	Arch             string `json:"Arch"`
-	CurrentMachine   string `json:"CurrentMachine"`
+	Arch           string `json:"Arch"`
+	CurrentMachine string `json:"CurrentMachine"`
+	// TODO(6.0): Change `DefaultName` to `ActiveMachineConnection` to fix address
+	// confusion as shown in https://github.com/containers/podman/issues/23353.
+	// The name `DefaultMachine` can cause confusion with the user in thinking that
+	// they can set a default podman machine via system connections. However,
+	// regardless of which system connection is default, the default podman machine
+	// will always be podman-machine-default.
 	DefaultMachine   string `json:"DefaultMachine"`
 	EventsDir        string `json:"EventsDir"`
 	MachineConfigDir string `json:"MachineConfigDir"`


### PR DESCRIPTION
Adds a note in the `podman machine info` manpage that clarifies
that `defaultmachine` in the `podman machine info` output does
not suggest that a user can set a default podman machine via
system connections.

Additionally adds a Podman 6.0 TODO comment to change the name of the
field to `ActiveMachineConnection` to better describe its purpose.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a note in the `podman machine info` manpage to clarify the meaning of the `defaultmachine` output
```
