### PR TITLE
Exposed ports are only included when not --net=host

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -211,7 +211,11 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		return nil, err
 	}
 	data.NetworkSettings = networkConfig
-	addInspectPortsExpose(c.config.ExposedPorts, data.NetworkSettings.Ports)
+	// Ports in NetworkSettings includes exposed ports for network modes that are not host,
+	// and not container.
+	if !(c.config.NetNsCtr != "" || c.NetworkMode() == "host") {
+		addInspectPortsExpose(c.config.ExposedPorts, data.NetworkSettings.Ports)
+	}
 
 	inspectConfig := c.generateInspectContainerConfig(ctrSpec)
 	data.Config = inspectConfig


### PR DESCRIPTION
Undoing some of my own work here from #24090 now that we have the ExposedPorts field implemented in inspect. I considered a revert of that patch, but it's still needed as without it we'd be including exposed ports when --net=container which is not correct.

Basically, exposed ports for a container should always go in the new ExposedPorts field we added. They sometimes go in the Ports field in NetworkSettings, but only when the container is not net=host and not net=container. We were always including exposed ports, which was not correct, but is an easy logical fix.

Also required is a test change to correct the expected behavior as we were testing for incorrect behavior.

Fixes https://issues.redhat.com/browse/RHEL-60382

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
