### PR TITLE
Fix device limitations in `podman-remote update` on remote systems

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -18,6 +18,7 @@ import (
 	api "github.com/containers/podman/v5/pkg/api/types"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/domain/infra/abi"
+	"github.com/containers/podman/v5/pkg/specgenutil"
 	"github.com/containers/podman/v5/pkg/util"
 	"github.com/gorilla/schema"
 	"github.com/sirupsen/logrus"
@@ -447,7 +448,14 @@ func UpdateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("decode(): %w", err))
 		return
 	}
-	err = ctr.Update(&options.LinuxResources, restartPolicy, restartRetries, &options.UpdateHealthCheckConfig)
+
+	resourceLimits, err := specgenutil.UpdateMajorAndMinorNumbers(&options.LinuxResources, &options.UpdateContainerDevicesLimits)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	err = ctr.Update(resourceLimits, restartPolicy, restartRetries, &options.UpdateHealthCheckConfig)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/handlers/swagger/responses.go
+++ b/pkg/api/handlers/swagger/responses.go
@@ -324,9 +324,13 @@ type containerCreateResponse struct {
 	Body entities.ContainerCreateResponse
 }
 
+// Update container
+// swagger:response
 type containerUpdateResponse struct {
 	// in:body
-	ID string
+	Body struct {
+		ID string
+	}
 }
 
 // Wait container

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -76,6 +76,7 @@ type LibpodContainersRmReport struct {
 type UpdateEntities struct {
 	specs.LinuxResources
 	define.UpdateHealthCheckConfig
+	define.UpdateContainerDevicesLimits
 }
 
 type Info struct {

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1804,9 +1804,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// produces:
 	// - application/json
 	// responses:
-	//   responses:
-	//     201:
-	//       $ref: "#/responses/containerUpdateResponse"
+	//   201:
+	//     $ref: "#/responses/containerUpdateResponse"
 	//   400:
 	//     $ref: "#/responses/badParamError"
 	//   404:

--- a/pkg/bindings/containers/update.go
+++ b/pkg/bindings/containers/update.go
@@ -20,15 +20,16 @@ func Update(ctx context.Context, options *types.ContainerUpdateOptions) (string,
 	}
 
 	params := url.Values{}
-	if options.Specgen.RestartPolicy != "" {
-		params.Set("restartPolicy", options.Specgen.RestartPolicy)
-		if options.Specgen.RestartRetries != nil {
-			params.Set("restartRetries", strconv.Itoa(int(*options.Specgen.RestartRetries)))
+	if options.RestartPolicy != nil {
+		params.Set("restartPolicy", *options.RestartPolicy)
+		if options.RestartRetries != nil {
+			params.Set("restartRetries", strconv.Itoa(int(*options.RestartRetries)))
 		}
 	}
 	updateEntities := &handlers.UpdateEntities{
-		LinuxResources:          *options.Specgen.ResourceLimits,
-		UpdateHealthCheckConfig: *options.ChangedHealthCheckConfiguration,
+		LinuxResources:               *options.Resources,
+		UpdateHealthCheckConfig:      *options.ChangedHealthCheckConfiguration,
+		UpdateContainerDevicesLimits: *options.DevicesLimits,
 	}
 	requestData, err := jsoniter.MarshalToString(updateEntities)
 	if err != nil {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -1061,13 +1061,6 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 
 // ContainerUpdate finds and updates the given container's cgroup config with the specified options
 func (ic *ContainerEngine) ContainerUpdate(ctx context.Context, updateOptions *entities.ContainerUpdateOptions) (string, error) {
-	err := specgen.WeightDevices(updateOptions.Specgen)
-	if err != nil {
-		return "", err
-	}
-	err = specgen.FinishThrottleDevices(updateOptions.Specgen)
-	if err != nil {
-		return "", err
-	}
+	updateOptions.ProcessSpecgen()
 	return containers.Update(ic.ClientCtx, updateOptions)
 }

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -1297,3 +1297,27 @@ func GetResources(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions) 
 	}
 	return s.ResourceLimits, nil
 }
+
+func UpdateMajorAndMinorNumbers(resources *specs.LinuxResources, devicesLimits *define.UpdateContainerDevicesLimits) (*specs.LinuxResources, error) {
+	spec := specgen.SpecGenerator{}
+	spec.ResourceLimits = &specs.LinuxResources{}
+	if resources != nil {
+		spec.ResourceLimits = resources
+	}
+
+	spec.WeightDevice = devicesLimits.GetMapOfLinuxWeightDevice()
+	spec.ThrottleReadBpsDevice = devicesLimits.GetMapOfDeviceReadBPs()
+	spec.ThrottleWriteBpsDevice = devicesLimits.GetMapOfDeviceWriteBPs()
+	spec.ThrottleReadIOPSDevice = devicesLimits.GetMapOfDeviceReadIOPs()
+	spec.ThrottleWriteIOPSDevice = devicesLimits.GetMapOfDeviceWriteIOPs()
+
+	err := specgen.WeightDevices(&spec)
+	if err != nil {
+		return nil, err
+	}
+	err = specgen.FinishThrottleDevices(&spec)
+	if err != nil {
+		return nil, err
+	}
+	return spec.ResourceLimits, nil
+}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -686,18 +686,56 @@ t GET libpod/containers/$cname/json 200 \
 
 if root; then
   podman run -dt --name=updateCtr alpine
-  echo '{"Memory":{"Limit":500000}, "CPU":{"Shares":123}}' >${TMPD}/update.json
+  echo '{
+    "Memory":{"Limit":500000},
+    "CPU":{"Shares":123},
+    "DeviceReadBPs": [{ "Path": "/dev/zero", "Rate": 10485760 }],
+    "DeviceWriteBPs": [{ "Path": "/dev/zero", "Rate": 31457280 }],
+    "DeviceReadIOPs": [{ "Path": "/dev/zero", "Rate": 2000 }],
+    "DeviceWriteIOPs": [{ "Path": "/dev/zero", "Rate": 4000 }]
+    }' >${TMPD}/update.json
   t POST libpod/containers/updateCtr/update ${TMPD}/update.json 201
 
   cgroupPath=/sys/fs/cgroup/cpu.weight
   # 002 is the byte length
   cpu_weight_expect=$'\001\0025'
 
-  # Verify
+  # Verify CPU weight
   echo '{ "AttachStdout":true,"Cmd":["cat", "'$cgroupPath'"]}' >${TMPD}/exec.json
   t POST containers/updateCtr/exec ${TMPD}/exec.json 201 .Id~[0-9a-f]\\{64\\}
   eid=$(jq -r '.Id' <<<"$output")
   t POST exec/$eid/start 200 $cpu_weight_expect
+
+  BlkioDeviceReadBps_expected='[
+  {
+    "Path": "/dev/zero",
+    "Rate": 10485760
+  }
+]'
+  BlkioDeviceWriteBPs_expected='[
+  {
+    "Path": "/dev/zero",
+    "Rate": 31457280
+  }
+]'
+  BlkioDeviceReadIOPs_expected='[
+  {
+    "Path": "/dev/zero",
+    "Rate": 2000
+  }
+]'
+  BlkioDeviceWriteIOPs_expected='[
+  {
+    "Path": "/dev/zero",
+    "Rate": 4000
+  }
+]'
+  # Verify Device limits
+  t GET containers/updateCtr/json 200 \
+  .HostConfig.BlkioDeviceReadBps="$BlkioDeviceReadBps_expected"     \
+  .HostConfig.BlkioDeviceWriteBps="$BlkioDeviceWriteBPs_expected"   \
+  .HostConfig.BlkioDeviceReadIOps="$BlkioDeviceReadIOPs_expected"   \
+  .HostConfig.BlkioDeviceWriteIOps="$BlkioDeviceWriteIOPs_expected" \
 
   # Now use the compat API
   echo '{ "Memory": 536870912 }' >${TMPD}/compatupdate.json


### PR DESCRIPTION
This PR fixes device limitations using `podman-remote update` on remote systems. The cause of the problem was that the major and minor numbers were loaded on the client system and then sent to the remote system, where there could be different major and minor numbers for each device. 

Reproducer in Issue: #24734

Fixes: https://issues.redhat.com/browse/RUN-2381
Fixes: https://github.com/containers/podman/issues/24734

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix device limitations in `podman-remote update` on remote systems
```
