### PR TITLE
CI: system tests: parallelize low-hanging fruit

### DIFF
--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -196,6 +196,7 @@ function check_help() {
 }
 
 
+# bats test_tags=ci:parallel
 @test "podman help - basic tests" {
     skip_if_remote
 

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -7,6 +7,9 @@
 
 load helpers
 
+# All tests here can be run in parallel
+# bats file_tags=ci:parallel
+
 @test "podman cp file from host to container" {
     srcdir=$PODMAN_TMPDIR/cp-test-file-host-to-ctr
     mkdir -p $srcdir

--- a/test/system/271-tcp-cors-server.bats
+++ b/test/system/271-tcp-cors-server.bats
@@ -13,6 +13,7 @@ SERVICE_TCP_HOST="localhost"
 SERVICE_FILE="$UNIT_DIR/$SERVICE_NAME.service"
 SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
 
+# bats test_tags=ci:parallel
 @test "podman system service - tcp CORS" {
     skip_if_remote "system service tests are meaningless over remote"
     PORT=$(random_free_port 63000-64999)
@@ -30,6 +31,7 @@ SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
            "podman warns about server on TCP"
 }
 
+# bats test_tags=ci:parallel
 @test "podman system service - tcp without CORS" {
     skip_if_remote "system service tests are meaningless over remote"
     PORT=$(random_free_port 63000-64999)
@@ -41,10 +43,15 @@ SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
     wait $podman_pid || true
 }
 
+# bats test_tags=ci:parallel
 @test "podman system service - CORS enabled in logs" {
     skip_if_remote "system service tests are meaningless over remote"
-    run_podman system service --log-level="debug" --cors="*" -t 1
+
+    PORT=$(random_free_port 63000-64999)
+    run_podman 0+w system service --log-level="debug" --cors="*" -t 1 tcp:$SERVICE_TCP_HOST:$PORT
     is "$output" ".*CORS Headers were set to ..\*...*" "debug log confirms CORS headers set"
+    assert "$output" =~ "level=warning msg=\"Using the Podman API service with TCP sockets is not recommended" \
+           "TCP socket warning"
 }
 
 # vim: filetype=sh

--- a/test/system/420-cgroups.bats
+++ b/test/system/420-cgroups.bats
@@ -5,6 +5,7 @@
 
 load helpers
 
+# bats test_tags=ci:parallel
 @test "podman run, preserves initial --cgroup-manager" {
     skip_if_remote "podman-remote does not support --cgroup-manager"
 
@@ -37,7 +38,7 @@ load helpers
     run_podman rm myc
 }
 
-# bats test_tags=distro-integration
+# bats test_tags=distro-integration, ci:parallel
 @test "podman run --cgroups=disabled keeps the current cgroup" {
     skip_if_remote "podman-remote does not support --cgroups=disabled"
     skip_if_rootless_cgroupsv1

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -262,6 +262,7 @@ function _check_no_suggestions() {
 }
 
 
+# bats test_tags=ci:parallel
 @test "podman shell completion test" {
 
     random_container_name="c-$(safename)"
@@ -351,6 +352,7 @@ function _check_no_suggestions() {
     done
 }
 
+# bats test_tags=ci:parallel
 @test "podman shell completion for paths in container/image" {
     skip_if_remote "mounting via remote does not work"
     for cmd in create run; do

--- a/test/system/620-option-conflicts.bats
+++ b/test/system/620-option-conflicts.bats
@@ -6,6 +6,7 @@
 load helpers
 
 
+# bats test_tags=ci:parallel
 @test "options that cannot be set together" {
     skip_if_remote "not much point testing remote, and container-cleanup fails anyway"
 


### PR DESCRIPTION
Add 'ci:parallel' tags to a few easy places. And, two
small easily-reviewed safename or random-port additions.

These have been working fine in #23275. I want to stop
carrying them there so I can work on simplifying my PR.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```