### PR TITLE
test/e2e: fix network prune flake

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1410,6 +1410,9 @@ func WaitForService(address url.URL) {
 // This needs to be called for all test they may remove networks from other tests,
 // so netwokr prune, system prune, or system reset.
 // see https://github.com/containers/podman/issues/17946
+// Note that when using this and running containers with custom networks you must use the
+// ginkgo Serial decorator to ensure no parallel test are running otherwise we get flakes,
+// https://github.com/containers/podman/issues/23876
 func useCustomNetworkDir(podmanTest *PodmanTestIntegration, tempdir string) {
 	// set custom network directory to prevent flakes since the dir is shared with all tests by default
 	podmanTest.NetworkConfigDir = tempdir

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -695,7 +695,7 @@ var _ = Describe("Podman network", func() {
 		Expect(listAgain.OutputToStringArray()).Should(ContainElement("podman"))
 	})
 
-	It("podman network prune", func() {
+	It("podman network prune", Serial, func() {
 		useCustomNetworkDir(podmanTest, tempdir)
 		// Create two networks
 		// Check they are there


### PR DESCRIPTION
Creating networks in a different dir is not parallel safe when running containers on them as the network configs may end up using the same bridge names which then causes conflicts on the host.

Fixes #23876

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
