### PR TITLE
prune: add `--build-cache` to support clearing build cache using `CleanCacheMount`

### DIFF
--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -46,6 +46,7 @@ func init() {
 
 	flags := pruneCmd.Flags()
 	flags.BoolVarP(&pruneOpts.All, "all", "a", false, "Remove all images not in use by containers, not just dangling ones")
+	flags.BoolVarP(&pruneOpts.BuildCache, "build-cache", "", false, "Remove persistent build cache created by --mount=type=cache")
 	flags.BoolVarP(&pruneOpts.External, "external", "", false, "Remove images even when they are used by external containers (e.g., by build containers)")
 	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation")
 

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -17,6 +17,10 @@ The image prune command does not prune cache images that only use layers that ar
 
 Remove dangling images and images that have no associated containers.
 
+#### **--build-cache**
+
+Remove persistent build cache create for `--mount=type=cache`.
+
 #### **--external**
 
 Remove images even when they are used by external containers (e.g., build containers).

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -118,8 +118,9 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		All      bool `schema:"all"`
-		External bool `schema:"external"`
+		All        bool `schema:"all"`
+		External   bool `schema:"external"`
+		BuildCache bool `schema:"buildcache"`
 	}{
 		// override any golang type defaults
 	}
@@ -157,9 +158,10 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
 	pruneOptions := entities.ImagePruneOptions{
-		All:      query.All,
-		External: query.External,
-		Filter:   libpodFilters,
+		All:        query.All,
+		External:   query.External,
+		Filter:     libpodFilters,
+		BuildCache: query.BuildCache,
 	}
 	imagePruneReports, err := imageEngine.Prune(r.Context(), pruneOptions)
 	if err != nil {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1129,6 +1129,12 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      Remove images even when they are used by external containers (e.g, by build containers)
 	//  - in: query
+	//    name: buildcache
+	//    default: false
+	//    type: boolean
+	//    description: |
+	//      Remove persistent build cache created by build instructions such as `--mount=type=cache`.
+	//  - in: query
 	//    name: filters
 	//    type: string
 	//    description: |

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -93,6 +93,8 @@ type PruneOptions struct {
 	All *bool
 	// Prune images even when they're used by external containers
 	External *bool
+	// Prune persistent build cache
+	BuildCache *bool
 	// Filters to apply when pruning images
 	Filters map[string][]string
 }

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -47,6 +47,21 @@ func (o *PruneOptions) GetExternal() bool {
 	return *o.External
 }
 
+// WithBuildCache set field BuildCache to given value
+func (o *PruneOptions) WithBuildCache(value bool) *PruneOptions {
+	o.BuildCache = &value
+	return o
+}
+
+// GetBuildCache returns value of field BuildCache
+func (o *PruneOptions) GetBuildCache() bool {
+	if o.BuildCache == nil {
+		var z bool
+		return z
+	}
+	return *o.BuildCache
+}
+
 // WithFilters set field Filters to given value
 func (o *PruneOptions) WithFilters(value map[string][]string) *PruneOptions {
 	o.Filters = value

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -249,9 +249,10 @@ type ImageListOptions struct {
 }
 
 type ImagePruneOptions struct {
-	All      bool     `json:"all" schema:"all"`
-	External bool     `json:"external" schema:"external"`
-	Filter   []string `json:"filter" schema:"filter"`
+	All        bool     `json:"all" schema:"all"`
+	External   bool     `json:"external" schema:"external"`
+	BuildCache bool     `json:"buildcache" schema:"buildcache"`
+	Filter     []string `json:"filter" schema:"filter"`
 }
 
 type ImageTagOptions struct{}

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	bdefine "github.com/containers/buildah/define"
+	"github.com/containers/buildah/pkg/volumes"
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/libimage/filter"
 	"github.com/containers/common/pkg/config"
@@ -105,6 +106,13 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 			break
 		}
 		numPreviouslyRemovedImages = numRemovedImages
+	}
+
+	if opts.BuildCache || opts.All {
+		// Clean build cache if any
+		if err := volumes.CleanCacheMount(); err != nil {
+			return nil, err
+		}
 	}
 
 	return pruneReports, nil

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -102,7 +102,7 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		f := strings.Split(filter, "=")
 		filters[f[0]] = f[1:]
 	}
-	options := new(images.PruneOptions).WithAll(opts.All).WithFilters(filters).WithExternal(opts.External)
+	options := new(images.PruneOptions).WithAll(opts.All).WithFilters(filters).WithExternal(opts.External).WithBuildCache(opts.BuildCache)
 	reports, err := images.Prune(ir.ClientCtx, options)
 	if err != nil {
 		return nil, err

--- a/test/e2e/build/buildkit-mount/Containerfilecacheread
+++ b/test/e2e/build/buildkit-mount/Containerfilecacheread
@@ -1,0 +1,4 @@
+FROM alpine
+RUN mkdir /test
+# use option z if selinux is enabled
+RUN --mount=type=cache,target=/test,z cat /test/world

--- a/test/e2e/build/buildkit-mount/Containerfilecachewrite
+++ b/test/e2e/build/buildkit-mount/Containerfilecachewrite
@@ -1,0 +1,4 @@
+FROM alpine
+RUN mkdir /test
+# use option z if selinux is enabled
+RUN --mount=type=cache,target=/test,z echo hello > /test/world


### PR DESCRIPTION
`podman builder prune` and `podman image prune` should also support cleaning build cache using buildah's public `CleanCacheMount` API.

Reference: https://docs.docker.com/reference/cli/docker/builder/prune/
Fixes: https://github.com/containers/podman/discussions/15612#discussioncomment-10532721
Context: https://github.com/containers/buildah/pull/4490

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman builder prune and podman image prune now cleans build cache as well using a new flag `--build-cache`
```
