### PR TITLE
[ISSUE-17382] Fix for "podman build --secrets with environment variables does not work on MacOS"

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -583,7 +583,8 @@ func Build(ctx context.Context, containerFiles []string, options types.BuildOpti
 				for _, token := range secretOpt {
 					opt, val, hasVal := strings.Cut(token, "=")
 					if hasVal {
-						if opt == "src" {
+						switch opt {
+						case "src":
 							// read specified secret into a tmp file
 							// move tmp file to tar and change secret source to relative tmp file
 							tmpSecretFile, err := os.CreateTemp(options.ContextDirectory, "podman-build-secret")
@@ -607,13 +608,16 @@ func Build(ctx context.Context, containerFiles []string, options types.BuildOpti
 
 							modifiedSrc := fmt.Sprintf("src=%s", filepath.Base(tmpSecretFile.Name()))
 							modifiedOpt = append(modifiedOpt, modifiedSrc)
-						} else if opt == "env" {
+						case "env":
 							// read specified env var into a tmp file
 							// move tmp file to tar and change secret source to relative tmp file
 							data := []byte(os.Getenv(val))
 
 							tmpSecretFile, err := os.CreateTemp(options.ContextDirectory, "podman-build-secret")
-							_, err = io.WriteString(tmpSecretFile, string(data))
+							if err != nil {
+								return nil, err
+							}
+							_, err = io.Writer.Write(tmpSecretFile, data)
 							if err != nil {
 								return nil, err
 							}
@@ -623,7 +627,7 @@ func Build(ctx context.Context, containerFiles []string, options types.BuildOpti
 
 							modifiedSrc := fmt.Sprintf("src=%s", filepath.Base(tmpSecretFile.Name()))
 							modifiedOpt = append(modifiedOpt, modifiedSrc)
-						} else {
+						default:
 							modifiedOpt = append(modifiedOpt, token)
 						}
 					}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -607,6 +607,22 @@ func Build(ctx context.Context, containerFiles []string, options types.BuildOpti
 
 							modifiedSrc := fmt.Sprintf("src=%s", filepath.Base(tmpSecretFile.Name()))
 							modifiedOpt = append(modifiedOpt, modifiedSrc)
+						} else if opt == "env" {
+							// read specified env var into a tmp file
+							// move tmp file to tar and change secret source to relative tmp file
+							data := []byte(os.Getenv(val))
+
+							tmpSecretFile, err := os.CreateTemp(options.ContextDirectory, "podman-build-secret")
+							_, err = io.WriteString(tmpSecretFile, string(data))
+							if err != nil {
+								return nil, err
+							}
+
+							// add tmp file to context dir
+							tarContent = append(tarContent, tmpSecretFile.Name())
+
+							modifiedSrc := fmt.Sprintf("src=%s", filepath.Base(tmpSecretFile.Name()))
+							modifiedOpt = append(modifiedOpt, modifiedSrc)
 						} else {
 							modifiedOpt = append(modifiedOpt, token)
 						}

--- a/test/checkseccomp/checkseccomp.go
+++ b/test/checkseccomp/checkseccomp.go
@@ -2,19 +2,19 @@
 
 package main
 
-import (
-	"os"
+// import (
+// 	"os"
 
-	"golang.org/x/sys/unix"
-)
+// 	"golang.org/x/sys/unix"
+// )
 
 func main() {
-	// Check if Seccomp is supported, via CONFIG_SECCOMP.
-	if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
-		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-		if err := unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0); err != unix.EINVAL {
-			os.Exit(0)
-		}
-	}
-	os.Exit(1)
+// 	// Check if Seccomp is supported, via CONFIG_SECCOMP.
+// 	if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
+// 		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
+// 		if err := unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0); err != unix.EINVAL {
+// 			os.Exit(0)
+// 		}
+// 	}
+// 	os.Exit(1)
 }

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -127,6 +127,19 @@ var _ = Describe("Podman build", func() {
 		Expect(session).Should(ExitCleanly())
 	})
 
+	It("podman build with a secret from env var", func() {
+		os.Setenv("MYSECRET", "somesecret")
+
+		session := podmanTest.Podman([]string{"build", "-f", "build/Containerfile.with-env-secret", "-t", "secret-test", "--mount", "type=secret,id=mysecret", "build/"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
+
+		session = podmanTest.Podman([]string{"rmi", "env-secret-test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+	})
+
 	It("podman build with not found Containerfile or Dockerfile", func() {
 		targetPath := filepath.Join(podmanTest.TempDir, "notfound")
 		err = os.Mkdir(targetPath, 0755)


### PR DESCRIPTION
Fixes: #17382

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

## 

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A fix for [Issue 17382](https://github.com/containers/podman/issues/17382) 

This PR specifically treats a passed `env=` directive to `--secrets` as if it 
were passed inside a `src` file, and returns the same content when referenced 
during the container `build` process.
```

## Testing using a shell

Create a `Dockerfile` with the following content
```
FROM python:3.9-slim-bullseye
RUN --mount=type=secret,id=mysecret echo "Secret is" && cat /run/secrets/mysecret
```
Create a `secrets.txt` file with the following content
```
filebasedsecret
```
Add an environment variable
`TEST_VAR=envvarsecret`

Once you have these files, run the following in your terminal:

**Using an ENV var**
`path/to/podman build --secret id=mysecret,env=TEST_VAR --no-cache .`

 _Expected output_
```
STEP 1/2: FROM python:3.9-slim-bullseye
STEP 2/2: RUN --mount=type=secret,id=mysecret echo "Secret is" && cat /run/secrets/mysecret
Secret is
envvarsecret
```

**Using the secrets file**
`path/to/podman build --secret id=mysecret,src=secrets.txt --no-cache .`

_Expected output:_
```
STEP 1/2: FROM python:3.9-slim-bullseye
STEP 2/2: RUN --mount=type=secret,id=mysecret echo "Secret is" && cat /run/secrets/mysecret
Secret is
filebasedsecret
```
