### PR TITLE
Add podman manifest rm --ignore

### DIFF
--- a/cmd/podman/manifest/rm.go
+++ b/cmd/podman/manifest/rm.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
+	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/errorhandling"
 	"github.com/spf13/cobra"
 )
 
 var (
-	rmCmd = &cobra.Command{
-		Use:               "rm LIST [LIST...]",
+	rmOptions = entities.ImageRemoveOptions{}
+	rmCmd     = &cobra.Command{
+		Use:               "rm [options] LIST [LIST...]",
 		Short:             "Remove manifest list or image index from local storage",
 		Long:              "Remove manifest list or image index from local storage.",
 		RunE:              rm,
@@ -27,10 +29,13 @@ func init() {
 		Command: rmCmd,
 		Parent:  manifestCmd,
 	})
+
+	flags := rmCmd.Flags()
+	flags.BoolVarP(&rmOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified manifest is missing")
 }
 
 func rm(cmd *cobra.Command, args []string) error {
-	report, rmErrors := registry.ImageEngine().ManifestRm(context.Background(), args)
+	report, rmErrors := registry.ImageEngine().ManifestRm(context.Background(), args, rmOptions)
 	if report != nil {
 		for _, u := range report.Untagged {
 			fmt.Println("Untagged: " + u)

--- a/docs/source/markdown/podman-manifest-rm.1.md
+++ b/docs/source/markdown/podman-manifest-rm.1.md
@@ -4,10 +4,16 @@
 podman\-manifest\-rm - Remove manifest list or image index from local storage
 
 ## SYNOPSIS
-**podman manifest rm** *list-or-index* [...]
+**podman manifest rm** [*options*] *list-or-index* [...]
 
 ## DESCRIPTION
 Removes one or more locally stored manifest lists.
+
+## OPTIONS
+
+#### **--ignore**, **-i**
+
+If a specified manifest does not exist in the local storage, ignore it and do not throw an error.
 
 ## EXAMPLE
 

--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -22,6 +22,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		Force   bool `schema:"force"`
 		NoPrune bool `schema:"noprune"`
+		Ignore  bool `schema:"ignore"`
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -42,6 +43,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	options := entities.ImageRemoveOptions{
 		Force:   query.Force,
 		NoPrune: query.NoPrune,
+		Ignore:  query.Ignore,
 	}
 	report, rmerrors := imageEngine.Remove(r.Context(), []string{possiblyNormalizedName}, options)
 	if len(rmerrors) > 0 && rmerrors[0] != nil {

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -668,6 +668,7 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		Force          bool `schema:"force"`
 		LookupManifest bool `schema:"lookupManifest"`
+		Ignore         bool `schema:"ignore"`
 	}{
 		Force: false,
 	}
@@ -677,7 +678,7 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts := entities.ImageRemoveOptions{Force: query.Force, LookupManifest: query.LookupManifest}
+	opts := entities.ImageRemoveOptions{Force: query.Force, LookupManifest: query.LookupManifest, Ignore: query.Ignore}
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	rmReport, rmErrors := imageEngine.Remove(r.Context(), []string{utils.GetName(r)}, opts)
 

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -322,6 +322,10 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: The name or ID of the  list to be deleted
+	//  - in: query
+	//    name: ignore
+	//    description: Ignore if a specified manifest does not exist and do not throw an error.
+	//    type: boolean
 	// responses:
 	//   200:
 	//     $ref: "#/responses/imagesRemoveResponseLibpod"

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -45,7 +45,7 @@ type ImageEngine interface { //nolint:interfacebloat
 	ManifestAddArtifact(ctx context.Context, name string, files []string, opts ManifestAddArtifactOptions) (string, error)
 	ManifestAnnotate(ctx context.Context, names, image string, opts ManifestAnnotateOptions) (string, error)
 	ManifestRemoveDigest(ctx context.Context, names, image string) (string, error)
-	ManifestRm(ctx context.Context, names []string) (*ImageRemoveReport, []error)
+	ManifestRm(ctx context.Context, names []string, imageRmOpts ImageRemoveOptions) (*ImageRemoveReport, []error)
 	ManifestPush(ctx context.Context, name, destination string, imagePushOpts ImagePushOptions) (string, error)
 	ManifestListClear(ctx context.Context, name string) (string, error)
 	Sign(ctx context.Context, names []string, options SignOptions) (*SignReport, error)

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -460,8 +460,8 @@ func (ir *ImageEngine) ManifestRemoveDigest(ctx context.Context, name, image str
 }
 
 // ManifestRm removes the specified manifest list from storage
-func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string) (report *entities.ImageRemoveReport, rmErrors []error) {
-	return ir.Remove(ctx, names, entities.ImageRemoveOptions{LookupManifest: true})
+func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string, opts entities.ImageRemoveOptions) (report *entities.ImageRemoveReport, rmErrors []error) {
+	return ir.Remove(ctx, names, entities.ImageRemoveOptions{LookupManifest: true, Ignore: opts.Ignore})
 }
 
 // ManifestPush pushes a manifest list or image index to the destination

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -178,8 +178,8 @@ func (ir *ImageEngine) ManifestRemoveDigest(ctx context.Context, name string, im
 }
 
 // ManifestRm removes the specified manifest list from storage
-func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string) (*entities.ImageRemoveReport, []error) {
-	return ir.Remove(ctx, names, entities.ImageRemoveOptions{LookupManifest: true})
+func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string, opts entities.ImageRemoveOptions) (report *entities.ImageRemoveReport, rmErrors []error) {
+	return ir.Remove(ctx, names, entities.ImageRemoveOptions{LookupManifest: true, Ignore: opts.Ignore})
 }
 
 // ManifestPush pushes a manifest list or image index to the destination

--- a/test/apiv2/15-manifest.at
+++ b/test/apiv2/15-manifest.at
@@ -66,6 +66,9 @@ t POST "/v4.0.0/libpod/manifests/xyz:latest/registry/localhost:$REGISTRY_PORT%2F
 # /v3.x cannot delete a manifest list
 t DELETE /v4.0.0/libpod/manifests/$id_abc 200
 t DELETE /v4.0.0/libpod/manifests/$id_xyz 200
+t GET /v4.0.0/libpod/manifests/$id_xyz/exists 404
+t DELETE /v4.0.0/libpod/manifests/$id_xyz 404
+t DELETE /v4.0.0/libpod/manifests/$id_xyz?ignore=true 200
 
 # manifest add --artifact tests
 truncate -s 20M $WORKDIR/zeroes

--- a/test/system/012-manifest.bats
+++ b/test/system/012-manifest.bats
@@ -94,6 +94,10 @@ function validate_instance_compression {
         --tls-verify=false $mid \
         $manifest1
     run_podman manifest rm $manifest1
+    run_podman 1 manifest rm $manifest1
+    is "$output" "Error: $manifest1: image not known" "Missing manifest is reported"
+    run_podman manifest rm --ignore $manifest1
+    is "$output" "" "Missing manifest is ignored"
 
     # Default is to require TLS; also test explicit opts
     for opt in '' '--insecure=false' '--tls-verify=true' "--authfile=$authfile"; do


### PR DESCRIPTION
When removing manifests, users should be allowed to ignore ones that no longer exists.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman manifest rm --ignore option added to ignore missing manifests.
```
