### PR TITLE
Document that zstd:chunked is downgraded to zstd when encrypting

### DIFF
--- a/docs/source/markdown/options/compression-format.md
+++ b/docs/source/markdown/options/compression-format.md
@@ -5,3 +5,4 @@
 #### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
 
 Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
+`zstd:chunked` is incompatible with encrypting images, and will be treated as `zstd` with a warning in that case.


### PR DESCRIPTION
A part of https://github.com/containers/common/issues/2117 .

#### Does this PR introduce a user-facing change?

```release-note
None
```
