### PR TITLE
allow exposed sctp ports

### DIFF
--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -158,7 +158,7 @@ func ParsePortMapping(portMappings []types.PortMapping, exposePorts map[uint16][
 	// First, we need to validate the ports passed in the specgen
 	for _, port := range portMappings {
 		// First, check proto
-		protocols, err := checkProtocol(port.Protocol, true)
+		protocols, err := checkProtocol(port.Protocol)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +355,7 @@ func createPortMappings(s *specgen.SpecGenerator, imageData *libimage.ImageData)
 			if port == 0 {
 				return nil, nil, fmt.Errorf("cannot expose 0 as it is not a valid port number")
 			}
-			protocols, err := checkProtocol(proto, false)
+			protocols, err := checkProtocol(proto)
 			if err != nil {
 				return nil, nil, fmt.Errorf("validating protocols for exposed port %d: %w", port, err)
 			}
@@ -376,7 +376,7 @@ func createPortMappings(s *specgen.SpecGenerator, imageData *libimage.ImageData)
 }
 
 // Check a string to ensure it is a comma-separated set of valid protocols
-func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
+func checkProtocol(protocol string) ([]string, error) {
 	protocols := make(map[string]struct{})
 	splitProto := strings.Split(protocol, ",")
 	// Don't error on duplicates - just deduplicate
@@ -388,9 +388,6 @@ func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
 		case protoUDP:
 			protocols[protoUDP] = struct{}{}
 		case protoSCTP:
-			if !allowSCTP {
-				return nil, fmt.Errorf("protocol SCTP is not allowed for exposed ports")
-			}
 			protocols[protoSCTP] = struct{}{}
 		default:
 			return nil, fmt.Errorf("unrecognized protocol %q in port mapping", p)

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -29,19 +29,19 @@ var _ = Describe("Podman container inspect", func() {
 
 	It("podman inspect shows exposed ports", func() {
 		name := "testcon"
-		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8787/udp", "--name", name, ALPINE, "sleep", "100"})
+		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8787/udp", "--expose", "99/sctp", "--name", name, ALPINE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		data := podmanTest.InspectContainer(name)
 
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
-			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil}))
+			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil, "99/sctp": nil}))
 
 		session = podmanTest.Podman([]string{"ps", "--format", "{{.Ports}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal("8787/udp"))
+		Expect(session.OutputToString()).To(Equal("99/sctp, 8787/udp"))
 	})
 
 	It("podman inspect shows exposed ports on image", func() {


### PR DESCRIPTION
There is no reason to disallow exposed sctp ports at all. As root we can publish them find and as rootless it should error later anyway.

And for the case mentioned in the issue it doesn't make sense as the port is not even published thus it is just part of the metadata which is totally in all cases.

Fixes #23911

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman no longer errors out when trying to expose sctp ports or when they are part of the image config.
```
