### PR TITLE
test/system: Fix spurious "duplicate tests" failures in pasta tests

### DIFF
--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -129,7 +129,7 @@ function pasta_test_do() {
     local tests_run=${BATS_FILE_TMPDIR}/tests_run
     touch ${tests_run}
     local testid="IPv${ip_ver} $proto $iftype $bind_type range=$range delta=$delta bytes=$bytes"
-    if grep -q -F -- "$testid" ${tests_run}; then
+    if grep -q -F -x -- "$testid" ${tests_run}; then
         die "Duplicate test! Have already run $testid"
     fi
     echo "$testid" >>${tests_run}


### PR DESCRIPTION
As an internal consistency check, the pasta tests check for duplicated test cases by grepping a log file for a parsed test id.  However it uses grep -F for the purpose which will not perform an exact match, but a substring match.  There are some tests which generate an id which is a substring of the id for other tests, so when test order is randomised, this can cause a spurious failure.  This can happen in practice when running the test in parallel with very high concurrency (e.g. -j 100).

Fix this by adding the -x option to grep, which only checks for full line exact matches.

Fixes: #24342 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
