### PR TITLE
Quadlet - prefer "param val" over "param=val" to allow env expansion

### DIFF
--- a/test/e2e/quadlet/annotation.build
+++ b/test/e2e/quadlet/annotation.build
@@ -3,7 +3,7 @@
 ## assert-podman-args "--annotation" "org.foo.Arg1=arg1"
 ## assert-podman-args "--annotation" "org.foo.Arg2=arg 2"
 ## assert-podman-args "--annotation" "org.foo.Arg3=arg3"
-## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--tag" "localhost/imagename"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/arch-os.image
+++ b/test/e2e/quadlet/arch-os.image
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --os=windows
-## assert-podman-args --arch=arm64
+## assert-podman-args "--os" "windows"
+## assert-podman-args "--arch" "arm64"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/arch.build
+++ b/test/e2e/quadlet/arch.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --arch=aarch64
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--arch" "aarch64"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/arch.image
+++ b/test/e2e/quadlet/arch.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --arch=aarch64
+## assert-podman-args "--arch" "aarch64"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/auth.image
+++ b/test/e2e/quadlet/auth.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --authfile=/etc/certs/auth.json
+## assert-podman-args "--authfile" "/etc/certs/auth.json"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/authfile.build
+++ b/test/e2e/quadlet/authfile.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --authfile=/etc/certs/auth.json
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--authfile" "/etc/certs/auth.json"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon  -d localhost/imagename
+## assert-podman-final-args run --name systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon  -d localhost/imagename
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/basic.build
+++ b/test/e2e/quadlet/basic.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--tag" "localhost/imagename"
 ## assert-key-is "Unit" "After" "network-online.target"
 ## assert-key-is "Unit" "Wants" "network-online.target"
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--name=systemd-%N"
+## assert-podman-args "--name" "systemd-%N"
 ## assert-podman-args "--cidfile=%t/%N.cid"
 ## assert-podman-args "--rm"
 ## assert-podman-args "--replace"

--- a/test/e2e/quadlet/basic.pod
+++ b/test/e2e/quadlet/basic.pod
@@ -1,7 +1,7 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type forking
 ## assert-key-is Service SyslogIdentifier "%N"
-## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --pod-id-file=%t/%N.pod-id --exit-policy=stop --replace --infra-name=systemd-basic-infra --name=systemd-basic"
+## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --pod-id-file=%t/%N.pod-id --exit-policy=stop --replace --infra-name systemd-basic-infra --name systemd-basic"
 ## assert-key-is-regex Service ExecStart ".*/podman pod start --pod-id-file=%t/%N.pod-id"
 ## assert-key-is-regex Service ExecStop ".*/podman pod stop --pod-id-file=%t/%N.pod-id --ignore --time=10"
 ## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --pod-id-file=%t/%N.pod-id --ignore --force"

--- a/test/e2e/quadlet/build.quadlet.servicename.volume
+++ b/test/e2e/quadlet/build.quadlet.servicename.volume
@@ -1,4 +1,4 @@
-## assert-podman-args --driver=image
+## assert-podman-args --driver image
 ## assert-podman-args --opt image=localhost/imagename
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "basic.service"

--- a/test/e2e/quadlet/build.quadlet.volume
+++ b/test/e2e/quadlet/build.quadlet.volume
@@ -1,4 +1,4 @@
-## assert-podman-args --driver=image
+## assert-podman-args --driver image
 ## assert-podman-args --opt image=localhost/imagename
 ## assert-key-is "Unit" "Requires" "basic-build.service"
 ## assert-key-is "Unit" "After" "basic-build.service"

--- a/test/e2e/quadlet/capabilities.container
+++ b/test/e2e/quadlet/capabilities.container
@@ -1,7 +1,7 @@
-## !assert-podman-args "--cap-drop=all"
-## assert-podman-args "--cap-add=cap_dac_override"
-## assert-podman-args "--cap-add=cap_audit_write"
-## assert-podman-args "--cap-add=cap_ipc_owner"
+## !assert-podman-args "--cap-drop" "all"
+## assert-podman-args "--cap-add" "cap_dac_override"
+## assert-podman-args "--cap-add" "cap_audit_write"
+## assert-podman-args "--cap-add" "cap_ipc_owner"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/capabilities2.container
+++ b/test/e2e/quadlet/capabilities2.container
@@ -1,7 +1,7 @@
-## !assert-podman-args "--cap-drop=all"
-## assert-podman-args "--cap-drop=cap_dac_override"
-## assert-podman-args "--cap-drop=cap_audit_write"
-## assert-podman-args "--cap-drop=cap_ipc_owner"
+## !assert-podman-args "--cap-drop" "all"
+## assert-podman-args "--cap-drop" "cap_dac_override"
+## assert-podman-args "--cap-drop" "cap_audit_write"
+## assert-podman-args "--cap-drop" "cap_ipc_owner"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/certs.image
+++ b/test/e2e/quadlet/certs.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --cert-dir=/etc/certs/auth.json
+## assert-podman-args "--cert-dir" "/etc/certs/auth.json"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/cgroups-mode.container
+++ b/test/e2e/quadlet/cgroups-mode.container
@@ -1,4 +1,4 @@
-## assert-podman-args --cgroups=no-conmon
+## assert-podman-args "--cgroups" "no-conmon"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/comment-with-continuation.container
+++ b/test/e2e/quadlet/comment-with-continuation.container
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename:latest
 ## assert-podman-args --publish 9091:9091
-## assert-podman-args "--name=greatName"
+## assert-podman-args "--name" "greatName"
 
 [Unit]
 Wants=network-online.target

--- a/test/e2e/quadlet/creds.image
+++ b/test/e2e/quadlet/creds.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --creds=myname:mypassword
+## assert-podman-args "--creds" "myname:mypassword"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/decrypt.image
+++ b/test/e2e/quadlet/decrypt.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --decryption-key=/etc/keys/decrypt:passphrase
+## assert-podman-args "--decryption-key" "/etc/keys/decrypt:passphrase"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/devices.container
+++ b/test/e2e/quadlet/devices.container
@@ -1,9 +1,9 @@
-## assert-podman-args --device=/dev/fuse
-## assert-podman-args --device=/dev/loop0:r
-## assert-podman-args --device=/dev/null:/dev/test
-## !assert-podman-args --device=/dev/bogus:r
-## !assert-podman-args --device=/dev/bogus
-## !assert-podman-args --device=/dev/bogus1
+## assert-podman-args --device /dev/fuse
+## assert-podman-args --device /dev/loop0:r
+## assert-podman-args --device /dev/null:/dev/test
+## !assert-podman-args --device /dev/bogus:r
+## !assert-podman-args --device /dev/bogus
+## !assert-podman-args --device /dev/bogus1
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/dns-option.pod
+++ b/test/e2e/quadlet/dns-option.pod
@@ -1,5 +1,5 @@
-## assert-podman-pre-args "--dns-option=ndots:1"
-## assert-podman-pre-args "--dns-option=color:blue"
+## assert-podman-pre-args "--dns-option" "ndots:1"
+## assert-podman-pre-args "--dns-option" "color:blue"
 
 [Pod]
 DNSOption=ndots:1

--- a/test/e2e/quadlet/dns-options.build
+++ b/test/e2e/quadlet/dns-options.build
@@ -1,7 +1,7 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args "--dns-option=ndots:1"
-## assert-podman-args "--dns-option=color:blue"
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--dns-option" "ndots:1"
+## assert-podman-args "--dns-option" "color:blue"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/dns-options.container
+++ b/test/e2e/quadlet/dns-options.container
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--dns-option=ndots:1"
-## assert-podman-args "--dns-option=color:blue"
+## assert-podman-args "--dns-option" "ndots:1"
+## assert-podman-args "--dns-option" "color:blue"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/dns-search.build
+++ b/test/e2e/quadlet/dns-search.build
@@ -1,7 +1,7 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args "--dns-search=foo.com"
-## assert-podman-args "--dns-search=bar.com"
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--dns-search" "foo.com"
+## assert-podman-args "--dns-search" "bar.com"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/dns-search.container
+++ b/test/e2e/quadlet/dns-search.container
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--dns-search=foo.com"
-## assert-podman-args "--dns-search=bar.com"
+## assert-podman-args "--dns-search" "foo.com"
+## assert-podman-args "--dns-search" "bar.com"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/dns-search.pod
+++ b/test/e2e/quadlet/dns-search.pod
@@ -1,5 +1,5 @@
-## assert-podman-pre-args "--dns-search=foo.com"
-## assert-podman-pre-args "--dns-search=bar.com"
+## assert-podman-pre-args "--dns-search" "foo.com"
+## assert-podman-pre-args "--dns-search" "bar.com"
 
 [Pod]
 DNSSearch=foo.com

--- a/test/e2e/quadlet/dns.build
+++ b/test/e2e/quadlet/dns.build
@@ -1,7 +1,7 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args "--dns=8.7.7.7"
-## assert-podman-args "--dns=8.8.8.8"
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--dns" "8.7.7.7"
+## assert-podman-args "--dns" "8.8.8.8"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/dns.container
+++ b/test/e2e/quadlet/dns.container
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--dns=8.7.7.7"
-## assert-podman-args "--dns=8.8.8.8"
+## assert-podman-args "--dns" "8.7.7.7"
+## assert-podman-args "--dns" "8.8.8.8"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/dns.network
+++ b/test/e2e/quadlet/dns.network
@@ -1,6 +1,6 @@
 ## assert-podman-final-args systemd-dns
-## assert-podman-args "--dns=8.7.7.7"
-## assert-podman-args "--dns=8.8.8.8"
+## assert-podman-args "--dns" "8.7.7.7"
+## assert-podman-args "--dns" "8.8.8.8"
 
 [Network]
 DNS=8.7.7.7

--- a/test/e2e/quadlet/dns.pod
+++ b/test/e2e/quadlet/dns.pod
@@ -1,5 +1,5 @@
-## assert-podman-pre-args "--dns=8.7.7.7"
-## assert-podman-pre-args "--dns=8.8.8.8"
+## assert-podman-pre-args "--dns" "8.7.7.7"
+## assert-podman-pre-args "--dns" "8.8.8.8"
 
 [Pod]
 DNS=8.7.7.7

--- a/test/e2e/quadlet/driver.network
+++ b/test/e2e/quadlet/driver.network
@@ -1,5 +1,5 @@
 ## assert-podman-final-args systemd-driver
-## assert-podman-args "--driver=macvlan"
+## assert-podman-args "--driver" "macvlan"
 
 [Network]
 Driver=macvlan

--- a/test/e2e/quadlet/entrypoint.container
+++ b/test/e2e/quadlet/entrypoint.container
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--entrypoint=top"
+## assert-podman-args "--entrypoint" "top -b"
 
 [Container]
 Image=localhost/imagename
-Entrypoint=top
+Entrypoint=top -b

--- a/test/e2e/quadlet/env.build
+++ b/test/e2e/quadlet/env.build
@@ -1,10 +1,10 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --env "FOO1=foo1"
-## assert-podman-args --env "FOO2=foo2 "
-## assert-podman-args --env "FOO3=foo3"
-## assert-podman-args --env "REPLACE=replaced"
-## assert-podman-args --env "FOO4=foo\\nfoo"
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--env" "FOO1=foo1"
+## assert-podman-args "--env" "FOO2=foo2 "
+## assert-podman-args "--env" "FOO3=foo3"
+## assert-podman-args "--env" "REPLACE=replaced"
+## assert-podman-args "--env" "FOO4=foo\\nfoo"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/file-abs.build
+++ b/test/e2e/quadlet/file-abs.build
@@ -1,4 +1,4 @@
-## assert-podman-final-args --file=/etc/containers/systemd/Containerfile
+## assert-podman-final-args "--file" "/etc/containers/systemd/Containerfile"
 
 [Build]
 File=/etc/containers/systemd/Containerfile

--- a/test/e2e/quadlet/file-https.build
+++ b/test/e2e/quadlet/file-https.build
@@ -1,5 +1,5 @@
-## assert-podman-args --tag=localhost/podman-hello
-## assert-podman-args --file=https://raw.githubusercontent.com/containers/PodmanHello/main/Containerfile
+## assert-podman-args "--tag" "localhost/podman-hello"
+## assert-podman-args "--file" "https://raw.githubusercontent.com/containers/PodmanHello/main/Containerfile"
 
 [Build]
 File=https://raw.githubusercontent.com/containers/PodmanHello/main/Containerfile

--- a/test/e2e/quadlet/file-rel.build
+++ b/test/e2e/quadlet/file-rel.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args .
-## assert-podman-args-regex "--file=Containerfile"
+## assert-podman-args-regex "--file" "Containerfile"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/force-rm.build
+++ b/test/e2e/quadlet/force-rm.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--tag" "localhost/imagename"
 ## assert-podman-args --force-rm=false
 
 [Build]

--- a/test/e2e/quadlet/gateway.network
+++ b/test/e2e/quadlet/gateway.network
@@ -1,5 +1,5 @@
 ## assert-podman-final-args systemd-gateway
-## assert-podman-args "--subnet=192.168.1.0/24" "--gateway=192.168.1.1"
+## assert-podman-args "--subnet" "192.168.1.0/24" "--gateway" "192.168.1.1"
 
 [Network]
 Subnet=192.168.1.0/24

--- a/test/e2e/quadlet/group-add.build
+++ b/test/e2e/quadlet/group-add.build
@@ -1,5 +1,5 @@
-## assert-podman-args "--group-add=keep-groups"
-## assert-podman-args "--group-add=users"
+## assert-podman-args "--group-add" "keep-groups"
+## assert-podman-args "--group-add" "users"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/group-add.container
+++ b/test/e2e/quadlet/group-add.container
@@ -1,5 +1,5 @@
-## assert-podman-args "--group-add=keep-groups"
-## assert-podman-args "--group-add=users"
+## assert-podman-args "--group-add" "keep-groups"
+## assert-podman-args "--group-add" "users"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/host.container
+++ b/test/e2e/quadlet/host.container
@@ -1,6 +1,6 @@
 [Container]
 Image=localhost/imagename
-## assert-podman-args "--add-host=my-host-name:192.168.10.10"
+## assert-podman-args "--add-host" "my-host-name:192.168.10.10"
 AddHost=my-host-name:192.168.10.10
-## assert-podman-args "--add-host=my-second-host-name:192.168.10.11"
+## assert-podman-args "--add-host" "my-second-host-name:192.168.10.11"
 AddHost=my-second-host-name:192.168.10.11

--- a/test/e2e/quadlet/host.pod
+++ b/test/e2e/quadlet/host.pod
@@ -1,5 +1,5 @@
 [Pod]
-## assert-podman-pre-args "--add-host=my-host-name:192.168.10.10"
+## assert-podman-pre-args "--add-host" "my-host-name:192.168.10.10"
 AddHost=my-host-name:192.168.10.10
-## assert-podman-pre-args "--add-host=my-second-host-name:192.168.10.11"
+## assert-podman-pre-args "--add-host" "my-second-host-name:192.168.10.11"
 AddHost=my-second-host-name:192.168.10.11

--- a/test/e2e/quadlet/idmapping.container
+++ b/test/e2e/quadlet/idmapping.container
@@ -1,7 +1,7 @@
-## assert-podman-args "--uidmap=0:10000:10"
-## assert-podman-args "--uidmap=10:20000:10"
-## assert-podman-args "--gidmap=0:10000:10"
-## assert-podman-args "--gidmap=10:20000:10"
+## assert-podman-args "--uidmap" "0:10000:10"
+## assert-podman-args "--uidmap" "10:20000:10"
+## assert-podman-args "--gidmap" "0:10000:10"
+## assert-podman-args "--gidmap" "10:20000:10"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/image.quadlet.servicename.volume
+++ b/test/e2e/quadlet/image.quadlet.servicename.volume
@@ -1,4 +1,4 @@
-## assert-podman-args --driver=image
+## assert-podman-args --driver image
 ## assert-podman-args --opt image=localhost/imagename
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "basic.service"

--- a/test/e2e/quadlet/image.quadlet.volume
+++ b/test/e2e/quadlet/image.quadlet.volume
@@ -1,4 +1,4 @@
-## assert-podman-args --driver=image
+## assert-podman-args --driver image
 ## assert-podman-args --opt image=localhost/imagename
 ## assert-key-is "Unit" "Requires" "basic-image.service"
 ## assert-key-is "Unit" "After" "basic-image.service"

--- a/test/e2e/quadlet/image.volume
+++ b/test/e2e/quadlet/image.volume
@@ -1,4 +1,4 @@
-## assert-podman-args --driver=image
+## assert-podman-args --driver image
 ## assert-podman-args --opt image=localhost/imagename
 
 [Volume]

--- a/test/e2e/quadlet/ip.pod
+++ b/test/e2e/quadlet/ip.pod
@@ -1,5 +1,5 @@
-## assert-podman-pre-args "--ip=10.88.64.128"
-## assert-podman-pre-args "--ip6=fd46:db93:aa76:ac37::10"
+## assert-podman-pre-args "--ip" "10.88.64.128"
+## assert-podman-pre-args "--ip6" "fd46:db93:aa76:ac37::10"
 
 [Pod]
 IP=10.88.64.128

--- a/test/e2e/quadlet/ipam-driver.network
+++ b/test/e2e/quadlet/ipam-driver.network
@@ -1,5 +1,5 @@
 ## assert-podman-final-args systemd-ipam-driver
-## assert-podman-args "--ipam-driver=dhcp"
+## assert-podman-args "--ipam-driver" "dhcp"
 
 [Network]
 IPAMDriver=dhcp

--- a/test/e2e/quadlet/label.build
+++ b/test/e2e/quadlet/label.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--tag" "localhost/imagename"
 ## assert-podman-args "--label" "org.foo.Arg0=arg0"
 ## assert-podman-args "--label" "org.foo.Arg1=arg1"
 ## assert-podman-args "--label" "org.foo.Arg2=arg 2"

--- a/test/e2e/quadlet/multiple-tags.build
+++ b/test/e2e/quadlet/multiple-tags.build
@@ -1,5 +1,5 @@
-## assert-podman-args --tag=localhost/imagename:v1
-## assert-podman-args --tag=localhost/imagename:latest
+## assert-podman-args "--tag" "localhost/imagename:v1"
+## assert-podman-args "--tag" "localhost/imagename:latest"
 
 [Build]
 ImageTag=localhost/imagename:v1

--- a/test/e2e/quadlet/name.container
+++ b/test/e2e/quadlet/name.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--name=foobar"
+## assert-podman-args "--name" "foobar"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/name.pod
+++ b/test/e2e/quadlet/name.pod
@@ -1,5 +1,5 @@
-## assert-podman-pre-args "--name=test-pod"
-## assert-podman-pre-args "--infra-name=test-pod-infra"
+## assert-podman-pre-args "--name" "test-pod"
+## assert-podman-pre-args "--infra-name" "test-pod-infra"
 
 [Pod]
 PodName=test-pod

--- a/test/e2e/quadlet/network.build
+++ b/test/e2e/quadlet/network.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args "--network=host"
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--network" "host"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/network.container
+++ b/test/e2e/quadlet/network.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=host"
+## assert-podman-args "--network" "host"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/network.kube
+++ b/test/e2e/quadlet/network.kube
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=basic"
+## assert-podman-args --network basic
 
 [Kube]
 Yaml=deployment.yml

--- a/test/e2e/quadlet/network.pod
+++ b/test/e2e/quadlet/network.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args "--network=host"
+## assert-podman-pre-args --network host
 ## assert-podman-pre-args --publish 127.0.0.1:80:90
 
 [Pod]

--- a/test/e2e/quadlet/network.quadlet.build
+++ b/test/e2e/quadlet/network.quadlet.build
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=systemd-basic"
+## assert-podman-args "--network" "systemd-basic"
 ## assert-key-is "Unit" "Requires" "basic-network.service"
 ## assert-key-is "Unit" "After" "network-online.target" "basic-network.service"
 

--- a/test/e2e/quadlet/network.quadlet.container
+++ b/test/e2e/quadlet/network.quadlet.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=systemd-basic"
+## assert-podman-args "--network" "systemd-basic"
 ## assert-key-is "Unit" "Requires" "basic-network.service"
 ## assert-key-is "Unit" "After" "network-online.target" "basic-network.service"
 

--- a/test/e2e/quadlet/network.quadlet.kube
+++ b/test/e2e/quadlet/network.quadlet.kube
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=systemd-basic"
+## assert-podman-args "--network" "systemd-basic"
 ## assert-key-is "Unit" "Requires" "basic-network.service"
 ## assert-key-is "Unit" "After" "basic-network.service"
 

--- a/test/e2e/quadlet/network.quadlet.pod
+++ b/test/e2e/quadlet/network.quadlet.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args "--network=systemd-basic"
+## assert-podman-pre-args "--network" "systemd-basic"
 ## assert-key-is "Unit" "Requires" "basic-network.service"
 ## assert-key-is "Unit" "After" "basic-network.service"
 

--- a/test/e2e/quadlet/network.quadlet.servicename.build
+++ b/test/e2e/quadlet/network.quadlet.servicename.build
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=test-network"
+## assert-podman-args "--network" "test-network"
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "network-online.target" "basic.service"
 

--- a/test/e2e/quadlet/network.quadlet.servicename.container
+++ b/test/e2e/quadlet/network.quadlet.servicename.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=test-network"
+## assert-podman-args "--network" "test-network"
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "network-online.target" "basic.service"
 

--- a/test/e2e/quadlet/network.quadlet.servicename.kube
+++ b/test/e2e/quadlet/network.quadlet.servicename.kube
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=test-network"
+## assert-podman-args "--network" "test-network"
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "basic.service"
 

--- a/test/e2e/quadlet/network.reuse.container
+++ b/test/e2e/quadlet/network.reuse.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=container:systemd-basic"
+## assert-podman-args "--network" "container:systemd-basic"
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "network-online.target" "basic.service"
 

--- a/test/e2e/quadlet/network.reuse.name.container
+++ b/test/e2e/quadlet/network.reuse.name.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--network=container:foobar"
+## assert-podman-args "--network" "container:foobar"
 ## assert-key-is "Unit" "Requires" "name.service"
 ## assert-key-is "Unit" "After" "network-online.target" "name.service"
 

--- a/test/e2e/quadlet/network.servicename.quadlet.pod
+++ b/test/e2e/quadlet/network.servicename.quadlet.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args "--network=test-network"
+## assert-podman-pre-args "--network" "test-network"
 ## assert-key-is "Unit" "Requires" "basic.service"
 ## assert-key-is "Unit" "After" "basic.service"
 

--- a/test/e2e/quadlet/os.image
+++ b/test/e2e/quadlet/os.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --os=windows
+## assert-podman-args "--os" "windows"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/ports.container
+++ b/test/e2e/quadlet/ports.container
@@ -1,8 +1,8 @@
 [Container]
 Image=localhost/imagename
-## assert-podman-args --expose=1000
+## assert-podman-args --expose 1000
 ExposeHostPort=1000
-## assert-podman-args --expose=2000-3000
+## assert-podman-args --expose 2000-3000
 ExposeHostPort=2000-3000
 
 ## assert-podman-args --publish 127.0.0.1:80:90
@@ -52,8 +52,8 @@ PublishPort=127.0.0.1:1234:1234/tcp
 ## assert-podman-args --publish ${PORT}:${PORT}
 PublishPort=${PORT}:${PORT}
 
-## assert-podman-args --expose=2000-3000/udp
+## assert-podman-args --expose 2000-3000/udp
 ExposeHostPort=2000-3000/udp
 
-## assert-podman-args --expose=2000-3000/tcp
+## assert-podman-args --expose 2000-3000/tcp
 ExposeHostPort=2000-3000/tcp

--- a/test/e2e/quadlet/pull.build
+++ b/test/e2e/quadlet/pull.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --pull=never
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--pull" "never"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/quotes.container
+++ b/test/e2e/quadlet/quotes.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --name=RemoveQuotes\"Name
+## assert-podman-args "--name" "RemoveQuotes\"Name"
 
 [Container]
 Image="localhost/imagename"

--- a/test/e2e/quadlet/range.network
+++ b/test/e2e/quadlet/range.network
@@ -1,5 +1,5 @@
 ## assert-podman-final-args systemd-range
-## assert-podman-args "--subnet=192.168.1.0/24" "--ip-range=192.168.1.0/32"
+## assert-podman-args "--subnet" "192.168.1.0/24" "--ip-range" "192.168.1.0/32"
 
 [Network]
 Subnet=192.168.1.0/24

--- a/test/e2e/quadlet/remap-auto.container
+++ b/test/e2e/quadlet/remap-auto.container
@@ -1,4 +1,4 @@
-## assert-podman-args --userns=auto
+## assert-podman-args --userns auto
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/remap-auto.kube
+++ b/test/e2e/quadlet/remap-auto.kube
@@ -1,4 +1,4 @@
-## assert-podman-args --userns=auto
+## assert-podman-args --userns auto
 
 [Kube]
 Yaml=/opt/k8s/deployment.yml

--- a/test/e2e/quadlet/remap-auto.pod
+++ b/test/e2e/quadlet/remap-auto.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args --userns=auto
+## assert-podman-pre-args --userns auto
 
 [Pod]
 RemapUsers=auto

--- a/test/e2e/quadlet/remap-auto2.container
+++ b/test/e2e/quadlet/remap-auto2.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--userns=auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
+## assert-podman-args "--userns" "auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/remap-auto2.kube
+++ b/test/e2e/quadlet/remap-auto2.kube
@@ -1,4 +1,4 @@
-## assert-podman-args "--userns=auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
+## assert-podman-args "--userns" "auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
 
 [Kube]
 Yaml=/opt/k8s/deployment.yml

--- a/test/e2e/quadlet/remap-auto2.pod
+++ b/test/e2e/quadlet/remap-auto2.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args "--userns=auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
+## assert-podman-pre-args "--userns" "auto:uidmapping=0:10000:10,uidmapping=10:20000:10,gidmapping=0:10000:10,gidmapping=10:20000:10,size=20"
 
 [Pod]
 RemapUsers=auto

--- a/test/e2e/quadlet/remap-keep-id.container
+++ b/test/e2e/quadlet/remap-keep-id.container
@@ -1,4 +1,4 @@
-## assert-podman-args --userns=keep-id
+## assert-podman-args --userns keep-id
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/remap-keep-id.pod
+++ b/test/e2e/quadlet/remap-keep-id.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args --userns=keep-id
+## assert-podman-pre-args --userns keep-id
 
 [Pod]
 RemapUsers=keep-id

--- a/test/e2e/quadlet/remap-keep-id2.container
+++ b/test/e2e/quadlet/remap-keep-id2.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--userns=keep-id:uid=200,gid=210"
+## assert-podman-args --userns keep-id:uid=200,gid=210
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/remap-manual.container
+++ b/test/e2e/quadlet/remap-manual.container
@@ -1,7 +1,7 @@
-## assert-podman-args "--uidmap=0:10000:10"
-## assert-podman-args "--uidmap=10:20000:10"
-## assert-podman-args "--gidmap=0:10000:10"
-## assert-podman-args "--gidmap=10:20000:10"
+## assert-podman-args "--uidmap" "0:10000:10"
+## assert-podman-args "--uidmap" "10:20000:10"
+## assert-podman-args "--gidmap" "0:10000:10"
+## assert-podman-args "--gidmap" "10:20000:10"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/remap-manual.pod
+++ b/test/e2e/quadlet/remap-manual.pod
@@ -1,7 +1,7 @@
-## assert-podman-pre-args "--uidmap=0:10000:10"
-## assert-podman-pre-args "--uidmap=10:20000:10"
-## assert-podman-pre-args "--gidmap=0:10000:10"
-## assert-podman-pre-args "--gidmap=10:20000:10"
+## assert-podman-pre-args "--uidmap" "0:10000:10"
+## assert-podman-pre-args "--uidmap" "10:20000:10"
+## assert-podman-pre-args "--gidmap" "0:10000:10"
+## assert-podman-pre-args "--gidmap" "10:20000:10"
 
 [Pod]
 RemapUsers=manual

--- a/test/e2e/quadlet/service-name.build
+++ b/test/e2e/quadlet/service-name.build
@@ -1,4 +1,4 @@
-## assert-podman-args --tag=localhost/imagename
+## assert-podman-args "--tag" "localhost/imagename"
 
 [Build]
 ServiceName=basic

--- a/test/e2e/quadlet/service-name.pod
+++ b/test/e2e/quadlet/service-name.pod
@@ -1,4 +1,4 @@
-## assert-podman-pre-args "--name=test-pod"
+## assert-podman-pre-args "--name" "test-pod"
 
 [Pod]
 ServiceName=basic

--- a/test/e2e/quadlet/setworkingdirectory-is-archive.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-archive.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args https://github.com/containers/PodmanHello/archive/refs/heads/main.tar.gz
-## assert-podman-args --tag=localhost/podman-hello-archive
-## assert-podman-args --file=PodmanHello-main/Containerfile
+## assert-podman-args "--tag" "localhost/podman-hello-archive"
+## assert-podman-args "--file" "PodmanHello-main/Containerfile"
 
 [Build]
 ImageTag=localhost/podman-hello-archive

--- a/test/e2e/quadlet/setworkingdirectory-is-file-abs.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-file-abs.build
@@ -1,4 +1,4 @@
-## assert-podman-args --file=/etc/containers/systemd/Containerfile
+## assert-podman-args "--file" "/etc/containers/systemd/Containerfile"
 ## assert-key-is "Service" "WorkingDirectory" "/etc/containers/systemd"
 
 [Build]

--- a/test/e2e/quadlet/setworkingdirectory-is-file-rel.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-file-rel.build
@@ -1,4 +1,4 @@
-## assert-podman-args --file=Containerfile
+## assert-podman-args "--file" "Containerfile"
 ## assert-key-is-regex "Service" "WorkingDirectory" "/.*/podman-e2e-.*/subtest-.*/quadlet"
 
 [Build]

--- a/test/e2e/quadlet/setworkingdirectory-is-git.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-git.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args git://git@git.sr.ht/~emersion/sr.ht-container-compose
-## assert-podman-args --tag=localhost/podman-hello
+## assert-podman-args "--tag" "localhost/podman-hello"
 
 [Build]
 ImageTag=localhost/podman-hello

--- a/test/e2e/quadlet/setworkingdirectory-is-github.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-github.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args github.com/containers/PodmanHello.git
-## assert-podman-args --tag=localhost/podman-hello
+## assert-podman-args "--tag" "localhost/podman-hello"
 
 [Build]
 ImageTag=localhost/podman-hello

--- a/test/e2e/quadlet/setworkingdirectory-is-https-git.build
+++ b/test/e2e/quadlet/setworkingdirectory-is-https-git.build
@@ -1,5 +1,5 @@
 ## assert-podman-final-args https://github.com/containers/PodmanHello.git
-## assert-podman-args --tag=localhost/podman-hello
+## assert-podman-args "--tag" "localhost/podman-hello"
 
 [Build]
 ImageTag=localhost/podman-hello

--- a/test/e2e/quadlet/shmsize.container
+++ b/test/e2e/quadlet/shmsize.container
@@ -1,4 +1,4 @@
-## assert-podman-args "--shm-size=5g"
+## assert-podman-args "--shm-size" "5g"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/subnet-trio.multiple.network
+++ b/test/e2e/quadlet/subnet-trio.multiple.network
@@ -1,6 +1,6 @@
 ## assert-podman-final-args systemd-subnet-trio.multiple
-## assert-podman-args "--subnet=192.168.1.0/24" "--gateway=192.168.1.1" "--ip-range=192.168.1.0/32"
-## assert-podman-args "--subnet=192.168.2.0/24" "--gateway=192.168.2.1" "--ip-range=192.168.2.0/32"
+## assert-podman-args "--subnet" "192.168.1.0/24" "--gateway" "192.168.1.1" "--ip-range" "192.168.1.0/32"
+## assert-podman-args "--subnet" "192.168.2.0/24" "--gateway" "192.168.2.1" "--ip-range" "192.168.2.0/32"
 
 [Network]
 Subnet=192.168.1.0/24

--- a/test/e2e/quadlet/subnet-trio.network
+++ b/test/e2e/quadlet/subnet-trio.network
@@ -1,5 +1,5 @@
 ## assert-podman-final-args systemd-subnet-trio
-## assert-podman-args "--subnet=192.168.1.0/24" "--gateway=192.168.1.1" "--ip-range=192.168.1.0/32"
+## assert-podman-args "--subnet" "192.168.1.0/24" "--gateway" "192.168.1.1" "--ip-range" "192.168.1.0/32"
 
 [Network]
 Subnet=192.168.1.0/24

--- a/test/e2e/quadlet/subnets.network
+++ b/test/e2e/quadlet/subnets.network
@@ -1,6 +1,6 @@
 ## assert-podman-final-args systemd-subnets
-## assert-podman-args "--subnet=192.168.0.0/24"
-## assert-podman-args "--subnet=192.168.1.0/24"
+## assert-podman-args "--subnet" "192.168.0.0/24"
+## assert-podman-args "--subnet" "192.168.1.0/24"
 
 [Network]
 Subnet=192.168.0.0/24

--- a/test/e2e/quadlet/sysctl.container
+++ b/test/e2e/quadlet/sysctl.container
@@ -1,6 +1,6 @@
-## assert-podman-args "--sysctl=net.ipv6.conf.all.disable_ipv6=1"
-## assert-podman-args "--sysctl=net.ipv6.conf.all.use_tempaddr=1"
-## assert-podman-args "--sysctl=net.ipv4.conf.lo.force_igmp_version=0"
+## assert-podman-args "--sysctl" "net.ipv6.conf.all.disable_ipv6=1"
+## assert-podman-args "--sysctl" "net.ipv6.conf.all.use_tempaddr=1"
+## assert-podman-args "--sysctl" "net.ipv4.conf.lo.force_igmp_version=0"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/target.build
+++ b/test/e2e/quadlet/target.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --target=my-app
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--target" "my-app"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/template@.container
+++ b/test/e2e/quadlet/template@.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--name=systemd-%p_%i"
+## assert-podman-args "--name" "systemd-%p_%i"
 ## assert-symlink want.service.wants/template@default.service ../template@.service
 ## assert-podman-args --env "FOO=bar"
 

--- a/test/e2e/quadlet/template@instance.container
+++ b/test/e2e/quadlet/template@instance.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/changed-image
-## assert-podman-args "--name=systemd-%p_%i"
+## assert-podman-args "--name" "systemd-%p_%i"
 ## assert-symlink want.service.wants/template@instance.service ../template@instance.service
 ## assert-podman-args --env "FOO=bar"
 

--- a/test/e2e/quadlet/timezone.container
+++ b/test/e2e/quadlet/timezone.container
@@ -1,4 +1,4 @@
-## assert-podman-args --tz=foo
+## assert-podman-args "--tz" "foo"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/tls-verify.build
+++ b/test/e2e/quadlet/tls-verify.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --tls-verify=false
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--tls-verify=false"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/user.container
+++ b/test/e2e/quadlet/user.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--user=998:999"
+## assert-podman-args "--user" "998:999"
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/user1.container
+++ b/test/e2e/quadlet/user1.container
@@ -1,6 +1,0 @@
-## assert-podman-final-args localhost/imagename
-## assert-podman-args "--user=%U:%G"
-
-[Container]
-Image=localhost/imagename
-User=%U:%G

--- a/test/e2e/quadlet/user2.container
+++ b/test/e2e/quadlet/user2.container
@@ -1,7 +1,0 @@
-## assert-podman-final-args localhost/imagename
-## assert-podman-args "--user=%U:%G"
-
-[Container]
-Image=localhost/imagename
-User=%U
-Group=%G

--- a/test/e2e/quadlet/variant.build
+++ b/test/e2e/quadlet/variant.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
-## assert-podman-args --tag=localhost/imagename
-## assert-podman-args --variant=arm/v7
+## assert-podman-args "--tag" "localhost/imagename"
+## assert-podman-args "--variant" "arm/v7"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/e2e/quadlet/variant.image
+++ b/test/e2e/quadlet/variant.image
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args --variant=arm/v5
+## assert-podman-args "--variant" "arm/v5"
 
 [Image]
 Image=localhost/imagename

--- a/test/e2e/quadlet/workingdir.container
+++ b/test/e2e/quadlet/workingdir.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "-w=%h"
+## assert-podman-args "--workdir" "%h"
 
 [Container]
 Image=localhost/imagename


### PR DESCRIPTION
When possible use a generic function to add strings and booleans
Adjust tests

#### Does this PR introduce a user-facing change?
No

```release-note
None
```

Resolves: #24105
