### PR TITLE
Fix panic in `manifest annotate --index`

### DIFF
--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -119,7 +119,7 @@ func annotate(cmd *cobra.Command, args []string) error {
 	} else {
 		opts.Annotations = annotations
 	}
-	id, err := registry.ImageEngine().ManifestAnnotate(registry.Context(), args[0], args[1], opts)
+	id, err := registry.ImageEngine().ManifestAnnotate(registry.Context(), listImageSpec, instanceSpec, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -706,14 +706,20 @@ func ManifestModify(w http.ResponseWriter, r *http.Request) {
 		}
 	case strings.EqualFold("annotate", body.Operation):
 		options := body.ManifestAnnotateOptions
-		for _, image := range body.Images {
+		images := []string{""}
+		if len(body.Images) > 0 {
+			images = body.Images
+		}
+		for _, image := range images {
 			id, err := imageEngine.ManifestAnnotate(r.Context(), name, image, options)
 			if err != nil {
 				report.Errors = append(report.Errors, err)
 				continue
 			}
 			report.ID = id
-			report.Images = append(report.Images, image)
+			if image != "" {
+				report.Images = append(report.Images, image)
+			}
 		}
 	default:
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("illegal operation %q for %q", body.Operation, r.URL.String()))

--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -19,7 +19,7 @@ type InspectOptions struct {
 type CreateOptions struct {
 	All        *bool
 	Amend      *bool
-	Annotation map[string]string
+	Annotation map[string]string `json:"annotations" schema:"annotations"`
 }
 
 // ExistsOptions are optional options for checking
@@ -35,7 +35,7 @@ type ExistsOptions struct {
 type AddOptions struct {
 	All *bool
 
-	Annotation map[string]string
+	Annotation map[string]string `json:"annotations" schema:"annotations"`
 	Arch       *string
 	Features   []string
 	OS         *string
@@ -54,7 +54,7 @@ type AddOptions struct {
 //
 //go:generate go run ../generator/generator.go AddArtifactOptions
 type AddArtifactOptions struct {
-	Annotation map[string]string
+	Annotation map[string]string `json:"annotations" schema:"annotations"`
 	Arch       *string
 	Features   []string
 	OS         *string
@@ -87,13 +87,14 @@ type ModifyOptions struct {
 	Operation *string
 	All       *bool // All when true, operate on all images in a manifest list that may be included in Images
 
-	Annotations map[string]string // Annotations to add to the entries for Images in the manifest list
-	Arch        *string           // Arch overrides the architecture for the image
-	Features    []string          // Feature list for the image
-	OS          *string           // OS overrides the operating system for the image
-	OSFeatures  []string          `json:"os_features" schema:"os_features"` // OSFeatures overrides the OS features for the image
-	OSVersion   *string           `json:"os_version" schema:"os_version"`   // OSVersion overrides the operating system version for the image
-	Variant     *string           // Variant overrides the architecture variant for the image
+	Annotations      map[string]string // Annotations to add to the entries for Images in the manifest list
+	IndexAnnotations map[string]string `json:"index_annotations" schema:"index_annotations"` // Annotations to add to the manifest list as a whole
+	Arch             *string           // Arch overrides the architecture for the image
+	Features         []string          // Feature list for the image
+	OS               *string           // OS overrides the operating system for the image
+	OSFeatures       []string          `json:"os_features" schema:"os_features"` // OSFeatures overrides the OS features for the image
+	OSVersion        *string           `json:"os_version" schema:"os_version"`   // OSVersion overrides the operating system version for the image
+	Variant          *string           // Variant overrides the architecture variant for the image
 
 	Images        []string // Images is an optional list of images to add/remove to/from manifest list depending on operation
 	Authfile      *string

--- a/pkg/bindings/manifests/types_modify_options.go
+++ b/pkg/bindings/manifests/types_modify_options.go
@@ -63,6 +63,21 @@ func (o *ModifyOptions) GetAnnotations() map[string]string {
 	return o.Annotations
 }
 
+// WithIndexAnnotations set annotations to add to the manifest list as a whole
+func (o *ModifyOptions) WithIndexAnnotations(value map[string]string) *ModifyOptions {
+	o.IndexAnnotations = value
+	return o
+}
+
+// GetIndexAnnotations returns value of annotations to add to the manifest list as a whole
+func (o *ModifyOptions) GetIndexAnnotations() map[string]string {
+	if o.IndexAnnotations == nil {
+		var z map[string]string
+		return z
+	}
+	return o.IndexAnnotations
+}
+
 // WithArch set arch overrides the architecture for the image
 func (o *ModifyOptions) WithArch(value string) *ModifyOptions {
 	o.Arch = &value

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -82,9 +82,9 @@ type ManifestAnnotateOptions struct {
 	// Variant for the item in the manifest list
 	Variant string `json:"variant" schema:"variant"`
 	// IndexAnnotation is a slice of key=value annotations to add to the manifest list itself
-	IndexAnnotation []string `json:"index_annotation" schema:"annotation"`
+	IndexAnnotation []string `json:"index_annotation" schema:"index_annotation"`
 	// IndexAnnotations is a map of key:value annotations to add to the manifest list itself, by a map which is preferred over IndexAnnotation
-	IndexAnnotations map[string]string `json:"index_annotations" schema:"annotations"`
+	IndexAnnotations map[string]string `json:"index_annotations" schema:"index_annotations"`
 	// IndexSubject is a subject value to set in the manifest list itself
 	IndexSubject string `json:"subject" schema:"subject"`
 }

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -49,9 +49,10 @@ func (ir *ImageEngine) ManifestCreate(ctx context.Context, name string, images [
 		}
 	}
 
-	annotateOptions := &libimage.ManifestListAnnotateOptions{}
 	if len(opts.Annotations) != 0 {
-		annotateOptions.IndexAnnotations = opts.Annotations
+		annotateOptions := &libimage.ManifestListAnnotateOptions{
+			IndexAnnotations: opts.Annotations,
+		}
 		if err := manifestList.AnnotateInstance("", annotateOptions); err != nil {
 			return "", err
 		}
@@ -230,18 +231,14 @@ func (ir *ImageEngine) ManifestAdd(ctx context.Context, name string, images []st
 			Variant:      opts.Variant,
 			Subject:      opts.IndexSubject,
 		}
-		if len(opts.Annotation) != 0 {
-			annotations := make(map[string]string)
-			for _, annotationSpec := range opts.Annotation {
-				key, val, hasVal := strings.Cut(annotationSpec, "=")
-				if !hasVal {
-					return "", fmt.Errorf("no value given for annotation %q", key)
-				}
-				annotations[key] = val
-			}
-			opts.Annotations = envLib.Join(opts.Annotations, annotations)
+
+		if annotateOptions.Annotations, err = mergeAnnotations(opts.Annotations, opts.Annotation); err != nil {
+			return "", err
 		}
-		annotateOptions.Annotations = opts.Annotations
+
+		if annotateOptions.IndexAnnotations, err = mergeAnnotations(opts.IndexAnnotations, opts.IndexAnnotation); err != nil {
+			return "", err
+		}
 
 		if err := manifestList.AnnotateInstance(instanceDigest, annotateOptions); err != nil {
 			return "", err
@@ -380,10 +377,12 @@ func (ir *ImageEngine) ManifestAddArtifact(ctx context.Context, name string, fil
 		Variant:      opts.Variant,
 		Subject:      opts.IndexSubject,
 	}
-	if annotateOptions.Annotations, err = mergeAnnotations(opts.Annotations, opts.Annotation); err != nil {
+
+	if annotateOptions.Annotations, err = mergeAnnotations(opts.ManifestAnnotateOptions.Annotations, opts.ManifestAnnotateOptions.Annotation); err != nil {
 		return "", err
 	}
-	if annotateOptions.IndexAnnotations, err = mergeAnnotations(opts.IndexAnnotations, opts.IndexAnnotation); err != nil {
+
+	if annotateOptions.IndexAnnotations, err = mergeAnnotations(opts.ManifestAnnotateOptions.IndexAnnotations, opts.ManifestAnnotateOptions.IndexAnnotation); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
When the --index flag is used, `manifest annotate` shouldn't be expecting a second non-flag argument.
Fixes #24750.

#### Does this PR introduce a user-facing change?

```release-note
`podman manifest annotate` no longer panics when the `--index` flag is used.
```