### PR TITLE
vendor latest c/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.5.1
 	github.com/containers/buildah v1.37.0
-	github.com/containers/common v0.60.1-0.20240911102244-e2c949db8a59
+	github.com/containers/common v0.60.1-0.20240918122915-db8145750e1d
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.5
 	github.com/containers/image/v5 v5.32.1-0.20240806084436-e3e9287ca8e6

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/buildah v1.37.0 h1:jvHwu1vIwIqnHyOSg9eef9Apdpry+5oWLrm43gdf8Rk=
 github.com/containers/buildah v1.37.0/go.mod h1:MKd79tkluMf6vtH06SedhBQK5OB7E0pFVIuiTTw3dJk=
-github.com/containers/common v0.60.1-0.20240911102244-e2c949db8a59 h1:X9km1EYMFpx80DZEy32/vKuadtYCJ/KJZuLamVbJX98=
-github.com/containers/common v0.60.1-0.20240911102244-e2c949db8a59/go.mod h1:I+AnVQDPUP6E9tWFOx1PngtVP6U6OIA4dcNGqFqjoQU=
+github.com/containers/common v0.60.1-0.20240918122915-db8145750e1d h1:AAEZbfeh92xKohiQoEk6sx+e/8OLIXzIElJ7H69cxVg=
+github.com/containers/common v0.60.1-0.20240918122915-db8145750e1d/go.mod h1:CPKbz94MP7eKS5LdkBZbcDbQgAHncjogq/hYY9r4Spw=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.5 h1:bTy4u3DOmmUPwurL6me2rsgfypAFDhyeJleUcQmBR/E=

--- a/vendor/github.com/containers/common/pkg/cgroups/cgroups_linux.go
+++ b/vendor/github.com/containers/common/pkg/cgroups/cgroups_linux.go
@@ -822,6 +822,12 @@ func UserOwnsCurrentSystemdCgroup() (bool, error) {
 			continue
 		}
 
+		// If we are on a cgroup v2 system and there are cgroup v1 controllers
+		// mounted, ignore them when the current process is at the root cgroup.
+		if cgroup2 && parts[1] != "" && parts[2] == "/" {
+			continue
+		}
+
 		var cgroupPath string
 
 		if cgroup2 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.60.1-0.20240911102244-e2c949db8a59
+# github.com/containers/common v0.60.1-0.20240918122915-db8145750e1d
 ## explicit; go 1.22.0
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
just to kick of some builds for testing

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
