### PR TITLE
Fix for podman machine init not creating necessary JSON file when an ignition-path is passed

### DIFF
--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -90,6 +90,11 @@ func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
 			if strings.Contains(session.errorToString(), "VM does not exist") {
 				return
 			}
+
+			// FIXME:#24344 work-around for custom ignition removal
+			if strings.Contains(session.errorToString(), "failed to remove machines files: unable to find connection named") {
+				return
+			}
 		}
 		Expect(session).To(Exit(0))
 	})

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -196,12 +196,15 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 	// copy it into the conf dir
 	if len(opts.IgnitionPath) > 0 {
 		err = ignBuilder.BuildWithIgnitionFile(opts.IgnitionPath)
-		return err
-	}
 
-	err = ignBuilder.GenerateIgnitionConfig()
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+	} else {
+		err = ignBuilder.GenerateIgnitionConfig()
+		if err != nil {
+			return err
+		}
 	}
 
 	readyIgnOpts, err := mp.PrepareIgnition(mc, &ignBuilder)
@@ -245,9 +248,10 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		return err
 	}
 
-	err = ignBuilder.Build()
-	if err != nil {
-		return err
+	if len(opts.IgnitionPath) == 0 {
+		if err := ignBuilder.Build(); err != nil {
+			return err
+		}
 	}
 
 	return mc.Write()


### PR DESCRIPTION
This bug was first described in https://github.com/containers/podman/issues/23544, and @cheesesashimi did most of the detective work to find the error!

Signed-off-by: Graceson Aufderheide <gracesonphoto@gmail.com>

Fixes #23544
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
