### PR TITLE
Quadlet - Use = sign when setting the pull arg for build

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1397,10 +1397,15 @@ func ConvertBuild(build *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, isU
 	podman := createBasePodmanCommand(build, BuildGroup)
 	podman.add("build")
 
+	// The `--pull` flag has to be handled separately and the `=` sign must be present
+	// See https://github.com/containers/podman/issues/24599 for details
+	if val, ok := build.Lookup(BuildGroup, KeyPull); ok && len(val) > 0 {
+		podman.addf("--pull=%s", val)
+	}
+
 	stringKeys := map[string]string{
 		KeyArch:     "--arch",
 		KeyAuthFile: "--authfile",
-		KeyPull:     "--pull",
 		KeyTarget:   "--target",
 		KeyVariant:  "--variant",
 	}

--- a/test/e2e/quadlet/pull.build
+++ b/test/e2e/quadlet/pull.build
@@ -1,6 +1,6 @@
 ## assert-podman-final-args-regex /.*/podman-e2e-.*/subtest-.*/quadlet
 ## assert-podman-args "--tag" "localhost/imagename"
-## assert-podman-args "--pull" "never"
+## assert-podman-args "--pull=never"
 
 [Build]
 ImageTag=localhost/imagename

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1699,4 +1699,31 @@ EOF
         fi
     done < <(parse_table "${dropin_files}")
 }
+
+# Following issue: https://github.com/containers/podman/issues/24599
+# Make sure future changes do not break
+@test "quadlet - build with pull" {
+    local quadlet_tmpdir=$PODMAN_TMPDIR/quadlets
+
+    mkdir $quadlet_tmpdir
+
+    local container_file_path=$quadlet_tmpdir/Containerfile
+    cat >$container_file_path << EOF
+FROM $IMAGE
+EOF
+
+    local image_tag=quay.io/i-$(safename):$(random_string)
+    local quadlet_file=$PODMAN_TMPDIR/pull_$(safename).build
+    cat >$quadlet_file << EOF
+[Build]
+ImageTag=$image_tag
+File=$container_file_path
+Pull=never
+EOF
+
+    run_quadlet "$quadlet_file"
+    service_setup $QUADLET_SERVICE_NAME "wait"
+
+    run_podman rmi -i $image_tag
+}
 # vim: filetype=sh

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -94,6 +94,8 @@ quadlet_to_service_name() {
         suffix="-image"
     elif [ "$extension" == "pod" ]; then
         suffix="-pod"
+    elif [ "$extension" == "build" ]; then
+        suffix="-build"
     fi
 
     echo "$filename$suffix.service"


### PR DESCRIPTION

#### Does this PR introduce a user-facing change?
No

```release-note
None
```

Fixes #24599
