### PR TITLE
refact: use uptime.minutes instead of uptime.seconds

### DIFF
--- a/libpod/info.go
+++ b/libpod/info.go
@@ -166,7 +166,7 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("%.0fh %.0fm %.2fs",
 		uptime.hours,
-		math.Mod(uptime.seconds, 3600)/60,
+		math.Mod(uptime.minutes, 60),
 		math.Mod(uptime.seconds, 60),
 	))
 	if int64(uptime.hours) > 0 {


### PR DESCRIPTION
In the `libpod/info.go`, within the `uptime` anonymous struct, there's a `minutes` field, but `seconds` are being used for processing. This PR refactors this issue.

#### Does this PR introduce a user-facing change?

```release-note
None
```
