### PR TITLE
systemd: simplify parser and fix infinite loop

### DIFF
--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -48,7 +48,6 @@ type UnitFileParser struct {
 
 	currentGroup    *unitGroup
 	pendingComments []*unitLine
-	lineNr          int
 }
 
 func newUnitLine(key string, value string, isComment bool) *unitLine {
@@ -347,7 +346,7 @@ func (p *UnitFileParser) parseKeyValuePair(line string) error {
 	return nil
 }
 
-func (p *UnitFileParser) parseLine(line string) error {
+func (p *UnitFileParser) parseLine(line string, lineNr int) error {
 	switch {
 	case lineIsComment(line):
 		return p.parseComment(line)
@@ -356,7 +355,7 @@ func (p *UnitFileParser) parseLine(line string) error {
 	case lineIsKeyValuePair(line):
 		return p.parseKeyValuePair(line)
 	default:
-		return fmt.Errorf("file contains line %d: “%s” which is not a key-value pair, group, or comment", p.lineNr, line)
+		return fmt.Errorf("file contains line %d: “%s” which is not a key-value pair, group, or comment", lineNr, line)
 	}
 }
 
@@ -376,53 +375,39 @@ func (p *UnitFileParser) flushPendingComments(toComment bool) {
 	}
 }
 
-func nextLine(data string, afterPos int) (string, string) {
-	rest := data[afterPos:]
-	if i := strings.Index(rest, "\n"); i >= 0 {
-		return strings.TrimSpace(data[:i+afterPos]), data[i+afterPos+1:]
-	}
-	return data, ""
-}
-
-func trimSpacesFromLines(data string) string {
-	lines := strings.Split(data, "\n")
-	for i, line := range lines {
-		lines[i] = strings.TrimSpace(line)
-	}
-	return strings.Join(lines, "\n")
-}
-
 // Parse an already loaded unit file (in the form of a string)
 func (f *UnitFile) Parse(data string) error {
 	p := &UnitFileParser{
-		file:   f,
-		lineNr: 1,
+		file: f,
 	}
 
-	data = trimSpacesFromLines(data)
+	lines := strings.Split(strings.TrimSuffix(data, "\n"), "\n")
+	remaining := ""
 
-	for len(data) > 0 {
-		origdata := data
-		nLines := 1
-		var line string
-		line, data = nextLine(data, 0)
-
-		if !lineIsComment(line) {
-			// Handle multi-line continuations
-			// Note: This doesn't support comments in the middle of the continuation, which systemd does
-			if lineIsKeyValuePair(line) {
-				for len(data) > 0 && line[len(line)-1] == '\\' {
-					line, data = nextLine(origdata, len(line)+1)
-					nLines++
+	for lineNr, line := range lines {
+		line = strings.TrimSpace(line)
+		if lineIsComment(line) {
+			// ignore the comment is inside a continuation line.
+			if remaining != "" {
+				continue
+			}
+		} else {
+			if strings.HasSuffix(line, "\\") {
+				line = line[:len(line)-1]
+				if lineNr != len(lines)-1 {
+					remaining += line
+					continue
 				}
 			}
+			// check whether the line is a continuation of the previous line
+			if remaining != "" {
+				line = remaining + line
+				remaining = ""
+			}
 		}
-
-		if err := p.parseLine(line); err != nil {
+		if err := p.parseLine(line, lineNr+1); err != nil {
 			return err
 		}
-
-		p.lineNr += nLines
 	}
 
 	if p.currentGroup == nil {
@@ -690,7 +675,6 @@ func (f *UnitFile) LookupInt(groupName string, key string, defaultValue int64) i
 	}
 
 	intVal, err := convertNumber(v)
-
 	if err != nil {
 		return defaultValue
 	}

--- a/test/e2e/quadlet/emptyline.container
+++ b/test/e2e/quadlet/emptyline.container
@@ -1,0 +1,4 @@
+[Container]
+Exec=true \
+
+# must have a blank line above, but this line can be anything (including another blank line)


### PR DESCRIPTION
This commit simplifies the systemd parser logic, and it solves an infinite loop when using a continuation line.

Closes: https://github.com/containers/podman/issues/24810

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Solves an infinite loop when parsing quadlet files with a continuation line
```
