### PR TITLE
New VMs: test crun 1.17

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240906t153420z-f40f39d13"
+    IMAGE_SUFFIX: "c20240911t151000z-f40f39d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -742,9 +742,9 @@ USER bin`, BB)
 	It("podman run limits host test", func() {
 		SkipIfRemote("This can only be used for local tests")
 		info := GetHostDistributionInfo()
-		if info.Distribution == "debian" {
+		if info.Distribution == "debian" && isRootless() {
 			// "expected 1048576 to be >= 1073741816"
-			Skip("FIXME 2024-05-28 fails on debian, maybe because of systemd 256?")
+			Skip("FIXME 2024-09 still fails on debian rootless, reason unknown")
 		}
 
 		var l syscall.Rlimit
@@ -2221,12 +2221,6 @@ WORKDIR /madethis`, BB)
 	})
 
 	It("podman run --shm-size-systemd", func() {
-		// FIXME Failed to set RLIMIT_CORE: Operation not permitted
-		info := GetHostDistributionInfo()
-		if info.Distribution == "debian" {
-			Skip("FIXME 2024-05-28 fails on debian, maybe because of systemd 256?")
-		}
-
 		ctrName := "testShmSizeSystemd"
 		run := podmanTest.Podman([]string{"run", "--name", ctrName, "--shm-size-systemd", "10mb", "-d", SYSTEMD_IMAGE, "/sbin/init"})
 		run.WaitWithDefaultTimeout()

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -89,7 +89,7 @@ verify_iid_and_name() {
         skip "impossible due to pitfalls in our SSH implementation"
     fi
 
-    # FIXME: Broken on debian SID systemd 256 <= rc3
+    # FIXME: Broken on debian SID; still broken 2024-09-11
     # See https://github.com/containers/podman/pull/23020#issuecomment-2179284640
     OS_RELEASE_ID="${OS_RELEASE_ID:-$(source /etc/os-release; echo $ID)}"
     if [[ "$OS_RELEASE_ID" == "debian" ]]; then


### PR DESCRIPTION
...and remove a bunch of old skip()s for older debian

~Do not merge, because crun-1.17 seems broken (https://github.com/containers/crun/issues/1560)~ That bug is not new in 1.17.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```