### PR TITLE
docs: fix broken example

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -194,9 +194,9 @@ Initialize the specified Podman machine overriding its memory size, pulling the 
 $ podman machine init --memory=1024 myvm
 ```
 
-Initialize the default Podman machine with the host directory `/Users` mounted into the VM at `/mnt/Users`.
+Initialize the default Podman machine with the host directory `/Users` mounted into the VM at `/Users`.
 ```
-$ podman machine init -v /Users:/mnt/Users
+$ podman machine init -v /Users:/Users
 ```
 
 Initialize the default Podman machine with a usb device passthrough specified with options. Only supported for QEMU Machines.


### PR DESCRIPTION
In coreos /mnt is a symlink to /vat/mnt and systemd does not like do use the symlink for some reason. Simply fix the example to use /Users which now works as we always create the directories even on /.

Fixes #24281

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
