### PR TITLE
quadlet: do not reject RemapUsers=keep-id as root

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -782,7 +782,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool, unitsInfoMap map[
 		return nil, err
 	}
 
-	if err := handleUserMappings(container, ContainerGroup, podman, isUser, true); err != nil {
+	if err := handleUserMappings(container, ContainerGroup, podman, true); err != nil {
 		return nil, err
 	}
 
@@ -1224,7 +1224,7 @@ func ConvertKube(kube *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, isUse
 	handleLogDriver(kube, KubeGroup, execStart)
 	handleLogOpt(kube, KubeGroup, execStart)
 
-	if err := handleUserMappings(kube, KubeGroup, execStart, isUser, false); err != nil {
+	if err := handleUserMappings(kube, KubeGroup, execStart, false); err != nil {
 		return nil, err
 	}
 
@@ -1613,7 +1613,7 @@ func ConvertPod(podUnit *parser.UnitFile, name string, unitsInfoMap map[string]*
 		"--replace",
 	)
 
-	if err := handleUserMappings(podUnit, PodGroup, execStartPre, isUser, true); err != nil {
+	if err := handleUserMappings(podUnit, PodGroup, execStartPre, true); err != nil {
 		return nil, err
 	}
 
@@ -1684,7 +1684,7 @@ func handleUser(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdli
 	return nil
 }
 
-func handleUserMappings(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline, isUser, supportManual bool) error {
+func handleUserMappings(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline, supportManual bool) error {
 	mappingsDefined := false
 
 	if userns, ok := unitFile.Lookup(groupName, KeyUserNS); ok && len(userns) > 0 {
@@ -1724,10 +1724,10 @@ func handleUserMappings(unitFile *parser.UnitFile, groupName string, podman *Pod
 		return nil
 	}
 
-	return handleUserRemap(unitFile, groupName, podman, isUser, supportManual)
+	return handleUserRemap(unitFile, groupName, podman, supportManual)
 }
 
-func handleUserRemap(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline, isUser, supportManual bool) error {
+func handleUserRemap(unitFile *parser.UnitFile, groupName string, podman *PodmanCmdline, supportManual bool) error {
 	uidMaps := unitFile.LookupAllStrv(groupName, KeyRemapUid)
 	gidMaps := unitFile.LookupAllStrv(groupName, KeyRemapGid)
 	remapUsers, _ := unitFile.LookupLast(groupName, KeyRemapUsers)
@@ -1765,10 +1765,6 @@ func handleUserRemap(unitFile *parser.UnitFile, groupName string, podman *Podman
 
 		podman.add("--userns", usernsOpts("auto", autoOpts))
 	case "keep-id":
-		if !isUser {
-			return fmt.Errorf("RemapUsers=keep-id is unsupported for system units")
-		}
-
 		keepidOpts := make([]string, 0)
 		if len(uidMaps) > 0 {
 			if len(uidMaps) > 1 {

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -660,7 +660,12 @@ var _ = Describe("quadlet system generator", func() {
 			}
 
 			// Run quadlet to convert the file
-			session := podmanTest.Quadlet([]string{"--user", "--no-kmsg-log", generatedDir}, quadletDir)
+			var args []string
+			if isRootless() {
+				args = append(args, "--user")
+			}
+			args = append(args, "--no-kmsg-log", generatedDir)
+			session := podmanTest.Quadlet(args, quadletDir)
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(exitCode))
 


### PR DESCRIPTION
This is simply wrong, as of commit https://github.com/containers/podman/commit/de63ad70442585790d34693169558fc6e897b3fd --userns=keep-id is also
allowed as root.

Also enable quadlet test to run as root/rootless 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
