### PR TITLE
packit: disable Centos Stream/fedora ELN teasks

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,29 +43,31 @@ jobs:
       - fedora-40-x86_64
       - fedora-40-aarch64
 
-  - job: copr_build
-    trigger: pull_request
-    packages: [podman-eln]
-    notifications: *packit_build_failure_notification
-    enable_net: true
-    targets:
-      fedora-eln-x86_64:
-        additional_repos:
-          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
-      fedora-eln-aarch64:
-        additional_repos:
-          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
+  # Disabled until there is go 1.22.6 in centos stream
+  # - job: copr_build
+  #   trigger: pull_request
+  #   packages: [podman-eln]
+  #   notifications: *packit_build_failure_notification
+  #   enable_net: true
+  #   targets:
+  #     fedora-eln-x86_64:
+  #       additional_repos:
+  #         - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
+  #     fedora-eln-aarch64:
+  #       additional_repos:
+  #         - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
 
-  - job: copr_build
-    trigger: pull_request
-    packages: [podman-centos]
-    notifications: *packit_build_failure_notification
-    enable_net: true
-    targets:
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-      - centos-stream-10-x86_64
-      - centos-stream-10-aarch64
+  # Disabled until there is go 1.22.6 in centos stream
+  # - job: copr_build
+  #   trigger: pull_request
+  #   packages: [podman-centos]
+  #   notifications: *packit_build_failure_notification
+  #   enable_net: true
+  #   targets:
+  #     - centos-stream-9-x86_64
+  #     - centos-stream-9-aarch64
+  #     - centos-stream-10-x86_64
+  #     - centos-stream-10-aarch64
 
   # Disabled until there is go 1.22 in epel-9
   # - job: copr_build
@@ -117,12 +119,13 @@ jobs:
     dist_git_branches: &fedora_targets
       - fedora-all
 
-  - job: propose_downstream
-    trigger: release
-    update_release: false
-    packages: [podman-centos]
-    dist_git_branches:
-      - c10s
+  # Disabled until there is go 1.22.6 in centos stream
+  # - job: propose_downstream
+  #   trigger: release
+  #   update_release: false
+  #   packages: [podman-centos]
+  #   dist_git_branches:
+  #     - c10s
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
The go version there is only go 1.22.5 but we need go 1.22.6 as of https://github.com/containers/podman/pull/24054

It is not clear to me how to best monitor the repos there to see when they get the update. And then there is the fear that podman keeps updating faster then these envs which makes testing there immposible[1]

[1] https://github.com/containers/image/pull/2550#discussion_r1743588062



#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
