### PR TITLE
[skip-ci] Packit: Enable sidetags for bodhi updates

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,8 @@ packages:
     specfile_path: rpm/podman.spec
   podman-rhel:
     specfile_path: rpm/podman.spec
+  podman-eln:
+    specfile_path: rpm/podman.spec
 
 srpm_build_deps:
   - git-archive-all
@@ -32,12 +34,21 @@ jobs:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     targets:
-      fedora-development-x86_64: {}
-      fedora-development-aarch64: {}
-      fedora-latest-x86_64: {}
-      fedora-latest-aarch64: {}
-      fedora-latest-stable-x86_64: {}
-      fedora-latest-stable-aarch64: {}
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-40-x86_64
+      - fedora-40-aarch64
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [podman-eln]
+    notifications: *packit_build_failure_notification
+    enable_net: true
+    targets:
       fedora-eln-x86_64:
         additional_repos:
           - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
@@ -103,7 +114,7 @@ jobs:
     trigger: release
     update_release: false
     packages: [podman-fedora]
-    dist_git_branches:
+    dist_git_branches: &fedora_targets
       - fedora-all
 
   - job: propose_downstream
@@ -116,8 +127,7 @@ jobs:
   - job: koji_build
     trigger: commit
     sidetag_group: podman-releases
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets
 
   - job: bodhi_update
     trigger: koji_build
@@ -129,5 +139,4 @@ jobs:
       - buildah
       - containers-common
       - skopeo
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -115,12 +115,19 @@ jobs:
 
   - job: koji_build
     trigger: commit
-    packages: [podman-fedora]
+    sidetag_group: podman-releases
     dist_git_branches:
       - fedora-all
 
   - job: bodhi_update
-    trigger: commit
-    packages: [podman-fedora]
+    trigger: koji_build
+    sidetag_group: podman-releases
+    # Dependencies are not rpm dependencies, but packages that should go in the
+    # same bodhi update
+    # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
+    dependencies:
+      - buildah
+      - containers-common
+      - skopeo
     dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+      - fedora-all


### PR DESCRIPTION
Packit now has sidetag support for adding multiple builds into a single bodhi update.
    
Since we release c/ccommon, skopeo, buildah and podman often almoost simultaneously, we should release them to Fedora in a single bodhi update using sidetags so all builds can be tested together.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
