### PR TITLE
quadlet: allow variables in PublishPort

### DIFF
--- a/test/e2e/quadlet/ports.container
+++ b/test/e2e/quadlet/ports.container
@@ -8,19 +8,19 @@ ExposeHostPort=2000-3000
 ## assert-podman-args --publish 127.0.0.1:80:90
 PublishPort=127.0.0.1:80:90
 
-## assert-podman-args --publish 80:91
+## assert-podman-args --publish 0.0.0.0:80:91
 PublishPort=0.0.0.0:80:91
 
-## assert-podman-args --publish 80:92
+## assert-podman-args --publish :80:92
 PublishPort=:80:92
 
 ## assert-podman-args --publish 127.0.0.1::93
 PublishPort=127.0.0.1::93
 
-## assert-podman-args --publish 94
+## assert-podman-args --publish 0.0.0.0::94
 PublishPort=0.0.0.0::94
 
-## assert-podman-args --publish 95
+## assert-podman-args --publish ::95
 PublishPort=::95
 
 ## assert-podman-args --publish 80:96
@@ -46,6 +46,11 @@ PublishPort=1234:1234/tcp
 
 ## assert-podman-args --publish 127.0.0.1:1234:1234/tcp
 PublishPort=127.0.0.1:1234:1234/tcp
+
+# https://github.com/containers/podman/issues/24081
+# Allow variables to be used as systemd expands them at runtime.
+## assert-podman-args --publish ${PORT}:${PORT}
+PublishPort=${PORT}:${PORT}
 
 ## assert-podman-args --expose=2000-3000/udp
 ExposeHostPort=2000-3000/udp

--- a/test/e2e/quadlet/ports.kube
+++ b/test/e2e/quadlet/ports.kube
@@ -4,19 +4,19 @@ Yaml=/opt/k8s/deployment.yml
 ## assert-podman-args --publish 127.0.0.1:80:90
 PublishPort=127.0.0.1:80:90
 
-## assert-podman-args --publish 80:91
+## assert-podman-args --publish 0.0.0.0:80:91
 PublishPort=0.0.0.0:80:91
 
-## assert-podman-args --publish 80:92
+## assert-podman-args --publish :80:92
 PublishPort=:80:92
 
 ## assert-podman-args --publish 127.0.0.1::93
 PublishPort=127.0.0.1::93
 
-## assert-podman-args --publish 94
+## assert-podman-args --publish 0.0.0.0::94
 PublishPort=0.0.0.0::94
 
-## assert-podman-args --publish 95
+## assert-podman-args --publish ::95
 PublishPort=::95
 
 ## assert-podman-args --publish 80:96


### PR DESCRIPTION
There is no reason to validate the args here, first podman may change the syntax so this is just duplication that may hurt us long term. It also added special handling of some options that just do not make sense, i.e. removing 0.0.0.0, podman should really be the only parser here. And more importantly this prevents variables from being used.

Fixes #24081

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
quadlet: Allow variables to be used in PublishPort
```
