### PR TITLE
[v5.2-rhel] Fix exposed ports

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -211,7 +211,11 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		return nil, err
 	}
 	data.NetworkSettings = networkConfig
-	addInspectPortsExpose(c.config.ExposedPorts, data.NetworkSettings.Ports)
+	// Ports in NetworkSettings includes exposed ports for network modes that are not host,
+	// and not container.
+	if !(c.config.NetNsCtr != "" || c.NetworkMode() == "host") {
+		addInspectPortsExpose(c.config.ExposedPorts, data.NetworkSettings.Ports)
+	}
 
 	inspectConfig := c.generateInspectContainerConfig(ctrSpec)
 	data.Config = inspectConfig

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -444,7 +444,7 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 	ctrConfig.SdNotifyMode = c.config.SdNotifyMode
 	ctrConfig.SdNotifySocket = c.config.SdNotifySocket
 
-	// Exosed ports consists of all exposed ports and all port mappings for
+	// Exposed ports consists of all exposed ports and all port mappings for
 	// this container. It does *NOT* follow to another container if we share
 	// the network namespace.
 	exposedPorts := make(map[string]struct{})
@@ -454,7 +454,7 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 		}
 	}
 	for _, mapping := range c.config.PortMappings {
-		for i := range mapping.Range {
+		for i := uint16(0); i < mapping.Range; i++ {
 			exposedPorts[fmt.Sprintf("%d/%s", mapping.ContainerPort+i, mapping.Protocol)] = struct{}{}
 		}
 	}

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -211,6 +211,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		return nil, err
 	}
 	data.NetworkSettings = networkConfig
+	addInspectPortsExpose(c.config.ExposedPorts, data.NetworkSettings.Ports)
 
 	inspectConfig := c.generateInspectContainerConfig(ctrSpec)
 	data.Config = inspectConfig

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -439,6 +439,25 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 
 	ctrConfig.SdNotifyMode = c.config.SdNotifyMode
 	ctrConfig.SdNotifySocket = c.config.SdNotifySocket
+
+	// Exosed ports consists of all exposed ports and all port mappings for
+	// this container. It does *NOT* follow to another container if we share
+	// the network namespace.
+	exposedPorts := make(map[string]struct{})
+	for port, protocols := range c.config.ExposedPorts {
+		for _, proto := range protocols {
+			exposedPorts[fmt.Sprintf("%d/%s", port, proto)] = struct{}{}
+		}
+	}
+	for _, mapping := range c.config.PortMappings {
+		for i := range mapping.Range {
+			exposedPorts[fmt.Sprintf("%d/%s", mapping.ContainerPort+i, mapping.Protocol)] = struct{}{}
+		}
+	}
+	if len(exposedPorts) > 0 {
+		ctrConfig.ExposedPorts = exposedPorts
+	}
+
 	return ctrConfig
 }
 

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -4,6 +4,7 @@ package libpod
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/pkg/shortnames"
@@ -173,6 +174,13 @@ func (c *Container) validate() error {
 	// Cannot set startup HC without a healthcheck
 	if c.config.HealthCheckConfig == nil && c.config.StartupHealthCheckConfig != nil {
 		return fmt.Errorf("cannot set a startup healthcheck when there is no regular healthcheck: %w", define.ErrInvalidArg)
+	}
+
+	// Ensure all ports list a single protocol
+	for _, p := range c.config.PortMappings {
+		if strings.Contains(p.Protocol, ",") {
+			return fmt.Errorf("each port mapping must define a single protocol, got a comma-separated list for container port %d (protocols requested %q): %w", p.ContainerPort, p.Protocol, define.ErrInvalidArg)
+		}
 	}
 
 	return nil

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -89,6 +89,8 @@ type InspectContainerConfig struct {
 	SdNotifyMode string `json:"sdNotifyMode,omitempty"`
 	// SdNotifySocket is the NOTIFY_SOCKET in use by/configured for the container.
 	SdNotifySocket string `json:"sdNotifySocket,omitempty"`
+	// ExposedPorts includes ports the container has exposed.
+	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
 
 	// V4PodmanCompatMarshal indicates that the json marshaller should
 	// use the old v4 inspect format to keep API compatibility.

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -204,7 +204,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	}
 
 	settings := new(define.InspectNetworkSettings)
-	settings.Ports = makeInspectPorts(c.config.PortMappings, c.config.ExposedPorts)
+	settings.Ports = makeInspectPortBindings(c.config.PortMappings)
 
 	networks, err := c.networks()
 	if err != nil {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1065,7 +1065,7 @@ func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 // namespace with a minimal configuration.
 // An optional array of port mappings can be provided.
 // Conflicts with WithNetNSFrom().
-func WithNetNS(portMappings []nettypes.PortMapping, exposedPorts map[uint16][]string, postConfigureNetNS bool, netmode string, networks map[string]nettypes.PerNetworkOptions) CtrCreateOption {
+func WithNetNS(portMappings []nettypes.PortMapping, postConfigureNetNS bool, netmode string, networks map[string]nettypes.PerNetworkOptions) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return define.ErrCtrFinalized
@@ -1075,12 +1075,25 @@ func WithNetNS(portMappings []nettypes.PortMapping, exposedPorts map[uint16][]st
 		ctr.config.NetMode = namespaces.NetworkMode(netmode)
 		ctr.config.CreateNetNS = true
 		ctr.config.PortMappings = portMappings
-		ctr.config.ExposedPorts = exposedPorts
 
 		if !ctr.config.NetMode.IsBridge() && len(networks) > 0 {
 			return errors.New("cannot use networks when network mode is not bridge")
 		}
 		ctr.config.Networks = networks
+
+		return nil
+	}
+}
+
+// WithExposedPorts includes a set of ports that were exposed by the image in
+// the container config, e.g. for display when the container is inspected.
+func WithExposedPorts(exposedPorts map[uint16][]string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.ExposedPorts = exposedPorts
 
 		return nil
 	}

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -535,19 +535,6 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	}
 	stopTimeout := int(l.StopTimeout())
 
-	exposedPorts := make(nat.PortSet)
-	for ep := range inspect.NetworkSettings.Ports {
-		port, proto, ok := strings.Cut(ep, "/")
-		if !ok {
-			return nil, fmt.Errorf("PORT/PROTOCOL Format required for %q", ep)
-		}
-		exposedPort, err := nat.NewPort(proto, port)
-		if err != nil {
-			return nil, err
-		}
-		exposedPorts[exposedPort] = struct{}{}
-	}
-
 	var healthcheck *container.HealthConfig
 	if inspect.Config.Healthcheck != nil {
 		healthcheck = &container.HealthConfig{
@@ -556,6 +543,16 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 			Timeout:     inspect.Config.Healthcheck.Timeout,
 			StartPeriod: inspect.Config.Healthcheck.StartPeriod,
 			Retries:     inspect.Config.Healthcheck.Retries,
+		}
+	}
+
+	// Apparently the compiler can't convert a map[string]struct{} into a nat.PortSet
+	// (Despite a nat.PortSet being that exact struct with some types added)
+	var exposedPorts nat.PortSet
+	if len(inspect.Config.ExposedPorts) > 0 {
+		exposedPorts = make(nat.PortSet)
+		for p := range inspect.Config.ExposedPorts {
+			exposedPorts[nat.Port(p)] = struct{}{}
 		}
 	}
 

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -297,6 +297,13 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 
 	postConfigureNetNS := needPostConfigureNetNS(s)
 
+	// Network
+	portMappings, expose, err := createPortMappings(s, imageData)
+	if err != nil {
+		return nil, err
+	}
+	toReturn = append(toReturn, libpod.WithExposedPorts(expose))
+
 	switch s.NetNS.NSMode {
 	case specgen.FromPod:
 		if pod == nil || infraCtr == nil {
@@ -316,28 +323,15 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 			toReturn = append(toReturn, libpod.WithNetNSFrom(netCtr))
 		}
 	case specgen.Slirp:
-		portMappings, expose, err := createPortMappings(s, imageData)
-		if err != nil {
-			return nil, err
-		}
 		val := "slirp4netns"
 		if s.NetNS.Value != "" {
 			val = fmt.Sprintf("slirp4netns:%s", s.NetNS.Value)
 		}
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, val, nil))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, postConfigureNetNS, val, nil))
 	case specgen.Pasta:
-		portMappings, expose, err := createPortMappings(s, imageData)
-		if err != nil {
-			return nil, err
-		}
 		val := "pasta"
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, val, nil))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, postConfigureNetNS, val, nil))
 	case specgen.Bridge, specgen.Private, specgen.Default:
-		portMappings, expose, err := createPortMappings(s, imageData)
-		if err != nil {
-			return nil, err
-		}
-
 		rtConfig, err := rt.GetConfigNoCopy()
 		if err != nil {
 			return nil, err
@@ -364,7 +358,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 			s.Networks[rtConfig.Network.DefaultNetwork] = opts
 			delete(s.Networks, "default")
 		}
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, "bridge", s.Networks))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, postConfigureNetNS, "bridge", s.Networks))
 	}
 
 	if s.UseImageHosts != nil && *s.UseImageHosts {

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -35,7 +35,9 @@ var _ = Describe("Podman container inspect", func() {
 
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
-			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil}))
+			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil, "99/sctp": nil}))
+		Expect(data[0].Config.ExposedPorts).
+			To(Equal(map[string]struct{}{"8787/udp": {}, "99/sctp": {}}))
 
 		session = podmanTest.Podman([]string{"ps", "--format", "{{.Ports}}"})
 		session.WaitWithDefaultTimeout()
@@ -58,6 +60,27 @@ var _ = Describe("Podman container inspect", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("80/tcp, 8989/tcp"))
+	})
+
+	It("podman inspect exposed ports includes published ports", func() {
+		c1 := "ctr1"
+		c1s := podmanTest.Podman([]string{"run", "-d", "--expose", "22/tcp", "-p", "8080:80/tcp", "--name", c1, ALPINE, "top"})
+		c1s.WaitWithDefaultTimeout()
+		Expect(c1s).Should(ExitCleanly())
+
+		c2 := "ctr2"
+		c2s := podmanTest.Podman([]string{"run", "-d", "--net", fmt.Sprintf("container:%s", c1), "--name", c2, ALPINE, "top"})
+		c2s.WaitWithDefaultTimeout()
+		Expect(c2s).Should(ExitCleanly())
+
+		data1 := podmanTest.InspectContainer(c1)
+		Expect(data1).To(HaveLen(1))
+		Expect(data1[0].Config.ExposedPorts).
+			To(Equal(map[string]struct{}{"22/tcp": {}, "80/tcp": {}}))
+
+		data2 := podmanTest.InspectContainer(c2)
+		Expect(data2).To(HaveLen(1))
+		Expect(data2[0].Config.ExposedPorts).To(BeNil())
 	})
 
 	It("podman inspect shows volumes-from with mount options", func() {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -441,6 +441,38 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(inspectOut[0].HostConfig.PublishAllPorts).To(BeTrue())
 	})
 
+	It("podman run --net=host --expose includes port in inspect output", func() {
+		containerName := "testctr"
+		session := podmanTest.Podman([]string{"run", "--name", containerName, "-d", "--expose", "8080/tcp", NGINX_IMAGE, "sleep", "+inf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		inspectOut := podmanTest.InspectContainer(containerName)
+		Expect(inspectOut).To(HaveLen(1))
+
+		// 80 from the image, 8080 from the expose
+		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveLen(2))
+		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveKey("80/tcp"))
+		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveKey("8080/tcp"))
+	})
+
+	It("podman run --net=container --expose exposed port from own container", func() {
+		ctr1 := "test1"
+		session1 := podmanTest.Podman([]string{"run", "-d", "--name", ctr1, "--expose", "8080/tcp", ALPINE, "top"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session1).Should(ExitCleanly())
+
+		ctr2 := "test2"
+		session2 := podmanTest.Podman([]string{"run", "-d", "--name", ctr2, "--net", fmt.Sprintf("container:%s", ctr1), "--expose", "8090/tcp", ALPINE, "top"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2).Should(ExitCleanly())
+
+		inspectOut := podmanTest.InspectContainer(ctr2)
+		Expect(inspectOut).To(HaveLen(1))
+		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveLen(1))
+		Expect(inspectOut[0].NetworkSettings.Ports).To(HaveKey("8090/tcp"))
+	})
+
 	It("podman run -p 127.0.0.1::8980/udp", func() {
 		name := "testctr"
 		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1::8980/udp", "--name", name, ALPINE, "/bin/sh"})


### PR DESCRIPTION
This fixes an exposed ports issue in RHEL 5.2-rhel for RHEL 9.5.

FIxes: https://issues.redhat.com/browse/RHEL-62566

This includes the fixes from the following PRs:

First PR: #24090
Second PR: #24110
Third PR: #24164

With an additional tweak from @Luap99 in https://github.com/containers/podman/pull/24333/commits/0889c74497b80a5205d35965170afd617ebb1590 
regarding the looping in libpod/container_inspect.go.

These changes are needed in the 5.2-rhel branch to ensure a successful
upgrades as the same patches have been used for the following issues
in the Podman v4.9-rhel branch for these issues:

Fixes: https://issues.redhat.com/browse/ACCELFIX-299
Fixes: https://issues.redhat.com/browse/ACCELFIX-300
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
