### PR TITLE
CORS system test: clean up

### DIFF
--- a/test/system/271-tcp-cors-server.bats
+++ b/test/system/271-tcp-cors-server.bats
@@ -8,7 +8,7 @@ load helpers.network
 
 SERVICE_NAME="podman_test_$(random_string)"
 
-SERVICE_TCP_HOST="localhost"
+SERVICE_TCP_HOST="127.0.0.1"
 
 SERVICE_FILE="$UNIT_DIR/$SERVICE_NAME.service"
 SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
@@ -16,13 +16,20 @@ SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
 # bats test_tags=ci:parallel
 @test "podman system service - tcp CORS" {
     skip_if_remote "system service tests are meaningless over remote"
-    PORT=$(random_free_port 63000-64999)
+    PORT=$(random_free_port)
+
     log=${PODMAN_TMPDIR}/system-service.log
     $PODMAN system service --cors="*" tcp:$SERVICE_TCP_HOST:$PORT -t 20 2> $log &
     podman_pid="$!"
-    sleep 5s
-    run curl -s --max-time 10 -vvv $SERVICE_TCP_HOST:$PORT/_ping 2>&1
-    is "$output" ".*< Access-Control-Allow-Origin: \*.*" "access-control-allow-origin verifies CORS is set"
+
+    wait_for_port $SERVICE_TCP_HOST $PORT
+    cmd="curl -s --max-time 10 -vvv $SERVICE_TCP_HOST:$PORT/_ping"
+    echo "$_LOG_PROMPT $cmd"
+    run -0 $cmd
+    echo "$output"
+    assert "$output" =~ " Access-Control-Allow-Origin: \*" \
+           "access-control-allow-origin verifies CORS is set"
+
     kill $podman_pid
     wait $podman_pid || true
 
@@ -34,11 +41,19 @@ SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
 # bats test_tags=ci:parallel
 @test "podman system service - tcp without CORS" {
     skip_if_remote "system service tests are meaningless over remote"
-    PORT=$(random_free_port 63000-64999)
+    PORT=$(random_free_port)
     $PODMAN system service tcp:$SERVICE_TCP_HOST:$PORT -t 20 &
     podman_pid="$!"
-    sleep 5s
-    (curl -s --max-time 10 -vvv $SERVICE_TCP_HOST:$PORT/_ping 2>&1 | grep -Eq "Access-Control-Allow-Origin:") && false || true
+
+    wait_for_port $SERVICE_TCP_HOST $PORT
+    cmd="curl -s --max-time 10 -vvv $SERVICE_TCP_HOST:$PORT/_ping"
+    echo "$_LOG_PROMPT $cmd"
+    run -0 $cmd
+    echo "$output"
+
+    assert "$output" !~ "Access-Control-Allow-Origin:" \
+           "CORS header should not be present"
+
     kill $podman_pid
     wait $podman_pid || true
 }
@@ -47,7 +62,7 @@ SOCKET_FILE="$UNIT_DIR/$SERVICE_NAME.socket"
 @test "podman system service - CORS enabled in logs" {
     skip_if_remote "system service tests are meaningless over remote"
 
-    PORT=$(random_free_port 63000-64999)
+    PORT=$(random_free_port)
     run_podman 0+w system service --log-level="debug" --cors="*" -t 1 tcp:$SERVICE_TCP_HOST:$PORT
     is "$output" ".*CORS Headers were set to ..\*...*" "debug log confirms CORS headers set"
     assert "$output" =~ "level=warning msg=\"Using the Podman API service with TCP sockets is not recommended" \


### PR DESCRIPTION
Primary motivator: 'curl -v' format changes in f42

Drive-bys:
 * 127.0.0.1, not localhost
 * use wait_for_port, not sleep
 * show curl commands and their output, to ease debugging failures
 * better failure assertions

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```