### PR TITLE
api: Error checking before NULL dereference

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -72,10 +72,10 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 		OverrideConfig:        options.CommitOptions.OverrideConfig,
 	}
 	importBuilder, err := buildah.ImportBuilder(ctx, c.runtime.store, builderOptions)
-	importBuilder.Format = options.PreferredManifestType
 	if err != nil {
 		return nil, err
 	}
+	importBuilder.Format = options.PreferredManifestType
 	if options.Author != "" {
 		importBuilder.SetMaintainer(options.Author)
 	}


### PR DESCRIPTION
Move error checking of possible null returned value before its dereference in importBuilder.Format

Found by Linux Verification Center (linuxtesting.org) with SVACE.

#### Does this PR introduce a user-facing change?

```release-note
   None
```
