### PR TITLE
Add help message when starting multiple machines

### DIFF
--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -210,10 +210,10 @@ var _ = Describe("podman machine start", func() {
 		Expect(startSession1).To(Or(Exit(0), Exit(125)), "start command should succeed or fail with 125")
 		if startSession1.ExitCode() == 0 {
 			Expect(startSession2).To(Exit(125), "first start worked, second start must fail")
-			Expect(startSession2.errorToString()).To(ContainSubstring("machine %s: VM already running or starting", machine1))
+			Expect(startSession2.errorToString()).To(ContainSubstring("machine %s is already running: only one VM can be active at a time", machine1))
 		} else {
 			Expect(startSession2).To(Exit(0), "first start failed, second start succeed")
-			Expect(startSession1.errorToString()).To(ContainSubstring("machine %s: VM already running or starting", machine2))
+			Expect(startSession1.errorToString()).To(ContainSubstring("machine %s is already running: only one VM can be active at a time", machine2))
 		}
 	})
 })

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -283,7 +283,10 @@ func checkExclusiveActiveVM(provider vmconfigs.VMProvider, mc *vmconfigs.Machine
 			return err
 		}
 		if state == machineDefine.Running || state == machineDefine.Starting {
-			return fmt.Errorf("unable to start %q: machine %s: %w", mc.Name, name, machineDefine.ErrVMAlreadyRunning)
+			if mc.Name == name {
+				return fmt.Errorf("unable to start %q: machine %s: %w", mc.Name, name, machineDefine.ErrVMAlreadyRunning)
+			}
+			return fmt.Errorf("unable to start %q: machine %s is already running: %w", mc.Name, name, machineDefine.ErrMultipleActiveVM)
 		}
 	}
 	return nil


### PR DESCRIPTION
Not much can be done when multiple machines are started but a help message is definitely of help in some instances

Resolves: https://github.com/containers/podman/issues/23436

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Output of podman machine start now gives a suggestion if a machine is already running
```
