### PR TITLE
On windows avoid installing WSL during an update of podman

### DIFF
--- a/build_windows.md
+++ b/build_windows.md
@@ -367,13 +367,30 @@ contrib\win-installer\podman-5.1.0-dev-setup.exe /install `
                       MachineProvider=wsl WSLCheckbox=0 HyperVCheckbox=0
 ```
 
+:information_source: If uninstallation fails, the installer may end up in an
+inconsistent state. Podman results as uninstalled, but some install packages are
+still tracked in the Windows registry and will affect further tentative to
+re-install Podman. When this is the case, trying to re-install Podman results in
+the installer returning zero (success) but no action is executed. The trailing
+packages `GID` can be found in installation logs:
+
+```
+Detected related package: {<GID>}
+```
+
+To fix this problem remove the related packages:
+
+```pwsh
+msiexec /x "{<GID>}"
+```
+
 #### Run the Windows installer automated tests
 
 The following command executes a number of tests of the windows installer. Running
 it requires an administrator terminal.
 
 ```pwsh
-.\winmake.ps1 installertest
+.\winmake.ps1 installertest [wsl|hyperv]
 ```
 
 ### Build and test the standalone `podman.msi` file
@@ -443,7 +460,12 @@ $env:PATH | Select-String -Pattern "Podman"
 
 :information_source: Podman CI uses script
 `contrib\cirrus\win-installer-main.ps1`. Use it locally, too, to build and test
-the installer.
+the installer:
+
+```pwsh
+$ENV:CONTAINERS_MACHINE_PROVIDER='wsl'; .\contrib\cirrus\win-installer-main.ps1
+$ENV:CONTAINERS_MACHINE_PROVIDER='hyperv'; .\contrib\cirrus\win-installer-main.ps1
+```
 
 ### Uninstall and clean-up
 
@@ -513,5 +535,6 @@ MacOS and Windows and then performs the same checks as the `lint` target plus
 many more.
 
 :information_source: Create and start a Podman machine before running
-`winmake.ps1 lint`. Configure the Podman machine with at least 4GB of memory:
+`winmake.ps1 validatepr`. Configure the Podman machine with at least 4GB of
+memory:
 `podman machine init -m 4096`.

--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -9,7 +9,7 @@ if ($Env:CI -eq "true") {
     $WIN_INST_FOLDER = "$PSScriptRoot\..\win-installer"
     $ENV:WIN_INST_VER = "9.9.9"
     $RELEASE_DIR = "$PSScriptRoot\..\..\contrib\win-installer\current"
-    $ENV:CONTAINERS_MACHINE_PROVIDER = "wsl"
+    if ($null -eq $ENV:CONTAINERS_MACHINE_PROVIDER) { $ENV:CONTAINERS_MACHINE_PROVIDER = 'wsl' }
 }
 
 Push-Location $WIN_INST_FOLDER
@@ -21,7 +21,6 @@ Run-Command ".\build.ps1 $Env:WIN_INST_VER dev `"$RELEASE_DIR`""
 Pop-Location
 
 # Run the installer silently and WSL/HyperV install options disabled (prevent reboots)
-# We need -skipWinVersionCheck for server 2019 (cirrus image), can be dropped after server 2022
 $command = "$WIN_INST_FOLDER\test-installer.ps1 "
 $command += "-scenario all "
 $command += "-provider $ENV:CONTAINERS_MACHINE_PROVIDER "

--- a/contrib/win-installer/burn.wxs
+++ b/contrib/win-installer/burn.wxs
@@ -30,7 +30,7 @@
         <MsiProperty Name="WITH_HYPERV" Value="[HyperVCheckbox]" />
         <MsiProperty Name="SKIP_CONFIG_FILE_CREATION" Value="[SkipConfigFileCreation]" />
       </MsiPackage>
-      <ExePackage DisplayName="WSL Kernel Install" InstallCondition="(MachineProvider = &quot;wsl&quot;) AND (WSLCheckbox = 1)" SourceFile="artifacts\podman-wslkerninst.exe" DetectCondition="" Permanent="true" />
+      <ExePackage DisplayName="WSL Kernel Install" InstallCondition="(MachineProvider = &quot;wsl&quot;) AND (WSLCheckbox = 1) AND (NOT PreviousInstallFolder)" SourceFile="artifacts\podman-wslkerninst.exe" DetectCondition="" Permanent="true" />
     </Chain>
     <OptionalUpdateRegistration />
   </Bundle>

--- a/contrib/win-installer/burn.wxs
+++ b/contrib/win-installer/burn.wxs
@@ -9,7 +9,7 @@
     <Variable Name="InstallFolder" Type="formatted" Value="[ProgramFiles64Folder]RedHat\Podman" bal:Overridable="yes" />
     <Variable Name="VERSION" Value="$(var.VERSION)" />
     <Variable Name="MachineProvider" Type="string" Value="wsl" bal:Overridable="yes" />
-    <Variable Name="WSLCheckbox" Type="numeric" Value="1" bal:Overridable="yes" />
+    <Variable Name="WSLCheckbox" Type="numeric" Value="0" bal:Overridable="yes" />
     <Variable Name="HyperVCheckbox" Type="numeric" Value="0" bal:Overridable="yes" />
     <Variable Name="AllowOldWin" Type="numeric" Value="0" bal:Overridable="yes" />
     <Variable Name="LaunchTarget" Value="explorer.exe" />

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -35,36 +35,36 @@
 		</Property>
 
 		<!--
-      Property WSL_INSTALL is set at runtime and used as the condition to run the `WSLFeatureComponent` Component:
-      WSL is installed only if all these conditions are met:
-        - WSL isn't already installed
-        - The user has set property `MACHINE_PROVIDER` to "wsl"
-        - The user hasn't set property `WITH_WSL` to 0
-     -->
+		Property WSL_INSTALL is set at runtime and used as the condition to run the `WSLFeatureComponent` Component:
+		WSL is installed only if all these conditions are met:
+			- WSL isn't already installed
+			- The user has set property `MACHINE_PROVIDER` to "wsl"
+			- The user hasn't set property `WITH_WSL` to 0
+		-->
 		<SetProperty Id="WSL_INSTALL" Before="AppSearch" Value="1" Sequence="first" Condition="(HAS_WSLFEATURE = 0) AND (MACHINE_PROVIDER = &quot;wsl&quot;) AND (NOT (WITH_WSL = 0))" />
 		<!--
-      Property HYPERV_INSTALL is set at runtime and used as the condition to run the `HyperVFeatureComponent` Component:
-      HyperV is installed only if all these conditions are met:
-        - HyperV isn't already installed
-        - The user has set property `MACHINE_PROVIDER` to "hyperv"
-        - The user hasn't set property `WITH_HYPERV` to 0
-     -->
+		Property HYPERV_INSTALL is set at runtime and used as the condition to run the `HyperVFeatureComponent` Component:
+		HyperV is installed only if all these conditions are met:
+			- HyperV isn't already installed
+			- The user has set property `MACHINE_PROVIDER` to "hyperv"
+			- The user hasn't set property `WITH_HYPERV` to 0
+		-->
 		<SetProperty Id="HYPERV_INSTALL" Before="AppSearch" Value="1" Sequence="first" Condition="(HAS_HYPERVFEATURE = 0) AND (MACHINE_PROVIDER = &quot;hyperv&quot;) AND (NOT (WITH_HYPERV = 0))" />
 		<!--
-      Property CREATE_MACHINE_PROVIDER_CONFIG_FILE is set at runtime and used as the condition to run the `MachineProviderConfigFile` Component:
-      The machine provider config file is created (or is not deleted if it already exist) if these conditions are met:
-        - The user hasn't set property `SKIP_CONFIG_FILE_CREATION` to 1
-        - The main executable file ($PROGRAMDATA/RedHat/Podman/podman.exe) doesn't exist or, if it exists, the machine provider config file exists
-     -->
+		Property CREATE_MACHINE_PROVIDER_CONFIG_FILE is set at runtime and used as the condition to run the `MachineProviderConfigFile` Component:
+		The machine provider config file is created (or is not deleted if it already exist) if these conditions are met:
+			- The user hasn't set property `SKIP_CONFIG_FILE_CREATION` to 1
+			- The main executable file ($PROGRAMDATA/RedHat/Podman/podman.exe) doesn't exist or, if it exists, the machine provider config file exists
+		-->
 		<SetProperty Id="CREATE_MACHINE_PROVIDER_CONFIG_FILE" After="AppSearch" Value="1" Sequence="first" Condition="(NOT (SKIP_CONFIG_FILE_CREATION = 1)) AND ((NOT MAIN_EXECUTABLE_FILE_PATH) OR (MACHINE_PROVIDER_CONFIG_FILE_PATH))" />
 		<!--
-      Property HIDE_PROVIDER_CHOICE is set at runtime and used as the condition to hide the Machine Provider
-      choice from the MSI GUI (the Radio Button Group and other related controls):
-      The machine provider choice isn't shown to the user if one of these conditions are met:
-        - The user has set the property `SKIP_CONFIG_FILE_CREATION` to 1
-        - The machine provider config file ($PROGRAMDATA/containers/containers.conf.d/99-podman-machine-provider.conf) exists
-        - The main executable file ($PROGRAMDATA/RedHat/Podman/podman.exe) exists
-     -->
+		Property HIDE_PROVIDER_CHOICE is set at runtime and used as the condition to hide the Machine Provider
+		choice from the MSI GUI (the Radio Button Group and other related controls):
+		The machine provider choice isn't shown to the user if one of these conditions are met:
+			- The user has set the property `SKIP_CONFIG_FILE_CREATION` to 1
+			- The machine provider config file ($PROGRAMDATA/containers/containers.conf.d/99-podman-machine-provider.conf) exists
+			- The main executable file ($PROGRAMDATA/RedHat/Podman/podman.exe) exists
+		-->
 		<SetProperty Id="HIDE_PROVIDER_CHOICE" After="AppSearch" Value="1" Sequence="first" Condition="(SKIP_CONFIG_FILE_CREATION = 1) OR (MACHINE_PROVIDER_CONFIG_FILE_PATH) OR (MAIN_EXECUTABLE_FILE_PATH)" />
 
 		<CustomAction Id="OpenGuide" DllEntry="WixShellExec" Impersonate="yes" BinaryRef="Wix4UtilCA_X86" />
@@ -72,14 +72,14 @@
 		<CustomAction Id="CheckHyperV" Execute="firstSequence" DllEntry="CheckHyperV" BinaryRef="PodmanHooks" />
 		<util:BroadcastEnvironmentChange />
 		<ComponentGroup Id="WSLFeature" Directory="INSTALLDIR">
-			<Component Id="WSLFeatureComponent" Guid="F6A693BC-186C-4E64-8015-C3073013B3A8" Condition="(NOT Installed) AND WSL_INSTALL = 1">
+			<Component Id="WSLFeatureComponent" Guid="F6A693BC-186C-4E64-8015-C3073013B3A8" Condition="(NOT WIX_UPGRADE_DETECTED) AND (WSL_INSTALL = 1)">
 				<CreateFolder />
 				<PanelSW:Dism EnableFeature="VirtualMachinePlatform" ErrorHandling="prompt" />
 				<PanelSW:Dism EnableFeature="Microsoft-Windows-Subsystem-Linux" ErrorHandling="prompt" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="HyperVFeature" Directory="INSTALLDIR">
-			<Component Id="HyperVFeatureComponent" Guid="F7B2D4C9-6C89-46BB-B4EA-FF39424972F3" Condition="(NOT Installed) AND HYPERV_INSTALL = 1">
+			<Component Id="HyperVFeatureComponent" Guid="F7B2D4C9-6C89-46BB-B4EA-FF39424972F3" Condition="(NOT WIX_UPGRADE_DETECTED) AND (HYPERV_INSTALL = 1)">
 				<CreateFolder />
 				<PanelSW:Dism EnableFeature="Microsoft-Hyper-V" ErrorHandling="prompt" />
 			</Component>
@@ -110,13 +110,13 @@
 		<WixVariable Id="WixUIDialogBmp" Value="resources\podman-dialog.png" />
 		<UIRef Id="PodmanUI" />
 		<UI>
-			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenGuide" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed" />
+			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenGuide" Condition="(WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1) AND (NOT WIX_UPGRADE_DETECTED)" />
 		</UI>
 
 		<InstallExecuteSequence>
 			<Custom Action="CheckWSL" Before="SetWSL_INSTALL" />
 			<Custom Action="CheckHyperV" Before="SetHYPERV_INSTALL" />
-			<ForceReboot Before="StopServices" Condition="(NOT Installed) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
+			<ForceReboot Before="StopServices" Condition="(NOT WIX_UPGRADE_DETECTED) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
 		</InstallExecuteSequence>
 		<Binary Id="PodmanHooks" SourceFile="artifacts/podman-msihooks.dll" />
 
@@ -147,10 +147,10 @@
 			</Directory>
 		</StandardDirectory>
 		<!--
-        The following code creates the `containers/containers.conf.d` folder under the system wide
-        `$CommonAppDataFolder`. That's preferred to the user specific `$AppDataFolder` to avoid the
-        Windows Installer ICE91 warning https://learn.microsoft.com/en-us/windows/win32/msi/ice91.
-      -->
+			The following code creates the `containers/containers.conf.d` folder under the system wide
+			`$CommonAppDataFolder`. That's preferred to the user specific `$AppDataFolder` to avoid the
+			Windows Installer ICE91 warning https://learn.microsoft.com/en-us/windows/win32/msi/ice91.
+		-->
 		<StandardDirectory Id="CommonAppDataFolder">
 			<Directory Id="CONFIGDIR" Name="containers">
 				<Directory Id="ContainersConfigSubDir" Name="containers.conf.d">

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -184,8 +184,8 @@ function Lint{
         Exit 1
     }
 
-    Run-Command "golangci-lint run --timeout=10m --build-tags=`"$remotetags`" $PSScriptRoot\cmd\podman"
     Run-Command "pre-commit run --all-files"
+    Run-Command "golangci-lint run --timeout=10m --build-tags=`"$remotetags`" $PSScriptRoot\cmd\podman"
 }
 
 # Helpers
@@ -246,11 +246,7 @@ function Build-Distribution-Zip-File{
 function Get-Podman-Version{
     $versionSrc = "$PSScriptRoot\test\version\"
     $versionBin = "$PSScriptRoot\test\version\version.exe"
-
-    # If version.exe doesn't exist, build it
-    if (-Not (Test-Path -Path "$versionBin" -PathType Leaf)) {
-        Run-Command "go build --o `"$versionBin`" `"$versionSrc`""
-    }
+    Run-Command "go build --o `"$versionBin`" `"$versionSrc`""
     $version = Invoke-Expression "$versionBin"
     # Remove the '-dev' suffix from the version
     $version = $version -replace "-.*", ""
@@ -323,7 +319,7 @@ switch ($target) {
         Write-Host " .\winmake installer"
         Write-Host
         Write-Host "Example: Run windows installer tests"
-        Write-Host " .\winmake installertest"
+        Write-Host " .\winmake installertest hyperv"
         Write-Host
         Write-Host "Example: Generate the documetation artifacts"
         Write-Host " .\winmake docs"


### PR DESCRIPTION
A condition to install WSL or Hyper-V was `NOT Installed` that used the [Windows installer `Installed` property](https://learn.microsoft.com/en-us/windows/win32/msi/installed). But that condition was evaluated to `true` even during an update so we switched to `NOT WIX_UPGRADE_DETECTED` now.

Another change introduced by this PR is the default value of the "Install WSLv2 if not present" checkbox. It's now unchecked by default (as it already was the case for the "Install Hyper-V if not present" checkbox). 

![image](https://github.com/user-attachments/assets/00f796db-f20d-4e42-b7fb-ab425e16861a)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
