### PR TITLE
quadlet: do not log ENOENT errors

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
 	"path"
@@ -120,7 +121,9 @@ func getUnitDirs(rootless bool) []string {
 	unitDirAdminUser = filepath.Join(quadlet.UnitDirAdmin, "users")
 	var err error
 	if resolvedUnitDirAdminUser, err = filepath.EvalSymlinks(unitDirAdminUser); err != nil {
-		Debugf("Error occurred resolving path %q: %s", unitDirAdminUser, err)
+		if !errors.Is(err, fs.ErrNotExist) {
+			Debugf("Error occurred resolving path %q: %s", unitDirAdminUser, err)
+		}
 		resolvedUnitDirAdminUser = unitDirAdminUser
 	}
 	systemUserDirLevel = len(strings.Split(resolvedUnitDirAdminUser, string(os.PathSeparator)))
@@ -166,7 +169,9 @@ func getUnitDirs(rootless bool) []string {
 func appendSubPaths(dirs []string, path string, isUserFlag bool, filterPtr func(string, bool) bool) []string {
 	resolvedPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		Debugf("Error occurred resolving path %q: %s", path, err)
+		if !errors.Is(err, fs.ErrNotExist) {
+			Debugf("Error occurred resolving path %q: %s", path, err)
+		}
 		// Despite the failure add the path to the list for logging purposes
 		// This is the equivalent of adding the path when info==nil below
 		dirs = append(dirs, path)


### PR DESCRIPTION
There is no point in logging them, the directories not existing is fine and expected and logging these by default when useing -dryrun just causes confusion.

Fixes #23620

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not log ENOENT errors in quadlet when resolving the unit dirs
```
