### PR TITLE
Remove exit file from persistent storage 

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -149,6 +149,10 @@ func (c *Container) exitFilePath() (string, error) {
 	return c.ociRuntime.ExitFilePath(c)
 }
 
+func (c *Container) persistExitFilePath() (string, error) {
+	return c.ociRuntime.PersistExitFilePath(c)
+}
+
 func (c *Container) oomFilePath() (string, error) {
 	return c.ociRuntime.OOMFilePath(c)
 }
@@ -759,6 +763,7 @@ func (c *Container) removeConmonFiles() error {
 
 	// Remove the exit file so we don't leak memory in tmpfs
 	exitFile, err := c.exitFilePath()
+
 	if err != nil {
 		return err
 	}
@@ -773,6 +778,15 @@ func (c *Container) removeConmonFiles() error {
 	}
 	if err := os.Remove(oomFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("removing container %s oom file: %w", c.ID(), err)
+	}
+
+	// Remove exit file from persistent storage
+	persistExitFilePath, err := c.persistExitFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(persistExitFilePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("removing container %s persist exit file: %w", c.ID(), err)
 	}
 
 	return nil

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -147,6 +147,9 @@ type OCIRuntime interface { //nolint:interfacebloat
 	// This is the path to that file for a given container.
 	ExitFilePath(ctr *Container) (string, error)
 
+	// PersistExitFilePath is the path to a container's persistent exit file.
+	PersistExitFilePath(ctr *Container) (string, error)
+
 	// OOMFilePath is the path to a container's oom file if it was oom killed.
 	// An oom file is only created when the container is oom killed. The existence
 	// of this file means that the container was oom killed.

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -862,6 +862,10 @@ func (r *ConmonOCIRuntime) OOMFilePath(ctr *Container) (string, error) {
 	return filepath.Join(r.persistDir, ctr.ID(), "oom"), nil
 }
 
+func (r *ConmonOCIRuntime) PersistExitFilePath(ctr *Container) (string, error) {
+	return filepath.Join(r.persistDir, ctr.ID(), "exit"), nil
+}
+
 // RuntimeInfo provides information on the runtime.
 func (r *ConmonOCIRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error) {
 	runtimePackage := version.Package(r.path)

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -220,6 +220,10 @@ func (r *MissingRuntime) ExitFilePath(ctr *Container) (string, error) {
 	return filepath.Join(r.exitsDir, ctr.ID()), nil
 }
 
+func (r *MissingRuntime) PersistExitFilePath(ctr *Container) (string, error) {
+	return filepath.Join(r.persistDir, ctr.ID(), "exit"), nil
+}
+
 // OOMFilePath returns the oom file path for a container.
 // The oom file will only exist if the container was oom killed.
 func (r *MissingRuntime) OOMFilePath(ctr *Container) (string, error) {


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
```
None
```

[NO NEW TESTS NEEDED]

 This MR changes this behaviour - podman will exit-file from  persist-dir after calling conmon.
 
 It helps avoid this situation in case of systemd restart-always policy
 
 
![image](https://github.com/user-attachments/assets/185e039f-97d2-47c6-96f1-6c389900432f)

