### PR TITLE
Revert "CI: test nftables driver on fedora"

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -147,11 +147,6 @@ case "$OS_RELEASE_ID" in
             msg "Enabling container_manage_cgroup"
             showrun setsebool container_manage_cgroup true
         fi
-
-        # Test nftables driver, https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault
-        # We can drop this once this implemented and pushed into fedora stable. We cannot test it on
-        # debian because the netavark version there is way to old for nftables support.
-        printf "[network]\nfirewall_driver=\"nftables\"\n" > /etc/containers/containers.conf.d/90-nftables.conf
         ;;
     *) die_unknown OS_RELEASE_ID
 esac


### PR DESCRIPTION
This reverts commit 43f6173cc6050cd07348d8e0532a27ec0f24a774.

The netavark version with nftables default is in f41 and rawhide already so this is no longer needed. While we do not yet test f41 in CI we have rawhide which is good enough until we update.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
