### PR TITLE
DO NOT MERGE: remote test setup failures are ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -737,8 +737,11 @@ remotesystem:
 			exit 1;\
 		fi;\
 		env PODMAN="$(CURDIR)/bin/podman-remote" bats -T --filter-tags '!ci:parallel' test/system/ ;\
-		env PODMAN="$(CURDIR)/bin/podman-remote" bats -T --filter-tags ci:parallel -j $$(nproc) test/system/ ;\
-		rc=$$?;\
+		rc=$$?; \
+		if [ $$rc -eq 0 ]]; then \
+		   env PODMAN="$(CURDIR)/bin/podman-remote" bats -T --filter-tags ci:parallel -j $$(nproc) test/system/ ;\
+		   rc=$$?;\
+		fi; \
 		kill %1;\
 	else \
 		echo "Skipping $@: 'timeout -v' unavailable'";\

--- a/test/system/155-partial-pull.bats
+++ b/test/system/155-partial-pull.bats
@@ -11,8 +11,6 @@ load helpers.registry
 # BEGIN filtering - none of these tests will work with podman-remote
 
 function setup() {
-    skip_if_remote "none of these tests work with podman-remote"
-
     basic_setup
     start_registry
 }
@@ -157,6 +155,7 @@ function mount_image_and_take_digest() {
 }
 
 @test "zstd chunked does not modify image content" {
+    skip_if_remote "need to mount an image"
     skip_if_rootless "need to mount the image without unshare"
 
     image=localhost:${PODMAN_LOGIN_REGISTRY_PORT}/img-$(safename)


### PR DESCRIPTION
Per https://github.com/containers/podman/pull/24686#issuecomment-2504582727 :
> https://cirrus-ci.com/task/6587238856785920 reports success, but the detailed logs https://api.cirrus-ci.com/v1/task/6587238856785920/logs/main.log show 4 failed tests (all in the setup phase).

This is an attempt to reproduce, and add more debug logging.

#### Does this PR introduce a user-facing change?

```release-note
None
```
