### PR TITLE
Fixes missing binary in systemd.

### DIFF
--- a/contrib/systemd/user/podman-user-wait-network-online.service
+++ b/contrib/systemd/user/podman-user-wait-network-online.service
@@ -8,5 +8,5 @@ Type=oneshot
 # Set a timeout as by default oneshot does not have one and in case network-online.target
 # never comes online we do not want to block forever, 90s is the default systemd unit timeout.
 TimeoutStartSec=90s
-ExecStart=sh -c 'until systemctl is-active network-online.target; do sleep 0.5; done'
+ExecStart=/bin/sh -c 'until systemctl is-active network-online.target; do sleep 0.5; done'
 RemainAfterExit=yes


### PR DESCRIPTION
This is broken on e.g. NixOS as systemd only searches a small set of directories for command binary, which does not include `/bin` [1].

[1]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
