### PR TITLE
[v4.9-rhel] Bump Buildah 1.33.10, CVE-2024-9675

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.0.0
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
-	github.com/containers/buildah v1.33.8
+	github.com/containers/buildah v1.33.10
 	github.com/containers/common v0.57.7
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM=
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
-github.com/containers/buildah v1.33.8 h1:/IfJm5gTHwWshFdRHgLTHkoHNZY85B/xePkpOypBKUw=
-github.com/containers/buildah v1.33.8/go.mod h1:aS1MZukKW39pe/yeJ7sRq9Jf2Sl04uePugPIto6ItNo=
+github.com/containers/buildah v1.33.10 h1:I2nVGxBXLva12ZQyRL2AOURbuMiy948HQwV4n0jLP7Y=
+github.com/containers/buildah v1.33.10/go.mod h1:/18oVHu3NIAm10tEaJMsH2K4e1+krBFqsCywD/kZjto=
 github.com/containers/common v0.57.7 h1:xA6/dXNbScnaytcFNQKTFGn6VDxwvDlCngJtfdGAf7g=
 github.com/containers/common v0.57.7/go.mod h1:GRtgIWNPc8zmo/vcA7VoZfLWpgQRH01/kzQbeNZH8WQ=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -137,15 +137,9 @@ cross_build_task:
     alias: cross_build
     only_if: >-
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
-
-    osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
-
+    env:
+        HOME: /root
     script:
-        - brew update
-        - brew install go
-        - brew install go-md2man
-        - brew install gpgme
         - go version
         - make cross CGO_ENABLED=0
 

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 # Changelog
 
+## v1.33.10 (2024-10-17)
+
+    [release-1.33] Properly validate cache IDs and sources
+    vendor: update c/common to v0.57.7
+    [release-1.33] Bump to v1.33.9
+    [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
+    Cross-build on Fedora
+
+## v1.33.9 (2024-07-16)
+
+    [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
+
 ## v1.33.8 (2024-05-17)
 
     [release-1.33] Bump c/image v5.29.3, c/common v0.57.5, CVE-2024-3727

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,13 @@
+- Changelog for v1.33.10 (2024-10-17)
+  * [release-1.33] Properly validate cache IDs and sources
+  * vendor: update c/common to v0.57.7
+  * [release-1.33] Bump to v1.33.9
+  * [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
+  * Cross-build on Fedora
+
+- Changelog for v1.33.9 (2024-07-16)
+  * [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
+
 - Changelog for v1.33.8 (2024-05-17)
   * [release-1.33] Bump c/image v5.29.3, c/common v0.57.5, CVE-2024-3727
   * integration test: handle new labels in "bud and test --unsetlabel"

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.33.8"
+	Version = "1.33.10"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,7 +147,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.3.0
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.33.8
+# github.com/containers/buildah v1.33.10
 ## explicit; go 1.20
 github.com/containers/buildah
 github.com/containers/buildah/bind


### PR DESCRIPTION
Bump Buildah to v1.33.10.  This will address

CVE-2024-9675, CVE-2024-9407

Fixes: https://issues.redhat.com/browse/RHEL-61154, https://issues.redhat.com/browse/RHEL-61151,
https://issues.redhat.com/browse/OCPBUGS-42896,
https://issues.redhat.com/browse/RHEL-61837,
https://issues.redhat.com/browse/RHEL-61850

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
