### PR TITLE
Yet another bump, to fixed f41 kernel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20241106t163000z-f41f40d13"
+    IMAGE_SUFFIX: "c20241107t210000z-f41f40d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -147,11 +147,6 @@ case "$OS_RELEASE_ID" in
             msg "Enabling container_manage_cgroup"
             showrun setsebool container_manage_cgroup true
         fi
-
-        # Test nftables driver, https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault
-        # We can drop this once this implemented and pushed into fedora stable. We cannot test it on
-        # debian because the netavark version there is way to old for nftables support.
-        printf "[network]\nfirewall_driver=\"nftables\"\n" > /etc/containers/containers.conf.d/90-nftables.conf
         ;;
     *) die_unknown OS_RELEASE_ID
 esac


### PR DESCRIPTION
- **Yet another bump, f41 with fixed kernel**
- **Reapply "cirrus: test only on f40/rawhide"**
- **Revert "Reapply "CI: test nftables driver on fedora""**

```release-note
None
```