### PR TITLE
CI: make 505-pasta parallel safe

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -1095,4 +1095,24 @@ function wait_for_restart_count() {
     run_podman network rm $netname
 }
 
+# 2024-07-23 moved from 505 pasta tests because it can't run in parallel
+# CANNOT BE PARALLELIZED
+@test "Podman unshare --rootless-netns with Pasta" {
+    skip_if_remote "unshare is local-only"
+    skip_if_not_rootless "pasta networking only available in rootless mode"
+    skip_if_no_pasta "pasta not found; this test requires pasta"
+
+    pasta_iface=$(default_ifname 4)
+    assert "$pasta_iface" != "" "pasta_iface is set"
+
+    # First let's force a setup error by making pasta be "false".
+    ln -s /usr/bin/false $PODMAN_TMPDIR/pasta
+    CONTAINERS_HELPER_BINARY_DIR="$PODMAN_TMPDIR" run_podman 125 unshare --rootless-netns ip addr
+    assert "$output" =~ "pasta failed with exit code 1"
+
+    # Now this should recover from the previous error and setup the netns correctly.
+    run_podman unshare --rootless-netns ip addr
+    is "$output" ".*${pasta_iface}.*"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Add ci:parallel tags; move one non-parallel-safe test to
another networking-test file; and a few drive-by fixes

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```