### PR TITLE
Replace ExclusiveArch with ifarch

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -179,17 +179,18 @@ capabilities specified in user quadlets.
 It is a symlink to %{_bindir}/%{name} and execs into the `%{name}sh` container
 when `%{_bindir}/%{name}sh` is set as a login shell or set as os.Args[0].
 
+%ifarch x86_64 aarch64
 %package machine
 Summary: Metapackage for setting up %{name} machine
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: gvisor-tap-vsock
 Requires: qemu
 Requires: virtiofsd
-ExclusiveArch: x86_64 aarch64
 
 %description machine
 This subpackage installs the dependencies for %{name} machine, for more see:
 https://docs.podman.io/en/latest/markdown/podman-machine.1.html
+%endif
 
 %prep
 %autosetup -Sgit -n %{name}-%{version_no_tilde}
@@ -283,8 +284,10 @@ rm -f %{buildroot}%{_mandir}/man5/docker*.5
 install -d -p %{buildroot}%{_datadir}/%{name}/test/system
 cp -pav test/system %{buildroot}%{_datadir}/%{name}/test/
 
+%ifarch x86_64 aarch64
 # symlink virtiofsd in %%{name} libexecdir for machine subpackage
 ln -s ../virtiofsd %{buildroot}%{_libexecdir}/%{name}
+%endif
 
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}
@@ -339,9 +342,11 @@ ln -s ../virtiofsd %{buildroot}%{_libexecdir}/%{name}
 %{_bindir}/%{name}sh
 %{_mandir}/man1/%{name}sh.1*
 
+%ifarch x86_64 aarch64
 %files machine
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/virtiofsd
+%endif
 
 %changelog
 %autochangelog


### PR DESCRIPTION
The ExclusiveArch spec macro is parsed only on spec parsing level. In this particular case that means that podman-machine is generated on all arches despite of ExclusiveArch present in a subpackage. It is confusing indeed. In order to assure podman-machine is built only on certain arches we need to use ifarch spec macro, as presented in this PR. I verified  it with a scratch build.