### PR TITLE
make podman-clean-transient.service work as user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1000,6 +1000,13 @@ install.systemd: $(PODMAN_GENERATED_UNIT_FILES)
 		install ${SELINUXOPT} -m 644 $$unit $(DESTDIR)${USERSYSTEMDDIR}/$$(basename $$unit); \
 		install ${SELINUXOPT} -m 644 $$unit $(DESTDIR)${SYSTEMDDIR}/$$(basename $$unit); \
 	done
+	# HACK; as rootless this unit will not work due the requires on a non existing target
+	# as the user session does not see system units. We could define two different units
+	# but this seems much more complicated then this small fixup here.
+	# https://github.com/containers/podman/issues/23790
+	sed -i '/Requires=/d' $(DESTDIR)${USERSYSTEMDDIR}/podman-clean-transient.service
+	sed -i '/After=/d' $(DESTDIR)${USERSYSTEMDDIR}/podman-clean-transient.service
+
 	# Important this unit should only be installed for the user session and is thus not added to the loop above.
 	install ${SELINUXOPT} -m 644 contrib/systemd/user/podman-user-wait-network-online.service \
 		$(DESTDIR)${USERSYSTEMDDIR}/podman-user-wait-network-online.service


### PR DESCRIPTION
In the user session there is no boot-complete.target so the Requires= fails. We do not need it and I am not sure if we need it for the root unit either but I deicded to keep it there to not change anything and for the user session we patch it out.

I patched this in the Makefile, while we could try to define two different source files for that it would make the Makefile logic even more complicated. In particular as this file is a .in we would need to add it to PODMAN_GENERATED_UNIT_FILES and then somehow fix the loop. To much work IMO so the sed trick to patch the user file is simpler.

Fixes #23790

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman-clean-transient.service can now be used in the user session correctly (only needed when podman is run with --transient-store)
```
