### PR TITLE
Bump VMs. ShellCheck is now built-in

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240821t171500z-f40f39d13"
+    IMAGE_SUFFIX: "c20240906t153420z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -51,7 +51,6 @@ get_env_key() {
 # shellcheck disable=SC2154
 if [[ "${DISTRO_NV}" == "$FEDORA_NAME" ]]; then
     msg "Checking shell scripts"
-    showrun ooe.sh dnf install -y ShellCheck  # small/quick addition
     showrun shellcheck --format=tty \
         --shell=bash --external-sources \
         --enable add-default-case,avoid-nullary-conditions,check-unassigned-uppercase \

--- a/test/e2e/container_iface_name_test.go
+++ b/test/e2e/container_iface_name_test.go
@@ -11,12 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// FIXME 2024-05-14: "Debian" here is a proxy for "netavark < 1.10"
-func isDebian() bool {
-	info := GetHostDistributionInfo()
-	return info.Distribution == "debian"
-}
-
 func createNetworkDevice(name string) {
 	session := SystemExec("ip", []string{"link", "add", name, "type", "bridge"})
 	session.WaitWithDefaultTimeout()
@@ -103,11 +97,6 @@ var _ = Describe("Podman container interface name", func() {
 			}
 
 			for _, driverType := range []string{"macvlan", "ipvlan"} {
-				if driverType == "ipvlan" && isDebian() {
-					GinkgoWriter.Println("FIXME: Fails with netavark < 1.10. Re-enable once Debian gets an update")
-					continue
-				}
-
 				netName1 := createNetworkName(driverType)
 				netName2 := createNetworkName(driverType)
 
@@ -156,11 +145,6 @@ var _ = Describe("Podman container interface name", func() {
 		SkipIfRootless("cannot create network device in rootless mode.")
 
 		for _, driverType := range []string{"macvlan", "ipvlan"} {
-			if driverType == "ipvlan" && isDebian() {
-				GinkgoWriter.Println("FIXME: Fails with netavark < 1.10. Re-enable once Debian gets an update")
-				continue
-			}
-
 			// Create a nic to be used as a parent for macvlan/ipvlan network.
 			nicName1 := createNetworkName("nic")[:8]
 			nicName2 := createNetworkName("nic")[:8]
@@ -222,11 +206,6 @@ var _ = Describe("Podman container interface name", func() {
 		createContainersConfFileWithDeviceIfaceName(podmanTest)
 
 		for _, driverType := range []string{"macvlan", "ipvlan"} {
-			if driverType == "ipvlan" && isDebian() {
-				GinkgoWriter.Println("FIXME: Fails with netavark < 1.10. Re-enable once Debian gets an update")
-				continue
-			}
-
 			// Create a nic to be used as a parent for the network.
 			nicName1 := createNetworkName("nic")[:8]
 			nicName2 := createNetworkName("nic")[:8]


### PR DESCRIPTION
Minor bump. Fedora VMs now include ShellCheck, so we can
remove the 'dnf install' at CI run time.

Also, FWIW, Debian *vark are now at 1.12 (from 1.9)

VMs built in https://github.com/containers/automation_images/pull/385

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```