### PR TITLE
[skip-ci] RPM: no qemu on RHEL

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -24,6 +24,8 @@
 
 %if %{defined fedora}
 %define build_with_btrfs 1
+# qemu-system* isn't packageed for CentOS Stream / RHEL
+%define qemu 1
 %endif
 
 %if %{defined copr_username}
@@ -187,7 +189,17 @@ when `%{_bindir}/%{name}sh` is set as a login shell or set as os.Args[0].
 Summary: Metapackage for setting up %{name} machine
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: gvisor-tap-vsock
-Requires: qemu
+%if %{defined qemu}
+%ifarch aarch64
+Requires: qemu-system-aarch64-core
+%endif
+%ifarch x86_64
+Requires: qemu-system-x86-core
+%endif
+%else
+Requires: qemu-kvm
+%endif
+Requires: qemu-img
 Requires: virtiofsd
 ExclusiveArch: x86_64 aarch64
 

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -308,6 +308,9 @@ ln -s ../virtiofsd %{buildroot}%{_libexecdir}/%{name}
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}
 
+# Include empty check to silence rpmlint warning
+%check
+
 %files -f %{name}.file-list
 %license LICENSE vendor/modules.txt
 %doc README.md CONTRIBUTING.md install.md transfer.md


### PR DESCRIPTION
This commit adjusts qemu dependency to be Fedora only.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
