### PR TITLE
vendor: switch to moby/sys/capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/vbauerster/mpb/v8 v8.8.3
 	github.com/vishvananda/netlink v1.3.0
 	go.etcd.io/bbolt v1.3.11
@@ -198,6 +197,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/sylabs/sif/v2 v2.19.1 // indirect
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -10,9 +10,9 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/util"
+	"github.com/moby/sys/capability"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"github.com/syndtr/gocapability/capability"
 )
 
 func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostConfig *define.InspectContainerHostConfig) error {
@@ -151,7 +151,7 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 			}
 		} else {
 			// If we are privileged, use all caps.
-			for _, cap := range capability.List() {
+			for _, cap := range capability.ListKnown() {
 				boundingCaps[fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String()))] = true
 			}
 		}

--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -11,8 +11,6 @@ import (
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/util"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/sirupsen/logrus"
 	"github.com/syndtr/gocapability/capability"
 )
@@ -152,15 +150,8 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 				boundingCaps[cap] = true
 			}
 		} else {
-			g, err := generate.New("linux")
-			if err != nil {
-				return err
-			}
 			// If we are privileged, use all caps.
 			for _, cap := range capability.List() {
-				if g.HostSpecific && cap > capabilities.LastCap() {
-					continue
-				}
 				boundingCaps[fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String()))] = true
 			}
 		}

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	. "github.com/containers/podman/v5/test/utils"
+	"github.com/moby/sys/capability"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/syndtr/gocapability/capability"
 )
 
 // helper function for confirming that container capabilities are equal
@@ -32,7 +32,7 @@ func containerCapMatchesHost(ctrCap string, hostCap string) {
 	// and host caps must always be a superset (inclusive) of container
 	Expect(hostCapN).To(BeNumerically(">", 0), "host cap %q should be nonzero", hostCap)
 	Expect(hostCapN).To(BeNumerically(">=", ctrCapN), "host cap %q should never be less than container cap %q", hostCap, ctrCap)
-	hostCapMasked := hostCapN & (1<<len(capability.List()) - 1)
+	hostCapMasked := hostCapN & (1<<len(capability.ListKnown()) - 1)
 	Expect(ctrCapN).To(Equal(hostCapMasked), "container cap %q is not a subset of host cap %q", ctrCap, hostCap)
 }
 


### PR DESCRIPTION
github.com/moby/sys/capability is a fork of the (no longer maintained) github.com/syndtr/gocapability package.

For changes since the fork took place, see https://github.com/moby/sys/blob/main/capability/CHANGELOG.md

Related:
 * https://github.com/containers/common/pull/2167
 * https://github.com/containers/storage/pull/2103
 * https://github.com/containers/buildah/pull/5754
 * https://github.com/opencontainers/runtime-tools/pull/777

#### Does this PR introduce a user-facing change?

```release-note
none
```
