### PR TITLE
Update gvproxy to v0.8.0 and disable ssh port forwarding on wsl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ endif
 
 # gvisor-tap-vsock version for gvproxy.exe and win-sshproxy.exe downloads
 # the upstream project ships pre-built binaries since version 0.7.1
-GV_VERSION=v0.7.5
+GV_VERSION=v0.8.0
 
 ###
 ### Primary entry-point targets

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -6,7 +6,7 @@ ifeq ($(ARCH), aarch64)
 else
 	GOARCH:=$(ARCH)
 endif
-GVPROXY_VERSION ?= 0.7.5
+GVPROXY_VERSION ?= 0.8.0
 VFKIT_VERSION ?= 0.5.1
 KRUNKIT_VERSION ?= 0.1.3
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -44,8 +45,12 @@ var _ = Describe("podman machine init - windows only", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(inspectSession).To(Exit(0))
 		Expect(inspectSession.outputToString()).To(Equal("true"))
-	})
 
+		// Ensure port 2222 is free
+		listener, err := net.Listen("tcp", "0.0.0.0:2222")
+		Expect(err).ToNot(HaveOccurred())
+		defer listener.Close()
+	})
 	It("init should not should not overwrite existing HyperV vms", func() {
 		skipIfNotVmtype(define.HyperVVirt, "HyperV test only")
 		name := randomString()

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -32,7 +32,7 @@ fi
 if [[ ! $ROUTE =~ default\ via ]]; then
 	exit 3
 fi
-nohup $GVFORWARDER -iface podman-usermode -stop-if-exist ignore -url "stdio:$GVPROXY?listen-stdio=accept" > /var/log/vm.log 2> /var/log/vm.err  < /dev/null &
+nohup $GVFORWARDER -iface podman-usermode -stop-if-exist ignore -url "stdio:$GVPROXY?listen-stdio=accept&ssh-port=-1" > /var/log/vm.log 2> /var/log/vm.err  < /dev/null &
 echo $! > $STATE/vm.pid
 sleep 1
 ps -eo args | grep -q -m1 ^$GVFORWARDER || exit 42

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -279,7 +279,7 @@ switch ($target) {
         if ($args.Count -gt 1) {
             $ref = $args[1]
         }
-        Win-SSHProxy -Ref $ref
+        Win-SSHProxy($ref)
     }
     'installer' {
         if ($args.Count -gt 1) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
This fixes https://github.com/containers/podman/issues/20327. 
This change will pass `-1` to the `-ssh-port` flag of `gvproxy` to disable port forwarding on wsl which will prevent port conflict with crc.
#### Does this PR introduce a user-facing change?
No

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
