### PR TITLE
Update 330-corrupt-images.bats for composefs behavior change

### DIFF
--- a/test/system/330-corrupt-images.bats
+++ b/test/system/330-corrupt-images.bats
@@ -23,7 +23,9 @@ function setup() {
     # DANGER! This completely changes the behavior of run_podman,
     # forcing it to use a quarantined directory. Make certain that
     # it gets unset in teardown.
-    _PODMAN_TEST_OPTS="--storage-driver=vfs $(podman_isolation_opts ${PODMAN_CORRUPT_TEST_WORKDIR})"
+    #
+    # --pull-option=convert_images=true is incompatible with VFS, and can be set when testing composefs.
+    _PODMAN_TEST_OPTS="--storage-driver=vfs --pull-option=convert_images=false $(podman_isolation_opts ${PODMAN_CORRUPT_TEST_WORKDIR})"
 }
 
 function teardown() {


### PR DESCRIPTION
With https://github.com/containers/storage/pull/2118 and https://github.com/containers/image/pull/2589 , the `convert_images` (i.e. “disallow non-partial pulls”) option fails with VFS.

The 330-corrupt-images tests were temporarily switching to VFS, possibly within a composefs test run with `convert_images` set, without disabling it. That is going to fail after we update c/image and c/storage; update the tests for the changed behavior.

#### Does this PR introduce a user-facing change?

```release-note
None
```
