### PR TITLE
Add ExposedPorts to Inspect's ContainerConfig

### DIFF
--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -4,6 +4,7 @@ package libpod
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/pkg/shortnames"
@@ -173,6 +174,13 @@ func (c *Container) validate() error {
 	// Cannot set startup HC without a healthcheck
 	if c.config.HealthCheckConfig == nil && c.config.StartupHealthCheckConfig != nil {
 		return fmt.Errorf("cannot set a startup healthcheck when there is no regular healthcheck: %w", define.ErrInvalidArg)
+	}
+
+	// Ensure all ports list a single protocol
+	for _, p := range c.config.PortMappings {
+		if strings.Contains(p.Protocol, ",") {
+			return fmt.Errorf("each port mapping must define a single protocol, got a comma-separated list for container port %d (protocols requested %q): %w", p.ContainerPort, p.Protocol, define.ErrInvalidArg)
+		}
 	}
 
 	return nil

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -97,6 +97,8 @@ type InspectContainerConfig struct {
 	SdNotifyMode string `json:"sdNotifyMode,omitempty"`
 	// SdNotifySocket is the NOTIFY_SOCKET in use by/configured for the container.
 	SdNotifySocket string `json:"sdNotifySocket,omitempty"`
+	// ExposedPorts includes ports the container has exposed.
+	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
 
 	// V4PodmanCompatMarshal indicates that the json marshaller should
 	// use the old v4 inspect format to keep API compatibility.

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -535,19 +535,6 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	}
 	stopTimeout := int(l.StopTimeout())
 
-	exposedPorts := make(nat.PortSet)
-	for ep := range inspect.NetworkSettings.Ports {
-		port, proto, ok := strings.Cut(ep, "/")
-		if !ok {
-			return nil, fmt.Errorf("PORT/PROTOCOL Format required for %q", ep)
-		}
-		exposedPort, err := nat.NewPort(proto, port)
-		if err != nil {
-			return nil, err
-		}
-		exposedPorts[exposedPort] = struct{}{}
-	}
-
 	var healthcheck *container.HealthConfig
 	if inspect.Config.Healthcheck != nil {
 		healthcheck = &container.HealthConfig{
@@ -556,6 +543,16 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 			Timeout:     inspect.Config.Healthcheck.Timeout,
 			StartPeriod: inspect.Config.Healthcheck.StartPeriod,
 			Retries:     inspect.Config.Healthcheck.Retries,
+		}
+	}
+
+	// Apparently the compiler can't convert a map[string]struct{} into a nat.PortSet
+	// (Despite a nat.PortSet being that exact struct with some types added)
+	var exposedPorts nat.PortSet
+	if len(inspect.Config.ExposedPorts) > 0 {
+		exposedPorts = make(nat.PortSet)
+		for p := range inspect.Config.ExposedPorts {
+			exposedPorts[nat.Port(p)] = struct{}{}
 		}
 	}
 

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -37,6 +37,8 @@ var _ = Describe("Podman container inspect", func() {
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
 			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil, "99/sctp": nil}))
+		Expect(data[0].Config.ExposedPorts).
+			To(Equal(map[string]struct{}{"8787/udp": {}, "99/sctp": {}}))
 
 		session = podmanTest.Podman([]string{"ps", "--format", "{{.Ports}}"})
 		session.WaitWithDefaultTimeout()
@@ -59,6 +61,27 @@ var _ = Describe("Podman container inspect", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("80/tcp, 8989/tcp"))
+	})
+
+	It("podman inspect exposed ports includes published ports", func() {
+		c1 := "ctr1"
+		c1s := podmanTest.Podman([]string{"run", "-d", "--expose", "22/tcp", "-p", "8080:80/tcp", "--name", c1, ALPINE, "top"})
+		c1s.WaitWithDefaultTimeout()
+		Expect(c1s).Should(ExitCleanly())
+
+		c2 := "ctr2"
+		c2s := podmanTest.Podman([]string{"run", "-d", "--net", fmt.Sprintf("container:%s", c1), "--name", c2, ALPINE, "top"})
+		c2s.WaitWithDefaultTimeout()
+		Expect(c2s).Should(ExitCleanly())
+
+		data1 := podmanTest.InspectContainer(c1)
+		Expect(data1).To(HaveLen(1))
+		Expect(data1[0].Config.ExposedPorts).
+			To(Equal(map[string]struct{}{"22/tcp": {}, "80/tcp": {}}))
+
+		data2 := podmanTest.InspectContainer(c2)
+		Expect(data2).To(HaveLen(1))
+		Expect(data2[0].Config.ExposedPorts).To(BeNil())
 	})
 
 	It("podman inspect shows volumes-from with mount options", func() {


### PR DESCRIPTION
A field we missed versus Docker. Matches the format of our existing Ports list in the NetworkConfig, but only includes exposed ports (and maps these to struct{}, as they never go to real ports on the host).

Fixes https://issues.redhat.com/browse/RHEL-60382

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a new field to the output of inspect for containers, `Config.ExposedPorts`, which includes all exposed ports from the container, improving our Docker compatibility.
```
