### PR TITLE
Instrument cleanup tracer to log weird volume removal flake

### DIFF
--- a/hack/podman_cleanup_tracer.bt
+++ b/hack/podman_cleanup_tracer.bt
@@ -149,3 +149,17 @@ tracepoint:syscalls:sys_enter_write
         $offset += $len
     }
 }
+
+// HACK: debug for https://github.com/containers/podman/issues/23913
+// The test uses "ebpf-debug-23913" volume name and because and volume rm
+// will delete the path we can trap the process here to find out who actually
+// deletes it.
+tracepoint:syscalls:sys_enter_unlink*
+/ strcontains(str(args.pathname), "ebpf-debug-23913") /
+{
+    printf("Special issue 23913 volume deleted by pid %d: ", pid);
+    // This can fail to open the file it is done in user space and
+    // thus racy if the process exits quickly.
+    cat("/proc/%d/cmdline", pid);
+    print("");
+}

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -270,7 +270,8 @@ function _check_no_suggestions() {
     random_image_name="i-$(safename)"
     random_image_tag=$(random_string 5)
     random_network_name="n-$(safename)"
-    random_volume_name="v-$(safename)"
+    # Do not change the suffix, it is special debug for #23913
+    random_volume_name="v-$(safename)-ebpf-debug-23913"
     random_secret_name="s-$(safename)"
     random_secret_content=$(random_string 30)
     secret_file=$PODMAN_TMPDIR/$(random_string 10)


### PR DESCRIPTION
Debug for #23913, I though if we have no idea which process is nuking the volume then we need to figure this out. As there is no reproducer we can (ab)use the cleanup tracer. Simply trace all unlink syscalls to see which process deletes our special named volume. Given the volume name is used as path on the fs and is deleted on volume rm we should know exactly which process deleted it the next time hopefully.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
