### PR TITLE
podman-manifest-remove: update docs and help output

### DIFF
--- a/cmd/podman/manifest/remove.go
+++ b/cmd/podman/manifest/remove.go
@@ -10,12 +10,12 @@ import (
 
 var (
 	removeCmd = &cobra.Command{
-		Use:               "remove LIST IMAGE",
-		Short:             "Remove an entry from a manifest list or image index",
-		Long:              "Removes an image from a manifest list or image index.",
+		Use:               "remove LIST DIGEST",
+		Short:             "Remove an item from a manifest list or image index",
+		Long:              "Removes an item from a manifest list or image index.",
 		RunE:              remove,
 		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: common.AutocompleteImages,
+		ValidArgsFunction: common.AutocompleteManifestListAndMember,
 		Example:           `podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`,
 	}
 )

--- a/docs/source/markdown/podman-manifest-remove.1.md
+++ b/docs/source/markdown/podman-manifest-remove.1.md
@@ -1,13 +1,13 @@
 % podman-manifest-remove 1
 
 ## NAME
-podman\-manifest\-remove - Remove an image from a manifest list or image index
+podman\-manifest\-remove - Remove an item from a manifest list or image index
 
 ## SYNOPSIS
-**podman manifest remove** *listnameorindexname* *transport:details*
+**podman manifest remove** *listnameorindexname* *digest*
 
 ## DESCRIPTION
-Removes the image with the specified digest from the specified manifest list or image index.
+Removes the item with the specified digest from the specified manifest list or image index.
 
 ## RETURN VALUE
 The list image's ID and the digest of the removed image's manifest.
@@ -17,7 +17,7 @@ The list image's ID and the digest of the removed image's manifest.
 Remove specified digest from the manifest list:
 ```
 podman manifest remove mylist:v1.11 sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221
-e604eabaaee4858232761b4fef84e2316ed8f93e15eceafce845966ee3400036 :sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221
+podman manifest remove e604eabaaee4858232761b4fef84e2316ed8f93e15eceafce845966ee3400036 sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-manifest.1.md
+++ b/docs/source/markdown/podman-manifest.1.md
@@ -21,7 +21,7 @@ The `podman manifest` command provides subcommands which can be used to:
 | exists   | [podman-manifest-exists(1)](podman-manifest-exists.1.md)     | Check if the given manifest list exists in local storage                                 |
 | inspect  | [podman-manifest-inspect(1)](podman-manifest-inspect.1.md)   | Display a manifest list or image index.                                                  |
 | push     | [podman-manifest-push(1)](podman-manifest-push.1.md)         | Push a manifest list or image index to a registry.                                       |
-| remove   | [podman-manifest-remove(1)](podman-manifest-remove.1.md)     | Remove an image from a manifest list or image index.                                     |
+| remove   | [podman-manifest-remove(1)](podman-manifest-remove.1.md)     | Remove an item from a manifest list or image index.                                     |
 | rm       | [podman-manifest-rm(1)](podman-manifest-rm.1.md)             | Remove manifest list or image index from local storage.                                  |
 
 ## EXAMPLES


### PR DESCRIPTION
* `podman manifest remove` doesn't accept references as descriptions of what to remove from a list or index; only use digests in the man page
* `podman manifest remove` only removes one thing at a time; correct the man page examples

#### Does this PR introduce a user-facing change?

```release-note
None
```