### PR TITLE
Excluse symlink from pre-commit end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,12 @@ repos:
       # trailing whitespace as part of its format. We can work around that,
       # but unfortunately the buildah repo has some files with tabs, which
       # git-diff formats as '[+/-]<space><tab>', which these hooks choke on.
-      # `contrib/systemd/user` is a symlink but for some reason, on windows,
-      # pre-commit consider it as a regular file and tries to fix it.
-      # Just disable checks on these files as a special case.
+      # `contrib/systemd/user` and `test/python/requirements.txt` are symlinks
+      # but for some reason, on windows, pre-commit consider it as a regular
+      # file and tries to fix it. Just disable checks on these files as a
+      # special case.
       - id: end-of-file-fixer
-        exclude: test/buildah-bud/buildah-tests.diff|contrib/systemd/user
+        exclude: test/buildah-bud/buildah-tests.diff|contrib/systemd/user|test/python/requirements.txt
       - id: trailing-whitespace
         exclude: test/buildah-bud/buildah-tests.diff|test/e2e/quadlet/remap-keep-id2.container|test/e2e/quadlet/line-continuation-whitespace.container
       - id: mixed-line-ending


### PR DESCRIPTION
Git on Windows clones the symlink `test/python/requirements.txt` as a regular file. That's not a big deal except that `pre-commit`, executed by `winmake.ps1 lint`, complains because there is no new line at end of the file.

To fix `winmake.ps1 lint` we exclude the symlink in `pre-commit` hook `end-of-file-fixer` configuration.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
