### PR TITLE
Hide secrets from container inspect command

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -372,6 +372,20 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 	if spec.Process != nil {
 		ctrConfig.Tty = spec.Process.Terminal
 		ctrConfig.Env = append([]string{}, spec.Process.Env...)
+
+		// finds all secrets mounted as env variables and hides the value
+		// the inspect command should not display it
+		envSecrets := c.config.EnvSecrets
+		for envIndex, envValue := range ctrConfig.Env {
+			// env variables come in the style `name=value`
+			envName := strings.Split(envValue, "=")[0]
+
+			envSecret, ok := envSecrets[envName]
+			if ok {
+				ctrConfig.Env[envIndex] = envSecret.Name + "=*******"
+			}
+		}
+
 		ctrConfig.WorkingDir = spec.Process.Cwd
 	}
 


### PR DESCRIPTION
Secret mounted as an env variables are exposed by the `podman container inspect` command.

This change replaces the content of the env var by `*******`.

To reproduce this, follow the commands reported by the original issue:
```bash
printf 'secret value' | podman secret create mysecret -
podman container run --rm --secret mysecret,type=env -d alpine sleep 300
podman container inspect -l --format '{{ .Config.Env }}'
```

Fixes #23788

```release-note
Fixed secrets being exposed by `podman container inspect` when mounted as an env var
```
