### PR TITLE
Add support for bridge mode

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -70,6 +70,14 @@ Because it bypasses the host network stack no additional restrictions can be set
 privileged container is run it can set a default route themselves. If this is a concern then the
 container connections should be blocked on your actual network gateway.
 
+Using the `bridge` driver with this option has the following effects:
+ - Global IP forwarding sysctls will not be changed in the host network namespace.
+ - IP forwarding is disabled on the bridge interface instead of setting up a firewall.
+ - No default route will be added to the container.
+
+In all cases, aardvark-dns will only resolve container names with this option enabled.
+Other queries will be answered with `NXDOMAIN`.
+
 #### **--ip-range**=*range*
 
 Allocate container IP from a range. The range must be a either a complete subnet in CIDR notation or be in

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -118,6 +118,9 @@ Additionally the `bridge` driver supports the following options:
 - `com.docker.network.bridge.name`: This option assigns the given name to the created Linux Bridge
 - `com.docker.network.driver.mtu`: Sets the Maximum Transmission Unit (MTU) and takes an integer value.
 - `vrf`: This option assigns a VRF to the bridge interface. It accepts the name of the VRF and defaults to none. Can only be used with the Netavark network backend.
+- `mode`: This option sets the specified bridge mode on the interface. Defaults to `managed`. Supported values:
+  - `managed`: Podman creates and deletes the bridge and changes sysctls of it. It adds firewall rules to masquerade outgoing traffic, as well as setup port forwarding for incoming traffic using DNAT.
+  - `unmanaged`: Podman uses an existing bridge. It must exist by the time you want to start a container which uses the network. There will be no NAT or port forwarding, even if such options were passed while creating the container.
 
 The `macvlan` and `ipvlan` driver support the following options:
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.5.1
 	github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33
-	github.com/containers/common v0.61.1-0.20241125104856-ceceb404e9aa
+	github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.0
 	github.com/containers/image/v5 v5.33.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33 h1:Ih6KuyByK7ZGGzkS0M5rVBPLWIyeDvdL5klhsKBo8vA=
 github.com/containers/buildah v1.38.1-0.20241119213149-52437ef15d33/go.mod h1:RxIuKhwTpRl3ma4d4BF6QzSSeg9zNNvo/xhYJOKeDQs=
-github.com/containers/common v0.61.1-0.20241125104856-ceceb404e9aa h1:XetqxHBrm3klRHIe8L1QIOr57B0HUVdihxY1wop0KXg=
-github.com/containers/common v0.61.1-0.20241125104856-ceceb404e9aa/go.mod h1:3mUU2/PxkOwvL46fmaRVj0YfBDBxNPOMctIvBHWo4Ak=
+github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0 h1:Vh8IytxprODmjd4sALcSVUzhT28vT537UWsfCXcahWk=
+github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0/go.mod h1:3mUU2/PxkOwvL46fmaRVj0YfBDBxNPOMctIvBHWo4Ak=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.0 h1:Z8ZEWb+Lio0d+lXexONdUWT4rm9lF91vH0g3ARnMy7o=

--- a/vendor/github.com/containers/common/libnetwork/netavark/config.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/config.go
@@ -207,6 +207,10 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 				if len(value) == 0 {
 					return nil, errors.New("invalid vrf name")
 				}
+			case types.ModeOption:
+				if !slices.Contains(types.ValidBridgeModes, value) {
+					return nil, fmt.Errorf("unknown bridge mode %q", value)
+				}
 			default:
 				return nil, fmt.Errorf("unsupported bridge network option %s", key)
 			}

--- a/vendor/github.com/containers/common/libnetwork/types/const.go
+++ b/vendor/github.com/containers/common/libnetwork/types/const.go
@@ -24,6 +24,9 @@ const (
 	// DefaultSubnet is the subnet that will be used for the default CNI network.
 	DefaultSubnet = "10.88.0.0/16"
 
+	BridgeModeManaged   = "managed"
+	BridgeModeUnmanaged = "unmanaged"
+
 	// valid macvlan driver mode values
 	MacVLANModeBridge   = "bridge"
 	MacVLANModePrivate  = "private"
@@ -52,6 +55,9 @@ const (
 	CNI      NetworkBackend = "cni"
 	Netavark NetworkBackend = "netavark"
 )
+
+// ValidBridgeModes is the list of valid mode options for the bridge driver
+var ValidBridgeModes = []string{BridgeModeManaged, BridgeModeUnmanaged}
 
 // ValidMacVLANModes is the list of valid mode options for the macvlan driver
 var ValidMacVLANModes = []string{MacVLANModeBridge, MacVLANModePrivate, MacVLANModeVepa, MacVLANModePassthru}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.61.1-0.20241125104856-ceceb404e9aa
+# github.com/containers/common v0.61.1-0.20241125172552-a801fac4edc0
 ## explicit; go 1.22.6
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
This simply updates `common`, as there is nothing to do from the podman side. I added documentation for this new option and improved the `--internal` documentation.

Related:
- https://github.com/containers/netavark/pull/1126
- https://github.com/containers/common/pull/2247

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
