### PR TITLE
test: set soft ulimit

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1315,7 +1315,7 @@ EOF
     default_value=$output
 
     # Set the current ulimit smaller than the default value
-    ulimit -n -H $((default_value - 1))
+    ulimit -n -SH $((default_value - 1))
 
     run_podman run --rm $IMAGE sh -c 'ulimit -n -H'
 


### PR DESCRIPTION
when the current soft limit is higher than the new value, ulimit fails to set the hard limit as (tested on Rawhide):

[root@rawhide ~]# ulimit -n -H 1048575
-bash: ulimit: open files: cannot modify limit: Invalid argument

to avoid the problem, set also the soft limit:

[root@rawhide ~]# ulimit -n -H
12345678
[root@rawhide ~]# ulimit -n -H 1048575
-bash: ulimit: open files: cannot modify limit: Invalid argument [root@rawhide ~]# ulimit -n -SH 1048575
[root@rawhide ~]# ulimit -n -H
1048575

commit 71d5ee0e04eb61802b7c59166d88eac19c563ff7 introduced the issue.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
