### PR TITLE
Validate the bind-propagation option to `--mount`

### DIFF
--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -272,6 +272,12 @@ func parseMountOptions(mountType string, args []string) (*spec.Mount, error) {
 			if !hasValue {
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
 			}
+			switch value {
+			case "shared", "rshared", "private", "rprivate", "slave", "rslave", "unbindable", "runbindable":
+				// Do nothing, sane value
+			default:
+				return nil, fmt.Errorf("invalid value %q", arg)
+			}
 			mnt.Options = append(mnt.Options, value)
 		case "consistency":
 			// Often used on MACs and mistakenly on Linux platforms.

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -122,6 +122,10 @@ var _ = Describe("Podman run with volumes", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, `"notmpcopyup" option not supported for "bind" mount types`))
 
+		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=bind,src=/tmp,target=/tmp,bind-propagation=fake", ALPINE, "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError(125, `invalid value "bind-propagation=fake"`))
+
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=/etc/ssl,notmpcopyup", ALPINE, "ls", "/etc/ssl"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())


### PR DESCRIPTION
Similar to github.com/containers/buildah/pull/5761 but not security critical as Podman does not have an expectation that mounts are scoped (the ability to write a --mount option is already the ability to mount arbitrary content into the container so sneaking arbitrary options into the mount doesn't have security implications). Still, bad practice to let users inject anything into the mount command line so let's not do that.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
