### PR TITLE
Docker compat: Return null when swappiness is unset instead of -1

### DIFF
--- a/docs/source/markdown/podman-container-inspect.1.md.in
+++ b/docs/source/markdown/podman-container-inspect.1.md.in
@@ -296,7 +296,7 @@ $ podman container inspect foobar
             "KernelMemory": 0,
             "MemoryReservation": 0,
             "MemorySwap": 0,
-            "MemorySwappiness": 0,
+            "MemorySwappiness": null,
             "OomKillDisable": false,
             "PidsLimit": 2048,
             "Ulimits": [],

--- a/libpod/container_inspect_linux.go
+++ b/libpod/container_inspect_linux.go
@@ -61,10 +61,8 @@ func (c *Container) platformInspectContainerHostConfig(ctrSpec *spec.Spec, hostC
 					hostConfig.MemorySwap = *ctrSpec.Linux.Resources.Memory.Swap
 				}
 				if ctrSpec.Linux.Resources.Memory.Swappiness != nil {
-					hostConfig.MemorySwappiness = int64(*ctrSpec.Linux.Resources.Memory.Swappiness)
-				} else {
-					// Swappiness has a default of -1
-					hostConfig.MemorySwappiness = -1
+					swappiness := int64(*ctrSpec.Linux.Resources.Memory.Swappiness)
+					hostConfig.MemorySwappiness = &swappiness
 				}
 				if ctrSpec.Linux.Resources.Memory.DisableOOMKiller != nil {
 					hostConfig.OomKillDisable = *ctrSpec.Linux.Resources.Memory.DisableOOMKiller

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -643,8 +643,8 @@ type InspectContainerHostConfig struct {
 	// MemorySwappiness is the willingness of the kernel to page container
 	// memory to swap. It is an integer from 0 to 100, with low numbers
 	// being more likely to be put into swap.
-	// -1, the default, will not set swappiness and use the system defaults.
-	MemorySwappiness int64 `json:"MemorySwappiness"`
+	// nil means swappiness is unset and the system default is used.
+	MemorySwappiness *int64 `json:"MemorySwappiness"`
 	// OomKillDisable indicates whether the kernel OOM killer is disabled
 	// for the container.
 	OomKillDisable bool `json:"OomKillDisable"`

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -870,6 +870,21 @@ t GET containers/$cid/json 200 \
 t DELETE containers/$cid 204
 podman rmi test1
 
+# test MemorySwappiness
+podman run -d --rm --name swappiness_with_mem_limit --memory 200M $IMAGE top
+podman run -d --rm --name swappiness_without_mem_limit $IMAGE top
+
+t GET containers/swappiness_with_mem_limit/json 200 \
+  .HostConfig.MemorySwappiness=null
+t GET containers/swappiness_without_mem_limit/json 200 \
+  .HostConfig.MemorySwappiness=null
+
+t GET libpod/containers/swappiness_with_mem_limit/json 200 \
+  .HostConfig.MemorySwappiness=null
+t GET libpod/containers/swappiness_without_mem_limit/json 200 \
+  .HostConfig.MemorySwappiness=null
+
+podman stop -t0 swappiness_with_mem_limit swappiness_without_mem_limit
 
 # test if API support -1 for ulimits https://github.com/containers/podman/issues/24886
 

--- a/test/e2e/container_clone_test.go
+++ b/test/e2e/container_clone_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Podman container clone", func() {
 		cloneInspect.WaitWithDefaultTimeout()
 		Expect(cloneInspect).To(ExitCleanly())
 		cloneData = cloneInspect.InspectContainerToJSON()
-		Expect(cloneData[0].HostConfig).To(HaveField("MemorySwappiness", int64(0)))
+		Expect(cloneData[0].HostConfig.MemorySwappiness).To(BeNil())
 	})
 
 	It("podman container clone in a pod", func() {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/23824

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman inspect` returns MemorySwappiness: null when it's not set
```
