### PR TITLE
api: Move close function in condition body

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -410,7 +410,10 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		tmpfile.Close()
+		if err := tmpfile.Close(); err != nil {
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to close tempfile: %w", err))
+			return
+		}
 		source = tmpfile.Name()
 	}
 

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -403,10 +403,10 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer os.Remove(tmpfile.Name())
-		defer tmpfile.Close()
 
 		if _, err := io.Copy(tmpfile, r.Body); err != nil && err != io.EOF {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to write archive to temporary file: %w", err))
+			tmpfile.Close()
 			return
 		}
 


### PR DESCRIPTION
The close is moved in the body of the error condition.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

#### Does this PR introduce a user-facing change?

```release-note
   None
```
