### PR TITLE
Buildah treadmill tweaks

### DIFF
--- a/hack/buildah-vendor-treadmill
+++ b/hack/buildah-vendor-treadmill
@@ -928,7 +928,12 @@ sub assert_buildah_vendor_commit {
     }
 
     if (! grep { m!^vendor/\Q$Buildah\E/! } @deltas) {
-        push @missing, "no changes under $Buildah";
+        # There's an infrequent corner case: changes in buildah are only in
+        # the tests and/or vendor dirs, which are not checked out in our tree.
+        my @go_mod_diffs = git('diff', '-U0', "$ref^", "$ref", "--", "go.mod");
+        if (! grep { /^[-+]\s+$Buildah\s/ } @go_mod_diffs) {
+            push @missing, "no changes under $Buildah";
+        }
     }
 
     return if !@missing;

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -241,7 +241,8 @@ skip_if_remote "--output option not implemented in podman-remote" \
 skip_if_remote "logfile not implemented on remote" "bud-logfile-with-split-logfile-by-platform"
 
 skip_if_remote "envariables do not automatically work with -remote." \
-               "build proxy"
+               "build proxy" \
+               "build-test --mount=type=secret test from env with chroot isolation"
 
 # 2022-07-04 this is a new test in buildah; it's failing in treadmill
 skip_if_remote "FIXME FIXME FIXME: does this test make sense in remote?" \
@@ -259,6 +260,9 @@ skip_if_remote "--events-backend does not work with podman-remote" \
 
 skip_if_remote "--cert-dir option not working via remote and retry warnings are printed on the server" \
             "build add https retry ca"
+
+skip_if_remote "Weird. This used to work remote, until Ed set TMPDIR in #5804" \
+               "bud-with-mount-cache-like-buildkit with buildah prune should clear the cache"
 
 ###############################################################################
 # BEGIN tests which are skipped due to actual podman or podman-remote bugs.

--- a/test/buildah-bud/buildah-tests.diff
+++ b/test/buildah-bud/buildah-tests.diff
@@ -1,4 +1,4 @@
-From e39e00a6d92acb83283705ea66c26261ca6a0170 Mon Sep 17 00:00:00 2001
+From d7839d93860915b2a43c486d0fed89fee7313ec0 Mon Sep 17 00:00:00 2001
 From: Ed Santiago <santiago@redhat.com>
 Date: Thu, 6 Oct 2022 17:32:59 -0600
 Subject: [PATCH] tweaks for running buildah tests under podman
@@ -9,10 +9,10 @@ Signed-off-by: Ed Santiago <santiago@redhat.com>
  1 file changed, 115 insertions(+), 4 deletions(-)
 
 diff --git a/tests/helpers.bash b/tests/helpers.bash
-index 20f0787ff..c356500ae 100644
+index f8ab624a8..0d8f5ce69 100644
 --- a/tests/helpers.bash
 +++ b/tests/helpers.bash
-@@ -79,6 +79,38 @@ EOF
+@@ -80,6 +80,38 @@ EOF
      BUILDAH_REGISTRY_OPTS="${regconfopt} ${regconfdir} --short-name-alias-conf ${TEST_SCRATCH_DIR}/cache/shortnames.conf"
      COPY_REGISTRY_OPTS="${BUILDAH_REGISTRY_OPTS}"
      PODMAN_REGISTRY_OPTS="${regconfopt}"
@@ -51,7 +51,7 @@ index 20f0787ff..c356500ae 100644
  }
  
  function starthttpd() { # directory [working-directory-or-"" [certfile, keyfile]]
-@@ -143,6 +175,32 @@ function teardown_tests() {
+@@ -144,6 +176,32 @@ function teardown_tests() {
      stop_git_daemon
      stop_registry
  
@@ -84,7 +84,7 @@ index 20f0787ff..c356500ae 100644
      # Workaround for #1991 - buildah + overlayfs leaks mount points.
      # Many tests leave behind /var/tmp/.../root/overlay and sub-mounts;
      # let's find those and clean them up, otherwise 'rm -rf' fails.
-@@ -232,7 +290,12 @@ function copy() {
+@@ -252,7 +310,12 @@ function copy() {
  }
  
  function podman() {
@@ -98,7 +98,7 @@ index 20f0787ff..c356500ae 100644
  }
  
  # There are various scenarios where we would like to execute `tests` as rootless user, however certain commands like `buildah mount`
-@@ -296,8 +359,36 @@ function run_buildah() {
+@@ -316,8 +379,36 @@ function run_buildah() {
          --retry)         retry=3;        shift;;  # retry network flakes
      esac
  
@@ -136,7 +136,7 @@ index 20f0787ff..c356500ae 100644
  
      # If session is rootless and `buildah mount` is invoked, perform unshare,
      # since normal user cannot mount a filesystem unless they're in a user namespace along with its own mount namespace.
-@@ -311,8 +402,8 @@ function run_buildah() {
+@@ -331,8 +422,8 @@ function run_buildah() {
          retry=$(( retry - 1 ))
  
          # stdout is only emitted upon error; this echo is to help a debugger
@@ -147,7 +147,7 @@ index 20f0787ff..c356500ae 100644
          # without "quotes", multiple lines are glommed together into one
          if [ -n "$output" ]; then
              echo "$output"
-@@ -673,6 +764,26 @@ function skip_if_no_unshare() {
+@@ -693,6 +784,26 @@ function skip_if_no_unshare() {
    fi
  }
  
@@ -175,5 +175,5 @@ index 20f0787ff..c356500ae 100644
    daemondir=${TEST_SCRATCH_DIR}/git-daemon
    mkdir -p ${daemondir}/repo
 -- 
-2.45.2
+2.47.0
 


### PR DESCRIPTION
* treadmill script: handle an obscure corner case
  wherein the script would bail because it thought
  there were no buildah-vendor changes.

* two new test skips

* update the diffs; line-number changes due to buildah
  PRs touching helpers.bash

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```