### PR TITLE
Allow removing implicit quadlet systemd dependencies

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -236,6 +236,14 @@ QUADLET_UNIT_DIRS=<Directory> /usr/lib/systemd/system-generators/podman-system-g
 This will instruct Quadlet to look for units in this directory instead of the common ones and by
 that limit the output to only the units you are debugging.
 
+### Implicit network dependencies
+
+In the case of Container, Image and Build units, Quadlet will add dependencies on the `network-online.target`
+by adding `After=` and `Wants=` properties to the unit. This is to ensure that the network is reachable if
+an image needs to be pulled.
+
+This behavior can be disabled by adding `DefaultDependencies=false` in the `Quadlet` section.
+
 ## Container units [Container]
 
 Container units are named with a `.container` extension and contain a `[Container]` section describing
@@ -1913,6 +1921,22 @@ This is equivalent to the Podman `--tls-verify` option.
 Override the default architecture variant of the container image.
 
 This is equivalent to the Podman `--variant` option.
+
+## Quadlet section [Quadlet]
+Some quadlet specific configuration is shared between different unit types. Those settings
+can be configured in the `[Quadlet]` section.
+
+Valid options for `[Quadlet]` are listed below:
+
+| **[Quadlet] options**      | **Description**                                   |
+|----------------------------|---------------------------------------------------|
+| DefaultDependencies=false  | Disable implicit network dependencies to the unit |
+
+### `DefaultDependencies=`
+
+Add Quadlet's default network dependencies to the unit (default is `true`).
+
+When set to false, Quadlet will **not** add a dependency (After=, Wants=) to `network-online.target` to the generated unit.
 
 ## EXAMPLES
 

--- a/hack/xref-quadlet-docs
+++ b/hack/xref-quadlet-docs
@@ -171,7 +171,7 @@ sub crossref_doc {
         chomp $line;
 
         # New section, with its own '| table |' and '### Keyword blocks'
-        if ($line =~ /^##\s+(\S+)\s+units\s+\[(\S+)\]/) {
+        if ($line =~ /^##\s+(\S+)\s+(?:units|section)\s+\[(\S+)\]/) {
             my $new_unit = $1;
             $new_unit eq $2
                 or warn "$ME: $path:$.: inconsistent block names in '$line'\n";
@@ -227,7 +227,7 @@ sub crossref_doc {
             }
 
             grep { $_ eq $key } @found_in_table
-                or warn "$ME: $path:$.: key '$key' is not listed in table for unit '$unit'\n";
+                or warn "$ME: $path:$.: key '$key' is not listed in table for unit/section '$unit'\n";
 
             push @described, $key;
             $documented{$key}++;

--- a/test/e2e/quadlet/no_deps.build
+++ b/test/e2e/quadlet/no_deps.build
@@ -1,0 +1,11 @@
+## assert-key-is-empty "Unit" "Wants"
+## assert-key-is-empty "Unit" "After"
+## assert-key-is-empty "Unit" "Before"
+
+[Quadlet]
+DefaultDependencies=no
+
+[Build]
+ImageTag=localhost/imagename
+File=Containerfile
+SetWorkingDirectory=dir

--- a/test/e2e/quadlet/no_deps.container
+++ b/test/e2e/quadlet/no_deps.container
@@ -1,0 +1,9 @@
+## assert-key-is-empty "Unit" "Wants"
+## assert-key-is-empty "Unit" "After"
+## assert-key-is-empty "Unit" "Before"
+
+[Quadlet]
+DefaultDependencies=no
+
+[Container]
+Image=localhost/imagename

--- a/test/e2e/quadlet/no_deps.image
+++ b/test/e2e/quadlet/no_deps.image
@@ -1,0 +1,9 @@
+## assert-key-is-empty "Unit" "Wants"
+## assert-key-is-empty "Unit" "After"
+## assert-key-is-empty "Unit" "Before"
+
+[Quadlet]
+DefaultDependencies=no
+
+[Image]
+Image=localhost/imagename

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -170,6 +170,15 @@ func (t *quadletTestcase) assertKeyIs(args []string, unit *parser.UnitFile) bool
 	return true
 }
 
+func (t *quadletTestcase) assertKeyIsEmpty(args []string, unit *parser.UnitFile) bool {
+	Expect(args).To(HaveLen(2))
+	group := args[0]
+	key := args[1]
+
+	realValues := unit.LookupAll(group, key)
+	return len(realValues) == 0
+}
+
 func (t *quadletTestcase) assertKeyIsRegex(args []string, unit *parser.UnitFile) bool {
 	Expect(len(args)).To(BeNumerically(">=", 3))
 	group := args[0]
@@ -501,6 +510,8 @@ func (t *quadletTestcase) doAssert(check []string, unit *parser.UnitFile, sessio
 		ok = t.assertStdErrContains(args, session)
 	case "assert-key-is":
 		ok = t.assertKeyIs(args, unit)
+	case "assert-key-is-empty":
+		ok = t.assertKeyIsEmpty(args, unit)
 	case "assert-key-is-regex":
 		ok = t.assertKeyIsRegex(args, unit)
 	case "assert-key-contains":
@@ -899,6 +910,7 @@ BOGUS=foo
 		Entry("Unit After Override", "unit-after-override.container"),
 		Entry("NetworkAlias", "network-alias.container"),
 		Entry("CgroupMode", "cgroups-mode.container"),
+		Entry("Container - No Default Dependencies", "no_deps.container"),
 
 		Entry("basic.volume", "basic.volume"),
 		Entry("device-copy.volume", "device-copy.volume"),
@@ -967,6 +979,7 @@ BOGUS=foo
 		Entry("Image - global args", "globalargs.image"),
 		Entry("Image - Containers Conf Modules", "containersconfmodule.image"),
 		Entry("Image - Unit After Override", "unit-after-override.image"),
+		Entry("Image - No Default Dependencies", "no_deps.image"),
 
 		Entry("Build - Basic", "basic.build"),
 		Entry("Build - Annotation Key", "annotation.build"),
@@ -1000,6 +1013,7 @@ BOGUS=foo
 		Entry("Build - Target Key", "target.build"),
 		Entry("Build - TLSVerify Key", "tls-verify.build"),
 		Entry("Build - Variant Key", "variant.build"),
+		Entry("Build - No Default Dependencies", "no_deps.build"),
 
 		Entry("Pod - Basic", "basic.pod"),
 		Entry("Pod - DNS", "dns.pod"),


### PR DESCRIPTION
Allow removing implicit quadlet systemd dependencies
    
Quadlet inserts network-online.target Wants/After dependencies to ensure pulling works.
Those systemd statements cannot be subsequently reset.

In the cases where those dependencies are not wanted, we add a new
configuration item called `DefaultDependencies=` in a new section called
[Quadlet]. This section is shared between different unit types.
    
fixes #24193

```release-note
Adds a directive in a new [Quadlet] section to prevent quadlet from adding implicit dependencies on the network-online target.
```