### PR TITLE
New `system connection add` test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: check-yaml
   - repo: https://github.com/codespell-project/codespell
     # Configuration for codespell is in .codespellrc
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell

--- a/test/system/800-config.bats
+++ b/test/system/800-config.bats
@@ -227,7 +227,9 @@ EOF
     cname="$output"
 
     # Make sure `env_host` is read
-    run_podman container inspect $cname --format "{{.Config.Env}}"
+    # Only print the env vars that start with "FOO" to avoid printing output that
+    # may be considered problematic (see run_podman in helpers.bash).
+    run_podman container inspect $cname --format '{{range .Config.Env}} {{if eq "F" (slice . 0 1) }} {{.}} {{end}} {{end}}'
     assert "$output" =~ "FOO=$random_env_var" "--module should yield injecting host env vars into the container"
 
     # Make sure `privileged` is read during container creation


### PR DESCRIPTION
⚠️  This PR is a draft as it uses my `containers/common` fork (until https://github.com/containers/common/pull/2212 get merged)

The changes included:
- Updates `containers/common` to include containers/common#2212
- Update `codespell` so that the new tests can use `AfterAll(func() { // codespell:ignore afterall`
- Introduce new e2e tests that add a new SSH connection with different `known_hosts` files

```shell
❯ ./test/tools/build/ginkgo -vv  --tags "systemd libsubid exclude_graphdriver_devicemapper seccomp  remote" -timeout=90m --flake-attempts 0 \
        --trace  \
        -p \
        --focus "sshd and API services required" --silence-skips \
        --focus-file "system_connection_test.go" --silence-skips test/e2e/.
Running Suite: Libpod Suite - /home/mariolet/github/podman/test/e2e
===================================================================
Random Seed: 1729869028

Will run 6 of 2279 specs
Running in parallel across 2 processes
------------------------------
[SynchronizedBeforeSuite] PASSED [5.330 seconds]
[SynchronizedBeforeSuite]
/home/mariolet/github/podman/test/e2e/common_test.go:158

  Timeline >>
  > Enter [SynchronizedBeforeSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:158 @ 10/25/24 15:10:36.317
  [image already cached: /var/tmp/quay.io-libpod-cirros-latest.tar]
  [image already cached: /var/tmp/quay.io-libpod-volume-plugin-test-img-20220623.tar]
  [image already cached: /var/tmp/quay.io-libpod-alpine-latest.tar]
  [image already cached: /var/tmp/quay.io-libpod-busybox-latest.tar]
  [image already cached: /var/tmp/quay.io-libpod-alpine_nginx-latest.tar]
  [image already cached: /var/tmp/quay.io-libpod-redis-alpine.tar]
  [image already cached: /var/tmp/quay.io-libpod-registry-2.8.2.tar]
  [image already cached: /var/tmp/quay.io-libpod-k8s-pause-3.5.tar]
  [image already cached: /var/tmp/quay.io-libpod-testimage-20241011.tar]
  [image already cached: /var/tmp/quay.io-libpod-alpine_healthcheck-latest.tar]
  [image already cached: /var/tmp/quay.io-libpod-systemd-image-20240124.tar]
  Restoring quay.io/libpod/alpine:latest...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-alpine-latest.tar
  Loaded image: quay.io/libpod/alpine:latest
  Restoring quay.io/libpod/busybox:latest...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-busybox-latest.tar
  Loaded image: quay.io/libpod/busybox:latest
  Restoring quay.io/libpod/alpine_nginx:latest...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-alpine_nginx-latest.tar
  Loaded image: quay.io/libpod/alpine_nginx:latest
  Restoring quay.io/libpod/redis:alpine...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-redis-alpine.tar
  Loaded image: quay.io/libpod/redis:alpine
  Restoring quay.io/libpod/registry:2.8.2...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-registry-2.8.2.tar
  Loaded image: quay.io/libpod/registry:2.8.2
  Restoring quay.io/libpod/k8s-pause:3.5...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-k8s-pause-3.5.tar
  Loaded image: quay.io/libpod/k8s-pause:3.5
  Restoring quay.io/libpod/testimage:20241011...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-testimage-20241011.tar
  Loaded image: quay.io/libpod/testimage:20241011
  Restoring quay.io/libpod/alpine_healthcheck:latest...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-alpine_healthcheck-latest.tar
  Loaded image: quay.io/libpod/alpine_healthcheck:latest
  Restoring quay.io/libpod/systemd-image:20240124...
  Running: /home/mariolet/github/podman/bin/podman --root /tmp/podman-e2e-2281833054/imagecachedir --runroot /tmp/podman-e2e-2281833054/image-init/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/image-init/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/image-init --events-backend none --db-backend sqlite --storage-driver overlay load -q -i /var/tmp/quay.io-libpod-systemd-image-20240124.tar
  Loaded image: quay.io/libpod/systemd-image:20240124
  -----------------------------
  < Exit [SynchronizedBeforeSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:158 @ 10/25/24 15:10:41.646 (5.329s)
  > Enter [SynchronizedBeforeSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:158 @ 10/25/24 15:10:41.647
  < Exit [SynchronizedBeforeSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:158 @ 10/25/24 15:10:41.647 (0s)
  << Timeline
------------------------------
[SynchronizedBeforeSuite] PASSED [5.333 seconds]
[SynchronizedBeforeSuite]
/home/mariolet/github/podman/test/e2e/common_test.go:158

  Timeline >>
  > Enter [SynchronizedBeforeSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:158 @ 10/25/24 15:10:41.653
  < Exit [SynchronizedBeforeSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:158 @ 10/25/24 15:10:41.653 (0s)
  << Timeline
------------------------------
• [1.192 seconds]
podman system connection
/home/mariolet/github/podman/test/e2e/system_connection_test.go:43
  sshd and API services required
  /home/mariolet/github/podman/test/e2e/system_connection_test.go:429
    add ssh:// socket path using connection heuristic
    /home/mariolet/github/podman/test/e2e/system_connection_test.go:457

  Timeline >>
  > Enter [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:41.751
  < Exit [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:41.752 (1ms)
  > Enter [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:41.753
  < Exit [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:41.753 (0s)
  > Enter [BeforeAll] sshd and API services required - /home/mariolet/github/podman/test/e2e/system_connection_test.go:433 @ 10/25/24 15:10:41.753
  active
  < Exit [BeforeAll] sshd and API services required - /home/mariolet/github/podman/test/e2e/system_connection_test.go:433 @ 10/25/24 15:10:41.789 (36ms)
  > Enter [It] add ssh:// socket path using connection heuristic - /home/mariolet/github/podman/test/e2e/system_connection_test.go:457 @ 10/25/24 15:10:41.789
  QA ssh://mariolet@localhost:22/run/user/1000/podman/podman.sock /home/mariolet/.ssh/id_ed25519 true true
  < Exit [It] add ssh:// socket path using connection heuristic - /home/mariolet/github/podman/test/e2e/system_connection_test.go:457 @ 10/25/24 15:10:42.659 (870ms)
  > Enter [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:42.66
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-747096499/root --runroot /tmp/podman-e2e-2281833054/subtest-747096499/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-747096499/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-747096499 --events-backend file --db-backend sqlite --storage-driver overlay stop --all -t 0
  Cannot connect to Podman. Please verify your connection to the Linux system using `podman system connection list`, or try `podman machine init` and `podman machine start` to manage a new Linux VM
  Error: unable to connect to Podman socket: failed to connect: ssh: handshake failed: EOF
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-747096499/root --runroot /tmp/podman-e2e-2281833054/subtest-747096499/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-747096499/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-747096499 --events-backend file --db-backend sqlite --storage-driver overlay pod rm -fa -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-747096499/root --runroot /tmp/podman-e2e-2281833054/subtest-747096499/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-747096499/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-747096499 --events-backend file --db-backend sqlite --storage-driver overlay rm -fa -t 0
  < Exit [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:42.943 (283ms)
  << Timeline
------------------------------
• [0.864 seconds]
podman system connection
/home/mariolet/github/podman/test/e2e/system_connection_test.go:43
  sshd and API services required
  /home/mariolet/github/podman/test/e2e/system_connection_test.go:429
    add ssh:// with known_hosts
    /home/mariolet/github/podman/test/e2e/system_connection_test.go:509
      ->
      /home/mariolet/github/podman/test/e2e/system_connection_test.go:537
        with a public key of the SSH server that matches the SSH server first key
        /home/mariolet/github/podman/test/e2e/system_connection_test.go:590

  Timeline >>
  > Enter [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:42.945
  < Exit [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:42.945 (0s)
  > Enter [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:42.945
  < Exit [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:42.946 (0s)
  > Enter [BeforeAll] add ssh:// with known_hosts - /home/mariolet/github/podman/test/e2e/system_connection_test.go:515 @ 10/25/24 15:10:42.946
  # localhost:22 SSH-2.0-OpenSSH_9.6
  # localhost:22 SSH-2.0-OpenSSH_9.6
  # localhost:22 SSH-2.0-OpenSSH_9.6
  # localhost:22 SSH-2.0-OpenSSH_9.6
  # localhost:22 SSH-2.0-OpenSSH_9.6
  localhost ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCwQFQvjD0Tmb3TI5x9RwUiQVKJj4J4dZV8OVSA/EZMMh1s51lNlePBWu4F4s2GGpM3YGu1kkSXVKB9CPtpc+LbcPHtZsU0Wck2LFzVnc21fZ5xRkjbULeWLBuRrysW8FL8bh4IN2mlldpgohK5e9cJGIp0IykOSq0P64bYDtsj2rNtE73n9vLawkscJ+iIBjRsD4OEQCNOptFRpZXw2kSxYFuaGRaJfBKE1Kbj8yGTw1duDsMhlnXUBCHwsbh6iCLv7tmvcBwGfve+wcFIktUYLIfShKJ0uOqmJ17mUlmZnUYV1vq1siA4GZzUDmm1WdCVNlViFGtrcXaIr7lQefxH8PpynrT5LeJFblhivzJkqQFSPqTTIaIjSU8w+wArXoQ/+ld+zklu62t+r6dHR3LLmngeehnFMfCdfUEO6xihSSnqPA0f4zyjUEccHaCViUjtwWwqEWun4ZHZf+gR3eNYk2L1bVwBuHbza2uk1v65UzTzd/jycKOfyLggQjVPUoc=
  localhost ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAMX+Qbv4kfLJ8Z+hzwXmn5rl1gR1mnI/ySce92GyOGxcBHo5e/lfoSUUq9tQ3yoc7JgISL56vEVCBgqyjzu0yA=
  localhost ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHPAJ0CX01iuX/dDxXThvdBN/vkWTpNhqEhyi9rWKkz
  < Exit [BeforeAll] add ssh:// with known_hosts - /home/mariolet/github/podman/test/e2e/system_connection_test.go:515 @ 10/25/24 15:10:43.061 (115ms)
  > Enter [It] with a public key of the SSH server that matches the SSH server first key - /home/mariolet/github/podman/test/e2e/system_connection_test.go:590 @ 10/25/24 15:10:43.061
  CONTAINER ID  IMAGE       COMMAND     CREATED     STATUS      PORTS       NAMES
  < Exit [It] with a public key of the SSH server that matches the SSH server first key - /home/mariolet/github/podman/test/e2e/system_connection_test.go:590 @ 10/25/24 15:10:43.594 (533ms)
  > Enter [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:43.594
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-1855305720/root --runroot /tmp/podman-e2e-2281833054/subtest-1855305720/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-1855305720/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-1855305720 --events-backend file --db-backend sqlite --storage-driver overlay stop --all -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-1855305720/root --runroot /tmp/podman-e2e-2281833054/subtest-1855305720/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-1855305720/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-1855305720 --events-backend file --db-backend sqlite --storage-driver overlay pod rm -fa -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-1855305720/root --runroot /tmp/podman-e2e-2281833054/subtest-1855305720/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-1855305720/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-1855305720 --events-backend file --db-backend sqlite --storage-driver overlay rm -fa -t 0
  < Exit [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:43.809 (214ms)
  << Timeline
------------------------------
• [0.714 seconds]
podman system connection
/home/mariolet/github/podman/test/e2e/system_connection_test.go:43
  sshd and API services required
  /home/mariolet/github/podman/test/e2e/system_connection_test.go:429
    add ssh:// with known_hosts
    /home/mariolet/github/podman/test/e2e/system_connection_test.go:509
      ->
      /home/mariolet/github/podman/test/e2e/system_connection_test.go:537
        with a public key of the SSH server that matches SSH server second key
        /home/mariolet/github/podman/test/e2e/system_connection_test.go:596

  Timeline >>
  > Enter [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:43.81
  < Exit [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:43.81 (0s)
  > Enter [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:43.81
  < Exit [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:43.81 (0s)
  > Enter [It] with a public key of the SSH server that matches SSH server second key - /home/mariolet/github/podman/test/e2e/system_connection_test.go:596 @ 10/25/24 15:10:43.81
  < Exit [It] with a public key of the SSH server that matches SSH server second key - /home/mariolet/github/podman/test/e2e/system_connection_test.go:596 @ 10/25/24 15:10:44.313 (503ms)
  > Enter [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:44.313
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-105281511/root --runroot /tmp/podman-e2e-2281833054/subtest-105281511/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-105281511/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-105281511 --events-backend file --db-backend sqlite --storage-driver overlay stop --all -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-105281511/root --runroot /tmp/podman-e2e-2281833054/subtest-105281511/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-105281511/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-105281511 --events-backend file --db-backend sqlite --storage-driver overlay pod rm -fa -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-105281511/root --runroot /tmp/podman-e2e-2281833054/subtest-105281511/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-105281511/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-105281511 --events-backend file --db-backend sqlite --storage-driver overlay rm -fa -t 0
  < Exit [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:44.524 (211ms)
  << Timeline
------------------------------
• [0.255 seconds]
podman system connection
/home/mariolet/github/podman/test/e2e/system_connection_test.go:43
  sshd and API services required
  /home/mariolet/github/podman/test/e2e/system_connection_test.go:429
    add ssh:// with known_hosts
    /home/mariolet/github/podman/test/e2e/system_connection_test.go:509
      ->
      /home/mariolet/github/podman/test/e2e/system_connection_test.go:537
        with a fake public key of the SSH server that doesn't match any of the SSH server keys (should fail)
        /home/mariolet/github/podman/test/e2e/system_connection_test.go:602

  Timeline >>
  > Enter [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:44.525
  < Exit [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:44.525 (0s)
  > Enter [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:44.525
  < Exit [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:44.525 (0s)
  > Enter [It] with a fake public key of the SSH server that doesn't match any of the SSH server keys (should fail) - /home/mariolet/github/podman/test/e2e/system_connection_test.go:602 @ 10/25/24 15:10:44.525
  time="2024-10-25T15:10:44Z" level=warning msg="ssh host key mismatch for host localhost:22, got key SHA256:xdDxsDmwVvJkueghu7VIQB+iF4jsQfuTEOYOasj1KmQ of type ssh-ed25519"
  Error: failed to connect: ssh: handshake failed: knownhosts: key mismatch
  < Exit [It] with a fake public key of the SSH server that doesn't match any of the SSH server keys (should fail) - /home/mariolet/github/podman/test/e2e/system_connection_test.go:602 @ 10/25/24 15:10:44.578 (53ms)
  > Enter [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:44.578
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-1741937752/root --runroot /tmp/podman-e2e-2281833054/subtest-1741937752/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-1741937752/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-1741937752 --events-backend file --db-backend sqlite --storage-driver overlay stop --all -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-1741937752/root --runroot /tmp/podman-e2e-2281833054/subtest-1741937752/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-1741937752/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-1741937752 --events-backend file --db-backend sqlite --storage-driver overlay pod rm -fa -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-1741937752/root --runroot /tmp/podman-e2e-2281833054/subtest-1741937752/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-1741937752/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-1741937752 --events-backend file --db-backend sqlite --storage-driver overlay rm -fa -t 0
  < Exit [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:44.78 (202ms)
  << Timeline
------------------------------
• [0.743 seconds]
podman system connection
/home/mariolet/github/podman/test/e2e/system_connection_test.go:43
  sshd and API services required
  /home/mariolet/github/podman/test/e2e/system_connection_test.go:429
    add ssh:// with known_hosts
    /home/mariolet/github/podman/test/e2e/system_connection_test.go:509
      ->
      /home/mariolet/github/podman/test/e2e/system_connection_test.go:537
        with no public key for the SSH server (new key should be added)
        /home/mariolet/github/podman/test/e2e/system_connection_test.go:608

  Timeline >>
  > Enter [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:44.781
  < Exit [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:44.782 (0s)
  > Enter [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:44.782
  < Exit [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:44.782 (0s)
  > Enter [It] with no public key for the SSH server (new key should be added) - /home/mariolet/github/podman/test/e2e/system_connection_test.go:608 @ 10/25/24 15:10:44.782
  < Exit [It] with no public key for the SSH server (new key should be added) - /home/mariolet/github/podman/test/e2e/system_connection_test.go:608 @ 10/25/24 15:10:45.314 (532ms)
  > Enter [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:45.314
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-679151185/root --runroot /tmp/podman-e2e-2281833054/subtest-679151185/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-679151185/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-679151185 --events-backend file --db-backend sqlite --storage-driver overlay stop --all -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-679151185/root --runroot /tmp/podman-e2e-2281833054/subtest-679151185/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-679151185/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-679151185 --events-backend file --db-backend sqlite --storage-driver overlay pod rm -fa -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-679151185/root --runroot /tmp/podman-e2e-2281833054/subtest-679151185/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-679151185/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-679151185 --events-backend file --db-backend sqlite --storage-driver overlay rm -fa -t 0
  < Exit [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:45.524 (210ms)
  << Timeline
------------------------------
• [0.777 seconds]
podman system connection
/home/mariolet/github/podman/test/e2e/system_connection_test.go:43
  sshd and API services required
  /home/mariolet/github/podman/test/e2e/system_connection_test.go:429
    add ssh:// with known_hosts
    /home/mariolet/github/podman/test/e2e/system_connection_test.go:509
      ->
      /home/mariolet/github/podman/test/e2e/system_connection_test.go:537
        not existing (should be created and a new key should be added)
        /home/mariolet/github/podman/test/e2e/system_connection_test.go:614

  Timeline >>
  > Enter [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:45.525
  < Exit [BeforeEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:113 @ 10/25/24 15:10:45.526 (1ms)
  > Enter [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:45.526
  < Exit [BeforeEach] podman system connection - /home/mariolet/github/podman/test/e2e/system_connection_test.go:45 @ 10/25/24 15:10:45.526 (0s)
  > Enter [It] not existing (should be created and a new key should be added) - /home/mariolet/github/podman/test/e2e/system_connection_test.go:614 @ 10/25/24 15:10:45.526
  < Exit [It] not existing (should be created and a new key should be added) - /home/mariolet/github/podman/test/e2e/system_connection_test.go:614 @ 10/25/24 15:10:46.06 (534ms)
  > Enter [AfterAll] sshd and API services required - /home/mariolet/github/podman/test/e2e/system_connection_test.go:452 @ 10/25/24 15:10:46.06
  < Exit [AfterAll] sshd and API services required - /home/mariolet/github/podman/test/e2e/system_connection_test.go:452 @ 10/25/24 15:10:46.06 (0s)
  > Enter [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:46.06
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-3371589571/root --runroot /tmp/podman-e2e-2281833054/subtest-3371589571/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-3371589571/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-3371589571 --events-backend file --db-backend sqlite --storage-driver overlay stop --all -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-3371589571/root --runroot /tmp/podman-e2e-2281833054/subtest-3371589571/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-3371589571/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-3371589571 --events-backend file --db-backend sqlite --storage-driver overlay pod rm -fa -t 0
  Running: /home/mariolet/github/podman/bin/podman --storage-opt overlay.imagestore=/tmp/podman-e2e-2281833054/imagecachedir --root /tmp/podman-e2e-2281833054/subtest-3371589571/root --runroot /tmp/podman-e2e-2281833054/subtest-3371589571/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman-e2e-2281833054/subtest-3371589571/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman-e2e-2281833054/subtest-3371589571 --events-backend file --db-backend sqlite --storage-driver overlay rm -fa -t 0
  < Exit [AfterEach] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:123 @ 10/25/24 15:10:46.303 (242ms)
  << Timeline
------------------------------
[SynchronizedAfterSuite] PASSED [0.000 seconds]
[SynchronizedAfterSuite]
/home/mariolet/github/podman/test/e2e/common_test.go:224

  Timeline >>
  > Enter [SynchronizedAfterSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:224 @ 10/25/24 15:10:46.305
  < Exit [SynchronizedAfterSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:224 @ 10/25/24 15:10:46.305 (0s)
  << Timeline
------------------------------
[SynchronizedAfterSuite] PASSED [0.252 seconds]
[SynchronizedAfterSuite]
/home/mariolet/github/podman/test/e2e/common_test.go:224

  Timeline >>
  > Enter [SynchronizedAfterSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:224 @ 10/25/24 15:10:46.317
  < Exit [SynchronizedAfterSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:224 @ 10/25/24 15:10:46.317 (0s)
  > Enter [SynchronizedAfterSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:224 @ 10/25/24 15:10:46.318
  integration timing results
  podman system connection sshd and API services required add ssh:// with known_hosts -> with a fake public key of the SSH server that doesn't match any of the SSH server keys (should fail)		0.053378
  podman system connection sshd and API services required add ssh:// with known_hosts -> with a public key of the SSH server that matches SSH server second key		0.503470
  podman system connection sshd and API services required add ssh:// with known_hosts -> with no public key for the SSH server (new key should be added)		0.532677
  podman system connection sshd and API services required add ssh:// with known_hosts -> not existing (should be created and a new key should be added)		0.535134
  podman system connection sshd and API services required add ssh:// with known_hosts -> with a public key of the SSH server that matches the SSH server first key		0.649166
  podman system connection sshd and API services required add ssh:// socket path using connection heuristic		0.907943
  < Exit [SynchronizedAfterSuite] TOP-LEVEL - /home/mariolet/github/podman/test/e2e/common_test.go:224 @ 10/25/24 15:10:46.569 (252ms)
  << Timeline
------------------------------

Ran 6 of 2279 Specs in 10.257 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 2273 Skipped


Ginkgo ran 1 suite in 17.746204614s
Test Suite Passed
```


Depends on https://github.com/containers/common/pull/2212
Fixes https://github.com/containers/podman/issues/23575

```release-note
None
```
