### PR TITLE
spec: clamp rlimits without CAP_SYS_RESOURCE

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -52,6 +53,7 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	stypes "github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/moby/sys/capability"
 	runcuser "github.com/moby/sys/user"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -176,6 +178,18 @@ func getOverlayUpperAndWorkDir(options []string) (string, string, error) {
 	}
 	return upperDir, workDir, nil
 }
+
+// hasCapSysResource returns whether the current process has CAP_SYS_RESOURCE.
+var hasCapSysResource = sync.OnceValues(func() (bool, error) {
+	currentCaps, err := capability.NewPid2(0)
+	if err != nil {
+		return false, err
+	}
+	if err = currentCaps.Load(); err != nil {
+		return false, err
+	}
+	return currentCaps.Get(capability.EFFECTIVE, capability.CAP_SYS_RESOURCE), nil
+})
 
 // Generate spec for a container
 // Accepts a map of the container's dependencies
@@ -678,10 +692,21 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 			nprocSet = true
 		}
 	}
+	needsClamping := false
+	if !nofileSet || !nprocSet {
+		needsClamping = isRunningInUserNs
+		if !needsClamping {
+			has, err := hasCapSysResource()
+			if err != nil {
+				return nil, nil, err
+			}
+			needsClamping = !has
+		}
+	}
 	if !nofileSet {
 		max := rlimT(define.RLimitDefaultValue)
 		current := rlimT(define.RLimitDefaultValue)
-		if isRunningInUserNs {
+		if needsClamping {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
 				logrus.Warnf("Failed to return RLIMIT_NOFILE ulimit %q", err)
@@ -698,7 +723,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	if !nprocSet {
 		max := rlimT(define.RLimitDefaultValue)
 		current := rlimT(define.RLimitDefaultValue)
-		if isRunningInUserNs {
+		if needsClamping {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err != nil {
 				logrus.Warnf("Failed to return RLIMIT_NPROC ulimit %q", err)


### PR DESCRIPTION
commit 5ebba75dbd4462da47283b3f018804b7361d52bf implemented this behaviour for rootless users and later commit
0a69aefa41d55d2aa30333d6a4ce76b178d1ed5b changed it when in a user namespace, but the same limitation exists for root without CAP_SYS_RESOURCE.  Change the check to use the clamp to the current values if running without CAP_SYS_RESOURCE.

Closes: https://github.com/containers/podman/issues/24692

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now default ulimits are clamped also for root when running without CAP_SYS_RESOURCE
```
