### PR TITLE
troubleshooting: adjust home path in tip 44

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1517,8 +1517,7 @@ The following steps create the user _containers_ and assigns big subuid and subg
 1. Create the user _containers_
    ```
    sudo useradd --comment "Helper user to reserve subuids and subgids for Podman" \
-		--no-create-home \
-                --home-dir / \
+                --no-create-home \
                 --shell /usr/sbin/nologin \
                 containers
    ```


### PR DESCRIPTION
 Modify the home dir path to make the troubleshooting tip more robust against mistakes.

`userdel` with force argument tries to remove home dir path "/" according to

* https://github.com/shadow-maint/shadow/issues/1050

(I haven't tried it myself)





<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
