### PR TITLE
Add man pages to Mac installer

### DIFF
--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -14,12 +14,17 @@ tmpBin="contrib/pkginstaller/tmp-bin"
 
 binDir="${BASEDIR}/root/podman/bin"
 libDir="${BASEDIR}/root/podman/lib"
+docDir="${BASEDIR}/root/podman/docs/man/man1"
 
 version=$(cat "${BASEDIR}/VERSION")
 arch=$(cat "${BASEDIR}/ARCH")
 
 function build_podman() {
   pushd "$1"
+
+  make podman-remote-darwin-docs
+  mkdir -p "contrib/pkginstaller/out/packaging/${docDir}"
+  cp -v docs/build/remote/darwin/*.1 "contrib/pkginstaller/out/packaging/${docDir}"
 
   case ${goArch} in
   universal)

--- a/contrib/pkginstaller/scripts/postinstall
+++ b/contrib/pkginstaller/scripts/postinstall
@@ -6,3 +6,7 @@ echo "/opt/podman/bin" > /etc/paths.d/podman-pkg
 
 # make sure to ignore errors, this is not a hard requirement to use podman
 /opt/podman/bin/podman-mac-helper install || :
+
+# Add pointer to podman docs in manpath
+mkdir -p /usr/local/etc/man.d/
+echo "MANPATH /opt/podman/docs/man" > /usr/local/etc/man.d/podman.man.conf

--- a/contrib/pkginstaller/scripts/preinstall
+++ b/contrib/pkginstaller/scripts/preinstall
@@ -7,3 +7,9 @@ rm -rf /opt/podman
 if [ ! -d "/etc/paths.d" ]; then
     mkdir -p /etc/paths.d
 fi
+
+# Create directory to be able to add podman
+# man pages into the "man" path
+if [ ! -d "/usr/local/etc/man.d" ]; then
+    mkdir -p /usr/local/etc/man.d
+fi


### PR DESCRIPTION
This PR adds the man1 pages to the mac installer.  It also sticks a small configuration file into `/usr/local/etc/man.d` that allows macos and the man binary to look for the podman pages in `/opt/podman/docs/man`.

Fixes #24756

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add man1 pages to Mac installer
```
