### PR TITLE
Use latest version of VS BuildTools

### DIFF
--- a/contrib/win-installer/build-hooks.ps1
+++ b/contrib/win-installer/build-hooks.ps1
@@ -17,7 +17,7 @@ function Build-MSIHooks {
     if ( Get-MingW ) {
         Build-MSIHooks-Using-MingW $msiHooksFolder $artifactsFolder
     } elseif ( Get-VSBuildTools ) {
-        $vsinstance = Get-VSSetupInstance | Select-VSSetupInstance -Product  Microsoft.VisualStudio.Product.BuildTools
+        $vsinstance = Get-VSSetupInstance | Select-VSSetupInstance -Product  Microsoft.VisualStudio.Product.BuildTools -Latest
         Build-MSIHooks-Using-VSBuildTools $msiHooksFolder $artifactsFolder $vsinstance
     } else {
         $msg = "A C/C++ compiler is required to build `"$msiHooksFolder\check.c`". "


### PR DESCRIPTION
When one or more versions of VS Build tools are installed the script .\winmake.ps1 installer does not finish with error.

...
Done!
Invoke-Expression: C:\...\podman\contrib\cirrus\win-lib.ps1:101:5 Line |
 101 |      Invoke-Expression $command -OutVariable unformattedLog | Write-Output
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot process argument transformation on parameter 'vsinstance'. Cannot convert the "System.Object[]" value of type "System.Object[]" to type
     | "Microsoft.VisualStudio.Setup.Instance".

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

cc: @l0rd 