### PR TITLE
test/e2e: try debug potential pasta issue

### DIFF
--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -664,13 +665,33 @@ var _ = Describe("Podman pull", func() {
 
 			podmanTest.AddImageToRWStore(ALPINE)
 
+			success := false
+			registryArgs := []string{"run", "-d", "--name", "registry", "-p", "5012:5000"}
 			if isRootless() {
 				err := podmanTest.RestoreArtifact(REGISTRY_IMAGE)
 				Expect(err).ToNot(HaveOccurred())
+
+				// Debug code for https://github.com/containers/podman/issues/24219
+				logFile := filepath.Join(podmanTest.TempDir, "pasta.log")
+				registryArgs = append(registryArgs, "--network", "pasta:--trace,--log-file,"+logFile)
+				defer func() {
+					if success {
+						// only print the log on errors otherwise it will clutter CI logs way to much
+						return
+					}
+
+					f, err := os.Open(logFile)
+					Expect(err).ToNot(HaveOccurred())
+					defer f.Close()
+					GinkgoWriter.Println("pasta trace log:")
+					_, err = io.Copy(GinkgoWriter, f)
+					Expect(err).ToNot(HaveOccurred())
+				}()
 			}
+			registryArgs = append(registryArgs, REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml")
 			lock := GetPortLock("5012")
 			defer lock.Unlock()
-			session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5012:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+			session := podmanTest.Podman(registryArgs)
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
 
@@ -683,6 +704,8 @@ var _ = Describe("Podman pull", func() {
 			session = decryptionTestHelper(imgPath)
 
 			Expect(session.LineInOutputContainsTag(imgPath, "latest")).To(BeTrue())
+
+			success = true
 		})
 	})
 


### PR DESCRIPTION
Run pasta with --trace and a log file to see if the hangs are caused by pasta not correctly closing connections as assumed in #24219.

As the log is super verbose do not log it by default so I added some extra logic to make sure it is only logged when the test fails.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
