### PR TITLE
[v4.4.1-rhel] CVE-2024-3727 & stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
 	github.com/containers/buildah v1.29.3
-	github.com/containers/common v0.51.3
+	github.com/containers/common v0.51.4
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/image/v5 v5.24.1
+	github.com/containers/image/v5 v5.24.3
 	github.com/containers/ocicrypt v1.1.10
 	github.com/containers/psgo v1.8.0
 	github.com/containers/storage v1.45.7

--- a/go.sum
+++ b/go.sum
@@ -272,12 +272,12 @@ github.com/containernetworking/plugins v1.2.0 h1:SWgg3dQG1yzUo4d9iD8cwSVh1VqI+bP
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
 github.com/containers/buildah v1.29.3 h1:OMHme3lsXULrGzWGsU2i/UzXgcCuwNTJmnNja0VRdrM=
 github.com/containers/buildah v1.29.3/go.mod h1:VSGsuTRlvCEHjRGki6drxhEagZ7HzEJJBGIsHg5AHVM=
-github.com/containers/common v0.51.3 h1:wwFXpQd0FtDWmaMZpnYYfEQvQB6dPGChRQfm71znzeY=
-github.com/containers/common v0.51.3/go.mod h1:3W2WIdalgQfrsX/T5tjX+6CxgT3ThJVN2G9sNuFjuCM=
+github.com/containers/common v0.51.4 h1:1m3D9lPYgY7sS4Xod962rCEZTsOlR2nuAbYFhzopME4=
+github.com/containers/common v0.51.4/go.mod h1:CVSTmQWOs6IbjOZW7ik+7QggrOR3gzKc6gqYfRipl1c=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/image/v5 v5.24.1 h1:XaRw3FJmvZtI297uBVTJluUVH4AQJ//YpHviaOw0C4M=
-github.com/containers/image/v5 v5.24.1/go.mod h1:oss5F6ssGQz8ZtC79oY+fuzYA3m3zBek9tq9gmhuvHc=
+github.com/containers/image/v5 v5.24.3 h1:IKrt9qWFqLkvu7trjH5XOKjkCdJ3y5vdcriOcm7j3GM=
+github.com/containers/image/v5 v5.24.3/go.mod h1:oss5F6ssGQz8ZtC79oY+fuzYA3m3zBek9tq9gmhuvHc=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/vendor/github.com/containers/common/pkg/cgroups/memory_linux.go
+++ b/vendor/github.com/containers/common/pkg/cgroups/memory_linux.go
@@ -4,7 +4,9 @@
 package cgroups
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
@@ -63,8 +65,25 @@ func (c *linuxMemHandler) Stat(ctr *CgroupControl, m *cgroups.Stats) error {
 	} else {
 		memoryRoot = ctr.getCgroupv1Path(Memory)
 		limitFilename = "memory.limit_in_bytes"
-		if memUsage.Usage.Usage, err = readFileAsUint64(filepath.Join(memoryRoot, "memory.usage_in_bytes")); err != nil {
+
+		path := filepath.Join(memoryRoot, "memory.stat")
+		values, err := readCgroup2MapPath(path)
+		if err != nil {
 			return err
+		}
+
+		// cgroup v1 does not have a single "anon" field, but we can calculate it
+		// from total_active_anon and total_inactive_anon
+		memUsage.Usage.Usage = 0
+		for _, key := range []string{"total_active_anon", "total_inactive_anon"} {
+			if _, found := values[key]; !found {
+				continue
+			}
+			res, err := strconv.ParseUint(values[key][0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("parse %s from %s: %w", key, path, err)
+			}
+			memUsage.Usage.Usage += res
 		}
 	}
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.51.3"
+const Version = "0.51.4"

--- a/vendor/github.com/containers/image/v5/copy/copy.go
+++ b/vendor/github.com/containers/image/v5/copy/copy.go
@@ -1085,7 +1085,10 @@ func (ic *imageCopier) copyConfig(ctx context.Context, src types.Image) error {
 		destInfo, err := func() (types.BlobInfo, error) { // A scope for defer
 			progressPool := ic.c.newProgressPool()
 			defer progressPool.Wait()
-			bar := ic.c.createProgressBar(progressPool, false, srcInfo, "config", "done")
+			bar, err := ic.c.createProgressBar(progressPool, false, srcInfo, "config", "done")
+			if err != nil {
+				return types.BlobInfo{}, err
+			}
 			defer bar.Abort(false)
 			ic.c.printCopyInfo("config", srcInfo)
 
@@ -1177,11 +1180,17 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		}
 		if reused {
 			logrus.Debugf("Skipping blob %s (already present):", srcInfo.Digest)
-			func() { // A scope for defer
-				bar := ic.c.createProgressBar(pool, false, types.BlobInfo{Digest: blobInfo.Digest, Size: 0}, "blob", "skipped: already exists")
+			if err := func() error { // A scope for defer
+				bar, err := ic.c.createProgressBar(pool, false, types.BlobInfo{Digest: blobInfo.Digest, Size: 0}, "blob", "skipped: already exists")
+				if err != nil {
+					return err
+				}
 				defer bar.Abort(false)
 				bar.mark100PercentComplete()
-			}()
+				return nil
+			}(); err != nil {
+				return types.BlobInfo{}, "", err
+			}
 
 			// Throw an event that the layer has been skipped
 			if ic.c.progress != nil && ic.c.progressInterval > 0 {
@@ -1212,8 +1221,11 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// Attempt a partial only when the source allows to retrieve a blob partially and
 	// the destination has support for it.
 	if canAvoidProcessingCompleteLayer && ic.c.rawSource.SupportsGetBlobAt() && ic.c.dest.SupportsPutBlobPartial() {
-		if reused, blobInfo := func() (bool, types.BlobInfo) { // A scope for defer
-			bar := ic.c.createProgressBar(pool, true, srcInfo, "blob", "done")
+		reused, blobInfo, err := func() (bool, types.BlobInfo, error) { // A scope for defer
+			bar, err := ic.c.createProgressBar(pool, true, srcInfo, "blob", "done")
+			if err != nil {
+				return false, types.BlobInfo{}, err
+			}
 			hideProgressBar := true
 			defer func() { // Note that this is not the same as defer bar.Abort(hideProgressBar); we need hideProgressBar to be evaluated lazily.
 				bar.Abort(hideProgressBar)
@@ -1231,18 +1243,25 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 				bar.mark100PercentComplete()
 				hideProgressBar = false
 				logrus.Debugf("Retrieved partial blob %v", srcInfo.Digest)
-				return true, info
+				return true, info, nil
 			}
 			logrus.Debugf("Failed to retrieve partial blob: %v", err)
-			return false, types.BlobInfo{}
-		}(); reused {
+			return false, types.BlobInfo{}, nil
+		}()
+		if err != nil {
+			return types.BlobInfo{}, "", err
+		}
+		if reused {
 			return blobInfo, cachedDiffID, nil
 		}
 	}
 
 	// Fallback: copy the layer, computing the diffID if we need to do so
 	return func() (types.BlobInfo, digest.Digest, error) { // A scope for defer
-		bar := ic.c.createProgressBar(pool, false, srcInfo, "blob", "done")
+		bar, err := ic.c.createProgressBar(pool, false, srcInfo, "blob", "done")
+		if err != nil {
+			return types.BlobInfo{}, "", err
+		}
 		defer bar.Abort(false)
 
 		srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(ctx, srcInfo, ic.c.blobInfoCache)

--- a/vendor/github.com/containers/image/v5/copy/progress_bars.go
+++ b/vendor/github.com/containers/image/v5/copy/progress_bars.go
@@ -48,10 +48,13 @@ type progressBar struct {
 // As a convention, most users of progress bars should call mark100PercentComplete on full success;
 // by convention, we don't leave progress bars in partial state when fully done
 // (even if we copied much less data than anticipated).
-func (c *copier) createProgressBar(pool *mpb.Progress, partial bool, info types.BlobInfo, kind string, onComplete string) *progressBar {
+func (c *copier) createProgressBar(pool *mpb.Progress, partial bool, info types.BlobInfo, kind string, onComplete string) (*progressBar, error) {
 	// shortDigestLen is the length of the digest used for blobs.
 	const shortDigestLen = 12
 
+	if err := info.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+		return nil, err
+	}
 	prefix := fmt.Sprintf("Copying %s %s", kind, info.Digest.Encoded())
 	// Truncate the prefix (chopping of some part of the digest) to make all progress bars aligned in a column.
 	maxPrefixLen := len("Copying blob ") + shortDigestLen
@@ -99,7 +102,7 @@ func (c *copier) createProgressBar(pool *mpb.Progress, partial bool, info types.
 	return &progressBar{
 		Bar:          bar,
 		originalSize: info.Size,
-	}
+	}, nil
 }
 
 // printCopyInfo prints a "Copying ..." message on the copier if the output is

--- a/vendor/github.com/containers/image/v5/directory/directory_transport.go
+++ b/vendor/github.com/containers/image/v5/directory/directory_transport.go
@@ -161,25 +161,34 @@ func (ref dirReference) DeleteImage(ctx context.Context, sys *types.SystemContex
 }
 
 // manifestPath returns a path for the manifest within a directory using our conventions.
-func (ref dirReference) manifestPath(instanceDigest *digest.Digest) string {
+func (ref dirReference) manifestPath(instanceDigest *digest.Digest) (string, error) {
 	if instanceDigest != nil {
-		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json")
+		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+			return "", err
+		}
+		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json"), nil
 	}
-	return filepath.Join(ref.path, "manifest.json")
+	return filepath.Join(ref.path, "manifest.json"), nil
 }
 
 // layerPath returns a path for a layer tarball within a directory using our conventions.
-func (ref dirReference) layerPath(digest digest.Digest) string {
+func (ref dirReference) layerPath(digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+		return "", err
+	}
 	// FIXME: Should we keep the digest identification?
-	return filepath.Join(ref.path, digest.Encoded())
+	return filepath.Join(ref.path, digest.Encoded()), nil
 }
 
 // signaturePath returns a path for a signature within a directory using our conventions.
-func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) string {
+func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) (string, error) {
 	if instanceDigest != nil {
-		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1))
+		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+			return "", err
+		}
+		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1)), nil
 	}
-	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1))
+	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1)), nil
 }
 
 // versionPath returns a path for the version file within a directory using our conventions.

--- a/vendor/github.com/containers/image/v5/docker/body_reader.go
+++ b/vendor/github.com/containers/image/v5/docker/body_reader.go
@@ -17,22 +17,27 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// bodyReaderMinimumProgress is the minimum progress we want to see before we retry
-const bodyReaderMinimumProgress = 1 * 1024 * 1024
+const (
+	// bodyReaderMinimumProgress is the minimum progress we consider a good reason to retry
+	bodyReaderMinimumProgress = 1 * 1024 * 1024
+	// bodyReaderMSSinceLastRetry is the minimum time since a last retry we consider a good reason to retry
+	bodyReaderMSSinceLastRetry = 60 * 1_000
+)
 
 // bodyReader is an io.ReadCloser returned by dockerImageSource.GetBlob,
 // which can transparently resume some (very limited) kinds of aborted connections.
 type bodyReader struct {
-	ctx context.Context
-	c   *dockerClient
-
-	path                string        // path to pass to makeRequest to retry
-	logURL              *url.URL      // a string to use in error messages
-	body                io.ReadCloser // The currently open connection we use to read data, or nil if there is nothing to read from / close.
-	lastRetryOffset     int64
-	offset              int64 // Current offset within the blob
+	ctx                 context.Context
+	c                   *dockerClient
+	path                string   // path to pass to makeRequest to retry
+	logURL              *url.URL // a string to use in error messages
 	firstConnectionTime time.Time
-	lastSuccessTime     time.Time // time.Time{} if N/A
+
+	body            io.ReadCloser // The currently open connection we use to read data, or nil if there is nothing to read from / close.
+	lastRetryOffset int64         // -1 if N/A
+	lastRetryTime   time.Time     // time.Time{} if N/A
+	offset          int64         // Current offset within the blob
+	lastSuccessTime time.Time     // time.Time{} if N/A
 }
 
 // newBodyReader creates a bodyReader for request path in c.
@@ -44,15 +49,17 @@ func newBodyReader(ctx context.Context, c *dockerClient, path string, firstBody 
 		return nil, err
 	}
 	res := &bodyReader{
-		ctx: ctx,
-		c:   c,
-
+		ctx:                 ctx,
+		c:                   c,
 		path:                path,
 		logURL:              logURL,
-		body:                firstBody,
-		lastRetryOffset:     0,
-		offset:              0,
 		firstConnectionTime: time.Now(),
+
+		body:            firstBody,
+		lastRetryOffset: -1,
+		lastRetryTime:   time.Time{},
+		offset:          0,
+		lastSuccessTime: time.Time{},
 	}
 	return res, nil
 }
@@ -190,6 +197,7 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 		consumedBody = true
 		br.body = res.Body
 		br.lastRetryOffset = br.offset
+		br.lastRetryTime = time.Time{}
 		return n, nil
 
 	default:
@@ -198,29 +206,40 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 	}
 }
 
-// millisecondsSince is like time.Since(tm).Milliseconds, but it returns a floating-point value
-func millisecondsSince(tm time.Time) float64 {
-	return float64(time.Since(tm).Nanoseconds()) / 1_000_000.0
+// millisecondsSinceOptional is like currentTime.Sub(tm).Milliseconds, but it returns a floating-point value.
+// If tm is time.Time{}, it returns math.NaN()
+func millisecondsSinceOptional(currentTime time.Time, tm time.Time) float64 {
+	if tm == (time.Time{}) {
+		return math.NaN()
+	}
+	return float64(currentTime.Sub(tm).Nanoseconds()) / 1_000_000.0
 }
 
 // errorIfNotReconnecting makes a heuristic decision whether we should reconnect after err at redactedURL; if so, it returns nil,
 // otherwise it returns an appropriate error to return to the caller (possibly augmented with data about the heuristic)
 func (br *bodyReader) errorIfNotReconnecting(originalErr error, redactedURL string) error {
-	totalTime := millisecondsSince(br.firstConnectionTime)
-	failureTime := math.NaN()
-	if (br.lastSuccessTime != time.Time{}) {
-		failureTime = millisecondsSince(br.lastSuccessTime)
-	}
-	logrus.Debugf("Reading blob body from %s failed (%#v), decision inputs: lastRetryOffset %d, offset %d, %.3f ms since first connection, %.3f ms since last progress",
-		redactedURL, originalErr, br.lastRetryOffset, br.offset, totalTime, failureTime)
+	currentTime := time.Now()
+	msSinceFirstConnection := millisecondsSinceOptional(currentTime, br.firstConnectionTime)
+	msSinceLastRetry := millisecondsSinceOptional(currentTime, br.lastRetryTime)
+	msSinceLastSuccess := millisecondsSinceOptional(currentTime, br.lastSuccessTime)
+	logrus.Debugf("Reading blob body from %s failed (%#v), decision inputs: total %d @%.3f ms, last retry %d @%.3f ms, last progress @%.3f ms",
+		redactedURL, originalErr, br.offset, msSinceFirstConnection, br.lastRetryOffset, msSinceLastRetry, msSinceLastSuccess)
 	progress := br.offset - br.lastRetryOffset
-	if progress < bodyReaderMinimumProgress {
-		logrus.Debugf("Not reconnecting to %s because only %d bytes progress made", redactedURL, progress)
-		return fmt.Errorf("(heuristic tuning data: last retry %d, current offset %d; %.3f ms total, %.3f ms since progress): %w",
-			br.lastRetryOffset, br.offset, totalTime, failureTime, originalErr)
+	if progress >= bodyReaderMinimumProgress {
+		logrus.Infof("Reading blob body from %s failed (%v), reconnecting after %d bytes…", redactedURL, originalErr, progress)
+		return nil
 	}
-	logrus.Infof("Reading blob body from %s failed (%v), reconnecting…", redactedURL, originalErr)
-	return nil
+	if br.lastRetryTime == (time.Time{}) {
+		logrus.Infof("Reading blob body from %s failed (%v), reconnecting (first reconnection)…", redactedURL, originalErr)
+		return nil
+	}
+	if msSinceLastRetry >= bodyReaderMSSinceLastRetry {
+		logrus.Infof("Reading blob body from %s failed (%v), reconnecting after %.3f ms…", redactedURL, originalErr, msSinceLastRetry)
+		return nil
+	}
+	logrus.Debugf("Not reconnecting to %s: insufficient progress %d / time since last retry %.3f ms", redactedURL, progress, msSinceLastRetry)
+	return fmt.Errorf("(heuristic tuning data: total %d @%.3f ms, last retry %d @%.3f ms, last progress @ %.3f ms): %w",
+		br.offset, msSinceFirstConnection, br.lastRetryOffset, msSinceLastRetry, msSinceLastSuccess, originalErr)
 }
 
 // Close implements io.ReadCloser

--- a/vendor/github.com/containers/image/v5/docker/docker_image.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
 )
 
 // Image is a Docker-specific implementation of types.ImageCloser with a few extra methods
@@ -87,7 +88,20 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 		if err = json.NewDecoder(res.Body).Decode(&tagsHolder); err != nil {
 			return nil, err
 		}
-		tags = append(tags, tagsHolder.Tags...)
+		for _, tag := range tagsHolder.Tags {
+			if _, err := reference.WithTag(dr.ref, tag); err != nil { // Ensure the tag does not contain unexpected values
+				// Per https://github.com/containers/skopeo/issues/2346 , unknown versions of JFrog Artifactory,
+				// contrary to the tag format specified in
+				// https://github.com/opencontainers/distribution-spec/blob/8a871c8234977df058f1a14e299fe0a673853da2/spec.md?plain=1#L160 ,
+				// include digests in the list.
+				if _, err := digest.Parse(tag); err == nil {
+					logrus.Debugf("Ignoring invalid tag %q matching a digest format", tag)
+					continue
+				}
+				return nil, fmt.Errorf("registry returned invalid tag %q: %w", tag, err)
+			}
+			tags = append(tags, tag)
+		}
 
 		link := res.Header.Get("Link")
 		if link == "" {

--- a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
@@ -226,6 +226,9 @@ func (d *dockerImageDestination) PutBlobWithOptions(ctx context.Context, stream 
 // If the destination does not contain the blob, or it is unknown, blobExists ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
 func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.Named, digest digest.Digest, extraScope *authScope) (bool, int64, error) {
+	if err := digest.Validate(); err != nil { // Make sure digest.String() does not contain any unexpected characters
+		return false, -1, err
+	}
 	checkPath := fmt.Sprintf(blobsPath, reference.Path(repo), digest.String())
 	logrus.Debugf("Checking %s", checkPath)
 	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScope)
@@ -414,6 +417,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 		// particular instance.
 		refTail = instanceDigest.String()
 		// Double-check that the manifest we've been given matches the digest we've been given.
+		// This also validates the format of instanceDigest.
 		matches, err := manifest.MatchesDigest(m, *instanceDigest)
 		if err != nil {
 			return fmt.Errorf("digesting manifest in PutManifest: %w", err)
@@ -580,9 +584,11 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 
 	// NOTE: Keep this in sync with docs/signature-protocols.md!
 	for i, signature := range signatures {
-		sigURL := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
-		err := d.putOneSignature(sigURL, signature)
+		sigURL, err := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
 		if err != nil {
+			return err
+		}
+		if err := d.putOneSignature(sigURL, signature); err != nil {
 			return err
 		}
 	}
@@ -592,7 +598,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 	// is enough for dockerImageSource to stop looking for other signatures, so that
 	// is sufficient.
 	for i := len(signatures); ; i++ {
-		sigURL := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
+		sigURL, err := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
+		if err != nil {
+			return err
+		}
 		missing, err := d.c.deleteOneSignature(sigURL)
 		if err != nil {
 			return err
@@ -719,8 +728,12 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 	if err != nil {
 		return err
 	}
+	attachmentTag, err := sigstoreAttachmentTag(manifestDigest)
+	if err != nil {
+		return err
+	}
 	logrus.Debugf("Uploading sigstore attachment manifest")
-	return d.uploadManifest(ctx, manifestBlob, sigstoreAttachmentTag(manifestDigest))
+	return d.uploadManifest(ctx, manifestBlob, attachmentTag)
 }
 
 func layerMatchesSigstoreSignature(layer imgspecv1.Descriptor, mimeType string,
@@ -846,6 +859,7 @@ sigExists:
 			return err
 		}
 
+		// manifestDigest is known to be valid because it was not rejected by getExtensionsSignatures above.
 		path := fmt.Sprintf(extensionsSignaturePath, reference.Path(d.ref.ref), manifestDigest.String())
 		res, err := d.c.makeRequest(ctx, http.MethodPut, path, nil, bytes.NewReader(body), v2Auth, nil)
 		if err != nil {

--- a/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
@@ -188,6 +188,9 @@ func simplifyContentType(contentType string) string {
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
 func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
+		if err := instanceDigest.Validate(); err != nil { // Make sure instanceDigest.String() does not contain any unexpected characters
+			return nil, "", err
+		}
 		return s.fetchManifest(ctx, instanceDigest.String())
 	}
 	err := s.ensureManifestIsLoaded(ctx)
@@ -197,6 +200,8 @@ func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *dig
 	return s.cachedManifest, s.cachedManifestMIMEType, nil
 }
 
+// fetchManifest fetches a manifest for tagOrDigest.
+// The caller is responsible for ensuring tagOrDigest uses the expected format.
 func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest string) ([]byte, string, error) {
 	return s.c.fetchManifest(ctx, s.physicalRef, tagOrDigest)
 }
@@ -346,6 +351,9 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, 
 		return nil, nil, fmt.Errorf("external URLs not supported with GetBlobAt")
 	}
 
+	if err := info.Digest.Validate(); err != nil { // Make sure info.Digest.String() does not contain any unexpected characters
+		return nil, nil, err
+	}
 	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
 	logrus.Debugf("Downloading %s", path)
 	res, err := s.c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
@@ -456,7 +464,10 @@ func (s *dockerImageSource) getSignaturesFromLookaside(ctx context.Context, inst
 			return nil, fmt.Errorf("server provided %d signatures, assuming that's unreasonable and a server error", maxLookasideSignatures)
 		}
 
-		sigURL := lookasideStorageURL(s.c.signatureBase, manifestDigest, i)
+		sigURL, err := lookasideStorageURL(s.c.signatureBase, manifestDigest, i)
+		if err != nil {
+			return nil, err
+		}
 		signature, missing, err := s.getOneSignature(ctx, sigURL)
 		if err != nil {
 			return nil, err
@@ -649,7 +660,10 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 	}
 
 	for i := 0; ; i++ {
-		sigURL := lookasideStorageURL(c.signatureBase, manifestDigest, i)
+		sigURL, err := lookasideStorageURL(c.signatureBase, manifestDigest, i)
+		if err != nil {
+			return err
+		}
 		missing, err := c.deleteOneSignature(sigURL)
 		if err != nil {
 			return err

--- a/vendor/github.com/containers/image/v5/docker/internal/tarfile/dest.go
+++ b/vendor/github.com/containers/image/v5/docker/internal/tarfile/dest.go
@@ -111,11 +111,19 @@ func (d *Destination) PutBlobWithOptions(ctx context.Context, stream io.Reader, 
 			return types.BlobInfo{}, fmt.Errorf("reading Config file stream: %w", err)
 		}
 		d.config = buf
-		if err := d.archive.sendFileLocked(d.archive.configPath(inputInfo.Digest), inputInfo.Size, bytes.NewReader(buf)); err != nil {
+		configPath, err := d.archive.configPath(inputInfo.Digest)
+		if err != nil {
+			return types.BlobInfo{}, err
+		}
+		if err := d.archive.sendFileLocked(configPath, inputInfo.Size, bytes.NewReader(buf)); err != nil {
 			return types.BlobInfo{}, fmt.Errorf("writing Config file: %w", err)
 		}
 	} else {
-		if err := d.archive.sendFileLocked(d.archive.physicalLayerPath(inputInfo.Digest), inputInfo.Size, stream); err != nil {
+		layerPath, err := d.archive.physicalLayerPath(inputInfo.Digest)
+		if err != nil {
+			return types.BlobInfo{}, err
+		}
+		if err := d.archive.sendFileLocked(layerPath, inputInfo.Size, stream); err != nil {
 			return types.BlobInfo{}, err
 		}
 	}

--- a/vendor/github.com/containers/image/v5/docker/internal/tarfile/writer.go
+++ b/vendor/github.com/containers/image/v5/docker/internal/tarfile/writer.go
@@ -92,7 +92,10 @@ func (w *Writer) ensureSingleLegacyLayerLocked(layerID string, layerDigest diges
 	if _, ok := w.legacyLayers[layerID]; !ok {
 		// Create a symlink for the legacy format, where there is one subdirectory per layer ("image").
 		// See also the comment in physicalLayerPath.
-		physicalLayerPath := w.physicalLayerPath(layerDigest)
+		physicalLayerPath, err := w.physicalLayerPath(layerDigest)
+		if err != nil {
+			return err
+		}
 		if err := w.sendSymlinkLocked(filepath.Join(layerID, legacyLayerFileName), filepath.Join("..", physicalLayerPath)); err != nil {
 			return fmt.Errorf("creating layer symbolic link: %w", err)
 		}
@@ -136,6 +139,9 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 		}
 
 		// This chainID value matches the computation in docker/docker/layer.CreateChainID …
+		if err := l.Digest.Validate(); err != nil { // This should never fail on this code path, still: make sure the chainID computation is unambiguous.
+			return err
+		}
 		if chainID == "" {
 			chainID = l.Digest
 		} else {
@@ -206,12 +212,20 @@ func checkManifestItemsMatch(a, b *ManifestItem) error {
 func (w *Writer) ensureManifestItemLocked(layerDescriptors []manifest.Schema2Descriptor, configDigest digest.Digest, repoTags []reference.NamedTagged) error {
 	layerPaths := []string{}
 	for _, l := range layerDescriptors {
-		layerPaths = append(layerPaths, w.physicalLayerPath(l.Digest))
+		p, err := w.physicalLayerPath(l.Digest)
+		if err != nil {
+			return err
+		}
+		layerPaths = append(layerPaths, p)
 	}
 
 	var item *ManifestItem
+	configPath, err := w.configPath(configDigest)
+	if err != nil {
+		return err
+	}
 	newItem := ManifestItem{
-		Config:       w.configPath(configDigest),
+		Config:       configPath,
 		RepoTags:     []string{},
 		Layers:       layerPaths,
 		Parent:       "", // We don’t have this information
@@ -296,21 +310,27 @@ func (w *Writer) Close() error {
 // configPath returns a path we choose for storing a config with the specified digest.
 // NOTE: This is an internal implementation detail, not a format property, and can change
 // any time.
-func (w *Writer) configPath(configDigest digest.Digest) string {
-	return configDigest.Hex() + ".json"
+func (w *Writer) configPath(configDigest digest.Digest) (string, error) {
+	if err := configDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in unexpected paths, so validate explicitly.
+		return "", err
+	}
+	return configDigest.Hex() + ".json", nil
 }
 
 // physicalLayerPath returns a path we choose for storing a layer with the specified digest
 // (the actual path, i.e. a regular file, not a symlink that may be used in the legacy format).
 // NOTE: This is an internal implementation detail, not a format property, and can change
 // any time.
-func (w *Writer) physicalLayerPath(layerDigest digest.Digest) string {
+func (w *Writer) physicalLayerPath(layerDigest digest.Digest) (string, error) {
+	if err := layerDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in unexpected paths, so validate explicitly.
+		return "", err
+	}
 	// Note that this can't be e.g. filepath.Join(l.Digest.Hex(), legacyLayerFileName); due to the way
 	// writeLegacyMetadata constructs layer IDs differently from inputinfo.Digest values (as described
 	// inside it), most of the layers would end up in subdirectories alone without any metadata; (docker load)
 	// tries to load every subdirectory as an image and fails if the config is missing.  So, keep the layers
 	// in the root of the tarball.
-	return layerDigest.Hex() + ".tar"
+	return layerDigest.Hex() + ".tar", nil
 }
 
 type tarFI struct {

--- a/vendor/github.com/containers/image/v5/docker/registries_d.go
+++ b/vendor/github.com/containers/image/v5/docker/registries_d.go
@@ -286,8 +286,11 @@ func (ns registryNamespace) signatureTopLevel(write bool) string {
 // lookasideStorageURL returns an URL usable for accessing signature index in base with known manifestDigest.
 // base is not nil from the caller
 // NOTE: Keep this in sync with docs/signature-protocols.md!
-func lookasideStorageURL(base lookasideStorageBase, manifestDigest digest.Digest, index int) *url.URL {
+func lookasideStorageURL(base lookasideStorageBase, manifestDigest digest.Digest, index int) (*url.URL, error) {
+	if err := manifestDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+		return nil, err
+	}
 	sigURL := *base
 	sigURL.Path = fmt.Sprintf("%s@%s=%s/signature-%d", sigURL.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
-	return &sigURL
+	return &sigURL, nil
 }

--- a/vendor/github.com/containers/image/v5/openshift/openshift_src.go
+++ b/vendor/github.com/containers/image/v5/openshift/openshift_src.go
@@ -108,6 +108,9 @@ func (s *openshiftImageSource) GetSignaturesWithFormat(ctx context.Context, inst
 		}
 		imageStreamImageName = s.imageStreamImageName
 	} else {
+		if err := instanceDigest.Validate(); err != nil { // Make sure instanceDigest.String() does not contain any unexpected characters
+			return nil, err
+		}
 		imageStreamImageName = instanceDigest.String()
 	}
 	image, err := s.client.getImage(ctx, imageStreamImageName)

--- a/vendor/github.com/containers/image/v5/ostree/ostree_dest.go
+++ b/vendor/github.com/containers/image/v5/ostree/ostree_dest.go
@@ -342,6 +342,10 @@ func (d *ostreeImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		}
 		d.repo = repo
 	}
+
+	if err := info.Digest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, so validate explicitly.
+		return false, private.ReusedBlob{}, err
+	}
 	branch := fmt.Sprintf("ociimage/%s", info.Digest.Hex())
 
 	found, data, err := readMetadata(d.repo, branch, "docker.uncompressed_digest")
@@ -467,12 +471,18 @@ func (d *ostreeImageDestination) Commit(context.Context, types.UnparsedImage) er
 		return nil
 	}
 	for _, layer := range d.schema.LayersDescriptors {
+		if err := layer.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+			return err
+		}
 		hash := layer.Digest.Hex()
 		if err = checkLayer(hash); err != nil {
 			return err
 		}
 	}
 	for _, layer := range d.schema.FSLayers {
+		if err := layer.BlobSum.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+			return err
+		}
 		hash := layer.BlobSum.Hex()
 		if err = checkLayer(hash); err != nil {
 			return err

--- a/vendor/github.com/containers/image/v5/ostree/ostree_src.go
+++ b/vendor/github.com/containers/image/v5/ostree/ostree_src.go
@@ -286,7 +286,9 @@ func (s *ostreeImageSource) readSingleFile(commit, path string) (io.ReadCloser, 
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
-
+	if err := info.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+		return nil, -1, err
+	}
 	blob := info.Digest.Hex()
 
 	// Ensure s.compressed is initialized.  It is build by LayerInfosForCopy.

--- a/vendor/github.com/containers/image/v5/pkg/blobcache/dest.go
+++ b/vendor/github.com/containers/image/v5/pkg/blobcache/dest.go
@@ -80,47 +80,58 @@ func (d *blobCacheDestination) IgnoresEmbeddedDockerReference() bool {
 // and this new file.
 func (d *blobCacheDestination) saveStream(wg *sync.WaitGroup, decompressReader io.ReadCloser, tempFile *os.File, compressedFilename string, compressedDigest digest.Digest, isConfig bool, alternateDigest *digest.Digest) {
 	defer wg.Done()
-	// Decompress from and digest the reading end of that pipe.
-	decompressed, err3 := archive.DecompressStream(decompressReader)
+	defer decompressReader.Close()
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			// Remove the temporary file.
+			if err := os.Remove(tempFile.Name()); err != nil {
+				logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err)
+			}
+		}
+	}()
+
 	digester := digest.Canonical.Digester()
-	if err3 == nil {
+	if err := func() error { // A scope for defer
+		defer tempFile.Close()
+
+		// Decompress from and digest the reading end of that pipe.
+		decompressed, err := archive.DecompressStream(decompressReader)
+		if err != nil {
+			// Drain the pipe to keep from stalling the PutBlob() thread.
+			if _, err2 := io.Copy(io.Discard, decompressReader); err2 != nil {
+				logrus.Debugf("error draining the pipe: %v", err2)
+			}
+			return err
+		}
+		defer decompressed.Close()
 		// Read the decompressed data through the filter over the pipe, blocking until the
 		// writing end is closed.
-		_, err3 = io.Copy(io.MultiWriter(tempFile, digester.Hash()), decompressed)
-	} else {
-		// Drain the pipe to keep from stalling the PutBlob() thread.
-		if _, err := io.Copy(io.Discard, decompressReader); err != nil {
-			logrus.Debugf("error draining the pipe: %v", err)
-		}
+		_, err = io.Copy(io.MultiWriter(tempFile, digester.Hash()), decompressed)
+		return err
+	}(); err != nil {
+		return
 	}
-	decompressReader.Close()
-	decompressed.Close()
-	tempFile.Close()
+
 	// Determine the name that we should give to the uncompressed copy of the blob.
-	decompressedFilename := d.reference.blobPath(digester.Digest(), isConfig)
-	if err3 == nil {
-		// Rename the temporary file.
-		if err3 = os.Rename(tempFile.Name(), decompressedFilename); err3 != nil {
-			logrus.Debugf("error renaming new decompressed copy of blob %q into place at %q: %v", digester.Digest().String(), decompressedFilename, err3)
-			// Remove the temporary file.
-			if err3 = os.Remove(tempFile.Name()); err3 != nil {
-				logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
-			}
-		} else {
-			*alternateDigest = digester.Digest()
-			// Note the relationship between the two files.
-			if err3 = ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedDigest.String()), 0600); err3 != nil {
-				logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedDigest.String(), err3)
-			}
-			if err3 = ioutils.AtomicWriteFile(compressedFilename+decompressedNote, []byte(digester.Digest().String()), 0600); err3 != nil {
-				logrus.Debugf("error noting that the decompressed version of %q is %q: %v", compressedDigest.String(), digester.Digest().String(), err3)
-			}
-		}
-	} else {
-		// Remove the temporary file.
-		if err3 = os.Remove(tempFile.Name()); err3 != nil {
-			logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
-		}
+	decompressedFilename, err := d.reference.blobPath(digester.Digest(), isConfig)
+	if err != nil {
+		return
+	}
+	// Rename the temporary file.
+	if err := os.Rename(tempFile.Name(), decompressedFilename); err != nil {
+		logrus.Debugf("error renaming new decompressed copy of blob %q into place at %q: %v", digester.Digest().String(), decompressedFilename, err)
+		return
+	}
+	succeeded = true
+	*alternateDigest = digester.Digest()
+	// Note the relationship between the two files.
+	if err := ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedDigest.String()), 0600); err != nil {
+		logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedDigest.String(), err)
+	}
+	if err := ioutils.AtomicWriteFile(compressedFilename+decompressedNote, []byte(digester.Digest().String()), 0600); err != nil {
+		logrus.Debugf("error noting that the decompressed version of %q is %q: %v", compressedDigest.String(), digester.Digest().String(), err)
 	}
 }
 
@@ -145,7 +156,10 @@ func (d *blobCacheDestination) PutBlobWithOptions(ctx context.Context, stream io
 	needToWait := false
 	compression := archive.Uncompressed
 	if inputInfo.Digest != "" {
-		filename := d.reference.blobPath(inputInfo.Digest, options.IsConfig)
+		filename, err2 := d.reference.blobPath(inputInfo.Digest, options.IsConfig)
+		if err2 != nil {
+			return types.BlobInfo{}, err2
+		}
 		tempfile, err = os.CreateTemp(filepath.Dir(filename), filepath.Base(filename))
 		if err == nil {
 			stream = io.TeeReader(stream, tempfile)
@@ -273,7 +287,10 @@ func (d *blobCacheDestination) PutManifest(ctx context.Context, manifestBytes []
 	if err != nil {
 		logrus.Warnf("error digesting manifest %q: %v", string(manifestBytes), err)
 	} else {
-		filename := d.reference.blobPath(manifestDigest, false)
+		filename, err := d.reference.blobPath(manifestDigest, false)
+		if err != nil {
+			return err
+		}
 		if err = ioutils.AtomicWriteFile(filename, manifestBytes, 0600); err != nil {
 			logrus.Warnf("error saving manifest as %q: %v", filename, err)
 		}

--- a/vendor/github.com/containers/image/v5/storage/storage_dest.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_dest.go
@@ -311,6 +311,13 @@ func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context,
 // tryReusingBlobAsPending implements TryReusingBlobWithOptions, filling s.blobDiffIDs and other metadata.
 // The caller must arrange the blob to be eventually committed using s.commitLayer().
 func (s *storageImageDestination) tryReusingBlobAsPending(ctx context.Context, blobinfo types.BlobInfo, options *private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
+	if blobinfo.Digest == "" {
+		return false, types.BlobInfo{}, errors.New(`Can not check for a blob with unknown digest`)
+	}
+	if err := blobinfo.Digest.Validate(); err != nil {
+		return false, types.BlobInfo{}, fmt.Errorf("Can not check for a blob with invalid digest: %w", err)
+	}
+
 	// lock the entire method as it executes fairly quickly
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -330,13 +337,6 @@ func (s *storageImageDestination) tryReusingBlobAsPending(ctx context.Context, b
 				MediaType: blobinfo.MediaType,
 			}, nil
 		}
-	}
-
-	if blobinfo.Digest == "" {
-		return false, types.BlobInfo{}, errors.New(`Can not check for a blob with unknown digest`)
-	}
-	if err := blobinfo.Digest.Validate(); err != nil {
-		return false, types.BlobInfo{}, fmt.Errorf("Can not check for a blob with invalid digest: %w", err)
 	}
 
 	// Check if we've already cached it in a file.
@@ -818,7 +818,10 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		if err != nil {
 			return fmt.Errorf("digesting top-level manifest: %w", err)
 		}
-		key := manifestBigDataKey(manifestDigest)
+		key, err := manifestBigDataKey(manifestDigest)
+		if err != nil {
+			return err
+		}
 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, toplevelManifest, manifest.Digest); err != nil {
 			logrus.Debugf("error saving top-level manifest for image %q: %v", img.ID, err)
 			return fmt.Errorf("saving top-level manifest for image %q: %w", img.ID, err)
@@ -827,7 +830,10 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	// Save the image's manifest.  Allow looking it up by digest by using the key convention defined by the Store.
 	// Record the manifest twice: using a digest-specific key to allow references to that specific digest instance,
 	// and using storage.ImageDigestBigDataKey for future users that don’t specify any digest and for compatibility with older readers.
-	key := manifestBigDataKey(s.manifestDigest)
+	key, err := manifestBigDataKey(s.manifestDigest)
+	if err != nil {
+		return err
+	}
 	if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, s.manifest, manifest.Digest); err != nil {
 		logrus.Debugf("error saving manifest for image %q: %v", img.ID, err)
 		return fmt.Errorf("saving manifest for image %q: %w", img.ID, err)
@@ -845,7 +851,10 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		}
 	}
 	for instanceDigest, signatures := range s.signatureses {
-		key := signatureBigDataKey(instanceDigest)
+		key, err := signatureBigDataKey(instanceDigest)
+		if err != nil {
+			return err
+		}
 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, signatures, manifest.Digest); err != nil {
 			logrus.Debugf("error saving signatures for image %q: %v", img.ID, err)
 			return fmt.Errorf("saving signatures for image %q: %w", img.ID, err)

--- a/vendor/github.com/containers/image/v5/storage/storage_image.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_image.go
@@ -26,14 +26,20 @@ type storageImageCloser struct {
 // manifestBigDataKey returns a key suitable for recording a manifest with the specified digest using storage.Store.ImageBigData and related functions.
 // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
 // for compatibility, if a manifest is not available under this key, check also storage.ImageDigestBigDataKey
-func manifestBigDataKey(digest digest.Digest) string {
-	return storage.ImageDigestManifestBigDataNamePrefix + "-" + digest.String()
+func manifestBigDataKey(digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil { // Make sure info.Digest.String() uses the expected format and does not collide with other BigData keys.
+		return "", err
+	}
+	return storage.ImageDigestManifestBigDataNamePrefix + "-" + digest.String(), nil
 }
 
 // signatureBigDataKey returns a key suitable for recording the signatures associated with the manifest with the specified digest using storage.Store.ImageBigData and related functions.
 // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
-func signatureBigDataKey(digest digest.Digest) string {
-	return "signature-" + digest.Encoded()
+func signatureBigDataKey(digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+		return "", err
+	}
+	return "signature-" + digest.Encoded(), nil
 }
 
 // Size() returns the previously-computed size of the image, with no error.

--- a/vendor/github.com/containers/image/v5/storage/storage_reference.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_reference.go
@@ -73,7 +73,10 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
 	// We don't need to care about storage.ImageDigestBigDataKey because
 	// manifests lists are only stored into storage by c/image versions
 	// that know about manifestBigDataKey, and only using that key.
-	key := manifestBigDataKey(manifestDigest)
+	key, err := manifestBigDataKey(manifestDigest)
+	if err != nil {
+		return false // This should never happen, manifestDigest comes from a reference.Digested, and that validates the format.
+	}
 	manifestBytes, err := store.ImageBigData(img.ID, key)
 	if err != nil {
 		return false
@@ -95,7 +98,10 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
 	if err != nil {
 		return false
 	}
-	key = manifestBigDataKey(chosenInstance)
+	key, err = manifestBigDataKey(chosenInstance)
+	if err != nil {
+		return false
+	}
 	_, err = store.ImageBigData(img.ID, key)
 	return err == nil // true if img.ID is based on chosenInstance.
 }

--- a/vendor/github.com/containers/image/v5/storage/storage_src.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_src.go
@@ -188,7 +188,10 @@ func (s *storageImageSource) getBlobAndLayerID(digest digest.Digest, layers []st
 // GetManifest() reads the image's manifest.
 func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) (manifestBlob []byte, MIMEType string, err error) {
 	if instanceDigest != nil {
-		key := manifestBigDataKey(*instanceDigest)
+		key, err := manifestBigDataKey(*instanceDigest)
+		if err != nil {
+			return nil, "", err
+		}
 		blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
 		if err != nil {
 			return nil, "", fmt.Errorf("reading manifest for image instance %q: %w", *instanceDigest, err)
@@ -200,7 +203,10 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
 		// Prefer the manifest corresponding to the user-specified digest, if available.
 		if s.imageRef.named != nil {
 			if digested, ok := s.imageRef.named.(reference.Digested); ok {
-				key := manifestBigDataKey(digested.Digest())
+				key, err := manifestBigDataKey(digested.Digest())
+				if err != nil {
+					return nil, "", err
+				}
 				blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
 				if err != nil && !os.IsNotExist(err) { // os.IsNotExist is true if the image exists but there is no data corresponding to key
 					return nil, "", err
@@ -315,7 +321,14 @@ func (s *storageImageSource) GetSignaturesWithFormat(ctx context.Context, instan
 	instance := "default instance"
 	if instanceDigest != nil {
 		signatureSizes = s.SignaturesSizes[*instanceDigest]
-		key = signatureBigDataKey(*instanceDigest)
+		k, err := signatureBigDataKey(*instanceDigest)
+		if err != nil {
+			return nil, err
+		}
+		key = k
+		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+			return nil, err
+		}
 		instance = instanceDigest.Encoded()
 	}
 	if len(signatureSizes) > 0 {

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 24
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 3
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,7 +129,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.51.3
+# github.com/containers/common v0.51.4
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define
@@ -183,7 +183,7 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/image/v5 v5.24.1
+# github.com/containers/image/v5 v5.24.3
 ## explicit; go 1.17
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
Addresses CVE-2024-3727 and Podman stats takes pagecache into account

Fixes: https://issues.redhat.com/browse/OCPBUGS-37008
       https://issues.redhat.com/browse/OCPBUGS-37010
       https://issues.redhat.com/browse/OCPBUGS-37011

Also addresses #1642 in the v4.4.1-rhel branch

Fixes: https://issues.redhat.com/browse/RHEL-16376

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
