### PR TITLE
System tests: set a default XDG_RUNTIME_DIR

### DIFF
--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -252,11 +252,6 @@ function _test_skopeo_credential_sharing() {
 }
 
 @test "podman login - shares credentials with skopeo - default auth file" {
-    if is_rootless; then
-        if [ -z "${XDG_RUNTIME_DIR}" ]; then
-            skip "skopeo does not match podman when XDG_RUNTIME_DIR unset; #823"
-        fi
-    fi
     _test_skopeo_credential_sharing
 }
 

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -3,13 +3,6 @@
 # BATS helpers for systemd-related functionality
 #
 
-# podman initializes this if unset, but systemctl doesn't
-if [ -z "$XDG_RUNTIME_DIR" ]; then
-    if is_rootless; then
-        export XDG_RUNTIME_DIR=/run/user/$(id -u)
-    fi
-fi
-
 # For tests which write systemd unit files
 UNIT_DIR="/run/systemd/system"
 _DASHUSER=


### PR DESCRIPTION
Yield to reality: if $XDG_RUNTIME_DIR is unset, assume a
reasonable default (rootless only). This clears up a
common failure in Fedora gating tests, and will probably
prevent future time wasters.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```