### PR TITLE
Execute add/remove registry entries in elevated mode with hyperv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -651,7 +651,7 @@ localunit: test/goecho/goecho test/version/version
 	UNIT=1 $(GINKGO) \
 		-r \
 		$(TESTFLAGS) \
-		--skip-package test/e2e,pkg/bindings,hack,pkg/machine/e2e \
+		--skip-package test/e2e,pkg/bindings,hack,pkg/machine/e2e,pkg/machine/hyperv/vsock \
 		--cover \
 		--covermode atomic \
 		--coverprofile coverprofile \

--- a/build_windows.md
+++ b/build_windows.md
@@ -295,8 +295,9 @@ When `machine init` completes, run `machine start`:
 .\bin\windows\podman.exe machine start
 ```
 
-:information_source: If the virtualization provider is Hyperv-V, execute the
-above commands in an administrator terminal.
+:information_source: If the virtualization provider is Hyperv-V, you will be asked
+to elevate privileges to add/remove specific Windows Registry Podman settings.
+Additionally, you must be a member of the Hyper-V Administrators group.
 
 ### Run a container using podman
 

--- a/pkg/machine/hyperv/hutil.go
+++ b/pkg/machine/hyperv/hutil.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package hyperv
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+func HasHyperVAdminRights() bool {
+	sid, err := windows.CreateWellKnownSid(windows.WinBuiltinHyperVAdminsSid)
+	if err != nil {
+		return false
+	}
+
+	//  From MS docs:
+	// "If TokenHandle is NULL, CheckTokenMembership uses the impersonation
+	//  token of the calling thread. If the thread is not impersonating,
+	//  the function duplicates the thread's primary token to create an
+	//  impersonation token."
+	token := windows.Token(0)
+	member, err := token.IsMember(sid)
+
+	if err != nil {
+		logrus.Warnf("Token Membership Error: %s", err)
+		return false
+	}
+
+	return member
+}

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -55,26 +55,43 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		Memory:   uint64(mc.Resources.Memory),
 	}
 
-	networkHVSock, err := vsock.NewHVSockRegistryEntry(mc.Name, vsock.Network)
+	networkHVSock, err := vsock.CreateHVSockRegistryEntry(mc.Name, vsock.Network)
 	if err != nil {
 		return err
 	}
 
 	mc.HyperVHypervisor.NetworkVSock = *networkHVSock
 
-	// Add vsock port numbers to mounts
-	err = createShares(mc)
+	// Create vsock port numbers to mounts
+	mountSharesVsockets, err := createShares(mc)
 	if err != nil {
 		return err
 	}
 
-	removeShareCallBack := func() error {
-		return removeShares(mc)
+	// Add all vsock entries
+	//
+	// When init a podman machine with hyperV, we have to add registry entries under
+	// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\GuestCommunicationServices
+	// so that host/guest can communicate using the vsock protocol.
+	// The location in the registry is fixed and cannot be changed, this is why elevated privileges are required.
+	// Entries under HKEY_LOCAL_MACHINE can just be created by an admin.
+	//
+	// To ensure compatibility between Linux guests and the Windows host, a "well-known GUID" is needed.
+	// The format, as described by HV_GUID_VSOCK_TEMPLATE, must be <port>-facb-11e6-bd58-64006a7986d3
+	// where <port> are the first four bytes ("00000000")  reserved for the port number
+	// (e.g  "00000ac9" represents port 2761 -> hexadecimal AC9 is decimal 2761)
+	// and the rest is a fixed string related to linux guests.
+	err = vsock.ElevateAndAddEntries(append([]vsock.HVSockRegistryEntry{
+		mc.HyperVHypervisor.ReadyVsock,
+		mc.HyperVHypervisor.NetworkVSock,
+	}, mountSharesVsockets...))
+	if err != nil {
+		return err
 	}
-	callbackFuncs.Add(removeShareCallBack)
 
 	removeRegistrySockets := func() error {
-		removeNetworkAndReadySocketsFromRegistry(mc)
+		sockets := getVsockShares(mc)
+		removeSocketsFromRegistry(mc, sockets)
 		return nil
 	}
 	callbackFuncs.Add(removeRegistrySockets)
@@ -144,7 +161,7 @@ func (h HyperVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() err
 
 	rmFunc := func() error {
 		// Tear down vsocks
-		removeNetworkAndReadySocketsFromRegistry(mc)
+		removeSocketsFromRegistry(mc, []vsock.HVSockRegistryEntry{})
 
 		// Remove ignition registry entries - not a fatal error
 		// for vm removal
@@ -358,7 +375,7 @@ func (h HyperVStubber) PrepareIgnition(mc *vmconfigs.MachineConfig, ignBuilder *
 	// simply be derived. So we create the HyperVConfig here.
 	mc.HyperVHypervisor = new(vmconfigs.HyperVConfig)
 	var ignOpts ignition.ReadyUnitOpts
-	readySock, err := vsock.NewHVSockRegistryEntry(mc.Name, vsock.Events)
+	readySock, err := vsock.CreateHVSockRegistryEntry(mc.Name, vsock.Events)
 	if err != nil {
 		return nil, err
 	}
@@ -461,17 +478,21 @@ func resizeDisk(newSize strongunits.GiB, imagePath *define.VMFile) error {
 	return nil
 }
 
-// removeNetworkAndReadySocketsFromRegistry removes the Network and Ready sockets
+// removeSocketsFromRegistry removes the Network, Ready and others (passed by the caller) sockets
 // from the Windows Registry
-func removeNetworkAndReadySocketsFromRegistry(mc *vmconfigs.MachineConfig) {
-	// Remove the HVSOCK for networking
-	if err := mc.HyperVHypervisor.NetworkVSock.Remove(); err != nil {
-		logrus.Errorf("unable to remove registry entry for %s: %q", mc.HyperVHypervisor.NetworkVSock.KeyName, err)
-	}
-
-	// Remove the HVSOCK for events
-	if err := mc.HyperVHypervisor.ReadyVsock.Remove(); err != nil {
-		logrus.Errorf("unable to remove registry entry for %s: %q", mc.HyperVHypervisor.ReadyVsock.KeyName, err)
+func removeSocketsFromRegistry(mc *vmconfigs.MachineConfig, others []vsock.HVSockRegistryEntry) {
+	// remove all sockets from registry
+	//
+	// When deleting a podman machine with hyperV, we have to remove its associated registry entries created under
+	// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\GuestCommunicationServices
+	//
+	// Entries under HKEY_LOCAL_MACHINE can just be deleted by an admin, this is why elevated privileges are required.
+	err := vsock.ElevateAndRemoveEntries(append([]vsock.HVSockRegistryEntry{
+		mc.HyperVHypervisor.ReadyVsock,
+		mc.HyperVHypervisor.NetworkVSock,
+	}, others...))
+	if err != nil {
+		logrus.Errorf("unable to remove registry entries: %q", err)
 	}
 }
 

--- a/pkg/machine/hyperv/vsock/vsock_test.go
+++ b/pkg/machine/hyperv/vsock/vsock_test.go
@@ -1,0 +1,318 @@
+//go:build windows
+
+package vsock
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containers/podman/v5/pkg/machine/windows"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/registry"
+)
+
+func TestCreateHVSockRegistryEntry(t *testing.T) {
+	originalFindOpenHVSockPort := hfindOpenHVSockPort
+	defer func() { hfindOpenHVSockPort = originalFindOpenHVSockPort }()
+
+	tests := []struct {
+		name                   string
+		machineName            string
+		purpose                HVSockPurpose
+		wantPort               uint64
+		wantErr                bool
+		findOpenHVSockPortMock func() (uint64, error)
+	}{
+		{
+			name:        "ValidInput",
+			machineName: "test-machine",
+			purpose:     Network,
+			wantPort:    1111,
+			wantErr:     false,
+			findOpenHVSockPortMock: func() (uint64, error) {
+				return 1111, nil
+			},
+		},
+		{
+			name:        "ErrorFindPort",
+			machineName: "test-machine",
+			purpose:     Events,
+			wantErr:     true,
+			findOpenHVSockPortMock: func() (uint64, error) {
+				return 0, errors.New("error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hfindOpenHVSockPort = tt.findOpenHVSockPortMock
+			got, err := CreateHVSockRegistryEntry(tt.machineName, tt.purpose)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantPort, got.Port)
+				assert.Equal(t, tt.machineName, got.MachineName)
+				assert.Equal(t, tt.purpose, got.Purpose)
+			}
+		})
+	}
+}
+
+func TestElevateAndAddEntries(t *testing.T) {
+	resultTestScript := make(map[string]string)
+
+	tests := []struct {
+		name                                    string
+		entries                                 []HVSockRegistryEntry
+		err                                     error
+		wantErr                                 bool
+		registryOpenKeyMock                     func(k registry.Key, path string, access uint32) (registry.Key, error)
+		windowsLaunchElevatedWaitWithWindowMode func(exe string, cwd string, args string, windowMode int) error
+		script                                  string
+	}{
+		{
+			name: "ErrorInvalidPort",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     Events,
+					Port:        0,
+					MachineName: "test-machine",
+				},
+			},
+			err:     errors.New("port must be larger than 1"),
+			wantErr: true,
+		},
+		{
+			name: "ErrorInvalidPurpose",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     HVSockPurpose(999),
+					Port:        8888,
+					MachineName: "test-machine",
+				},
+			},
+			err:     errors.New("required field purpose is empty"),
+			wantErr: true,
+		},
+		{
+			name: "ErrorEmptyMachineName",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     Events,
+					Port:        8888,
+					MachineName: "",
+				},
+			},
+			err:     errors.New("required field machinename is empty"),
+			wantErr: true,
+		},
+		{
+			name: "ErrorEmptyKeyName",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "",
+					Purpose:     Events,
+					Port:        8888,
+					MachineName: "test-machine",
+				},
+			},
+			err:     errors.New("required field keypath is empty"),
+			wantErr: true,
+		},
+		{
+			name: "ErrorCannotOpenRegistryEntry",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     Events,
+					Port:        8888,
+					MachineName: "test-machine",
+				},
+			},
+			err:     errors.New("cannot open my mocked registry key"),
+			wantErr: true,
+			registryOpenKeyMock: func(k registry.Key, path string, access uint32) (registry.Key, error) {
+				return k, errors.New("cannot open my mocked registry key")
+			},
+		},
+		{
+			name: "ErrorRegistryEntryExists",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     Events,
+					Port:        8888,
+					MachineName: "test-machine",
+				},
+			},
+			err:     fmt.Errorf("%q: %s", ErrVSockRegistryEntryExists, "key"),
+			wantErr: true,
+			registryOpenKeyMock: func(k registry.Key, path string, access uint32) (registry.Key, error) {
+				return k, nil
+			},
+		},
+		{
+			name: "ErrorRegistryEntryExists",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     Events,
+					Port:        8888,
+					MachineName: "test-machine",
+				},
+			},
+			err:     errors.New("error when opening parent key"),
+			wantErr: true,
+			registryOpenKeyMock: func(k registry.Key, path string, access uint32) (registry.Key, error) {
+				if path == VsockRegistryPath {
+					return k, errors.New("error when opening parent key")
+				}
+				return k, registry.ErrNotExist
+			},
+		},
+		{
+			name: "ValidInput",
+			entries: []HVSockRegistryEntry{
+				{
+					KeyName:     "key",
+					Purpose:     Events,
+					Port:        8888,
+					MachineName: "test-machine",
+				},
+			},
+			wantErr: false,
+			registryOpenKeyMock: func(k registry.Key, path string, access uint32) (registry.Key, error) {
+				if path == VsockRegistryPath {
+					return k, nil
+				}
+				return k, registry.ErrNotExist
+			},
+			windowsLaunchElevatedWaitWithWindowMode: func(exe, cwd, args string, windowMode int) error {
+				resultTestScript["ValidInput"] = args
+				return nil
+			},
+			script: "New-Item -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices' -Name 'key'; New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices\\key' -Name 'Purpose' -Value 'Events' -PropertyType String; New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices\\key' -Name 'MachineName' -Value 'test-machine' -PropertyType String;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.registryOpenKeyMock != nil {
+				originalegistryOpenKey := rOpenKey
+				defer func() { rOpenKey = originalegistryOpenKey }()
+				rOpenKey = tt.registryOpenKeyMock
+			}
+			if tt.windowsLaunchElevatedWaitWithWindowMode != nil {
+				originalLaunchElevatedWaitWithWindowMode := wLaunchElevatedWaitWithWindowMode
+				defer func() { wLaunchElevatedWaitWithWindowMode = originalLaunchElevatedWaitWithWindowMode }()
+				wLaunchElevatedWaitWithWindowMode = tt.windowsLaunchElevatedWaitWithWindowMode
+			}
+			err := ElevateAndAddEntries(tt.entries)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.EqualValues(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				resultingScript := resultTestScript[tt.name]
+				assert.EqualValues(t, resultingScript, tt.script)
+			}
+		})
+	}
+}
+
+func TestElevateAndRemoveEntries(t *testing.T) {
+	expectedScript := "Remove-Item -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices\\key' -Force -Recurse;"
+	script := ""
+	originalLaunchElevatedWaitWithWindowMode := wLaunchElevatedWaitWithWindowMode
+	defer func() { wLaunchElevatedWaitWithWindowMode = originalLaunchElevatedWaitWithWindowMode }()
+	wLaunchElevatedWaitWithWindowMode = func(exe, cwd, args string, windowMode int) error {
+		script = args
+		return nil
+	}
+
+	err := ElevateAndRemoveEntries([]HVSockRegistryEntry{
+		{
+			KeyName:     "key",
+			Purpose:     Events,
+			Port:        8888,
+			MachineName: "test-machine",
+		},
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, script, expectedScript)
+}
+
+func TestVerifyPowershellScriptActuallyWork(t *testing.T) {
+	// this test is used to verify that the powershell script works as expected and the registry is actually written.
+	// To avoid requiring admin privileges the original path
+	// HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices\\key
+	// gets replaced by
+	// HKCU:\\Software
+
+	// the openKey func gets called after the path have been edited
+	originalegistryOpenKey := rOpenKey
+	defer func() { rOpenKey = originalegistryOpenKey }()
+	rOpenKey = func(k registry.Key, path string, access uint32) (registry.Key, error) {
+		path = strings.ReplaceAll(path, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices", "Software")
+		return registry.OpenKey(registry.CURRENT_USER, path, registry.QUERY_VALUE)
+	}
+
+	// the LaunchElevatedWaitWithWindowMode gets replaced by its "no-elevated" version that executes the script as a normal user
+	originalLaunchElevatedWaitWithWindowMode := wLaunchElevatedWaitWithWindowMode
+	defer func() { wLaunchElevatedWaitWithWindowMode = originalLaunchElevatedWaitWithWindowMode }()
+	wLaunchElevatedWaitWithWindowMode = func(exe, cwd, args string, windowMode int) error {
+		args = strings.ReplaceAll(args, "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\GuestCommunicationServices", "HKCU:\\Software")
+		return windows.LaunchWaitWithWindowMode(exe, cwd, args, windowMode)
+	}
+
+	entries := []HVSockRegistryEntry{
+		{
+			KeyName:     "key",
+			Purpose:     Events,
+			Port:        8888,
+			MachineName: "test-machine",
+		},
+		{
+			KeyName:     "key1",
+			Purpose:     Fileserver,
+			Port:        8889,
+			MachineName: "test-machine",
+		},
+		{
+			KeyName:     "key2",
+			Purpose:     Network,
+			Port:        8890,
+			MachineName: "test-machine",
+		},
+	}
+
+	// call the func to add entries to the registry
+	err := ElevateAndAddEntries(entries)
+	assert.NoError(t, err)
+
+	// check the registry entries have been created
+	for _, entry := range entries {
+		_, err = registry.OpenKey(registry.CURRENT_USER, fmt.Sprintf("%s\\%s", "Software", entry.KeyName), registry.QUERY_VALUE)
+		assert.NoError(t, err)
+	}
+
+	// remove entries from registry
+	err = ElevateAndRemoveEntries(entries)
+	assert.NoError(t, err)
+
+	// check the registry entries do not exist
+	for _, entry := range entries {
+		_, err = registry.OpenKey(registry.CURRENT_USER, fmt.Sprintf("%s\\%s", "Software", entry.KeyName), registry.QUERY_VALUE)
+		assert.ErrorIs(t, err, registry.ErrNotExist)
+	}
+}

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -34,8 +34,11 @@ func Get() (vmconfigs.VMProvider, error) {
 	case define.WSLVirt:
 		return new(wsl.WSLStubber), nil
 	case define.HyperVVirt:
-		if !wsl.HasAdminRights() {
-			return nil, fmt.Errorf("hyperv machines require admin authority")
+		// to manage hyper-v on a local computer the user account must belong to
+		// the Administrators group or the Hyper-V Administrators group
+		// https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/remotely-manage-hyper-v-hosts#manage-hyper-v-on-a-local-computer
+		if !hyperv.HasHyperVAdminRights() && !wsl.HasAdminRights() {
+			return nil, fmt.Errorf("hyperv machines require hyperv admin authority or admin authority")
 		}
 		return new(hyperv.HyperVStubber), nil
 	default:

--- a/pkg/machine/vmconfigs/config_windows.go
+++ b/pkg/machine/vmconfigs/config_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package vmconfigs
 
 import (

--- a/pkg/machine/windows/windows.go
+++ b/pkg/machine/windows/windows.go
@@ -1,0 +1,117 @@
+//go:build windows
+
+package windows
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+type SHELLEXECUTEINFO struct {
+	cbSize         uint32
+	fMask          uint32
+	hwnd           syscall.Handle
+	lpVerb         uintptr
+	lpFile         uintptr
+	lpParameters   uintptr
+	lpDirectory    uintptr
+	nShow          int
+	hInstApp       syscall.Handle
+	lpIDList       uintptr
+	lpClass        uintptr
+	hkeyClass      syscall.Handle
+	dwHotKey       uint32
+	hIconOrMonitor syscall.Handle
+	hProcess       syscall.Handle
+}
+
+// Cleaner to refer to the official OS constant names, and consistent with syscall
+// Ref: https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-shellexecuteinfow#members
+const (
+	//nolint:stylecheck
+	SEE_MASK_NOCLOSEPROCESS = 0x40
+	//nolint:stylecheck
+	SE_ERR_ACCESSDENIED = 0x05
+)
+
+type ExitCodeError struct {
+	Code uint
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("Process failed with exit code: %d", e.Code)
+}
+
+func LaunchElevatedWait(exe string, cwd string, args string) error {
+	return LaunchElevatedWaitWithWindowMode(exe, cwd, args, syscall.SW_SHOWNORMAL)
+}
+
+func LaunchElevatedWaitWithWindowMode(exe string, cwd string, args string, windowMode int) error {
+	exePtr, _ := syscall.UTF16PtrFromString(exe)
+	cwdPtr, _ := syscall.UTF16PtrFromString(cwd)
+	arg, _ := syscall.UTF16PtrFromString(args)
+	verb, _ := syscall.UTF16PtrFromString("runas")
+
+	shell32 := syscall.NewLazyDLL("shell32.dll")
+
+	info := &SHELLEXECUTEINFO{
+		fMask:        SEE_MASK_NOCLOSEPROCESS,
+		hwnd:         0,
+		lpVerb:       uintptr(unsafe.Pointer(verb)),
+		lpFile:       uintptr(unsafe.Pointer(exePtr)),
+		lpParameters: uintptr(unsafe.Pointer(arg)),
+		lpDirectory:  uintptr(unsafe.Pointer(cwdPtr)),
+		nShow:        windowMode,
+	}
+	info.cbSize = uint32(unsafe.Sizeof(*info))
+	procShellExecuteEx := shell32.NewProc("ShellExecuteExW")
+	if ret, _, _ := procShellExecuteEx.Call(uintptr(unsafe.Pointer(info))); ret == 0 { // 0 = False
+		err := syscall.GetLastError()
+		if info.hInstApp == SE_ERR_ACCESSDENIED {
+			return wrapMaybe(err, "request to elevate privileges was denied")
+		}
+		return wrapMaybef(err, "could not launch process, ShellEX Error = %d", info.hInstApp)
+	}
+
+	handle := info.hProcess
+	defer func() {
+		_ = syscall.CloseHandle(handle)
+	}()
+
+	w, err := syscall.WaitForSingleObject(handle, syscall.INFINITE)
+	switch w {
+	case syscall.WAIT_OBJECT_0:
+		break
+	case syscall.WAIT_FAILED:
+		return fmt.Errorf("could not wait for process, failed: %w", err)
+	default:
+		return fmt.Errorf("could not wait for process, unknown error. event: %X, err: %v", w, err)
+	}
+	var code uint32
+	if err := syscall.GetExitCodeProcess(handle, &code); err != nil {
+		return err
+	}
+	if code != 0 {
+		return &ExitCodeError{uint(code)}
+	}
+
+	return nil
+}
+
+func wrapMaybe(err error, message string) error {
+	if err != nil {
+		return fmt.Errorf("%v: %w", message, err)
+	}
+
+	return errors.New(message)
+}
+
+func wrapMaybef(err error, format string, args ...interface{}) error {
+	if err != nil {
+		return fmt.Errorf(format+": %w", append(args, err)...)
+	}
+
+	return fmt.Errorf(format, args...)
+}

--- a/pkg/machine/windows/windows.go
+++ b/pkg/machine/windows/windows.go
@@ -49,10 +49,20 @@ func LaunchElevatedWait(exe string, cwd string, args string) error {
 }
 
 func LaunchElevatedWaitWithWindowMode(exe string, cwd string, args string, windowMode int) error {
+	verb, _ := syscall.UTF16PtrFromString("runas")
+	return launchWaitWithWindowMode(exe, cwd, args, windowMode, verb)
+}
+
+// this func is used for testing
+func LaunchWaitWithWindowMode(exe string, cwd string, args string, windowMode int) error {
+	verb, _ := syscall.UTF16PtrFromString("open")
+	return launchWaitWithWindowMode(exe, cwd, args, windowMode, verb)
+}
+
+func launchWaitWithWindowMode(exe string, cwd string, args string, windowMode int, verb *uint16) error {
 	exePtr, _ := syscall.UTF16PtrFromString(exe)
 	cwdPtr, _ := syscall.UTF16PtrFromString(cwd)
 	arg, _ := syscall.UTF16PtrFromString(args)
-	verb, _ := syscall.UTF16PtrFromString("runas")
 
 	shell32 := syscall.NewLazyDLL("shell32.dll")
 

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -22,6 +22,8 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/ignition"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/containers/podman/v5/pkg/machine/windows"
+	winutil "github.com/containers/podman/v5/pkg/machine/windows"
 	"github.com/containers/podman/v5/pkg/machine/wsl/wutil"
 	"github.com/containers/podman/v5/utils"
 	"github.com/containers/storage/pkg/homedir"
@@ -34,14 +36,6 @@ var (
 	// vmtype refers to qemu (vs libvirt, krun, etc)
 	vmtype = define.WSLVirt
 )
-
-type ExitCodeError struct {
-	code uint
-}
-
-func (e *ExitCodeError) Error() string {
-	return fmt.Sprintf("Process failed with exit code: %d", e.code)
-}
 
 //nolint:unused
 func getConfigPath(name string) (string, error) {
@@ -372,10 +366,18 @@ func launchElevate(operation string) error {
 	if err := truncateElevatedOutputFile(); err != nil {
 		return err
 	}
-	err := relaunchElevatedWait()
+	exe, err := os.Executable()
 	if err != nil {
-		if eerr, ok := err.(*ExitCodeError); ok {
-			if eerr.code == ErrorSuccessRebootRequired {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	err = winutil.LaunchElevatedWait(exe, cwd, buildCommandArgs(true))
+	if err != nil {
+		if eerr, ok := err.(*windows.ExitCodeError); ok {
+			if eerr.Code == ErrorSuccessRebootRequired {
 				fmt.Println("Reboot is required to continue installation, please reboot at your convenience")
 				return nil
 			}


### PR DESCRIPTION
Adding/removing a key in the Windows registry requires elevated rights. For this reason, using podman with hyperv had the constraint to run it as admin otherwise it was not possible to init/rm a hyperv machine.

This patch adds a couple of functions to add/remove registry entries in bulk in privileged mode. When creating/deleting a machine the user is asked only once to elevate the rights to perform the action. So now podman can be started without being admin.

This will also be leveraged by podman desktop so users could switch from wsl to hyperv without restarting desktop in elevated mode.

#### Does this PR introduce a user-facing change?

Not sure what you mean by user-facing change but i would say yes. 
Now the user who init a hyperv machine is asked to give elevated rights to execute the script to add registry entries to the Windows registry 

```release-note
Podman will request elevated privileges to modify Windows Registry entries when initializing/removing a machine using Hyper-V, allowing to run Podman as a normal user.
```
