### PR TITLE
Mention `no_hosts` and `base_hosts_file` configs in CLI option docs

### DIFF
--- a/docs/source/markdown/options/add-host.md
+++ b/docs/source/markdown/options/add-host.md
@@ -11,7 +11,8 @@ a single IPv4 or IPv6 address, separated by a colon. It can also be used to
 overwrite the IP addresses of hostnames Podman adds to `/etc/hosts` by default
 (also see the **--name** and **--hostname** options). This option can be
 specified multiple times to add additional mappings to `/etc/hosts`. It
-conflicts with the **--no-hosts** option.
+conflicts with the **--no-hosts** option and conflicts with *no_hosts=true* in
+`containers.conf`.
 
 Instead of an IP address, the special flag *host-gateway* can be given. This
 resolves to an IP address the container can use to connect to the host. The
@@ -26,4 +27,13 @@ You can prevent that by either giving the **--no-hosts** option, or by setting
 *host_containers_internal_ip="none"* in *containers.conf*. If no *host-gateway*
 address was configured manually and Podman fails to determine the IP address
 automatically, Podman will silently skip adding these internal hostnames to
-`/etc/hosts`.
+`/etc/hosts`. If Podman is running in a virtual machine using `podman machine`
+(this includes Mac and Windows hosts), Podman will silently skip adding the
+internal hostnames to `/etc/hosts`, unless an IP address was configured
+manually; the internal hostnames are resolved by the gvproxy DNS resolver
+instead.
+
+Podman will use the `/etc/hosts` file of the host as a basis by default, i.e.
+any hostname present in this file will also be present in the `/etc/hosts` file
+of the container. A different base file can be configured using the
+*base_hosts_file* config in `containers.conf`.

--- a/docs/source/markdown/options/no-hosts.md
+++ b/docs/source/markdown/options/no-hosts.md
@@ -12,4 +12,5 @@ hostname (see **--hostname** option), the internal `host.containers.internal`
 and `host.docker.internal` hosts, as well as any hostname added using the
 **--add-host** option. Refer to the **--add-host** option for details. Passing
 **--no-hosts** disables this, so that the image's `/etc/hosts` file is kept
-unmodified.
+unmodified. The same can be achieved globally by setting *no_hosts=true* in
+`containers.conf`.


### PR DESCRIPTION
Also mention the `no_hosts` and `base_hosts_file` configs of `containers.conf` in the docs of the `--add-hosts` and `--no-hosts` CLI options.

Follow-up to #24043 
Related: https://github.com/containers/common/pull/2184

Cc: @Luap99 (feel free to also ping @‎mheon and @‎edsantiago)

#### Does this PR introduce a user-facing change?

```release-note
None
```
