### PR TITLE
Show Startup HealthCheck configuration with `podman inspect`

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -427,6 +427,8 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 	ctrConfig.StopSignal = signal.ToDockerFormat(c.config.StopSignal)
 	// TODO: should JSON deep copy this to ensure internal pointers don't
 	// leak.
+	ctrConfig.StartupHealthCheck = c.config.StartupHealthCheckConfig
+
 	ctrConfig.Healthcheck = c.config.HealthCheckConfig
 
 	ctrConfig.HealthcheckOnFailureAction = c.config.HealthCheckOnFailureAction.String()

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -57,6 +57,8 @@ type InspectContainerConfig struct {
 	Annotations map[string]string `json:"Annotations"`
 	// Container stop signal
 	StopSignal string `json:"StopSignal"`
+	// Configured startup healthcheck for the container
+	StartupHealthCheck *StartupHealthCheck `json:"StartupHealthCheck,omitempty"`
 	// Configured healthcheck for the container
 	Healthcheck *manifest.Schema2HealthConfig `json:"Healthcheck,omitempty"`
 	// HealthcheckOnFailureAction defines an action to take once the container turns unhealthy.

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -67,6 +67,9 @@ function _check_health {
     run_podman inspect $ctrname --format "{{.Config.HealthcheckOnFailureAction}}"
     is "$output" "kill" "on-failure action is set to kill"
 
+    run_podman inspect $ctrname --format "{{.Config.StartupHealthCheck.Test}}"
+    is "$output" "[CMD-SHELL /home/podman/healthcheck]" ".Config.StartupHealthCheck.Test"
+
     current_time=$(date --iso-8601=ns)
     # We can't check for 'starting' because a 1-second interval is too
     # short; it could run healthcheck before we get to our first check.


### PR DESCRIPTION
This PR adds the startup HealtCheck configuration to the output of the `podman inspect` command.

For RHEL-60561 testing purposes.

Fixes: https://issues.redhat.com/browse/RHEL-60561

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman inspect` command now includes startup HealthCheck configuration.
```
