### PR TITLE
quadlet: fix inter-dependency of containers in `Network=`

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -591,6 +591,8 @@ func generateUnitsInfoMap(units []*parser.UnitFile) map[string]*quadlet.UnitInfo
 		switch {
 		case strings.HasSuffix(unit.Filename, ".container"):
 			serviceName = quadlet.GetContainerServiceName(unit)
+			// Prefill resouceNames for .container files. This solves network reusing.
+			resourceName = quadlet.GetContainerResourceName(unit)
 		case strings.HasSuffix(unit.Filename, ".volume"):
 			serviceName = quadlet.GetVolumeServiceName(unit)
 		case strings.HasSuffix(unit.Filename, ".kube"):

--- a/test/e2e/quadlet/a.network.reuse.container
+++ b/test/e2e/quadlet/a.network.reuse.container
@@ -1,0 +1,7 @@
+## assert-podman-args "--network" "container:systemd-basic"
+## assert-key-is "Unit" "Requires" "basic.service"
+## assert-key-is-regex "Unit" "After" "network-online.target|podman-user-wait-network-online.service" "basic.service"
+
+[Container]
+Image=localhost/imagename
+Network=basic.container

--- a/test/e2e/quadlet/a.network.reuse.name.container
+++ b/test/e2e/quadlet/a.network.reuse.name.container
@@ -1,0 +1,7 @@
+## assert-podman-args "--network" "container:foobar"
+## assert-key-is "Unit" "Requires" "name.service"
+## assert-key-is-regex "Unit" "After" "network-online.target|podman-user-wait-network-online.service" "name.service"
+
+[Container]
+Image=localhost/imagename
+Network=name.container

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1109,6 +1109,8 @@ BOGUS=foo
 		Entry("Container - Quadlet build with multiple tags", "build.multiple-tags.container", []string{"multiple-tags.build"}),
 		Entry("Container - Reuse another container's network", "network.reuse.container", []string{"basic.container"}),
 		Entry("Container - Reuse another named container's network", "network.reuse.name.container", []string{"name.container"}),
+		Entry("Container - Reuse another container's network", "a.network.reuse.container", []string{"basic.container"}),
+		Entry("Container - Reuse another named container's network", "a.network.reuse.name.container", []string{"name.container"}),
 
 		Entry("Volume - Quadlet image (.build)", "build.quadlet.volume", []string{"basic.build"}),
 		Entry("Volume - Quadlet image (.image)", "image.quadlet.volume", []string{"basic.image"}),


### PR DESCRIPTION
This PR fixes a bug introduced by #23814.

Unlike network quadlet units, which are sorted before container quadlet units so that the `ResourceName` of which are guaranteed to be present when used in `addNetworks()`, there is no guaranteed resolving order between containers. As a result, `ResourceName` of a container when used in `addNetworks()` may be empty because the container is not resolved (i.e. `ConventContainer()` is not called for it) yet.

This PR fixes this by adding special handling to resolve the resource name in `addNetworks()` for containers.

@ygalblum PTAL

```release-note
Fix a bug that when reusing another container's network in Quadlet, an error of "cannot get the resource name" may appear.
```