### PR TITLE
stop podman kube play --wait from using 100% CPU

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -543,6 +543,8 @@ func (c *Container) Wait(ctx context.Context) (int32, error) {
 
 // WaitForExit blocks until the container exits and returns its exit code. The
 // argument is the interval at which checks the container's status.
+// If the argument is less than or equal to 0 Nanoseconds a default interval is
+// used.
 func (c *Container) WaitForExit(ctx context.Context, pollInterval time.Duration) (int32, error) {
 	id := c.ID()
 	if !c.valid {
@@ -591,6 +593,10 @@ func (c *Container) WaitForExit(ctx context.Context, pollInterval time.Duration)
 	conmonPidFd := c.getConmonPidFd()
 	if conmonPidFd > -1 {
 		defer unix.Close(conmonPidFd)
+	}
+
+	if pollInterval <= 0 {
+		pollInterval = DefaultWaitInterval
 	}
 
 	// we cannot wait locked as we would hold the lock forever, so we unlock and then lock again


### PR DESCRIPTION
When running `podman kube play --wait pod.yaml` the podman process invoked on the commandline will use 100% of a single CPU waiting for the pod to exit.
This can be reproduced with the following file and then opening another terminal and observing the CPU load of the process.

```yaml
# https://kubernetes.io/docs/concepts/workloads/pods/
apiVersion: v1
kind: Pod
metadata:
  name: "high-cpu-load"
  namespace: default
  labels:
    app: "high-cpu-load"
spec:
  containers:
  - name: high-cpu-load
    image: docker.io/library/debian:bookworm-slim
    command: ["bash"]
    args: ["-c", "handler() { exit 0; } ; trap handler TERM; sleep infinity& wait"]
  restartPolicy: Never
```

This is fixed by adding a proper `Interval` value to the options given to `ContainerWait`. Previously the default value of `time.Duration` was used which is 0 thus creating a busy-wait.

I have set it to 250ms similarly how it was done here #18149 
Likewise I don't know if there are additional tests needed for this PR.

#### Does this PR introduce a user-facing change?
```release-note
podman kube play --wait will no longer busy poll which resulted excessive cpu usage.
```