### PR TITLE
Pass container hostname to netavark

### DIFF
--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -55,9 +55,10 @@ func (c *Container) getNetworkOptions(networkOpts map[string]types.PerNetworkOpt
 		nameservers = append(nameservers, ip.String())
 	}
 	opts := types.NetworkOptions{
-		ContainerID:   c.config.ID,
-		ContainerName: getNetworkPodName(c),
-		DNSServers:    nameservers,
+		ContainerID:       c.config.ID,
+		ContainerName:     getNetworkPodName(c),
+		DNSServers:        nameservers,
+		ContainerHostname: c.NetworkHostname(),
 	}
 	opts.PortMappings = c.convertPortMappings()
 


### PR DESCRIPTION
Passing the hostname allows netavark to include it in DHCP lease
requests which, in an environment where DDNS is used, can cause
DNS entries to be created automatically.

* The current Hostname() function in container.go was updated to
check the new `container_name_as_hostname` option in the
CONTAINERS table of containers.conf.  If set and no hostname
was configured for the container, it causes the hostname to be
set to a version of the container's name with the characters not
valid for a hostname removed.  If not set (the default), the original
behavior of setting the hostname to the short container ID is
preserved.

* Because the Hostname() function can return the host's hostname
if the container isn't running in a private UTS namespace, and we'd
NEVER want to send _that_ in a DHCP request for a container, a new
function NetworkHostname() was added which functions like Hostname()
except that it will return an empty string instead of the host's
hostname if the container is not running in a private UTS namespace.

* networking_common.getNetworkOptions() now uses NetworkHostname()
to set the ContainerHostname member of the NetworkOptions structure.
That member was added to the structure in a corresponding commit in
common/libnetwork/types/network.go.

* Added test to containers_conf_test.go

Signed-off-by: George Joseph <g.devel@wxy78.net>

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Container hostname is now passed to netavark which will include it in DHCP requests
for applicable networks. This could enable automatic creation of DNS records for
containers in environments where DDNS is used.
```
