### PR TITLE
Avoid rebooting on windows when upgrading from 5.3.1 and WSL isn't installed

### DIFF
--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -12,7 +12,7 @@
 
 	<Package Name="podman" Manufacturer="Red Hat Inc." Version="$(VERSION)" UpgradeCode="a6a9dd9c-0732-44ba-9279-ffe22ea50671">
 		<Media Id="1" Cabinet="Podman.cab" EmbedCab="yes" />
-		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." RemoveFeatures="Complete" Schedule="afterInstallExecute" />
+		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." RemoveFeatures="ExecutablesDocsAndWindowsFeatures" Schedule="afterInstallExecute" IgnoreRemoveFailure="true" />
 		<Property Id="DiskPrompt" Value="Red Hat's Podman $(VERSION) Installation" />
 		<Property Id="MACHINE_PROVIDER" Value="wsl" />
 		<Property Id="MACHINE_PROVIDER_CONFIG_FILE_PATH">
@@ -84,7 +84,7 @@
 				<PanelSW:Dism EnableFeature="Microsoft-Hyper-V" ErrorHandling="prompt" />
 			</Component>
 		</ComponentGroup>
-		<Feature Id="Complete" Level="1">
+		<Feature Id="ExecutablesDocsAndWindowsFeatures" Level="1">
 			<ComponentRef Id="INSTALLDIR_Component" />
 			<ComponentRef Id="EnvEntriesComponent" />
 			<ComponentRef Id="MainExecutable" />

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -41,7 +41,7 @@
 			- The user has set property `MACHINE_PROVIDER` to "wsl"
 			- The user hasn't set property `WITH_WSL` to 0
 		-->
-		<SetProperty Id="WSL_INSTALL" Before="AppSearch" Value="1" Sequence="first" Condition="(HAS_WSLFEATURE = 0) AND (MACHINE_PROVIDER = &quot;wsl&quot;) AND (NOT (WITH_WSL = 0))" />
+		<SetProperty Id="WSL_INSTALL" Before="AppSearch" Value="0" Sequence="first" Condition="(HAS_WSLFEATURE = 0) AND (MACHINE_PROVIDER = &quot;wsl&quot;) AND (NOT (WITH_WSL = 0))" />
 		<!--
 		Property HYPERV_INSTALL is set at runtime and used as the condition to run the `HyperVFeatureComponent` Component:
 		HyperV is installed only if all these conditions are met:
@@ -49,7 +49,7 @@
 			- The user has set property `MACHINE_PROVIDER` to "hyperv"
 			- The user hasn't set property `WITH_HYPERV` to 0
 		-->
-		<SetProperty Id="HYPERV_INSTALL" Before="AppSearch" Value="1" Sequence="first" Condition="(HAS_HYPERVFEATURE = 0) AND (MACHINE_PROVIDER = &quot;hyperv&quot;) AND (NOT (WITH_HYPERV = 0))" />
+		<SetProperty Id="HYPERV_INSTALL" Before="AppSearch" Value="0" Sequence="first" Condition="(HAS_HYPERVFEATURE = 0) AND (MACHINE_PROVIDER = &quot;hyperv&quot;) AND (NOT (WITH_HYPERV = 0))" />
 		<!--
 		Property CREATE_MACHINE_PROVIDER_CONFIG_FILE is set at runtime and used as the condition to run the `MachineProviderConfigFile` Component:
 		The machine provider config file is created (or is not deleted if it already exist) if these conditions are met:
@@ -72,14 +72,14 @@
 		<CustomAction Id="CheckHyperV" Execute="firstSequence" DllEntry="CheckHyperV" BinaryRef="PodmanHooks" />
 		<util:BroadcastEnvironmentChange />
 		<ComponentGroup Id="WSLFeature" Directory="INSTALLDIR">
-			<Component Id="WSLFeatureComponent" Guid="F6A693BC-186C-4E64-8015-C3073013B3A8" Condition="(NOT WIX_UPGRADE_DETECTED) AND (WSL_INSTALL = 1)">
+			<Component Id="WSLFeatureComponent" Guid="F6A693BC-186C-4E64-8015-C3073013B3A8" Condition="(NOT Installed) AND (NOT UpdateStarted) AND (WSL_INSTALL = 1)">
 				<CreateFolder />
 				<PanelSW:Dism EnableFeature="VirtualMachinePlatform" ErrorHandling="prompt" />
 				<PanelSW:Dism EnableFeature="Microsoft-Windows-Subsystem-Linux" ErrorHandling="prompt" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="HyperVFeature" Directory="INSTALLDIR">
-			<Component Id="HyperVFeatureComponent" Guid="F7B2D4C9-6C89-46BB-B4EA-FF39424972F3" Condition="(NOT WIX_UPGRADE_DETECTED) AND (HYPERV_INSTALL = 1)">
+			<Component Id="HyperVFeatureComponent" Guid="F7B2D4C9-6C89-46BB-B4EA-FF39424972F3" Condition="(NOT Installed) AND (NOT UpdateStarted) AND (HYPERV_INSTALL = 1)">
 				<CreateFolder />
 				<PanelSW:Dism EnableFeature="Microsoft-Hyper-V" ErrorHandling="prompt" />
 			</Component>
@@ -110,13 +110,13 @@
 		<WixVariable Id="WixUIDialogBmp" Value="resources\podman-dialog.png" />
 		<UIRef Id="PodmanUI" />
 		<UI>
-			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenGuide" Condition="(WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1) AND (NOT WIX_UPGRADE_DETECTED)" />
+			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenGuide" Condition="(WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1) AND (NOT Installed) AND (NOT UpdateStarted)" />
 		</UI>
 
 		<InstallExecuteSequence>
 			<Custom Action="CheckWSL" Before="SetWSL_INSTALL" />
 			<Custom Action="CheckHyperV" Before="SetHYPERV_INSTALL" />
-			<ForceReboot Before="StopServices" Condition="(NOT WIX_UPGRADE_DETECTED) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
+			<ForceReboot Before="StopServices" Condition="(NOT Installed) AND (NOT UpdateStarted) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
 		</InstallExecuteSequence>
 		<Binary Id="PodmanHooks" SourceFile="artifacts/podman-msihooks.dll" />
 

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -221,11 +221,13 @@ function Remove-Podman-Machine-Conf {
 }
 
 function Get-Latest-Podman-Setup-From-GitHub {
-    $tag = "5.3.0"
-    Write-Host "Downloading the $tag Podman windows setup from GitHub..."
-    $downloadUrl = "https://github.com/containers/podman/releases/download/v$tag/podman-$tag-setup.exe"
+    Write-Host "Downloading the latest Podman windows setup from GitHub..."
+    $apiUrl = "https://api.github.com/repos/containers/podman/releases/latest"
+    $response = Invoke-RestMethod -Uri $apiUrl -Headers @{"User-Agent"="PowerShell"} -ErrorAction Stop
+    $downloadUrl = $response.assets[0].browser_download_url
     Write-Host "Downloading URL: $downloadUrl"
-    $destinationPath = "$PSScriptRoot\podman-$tag-setup.exe"
+    $latestTag = $response.tag_name
+    $destinationPath = "$PSScriptRoot\podman-$latestTag-setup.exe"
     Write-Host "Destination Path: $destinationPath"
     Invoke-WebRequest -Uri $downloadUrl -OutFile $destinationPath
     Write-Host "Command completed successfully!`n"

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -1,6 +1,11 @@
 #!/usr/bin/env pwsh
 
-# Example usage:
+# Usage examples:
+#
+# 1) Build a v9.9.9 installer and run `update-without-user-chages`
+#    scenario without specifying the previous setup exe (it will download from
+#    GitHub):
+#
 # rm .\contrib\win-installer\*.log &&
 # rm .\contrib\win-installer\*.exe &&
 # rm .\contrib\win-installer\*.wixpdb &&
@@ -9,6 +14,21 @@
 #     -scenario update-without-user-changes `
 #     -setupExePath ".\contrib\win-installer\podman-9.9.9-dev-setup.exe" `
 #     -provider hyperv
+#
+# 2) Build v5.4.0 and v9.9.9 installers and run
+#    `update-without-user-chages` scenario from v5.4.0 to v9.9.9:
+#
+# rm .\contrib\win-installer\*.log &&
+# rm .\contrib\win-installer\*.exe &&
+# rm .\contrib\win-installer\*.wixpdb &&
+# .\winmake.ps1 installer 5.4.0 &&
+# .\winmake.ps1 installer 9.9.9 &&
+# .\contrib\win-installer\test-installer.ps1 `
+#     -scenario update-without-user-changes `
+#     -previousSetupExePath ".\contrib\win-installer\podman-5.4.0-dev-setup.exe" `
+#     -setupExePath ".\contrib\win-installer\podman-9.9.9-dev-setup.exe" `
+#     -provider hyperv
+#
 
 # The Param statement must be the first statement, except for comments and any #Require statements.
 param (
@@ -77,10 +97,10 @@ function Install-Podman-With-Defaults {
     $ret = Start-Process -Wait `
                             -PassThru "$setupExePath" `
                             -ArgumentList "/install /quiet `
-                                /log $PSScriptRoot\podman-setup.log"
+                                /log $PSScriptRoot\podman-setup-default.log"
     if ($ret.ExitCode -ne 0) {
         Write-Host "Install failed, dumping log"
-        Get-Content $PSScriptRoot\podman-setup.log
+        Get-Content $PSScriptRoot\podman-setup-default.log
         throw "Exit code is $($ret.ExitCode)"
     }
     Write-Host "Installation completed successfully!`n"


### PR DESCRIPTION
### The problem

If WSL is not installed, the machine reboots when upgrading from 5.3.1 to a newer version.

### Why it happens

During an upgrade, the old v5.3.1 installer is invoked to uninstall the existing package. The v5.3.1 included a regression that triggered a reboot only when it gets updated.

### Changes introduced by this PR

There doesn't seem to be a simple way to avoid the 5.3.1 to force a reboot except maybe by creating a patch as part of a `MinorUpgrade` release. But we currently use the default `MajorUpgrade` release. Which is simpler, even if it runs the uninstallation of the previous release.

This PR proposes a trick to avoid creating a Patch and includes three commits:

1. Fixes the root cause of the problem: `ForceReboot` is executed only if `NOT Installed` and the default value of `WSL_INSTALL` and `HYPERV_INSTALL` properties is set to zero
2. Introduces a trick to provoke a`v5.3.1` uninstallation failure. The failure is ignored, but the reboot isn't triggered and the upgrade completes successfully.
3. Reverts the commit that disabled the `v5.3.1` upgrade test

Reference:  https://github.com/orgs/wixtoolset/discussions/8854
Related issue: https://github.com/containers/podman/issues/24735

#### Does this PR introduce a user-facing change?

```release-note
None
```
