### PR TITLE
Fix additional image stores in podman info

### DIFF
--- a/libpod/info.go
+++ b/libpod/info.go
@@ -250,7 +250,8 @@ func (r *Runtime) storeInfo() (*define.StoreInfo, error) {
 	graphOptions := map[string]interface{}{}
 	for _, o := range r.store.GraphOptions() {
 		split := strings.SplitN(o, "=", 2)
-		if strings.HasSuffix(split[0], "mount_program") {
+		switch {
+		case strings.HasSuffix(split[0], "mount_program"):
 			ver, err := version.Program(split[1])
 			if err != nil {
 				logrus.Warnf("Failed to retrieve program version for %s: %v", split[1], err)
@@ -260,7 +261,17 @@ func (r *Runtime) storeInfo() (*define.StoreInfo, error) {
 			program["Version"] = ver
 			program["Package"] = version.Package(split[1])
 			graphOptions[split[0]] = program
-		} else {
+		case strings.HasSuffix(split[0], "imagestore"):
+			key := strings.ReplaceAll(split[0], "imagestore", "additionalImageStores")
+			if graphOptions[key] == nil {
+				graphOptions[key] = []string{split[1]}
+			} else {
+				graphOptions[key] = append(graphOptions[key].([]string), split[1])
+			}
+			// Fallthrough to include the `imagestore` key to avoid breaking
+			// Podman v5 API. Should be removed in Podman v6.0.0.
+			fallthrough
+		default:
 			graphOptions[split[0]] = split[1]
 		}
 	}

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -182,6 +182,19 @@ host.slirp4netns.executable | $expr_path
     is "$output" ".*graphOptions: {}" "output includes graphOptions: {}"
 }
 
+@test "podman info - additional image stores" {
+    skip_if_remote "--storage-opt flag is not supported for remote"
+    driver=$(podman_storage_driver)
+    store1=$PODMAN_TMPDIR/store1
+    store2=$PODMAN_TMPDIR/store2
+    mkdir -p $store1 $store2
+    run_podman info --storage-opt=$driver'.imagestore='$store1 \
+                    --storage-opt=$driver'.imagestore='$store2 \
+                    --format '{{index .Store.GraphOptions "'$driver'.additionalImageStores"}}\n{{index .Store.GraphOptions "'$driver'.imagestore"}}'
+    assert "${lines[0]}" == "["$store1" "$store2"]" "output includes additional image stores"
+    assert "${lines[1]}" == "$store2" "old imagestore output"
+}
+
 @test "podman info netavark " {
     # Confirm netavark in use when explicitly required by execution environment.
     if [[ "$NETWORK_BACKEND" == "netavark" ]]; then


### PR DESCRIPTION
The command `podman info` returned only one imagestore in `store.graphOptions.<driver>.imagestore` even if multiple
image stores were configured.

This change replaces the field `<driver>.imagestore` with the field `<driver>.additionalImageStores`, that is an array of strings that includes all the configured additional image stores.

Fix containers/storage#2094

#### Does this PR introduce a user-facing change?

```release-note
Fix `podman info` when there are multiple additional image stores
```
