### PR TITLE
Match output of Compat Top API to Docker

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -144,6 +144,14 @@ if root; then
     podman rm -f $CTRNAME
 fi
 
+# Verify that compat top endpoint combines multi-entry COMMAND lines
+CTRNAME=testtopproc
+podman run --name $CTRNAME -d $IMAGE sleep 25
+t GET containers/$CTRNAME/top?stream=false 200 \
+  .Processes.[0].[6]="00:00:00" \
+  .Processes.[0].[7]="sleep 25"
+podman rm -f -t0 $CTRNAME
+
 CTRNAME=test123
 podman run --name $CTRNAME -d $IMAGE top
 t GET libpod/containers/$CTRNAME/top?ps_args=--invalid 500 \


### PR DESCRIPTION
We were only splitting on tabs, not spaces, so we returned just a single line most of the time, not an array of the fields in the output of `ps`. Unfortunately, some of these fields are allowed to contain spaces themselves, which makes things complicated, but we got lucky in that Docker took the simplest possible solution and just assumed that only one field would contain spaces and it would always be the last one, which is easy enough to duplicate on our end.

Fixes #23981

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the output for the Compat Top API for Containers did not properly split the output into an array.
```
