### PR TITLE
[skip-ci] Packit: reorg Fedora and ELN targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,8 @@ packages:
     specfile_path: rpm/podman.spec
   podman-rhel:
     specfile_path: rpm/podman.spec
+  podman-eln:
+    specfile_path: rpm/podman.spec
 
 srpm_build_deps:
   - git-archive-all
@@ -31,13 +33,22 @@ jobs:
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
+    targets: &fedora_copr_targets
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-40-x86_64
+      - fedora-40-aarch64
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [podman-eln]
+    notifications: *packit_build_failure_notification
+    enable_net: true
     targets:
-      fedora-development-x86_64: {}
-      fedora-development-aarch64: {}
-      fedora-latest-x86_64: {}
-      fedora-latest-aarch64: {}
-      fedora-latest-stable-x86_64: {}
-      fedora-latest-stable-aarch64: {}
       fedora-eln-x86_64:
         additional_repos:
           - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
@@ -103,8 +114,11 @@ jobs:
     trigger: release
     update_release: false
     packages: [podman-fedora]
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: &fedora_targets
+      - fedora-development
+      - fedora-latest
+      - fedora-latest-stable
+      - fedora-40
 
   - job: propose_downstream
     trigger: release
@@ -116,11 +130,13 @@ jobs:
   - job: koji_build
     trigger: commit
     packages: [podman-fedora]
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets
 
   - job: bodhi_update
     trigger: commit
     packages: [podman-fedora]
     dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+      # rawhide updates are created automatically
+      - fedora-latest
+      - fedora-latest-stable
+      - fedora-40


### PR DESCRIPTION
This commit separates out ELN copr jobs into a separate set so that other Fedora targets can be reused with yaml anchors. Also, given ELN is not really Fedora, but rather a RHEL-next, it only makes sense to separate it out this way.

The Fedora copr and downstream targets also mention fedora-40 explicitly because once Fedora-41 is released, `fedora-latest` and `fedora-latest-stable` will both point to `fedora-41` , so we need to include fedora-40 as well.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
