### PR TITLE
Makefile - allow setting ginkgo run arguments on integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ GINKGO ?= ./test/tools/build/ginkgo
 # Allow control over some Ginkgo parameters
 GINKGO_FLAKE_ATTEMPTS ?= 0
 GINKGO_NO_COLOR ?= y
+GINKGO_EXTRA_FLAGS ?=
 
 # Conditional required to produce empty-output if binary not built yet.
 RELEASE_VERSION = $(shell if test -x test/version/version; then test/version/version; fi)
@@ -657,7 +658,8 @@ ginkgo-run: .install.ginkgo
 		--trace $(if $(findstring y,$(GINKGO_NO_COLOR)),--no-color,) \
 		$(if $(findstring y,$(GINKGO_PARALLEL)),-p,) \
 		$(if $(FOCUS),--focus "$(FOCUS) --silence-skips",) \
-		$(if $(FOCUS_FILE),--focus-file "$(FOCUS_FILE)" --silence-skips,) $(GINKGOWHAT)
+		$(if $(FOCUS_FILE),--focus-file "$(FOCUS_FILE)" --silence-skips,) \
+		$(GINKGO_EXTRA_FLAGS) $(GINKGOWHAT)
 
 .PHONY: ginkgo
 ginkgo:

--- a/test/README.md
+++ b/test/README.md
@@ -127,11 +127,16 @@ make localintegration FOCUS="podman inspect bogus pod"
 ```
 
 ### Controlling Ginkgo parameters
-You can control some of the parameters passed to Ginkgo
+You can control the parameters passed to Ginkgo.
+
+The flags already used can be set by their corresponding environment variable:
 
 - Disable parallel tests by setting `GINKGO_PARALLEL=n`
 - Set flake retry count (default 0) to one by setting `GINKGO_FLAKE_ATTEMPTS=1`
 - Produce colorful tests report by setting `GINKGO_NO_COLOR=n`
+
+For anything else, use `GINKGO_EXTRA_FLAGS`.
+For example for failing fast, set `GINKGO_EXTRA_FLAGS=--fail-fast`
 
 # System tests
 System tests are used for testing the *podman* CLI in the context of a complete system. It


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
No

```release-note
None
```
