### PR TITLE
RFC: Fix compilation issues in QEMU machine files (Windows platform)

### DIFF
--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containers/common/pkg/strongunits"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/storage/pkg/fileutils"
 )
@@ -31,14 +30,6 @@ type QemuCmd []string
 func NewQemuBuilder(binary string, options []string) QemuCmd {
 	q := QemuCmd{binary}
 	return append(q, options...)
-}
-
-// SetMemory adds the specified amount of memory for the machine
-func (q *QemuCmd) SetMemory(m strongunits.MiB) {
-	serializedMem := strconv.FormatUint(uint64(m), 10)
-	// In order to use virtiofsd, we must enable shared memory
-	*q = append(*q, "-object", fmt.Sprintf("memory-backend-memfd,id=mem,size=%sM,share=on", serializedMem))
-	*q = append(*q, "-m", serializedMem)
 }
 
 // SetCPUs adds the number of CPUs the machine will have

--- a/pkg/machine/qemu/command/command_unix.go
+++ b/pkg/machine/qemu/command/command_unix.go
@@ -1,0 +1,18 @@
+//go:build dragonfly || freebsd || linux || netbsd || openbsd
+
+package command
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/containers/common/pkg/strongunits"
+)
+
+// SetMemory adds the specified amount of memory for the machine
+func (q *QemuCmd) SetMemory(m strongunits.MiB) {
+	serializedMem := strconv.FormatUint(uint64(m), 10)
+	// In order to use virtiofsd, we must enable shared memory
+	*q = append(*q, "-object", fmt.Sprintf("memory-backend-memfd,id=mem,size=%sM,share=on", serializedMem))
+	*q = append(*q, "-m", serializedMem)
+}

--- a/pkg/machine/qemu/command/command_windows.go
+++ b/pkg/machine/qemu/command/command_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package command
+
+import (
+	"strconv"
+
+	"github.com/containers/common/pkg/strongunits"
+)
+
+// SetMemory adds the specified amount of memory for the machine
+func (q *QemuCmd) SetMemory(m strongunits.MiB) {
+	serializedMem := strconv.FormatUint(uint64(m), 10)
+	*q = append(*q, "-m", serializedMem)
+}

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows
+//go:build !darwin
 
 package qemu
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1,4 +1,4 @@
-//go:build linux || freebsd
+//go:build linux || freebsd || windows
 
 package qemu
 

--- a/pkg/machine/qemu/machine_unsupported.go
+++ b/pkg/machine/qemu/machine_unsupported.go
@@ -1,3 +1,0 @@
-//go:build !amd64 && !arm64 && darwin
-
-package qemu

--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -1,4 +1,4 @@
-//go:build tempoff
+//go:build windows && amd64
 
 package qemu
 

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -1,4 +1,4 @@
-//go:build linux || freebsd
+//go:build linux || freebsd || windows
 
 package qemu
 

--- a/pkg/machine/qemu/virtiofsd.go
+++ b/pkg/machine/qemu/virtiofsd.go
@@ -1,4 +1,4 @@
-//go:build linux || freebsd
+//go:build linux || freebsd || windows
 
 package qemu
 

--- a/pkg/machine/vmconfigs/config_windows.go
+++ b/pkg/machine/vmconfigs/config_windows.go
@@ -1,7 +1,9 @@
 package vmconfigs
 
 import (
+	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/hyperv/vsock"
+	"github.com/containers/podman/v5/pkg/machine/qemu/command"
 )
 
 type HyperVConfig struct {
@@ -17,10 +19,16 @@ type WSLConfig struct {
 	UserModeNetworking bool
 }
 
+type QEMUConfig struct {
+	// QMPMonitor is the qemu monitor object for sending commands
+	QMPMonitor command.Monitor
+	// QEMUPidPath is where to write the PID for QEMU when running
+	QEMUPidPath *define.VMFile
+}
+
 // Stubs
 type AppleHVConfig struct{}
 type LibKrunConfig struct{}
-type QEMUConfig struct{}
 
 func getHostUID() int {
 	return 1000


### PR DESCRIPTION
There are QEMU machine parts related to Windows platform, which were "fast patched" during 5.0 version development with disabling compilation for a part of them and making them unattended. These files accumulated some amount of code rot.  This PR addresses only the code rot issues w/o enabling the actual QEMU Windows support. It does this in a way that also prevents any new warnings in VSCode.

There is expectation that at some point the whole Windows specific parts could be dropped, but I believe that fixing code rot before would not make any harm (especially with a limited scope and changes being compact). The only ugly part is that shared memory backend for virtiofs has to be handled, because this is not supported on Windows. This could count towards added complexity, but I hope this could be acceptable.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
