### PR TITLE
wait: fix handling of multiple conditions with exited

### DIFF
--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -108,4 +108,19 @@ var _ = Describe("Podman wait", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(Equal([]string{"0", "0", "0"}))
 	})
+
+	It("podman wait on multiple conditions", func() {
+		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "sleep", "100"})
+		session.Wait(20)
+		Expect(session).Should(ExitCleanly())
+		cid := session.OutputToString()
+
+		// condition should return once nay of the condition is met not all of them,
+		// as the container is running this should return immediately
+		// https://github.com/containers/podman-py/issues/425
+		session = podmanTest.Podman([]string{"wait", "--condition", "running,exited", cid})
+		session.Wait(20)
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("-1"))
+	})
 })

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -136,10 +136,6 @@ function _log_test_restarted() {
     fi
     cname="c-ltr-$(safename)"
     run_podman run --log-driver=$driver ${events_backend} --name $cname $IMAGE sh -c 'start=0; if test -s log; then start=`tail -n 1 log`; fi; seq `expr $start + 1` `expr $start + 10` | tee -a log'
-    # FIXME: #9597
-    # run/start is flaking for remote so let's wait for the container condition
-    # to stop wasting energy until the root cause gets fixed.
-    run_podman container wait --condition=exited --condition=stopped $cname
     run_podman ${events_backend} start -a $cname
     logfile=$(mktemp -p ${PODMAN_TMPDIR} logfileXXXXXXXX)
     $PODMAN $_PODMAN_TEST_OPTS ${events_backend} logs -f $cname > $logfile


### PR DESCRIPTION
As it turns on things are not so simple after all...
In podman-py it was reported[1] that waiting might hang, per our docs wait
on multiple conditions should exit once the first one is hit and not all
of them. However because the new wait logic never checked if the context
was cancelled the goroutine kept running until conmon exited and because
we used a waitgroup to wait for all of them to finish it blocked until
that happened.

First we can remove the waitgroup as we only need to wait for one of
them anyway via the channel. While this alone fixes the hang it would
still leak the other goroutine. As there is no way to cancel a goroutine
all the code must check for a cancelled context in the wait loop to no
leak.

Fixes https://github.com/containers/podman/commit/8a943311db5b686af231ddc026b7a0a072eb25d2 ("libpod: simplify WaitForExit()")
[1] https://github.com/containers/podman-py/issues/425

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None (The bug was only in main so not worth to include it in the changlog)
```
