### PR TITLE
Handle default system connection transfer properly on machine removal

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	ldefine "github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/libpod/events"
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/shim"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
@@ -34,7 +33,7 @@ var (
 
 	initOpts           = define.InitOptions{}
 	initOptionalFlags  = InitOptionalFlags{}
-	defaultMachineName = machine.DefaultMachineName
+	defaultMachineName = define.DefaultMachineName
 	now                bool
 )
 

--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	machineconfig "github.com/containers/common/pkg/machine"
-	pkgMachine "github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	pkgOS "github.com/containers/podman/v5/pkg/machine/os"
 	"github.com/containers/podman/v5/pkg/machine/provider"
@@ -47,7 +47,7 @@ func guestOSManager() (pkgOS.Manager, error) {
 func machineOSManager(opts ManagerOpts, _ vmconfigs.VMProvider) (pkgOS.Manager, error) {
 	vmName := opts.VMName
 	if opts.VMName == "" {
-		vmName = pkgMachine.DefaultMachineName
+		vmName = define.DefaultMachineName
 	}
 	p, err := provider.Get()
 	if err != nil {

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -30,6 +30,11 @@ func resetMachine() error {
 		logrus.Errorf("unable to load machines: %q", err)
 	}
 
+	machines, err := p.GetAllMachinesAndRootfulness()
+	if err != nil {
+		return err
+	}
+
 	for _, mc := range mcs {
 		state, err := provider.State(mc, false)
 		if err != nil {
@@ -42,7 +47,7 @@ func resetMachine() error {
 			}
 		}
 
-		if err := connection.RemoveConnections(mc.Name, mc.Name+"-root"); err != nil {
+		if err := connection.RemoveConnections(machines, mc.Name, mc.Name+"-root"); err != nil {
 			logrus.Error(err)
 		}
 

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -20,10 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	DefaultMachineName string = "podman-machine-default"
-	apiUpTimeout              = 20 * time.Second
-)
+const apiUpTimeout = 20 * time.Second
 
 var (
 	ForwarderBinaryName = "gvproxy"

--- a/pkg/machine/connection/connection.go
+++ b/pkg/machine/connection/connection.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 
 	"github.com/containers/common/pkg/config"
-	"github.com/sirupsen/logrus"
 )
 
 const LocalhostIP = "127.0.0.1"
@@ -104,18 +102,6 @@ func RemoveConnections(names ...string) error {
 		}
 		return nil
 	})
-}
-
-// removeFilesAndConnections removes any files and connections with the given names
-func RemoveFilesAndConnections(files []string, names ...string) {
-	for _, f := range files {
-		if err := os.Remove(f); err != nil && !errors.Is(err, os.ErrNotExist) {
-			logrus.Error(err)
-		}
-	}
-	if err := RemoveConnections(names...); err != nil {
-		logrus.Error(err)
-	}
 }
 
 // makeSSHURL creates a URL from the given input

--- a/pkg/machine/define/config.go
+++ b/pkg/machine/define/config.go
@@ -2,8 +2,11 @@ package define
 
 import "os"
 
-const UserCertsTargetPath = "/etc/containers/certs.d"
-const DefaultIdentityName = "machine"
+const (
+	UserCertsTargetPath = "/etc/containers/certs.d"
+	DefaultIdentityName = "machine"
+	DefaultMachineName  = "podman-machine-default"
+)
 
 // MountTag is an identifier to mount a VirtioFS file system tag on a mount point in the VM.
 // Ref: https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/connection"
+	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/storage/pkg/ioutils"
 )
 
@@ -36,7 +37,7 @@ func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardS
 	suffix := ""
 	var fmtString string
 
-	if name != DefaultMachineName {
+	if name != define.DefaultMachineName {
 		suffix = " " + name
 	}
 
@@ -95,7 +96,7 @@ following command in your terminal session:
 
 func PrintRootlessWarning(name string) {
 	suffix := ""
-	if name != DefaultMachineName {
+	if name != define.DefaultMachineName {
 		suffix = " " + name
 	}
 

--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/env"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 )
 
 func InstalledProviders() ([]define.VMType, error) {
@@ -17,4 +19,27 @@ func InstalledProviders() ([]define.VMType, error) {
 		}
 	}
 	return installedTypes, nil
+}
+
+// GetAllMachinesAndRootfulness collects all podman machine configs and returns
+// a map in the format: { machineName: isRootful }
+func GetAllMachinesAndRootfulness() (map[string]bool, error) {
+	providers := GetAll()
+	machines := map[string]bool{}
+	for _, provider := range providers {
+		dirs, err := env.GetMachineDirs(provider.VMType())
+		if err != nil {
+			return nil, err
+		}
+		providerMachines, err := vmconfigs.LoadMachinesInDir(dirs)
+		if err != nil {
+			return nil, err
+		}
+
+		for n, m := range providerMachines {
+			machines[n] = m.HostUser.Rootful
+		}
+	}
+
+	return machines, nil
 }

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/ignition"
 	"github.com/containers/podman/v5/pkg/machine/lock"
+	"github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/proxyenv"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v5/utils"
@@ -230,7 +231,11 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 	}
 
 	cleanup := func() error {
-		return connection.RemoveConnections(mc.Name, mc.Name+"-root")
+		machines, err := provider.GetAllMachinesAndRootfulness()
+		if err != nil {
+			return err
+		}
+		return connection.RemoveConnections(machines, mc.Name, mc.Name+"-root")
 	}
 	callbackFuncs.Add(cleanup)
 
@@ -580,7 +585,12 @@ func Remove(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineD
 		}
 	}
 
-	rmFiles, genericRm, err := mc.Remove(opts.SaveIgnition, opts.SaveImage)
+	machines, err := provider.GetAllMachinesAndRootfulness()
+	if err != nil {
+		return err
+	}
+
+	rmFiles, genericRm, err := mc.Remove(machines, opts.SaveIgnition, opts.SaveImage)
 	if err != nil {
 		return err
 	}
@@ -655,12 +665,17 @@ func Reset(mps []vmconfigs.VMProvider, opts machine.ResetOptions) error {
 		}
 		removeDirs = append(removeDirs, d)
 
+		machines, err := provider.GetAllMachinesAndRootfulness()
+		if err != nil {
+			return err
+		}
+
 		for _, mc := range mcs {
 			err := Stop(mc, p, d, true)
 			if err != nil {
 				resetErrors = multierror.Append(resetErrors, err)
 			}
-			_, genericRm, err := mc.Remove(false, false)
+			_, genericRm, err := mc.Remove(machines, false, false)
 			if err != nil {
 				resetErrors = multierror.Append(resetErrors, err)
 			}

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -153,7 +153,7 @@ func (mc *MachineConfig) updateLastBoot() error { //nolint:unused
 	return mc.Write()
 }
 
-func (mc *MachineConfig) Remove(saveIgnition, saveImage bool) ([]string, func() error, error) {
+func (mc *MachineConfig) Remove(machines map[string]bool, saveIgnition, saveImage bool) ([]string, func() error, error) {
 	ignitionFile, err := mc.IgnitionFile()
 	if err != nil {
 		return nil, nil, err
@@ -195,7 +195,7 @@ func (mc *MachineConfig) Remove(saveIgnition, saveImage bool) ([]string, func() 
 
 	mcRemove := func() error {
 		var errs []error
-		if err := connection.RemoveConnections(mc.Name, mc.Name+"-root"); err != nil {
+		if err := connection.RemoveConnections(machines, mc.Name, mc.Name+"-root"); err != nil {
 			errs = append(errs, err)
 		}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
Changes system connection removal so the following case now works as expected:

- Rootless podman machine 1 is initialized and running.
- Rootful podman machine 2 is initialized.
- Delete podman machine 1.
- The **rootful** system connection associated with podman machine 2 now becomes the default, not the rootless.

Fixes: #22577

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When a user has a rootless machine running and another rootful podman machine initialized, and the rootless machine is removed, the rootful system connection associated with the podman machine now becomes the default as expected.
```
