### PR TITLE
[skip-ci] Packit: remove epel and re-enable c9s

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,8 +12,6 @@ packages:
   podman-centos:
     pkg_tool: centpkg
     specfile_path: rpm/podman.spec
-  podman-rhel:
-    specfile_path: rpm/podman.spec
   podman-eln:
     specfile_path: rpm/podman.spec
 
@@ -62,20 +60,10 @@ jobs:
     notifications: *packit_build_failure_notification
     enable_net: true
     targets:
-    #  - centos-stream-9-x86_64
-    #  - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
-
-  # Disabled until there is go 1.22 in epel-9
-  # - job: copr_build
-  #   trigger: pull_request
-  #   packages: [podman-rhel]
-  #   notifications: *packit_build_failure_notification
-  #   enable_net: true
-  #   targets:
-  #     - epel-9-x86_64
-  #     - epel-9-aarch64
 
   # Run on commit to main branch
   - job: copr_build


### PR DESCRIPTION
We're moving away from proper rhel testing on upstream because of the slower pace of RHEL. This has already been done on aardvark-dns and some others.

CentOS 9 Stream does move fast enough that we can re-enable it here.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
