### PR TITLE
Add BuildOrigin field to podman info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ GOFLAGS ?= -trimpath
 LDFLAGS_PODMAN ?= \
 	$(if $(GIT_COMMIT),-X $(LIBPOD)/define.gitCommit=$(GIT_COMMIT),) \
 	$(if $(BUILD_INFO),-X $(LIBPOD)/define.buildInfo=$(BUILD_INFO),) \
+	$(if $(BUILD_ORIGIN),-X $(LIBPOD)/define.buildOrigin=$(BUILD_ORIGIN),) \
 	-X $(LIBPOD)/config._installPrefix=$(PREFIX) \
 	-X $(LIBPOD)/config._etcDir=$(ETCDIR) \
 	-X $(PROJECT)/v5/pkg/systemd/quadlet._binDir=$(BINDIR) \

--- a/cmd/podman/client.go
+++ b/cmd/podman/client.go
@@ -3,9 +3,10 @@ package main
 import "github.com/containers/podman/v5/libpod/define"
 
 type clientInfo struct {
-	OSArch   string `json:"OS"`
-	Provider string `json:"provider"`
-	Version  string `json:"version"`
+	OSArch      string `json:"OS"`
+	Provider    string `json:"provider"`
+	Version     string `json:"version"`
+	BuildOrigin string `json:"buildOrigin,omitempty" yaml:",omitempty"`
 }
 
 func getClientInfo() (*clientInfo, error) {
@@ -18,8 +19,9 @@ func getClientInfo() (*clientInfo, error) {
 		return nil, err
 	}
 	return &clientInfo{
-		OSArch:   vinfo.OsArch,
-		Provider: p,
-		Version:  vinfo.Version,
+		OSArch:      vinfo.OsArch,
+		Provider:    p,
+		Version:     vinfo.Version,
+		BuildOrigin: vinfo.BuildOrigin,
 	}, nil
 }

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -97,6 +97,7 @@ API Version:\t{{.APIVersion}}
 Go Version:\t{{.GoVersion}}
 {{if .GitCommit -}}Git Commit:\t{{.GitCommit}}\n{{end -}}
 Built:\t{{.BuiltTime}}
+{{if .BuildOrigin -}}Build Origin:\t{{.BuildOrigin}}\n{{end -}}
 OS/Arch:\t{{.OsArch}}
 {{- end}}
 
@@ -108,6 +109,7 @@ API Version:\t{{.APIVersion}}
 Go Version:\t{{.GoVersion}}
 {{if .GitCommit -}}Git Commit:\t{{.GitCommit}}\n{{end -}}
 Built:\t{{.BuiltTime}}
+{{if .BuildOrigin -}}Build Origin:\t{{.BuildOrigin}}\n{{end -}}
 OS/Arch:\t{{.OsArch}}
 {{- end}}{{- end}}
 `

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -9,6 +9,7 @@ PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
 NO_CODESIGN=${NO_CODESIGN:-0}
 HELPER_BINARIES_DIR="/opt/podman/bin"
 MACHINE_POLICY_JSON_DIR="/opt/podman/config"
+BUILD_ORIGIN="pkginstaller"
 
 tmpBin="contrib/pkginstaller/tmp-bin"
 
@@ -47,7 +48,7 @@ function build_podman() {
 }
 
 function build_podman_arch(){
-    make -B GOARCH="$1" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}"
+    make -B GOARCH="$1" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}" BUILD_ORIGIN="${BUILD_ORIGIN}"
     make -B GOARCH="$1" podman-mac-helper
     mkdir -p "${tmpBin}"
     cp bin/darwin/podman "${tmpBin}/podman-$1"

--- a/libpod/define/version.go
+++ b/libpod/define/version.go
@@ -16,18 +16,22 @@ var (
 	// BuildInfo is the time at which the binary was built
 	// It will be populated by the Makefile.
 	buildInfo string
+	// BuildOrigin is the packager of the binary.
+	// It will be populated at build-time.
+	buildOrigin string
 )
 
 // Version is an output struct for API
 type Version struct {
-	APIVersion string
-	Version    string
-	GoVersion  string
-	GitCommit  string
-	BuiltTime  string
-	Built      int64
-	OsArch     string
-	Os         string
+	APIVersion  string
+	Version     string
+	GoVersion   string
+	GitCommit   string
+	BuiltTime   string
+	Built       int64
+	BuildOrigin string `json:",omitempty" yaml:",omitempty"`
+	OsArch      string
+	Os          string
 }
 
 // GetVersion returns a VersionOutput struct for API and podman
@@ -43,13 +47,14 @@ func GetVersion() (Version, error) {
 		}
 	}
 	return Version{
-		APIVersion: version.APIVersion[version.Libpod][version.CurrentAPI].String(),
-		Version:    version.Version.String(),
-		GoVersion:  runtime.Version(),
-		GitCommit:  gitCommit,
-		BuiltTime:  time.Unix(buildTime, 0).Format(time.ANSIC),
-		Built:      buildTime,
-		OsArch:     runtime.GOOS + "/" + runtime.GOARCH,
-		Os:         runtime.GOOS,
+		APIVersion:  version.APIVersion[version.Libpod][version.CurrentAPI].String(),
+		Version:     version.Version.String(),
+		GoVersion:   runtime.Version(),
+		GitCommit:   gitCommit,
+		BuiltTime:   time.Unix(buildTime, 0).Format(time.ANSIC),
+		Built:       buildTime,
+		BuildOrigin: buildOrigin,
+		OsArch:      runtime.GOOS + "/" + runtime.GOARCH,
+		Os:          runtime.GOOS,
 	}, nil
 }

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -291,4 +291,16 @@ var _ = Describe("Podman Info", func() {
 		Expect(info).ToNot(ExitCleanly())
 		podmanTest.StartRemoteService() // Start service again so teardown runs clean
 	})
+
+	It("Podman info: check client information", func() {
+		info := podmanTest.Podman([]string{"info", "--format", "{{ .Client }}"})
+		info.WaitWithDefaultTimeout()
+		Expect(info).To(ExitCleanly())
+		// client info should only appear when using the remote client
+		if IsRemote() {
+			Expect(info.OutputToString()).ToNot(Equal("<nil>"))
+		} else {
+			Expect(info.OutputToString()).To(Equal("<nil>"))
+		}
+	})
 })


### PR DESCRIPTION
BuiltOrigin is a field that can be set at build time by packagers. This helps us trace how and where the binary was built and installed from, allowing us to see if the issue is due to a specfic installation or a general podman bug. This field shows up in podman version and in podman info when populated.

Automatically set the BuildOrigin field when building the macOS pkginstaller to pkginstaller.

Usage: make podman-remote BUILD_ORIGIN="mypackaging"

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Packagers can now set the `BUILT_FOR` environment variable when building podman from the makefile. This data shows up in podman version and in podman info, which helps us trace how and where the binary was built and installed from.
```
