### PR TITLE
podman images: sort repository with tags

### DIFF
--- a/docs/source/markdown/podman-images.1.md.in
+++ b/docs/source/markdown/podman-images.1.md.in
@@ -119,6 +119,7 @@ Lists only the image IDs.
 #### **--sort**=*sort*
 
 Sort by *created*, *id*, *repository*, *size* or *tag* (default: **created**)
+When sorting by *repository* it also sorts by the *tag* as second criteria to provide a stable output.
 
 ## EXAMPLE
 


### PR DESCRIPTION
When you sort by repository a user most likely also want the tags to be sorted as well. At the very least to get a stable output as the order could be changed pull podman tag/pull even if they keep using the same tag name.

Fixes #23803

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman images --sort repository now also sorts the tags as well
```
