### PR TITLE
use slices.Clone instead of assignment

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -13,6 +13,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -803,7 +804,8 @@ func Transfer(ctx context.Context, source entities.ImageScpOptions, dest entitie
 // TransferRootless creates new podman processes using exec.Command and sudo, transferring images between the given source and destination users
 func transferRootless(source entities.ImageScpOptions, dest entities.ImageScpOptions, podman string, parentFlags []string) error {
 	var cmdSave *exec.Cmd
-	saveCommand, loadCommand := parentFlags, parentFlags
+	saveCommand := slices.Clone(parentFlags)
+	loadCommand := slices.Clone(parentFlags)
 	saveCommand = append(saveCommand, []string{"save"}...)
 	loadCommand = append(loadCommand, []string{"load"}...)
 	if source.Quiet {


### PR DESCRIPTION
Fixes #24267

This commit replaces a potentially unsafe slice-assignment with a call to `slices.Clone`.

This could prevent a bug where `saveCommand` and `loadCommand` could end up sharing an underlying array if `parentFlags` has a cap > it's len.

I did not write/change any tests for this PR, because it seems like a small enough change to be OK and because a test for this would be seem strange on the surface (passing in `parentFlags` with a cap > it's len to see if it causes issues). But if a test is needed I could amend one in at request.

Also, there could be other places in the code that could use this change, but I did not check. Some kind of linter for this would be ideal. gocritic did not seem to catch this when I checked.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
