### PR TITLE
api: replace inspectID with name

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -107,7 +107,7 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 	options := &libimage.InspectOptions{WithParent: true, WithSize: true}
 	inspect, err := newImage.Inspect(r.Context(), options)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed in inspect image %s: %w", inspect.ID, err))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed in inspect image %s: %w", name, err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, inspect)


### PR DESCRIPTION
If err != nil then inspect is nil thus here it is better to use name when outputting the error instead of inspectID.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

#### Does this PR introduce a user-facing change?

```release-note
None
```
