### PR TITLE
Quadlet - make sure the /etc/containers/systemd/users is traversed in rootless

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -186,9 +186,9 @@ func getRootlessDirs(paths *searchPaths, nonNumericFilter, userLevelFilter func(
 		appendSubPaths(paths, filepath.Join(quadlet.UnitDirAdmin, "users", u.Uid), true, userLevelFilter)
 	} else {
 		fmt.Fprintf(os.Stderr, "Warning: %v", err)
+		// Add the base directory even if the UID was not found
+		paths.Add(filepath.Join(quadlet.UnitDirAdmin, "users"))
 	}
-
-	paths.Add(filepath.Join(quadlet.UnitDirAdmin, "users"))
 }
 
 func getRootDirs(paths *searchPaths, userLevelFilter func(string, bool) bool) {
@@ -279,6 +279,10 @@ func getNonNumericFilter(resolvedUnitDirAdminUser string, systemUserDirLevel int
 		// ignore sub dirs under the `users` directory which correspond to a user id
 		if strings.HasPrefix(path, resolvedUnitDirAdminUser) {
 			listDirUserPathLevels := strings.Split(path, string(os.PathSeparator))
+			// Make sure to add the base directory
+			if len(listDirUserPathLevels) == systemUserDirLevel {
+				return true
+			}
 			if len(listDirUserPathLevels) > systemUserDirLevel {
 				if !(regexp.MustCompile(`^[0-9]*$`).MatchString(listDirUserPathLevels[systemUserDirLevel])) {
 					return true


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
No

```release-note
None
```

Resolves: #24783