### PR TITLE
Allow forcing compression with v2s2 format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.5.1
 	github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33
-	github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0
+	github.com/containers/common v0.61.1-0.20241202111335-2d4a9a65dd81
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.0
 	github.com/containers/image/v5 v5.33.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33 h1:Ih6KuyByK7ZGGzkS0M5rVBPLWIyeDvdL5klhsKBo8vA=
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33/go.mod h1:RxIuKhwTpRl3ma4d4BF6QzSSeg9zNNvo/xhYJOKeDQs=
-github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0 h1:Vh8IytxprODmjd4sALcSVUzhT28vT537UWsfCXcahWk=
-github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0/go.mod h1:3mUU2/PxkOwvL46fmaRVj0YfBDBxNPOMctIvBHWo4Ak=
+github.com/containers/common v0.61.1-0.20241202111335-2d4a9a65dd81 h1:Nw7YRDWv0ZO/AINzOeyR2KnJyfcIz1Ek3Ube/akl4U4=
+github.com/containers/common v0.61.1-0.20241202111335-2d4a9a65dd81/go.mod h1:ySiyZ85+F3xk7kcQvaZo0Ii67Hma7T4JEeILEQPWEKY=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.0 h1:Z8ZEWb+Lio0d+lXexONdUWT4rm9lF91vH0g3ARnMy7o=

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -141,6 +141,47 @@ var _ = Describe("Podman push", func() {
 		Expect(output).To(ContainSubstring("zstd"))
 	})
 
+	It("push test --force-compression --format=v2s2", func() {
+		if podmanTest.Host.Arch == "ppc64le" {
+			Skip("No registry image for ppc64le")
+		}
+		if isRootless() {
+			err := podmanTest.RestoreArtifact(REGISTRY_IMAGE)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		lock := GetPortLock("5005")
+		defer lock.Unlock()
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5005:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		if !WaitContainerReady(podmanTest, "registry", "listening on", 20, 1) {
+			Skip("Cannot start docker registry.")
+		}
+
+		session = podmanTest.Podman([]string{"build", "-t", "imageone", "build/basicalpine"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		push := podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--force-compression=true", "--compression-format", "gzip", "--format", "v2s2", "--remove-signatures", "imageone", "localhost:5005/image"})
+		push.WaitWithDefaultTimeout()
+		Expect(push).Should(ExitCleanly())
+
+		skopeoInspect := []string{"inspect", "--tls-verify=false", "--raw", "docker://localhost:5005/image:latest"}
+		skopeo := SystemExec("skopeo", skopeoInspect)
+		skopeo.WaitWithDefaultTimeout()
+		Expect(skopeo).Should(ExitCleanly())
+		output := skopeo.OutputToString()
+		Expect(output).To(ContainSubstring("gzip"))
+
+		push = podmanTest.Podman([]string{"push", "-q", "--tls-verify=false", "--force-compression=true", "--compression-format", "zstd", "--format", "v2s2", "--remove-signatures", "imageone", "localhost:5005/image"})
+		push.WaitWithDefaultTimeout()
+		// the command is asking for an impossible thing; per containers/common#1869, we should detect
+		// that and fail with a precise error, but that does not exist, so we end up reporting this
+		// misleading text. When that is resolved, this test will need updating.
+		Expect(push).Should(ExitWithError(125, "cannot use ForceCompressionFormat with undefined default compression format"))
+	})
+
 	It("podman push to local registry", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")

--- a/vendor/github.com/containers/common/libnetwork/types/network.go
+++ b/vendor/github.com/containers/common/libnetwork/types/network.go
@@ -277,7 +277,7 @@ type PerNetworkOptions struct {
 type NetworkOptions struct {
 	// ContainerID is the container id, used for iptables comments and ipam allocation.
 	ContainerID string `json:"container_id"`
-	// ContainerName is the container name, used as dns name.
+	// ContainerName is the container name.
 	ContainerName string `json:"container_name"`
 	// PortMappings contains the port mappings for this container
 	PortMappings []PortMapping `json:"port_mappings,omitempty"`
@@ -287,6 +287,8 @@ type NetworkOptions struct {
 	// List of custom DNS server for podman's DNS resolver.
 	// Priority order will be kept as defined by user in the configuration.
 	DNSServers []string `json:"dns_servers,omitempty"`
+	// ContainerHostname is the configured DNS hostname of the container.
+	ContainerHostname string `json:"container_hostname"`
 }
 
 // PortMapping is one or more ports that will be mapped into the container.

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -96,6 +96,13 @@ type ContainersConfig struct {
 	// "memory.high=1073741824" sets the memory.high limit to 1GB.
 	CgroupConf attributedstring.Slice `toml:"cgroup_conf,omitempty"`
 
+	// When no hostname is set for a container, use the container's name, with
+	// characters not valid for a hostname removed, as the hostname instead of
+	// the first 12 characters of the container's ID. Containers not running
+	// in a private UTS namespace will have their hostname set to the host's
+	// hostname regardless of this setting.
+	ContainerNameAsHostName bool `toml:"container_name_as_hostname,omitempty"`
+
 	// Capabilities to add to all containers.
 	DefaultCapabilities attributedstring.Slice `toml:"default_capabilities,omitempty"`
 

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -58,6 +58,14 @@
 #
 #cgroups = "enabled"
 
+# When no hostname is set for a container, use the container's name, with
+# characters not valid for a hostname removed, as the hostname instead of
+# the first 12 characters of the container's ID. Containers not running
+# in a private UTS namespace will have their hostname set to the host's
+# hostname regardless of this setting.
+#
+#container_name_as_hostname = false
+
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #

--- a/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
@@ -29,6 +29,12 @@
 #
 #base_hosts_file = ""
 
+# When no hostname is set for a container, use the container's name, with
+# characters not valid for a hostname removed, as the hostname instead of
+# the first 12 characters of the container's ID.
+#
+#container_name_as_hostname = false
+
 # The database backend of Podman.  Supported values are "" (default), "boltdb"
 # and "sqlite". An empty value means it will check whenever a boltdb already
 # exists and use it when it does, otherwise it will use sqlite as default

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0
+# github.com/containers/common v0.61.1-0.20241202111335-2d4a9a65dd81
 ## explicit; go 1.22.6
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
This highlights a bug in common where the compression format is reset if the format is v2s2, even if its a valid compression format.

#### Does this PR introduce a user-facing change?

```release-note
None
```
