### PR TITLE
docs: remove usage of deprecated `--storage` in the doc of podman-build

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -44,9 +44,8 @@ NOTE: `podman build` uses code sourced from the `Buildah` project to build
 container images.  This `Buildah` code creates `Buildah` containers for the
 `RUN` options in container storage. In certain situations, when the
 `podman build` crashes or users kill the `podman build` process, these external
-containers can be left in container storage. Use the `podman ps --all --storage`
-command to see these containers. External containers can be removed with the
-`podman rm --storage` command.
+containers can be left in container storage. Use the `podman ps --all --external`
+command to see these containers.
 
 `podman buildx build` command is an alias of `podman build`.  Not all `buildx build` features are available in Podman. The `buildx build` option is provided for scripting compatibility.
 


### PR DESCRIPTION
```release-note
None
```
