### PR TITLE
doc: explain --interactive in more detail

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -279,7 +279,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.BoolVarP(
 			&cf.Interactive,
 			"interactive", "i", false,
-			"Keep STDIN open even if not attached",
+			"Make STDIN available to the contained process",
 		)
 		ipcFlagName := "ipc"
 		createFlags.String(

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -71,7 +71,7 @@ func execFlags(cmd *cobra.Command) {
 	flags.StringArrayVar(&envFile, envFileFlagName, []string{}, "Read in a file of environment variables")
 	_ = cmd.RegisterFlagCompletionFunc(envFileFlagName, completion.AutocompleteDefault)
 
-	flags.BoolVarP(&execOpts.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
+	flags.BoolVarP(&execOpts.Interactive, "interactive", "i", false, "Make STDIN available to the contained process")
 	flags.BoolVar(&execOpts.Privileged, "privileged", podmanConfig.ContainersConfDefaultsRO.Containers.Privileged, "Give the process extended Linux capabilities inside the container.  The default is false")
 	flags.BoolVarP(&execOpts.Tty, "tty", "t", false, "Allocate a pseudo-TTY. The default is false")
 

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -55,7 +55,7 @@ func startFlags(cmd *cobra.Command) {
 	flags.StringVar(&startOptions.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Select the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
-	flags.BoolVarP(&startOptions.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
+	flags.BoolVarP(&startOptions.Interactive, "interactive", "i", false, "Make STDIN available to the contained process")
 	flags.BoolVar(&startOptions.SigProxy, "sig-proxy", false, "Proxy received signals to the process (default true if attaching, false otherwise)")
 
 	filterFlagName := "filter"

--- a/docs/source/markdown/options/interactive.md
+++ b/docs/source/markdown/options/interactive.md
@@ -4,4 +4,8 @@
 ####> are applicable to all of those.
 #### **--interactive**, **-i**
 
-When set to **true**, keep stdin open even if not attached. The default is **false**.
+When set to **true**, make stdin available to the contained process. If **false**, the stdin of the contained process is empty and immediately closed.
+
+If attached, stdin is piped to the contained process. If detached, reading stdin will block until later attached.
+
+**Caveat:** Podman will consume input from stdin as soon as it becomes available, even if the contained process doesn't request it.


### PR DESCRIPTION
Clarifies the behavior of --interactive in both attached and unattached scenarios.

Adds a caveat and explanation for --interactive being hungry as described in https://github.com/containers/podman/issues/24370.

Fixes #24370

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Clarified the --interactive flag in the documentation
```
