### PR TITLE
libpod API: only return exit code without conditions

### DIFF
--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -137,9 +137,11 @@ func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
 			// However we keep the exit code around for longer than the container so
 			// we can just look it up here. Of course this only works when we get a
 			// full id as param but podman-remote will do that
-			if code, err := runtime.GetContainerExitCode(name); err == nil {
-				WriteResponse(w, http.StatusOK, strconv.Itoa(int(code)))
-				return
+			if len(opts.Conditions) == 0 {
+				if code, err := runtime.GetContainerExitCode(name); err == nil {
+					WriteResponse(w, http.StatusOK, strconv.Itoa(int(code)))
+					return
+				}
 			}
 			ContainerNotFound(w, name, err)
 			return

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -15,6 +15,12 @@ t POST "containers/nonExistent/wait?condition=next-exit" 404
 # Make sure to test a non-zero exit code (see #18889)
 podman create --name "${CTR}" "${IMAGE}" sh -c "exit 3"
 
+t GET libpod/containers/${CTR}/json 200 \
+  .Id~[0-9a-f]\\{64\\}
+
+# We need the cid for the wait test at the end
+cid=$(jq -r '.Id' <<<"$output")
+
 t POST "containers/${CTR}/wait?condition=non-existent-cond" 400
 
 t POST "containers/${CTR}/wait?condition=not-running" 200
@@ -49,3 +55,12 @@ t POST "containers/${CTR}/wait?condition=removed" 200 \
 # work correctly.
 t POST "containers/${CTR}/wait?condition=next-exit" 404
 wait "${child_pid}"
+
+t POST "libpod/containers/${CTR}/wait?condition=running" 404
+t POST "libpod/containers/${cid}/wait?condition=running" 404
+# The container no longer exists but we want to ensure the remote client
+# can still fetch the exit code correctly until the exit code is pruned
+# (after 5 mins) but only by the container id and not the name.
+t POST "libpod/containers/${CTR}/wait" 404
+t POST "libpod/containers/${cid}/wait" 200 \
+ "3"


### PR DESCRIPTION
The special handling to return the exit code after the container has been removed should only be done if there are no special conditions requested. If a user asked for running or nay other state returning the exit code immediately with a success response is just wrong. We only want to allow that so the remote client can fetch the exit code without races.

Fixes b3829a2932 ("libpod API: make wait endpoint better against rm races")

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
