### PR TITLE
refact: EventerType and improve consistency

### DIFF
--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -6,16 +6,17 @@ import (
 	"time"
 )
 
-// EventerType ...
-type EventerType int
+// EventerType describes the type of event logger
+// The string values for EventerType should be entirely lowercase.
+type EventerType string
 
 const (
 	// LogFile indicates the event logger will be a logfile
-	LogFile EventerType = iota
+	LogFile EventerType = "file"
 	// Journald indicates journald should be used to log events
-	Journald EventerType = iota
+	Journald EventerType = "journald"
 	// Null is a no-op events logger. It does not read or write events.
-	Null EventerType = iota
+	Null EventerType = "none"
 )
 
 // Event describes the attributes of a libpod event

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -15,26 +15,13 @@ var ErrNoJournaldLogging = errors.New("no support for journald logging")
 
 // String returns a string representation of EventerType
 func (et EventerType) String() string {
-	switch et {
-	case LogFile:
-		return "file"
-	case Journald:
-		return "journald"
-	case Null:
-		return "none"
-	default:
-		return "invalid"
-	}
+	return string(et)
 }
 
 // IsValidEventer checks if the given string is a valid eventer type.
 func IsValidEventer(eventer string) bool {
-	switch eventer {
-	case LogFile.String():
-		return true
-	case Journald.String():
-		return true
-	case Null.String():
+	switch EventerType(eventer) {
+	case LogFile, Journald, Null:
 		return true
 	default:
 		return false

--- a/libpod/events/events_freebsd.go
+++ b/libpod/events/events_freebsd.go
@@ -10,12 +10,12 @@ import (
 // NewEventer creates an eventer based on the eventer type
 func NewEventer(options EventerOptions) (Eventer, error) {
 	logrus.Debugf("Initializing event backend %s", options.EventerType)
-	switch strings.ToUpper(options.EventerType) {
-	case strings.ToUpper(LogFile.String()):
+	switch EventerType(strings.ToLower(options.EventerType)) {
+	case LogFile:
 		return EventLogFile{options}, nil
-	case strings.ToUpper(Null.String()):
+	case Null:
 		return newNullEventer(), nil
 	default:
-		return nil, fmt.Errorf("unknown event logger type: %s", strings.ToUpper(options.EventerType))
+		return nil, fmt.Errorf("unknown event logger type: %s", strings.ToLower(options.EventerType))
 	}
 }

--- a/libpod/events/events_linux.go
+++ b/libpod/events/events_linux.go
@@ -10,18 +10,14 @@ import (
 // NewEventer creates an eventer based on the eventer type
 func NewEventer(options EventerOptions) (Eventer, error) {
 	logrus.Debugf("Initializing event backend %s", options.EventerType)
-	switch strings.ToUpper(options.EventerType) {
-	case strings.ToUpper(Journald.String()):
-		eventer, err := newEventJournalD(options)
-		if err != nil {
-			return nil, fmt.Errorf("eventer creation: %w", err)
-		}
-		return eventer, nil
-	case strings.ToUpper(LogFile.String()):
+	switch EventerType(strings.ToLower(options.EventerType)) {
+	case Journald:
+		return newJournalDEventer(options)
+	case LogFile:
 		return newLogFileEventer(options)
-	case strings.ToUpper(Null.String()):
+	case Null:
 		return newNullEventer(), nil
 	default:
-		return nil, fmt.Errorf("unknown event logger type: %s", strings.ToUpper(options.EventerType))
+		return nil, fmt.Errorf("unknown event logger type: %s", strings.ToLower(options.EventerType))
 	}
 }

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -25,8 +25,8 @@ type EventJournalD struct {
 	options EventerOptions
 }
 
-// newEventJournalD creates a new journald Eventer
-func newEventJournalD(options EventerOptions) (Eventer, error) {
+// newJournalDEventer creates a new EventJournalD Eventer
+func newJournalDEventer(options EventerOptions) (Eventer, error) {
 	return EventJournalD{options}, nil
 }
 

--- a/libpod/events/journal_unsupported.go
+++ b/libpod/events/journal_unsupported.go
@@ -5,7 +5,7 @@ package events
 // DefaultEventerType is logfile when systemd is not present
 const DefaultEventerType = LogFile
 
-// newEventJournalD always returns an error if libsystemd not found
-func newEventJournalD(options EventerOptions) (Eventer, error) {
+// newJournalDEventer always returns an error if libsystemd not found
+func newJournalDEventer(options EventerOptions) (Eventer, error) {
 	return nil, ErrNoJournaldLogging
 }


### PR DESCRIPTION
In the original implementation in `libpod/events/config.go`, `iota` was used to design `EventerType`. 
However, in `libpod/events/events_freebsd.go` and `libpod/events/events_linux.go`, the `NewEventer` function still relies on string comparisons to determine which `EventerType` to use.

1. Completed the `EventerType` comment.
2. Changed `EventerType` to be represented as a `string`.
3. Since `EventerType` is designed to be entirely lowercase, changed the comparison to use lowercase instead of uppercase.
4. Renamed `newEventJournalD` to `newJournalDEventer`, similar to the functions `newLogFileEventer` and `newNullEventer`
5. Removed redundant error-checking steps in `events_linux.go`.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
