### PR TITLE
fix: error logging when failed to get exit code

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -972,7 +972,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	// Wait for all events to be read
 	mutex.Lock()
 	if eventsErr != nil || lastEvent == nil {
-		logrus.Errorf("Cannot get exit code: %v", err)
+		logrus.Errorf("Cannot get exit code: %v, last event: %v", eventsErr, lastEvent)
 		report.ExitCode = define.ExecErrorCodeNotFound
 		return &report, nil //nolint: nilerr
 	}


### PR DESCRIPTION
The error logging when podman fails to read the exit code from the last event seems wrong: it's referring to `err` which is handled previously and should always be nil in that line. I think we should log `eventsErr` instead.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes logging when podman fails to read the exit code
```
