### PR TITLE
[skip-ci] Packit: re-enable CentOS Stream 10/Fedora ELN tasks

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,31 +43,29 @@ jobs:
       - fedora-40-x86_64
       - fedora-40-aarch64
 
-  # Disabled until there is go 1.22.6 in centos stream
-  # - job: copr_build
-  #   trigger: pull_request
-  #   packages: [podman-eln]
-  #   notifications: *packit_build_failure_notification
-  #   enable_net: true
-  #   targets:
-  #     fedora-eln-x86_64:
-  #       additional_repos:
-  #         - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
-  #     fedora-eln-aarch64:
-  #       additional_repos:
-  #         - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
+  - job: copr_build
+    trigger: pull_request
+    packages: [podman-eln]
+    notifications: *packit_build_failure_notification
+    enable_net: true
+    targets:
+      fedora-eln-x86_64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
+      fedora-eln-aarch64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
 
-  # Disabled until there is go 1.22.6 in centos stream
-  # - job: copr_build
-  #   trigger: pull_request
-  #   packages: [podman-centos]
-  #   notifications: *packit_build_failure_notification
-  #   enable_net: true
-  #   targets:
-  #     - centos-stream-9-x86_64
-  #     - centos-stream-9-aarch64
-  #     - centos-stream-10-x86_64
-  #     - centos-stream-10-aarch64
+  - job: copr_build
+    trigger: pull_request
+    packages: [podman-centos]
+    notifications: *packit_build_failure_notification
+    enable_net: true
+    targets:
+    #  - centos-stream-9-x86_64
+    #  - centos-stream-9-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
 
   # Disabled until there is go 1.22 in epel-9
   # - job: copr_build
@@ -119,13 +117,12 @@ jobs:
     dist_git_branches: &fedora_targets
       - fedora-all
 
-  # Disabled until there is go 1.22.6 in centos stream
-  # - job: propose_downstream
-  #   trigger: release
-  #   update_release: false
-  #   packages: [podman-centos]
-  #   dist_git_branches:
-  #     - c10s
+  - job: propose_downstream
+    trigger: release
+    update_release: false
+    packages: [podman-centos]
+    dist_git_branches:
+      - c10s
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
We now have golang 1.23.1 in centos stream 10.

This reverts commit f47abd8e1e9f46e43acf1cd10e3ee7521bf32b31.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
