### PR TITLE
Add radio buttons to select WSL or Hyper-V in windows setup.exe

### DIFF
--- a/build_windows.md
+++ b/build_windows.md
@@ -411,9 +411,9 @@ msiexec /package contrib\win-installer\en-US\podman.msi /l*v podman-msi.log /qui
 ```
 
 :information_source: `podman.msi` GUI dialogs, defined in the file
-`contrib\win-installer\podman-ui.wxs`, are distinct from the installation bundle
+`contrib\win-installer\welcome-install-dlg.wxs`, are distinct from the installation bundle
 `podman-setup.exe` GUI dialogs, defined in
-`contrib\win-installer\welcome-install-dlg.wxs`.
+`contrib\win-installer\podman-theme.xml`.
 
 ### Verify the installation
 

--- a/contrib/win-installer/podman-theme.wxl
+++ b/contrib/win-installer/podman-theme.wxl
@@ -6,9 +6,10 @@
   <String Id="Caption" Value="[WixBundleName] [VERSION] Setup" />
   <String Id="Title" Value="[WixBundleName] [VERSION]" />
   <String Id="InstallHeader" Value="Welcome to [WixBundleName] Setup" />
-  <String Id="InstallMessage" Value="Welcome to the [WixBundleName] [VERSION] setup wizard. This will install [WixBundleName] on your computer.
+  <String Id="InstallMessage" Value="Welcome to the [WixBundleName] [VERSION] setup wizard. This will install [WixBundleName] on your computer." />
+  <String Id="ProvidersMessage" Value="Additionally, you have the option to select the virtualization provider required by Podman: WSLv2 or Hyper-V.
 
-Additionally, you have the option to also install WSL (required by podman) if it is not already enabled. This operation requires a reboot during the installation process. Alternatively, you can deselect the WSL checkbox, and install WSL manually using the wsl --install command.
+You can choose to also install the virtualization provider if it is not already enabled. This operation requires a reboot during the installation process. Alternatively, you can deselect the checkbox, and install the virtualization provider manually.
 
 Finally, click install to continue, or Close to abort the installation." />
   <String Id="InstallVersion" Value="Version [WixBundleVersion]" />
@@ -26,7 +27,8 @@ Finally, click install to continue, or Close to abort the installation." />
   <String Id="HelpCloseButton" Value="&amp;Close" />
   <String Id="InstallLicenseLinkText" Value='[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.' />
   <String Id="InstallAcceptCheckbox" Value="I &amp;agree to the license terms and conditions" />
-  <String Id="InstallOptionsButton" Value="&amp;Options" />
+  <String Id="InstallWSLCheckbox" Value="&amp;Install WSLv2 if not present" />
+  <String Id="InstallHypervCheckbox" Value="&amp;Install Hyper-V if not present" />
   <String Id="InstallInstallButton" Value="&amp;Install" />
   <String Id="InstallCancelButton" Value="&amp;Close" />
   <String Id="OptionsHeader" Value="Setup Options" />

--- a/contrib/win-installer/podman-theme.xml
+++ b/contrib/win-installer/podman-theme.xml
@@ -31,10 +31,16 @@
         <Page Name="Install">
             <ImageControl X="11" Y="11" Width="165" Height="400" ImageFile="logoside.png"/>
             <Label X="185" Y="11" Width="-11" Height="40" FontId="5" DisablePrefix="yes">#(loc.InstallHeader)</Label>
-            <Label X="185" Y="82" Width="-11" Height="160" FontId="3" DisablePrefix="yes">#(loc.InstallMessage)</Label>
+            <Label X="185" Y="82" Width="-11" Height="40" FontId="3" DisablePrefix="yes">#(loc.InstallMessage)</Label>
+            <Label X="185" Y="127" Width="-11" Height="120" VisibleCondition="NOT PreviousInstallFolder" FontId="3" DisablePrefix="yes">#(loc.ProvidersMessage)</Label>
+            <RadioButtons Name="MachineProvider">
+                <RadioButton Name="WSLRadioButton" Value="wsl" VisibleCondition="NOT PreviousInstallFolder" X="185" Y="260" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes" EnableCondition="" >Windows Linux Subsystem (WSLv2)</RadioButton>
+                <RadioButton Name="HyperVRadioButton"  Value="hyperv" VisibleCondition="NOT PreviousInstallFolder" X="185" Y="285" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">Windows Hyper-V</RadioButton>
+            </RadioButtons>
             <Hypertext Name="EulaHyperlink" X="185" Y="-111" Width="-11" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
-            <Label Name="InstallVersion" X="185" Y="-81" Width="-11" Height="17" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">#(loc.InstallVersion)</Label>
-            <Checkbox Name="WSLCheckbox" X="185" Y="250" Width="-11" Height="17" TabStop="yes" FontId="6" HideWhenDisabled="yes">Install WSL if not present</Checkbox>
+            <Label Name="InstallVersion" X="510" Y="-50" Width="-11" Height="17" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">#(loc.InstallVersion)</Label>
+            <Checkbox Name="WSLCheckbox" VisibleCondition="(MachineProvider = &quot;wsl&quot;) AND (NOT PreviousInstallFolder)" X="185" Y="320" Width="-11" Height="17" TabStop="yes" FontId="6" HideWhenDisabled="yes">#(loc.InstallWSLCheckbox)</Checkbox>
+            <Checkbox Name="HyperVCheckbox" VisibleCondition="(MachineProvider = &quot;hyperv&quot;) AND (NOT PreviousInstallFolder)" X="185" Y="320" Width="-11" Height="17" TabStop="yes" FontId="6" HideWhenDisabled="yes">#(loc.InstallHypervCheckbox)</Checkbox>
             <Button Name="OptionsButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" VisibleCondition="NOT WixStdBASuppressOptionsUI">
                 <Text>#(loc.InstallOptionsButton)</Text>
                 <ChangePageAction Page="Options" />


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Fixes #22492

## Before

![podman-setup-original](https://github.com/user-attachments/assets/97390433-6164-4b0b-86c4-6d7a2a6806f2)

## After

The last screenshot is when a previous version of podman is found, and we don't want the user to select the provider):

![podman-setup-new1](https://github.com/user-attachments/assets/82bf8ff9-f602-413e-b206-7087288b6abe)

![podman-setup-new2](https://github.com/user-attachments/assets/1566c600-0884-41fb-b509-ad30fb4e3088)

![podman-setup-new3](https://github.com/user-attachments/assets/530a1afb-7beb-4017-8188-9c004391cf5c)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The Windows installer has a new radio button to select the virtualization provider (WSLv2 or Hyper-V)
```
