### PR TITLE
libpod: journald do not lock thread

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -99,8 +98,6 @@ func (e EventJournalD) Write(ee Event) error {
 
 // Read reads events from the journal and sends qualified events to the event channel
 func (e EventJournalD) Read(ctx context.Context, options ReadOptions) (retErr error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	filterMap, err := generateEventFilters(options.Filters, options.Since, options.Until)
 	if err != nil {
 		return fmt.Errorf("failed to parse event filters: %w", err)


### PR DESCRIPTION
This is not needed and was added by during debugging but it turned out to be something else. We should not lock the thread unless needed because this just raises question why it is here otherwise. Also the lock would not do much as we spawn a goroutine below anyway so it runs on another thread no matter what.

From the review comment by Miloslav but it was merged before I had the chance to fix it:
https://github.com/containers/podman/pull/24406#discussion_r1828102666

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
