### PR TITLE
Honor users requests in quadlet files

### DIFF
--- a/test/e2e/quadlet/basic.build
+++ b/test/e2e/quadlet/basic.build
@@ -5,7 +5,7 @@
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
 ## assert-key-is-regex "Service" "WorkingDirectory" "/.*/podman-e2e-.*/subtest-.*/quadlet"
 ## assert-key-is "Service" "Type" "oneshot"
-## assert-key-is "Service" "RemainAfterExit" "yes"
+## !assert-key-is "Service" "RemainAfterExit" "yes"
 ## assert-key-is "Service" "SyslogIdentifier" "%N"
 
 [Build]

--- a/test/e2e/quadlet/ipv6.network
+++ b/test/e2e/quadlet/ipv6.network
@@ -1,5 +1,13 @@
 ## assert-podman-final-args systemd-ipv6
 ## assert-podman-args "--ipv6"
+## assert-key-is Service Type exec
+## assert-key-is Service RemainAfterExit no
+## assert-key-contains Service SyslogIdentifier "Modify %N"
 
 [Network]
 IPv6=yes
+
+[Service]
+Type=exec
+RemainAfterExit=no
+SyslogIdentifier="Modify %N"

--- a/test/e2e/quadlet/network.build
+++ b/test/e2e/quadlet/network.build
@@ -1,8 +1,13 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
 ## assert-podman-args "--tag" "localhost/imagename"
 ## assert-podman-args "--network" "host"
+## assert-key-is "Service" "Type" "oneshot"
+## assert-key-is "Service" "RemainAfterExit" "no"
 
 [Build]
 ImageTag=localhost/imagename
 SetWorkingDirectory=unit
 Network=host
+
+[Service]
+RemainAfterExit=no

--- a/test/e2e/quadlet/uid.volume
+++ b/test/e2e/quadlet/uid.volume
@@ -1,6 +1,13 @@
 ## assert-key-contains Service ExecStart " --opt o=uid=0,gid=11 "
+## assert-key-is Service Type oneshot
+## assert-key-is Service RemainAfterExit no
+## assert-key-contains Service SyslogIdentifier "Modify %N"
 
 [Volume]
 # Test usernames too
 User=root
 Group=11
+
+[Service]
+RemainAfterExit=no
+SyslogIdentifier="Modify %N"

--- a/test/e2e/quadlet/volume.build
+++ b/test/e2e/quadlet/volume.build
@@ -4,6 +4,7 @@
 ## assert-podman-args -v named:/container/named
 ## assert-podman-args -v systemd-basic:/container/quadlet
 ## assert-podman-args -v %h/container:/container/volume4
+## assert-key-is "Service" "Type" "notify"
 
 [Build]
 ImageTag=localhost/imagename
@@ -15,3 +16,6 @@ Volume=/container/empty
 Volume=named:/container/named
 Volume=basic.volume:/container/quadlet
 Volume=%h/container:/container/volume4
+
+[Service]
+Type=notify


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/24322

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Service section of quadlets now take precedence over built in defaults.
Quadlet build units no longer use RemainAfterExit=yes by default.
```
