### PR TITLE
libpod: use pasta Setup() over Setup2()

### DIFF
--- a/libpod/networking_pasta_linux.go
+++ b/libpod/networking_pasta_linux.go
@@ -12,7 +12,7 @@ package libpod
 import "github.com/containers/common/libnetwork/pasta"
 
 func (r *Runtime) setupPasta(ctr *Container, netns string) error {
-	res, err := pasta.Setup2(&pasta.SetupOptions{
+	res, err := pasta.Setup(&pasta.SetupOptions{
 		Config:       r.config,
 		Netns:        netns,
 		Ports:        ctr.convertPortMappings(),


### PR DESCRIPTION
Setup2() calls Setup() so they are both the same thing, the idea was to keep Setup2() around in c/common for a bit to avoid breaking changes during our regular vendoring. Now just use Setup() so we can get rid of Setup2() in c/common.

https://github.com/containers/common/pull/2136/commits/a7415c3eab4675a5b37dbee9d33833af5f2b086e

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
