### PR TITLE
add support for driver-specific options during container creation

### DIFF
--- a/docs/source/markdown/options/network.md
+++ b/docs/source/markdown/options/network.md
@@ -14,6 +14,9 @@ Valid _mode_ values are:
     - **ip6=**_IPv6_: Specify a static IPv6 address for this container.
     - **mac=**_MAC_: Specify a static MAC address for this container.
     - **interface_name=**_name_: Specify a name for the created network interface inside the container.
+    - **host_interface_name=**_name_: Specify a name for the created network interface outside the container.
+
+    Any other options will be passed through to netavark without validation. This can be useful to pass arguments to netavark plugins.
 
     For example, to set a static ipv4 address and a static mac address, use `--network bridge:ip=10.88.0.10,mac=44:33:22:11:00:99`.
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.5.1
 	github.com/containers/buildah v1.38.0
-	github.com/containers/common v0.61.0
+	github.com/containers/common v0.61.1-0.20241112152446-305e9ce69b0f
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.0
 	github.com/containers/image/v5 v5.33.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/buildah v1.38.0 h1:FmciZMwzhdcvtWj+8IE+61+lfTG2JfgrbZ2DUnEMnTE=
 github.com/containers/buildah v1.38.0/go.mod h1:tUsHC2bcgR5Q/R76qZUn7x0FRglqPFry2g5KhWfH4LI=
-github.com/containers/common v0.61.0 h1:j/84PTqZIKKYy42OEJsZmjZ4g4Kq2ERuC3tqp2yWdh4=
-github.com/containers/common v0.61.0/go.mod h1:NGRISq2vTFPSbhNqj6MLwyes4tWSlCnqbJg7R77B8xc=
+github.com/containers/common v0.61.1-0.20241112152446-305e9ce69b0f h1:K3jmJrkDJJhLnRdVFI7Gb5mv4/jb2ue9StZ2F1y2rsE=
+github.com/containers/common v0.61.1-0.20241112152446-305e9ce69b0f/go.mod h1:NGRISq2vTFPSbhNqj6MLwyes4tWSlCnqbJg7R77B8xc=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.0 h1:Z8ZEWb+Lio0d+lXexONdUWT4rm9lF91vH0g3ARnMy7o=

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -482,7 +482,10 @@ func parseBridgeNetworkOptions(opts string) (types.PerNetworkOptions, error) {
 			netOpts.InterfaceName = value
 
 		default:
-			return netOpts, fmt.Errorf("unknown bridge network option: %s", name)
+			if netOpts.Options == nil {
+				netOpts.Options = make(map[string]string)
+			}
+			netOpts.Options[name] = value
 		}
 	}
 	return netOpts, nil

--- a/pkg/specgen/namespaces_test.go
+++ b/pkg/specgen/namespaces_test.go
@@ -158,10 +158,32 @@ func TestParseNetworkFlag(t *testing.T) {
 			},
 		},
 		{
-			name:   "bridge mode with invalid option",
+			name:   "bridge mode with unknown option",
 			args:   []string{"bridge:abc=123"},
 			nsmode: Namespace{NSMode: Bridge},
-			err:    "unknown bridge network option: abc",
+			networks: map[string]types.PerNetworkOptions{
+				defaultNetName: {
+					InterfaceName: "",
+					Options: map[string]string{
+						"abc": "123",
+					},
+				},
+			},
+		},
+		{
+			name:   "bridge mode with multiple unknown options",
+			args:   []string{"bridge:abc=123,xyz=789,other=a-much-longer-value"},
+			nsmode: Namespace{NSMode: Bridge},
+			networks: map[string]types.PerNetworkOptions{
+				defaultNetName: {
+					InterfaceName: "",
+					Options: map[string]string{
+						"abc":   "123",
+						"xyz":   "789",
+						"other": "a-much-longer-value",
+					},
+				},
+			},
 		},
 		{
 			name:   "bridge mode with invalid ip",
@@ -174,6 +196,19 @@ func TestParseNetworkFlag(t *testing.T) {
 			args:   []string{"bridge:mac=123"},
 			nsmode: Namespace{NSMode: Bridge},
 			err:    "address 123: invalid MAC address",
+		},
+		{
+			name:   "bridge mode with host interface name",
+			args:   []string{"bridge:host_interface_name=my-veth"},
+			nsmode: Namespace{NSMode: Bridge},
+			networks: map[string]types.PerNetworkOptions{
+				defaultNetName: {
+					InterfaceName: "",
+					Options: map[string]string{
+						"host_interface_name": "my-veth",
+					},
+				},
+			},
 		},
 		{
 			name:   "network name",

--- a/vendor/github.com/containers/common/libnetwork/types/network.go
+++ b/vendor/github.com/containers/common/libnetwork/types/network.go
@@ -269,6 +269,8 @@ type PerNetworkOptions struct {
 	// InterfaceName for this container. Required in the backend.
 	// Optional in the frontend. Will be filled with ethX (where X is a integer) when empty.
 	InterfaceName string `json:"interface_name"`
+	// Driver-specific options for this container.
+	Options map[string]string `json:"options,omitempty"`
 }
 
 // NetworkOptions for a given container.

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.61.0"
+const Version = "0.62.0-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.61.0
+# github.com/containers/common v0.61.1-0.20241112152446-305e9ce69b0f
 ## explicit; go 1.22.6
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
This way has a huge disadvantage: The user will not see an error when he uses a non-existent option. Another disadvantage is, that if we add more options within podman, they might collide with the names chosen by plugins. Such issues might be hard to debug.
The advantage is that the usage is very nice:
`--network bridge:opt1=val1,opt2=val2`.

Alternatively, we could put this behind `opt=`, which is harder to use, but would solve all issues above:
`--network bridge:opt=opt1=val1,opt=opt2=val2`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A new `host_interface_name` option was added for bridge networks to specify the host side veth name, requires netavark >= 1.14.
```

Depends on: https://github.com/containers/common/pull/2245
Required by: https://github.com/containers/netavark/pull/1125