### PR TITLE
Enable pod restore with crun

### DIFF
--- a/pkg/checkpoint/crutils/checkpoint_restore_utils.go
+++ b/pkg/checkpoint/crutils/checkpoint_restore_utils.go
@@ -229,7 +229,18 @@ func CRRuntimeSupportsCheckpointRestore(runtimePath string) bool {
 func CRRuntimeSupportsPodCheckpointRestore(runtimePath string) bool {
 	cmd := exec.Command(runtimePath, "restore", "--lsm-mount-context")
 	out, _ := cmd.CombinedOutput()
-	return bytes.Contains(out, []byte("flag needs an argument"))
+
+	// check for runc
+	if bytes.Contains(out, []byte("flag needs an argument")) {
+		return true
+	}
+
+	// check for crun
+	if bytes.Contains(out, []byte("requires an argument")) {
+		return true
+	}
+
+	return false
 }
 
 // CRGetRuntimeFromArchive extracts the checkpoint metadata from the


### PR DESCRIPTION
`CRRuntimeSupportsPodCheckpointRestore()` is used to check if the current container runtime (e.g., runc or crun) can restore a container into an existing Pod. It does this by processing output message to check if the `--lsm-mount-context` option is supported.  This option was [recently added to crun](https://github.com/containers/crun/pull/1578), however, crun and runc have slightly different output messages:

```
$ crun restore --lsm-mount-contextt
restore: option '--lsm-mount-context' requires an argument
Try `restore --help' or `restore --usage' for more information.
```

```
$ runc restore --lsm-mount-context
ERRO[0000] flag needs an argument: -lsm-mount-context
```

This pull request updates the `CRRuntimeSupportsPodCheckpointRestore()` function to support both runtimes.
