### PR TITLE
bin/docker support warning message suppression from user config dir

### DIFF
--- a/docker/docker.in
+++ b/docker/docker.in
@@ -1,4 +1,4 @@
 #!/bin/sh
-[ -e ${ETCDIR}/containers/nodocker ] || \
+[ -e ${ETCDIR}/containers/nodocker ] || [ -e "\${XDG_CONFIG_HOME-\$HOME/.config}/containers/nodocker" ] || \
 echo "Emulate Docker CLI using podman. Create ${ETCDIR}/containers/nodocker to quiet msg." >&2
 exec ${BINDIR}/podman "$@"


### PR DESCRIPTION
The `bin/docker` command should also honor the presence of `$XDG_CONFIG_HOME/containers/nodocker` when considering whether it should print the warning message.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `bin/docker` command will not also honor the presence of `$XDG_CONFIG_HOME/containers/nodocker` when considering whether it should print the warning message.
```
