### PR TITLE
server: fix url parsing in info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ ginkgo-run: .install.ginkgo
 	$(GINKGO) -vv $(TESTFLAGS) --tags "$(TAGS) remote" $(GINKGOTIMEOUT) --flake-attempts $(GINKGO_FLAKE_ATTEMPTS) \
 		--trace $(if $(findstring y,$(GINKGO_NO_COLOR)),--no-color,) \
 		$(if $(findstring y,$(GINKGO_PARALLEL)),-p,) \
-		$(if $(FOCUS),--focus "$(FOCUS) --silence-skips",) \
+		$(if $(FOCUS),--focus "$(FOCUS)" --silence-skips,) \
 		$(if $(FOCUS_FILE),--focus-file "$(FOCUS_FILE)" --silence-skips,) $(GINKGOWHAT)
 
 .PHONY: ginkgo

--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -48,7 +48,7 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 		if listener == nil {
 			return errors.New("unexpected fd received from systemd: cannot listen on it")
 		}
-		libpodRuntime.SetRemoteURI(listeners[0].Addr().String())
+		libpodRuntime.SetRemoteURI(listeners[0].Addr().Network() + "://" + listeners[0].Addr().String())
 	} else {
 		uri, err := url.Parse(opts.URI)
 		if err != nil {

--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -82,6 +82,11 @@ var _ = Describe("Systemd activate", func() {
 			return testUtils.SystemExec(podmanTest.PodmanBinary, args)
 		}
 
+		// regression check for https://github.com/containers/podman/issues/24152
+		session := podmanRemote("info", "--format", "{{.Host.RemoteSocket.Path}}--{{.Host.RemoteSocket.Exists}}")
+		Expect(session).Should(testUtils.ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("tcp://" + addr + "--true"))
+
 		containerName := "top_" + testUtils.RandomString(8)
 		apiSession := podmanRemote(
 			"create", "--tty", "--name", containerName, "--entrypoint", "top",


### PR DESCRIPTION
When we are activated by systemd the code assumed that we had a valid URL
which was not the case so it failed to parse the URL which causes the
info call to fail all the time.
This fixes two problems first add the schema to the systemd activated
listener URL so it can be parsed correctly but second simply do not
parse it as url as all we care about in the info call is if it is unix
and the file path exists.

Fixes #24152

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a problem that caused the info API endpoint to fail when running the podman system service on systemd activated tcp socket. 
```
