### PR TITLE
man pages: refactor two more options

### DIFF
--- a/docs/source/markdown/options/compat-auth-file.md
+++ b/docs/source/markdown/options/compat-auth-file.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman login, logout
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--compat-auth-file**=*path*
+
+Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.

--- a/docs/source/markdown/options/sign-by-sigstore.md
+++ b/docs/source/markdown/options/sign-by-sigstore.md
@@ -1,0 +1,8 @@
+####> This option file is used in:
+####>   podman manifest push, push
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--sign-by-sigstore**=*param-file*
+
+Add a sigstore signature based on further options specified in a container's sigstore signing parameter file *param-file*.
+See containers-sigstore-signing-params.yaml(5) for details about the file format.

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -32,9 +32,7 @@ For more details about format and configurations of the auth.json file, see cont
 
 @@option cert-dir
 
-#### **--compat-auth-file**=*path*
-
-Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.
+@@option compat-auth-file
 
 #### **--get-login**
 

--- a/docs/source/markdown/podman-logout.1.md.in
+++ b/docs/source/markdown/podman-logout.1.md.in
@@ -27,9 +27,7 @@ Remove the cached credentials for all registries in the auth file
 
 @@option authfile
 
-#### **--compat-auth-file**=*path*
-
-Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.
+@@option compat-auth-file
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -64,10 +64,7 @@ Delete the manifest list or image index from local storage if pushing succeeds.
 
 Sign the pushed images with a “simple signing” signature using the specified key. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--sign-by-sigstore**=*param-file*
-
-Add a sigstore signature based on further options specified in a container's sigstore signing parameter file *param-file*.
-See containers-sigstore-signing-params.yaml(5) for details about the file format.
+@@option sign-by-sigstore
 
 #### **--sign-by-sigstore-private-key**=*path*
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -92,10 +92,7 @@ Discard any pre-existing signatures in the image.
 
 Add a “simple signing” signature at the destination using the specified key. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--sign-by-sigstore**=*param-file*
-
-Add a sigstore signature based on further options specified in a container's sigstore signing parameter file *param-file*.
-See containers-sigstore-signing-params.yaml(5) for details about the file format.
+@@option sign-by-sigstore
 
 #### **--sign-by-sigstore-private-key**=*path*
 


### PR DESCRIPTION
We're supposed to catch duplicate man-page options in review,
but once in a while they sneak in. These are two dups that
are 100% identical, and were auto-refactored by a script
that I have. A few more options have snuck in (--dns, --usb)
but those have different text so they can't be handled by
my script. If anyone feels like refactoring those, go ahead.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```