### PR TITLE
scp: add option types

### DIFF
--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
+	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +74,11 @@ func scp(cmd *cobra.Command, args []string) (finalErr error) {
 	}
 
 	sshEngine := ssh.DefineMode(sshType)
-	err = registry.ImageEngine().Scp(registry.Context(), src, dst, parentFlags, quiet, sshEngine)
+	scpOpts := entities.ImageScpOptions{}
+	scpOpts.ParentFlags = parentFlags
+	scpOpts.Quiet = quiet
+	scpOpts.SSHMode = sshEngine
+	_, err = registry.ImageEngine().Scp(registry.Context(), src, dst, scpOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -713,18 +713,21 @@ func ImageScp(w http.ResponseWriter, r *http.Request) {
 
 	sourceArg := utils.GetName(r)
 
-	rep, source, dest, _, err := domainUtils.ExecuteTransfer(sourceArg, query.Destination, []string{}, query.Quiet, ssh.GolangMode)
+	opts := entities.ScpExecuteTransferOptions{}
+	opts.Quiet = query.Quiet
+	opts.SSHMode = ssh.GolangMode
+	report, err := domainUtils.ExecuteTransfer(sourceArg, query.Destination, opts)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	if source != nil || dest != nil {
+	if report.Source != nil || report.Dest != nil {
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("cannot use the user transfer function on the remote client: %w", define.ErrInvalidArg))
 		return
 	}
 
-	utils.WriteResponse(w, http.StatusOK, &reports.ScpReport{Id: rep.Names[0]})
+	utils.WriteResponse(w, http.StatusOK, &reports.ScpReport{Id: report.LoadReport.Names[0]})
 }
 
 // Resolve the passed (short) name to one more candidates it may resolve to.

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/common/libimage/define"
 	"github.com/containers/common/pkg/config"
-	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/podman/v5/pkg/domain/entities/reports"
 )
 
@@ -24,7 +23,7 @@ type ImageEngine interface { //nolint:interfacebloat
 	Push(ctx context.Context, source string, destination string, opts ImagePushOptions) (*ImagePushReport, error)
 	Remove(ctx context.Context, images []string, opts ImageRemoveOptions) (*ImageRemoveReport, []error)
 	Save(ctx context.Context, nameOrID string, tags []string, options ImageSaveOptions) error
-	Scp(ctx context.Context, src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode) error
+	Scp(ctx context.Context, src, dst string, opts ImageScpOptions) (*ImageScpReport, error)
 	Search(ctx context.Context, term string, opts ImageSearchOptions) ([]ImageSearchReport, error)
 	SetTrust(ctx context.Context, args []string, options SetTrustOptions) error
 	ShowTrust(ctx context.Context, args []string, options ShowTrustOptions) (*ShowTrustReport, error)

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -305,21 +305,13 @@ type ImageSaveOptions struct {
 	SignaturePolicy string
 }
 
-// ImageScpOptions provide options for securely copying images to and from a remote host
+// ImageScpOptions provides options for ImageEngine.Scp()
 type ImageScpOptions struct {
-	// Remote determines if this entity is operating on a remote machine
-	Remote bool `json:"remote,omitempty"`
-	// File is the input/output file for the save and load Operation
-	File string `json:"file,omitempty"`
-	// Quiet Determines if the save and load operation will be done quietly
-	Quiet bool `json:"quiet,omitempty"`
-	// Image is the image the user is providing to save and load
-	Image string `json:"image,omitempty"`
-	// User is used in conjunction with Transfer to determine if a valid user was given to save from/load into
-	User string `json:"user,omitempty"`
-	// Tag is the name to be used for the image on the destination
-	Tag string `json:"tag,omitempty"`
+	ScpExecuteTransferOptions
 }
+
+// ImageScpReport provides results from ImageEngine.Scp()
+type ImageScpReport struct{}
 
 // ImageScpConnections provides the ssh related information used in remote image transfer
 type ImageScpConnections struct {

--- a/pkg/domain/entities/scp.go
+++ b/pkg/domain/entities/scp.go
@@ -1,0 +1,97 @@
+package entities
+
+import (
+	"net/url"
+
+	"github.com/containers/common/pkg/ssh"
+)
+
+// ScpTransferImageOptions provide options for securely copying images to and from a remote host
+type ScpTransferImageOptions struct {
+	// Remote determines if this entity is operating on a remote machine
+	Remote bool `json:"remote,omitempty"`
+	// File is the input/output file for the save and load Operation
+	File string `json:"file,omitempty"`
+	// Quiet Determines if the save and load operation will be done quietly
+	Quiet bool `json:"quiet,omitempty"`
+	// Image is the image the user is providing to save and load
+	Image string `json:"image,omitempty"`
+	// User is used in conjunction with Transfer to determine if a valid user was given to save from/load into
+	User string `json:"user,omitempty"`
+	// Tag is the name to be used for the image on the destination
+	Tag string `json:"tag,omitempty"`
+}
+
+type ScpLoadReport = ImageLoadReport
+
+type ScpExecuteTransferOptions struct {
+	// ParentFlags are the arguments to apply to the parent podman command when called via ssh
+	ParentFlags []string
+	// Quiet Determines if the save and load operation will be done quietly
+	Quiet bool
+	// SSHMode is the specified ssh.EngineMode which should be used
+	SSHMode ssh.EngineMode
+}
+
+type ScpExecuteTransferReport struct {
+	// LoadReport provides results from calling podman load
+	LoadReport *ScpLoadReport
+	// Source contains data relating to the source of the image to transfer
+	Source *ScpTransferImageOptions
+	// Dest contains data relating to the destination of the image to transfer
+	Dest *ScpTransferImageOptions
+	// ParentFlags are the arguments to apply to the parent podman command when called via ssh
+	ParentFlags []string
+}
+
+type ScpTransferOptions struct {
+	// ParentFlags are the arguments to apply to the parent podman command when called.
+	ParentFlags []string
+}
+
+type ScpTransferReport struct{}
+
+type ScpLoadToRemoteOptions struct {
+	// Dest contains data relating to the destination of the image to transfer
+	Dest ScpTransferImageOptions
+	// LocalFile is a path to a local file containing saved image data to transfer
+	LocalFile string
+	// Tag is the name of the tag to be given to the loaded image (unused)
+	Tag string
+	// URL points to the remote location for loading to
+	URL *url.URL
+	// Iden is a path to an optional identity file with ssh key
+	Iden string
+	// SSHMode is the specified ssh.EngineMode which should be used
+	SSHMode ssh.EngineMode
+}
+
+type ScpLoadToRemoteReport struct {
+	// Response contains any additional information from the executed load command
+	Response string
+	// ID is the identifier of the loaded image
+	ID string
+}
+
+type ScpSaveToRemoteOptions struct {
+	Image string
+	// LocalFile is a path to a local file to copy the saved image to
+	LocalFile string
+	// Tag is the name of the tag to be given to the saved image (unused)
+	Tag string
+	// URL points to the remote location for saving from
+	URL *url.URL
+	// Iden is a path to an optional identity file with ssh key
+	Iden string
+	// SSHMode is the specified ssh.EngineMode which should be used
+	SSHMode ssh.EngineMode
+}
+
+type ScpSaveToRemoteReport struct{}
+
+type ScpCreateCommandsOptions struct {
+	// ParentFlags are the arguments to apply to the parent podman command when called via ssh
+	ParentFlags []string
+	// Podman is the path to the local podman executable
+	Podman string
+}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -12,7 +12,6 @@ import (
 	bdefine "github.com/containers/buildah/define"
 	"github.com/containers/common/libimage/filter"
 	"github.com/containers/common/pkg/config"
-	"github.com/containers/common/pkg/ssh"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/libpod/define"
@@ -415,22 +414,22 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 	return nil, errors.New("not implemented yet")
 }
 
-func (ir *ImageEngine) Scp(ctx context.Context, src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode) error {
+func (ir *ImageEngine) Scp(ctx context.Context, src, dst string, opts entities.ImageScpOptions) (*entities.ImageScpReport, error) {
 	options := new(images.ScpOptions)
 
 	var destination *string
 	if len(dst) > 1 {
 		destination = &dst
 	}
-	options.Quiet = &quiet
+	options.Quiet = &opts.Quiet
 	options.Destination = destination
 
 	rep, err := images.Scp(ir.ClientCtx, &src, destination, *options)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fmt.Println("Loaded Image(s):", rep.Id)
 
-	return nil
+	return &entities.ImageScpReport{}, nil
 }

--- a/pkg/domain/utils/scp_test.go
+++ b/pkg/domain/utils/scp_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestValidateSCPArgs(t *testing.T) {
 	type args struct {
-		locations []*entities.ImageScpOptions
+		locations []*entities.ScpTransferImageOptions
 	}
 	tests := []struct {
 		name    string
@@ -20,7 +20,7 @@ func TestValidateSCPArgs(t *testing.T) {
 		{
 			name: "test args length more than 2",
 			args: args{
-				locations: []*entities.ImageScpOptions{
+				locations: []*entities.ScpTransferImageOptions{
 					{
 						Image: "source image one",
 					},
@@ -40,7 +40,7 @@ func TestValidateSCPArgs(t *testing.T) {
 		{
 			name: "test source image is empty",
 			args: args{
-				locations: []*entities.ImageScpOptions{
+				locations: []*entities.ScpTransferImageOptions{
 					{
 						Image: "",
 					},
@@ -54,7 +54,7 @@ func TestValidateSCPArgs(t *testing.T) {
 		{
 			name: "test target image is empty",
 			args: args{
-				locations: []*entities.ImageScpOptions{
+				locations: []*entities.ScpTransferImageOptions{
 					{
 						Image: "source image",
 					},

--- a/pkg/domain/utils/utils_test.go
+++ b/pkg/domain/utils/utils_test.go
@@ -78,8 +78,8 @@ func TestToURLValues(t *testing.T) {
 
 func TestParseSCPArgs(t *testing.T) {
 	args := []string{"alpine", "root@localhost::"}
-	var source *entities.ImageScpOptions
-	var dest *entities.ImageScpOptions
+	var source *entities.ScpTransferImageOptions
+	var dest *entities.ScpTransferImageOptions
 	var err error
 	source, _, err = ParseImageSCPArg(args[0])
 	assert.Nil(t, err)


### PR DESCRIPTION
Prior to this commit, many scp functions existed without option structs, which would make extending functionality (adding new options) impossible without breaking changes, or without adding redundant wrapper functions.

This commit adds in new option types for various scp related functions, and changes those functions' signatures to use the new options.

This commit also modifies the `ImageEngine.Scp()` function's interface to use the new opts.

The commit also renames the existing `ImageScpOptions` entity type to `ScpTransferImageOptions`. This is because the previous `ImageScpOptions` was inaccurate, as it is not the actual options for `ImageEngine.Scp()`. `ImageEngine.Scp()` should instead receive `ImageScpOptions`.

This commit should not change any behavior, however it will break the existing functions' signatures.

--

Created this PR to replace #24234 to go ahead and make the breaking changes.

Worth noting: I selected the functions to change pretty arbitrarily. Just based on if I think they have a realistic chance of needing to change in order to add new features. I based it on my experience working on #24211 so it is at least grounded in some way. But I am open to feedback if more or fewer functions should be changed.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
