### PR TITLE
feat(podman-remote): support kube play build client

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	util2 "github.com/containers/podman/v5/pkg/bindings/internal/util"
 	"io"
 	"io/fs"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	util2 "github.com/containers/podman/v5/pkg/bindings/internal/util"
 
 	"github.com/containers/buildah/define"
 	imageTypes "github.com/containers/image/v5/types"

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	util2 "github.com/containers/podman/v5/pkg/bindings/internal/util"
 	"io"
 	"io/fs"
 	"net/http"
@@ -34,11 +35,6 @@ import (
 	gzip "github.com/klauspost/pgzip"
 	"github.com/sirupsen/logrus"
 )
-
-type devino struct {
-	Dev uint64
-	Ino uint64
-}
 
 var iidRegex = regexp.Delayed(`^[0-9a-f]{12}`)
 
@@ -723,7 +719,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 		defer pw.Close()
 		defer gw.Close()
 		defer tw.Close()
-		seen := make(map[devino]string)
+		seen := make(map[util2.Devino]string)
 		for i, src := range sources {
 			source, err := filepath.Abs(src)
 			if err != nil {
@@ -786,7 +782,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					if err != nil {
 						return err
 					}
-					di, isHardLink := checkHardLink(info)
+					di, isHardLink := util2.CheckHardLink(info)
 					if err != nil {
 						return err
 					}

--- a/pkg/bindings/images/build_windows.go
+++ b/pkg/bindings/images/build_windows.go
@@ -1,9 +1,0 @@
-package images
-
-import (
-	"os"
-)
-
-func checkHardLink(fi os.FileInfo) (devino, bool) {
-	return devino{}, false
-}

--- a/pkg/bindings/internal/util/build_unix.go
+++ b/pkg/bindings/internal/util/build_unix.go
@@ -1,15 +1,15 @@
 //go:build !windows
 
-package images
+package util
 
 import (
 	"os"
 	"syscall"
 )
 
-func checkHardLink(fi os.FileInfo) (devino, bool) {
+func CheckHardLink(fi os.FileInfo) (Devino, bool) {
 	st := fi.Sys().(*syscall.Stat_t)
-	return devino{
+	return Devino{
 		Dev: uint64(st.Dev), //nolint: unconvert
 		Ino: st.Ino,
 	}, st.Nlink > 1

--- a/pkg/bindings/internal/util/build_windows.go
+++ b/pkg/bindings/internal/util/build_windows.go
@@ -1,0 +1,9 @@
+package util
+
+import (
+	"os"
+)
+
+func CheckHardLink(fi os.FileInfo) (Devino, bool) {
+	return Devino{}, false
+}

--- a/pkg/bindings/internal/util/tar_builder.go
+++ b/pkg/bindings/internal/util/tar_builder.go
@@ -1,0 +1,187 @@
+package util
+
+import (
+	"archive/tar"
+	"fmt"
+	"github.com/containers/storage/pkg/fileutils"
+	"github.com/containers/storage/pkg/ioutils"
+	"github.com/hashicorp/go-multierror"
+	gzip "github.com/klauspost/pgzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type Devino struct {
+	Dev uint64
+	Ino uint64
+}
+
+type TarBuilder struct {
+	sources  []sourceMapping
+	excludes []string
+}
+
+type sourceMapping struct {
+	source string // Absolute path of the source directory/file
+	target string // Custom path inside the tar archive
+}
+
+// NewTarBuilder returns a new TarBuilder
+func NewTarBuilder() *TarBuilder {
+	return &TarBuilder{
+		sources:  []sourceMapping{},
+		excludes: []string{},
+	}
+}
+
+// Add adds a new source directory or file and the corresponding target inside the tar.
+func (tb *TarBuilder) Add(source string, target string) error {
+	absSource, err := filepath.Abs(source)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path for source: %v", err)
+	}
+	tb.sources = append(tb.sources, sourceMapping{source: absSource, target: target})
+	return nil
+}
+
+// Exclude adds patterns to be excluded during tar creation.
+func (tb *TarBuilder) Exclude(patterns ...string) {
+	tb.excludes = append(tb.excludes, patterns...)
+}
+
+// Build generates the tarball and returns a ReadCloser for the tar stream.
+func (tb *TarBuilder) Build() (io.ReadCloser, error) {
+	if len(tb.sources) == 0 {
+		return nil, fmt.Errorf("no source(s) added for tar creation")
+	}
+
+	pm, err := fileutils.NewPatternMatcher(tb.excludes)
+	if err != nil {
+		return nil, fmt.Errorf("processing excludes list %v: %w", tb.excludes, err)
+	}
+
+	pr, pw := io.Pipe()
+	gw := gzip.NewWriter(pw)
+	tw := tar.NewWriter(gw)
+
+	var merr *multierror.Error
+	go func() {
+		defer pw.Close()
+		defer gw.Close()
+		defer tw.Close()
+
+		seen := make(map[Devino]string)
+
+		for _, src := range tb.sources {
+			err = filepath.WalkDir(src.source, func(path string, dentry fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				// Build the relative path under the custom target path
+				relPath, err := filepath.Rel(src.source, path)
+				if err != nil {
+					return err
+				}
+				targetPath := filepath.ToSlash(filepath.Join(src.target, relPath))
+
+				// Check exclusion patterns
+				if !filepath.IsAbs(targetPath) {
+					excluded, err := pm.Matches(targetPath)
+					if err != nil {
+						return fmt.Errorf("checking if %q is excluded: %w", targetPath, err)
+					}
+					if excluded {
+						return nil
+					}
+				}
+
+				switch {
+				case dentry.Type().IsRegular(): // Handle files
+					info, err := dentry.Info()
+					if err != nil {
+						return err
+					}
+					di, isHardLink := CheckHardLink(info)
+					if err != nil {
+						return err
+					}
+
+					hdr, err := tar.FileInfoHeader(info, "")
+					if err != nil {
+						return err
+					}
+					hdr.Name = targetPath
+					hdr.Uid, hdr.Gid = 0, 0
+					orig, ok := seen[di]
+					if ok {
+						hdr.Typeflag = tar.TypeLink
+						hdr.Linkname = orig
+						hdr.Size = 0
+						return tw.WriteHeader(hdr)
+					}
+
+					f, err := os.Open(path)
+					if err != nil {
+						return err
+					}
+					defer f.Close()
+
+					if err := tw.WriteHeader(hdr); err != nil {
+						return err
+					}
+					_, err = io.Copy(tw, f)
+					if err == nil && isHardLink {
+						seen[di] = targetPath
+					}
+					return err
+				case dentry.IsDir(): // Handle directories
+					info, err := dentry.Info()
+					if err != nil {
+						return err
+					}
+					hdr, lerr := tar.FileInfoHeader(info, targetPath)
+					if lerr != nil {
+						return lerr
+					}
+					hdr.Name = targetPath
+					hdr.Uid, hdr.Gid = 0, 0
+					return tw.WriteHeader(hdr)
+				case dentry.Type()&os.ModeSymlink != 0: // Handle symlinks
+					link, err := os.Readlink(path)
+					if err != nil {
+						return err
+					}
+					info, err := dentry.Info()
+					if err != nil {
+						return err
+					}
+					hdr, lerr := tar.FileInfoHeader(info, link)
+					if lerr != nil {
+						return lerr
+					}
+					hdr.Name = targetPath
+					hdr.Uid, hdr.Gid = 0, 0
+					return tw.WriteHeader(hdr)
+				}
+				return nil
+			})
+
+			if err != nil {
+				merr = multierror.Append(merr, err)
+			}
+		}
+	}()
+
+	rc := ioutils.NewReadCloserWrapper(pr, func() error {
+		if merr != nil {
+			merr = multierror.Append(merr, pr.Close())
+			return merr.ErrorOrNil()
+		}
+		return pr.Close()
+	})
+
+	return rc, nil
+}

--- a/pkg/bindings/internal/util/tar_builder.go
+++ b/pkg/bindings/internal/util/tar_builder.go
@@ -3,14 +3,15 @@ package util
 import (
 	"archive/tar"
 	"fmt"
-	"github.com/containers/storage/pkg/fileutils"
-	"github.com/containers/storage/pkg/ioutils"
-	"github.com/hashicorp/go-multierror"
-	gzip "github.com/klauspost/pgzip"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/containers/storage/pkg/fileutils"
+	"github.com/containers/storage/pkg/ioutils"
+	"github.com/hashicorp/go-multierror"
+	gzip "github.com/klauspost/pgzip"
 )
 
 type Devino struct {
@@ -89,7 +90,7 @@ func (tb *TarBuilder) Build() (io.ReadCloser, error) {
 
 				// Check exclusion patterns
 				if !filepath.IsAbs(targetPath) {
-					excluded, err := pm.Matches(targetPath)
+					excluded, err := pm.IsMatch(targetPath)
 					if err != nil {
 						return fmt.Errorf("checking if %q is excluded: %w", targetPath, err)
 					}

--- a/pkg/bindings/internal/util/tar_builder_test.go
+++ b/pkg/bindings/internal/util/tar_builder_test.go
@@ -1,0 +1,212 @@
+package util
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTarBuilder(t *testing.T) {
+	testCases := []struct {
+		description string
+		setup       func(tempDir string) []struct{ source, target string }
+		excludes    []string
+		validate    func(t *testing.T, destDir string)
+		expectError bool
+	}{
+		{
+			description: "single file",
+			setup: func(tempDir string) []struct{ source, target string } {
+				srcFile := filepath.Join(tempDir, "file1.txt")
+				os.WriteFile(srcFile, []byte("hello"), 0644)
+				return []struct{ source, target string }{
+					{source: srcFile, target: "file1.txt"},
+				}
+			},
+			validate: func(t *testing.T, destDir string) {
+				fileContent, err := os.ReadFile(filepath.Join(destDir, "file1.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "hello", string(fileContent))
+			},
+		},
+		{
+			description: "multiple files with custom targets",
+			setup: func(tempDir string) []struct{ source, target string } {
+				srcFile1 := filepath.Join(tempDir, "file1.txt")
+				srcFile2 := filepath.Join(tempDir, "file2.txt")
+				os.WriteFile(srcFile1, []byte("hello1"), 0644)
+				os.WriteFile(srcFile2, []byte("hello2"), 0644)
+				return []struct{ source, target string }{
+					{source: srcFile1, target: "dir1/file1.txt"},
+					{source: srcFile2, target: "dir2/file2.txt"},
+				}
+			},
+			validate: func(t *testing.T, destDir string) {
+				file1Content, err := os.ReadFile(filepath.Join(destDir, "dir1/file1.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "hello1", string(file1Content))
+
+				file2Content, err := os.ReadFile(filepath.Join(destDir, "dir2/file2.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "hello2", string(file2Content))
+			},
+		},
+		{
+			description: "nested directories",
+			setup: func(tempDir string) []struct{ source, target string } {
+				dir := filepath.Join(tempDir, "nested")
+				os.Mkdir(dir, 0755)
+				os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("nested file1"), 0644)
+				os.Mkdir(filepath.Join(dir, "subdir"), 0755)
+				os.WriteFile(filepath.Join(dir, "subdir", "file2.txt"), []byte("nested file2"), 0644)
+				return []struct{ source, target string }{
+					{source: dir, target: "nested"},
+				}
+			},
+			validate: func(t *testing.T, destDir string) {
+				file1Content, err := os.ReadFile(filepath.Join(destDir, "nested/file1.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "nested file1", string(file1Content))
+
+				file2Content, err := os.ReadFile(filepath.Join(destDir, "nested/subdir/file2.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "nested file2", string(file2Content))
+			},
+		},
+		{
+			description: "empty directories",
+			setup: func(tempDir string) []struct{ source, target string } {
+				dir := filepath.Join(tempDir, "emptydir")
+				os.Mkdir(dir, 0755)
+				return []struct{ source, target string }{
+					{source: dir, target: "emptydir"},
+				}
+			},
+			validate: func(t *testing.T, destDir string) {
+				info, err := os.Stat(filepath.Join(destDir, "emptydir"))
+				assert.NoError(t, err)
+				assert.True(t, info.IsDir())
+			},
+		},
+		{
+			description: "exclude specific files",
+			setup: func(tempDir string) []struct{ source, target string } {
+				os.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("file1"), 0644)
+				os.WriteFile(filepath.Join(tempDir, "file2.log"), []byte("file2"), 0644)
+				os.WriteFile(filepath.Join(tempDir, "file3.tmp"), []byte("file3"), 0644)
+				return []struct{ source, target string }{
+					{source: tempDir, target: ""},
+				}
+			},
+			excludes: []string{"*.log", "*.tmp"},
+			validate: func(t *testing.T, destDir string) {
+				_, err := os.Stat(filepath.Join(destDir, "file2.log"))
+				assert.Error(t, err) // file2.log should be excluded
+
+				_, err = os.Stat(filepath.Join(destDir, "file3.tmp"))
+				assert.Error(t, err) // file3.tmp should be excluded
+
+				file1Content, err := os.ReadFile(filepath.Join(destDir, "file1.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "file1", string(file1Content))
+			},
+		},
+		{
+			description: "symlink handling",
+			setup: func(tempDir string) []struct{ source, target string } {
+				filePath := filepath.Join(tempDir, "file.txt")
+				os.WriteFile(filePath, []byte("real file"), 0644)
+				linkPath := filepath.Join(tempDir, "symlink")
+				os.Symlink("file.txt", linkPath)
+				return []struct{ source, target string }{
+					{source: tempDir, target: ""},
+				}
+			},
+			validate: func(t *testing.T, destDir string) {
+				// Check the symlink exists
+				linkDest, err := os.Readlink(filepath.Join(destDir, "symlink"))
+				assert.NoError(t, err)
+				assert.Equal(t, "file.txt", linkDest)
+
+				// Check the file is also correctly copied
+				fileContent, err := os.ReadFile(filepath.Join(destDir, "file.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "real file", string(fileContent))
+			},
+		},
+		{
+			description: "multiple sources",
+			setup: func(tempDir string) []struct{ source, target string } {
+				srcFile1 := filepath.Join(tempDir, "source1", "file1.txt")
+				srcFile2 := filepath.Join(tempDir, "source2", "file2.txt")
+				os.Mkdir(filepath.Dir(srcFile1), 0755)
+				os.Mkdir(filepath.Dir(srcFile2), 0755)
+				os.WriteFile(srcFile1, []byte("hello1"), 0644)
+				os.WriteFile(srcFile2, []byte("hello2"), 0644)
+				return []struct{ source, target string }{
+					{source: filepath.Dir(srcFile1), target: "target1"},
+					{source: filepath.Dir(srcFile2), target: "target2"},
+				}
+			},
+			validate: func(t *testing.T, destDir string) {
+				file1Content, err := os.ReadFile(filepath.Join(destDir, "target1/file1.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "hello1", string(file1Content))
+
+				file2Content, err := os.ReadFile(filepath.Join(destDir, "target2/file2.txt"))
+				assert.NoError(t, err)
+				assert.Equal(t, "hello2", string(file2Content))
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			// Create a temporary directory for the test setup
+			tempDir := t.TempDir()
+
+			// Set up the test files and directories
+			sourceMappings := testCase.setup(tempDir)
+
+			// Create a new TarBuilder
+			tb := NewTarBuilder()
+
+			// Add source mappings
+			for _, mapping := range sourceMappings {
+				err := tb.Add(mapping.source, mapping.target)
+				assert.NoError(t, err)
+			}
+
+			// Add excludes, if any
+			tb.Exclude(testCase.excludes...)
+
+			// Build the tarball
+			tarStream, err := tb.Build()
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			defer tarStream.Close()
+
+			// Create a temporary directory to untar the result
+			destDir := t.TempDir()
+
+			// Untar the resulting tarball
+			err = untar(tarStream, destDir)
+			assert.NoError(t, err)
+
+			// Validate the output
+			testCase.validate(t, destDir)
+		})
+	}
+}
+
+// Helper function to untar the resulting tarball
+func untar(tarStream io.Reader, destDir string) error {
+	return archive.Untar(tarStream, destDir, nil)
+}

--- a/pkg/bindings/internal/util/tar_builder_test.go
+++ b/pkg/bindings/internal/util/tar_builder_test.go
@@ -22,7 +22,8 @@ func TestTarBuilder(t *testing.T) {
 			description: "single file",
 			setup: func(tempDir string) []struct{ source, target string } {
 				srcFile := filepath.Join(tempDir, "file1.txt")
-				os.WriteFile(srcFile, []byte("hello"), 0644)
+				err := os.WriteFile(srcFile, []byte("hello"), 0644)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: srcFile, target: "file1.txt"},
 				}
@@ -38,8 +39,10 @@ func TestTarBuilder(t *testing.T) {
 			setup: func(tempDir string) []struct{ source, target string } {
 				srcFile1 := filepath.Join(tempDir, "file1.txt")
 				srcFile2 := filepath.Join(tempDir, "file2.txt")
-				os.WriteFile(srcFile1, []byte("hello1"), 0644)
-				os.WriteFile(srcFile2, []byte("hello2"), 0644)
+				err := os.WriteFile(srcFile1, []byte("hello1"), 0644)
+				assert.NoError(t, err)
+				err = os.WriteFile(srcFile2, []byte("hello2"), 0644)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: srcFile1, target: "dir1/file1.txt"},
 					{source: srcFile2, target: "dir2/file2.txt"},
@@ -59,10 +62,14 @@ func TestTarBuilder(t *testing.T) {
 			description: "nested directories",
 			setup: func(tempDir string) []struct{ source, target string } {
 				dir := filepath.Join(tempDir, "nested")
-				os.Mkdir(dir, 0755)
-				os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("nested file1"), 0644)
-				os.Mkdir(filepath.Join(dir, "subdir"), 0755)
-				os.WriteFile(filepath.Join(dir, "subdir", "file2.txt"), []byte("nested file2"), 0644)
+				err := os.Mkdir(dir, 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("nested file1"), 0644)
+				assert.NoError(t, err)
+				err = os.Mkdir(filepath.Join(dir, "subdir"), 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(dir, "subdir", "file2.txt"), []byte("nested file2"), 0644)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: dir, target: "nested"},
 				}
@@ -81,7 +88,8 @@ func TestTarBuilder(t *testing.T) {
 			description: "empty directories",
 			setup: func(tempDir string) []struct{ source, target string } {
 				dir := filepath.Join(tempDir, "emptydir")
-				os.Mkdir(dir, 0755)
+				err := os.Mkdir(dir, 0755)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: dir, target: "emptydir"},
 				}
@@ -95,9 +103,12 @@ func TestTarBuilder(t *testing.T) {
 		{
 			description: "exclude specific files",
 			setup: func(tempDir string) []struct{ source, target string } {
-				os.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("file1"), 0644)
-				os.WriteFile(filepath.Join(tempDir, "file2.log"), []byte("file2"), 0644)
-				os.WriteFile(filepath.Join(tempDir, "file3.tmp"), []byte("file3"), 0644)
+				err := os.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("file1"), 0644)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(tempDir, "file2.log"), []byte("file2"), 0644)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(tempDir, "file3.tmp"), []byte("file3"), 0644)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: tempDir, target: ""},
 				}
@@ -119,9 +130,11 @@ func TestTarBuilder(t *testing.T) {
 			description: "symlink handling",
 			setup: func(tempDir string) []struct{ source, target string } {
 				filePath := filepath.Join(tempDir, "file.txt")
-				os.WriteFile(filePath, []byte("real file"), 0644)
+				err := os.WriteFile(filePath, []byte("real file"), 0644)
+				assert.NoError(t, err)
 				linkPath := filepath.Join(tempDir, "symlink")
-				os.Symlink("file.txt", linkPath)
+				err = os.Symlink("file.txt", linkPath)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: tempDir, target: ""},
 				}
@@ -143,10 +156,14 @@ func TestTarBuilder(t *testing.T) {
 			setup: func(tempDir string) []struct{ source, target string } {
 				srcFile1 := filepath.Join(tempDir, "source1", "file1.txt")
 				srcFile2 := filepath.Join(tempDir, "source2", "file2.txt")
-				os.Mkdir(filepath.Dir(srcFile1), 0755)
-				os.Mkdir(filepath.Dir(srcFile2), 0755)
-				os.WriteFile(srcFile1, []byte("hello1"), 0644)
-				os.WriteFile(srcFile2, []byte("hello2"), 0644)
+				err := os.Mkdir(filepath.Dir(srcFile1), 0755)
+				assert.NoError(t, err)
+				err = os.Mkdir(filepath.Dir(srcFile2), 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(srcFile1, []byte("hello1"), 0644)
+				assert.NoError(t, err)
+				err = os.WriteFile(srcFile2, []byte("hello2"), 0644)
+				assert.NoError(t, err)
 				return []struct{ source, target string }{
 					{source: filepath.Dir(srcFile1), target: "target1"},
 					{source: filepath.Dir(srcFile2), target: "target2"},

--- a/pkg/bindings/kube/kube.go
+++ b/pkg/bindings/kube/kube.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	util2 "github.com/containers/podman/v5/pkg/bindings/internal/util"
-	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
-	"github.com/containers/podman/v5/pkg/util"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	util2 "github.com/containers/podman/v5/pkg/bindings/internal/util"
+	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
+	"github.com/containers/podman/v5/pkg/util"
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/pkg/auth"
@@ -162,7 +163,7 @@ func getTarKubePlayContext(reader io.Reader, contextDir string) (io.ReadCloser, 
 	}
 
 	// create a tmp directory
-	tmp, err := os.MkdirTemp("", "kube")
+	tmp, err := os.MkdirTemp(os.TempDir(), "kube")
 	if err != nil {
 		return nil, err
 	}
@@ -175,6 +176,9 @@ func getTarKubePlayContext(reader io.Reader, contextDir string) (io.ReadCloser, 
 	}
 
 	err = tb.Add(playYaml, "play.yaml")
+	if err != nil {
+		return nil, err
+	}
 
 	tarfile, err := tb.Build()
 	if err != nil {

--- a/pkg/bindings/kube/kube.go
+++ b/pkg/bindings/kube/kube.go
@@ -3,9 +3,14 @@ package kube
 import (
 	"bytes"
 	"context"
+	"fmt"
+	util2 "github.com/containers/podman/v5/pkg/bindings/internal/util"
+	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
+	"github.com/containers/podman/v5/pkg/util"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/containers/image/v5/types"
@@ -14,6 +19,7 @@ import (
 	"github.com/containers/podman/v5/pkg/bindings/generate"
 	entitiesTypes "github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 func Play(ctx context.Context, path string, options *PlayOptions) (*entitiesTypes.KubePlayReport, error) {
@@ -75,6 +81,21 @@ func PlayWithBody(ctx context.Context, body io.Reader, options *PlayOptions) (*e
 		return nil, err
 	}
 
+	if options.GetBuild() && len(options.GetContextDir()) == 0 {
+		return nil, fmt.Errorf("build option may be specified only with context-dir")
+	}
+
+	if options.GetBuild() {
+		// specify the content type
+		header.Set("Content-Type", "application/x-tar")
+		tar, err := getTarKubePlayContext(body, options.GetContextDir())
+		if err != nil {
+			return nil, err
+		}
+		defer tar.Close()
+		body = tar
+	}
+
 	response, err := conn.DoRequest(ctx, body, http.MethodPost, "/play/kube", params, header)
 	if err != nil {
 		return nil, err
@@ -86,6 +107,82 @@ func PlayWithBody(ctx context.Context, body io.Reader, options *PlayOptions) (*e
 	}
 
 	return &report, nil
+}
+
+func getTarKubePlayContext(reader io.Reader, contextDir string) (io.ReadCloser, error) {
+	// read the document
+	yamlBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// split yaml document
+	documentList, err := util.SplitMultiDocYAML(yamlBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new TarBuilder
+	tb := util2.NewTarBuilder()
+
+	// Iterate over the documents
+	for _, document := range documentList {
+		// Get the kind
+		kind, err := util.GetKubeKind(document)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read kube YAML: %w", err)
+		}
+
+		// ignore non-pod resources
+		if kind != "Pod" {
+			continue
+		}
+
+		var podYAML v1.Pod
+		if err := yaml.Unmarshal(document, &podYAML); err != nil {
+			return nil, fmt.Errorf("unable to read YAML as Kube Pod: %w", err)
+		}
+
+		for _, container := range podYAML.Spec.Containers {
+			buildFile, err := util.GetBuildFile(container.Image, contextDir)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(buildFile) == 0 {
+				continue
+			}
+
+			// add the context directory of the container image to the tar
+			err = tb.Add(filepath.Dir(buildFile), container.Image)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// create a tmp directory
+	tmp, err := os.MkdirTemp("", "kube")
+	if err != nil {
+		return nil, err
+	}
+
+	// create a tmp file for the yaml document
+	playYaml := filepath.Join(tmp, "play.yaml")
+	err = os.WriteFile(playYaml, yamlBytes, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tb.Add(playYaml, "play.yaml")
+
+	tarfile, err := tb.Build()
+	if err != nil {
+		logrus.Errorf("Cannot tar entries %v error: %v", contextDir, err)
+		return nil, err
+	}
+
+	return tarfile, nil
 }
 
 func Down(ctx context.Context, path string, options DownOptions) (*entitiesTypes.KubePlayReport, error) {

--- a/pkg/bindings/kube/kube_test.go
+++ b/pkg/bindings/kube/kube_test.go
@@ -40,8 +40,10 @@ spec:
 				// Create a temporary context directory with a Dockerfile for the "foobar" image
 				tmpDir := t.TempDir()
 				fooBarDir := filepath.Join(tmpDir, "foobar")
-				os.Mkdir(fooBarDir, 0755)
-				os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox"), 0644)
+				err := os.Mkdir(fooBarDir, 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox"), 0644)
+				assert.NoError(t, err)
 				return tmpDir
 			},
 			expectedFiles: map[string]string{
@@ -74,12 +76,16 @@ spec:
 			setup: func(t *testing.T) string {
 				tmpDir := t.TempDir()
 				fooBarDir := filepath.Join(tmpDir, "foobar")
-				os.Mkdir(fooBarDir, 0755)
-				os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox:1"), 0644)
+				err := os.Mkdir(fooBarDir, 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox:1"), 0644)
+				assert.NoError(t, err)
 
 				barfooDir := filepath.Join(tmpDir, "barfoo")
-				os.Mkdir(barfooDir, 0755)
-				os.WriteFile(filepath.Join(barfooDir, "Containerfile"), []byte("FROM busybox:2"), 0644)
+				err = os.Mkdir(barfooDir, 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(barfooDir, "Containerfile"), []byte("FROM busybox:2"), 0644)
+				assert.NoError(t, err)
 				return tmpDir
 			},
 			expectedFiles: map[string]string{
@@ -177,12 +183,16 @@ spec:
 			setup: func(t *testing.T) string {
 				tmpDir := t.TempDir()
 				fooBarDir := filepath.Join(tmpDir, "foobar")
-				os.Mkdir(fooBarDir, 0755)
-				os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox:1"), 0644)
+				err := os.Mkdir(fooBarDir, 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox:1"), 0644)
+				assert.NoError(t, err)
 
 				barfooDir := filepath.Join(tmpDir, "barfoo")
-				os.Mkdir(barfooDir, 0755)
-				os.WriteFile(filepath.Join(barfooDir, "Containerfile"), []byte("FROM busybox:2"), 0644)
+				err = os.Mkdir(barfooDir, 0755)
+				assert.NoError(t, err)
+				err = os.WriteFile(filepath.Join(barfooDir, "Containerfile"), []byte("FROM busybox:2"), 0644)
+				assert.NoError(t, err)
 				return tmpDir
 			},
 			expectedFiles: map[string]string{

--- a/pkg/bindings/kube/kube_test.go
+++ b/pkg/bindings/kube/kube_test.go
@@ -1,0 +1,246 @@
+package kube
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper function to untar the resulting tarball
+func untar(tarStream io.Reader, destDir string) error {
+	return archive.Untar(tarStream, destDir, nil)
+}
+
+func TestGetTarKubePlayContext(t *testing.T) {
+	testCases := []struct {
+		description   string
+		yamlContent   string
+		setup         func(t *testing.T) string
+		expectedFiles map[string]string
+		expectError   bool
+	}{
+		{
+			description: "Basic pod definition with a single container",
+			yamlContent: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container
+      image: foobar
+`,
+			setup: func(t *testing.T) string {
+				// Create a temporary context directory with a Dockerfile for the "foobar" image
+				tmpDir := t.TempDir()
+				fooBarDir := filepath.Join(tmpDir, "foobar")
+				os.Mkdir(fooBarDir, 0755)
+				os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox"), 0644)
+				return tmpDir
+			},
+			expectedFiles: map[string]string{
+				"play.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container
+      image: foobar
+`, "foobar/Containerfile": "FROM busybox",
+			},
+		},
+		{
+			description: "Pod with multiple containers",
+			yamlContent: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container1
+      image: foobar
+    - name: container2
+      image: barfoo
+`,
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				fooBarDir := filepath.Join(tmpDir, "foobar")
+				os.Mkdir(fooBarDir, 0755)
+				os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox:1"), 0644)
+
+				barfooDir := filepath.Join(tmpDir, "barfoo")
+				os.Mkdir(barfooDir, 0755)
+				os.WriteFile(filepath.Join(barfooDir, "Containerfile"), []byte("FROM busybox:2"), 0644)
+				return tmpDir
+			},
+			expectedFiles: map[string]string{
+				"play.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container1
+      image: foobar
+    - name: container2
+      image: barfoo
+`,
+				"foobar/Containerfile": "FROM busybox:1",
+				"barfoo/Containerfile": "FROM busybox:2",
+			},
+		},
+		{
+			description: "Non-pod resources are ignored",
+			yamlContent: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-service
+spec:
+  ports:
+    - port: 80
+`,
+			setup: func(t *testing.T) string {
+				return t.TempDir() // No Dockerfile needed since no Pod exists
+			},
+			expectedFiles: map[string]string{
+				"play.yaml": `
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-service
+spec:
+  ports:
+    - port: 80
+`,
+			},
+		},
+		{
+			description: "Missing build file for container",
+			yamlContent: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container
+      image: missing-image
+`,
+			setup: func(t *testing.T) string {
+				return t.TempDir() // No Dockerfile for the missing image
+			},
+			expectedFiles: map[string]string{
+				"play.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container
+      image: missing-image
+`,
+			},
+		},
+		{
+			description: "Multiple YAML documents",
+			yamlContent: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+spec:
+  containers:
+    - name: container1
+      image: foobar
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+spec:
+  containers:
+    - name: container1
+      image: barfoo
+`,
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				fooBarDir := filepath.Join(tmpDir, "foobar")
+				os.Mkdir(fooBarDir, 0755)
+				os.WriteFile(filepath.Join(fooBarDir, "Containerfile"), []byte("FROM busybox:1"), 0644)
+
+				barfooDir := filepath.Join(tmpDir, "barfoo")
+				os.Mkdir(barfooDir, 0755)
+				os.WriteFile(filepath.Join(barfooDir, "Containerfile"), []byte("FROM busybox:2"), 0644)
+				return tmpDir
+			},
+			expectedFiles: map[string]string{
+				"play.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+spec:
+  containers:
+    - name: container1
+      image: foobar
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+spec:
+  containers:
+    - name: container1
+      image: barfoo
+`,
+				"foobar/Containerfile": "FROM busybox:1",
+				"barfoo/Containerfile": "FROM busybox:2",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			// Create the context directory based on the setup
+			contextDir := testCase.setup(t)
+
+			// Convert the YAML content to a reader
+			reader := bytes.NewReader([]byte(testCase.yamlContent))
+
+			// Call getTarKubePlayContext
+			tarStream, err := getTarKubePlayContext(reader, contextDir)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			defer tarStream.Close()
+
+			// Create a temporary directory to untar the result
+			destDir := t.TempDir()
+
+			// Untar the resulting tarball
+			err = untar(tarStream, destDir)
+			assert.NoError(t, err)
+
+			// Validate the contents of the tarball
+			for expectedPath, expectedContent := range testCase.expectedFiles {
+				actualContent, err := os.ReadFile(filepath.Join(destDir, expectedPath))
+				assert.NoError(t, err)
+				assert.Equal(t, expectedContent, string(actualContent))
+			}
+		})
+	}
+}

--- a/pkg/bindings/kube/types.go
+++ b/pkg/bindings/kube/types.go
@@ -61,6 +61,10 @@ type PlayOptions struct {
 	// Wait - indicates whether to return after having created the pods
 	Wait             *bool
 	ServiceContainer *bool
+	// Build - whether to build the image in the pods definition
+	Build *bool
+	// ContextDir - the context dir to use when Build option is defined
+	ContextDir *string
 }
 
 // ApplyOptions are optional options for applying kube YAML files to a k8s cluster

--- a/pkg/bindings/kube/types_play_options.go
+++ b/pkg/bindings/kube/types_play_options.go
@@ -392,3 +392,33 @@ func (o *PlayOptions) GetServiceContainer() bool {
 	}
 	return *o.ServiceContainer
 }
+
+// WithBuild set field Build to given value
+func (o *PlayOptions) WithBuild(value bool) *PlayOptions {
+	o.Build = &value
+	return o
+}
+
+// GetBuild returns value of field Build
+func (o *PlayOptions) GetBuild() bool {
+	if o.Build == nil {
+		var z bool
+		return z
+	}
+	return *o.Build
+}
+
+// WithContextDir set field ContextDir to given value
+func (o *PlayOptions) WithContextDir(value string) *PlayOptions {
+	o.ContextDir = &value
+	return o
+}
+
+// GetContextDir returns value of field ContextDir
+func (o *PlayOptions) GetContextDir() string {
+	if o.ContextDir == nil {
+		var z string
+		return z
+	}
+	return *o.ContextDir
+}

--- a/pkg/domain/infra/abi/apply.go
+++ b/pkg/domain/infra/abi/apply.go
@@ -9,11 +9,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/containers/podman/v5/pkg/util"
 	"io"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/containers/podman/v5/pkg/util"
 
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	k8sAPI "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"

--- a/pkg/domain/infra/abi/apply.go
+++ b/pkg/domain/infra/abi/apply.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/containers/podman/v5/pkg/util"
 	"io"
 	"net/http"
 	"os"
@@ -30,7 +31,7 @@ func (ic *ContainerEngine) KubeApply(ctx context.Context, body io.Reader, option
 	}
 
 	// Split the yaml file
-	documentList, err := splitMultiDocYAML(content)
+	documentList, err := util.SplitMultiDocYAML(content)
 	if err != nil {
 		return err
 	}
@@ -60,7 +61,7 @@ func (ic *ContainerEngine) KubeApply(ctx context.Context, body io.Reader, option
 	}
 
 	for _, document := range documentList {
-		kind, err := getKubeKind(document)
+		kind, err := util.GetKubeKind(document)
 		if err != nil {
 			return fmt.Errorf("unable to read kube YAML: %w", err)
 		}

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -3,7 +3,6 @@
 package abi
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -31,7 +30,6 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/infra/abi/internal/expansion"
 	v1apps "github.com/containers/podman/v5/pkg/k8s.io/api/apps/v1"
 	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
-	metav1 "github.com/containers/podman/v5/pkg/k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/containers/podman/v5/pkg/specgen/generate"
 	"github.com/containers/podman/v5/pkg/specgen/generate/kube"
@@ -39,12 +37,10 @@ import (
 	"github.com/containers/podman/v5/pkg/systemd/notifyproxy"
 	"github.com/containers/podman/v5/pkg/util"
 	"github.com/containers/podman/v5/utils"
-	"github.com/containers/storage/pkg/fileutils"
 	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
-	yamlv3 "gopkg.in/yaml.v3"
 	"sigs.k8s.io/yaml"
 )
 
@@ -267,7 +263,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 	}
 
 	// split yaml document
-	documentList, err := splitMultiDocYAML(content)
+	documentList, err := util.SplitMultiDocYAML(content)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +301,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 	// create pod on each document if it is a pod or deployment
 	// any other kube kind will be skipped
 	for _, document := range documentList {
-		kind, err := getKubeKind(document)
+		kind, err := util.GetKubeKind(document)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read kube YAML: %w", err)
 		}
@@ -1191,7 +1187,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 //   - A Dockerfile or Containerfile exists in that folder
 //   - The image doesn't exist locally OR the user explicitly provided the option `--build`
 func (ic *ContainerEngine) buildImageFromContainerfile(ctx context.Context, cwd string, writer io.Writer, image string, options entities.PlayKubeOptions) (*libimage.Image, error) {
-	buildFile, err := getBuildFile(image, cwd)
+	buildFile, err := util.GetBuildFile(image, cwd)
 	if err != nil {
 		return nil, err
 	}
@@ -1490,13 +1486,13 @@ func readConfigMapFromFile(r io.Reader) ([]v1.ConfigMap, error) {
 	}
 
 	// split yaml document
-	documentList, err := splitMultiDocYAML(content)
+	documentList, err := util.SplitMultiDocYAML(content)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read as kube YAML: %w", err)
 	}
 
 	for _, document := range documentList {
-		kind, err := getKubeKind(document)
+		kind, err := util.GetKubeKind(document)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read as kube YAML: %w", err)
 		}
@@ -1515,79 +1511,13 @@ func readConfigMapFromFile(r io.Reader) ([]v1.ConfigMap, error) {
 	return configMaps, nil
 }
 
-// splitMultiDocYAML reads multiple documents in a YAML file and
-// returns them as a list.
-func splitMultiDocYAML(yamlContent []byte) ([][]byte, error) {
-	var documentList [][]byte
-
-	d := yamlv3.NewDecoder(bytes.NewReader(yamlContent))
-	for {
-		var o interface{}
-		// read individual document
-		err := d.Decode(&o)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("multi doc yaml could not be split: %w", err)
-		}
-
-		if o == nil {
-			continue
-		}
-
-		// back to bytes
-		document, err := yamlv3.Marshal(o)
-		if err != nil {
-			return nil, fmt.Errorf("individual doc yaml could not be marshalled: %w", err)
-		}
-
-		kind, err := getKubeKind(document)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't get object kind: %w", err)
-		}
-
-		// The items in a document of kind "List" are fully qualified resources
-		// So, they can be treated as separate documents
-		if kind == "List" {
-			var kubeList metav1.List
-			if err := yaml.Unmarshal(document, &kubeList); err != nil {
-				return nil, err
-			}
-			for _, item := range kubeList.Items {
-				itemDocument, err := yamlv3.Marshal(item)
-				if err != nil {
-					return nil, fmt.Errorf("individual doc yaml could not be marshalled: %w", err)
-				}
-
-				documentList = append(documentList, itemDocument)
-			}
-		} else {
-			documentList = append(documentList, document)
-		}
-	}
-
-	return documentList, nil
-}
-
-// getKubeKind unmarshals a kube YAML document and returns its kind.
-func getKubeKind(obj []byte) (string, error) {
-	var kubeObject v1.ObjectReference
-
-	if err := yaml.Unmarshal(obj, &kubeObject); err != nil {
-		return "", err
-	}
-
-	return kubeObject.Kind, nil
-}
-
 // sortKubeKinds adds the correct creation order for the kube kinds.
 // Any pod dependency will be created first like volumes, secrets, etc.
 func sortKubeKinds(documentList [][]byte) ([][]byte, error) {
 	var sortedDocumentList [][]byte
 
 	for _, document := range documentList {
-		kind, err := getKubeKind(document)
+		kind, err := util.GetKubeKind(document)
 		if err != nil {
 			return nil, err
 		}
@@ -1601,52 +1531,6 @@ func sortKubeKinds(documentList [][]byte) ([][]byte, error) {
 	}
 
 	return sortedDocumentList, nil
-}
-
-func imageNamePrefix(imageName string) string {
-	prefix := imageName
-	s := strings.Split(prefix, ":")
-	if len(s) > 0 {
-		prefix = s[0]
-	}
-	s = strings.Split(prefix, "/")
-	if len(s) > 0 {
-		prefix = s[len(s)-1]
-	}
-	s = strings.Split(prefix, "@")
-	if len(s) > 0 {
-		prefix = s[0]
-	}
-	return prefix
-}
-
-func getBuildFile(imageName string, cwd string) (string, error) {
-	buildDirName := imageNamePrefix(imageName)
-	containerfilePath := filepath.Join(cwd, buildDirName, "Containerfile")
-	dockerfilePath := filepath.Join(cwd, buildDirName, "Dockerfile")
-
-	err := fileutils.Exists(containerfilePath)
-	if err == nil {
-		logrus.Debugf("Building %s with %s", imageName, containerfilePath)
-		return containerfilePath, nil
-	}
-	// If the error is not because the file does not exist, take
-	// a mulligan and try Dockerfile.  If that also fails, return that
-	// error
-	if err != nil && !os.IsNotExist(err) {
-		logrus.Error(err.Error())
-	}
-
-	err = fileutils.Exists(dockerfilePath)
-	if err == nil {
-		logrus.Debugf("Building %s with %s", imageName, dockerfilePath)
-		return dockerfilePath, nil
-	}
-	// Strike two
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	return "", err
 }
 
 func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, options entities.PlayKubeDownOptions) (*entities.PlayKubeReport, error) {
@@ -1664,7 +1548,7 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 	}
 
 	// split yaml document
-	documentList, err := splitMultiDocYAML(content)
+	documentList, err := util.SplitMultiDocYAML(content)
 	if err != nil {
 		return nil, err
 	}
@@ -1676,7 +1560,7 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, opt
 	}
 
 	for _, document := range documentList {
-		kind, err := getKubeKind(document)
+		kind, err := util.GetKubeKind(document)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read as kube YAML: %w", err)
 		}

--- a/pkg/domain/infra/abi/play_test.go
+++ b/pkg/domain/infra/abi/play_test.go
@@ -4,8 +4,9 @@ package abi
 
 import (
 	"bytes"
-	"github.com/containers/podman/v5/pkg/util"
 	"testing"
+
+	"github.com/containers/podman/v5/pkg/util"
 
 	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
 	v12 "github.com/containers/podman/v5/pkg/k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/domain/infra/abi/play_test.go
+++ b/pkg/domain/infra/abi/play_test.go
@@ -4,6 +4,7 @@ package abi
 
 import (
 	"bytes"
+	"github.com/containers/podman/v5/pkg/util"
 	"testing"
 
 	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
@@ -196,84 +197,13 @@ kind: Pod
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			kind, err := getKubeKind([]byte(test.kubeYAML))
+			kind, err := util.GetKubeKind([]byte(test.kubeYAML))
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedErrorMsg)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, test.expected, kind)
-			}
-		})
-	}
-}
-
-func TestSplitMultiDocYAML(t *testing.T) {
-	tests := []struct {
-		name             string
-		kubeYAML         string
-		expectError      bool
-		expectedErrorMsg string
-		expected         int
-	}{
-		{
-			"ValidNumberOfDocs",
-			`
-apiVersion: v1
-kind: Pod
----
-apiVersion: v1
-kind: Pod
----
-apiVersion: v1
-kind: Pod
-`,
-			false,
-			"",
-			3,
-		},
-		{
-			"InvalidMultiDocYAML",
-			`
-apiVersion: v1
-kind: Pod
----
-apiVersion: v1
-kind: Pod
--
-`,
-			true,
-			"multi doc yaml could not be split",
-			0,
-		},
-		{
-			"DocWithList",
-			`
-apiVersion: v1
-kind: List
-items:
-- apiVersion: v1
-  kind: Pod
-- apiVersion: v1
-  kind: Pod
-- apiVersion: v1
-  kind: Pod
-`,
-			false,
-			"",
-			3,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			docs, err := splitMultiDocYAML([]byte(test.kubeYAML))
-			if test.expectError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectedErrorMsg)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.expected, len(docs))
 			}
 		})
 	}

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -75,6 +75,10 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts en
 	options.WithPublishPorts(opts.PublishPorts)
 	options.WithPublishAllPorts(opts.PublishAllPorts)
 	options.WithNoTrunc(opts.UseLongAnnotations)
+	if build := opts.Build; build != types.OptionalBoolUndefined {
+		options.WithBuild(build == types.OptionalBoolTrue)
+	}
+	options.WithContextDir(opts.ContextDir)
 	return play.KubeWithBody(ic.ClientCtx, body, options)
 }
 

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -1,5 +1,22 @@
 package util
 
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	v1 "github.com/containers/podman/v5/pkg/k8s.io/api/core/v1"
+	metav1 "github.com/containers/podman/v5/pkg/k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/containers/storage/pkg/fileutils"
+	"github.com/sirupsen/logrus"
+	yamlv3 "gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
+)
+
 const (
 	// Kube annotation for podman volume driver.
 	VolumeDriverAnnotation = "volume.podman.io/driver"
@@ -18,3 +35,115 @@ const (
 	// Kube annotation for podman volume image.
 	VolumeImageAnnotation = "volume.podman.io/image"
 )
+
+// SplitMultiDocYAML reads multiple documents in a YAML file and
+// returns them as a list.
+func SplitMultiDocYAML(yamlContent []byte) ([][]byte, error) {
+	var documentList [][]byte
+
+	d := yamlv3.NewDecoder(bytes.NewReader(yamlContent))
+	for {
+		var o interface{}
+		// read individual document
+		err := d.Decode(&o)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("multi doc yaml could not be split: %w", err)
+		}
+
+		if o == nil {
+			continue
+		}
+
+		// back to bytes
+		document, err := yamlv3.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("individual doc yaml could not be marshalled: %w", err)
+		}
+
+		kind, err := GetKubeKind(document)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't get object kind: %w", err)
+		}
+
+		// The items in a document of kind "List" are fully qualified resources
+		// So, they can be treated as separate documents
+		if kind == "List" {
+			var kubeList metav1.List
+			if err := yaml.Unmarshal(document, &kubeList); err != nil {
+				return nil, err
+			}
+			for _, item := range kubeList.Items {
+				itemDocument, err := yamlv3.Marshal(item)
+				if err != nil {
+					return nil, fmt.Errorf("individual doc yaml could not be marshalled: %w", err)
+				}
+
+				documentList = append(documentList, itemDocument)
+			}
+		} else {
+			documentList = append(documentList, document)
+		}
+	}
+
+	return documentList, nil
+}
+
+// GetKubeKind unmarshals a kube YAML document and returns its kind.
+func GetKubeKind(obj []byte) (string, error) {
+	var kubeObject v1.ObjectReference
+
+	if err := yaml.Unmarshal(obj, &kubeObject); err != nil {
+		return "", err
+	}
+
+	return kubeObject.Kind, nil
+}
+
+func imageNamePrefix(imageName string) string {
+	prefix := imageName
+	s := strings.Split(prefix, ":")
+	if len(s) > 0 {
+		prefix = s[0]
+	}
+	s = strings.Split(prefix, "/")
+	if len(s) > 0 {
+		prefix = s[len(s)-1]
+	}
+	s = strings.Split(prefix, "@")
+	if len(s) > 0 {
+		prefix = s[0]
+	}
+	return prefix
+}
+
+func GetBuildFile(imageName string, cwd string) (string, error) {
+	buildDirName := imageNamePrefix(imageName)
+	containerfilePath := filepath.Join(cwd, buildDirName, "Containerfile")
+	dockerfilePath := filepath.Join(cwd, buildDirName, "Dockerfile")
+
+	err := fileutils.Exists(containerfilePath)
+	if err == nil {
+		logrus.Debugf("Building %s with %s", imageName, containerfilePath)
+		return containerfilePath, nil
+	}
+	// If the error is not because the file does not exist, take
+	// a mulligan and try Dockerfile.  If that also fails, return that
+	// error
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		logrus.Error(err.Error())
+	}
+
+	err = fileutils.Exists(dockerfilePath)
+	if err == nil {
+		logrus.Debugf("Building %s with %s", imageName, dockerfilePath)
+		return dockerfilePath, nil
+	}
+	// Strike two
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	return "", err
+}

--- a/pkg/util/kube_test.go
+++ b/pkg/util/kube_test.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetKubeKind(t *testing.T) {
+	tests := []struct {
+		name             string
+		kubeYAML         string
+		expectError      bool
+		expectedErrorMsg string
+		expected         string
+	}{
+		{
+			"ValidKubeYAML",
+			`
+apiVersion: v1
+kind: Pod
+`,
+			false,
+			"",
+			"Pod",
+		},
+		{
+			"InvalidKubeYAML",
+			"InvalidKubeYAML",
+			true,
+			"cannot unmarshal",
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kind, err := GetKubeKind([]byte(test.kubeYAML))
+			if test.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedErrorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, kind)
+			}
+		})
+	}
+}
+
+func TestSplitMultiDocYAML(t *testing.T) {
+	tests := []struct {
+		name             string
+		kubeYAML         string
+		expectError      bool
+		expectedErrorMsg string
+		expected         int
+	}{
+		{
+			"ValidNumberOfDocs",
+			`
+apiVersion: v1
+kind: Pod
+---
+apiVersion: v1
+kind: Pod
+---
+apiVersion: v1
+kind: Pod
+`,
+			false,
+			"",
+			3,
+		},
+		{
+			"InvalidMultiDocYAML",
+			`
+apiVersion: v1
+kind: Pod
+---
+apiVersion: v1
+kind: Pod
+-
+`,
+			true,
+			"multi doc yaml could not be split",
+			0,
+		},
+		{
+			"DocWithList",
+			`
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+- apiVersion: v1
+  kind: Pod
+- apiVersion: v1
+  kind: Pod
+`,
+			false,
+			"",
+			3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			docs, err := SplitMultiDocYAML([]byte(test.kubeYAML))
+			if test.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedErrorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, len(docs))
+			}
+		})
+	}
+}

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -1,4 +1,4 @@
-//go:build !remote_testing && (linux || freebsd)
+//go:build linux || freebsd
 
 // build for play kube is not supported on remote yet.
 
@@ -83,12 +83,14 @@ LABEL marge=mom
 		Expect(os.Chdir(yamlDir)).To(Succeed())
 		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
 
-		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "--build", "top.yaml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		stdErrString := session.ErrorToString()
-		Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
-		Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		if !IsRemote() {
+			stdErrString := session.ErrorToString()
+			Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
+			Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		}
 
 		exists := podmanTest.Podman([]string{"image", "exists", "foobar"})
 		exists.WaitWithDefaultTimeout()
@@ -123,12 +125,14 @@ LABEL marge=mom
 		Expect(os.Chdir(yamlDir)).To(Succeed())
 		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
 
-		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "--build", "top.yaml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		stdErrString := session.ErrorToString()
-		Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
-		Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		if !IsRemote() {
+			stdErrString := session.ErrorToString()
+			Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
+			Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		}
 
 		exists := podmanTest.Podman([]string{"image", "exists", "foobar"})
 		exists.WaitWithDefaultTimeout()
@@ -273,9 +277,11 @@ LABEL marge=mom
 		session := podmanTest.Podman([]string{"kube", "play", "--build", "top.yaml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		stdErrString := session.ErrorToString()
-		Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
-		Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		if !IsRemote() {
+			stdErrString := session.ErrorToString()
+			Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
+			Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		}
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "top_pod-foobar"})
 		inspect.WaitWithDefaultTimeout()
@@ -358,12 +364,14 @@ echo GOT-HERE
 		Expect(os.Chdir(yamlDir)).To(Succeed())
 		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
 
-		session := podmanTest.Podman([]string{"kube", "play", "echo.yaml"})
+		session := podmanTest.Podman([]string{"kube", "play", "--build", "echo.yaml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		stdErrString := session.ErrorToString()
-		Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
-		Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		if !IsRemote() {
+			stdErrString := session.ErrorToString()
+			Expect(stdErrString).To(ContainSubstring("Getting image source signatures"))
+			Expect(stdErrString).To(ContainSubstring("Writing manifest to image destination"))
+		}
 
 		cid := "echo_pod-foobar"
 		wait := podmanTest.Podman([]string{"wait", cid})


### PR DESCRIPTION
Fixes https://github.com/containers/podman/issues/14527

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add podman play kube --build support for podman remotes
```

## Changes

I can split this PR in smaller chunk if needed.

### Yaml Parsing Utility methods

Moving `SplitMultiDocYAML`, `getKubeKind`, `imageNamePrefix`, `getBuildFile` from `pkg/domain/infra/abi/play.go` to the utility `pkg/util/kube.go` to be able to access it from the binding

This is _necessary_ to have a single way of parsing those file between the client and the server, otherwise the client could send contexts that the server may not use.

### TarBuilder

The kube play binding will create a tarball and add several folders to a specific place in the tar. The images build have some similar logic, however the `nTar` function they used (bellow)

https://github.com/containers/podman/blob/66fa0149779d3330cb6d9485d42cba404b76d322/pkg/bindings/images/build.go#L703

Cannot be used, as it has very particular mechanism for any files/folder added after the first one. Therefore I created a TarBuilder struct, to be able to easily manipulate the creation of the tar.

I was hopeful to have some easy support through the `github.com/containers/storage/pkg/archive` package, has they have similar method implemented, but they do not expose it. (See discussion i opened on their repo https://github.com/moby/moby/discussions/48610)

I had to move `pkg/bindings/images/build_*.go` to the `pkg/bindings/internal/util/build_*.go` because importing those from the internal/util was leading to a circular import issue.

### Adding `Build` and `ContextDir` to types

In `pkg/bindings/kube/types.go` adding the `Build` and `ContextDir` types, to binding can use them.

## Testing

- [x] `pkg/bindings/internal/util/tar_builder_test.go` ensure the TarBuilder struct works as expected
- [x] `pkg/bindings/kube/kube_test.go` ensure client parse properly yaml files
- [x] `tests/e2e/play_build_test.go` ensure podman-remote can use `--build`

You may now use `./bin/podman-remote kube play --build example.yaml` :)