### PR TITLE
[v5.2] Backports for v5.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,15 @@ import re
 import os
 import subprocess
 
+# Define the canonical URL for our custom docs.podman.io domain configured on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # We have to run the preprocessor to create the actual markdown files from .in files.
 # Do it here so the it can work on readthedocs as well.
 path = os.path.join(os.path.abspath(os.path.dirname(

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.1.0
 	github.com/containernetworking/plugins v1.5.1
 	github.com/containers/buildah v1.37.2
-	github.com/containers/common v0.60.2
+	github.com/containers/common v0.60.3
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.4
 	github.com/containers/image/v5 v5.32.2

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/buildah v1.37.2 h1:KiJ3jVNUvdtGORxDz8fjjLkR81ZHQZIfnGWJWavks40=
 github.com/containers/buildah v1.37.2/go.mod h1:alFCM3X0xfhE6ZjsFQkUlOMyKzOnbv9FL9fe1Ho48PA=
-github.com/containers/common v0.60.2 h1:utcwp2YkO8c0mNlwRxsxfOiqfj157FRrBjxgjR6f+7o=
-github.com/containers/common v0.60.2/go.mod h1:I0upBi1qJX3QmzGbUOBN1LVP6RvkKhd3qQpZbQT+Q54=
+github.com/containers/common v0.60.3 h1:pToT7gtFx/KWyMtWw98g4pIbW54i9KfGH2QrdN2s1io=
+github.com/containers/common v0.60.3/go.mod h1:I0upBi1qJX3QmzGbUOBN1LVP6RvkKhd3qQpZbQT+Q54=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.7.4 h1:iOtr/KEi+r599OOx1+9Qbss91jD5yxh1HO35MKTdths=

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -513,16 +513,11 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			volOptions = append(volOptions, withSetAnon())
 		}
 
-		needsChown := true
-
 		// If volume-opts are set, parse and add driver opts.
 		if len(vol.Options) > 0 {
 			isDriverOpts := false
 			driverOpts := make(map[string]string)
 			for _, opts := range vol.Options {
-				if opts == "idmap" {
-					needsChown = false
-				}
 				if strings.HasPrefix(opts, "volume-opt") {
 					isDriverOpts = true
 					driverOptKey, driverOptValue, err := util.ParseDriverOpts(opts)
@@ -538,11 +533,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			}
 		}
 
-		if needsChown {
-			volOptions = append(volOptions, WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()))
-		} else {
-			volOptions = append(volOptions, WithVolumeNoChown())
-		}
+		volOptions = append(volOptions, WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()))
 
 		_, err = r.newVolume(ctx, false, volOptions...)
 		if err != nil {

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -158,7 +158,7 @@ func ParsePortMapping(portMappings []types.PortMapping, exposePorts map[uint16][
 	// First, we need to validate the ports passed in the specgen
 	for _, port := range portMappings {
 		// First, check proto
-		protocols, err := checkProtocol(port.Protocol, true)
+		protocols, err := checkProtocol(port.Protocol)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +356,7 @@ func createPortMappings(s *specgen.SpecGenerator, imageData *libimage.ImageData)
 			if port == 0 {
 				return nil, nil, fmt.Errorf("cannot expose 0 as it is not a valid port number")
 			}
-			protocols, err := checkProtocol(proto, false)
+			protocols, err := checkProtocol(proto)
 			if err != nil {
 				return nil, nil, fmt.Errorf("validating protocols for exposed port %d: %w", port, err)
 			}
@@ -377,7 +377,7 @@ func createPortMappings(s *specgen.SpecGenerator, imageData *libimage.ImageData)
 }
 
 // Check a string to ensure it is a comma-separated set of valid protocols
-func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
+func checkProtocol(protocol string) ([]string, error) {
 	protocols := make(map[string]struct{})
 	splitProto := strings.Split(protocol, ",")
 	// Don't error on duplicates - just deduplicate
@@ -389,9 +389,6 @@ func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
 		case protoUDP:
 			protocols[protoUDP] = struct{}{}
 		case protoSCTP:
-			if !allowSCTP {
-				return nil, fmt.Errorf("protocol SCTP is not allowed for exposed ports")
-			}
 			protocols[protoSCTP] = struct{}{}
 		default:
 			return nil, fmt.Errorf("unrecognized protocol %q in port mapping", p)

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -28,19 +28,19 @@ var _ = Describe("Podman container inspect", func() {
 
 	It("podman inspect shows exposed ports", func() {
 		name := "testcon"
-		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8787/udp", "--name", name, ALPINE, "sleep", "100"})
+		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8787/udp", "--expose", "99/sctp", "--name", name, ALPINE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		data := podmanTest.InspectContainer(name)
 
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
-			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil}))
+			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil, "99/sctp": nil}))
 
 		session = podmanTest.Podman([]string{"ps", "--format", "{{.Ports}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal("8787/udp"))
+		Expect(session.OutputToString()).To(Equal("99/sctp, 8787/udp"))
 	})
 
 	It("podman inspect shows exposed ports on image", func() {

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.60.2"
+const Version = "0.60.3"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -170,7 +170,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.60.2
+# github.com/containers/common v0.60.3
 ## explicit; go 1.21.0
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that made it impossible to unmount our netns on cleanup which causes our commands to hang.
Podman no longer errors out when trying to expose sctp ports or when they are part of the image config.
Allow the pasta network mode to be used when running as uid 0 but already in a userns (container).
Now copyup keeps the original directory ownership for the directory when ":idmap" is used and the volume is empty
```
