### PR TITLE
test/system: For pasta port forwarding tests don't bind socat server

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -169,10 +169,6 @@ function pasta_test_do() {
 
     # socat options for first <address> in server ("LISTEN" address types),
     local bind="${proto_upper}${ip_ver}-LISTEN:\${port}"
-    # For IPv6 via tap, we can pick either link-local or global unicast
-    if [ ${ip_ver} -eq 4 ] || [ ${iftype} = "loopback" ]; then
-        bind="${bind},bind=[${addr}]"
-    fi
     if [ "${proto}" = "udp" ]; then
         bind="${bind},null-eof"
     fi


### PR DESCRIPTION
The various pasta port forwarding tests run a socat server inside a container, then connect to it from a socat client on the host.  Currently we have the server bind to the same specific address within the container as we connect to on the host.

That's not quite what we want.  For "tap" tests where the traffic goes over pasta's L2 link to the container it's fine, though unnecessary.  For "loopback" tests where traffic is forwarded by pasta at the L4 socket level, however, it's not quite right.  In this case the address used is either 127.0.0.1 or ::.  That's correct and as needed for the host side address we're connecting to.  However on the container side, this only works because of an odd and arguably undesirable behaviour of pasta: we use the fact that we have an L4 socket within the container to make such "spliced" L4 connections appear as if they come from loopback within the container.  A container will generally expect it's loopback address to be only accessible from within the container, and this odd behaviour may be changed in pasta in future.

In any case, the binding of the container side server is unnecessary, so simply remove it.

Link: https://github.com/containers/podman/issues/24045

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
No.
```
