### PR TITLE
libpod: hasCurrentUserMapped checks for gid too

### DIFF
--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -169,3 +169,15 @@ EOF
     run_podman run --rm --userns=auto:uidmapping=$mapping $IMAGE awk '{if($1 == 1){print $2}}' /proc/self/uid_map
     assert "$output" == 1
 }
+
+# bats test_tags=ci:parallel
+@test "podman current user not mapped in the userns" {
+    # both uid and gid not mapped
+    run_podman run --rm --uidmap 0:1:1000 $IMAGE true
+
+    # uid not mapped
+    run_podman run --rm --uidmap 0:1:1000 --gidmap 0:0:1000 $IMAGE true
+
+    # gid not mapped
+    run_podman run --rm --uidmap 0:0:1000 --gidmap 0:1:1000 $IMAGE true
+}


### PR DESCRIPTION
the kernel checks that both the uid and the gid are mapped inside the user namespace, not only the uid:

/**
 * privileged_wrt_inode_uidgid - Do capabilities in the namespace work over the inode?
 * @ns: The user namespace in question
 * @idmap: idmap of the mount @inode was found from
 * @inode: The inode in question *
 * Return true if the inode uid and gid are within the namespace. */ bool privileged_wrt_inode_uidgid(struct user_namespace *ns,
				 struct mnt_idmap *idmap,
				 const struct inode *inode)
{
	return vfsuid_has_mapping(ns, i_uid_into_vfsuid(idmap, inode)) &&
	       vfsgid_has_mapping(ns, i_gid_into_vfsgid(idmap, inode));
}

for this reason, improve the check for hasCurrentUserMapped to verify that the gid is also mapped, and if it is not, use an intermediate mount for the container rootfs.

Closes: https://github.com/containers/podman/issues/24159

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
