### PR TITLE
Added escaping to invoked powershell command for hyperv stubber.

### DIFF
--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -451,7 +451,7 @@ func (h HyperVStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) erro
 }
 
 func resizeDisk(newSize strongunits.GiB, imagePath *define.VMFile) error {
-	resize := exec.Command("powershell", []string{"-command", fmt.Sprintf("Resize-VHD %s %d", imagePath.GetPath(), newSize.ToBytes())}...)
+	resize := exec.Command("powershell", []string{"-command", fmt.Sprintf("Resize-VHD \"%s\" %d", imagePath.GetPath(), newSize.ToBytes())}...)
 	logrus.Debug(resize.Args)
 	resize.Stdout = os.Stdout
 	resize.Stderr = os.Stderr


### PR DESCRIPTION
# Overview
This PR concerns a small edge case when using podman on windows under Hyper V with a poorly named user profile.
When the user does not have control over the profile name, they will be unable to init a new podman machine.

For some user profile name `SomeUser(SomeIdentifier)`, and the target machine path.
```
C:\Users\SomeUser(SomeIdentifier)\.local\share\containers\podman\machine\hyperv\podman-machine-default-amd64.vhdx
```

Podman creates this machine, however, execution will fail when invoking a `powershell` command to resize the disk. `powershell` interprets the contents contained in brackets (in this case `(SomeIdentifier)`) as a grouping expression, attempts to execute it:
```
time="2024-10-16T11:51:17+11:00" level=debug msg="[powershell -command Resize-VHD C:\\Users\\SomeUser(SomeIdentifier)\\.local\\share\\containers\\podman\\machine\\hyperv\\some-machine-amd64.vhdx 107374182400]"
SomeIdentifier : The term 'SomeIdentifier' is not recognized as the name of a cmdlet, function, script file, or operable program. Check
the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:32
+ Resize-VHD C:\Users\SomeUser(SomeIdentifier)\.local\share\containers\podman\ ...
+                                ~~~~~
    + CategoryInfo          : ObjectNotFound: (SomeIdentifier:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException

Error: resizing image: "exit status 1"
```

# A Deeper Dive

The error occurs when exeuting [this function](https://github.com/containers/podman/blob/a2eb5429b38b3629151996a097161ae144389d77/pkg/machine/hyperv/stubber.go#L453)

The resulting `powershell` command will be:
```
Resize-VHD <machine path> <disk size>
```

expanding this out yields:
```
Resize-VHD C:\Users\SomeUser(SomeIdentifier)\.local\share\containers\podman\machine\hyperv\podman-machine-default-amd64.vhdx 107374182400
                              ~~~~~~~~~~~~~ 
                              |> Powershell interprets this as a grouping expression.
```

At which point, the `powershell` command will fail, propagating up through the program.

# Solution

By surrounding the disk path in quotes, `powershell` will no longer attempt to expand the group:
```
Resize-VHD "C:\Users\SomeUser(SomeIdentifier)\.local\share\containers\podman\machine\hyperv\podman-machine-default-amd64.vhdx" 107374182400
```

The solution in the attached commit makes no user facing changes, and will not affect users not experiencing this edge case.

## Caveat

Note that users will still have to mount a different directory to the default `[C:\Users\<USER>:/Users/<USER>]` as this will cause issues with the bash scripts inside of the virtual machine.  
Although it would be possible to rewrite the machine scripts to accomodate this case, it would be excessive given how rare this should be, and users can work around this mounting problem by mounting the volume to a directory not in the user profile folder.

```release-note
None
```
