### PR TITLE
Fix: To print create and remove network in podman events

### DIFF
--- a/libpod/events.go
+++ b/libpod/events.go
@@ -136,6 +136,19 @@ func (c *Container) newExecDiedEvent(sessionID string, exitCode int) {
 	}
 }
 
+// newNetworkEvent creates a new event based on a network create/remove
+func (r *Runtime) NewNetworkEvent(status events.Status, netName, netID, netDriver string) {
+	e := events.NewEvent(status)
+	e.Network = netName
+	e.ID = netID
+	e.Attributes = make(map[string]string)
+	e.Attributes["driver"] = netDriver
+	e.Type = events.Network
+	if err := r.eventer.Write(e); err != nil {
+		logrus.Errorf("Unable to write network event: %q", err)
+	}
+}
+
 // newNetworkEvent creates a new event based on a network connect/disconnect
 func (c *Container) newNetworkEvent(status events.Status, netName string) {
 	e := events.NewEvent(status)

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -89,7 +89,13 @@ func (e *Event) ToHumanReadable(truncate bool) string {
 		}
 		humanFormat += ")"
 	case Network:
-		humanFormat = fmt.Sprintf("%s %s %s %s (container=%s, name=%s)", e.Time, e.Type, e.Status, id, id, e.Network)
+		if e.Status == Create || e.Status == Remove {
+			if netdriver, exists := e.Attributes["driver"]; exists {
+				humanFormat = fmt.Sprintf("%s %s %s %s (name=%s, type=%s)", e.Time, e.Type, e.Status, e.ID, e.Network, netdriver)
+			}
+		} else {
+			humanFormat = fmt.Sprintf("%s %s %s %s (container=%s, name=%s)", e.Time, e.Type, e.Status, id, id, e.Network)
+		}
 	case Image:
 		humanFormat = fmt.Sprintf("%s %s %s %s %s", e.Time, e.Type, e.Status, id, e.Name)
 		if e.Error != "" {

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -242,7 +242,8 @@ var _ = Describe("Podman events", func() {
 
 	It("podman events network connection", func() {
 		network := stringid.GenerateRandomID()
-		result := podmanTest.Podman([]string{"create", "--network", "bridge", ALPINE, "top"})
+		networkDriver := "bridge"
+		result := podmanTest.Podman([]string{"create", "--network", networkDriver, ALPINE, "top"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
 		ctrID := result.OutputToString()
@@ -259,11 +260,16 @@ var _ = Describe("Podman events", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
 
+		result = podmanTest.Podman([]string{"network", "rm", network})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+
 		result = podmanTest.Podman([]string{"events", "--stream=false", "--since", "30s"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
 
 		eventDetails := fmt.Sprintf(" %s (container=%s, name=%s)", ctrID, ctrID, network)
+		networkCreateRemoveDetails := fmt.Sprintf("(name=%s, type=%s)", network, networkDriver)
 		// Workaround for #23634, event order not guaranteed when remote.
 		// Although the issue is closed, the bug is a real one. It seems
 		// unlikely ever to be fixed.
@@ -274,9 +280,11 @@ var _ = Describe("Podman events", func() {
 			Expect(lines).To(MatchRegexp(" network connect .* network disconnect "))
 		} else {
 			lines := result.OutputToStringArray()
-			Expect(lines).To(HaveLen(5))
-			Expect(lines[3]).To(ContainSubstring("network connect" + eventDetails))
-			Expect(lines[4]).To(ContainSubstring("network disconnect" + eventDetails))
+			Expect(lines).To(HaveLen(7))
+			Expect(lines[3]).To(And(ContainSubstring("network create"), ContainSubstring(networkCreateRemoveDetails)))
+			Expect(lines[4]).To(ContainSubstring("network connect" + eventDetails))
+			Expect(lines[5]).To(ContainSubstring("network disconnect" + eventDetails))
+			Expect(lines[6]).To(And(ContainSubstring("network remove"), ContainSubstring(networkCreateRemoveDetails)))
 		}
 	})
 


### PR DESCRIPTION
Fixes :  #24032
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman events now support logging for network creation and removal events.
```
