### PR TITLE
Update system tests to handle zstd:chunked images

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -383,9 +383,13 @@ EOF
     assert "${lines[-2]}" =~ ".*$IMAGE false" "image from readwrite store"
     assert "${lines[-1]}" =~ ".*$IMAGE true" "image from readonly store"
     id=${lines[-2]%% *}
+    local config_digest; config_digest=$(image_config_digest "@$id") # Without $sconf, i.e. from the read-write store.
 
     CONTAINERS_STORAGE_CONF=$sconf run_podman pull -q $IMAGE
-    is "$output" "$id" "pull -q $IMAGE, using storage.conf"
+    # This is originally a regression test, (podman pull) used to output multiple image IDs. Ensure it only prints one.
+    assert "${#lines[*]}" -le 1 "Number of output lines from podman pull"
+    local config_digest2; config_digest2=$(image_config_digest "@$output")
+    assert "$config_digest2" = "$config_digest" "pull -q $IMAGE, using storage.conf"
 
     run_podman --root $imstore/root rmi --all
 }

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -391,6 +391,12 @@ EOF
     local config_digest2; config_digest2=$(image_config_digest "@$output")
     assert "$config_digest2" = "$config_digest" "pull -q $IMAGE, using storage.conf"
 
+    # $IMAGE might now be reusing layers from the additional store;
+    # Removing the additional store underneath can result in dangling layer references.
+    # Try to fix that up.
+    CONTAINERS_STORAGE_CONF=$sconf run_podman rmi $IMAGE
+    _prefetch $IMAGE
+
     run_podman --root $imstore/root rmi --all
 }
 

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -380,11 +380,11 @@ EOF
     # present in store, and if it is it will precede $IMAGE.
     CONTAINERS_STORAGE_CONF=$sconf run_podman images -a -n --format "{{.Repository}}:{{.Tag}} {{.ReadOnly}}"
     assert "${#lines[*]}" -ge 2 "at least 2 lines from 'podman images'"
-    is "${lines[-2]}" "$IMAGE false" "image from readonly store"
-    is "${lines[-1]}" "$IMAGE true" "image from readwrite store"
+    is "${lines[-2]}" "$IMAGE false" "image from readwrite store"
+    is "${lines[-1]}" "$IMAGE true" "image from readonly store"
 
     CONTAINERS_STORAGE_CONF=$sconf run_podman images -a -n --format "{{.Id}}"
-    id=${lines[-1]}
+    id=${lines[-2]}
 
     CONTAINERS_STORAGE_CONF=$sconf run_podman pull -q $IMAGE
     is "$output" "$id" "pull -q $IMAGE, using storage.conf"

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -378,13 +378,11 @@ EOF
 
     # IMPORTANT! Use -2/-1 indices, not 0/1, because $SYSTEMD_IMAGE may be
     # present in store, and if it is it will precede $IMAGE.
-    CONTAINERS_STORAGE_CONF=$sconf run_podman images -a -n --format "{{.Repository}}:{{.Tag}} {{.ReadOnly}}"
+    CONTAINERS_STORAGE_CONF=$sconf run_podman images -a -n --format "{{.ID}} {{.Repository}}:{{.Tag}} {{.ReadOnly}}"
     assert "${#lines[*]}" -ge 2 "at least 2 lines from 'podman images'"
-    is "${lines[-2]}" "$IMAGE false" "image from readwrite store"
-    is "${lines[-1]}" "$IMAGE true" "image from readonly store"
-
-    CONTAINERS_STORAGE_CONF=$sconf run_podman images -a -n --format "{{.Id}}"
-    id=${lines[-2]}
+    assert "${lines[-2]}" =~ ".*$IMAGE false" "image from readwrite store"
+    assert "${lines[-1]}" =~ ".*$IMAGE true" "image from readonly store"
+    id=${lines[-2]%% *}
 
     CONTAINERS_STORAGE_CONF=$sconf run_podman pull -q $IMAGE
     is "$output" "$id" "pull -q $IMAGE, using storage.conf"

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -149,9 +149,8 @@ EOF
 }
 
 function _push_search_test() {
-    # Preserve image ID for later comparison against push/pulled image
-    run_podman inspect --format '{{.Id}}' $IMAGE
-    iid=$output
+    # Look up image config digest for later comparison against push/pulled image
+    local img_config_digest; img_config_digest=$(image_config_digest $IMAGE)
 
     destname=ok-$(random_string 10 | tr A-Z a-z)-ok
     # Use command-line credentials
@@ -188,8 +187,8 @@ function _push_search_test() {
                localhost:${PODMAN_LOGIN_REGISTRY_PORT}/$destname
 
     # Compare to original image
-    run_podman inspect --format '{{.Id}}' $destname
-    is "$output" "$iid" "Image ID of pulled image == original IID"
+    local img_config_digest2; img_config_digest2=$(image_config_digest localhost:${PODMAN_LOGIN_REGISTRY_PORT}/$destname)
+    assert "$img_config_digest2" = "$img_config_digest" "config digest of pulled image == original digest"
 
     run_podman rmi $destname
 }
@@ -345,12 +344,12 @@ function _test_skopeo_credential_sharing() {
         $image1
     run_podman rmi $image1
 
-    run_podman images $IMAGE --format {{.ID}}
-    local podman_image_id=$output
+    local podman_image_config_digest=$(image_config_digest $IMAGE)
 
     run_podman pull -q --retry 4 --retry-delay "0s" --authfile=$authfile \
         --tls-verify=false $image1
-    assert "${output:0:12}" = "$podman_image_id" "First pull (before stopping registry)"
+    local pulled_image_config_digest; pulled_image_config_digest=$(image_config_digest @$output)
+    assert "$pulled_image_config_digest" = "$podman_image_config_digest" "First pull (before stopping registry)"
     run_podman rmi $image1
 
     # This actually STOPs the registry, so the port is unbound...
@@ -360,7 +359,8 @@ function _test_skopeo_credential_sharing() {
     run_podman 0+w pull -q --retry 4 --retry-delay "5s" --authfile=$authfile \
             --tls-verify=false $image1
     assert "$output" =~ "Failed, retrying in 5s.*Error: initializing.* connection refused"
-    assert "${lines[-1]:0:12}" = "$podman_image_id" "push should succeed via retry"
+    local pulled_image_config_digest2; pulled_image_config_digest2=$(image_config_digest "@${lines[-1]}")
+    assert "$pulled_image_config_digest2" = "$podman_image_config_digest" "push should succeed via retry"
     unpause_registry
 
     run_podman rmi $image1

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -847,6 +847,17 @@ function _ensure_container_running() {
     die "Timed out waiting for container $1 to enter state running=$2"
 }
 
+# Return the config digest of an image in containers-storage.
+# The input can be a named reference, or an @imageID (including shorter imageID prefixes)
+# Historically, the image ID was a good indicator of “the same” image;
+# with zstd:chunked, the same image might have different IDs depending on whether
+# creating layers happened based on the TOC (and per-file operations) or the full layer tarball
+function image_config_digest() {
+    local sha_output; sha_output=$(skopeo inspect --raw --config "containers-storage:$1" | sha256sum)
+    # strip filename ("-") from sha output
+    echo "${sha_output%% *}"
+}
+
 ###########################
 #  _add_label_if_missing  #  make sure skip messages include rootless/remote
 ###########################


### PR DESCRIPTION
- Compare image configs, not IDs, when checking image identity from different way of pulling them
- Try to make the additional image store test a bit more robust
- Remove an image identity assumption from the “load by URL” test.

Working on test failures as discussed in https://github.com/containers/storage/pull/2130 .

<s>At this point absolutely untested, and</s> I don’t really know what I’m doing.

Cc: @edsantiago — perhaps read this only later after this is at least minimally shown to be working.

#### Does this PR introduce a user-facing change?

```release-note
None
```
