### PR TITLE
logformatter: add cleanup tracer log link

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -878,11 +878,14 @@ END_SYNOPSIS
                                 _a("{CIRRUS_BUILD_ID}", "https://cirrus-ci.com/build/{CIRRUS_BUILD_ID}"),
                                 _a("{CIRRUS_TASK_ID}", "https://cirrus-ci.com/task/{CIRRUS_TASK_ID}")));
 
-    # Logs: link to original (unformatted) log; journal; and, if remote, server
+    # Logs: link to original (unformatted) log; journal; cleanup tracer; and, if remote, server
     my @logs;
     push @logs, _a("main", sprintf("https://api.cirrus-ci.com/v1/task/{CIRRUS_TASK_ID}/logs/%s.log",
                                    ($is_mac ? 'test' : 'main')));
     push @logs, _a("journal", "https://api.cirrus-ci.com/v1/task/{CIRRUS_TASK_ID}/logs/journal.log")
+        unless $is_mac;
+
+    push @logs, _a("cleanup tracer", "https://api.cirrus-ci.com/v1/artifact/task/{CIRRUS_TASK_ID}/cleanup_tracer/podman-cleanup-tracer.log")
         unless $is_mac;
 
     # System tests are single-threaded, and have a server log available


### PR DESCRIPTION
I had a few cases where this is super handy in CI and if I can access the link without one extra click it safes me some time and hopefully makes it more discoverable for other to see how useful it can be sometimes.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
