### PR TITLE
make remotesystem: fail early if serial tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -737,8 +737,11 @@ remotesystem:
 			exit 1;\
 		fi;\
 		env PODMAN="$(CURDIR)/bin/podman-remote" bats -T --filter-tags '!ci:parallel' test/system/ ;\
-		env PODMAN="$(CURDIR)/bin/podman-remote" bats -T --filter-tags ci:parallel -j $$(nproc) test/system/ ;\
-		rc=$$?;\
+		rc=$$?; \
+		if [ $$rc -eq 0 ]; then \
+		   env PODMAN="$(CURDIR)/bin/podman-remote" bats -T --filter-tags ci:parallel -j $$(nproc) test/system/ ;\
+		   rc=$$?;\
+		fi; \
 		kill %1;\
 	else \
 		echo "Skipping $@: 'timeout -v' unavailable'";\


### PR DESCRIPTION
Completely my fault, and I'm so sorry.

Untested because I use podman on my home system (for real stuff) and can't afford a `make remotesystem` nuke.

```release-note
None
```
