### PR TITLE
libpod: fix rootless cgroup path with --cgroup-parent

### DIFF
--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -120,7 +120,7 @@ func assembleSystemdCgroupName(baseSlice, newSlice string) (string, string, erro
 		// When we run as rootless, the cgroup has a path like the following:
 		///sys/fs/cgroup/user.slice/user-@$UID.slice/user@$UID.service/user.slice/user-libpod_pod_$POD_ID.slice
 		uid := rootless.GetRootlessUID()
-		raw := fmt.Sprintf("user.slice/%s-%d.slice/user@%d.service/%s/%s-%s%s", noSlice, uid, uid, baseSlice, noSlice, newSlice, sliceSuffix)
+		raw := fmt.Sprintf("user.slice/user-%d.slice/user@%d.service/%s/%s-%s%s", uid, uid, baseSlice, noSlice, newSlice, sliceSuffix)
 		return raw, systemdPath, nil
 	}
 	return systemdPath, systemdPath, nil


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
The cgroup path following /sys/fs/cgroup/user.slice is not named user, but rather it is named after the parent slice.

Fixes #23780
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where rootless Podman could fail to start container with option --cgroup-parent ([#23780](https://github.com/containers/podman/issues/23780)).
```
