### PR TITLE
[v5.3] v5.3 backports

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "v5.3"
     # Sane (default) value for GOPROXY and GOSUMDB.
     GOPROXY: "https://proxy.golang.org,direct"
     GOSUMDB: "sum.golang.org"

--- a/docs/source/Reference.rst
+++ b/docs/source/Reference.rst
@@ -7,6 +7,8 @@ Show the API documentation for version:
 
 * `latest (main branch) <_static/api.html>`_
 
+* `version 5.3 <_static/api.html?version=v5.3>`_
+
 * `version 5.2 <_static/api.html?version=v5.2>`_
 
 * `version 5.1 <_static/api.html?version=v5.1>`_

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -662,7 +662,6 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	// setup rlimits
 	nofileSet := false
 	nprocSet := false
-	isRootless := rootless.IsRootless()
 	isRunningInUserNs := unshare.IsRootless()
 	if isRunningInUserNs && g.Config.Process != nil && g.Config.Process.OOMScoreAdj != nil {
 		var err error
@@ -682,7 +681,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	if !nofileSet {
 		max := rlimT(define.RLimitDefaultValue)
 		current := rlimT(define.RLimitDefaultValue)
-		if isRootless {
+		if isRunningInUserNs {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
 				logrus.Warnf("Failed to return RLIMIT_NOFILE ulimit %q", err)
@@ -699,7 +698,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	if !nprocSet {
 		max := rlimT(define.RLimitDefaultValue)
 		current := rlimT(define.RLimitDefaultValue)
-		if isRootless {
+		if isRunningInUserNs {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err != nil {
 				logrus.Warnf("Failed to return RLIMIT_NPROC ulimit %q", err)

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -162,68 +162,73 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 			return connection, err
 		}
 	}
-	// ssh_config
-	alias := _url.Hostname()
-	cfg := ssh_config.DefaultUserSettings
-	cfg.IgnoreErrors = true
-	found := false
 
-	if userinfo == nil {
-		if val := cfg.Get(alias, "User"); val != "" {
-			userinfo = url.User(val)
+	// only parse ssh_config when we are not connecting to a machine
+	// For machine connections we always have the full URL in the
+	// system connection so reading the file is just unnecessary.
+	if !machine {
+		alias := _url.Hostname()
+		cfg := ssh_config.DefaultUserSettings
+		cfg.IgnoreErrors = true
+		found := false
+
+		if userinfo == nil {
+			if val := cfg.Get(alias, "User"); val != "" {
+				userinfo = url.User(val)
+				found = true
+			}
+		}
+		// not in url or ssh_config so default to current user
+		if userinfo == nil {
+			u, err := user.Current()
+			if err != nil {
+				return connection, fmt.Errorf("current user could not be determined: %w", err)
+			}
+			userinfo = url.User(u.Username)
+		}
+
+		if val := cfg.Get(alias, "Hostname"); val != "" {
+			uri = val
 			found = true
 		}
-	}
-	// not in url or ssh_config so default to current user
-	if userinfo == nil {
-		u, err := user.Current()
-		if err != nil {
-			return connection, fmt.Errorf("current user could not be determined: %w", err)
+
+		if port == 0 {
+			if val := cfg.Get(alias, "Port"); val != "" {
+				if val != ssh_config.Default("Port") {
+					port, err = strconv.Atoi(val)
+					if err != nil {
+						return connection, fmt.Errorf("port is not an int: %s: %w", val, err)
+					}
+					found = true
+				}
+			}
 		}
-		userinfo = url.User(u.Username)
-	}
+		// not in ssh config or url so use default 22 port
+		if port == 0 {
+			port = 22
+		}
 
-	if val := cfg.Get(alias, "Hostname"); val != "" {
-		uri = val
-		found = true
-	}
-
-	if port == 0 {
-		if val := cfg.Get(alias, "Port"); val != "" {
-			if val != ssh_config.Default("Port") {
-				port, err = strconv.Atoi(val)
-				if err != nil {
-					return connection, fmt.Errorf("port is not an int: %s: %w", val, err)
+		if identity == "" {
+			if val := cfg.Get(alias, "IdentityFile"); val != "" {
+				identity = strings.Trim(val, "\"")
+				if strings.HasPrefix(identity, "~/") {
+					homedir, err := os.UserHomeDir()
+					if err != nil {
+						return connection, fmt.Errorf("failed to find home dir: %w", err)
+					}
+					identity = filepath.Join(homedir, identity[2:])
 				}
 				found = true
 			}
 		}
-	}
-	// not in ssh config or url so use default 22 port
-	if port == 0 {
-		port = 22
-	}
 
-	if identity == "" {
-		if val := cfg.Get(alias, "IdentityFile"); val != "" {
-			identity = strings.Trim(val, "\"")
-			if strings.HasPrefix(identity, "~/") {
-				homedir, err := os.UserHomeDir()
-				if err != nil {
-					return connection, fmt.Errorf("failed to find home dir: %w", err)
-				}
-				identity = filepath.Join(homedir, identity[2:])
-			}
-			found = true
+		if found {
+			logrus.Debugf("ssh_config alias found: %s", alias)
+			logrus.Debugf("  User: %s", userinfo.Username())
+			logrus.Debugf("  Hostname: %s", uri)
+			logrus.Debugf("  Port: %d", port)
+			logrus.Debugf("  IdentityFile: %q", identity)
 		}
-	}
-
-	if found {
-		logrus.Debugf("ssh_config alias found: %s", alias)
-		logrus.Debugf("  User: %s", userinfo.Username())
-		logrus.Debugf("  Hostname: %s", uri)
-		logrus.Debugf("  Port: %d", port)
-		logrus.Debugf("  IdentityFile: %q", identity)
 	}
 	conn, err := ssh.Dial(&ssh.ConnectionDialOptions{
 		Host:                        uri,

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -170,6 +170,7 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 	// ssh_config
 	alias := _url.Hostname()
 	cfg := ssh_config.DefaultUserSettings
+	cfg.IgnoreErrors = true
 	found := false
 	if val := cfg.Get(alias, "User"); val != "" {
 		userinfo = url.User(val)

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -205,10 +206,15 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 
 	if identity == "" {
 		if val := cfg.Get(alias, "IdentityFile"); val != "" {
-			if val != ssh_config.Default("IdentityFile") {
-				identity = strings.Trim(val, "\"")
-				found = true
+			identity = strings.Trim(val, "\"")
+			if strings.HasPrefix(identity, "~/") {
+				homedir, err := os.UserHomeDir()
+				if err != nil {
+					return connection, fmt.Errorf("failed to find home dir: %w", err)
+				}
+				identity = filepath.Join(homedir, identity[2:])
 			}
+			found = true
 		}
 	}
 

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -98,6 +98,19 @@ var _ = SynchronizedAfterSuite(func() {}, func() {
 	}
 })
 
+// The config does not matter to much for our testing, however we
+// would like to be sure podman machine is not effected by certain
+// settings as we should be using full URLs anywhere.
+// https://github.com/containers/podman/issues/24567
+const sshConfigContent = `
+Host *
+  User NOT_REAL
+  Port 9999
+Host 127.0.0.1
+  User blah
+  IdentityFile ~/.ssh/id_ed25519
+`
+
 func setup() (string, *machineTestBuilder) {
 	// Set TMPDIR if this needs a new directory
 	if value, ok := os.LookupEnv("TMPDIR"); ok {
@@ -118,7 +131,7 @@ func setup() (string, *machineTestBuilder) {
 	if err != nil {
 		Fail(fmt.Sprintf("failed to create ssh config: %q", err))
 	}
-	if _, err := sshConfig.WriteString("IdentitiesOnly=yes"); err != nil {
+	if _, err := sshConfig.WriteString(sshConfigContent); err != nil {
 		Fail(fmt.Sprintf("failed to write ssh config: %q", err))
 	}
 	if err := sshConfig.Close(); err != nil {


### PR DESCRIPTION
Backports of 
https://github.com/containers/podman/pull/24547
https://github.com/containers/podman/pull/24568
https://github.com/containers/podman/pull/24607

And fix the DEST_BRANCH so the bloat check works.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes podman remote connection issue with certain ssh config settings. https://github.com/containers/podman/issues/24567
Do not increase resource limits when running in a user namespace. https://github.com/containers/podman/issues/24508 
```
