### PR TITLE
libpod: fix a confusing error message from 'podman system reset' on F…

### DIFF
--- a/libpod/runtime_migrate_freebsd.go
+++ b/libpod/runtime_migrate_freebsd.go
@@ -1,4 +1,4 @@
-//go:build !remote && !linux && !freebsd
+//go:build !remote
 
 package libpod
 
@@ -7,7 +7,7 @@ import (
 )
 
 func (r *Runtime) stopPauseProcess() error {
-	return errors.New("not implemented (*Runtime) stopPauseProcess")
+	return nil
 }
 
 func (r *Runtime) Migrate(newRuntime string) error {


### PR DESCRIPTION
…reeBSD

This was discovered by a user while testing Podman on FreeBSD (oci-playground/freebsd-podman-testing/issues/17). The error message didn't stop 'podman system reset' from working and this commit simply suppressses the error on FreeBSD.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
