### PR TITLE
libpod: addHosts() prevent nil deref

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2322,7 +2322,7 @@ func (c *Container) addHosts() error {
 		// not be routed to the host.
 		// https://github.com/containers/podman/issues/22653
 		info, err := c.runtime.network.RootlessNetnsInfo()
-		if err == nil {
+		if err == nil && info != nil {
 			exclude = info.IPAddresses
 			if len(info.MapGuestIps) > 0 {
 				// we used --map-guest-addr to setup pasta so prefer this address

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -624,7 +624,7 @@ func (c *Container) addSpecialDNS(nameservers []string) []string {
 	switch {
 	case c.config.NetMode.IsBridge():
 		info, err := c.runtime.network.RootlessNetnsInfo()
-		if err == nil {
+		if err == nil && info != nil {
 			nameservers = append(nameservers, info.DnsForwardIps...)
 		}
 	case c.pastaResult != nil:


### PR DESCRIPTION
In theory RootlessNetnsInfo() should never return nil here. However that was actually only true when the rootless netns was set up before and wrote the right cache file with the ip addresses.

Given this cache file is a new feature just added in 5.3 if you updated from 5.2 or earlier the file will not exists thus cause failures for all following started containers.
The fix for this is to stop all containers and make sure the rootless-netns was removed so the next start creates it new with the proper 5.3 cache file. However as there is no way to rely on users doing that and it is also not requirement so simply handle the nil deref here.

The only way to test this would be to run the old version then the new version which we cannot really do in CI. We do have upgrade test for that but they are root only and likely need a lot more work to get them going rootless but certainly worth to explore to prevent such problems in the future.

Fixes: a1e6603133 ("libpod: make use of new pasta option from c/common")
Fixes: #24566

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in 5.3.0 that caused rootless containers using the bridge networking mode to cause a nil pointer dereference and thus fail to start.
```
