### PR TITLE
readthedocs: build extra formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,12 @@ build:
 sphinx:
   configuration: docs/source/conf.py
 
+# Optionally build your docs in additional formats
+formats:
+  - htmlzip
+  - epub
+  - pdf
+
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:

--- a/docs/source/Reference.rst
+++ b/docs/source/Reference.rst
@@ -7,6 +7,10 @@ Show the API documentation for version:
 
 * `latest (main branch) <_static/api.html>`_
 
+* `version 5.2 <_static/api.html?version=v5.2>`_
+
+* `version 5.1 <_static/api.html?version=v5.1>`_
+
 * `version 5.0 <_static/api.html?version=v5.0>`_
 
 * `version 4.9 <_static/api.html?version=v4.9>`_


### PR DESCRIPTION
Make our docs available in extra formats to download, ref
https://docs.readthedocs.io/en/stable/config-file/v2.html#formats

Also add the missing swagger links for the other branches.

Fixes #24354

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
