### PR TITLE
Add a Windows Installer patch to avoid unrequested reboots

### DIFF
--- a/build_windows.md
+++ b/build_windows.md
@@ -315,7 +315,7 @@ The Podman Windows installer (e.g., `podman-5.1.0-dev-setup.exe`) is a bundle
 that includes an msi package (`podman.msi`) and installs the WSL kernel
 (`podman-wslkerninst.exe`). It's built using the
 [WiX Toolset](https://wixtoolset.org/) and the
-[PanelSwWixExtension](https://github.com/nirbar/PanelSwWixExtension/tree/wix3-v3.11.1.353)
+[PanelSwWixExtension](https://github.com/nirbar/PanelSwWixExtension/tree/master5)
 WiX extension. The source code is in the folder `contrib\win-installer`.
 
 ### Build the Windows installer

--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -7,16 +7,31 @@ if ($Env:CI -eq "true") {
     $RELEASE_DIR = "$ENV:CIRRUS_WORKING_DIR\repo"
 } else {
     $WIN_INST_FOLDER = "$PSScriptRoot\..\win-installer"
-    $ENV:WIN_INST_VER = "9.9.9"
+    $ENV:WIN_INST_VER = "9.9.8"
     $RELEASE_DIR = "$PSScriptRoot\..\..\contrib\win-installer\current"
     if ($null -eq $ENV:CONTAINERS_MACHINE_PROVIDER) { $ENV:CONTAINERS_MACHINE_PROVIDER = 'wsl' }
 }
 
 Push-Location $WIN_INST_FOLDER
 
-# Build Installer
+# Build and test the windows installer
+
+# Downlaod v5.3.1 installer as `build.ps1` uses it to build the patch
+# (podman.msp). `build.ps1` reads `$env:V531_SETUP_EXE_PATH` to get its path.
+# The v5.3.1 installer is also used to test the "v5.3.1 -> current" version minor
+# update (with patch).
+$env:V531_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
+
+# Downlaod the previous installer to test a major update (without patch)
+# After v5.3.2 release we should download latest instead of v5.3.0 (i.e.
+# `Get-Latest-Podman-Setup-From-GitHub`)
+$env:PREV_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.0"
+
 # Note: consumes podman-remote-release-windows_amd64.zip from repo.tar.zst
 Run-Command ".\build.ps1 $Env:WIN_INST_VER dev `"$RELEASE_DIR`""
+
+# Build a v9.9.9 installer to test an update from current to next version
+Run-Command ".\build.ps1 9.9.9 dev `"$RELEASE_DIR`""
 
 Pop-Location
 
@@ -25,4 +40,7 @@ $command = "$WIN_INST_FOLDER\test-installer.ps1 "
 $command += "-scenario all "
 $command += "-provider $ENV:CONTAINERS_MACHINE_PROVIDER "
 $command += "-setupExePath `"$WIN_INST_FOLDER\podman-$ENV:WIN_INST_VER-dev-setup.exe`""
+$command += "-previousSetupExePath `"$env:PREV_SETUP_EXE_PATH`""
+$command += "-nextSetupExePath `"$WIN_INST_FOLDER\podman-9.9.9-dev-setup.exe`""
+$command += "-v531SetupExePath `"$env:V531_SETUP_EXE_PATH`""
 Run-Command "${command}"

--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -1,13 +1,14 @@
 #!/usr/bin/env powershell
 
 . $PSScriptRoot\win-lib.ps1
+. $PSScriptRoot\..\win-installer\utils.ps1
 
 if ($Env:CI -eq "true") {
     $WIN_INST_FOLDER = "$ENV:CIRRUS_WORKING_DIR\repo\contrib\win-installer"
     $RELEASE_DIR = "$ENV:CIRRUS_WORKING_DIR\repo"
 } else {
     $WIN_INST_FOLDER = "$PSScriptRoot\..\win-installer"
-    $ENV:WIN_INST_VER = "9.9.8"
+    $ENV:WIN_INST_VER = "9.9.9"
     $RELEASE_DIR = "$PSScriptRoot\..\..\contrib\win-installer\current"
     if ($null -eq $ENV:CONTAINERS_MACHINE_PROVIDER) { $ENV:CONTAINERS_MACHINE_PROVIDER = 'wsl' }
 }
@@ -16,22 +17,27 @@ Push-Location $WIN_INST_FOLDER
 
 # Build and test the windows installer
 
-# Downlaod v5.3.1 installer as `build.ps1` uses it to build the patch
+# Download v5.3.1 installer as `build.ps1` uses it to build the patch
 # (podman.msp). `build.ps1` reads `$env:V531_SETUP_EXE_PATH` to get its path.
 # The v5.3.1 installer is also used to test the "v5.3.1 -> current" version minor
 # update (with patch).
-$env:V531_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
+if (!$env:V531_SETUP_EXE_PATH) {
+    $env:V531_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
+}
 
-# Downlaod the previous installer to test a major update (without patch)
+# Download the previous installer to test a major update (without patch)
 # After v5.3.2 release we should download latest instead of v5.3.0 (i.e.
 # `Get-Latest-Podman-Setup-From-GitHub`)
-$env:PREV_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.0"
+if (!$env:PREV_SETUP_EXE_PATH) {
+    $env:PREV_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.0"
+}
 
 # Note: consumes podman-remote-release-windows_amd64.zip from repo.tar.zst
 Run-Command ".\build.ps1 $Env:WIN_INST_VER dev `"$RELEASE_DIR`""
 
-# Build a v9.9.9 installer to test an update from current to next version
-Run-Command ".\build.ps1 9.9.9 dev `"$RELEASE_DIR`""
+# Build a v9.9.10 installer to test an update from current to next version
+$NEXT_WIN_INST_VER="9.9.10"
+Run-Command ".\build.ps1 `"$NEXT_WIN_INST_VER`" dev `"$RELEASE_DIR`""
 
 Pop-Location
 
@@ -41,6 +47,6 @@ $command += "-scenario all "
 $command += "-provider $ENV:CONTAINERS_MACHINE_PROVIDER "
 $command += "-setupExePath `"$WIN_INST_FOLDER\podman-$ENV:WIN_INST_VER-dev-setup.exe`""
 $command += "-previousSetupExePath `"$env:PREV_SETUP_EXE_PATH`""
-$command += "-nextSetupExePath `"$WIN_INST_FOLDER\podman-9.9.9-dev-setup.exe`""
+$command += "-nextSetupExePath `"$WIN_INST_FOLDER\podman-$NEXT_WIN_INST_VER-dev-setup.exe`""
 $command += "-v531SetupExePath `"$env:V531_SETUP_EXE_PATH`""
 Run-Command "${command}"

--- a/contrib/win-installer/README.md
+++ b/contrib/win-installer/README.md
@@ -1,3 +1,64 @@
 # Windows Installer Build
 
 Instructions [have moved here](Build and test the Podman Windows installer](#build-and-test-the-podman-windows-installer)).
+
+## How to run a full tests scenarios
+
+Manual tests to validate changes the wxs files or a WiX upgrade.
+
+## Preparation
+
+- checkout previous release tag (e.g. 5.3.0)
+`git fetch --all --tags --prune && git tag --list v5.* && git checkout tags/v5.3.0`
+- make the installer
+`./winmake podman && ./winmake docs && ./winmake win-gvproxy && ./winmake installer`
+- checkout tag `v5.3.1` make the installer
+`./winmake podman && ./winmake docs && ./winmake win-gvproxy && ./winmake installer`
+- get the `v5.3.1` msi product id (with superorca)
+- checkout the main branch and change the product id on `podman.wxs` to match `v5.3.1` product id
+- set `$env:V531_SETUP_EXE_PATH` and make current and next installer
+`$env:V531_SETUP_EXE_PATH=<path> && ./winmake podman && ./winmake docs && ./winmake win-gvproxy && ./winmake installer && ./winmake installer 9.9.9`
+- patch installertest to make sure it doesn't download the setup.exe from internet but uses the one just built
+
+## Run the tests
+
+1. Uninstall the virtualization providers (WSL and Hyper-V) using the "Windows Features" app
+2. Run installtest for both `wsl` and `hyperv` (**as an admin**)
+```pwsh
+.\contrib\win-installer\test-installer.ps1 `
+    -scenario all `
+    -setupExePath ".\contrib\win-installer\podman-5.4.0-dev-setup.exe" `
+    -previousSetupExePath ".\contrib\win-installer\podman-5.3.0-dev-setup.exe" `
+    -nextSetupExePath ".\contrib\win-installer\podman-9.9.9-dev-setup.exe" `
+    -v531SetupExePath ".\contrib\win-installer\podman-5.3.1-dev-setup.exe" `
+    -provider hyperv
+```
+3. Manually test the upgrade "from v5.3.1 to current to next"
+```pwsh
+contrib\win-installer\podman-5.3.1-dev-setup.exe /install /log contrib\win-installer\podman-setup-531.log
+contrib\win-installer\podman-5.4.0-dev-setup.exe /install /log contrib\win-installer\podman-setup-540.log
+contrib\win-installer\podman-9.9.9-dev-setup.exe /install /log contrib\win-installer\podman-setup-999.log
+contrib\win-installer\podman-9.9.9-dev-setup.exe /x /log contrib\win-installer\podman-uninstall-999.log
+```
+4. manually run the current installer with the option to install wsl and confirm it reboots and install both podman and wsl
+5. manually run the current installer with the option to install hyperv and confirm it reboots and install both podman and wsl
+6. run installtest for both wsl and hyperv
+7. manually run the current installer with the option to install wsl and confirm it doesn't reboot
+8. manually run the current installer with the option to install hyperv and confirm it doesn't reboot
+
+## retrieve installed podman msi package information
+
+```pwsh
+$Installer = New-Object -ComObject WindowsInstaller.Installer;
+$InstallerProducts = $Installer.ProductsEx("", "", 7);
+$InstalledProducts = ForEach($Product in $InstallerProducts){
+    [PSCustomObject]@{ProductCode = $Product.ProductCode();
+                      LocalPackage = $Product.InstallProperty("LocalPackage");
+                      VersionString = $Product.InstallProperty("VersionString");
+                      ProductName = $Product.InstallProperty("ProductName")
+                      }
+};
+$InstalledProducts | Where-Object {$_.ProductName -match "podman"}
+```
+
+and uninstall it with `msiexec /x "{<product-code>}"`

--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -49,12 +49,28 @@ function CheckRequirements() {
     CheckCommand "go" "Golang"
 }
 
+function Build-531-Patch() {
+    param(
+        [ValidateScript({Test-Path $_ -PathType Leaf})]
+        [string]$v531SetupExePath=$ENV:V531_SETUP_EXE_PATH
+    )
+
+    if (!$v531SetupExePath) {
+      . $PSScriptRoot\utils.ps1
+      $v531SetupExePath=Get-Podman-Setup-From-GitHub "tags/v5.3.1"
+    }
+    wix burn extract $v531SetupExePath -o $PSScriptRoot\prevPodmanMsi; ExitOnError
+    Move-Item $PSScriptRoot\prevPodmanMsi\a1 $PSScriptRoot\en-US\prev-podman.wixpdb -Force; ExitOnError
+    Move-Item $PSScriptRoot\prevPodmanMsi\a0 $PSScriptRoot\en-US\prev-podman.msi -Force; ExitOnError
+    wix build -define "Version=$ENV:INSTVER" -bindpath $PSScriptRoot\en-US -out $PSScriptRoot\en-US\podman.msp podman-patch.wxs; ExitOnError
+}
 
 if ($args.Count -lt 1 -or $args[0].Length -lt 1) {
     Write-Host "Usage: " $MyInvocation.MyCommand.Name "<version> [dev|prod] [release_dir]"
     Write-Host
     Write-Host 'Uses Env Vars: '
     Write-Host '   $ENV:FETCH_BASE_URL - GitHub Repo Address to locate release on'
+    Write-Host '   $ENV:V531_SETUP_EXE_PATH - Path to v5.3.1 setup.exe used to build the patch'
     Write-Host 'Env Settings for signing (optional)'
     Write-Host '   $ENV:VAULT_ID'
     Write-Host '   $ENV:APP_ID'
@@ -128,6 +144,10 @@ if (Test-Path ./obj) {
 }
 dotnet build podman.wixproj /property:DefineConstants="VERSION=$ENV:INSTVER" -o .; ExitOnError
 SignItem @("en-US\podman.msi")
+
+# Build the Patch for 5.3.1
+Build-531-Patch
+SignItem @("en-US\podman.msp")
 
 dotnet build podman-setup.wixproj /property:DefineConstants="VERSION=$ENV:INSTVER" -o .; ExitOnError
 wix burn detach podman-setup.exe -engine engine.exe; ExitOnError

--- a/contrib/win-installer/burn.wxs
+++ b/contrib/win-installer/burn.wxs
@@ -30,6 +30,7 @@
         <MsiProperty Name="WITH_HYPERV" Value="[HyperVCheckbox]" />
         <MsiProperty Name="SKIP_CONFIG_FILE_CREATION" Value="[SkipConfigFileCreation]" />
       </MsiPackage>
+      <MspPackage Id="Patch" SourceFile="en-US\podman.msp" Vital="yes" />
       <ExePackage DisplayName="WSL Kernel Install" InstallCondition="(MachineProvider = &quot;wsl&quot;) AND (WSLCheckbox = 1) AND (NOT PreviousInstallFolder)" SourceFile="artifacts\podman-wslkerninst.exe" DetectCondition="" Permanent="true" />
     </Chain>
     <OptionalUpdateRegistration />

--- a/contrib/win-installer/podman-patch.wxs
+++ b/contrib/win-installer/podman-patch.wxs
@@ -1,0 +1,21 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Patch
+     AllowRemoval="yes"
+     Classification="Update"
+     DisplayName="Podman Patch v$(Version)"
+     Description="Podman Patch v$(Version)"
+     Manufacturer="Red Hat Inc.">
+
+    <Media Id="1000" Cabinet="PodmanPatch.cab">
+      <PatchBaseline
+         Id="podmanPatch"
+         BaselineFile="podman.msi"
+         UpdateFile="prev-podman.msi"/>
+    </Media>
+
+    <PatchFamily
+      Id="PodmanPatches"
+      Version="$(Version)"
+      Supersede="yes" />
+  </Patch>
+</Wix>

--- a/contrib/win-installer/podman-setup.wixproj
+++ b/contrib/win-installer/podman-setup.wixproj
@@ -1,12 +1,12 @@
-<Project Sdk="WixToolset.Sdk/5.0.0">
+<Project Sdk="WixToolset.Sdk/5.0.2">
     <PropertyGroup>
 		<InstallerPlatform>x64</InstallerPlatform>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<OutputType>Bundle</OutputType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="WixToolset.BootstrapperApplications.wixext" Version="5.0.0" />
-		<PackageReference Include="WixToolset.Util.wixext" Version="5.0.0" />
+		<PackageReference Include="WixToolset.BootstrapperApplications.wixext" Version="5.0.2" />
+		<PackageReference Include="WixToolset.Util.wixext" Version="5.0.2" />
 		<Compile Include="burn.wxs" />
 	 </ItemGroup>
 </Project>

--- a/contrib/win-installer/podman.wixproj
+++ b/contrib/win-installer/podman.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/5.0.0">
+<Project Sdk="WixToolset.Sdk/5.0.2">
 	<PropertyGroup>
 		<InstallerPlatform>x64</InstallerPlatform>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -13,9 +13,9 @@
 		<Compile Include="podman.wxs;podman-ui.wxs;welcome-install-dlg.wxs" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="PanelSwWixExtension4" Version="5.1.1.375" />
-		<PackageReference Include="WixToolset.Heat" Version="5.0.0" />
-		<PackageReference Include="WixToolset.UI.wixext" Version="5.0.0" />
-		<PackageReference Include="WixToolset.Util.wixext" Version="5.0.0" />
+		<PackageReference Include="PanelSwWixExtension4" Version="5.4.5.422" />
+		<PackageReference Include="WixToolset.Heat" Version="5.0.2" />
+		<PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
+		<PackageReference Include="WixToolset.Util.wixext" Version="5.0.2" />
 	 </ItemGroup>
 </Project>

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -72,14 +72,14 @@
 		<CustomAction Id="CheckHyperV" Execute="firstSequence" DllEntry="CheckHyperV" BinaryRef="PodmanHooks" />
 		<util:BroadcastEnvironmentChange />
 		<ComponentGroup Id="WSLFeature" Directory="INSTALLDIR">
-			<Component Id="WSLFeatureComponent" Guid="F6A693BC-186C-4E64-8015-C3073013B3A8" Condition="(NOT WIX_UPGRADE_DETECTED) AND (WSL_INSTALL = 1)">
+			<Component Id="WSLFeatureComponent" Guid="F6A693BC-186C-4E64-8015-C3073013B3A8" Condition="(NOT Installed) AND (WSL_INSTALL = 1)">
 				<CreateFolder />
 				<PanelSW:Dism EnableFeature="VirtualMachinePlatform" ErrorHandling="prompt" />
 				<PanelSW:Dism EnableFeature="Microsoft-Windows-Subsystem-Linux" ErrorHandling="prompt" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="HyperVFeature" Directory="INSTALLDIR">
-			<Component Id="HyperVFeatureComponent" Guid="F7B2D4C9-6C89-46BB-B4EA-FF39424972F3" Condition="(NOT WIX_UPGRADE_DETECTED) AND (HYPERV_INSTALL = 1)">
+			<Component Id="HyperVFeatureComponent" Guid="F7B2D4C9-6C89-46BB-B4EA-FF39424972F3" Condition="(NOT Installed) AND (HYPERV_INSTALL = 1)">
 				<CreateFolder />
 				<PanelSW:Dism EnableFeature="Microsoft-Hyper-V" ErrorHandling="prompt" />
 			</Component>
@@ -110,13 +110,13 @@
 		<WixVariable Id="WixUIDialogBmp" Value="resources\podman-dialog.png" />
 		<UIRef Id="PodmanUI" />
 		<UI>
-			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenGuide" Condition="(WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1) AND (NOT WIX_UPGRADE_DETECTED)" />
+			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenGuide" Condition="(WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1) AND (NOT Installed) AND (NOT UpdateStarted)" />
 		</UI>
 
 		<InstallExecuteSequence>
 			<Custom Action="CheckWSL" Before="SetWSL_INSTALL" />
 			<Custom Action="CheckHyperV" Before="SetHYPERV_INSTALL" />
-			<ForceReboot Before="StopServices" Condition="(NOT WIX_UPGRADE_DETECTED) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
+			<ForceReboot Before="StopServices" Condition="(NOT Installed) AND (NOT UpdateStarted) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
 		</InstallExecuteSequence>
 		<Binary Id="PodmanHooks" SourceFile="artifacts/podman-msihooks.dll" />
 

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -10,7 +10,7 @@
 	<?define UseGVProxy = ""?>
 	<?endif?>
 
-	<Package Name="podman" Manufacturer="Red Hat Inc." Version="$(VERSION)" UpgradeCode="a6a9dd9c-0732-44ba-9279-ffe22ea50671">
+	<Package Name="podman" Manufacturer="Red Hat Inc." Version="$(VERSION)" UpgradeCode="a6a9dd9c-0732-44ba-9279-ffe22ea50671" ProductCode="18107131-1820-4878-8AEE-65AAE37BC1E3">
 		<Media Id="1" Cabinet="Podman.cab" EmbedCab="yes" />
 		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." RemoveFeatures="Complete" Schedule="afterInstallExecute" />
 		<Property Id="DiskPrompt" Value="Red Hat's Podman $(VERSION) Installation" />
@@ -154,7 +154,7 @@
 		<StandardDirectory Id="CommonAppDataFolder">
 			<Directory Id="CONFIGDIR" Name="containers">
 				<Directory Id="ContainersConfigSubDir" Name="containers.conf.d">
-					<Component Id="MachineProviderConfigFile" Guid="C32C0040-D9AF-4155-AC7E-465B63B6BE3B" Condition="CREATE_MACHINE_PROVIDER_CONFIG_FILE">
+					<Component Id="MachineProviderConfigFile" Guid="C32C0040-D9AF-4155-AC7E-465B63B6BE3B" Condition="CREATE_MACHINE_PROVIDER_CONFIG_FILE" Transitive="true">
 						<CreateFolder />
 						<IniFile Id="MachineProviderConfigFile" Action="createLine" Directory="ContainersConfigSubDir" Section="machine" Name="99-podman-machine-provider.conf" Key="provider" Value="&quot;[MACHINE_PROVIDER]&quot;" />
 					</Component>

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -116,7 +116,7 @@
 		<InstallExecuteSequence>
 			<Custom Action="CheckWSL" Before="SetWSL_INSTALL" />
 			<Custom Action="CheckHyperV" Before="SetHYPERV_INSTALL" />
-			<ForceReboot Before="StopServices" Condition="(NOT Installed) AND (NOT UpdateStarted) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
+			<ForceReboot After="DismX86" Condition="(NOT Installed) AND (NOT UpdateStarted) AND (NOT BURNMSIUNINSTALL) AND ((WSL_INSTALL = 1) OR (HYPERV_INSTALL = 1)) AND (NOT AFTERREBOOT)" />
 		</InstallExecuteSequence>
 		<Binary Id="PodmanHooks" SourceFile="artifacts/podman-msihooks.dll" />
 

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -204,18 +204,6 @@ function Remove-Podman-Machine-Conf {
     Write-Host "Deletion successful!`n"
 }
 
-function Get-Latest-Podman-Setup-From-GitHub {
-    $tag = "5.3.0"
-    Write-Host "Downloading the $tag Podman windows setup from GitHub..."
-    $downloadUrl = "https://github.com/containers/podman/releases/download/v$tag/podman-$tag-setup.exe"
-    Write-Host "Downloading URL: $downloadUrl"
-    $destinationPath = "$PSScriptRoot\podman-$tag-setup.exe"
-    Write-Host "Destination Path: $destinationPath"
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $destinationPath
-    Write-Host "Command completed successfully!`n"
-    return $destinationPath
-}
-
 function Test-Installation {
     param (
         [ValidateSet("wsl", "hyperv")]

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -4,21 +4,34 @@
 # rm .\contrib\win-installer\*.log &&
 # rm .\contrib\win-installer\*.exe &&
 # rm .\contrib\win-installer\*.wixpdb &&
+# .\winmake.ps1 installer &&
 # .\winmake.ps1 installer 9.9.9 &&
 # .\contrib\win-installer\test-installer.ps1 `
 #     -scenario update-without-user-changes `
-#     -setupExePath ".\contrib\win-installer\podman-9.9.9-dev-setup.exe" `
+#     -previousSetupExePath ".\contrib\win-installer\podman-5.3.0-dev-setup.exe" `
+#     -setupExePath ".\contrib\win-installer\podman-5.4.0-dev-setup.exe" `
+#     -nextSetupExePath ".\contrib\win-installer\podman-9.9.9-dev-setup.exe" `
+#     -v531SetupExePath ".\contrib\win-installer\podman-5.3.1-dev-setup.exe" `
 #     -provider hyperv
+#
 
 # The Param statement must be the first statement, except for comments and any #Require statements.
 param (
     [Parameter(Mandatory)]
-    [ValidateSet("test-objects-exist", "test-objects-exist-not", "installation-green-field", "installation-skip-config-creation-flag", "installation-with-pre-existing-podman-exe", "update-without-user-changes", "update-with-user-changed-config-file", "update-with-user-removed-config-file", "all")]
+    [ValidateSet("test-objects-exist", "test-objects-exist-not", "installation-green-field", "installation-skip-config-creation-flag", "installation-with-pre-existing-podman-exe",
+                 "update-without-user-changes", "update-with-user-changed-config-file", "update-with-user-removed-config-file",
+                 "update-without-user-changes-from-531", "update-with-user-changed-config-file-from-531", "update-with-user-removed-config-file-from-531",
+                 "update-without-user-changes-to-next", "update-with-user-changed-config-file-to-next", "update-with-user-removed-config-file-to-next",
+                 "all")]
     [string]$scenario,
     [ValidateScript({Test-Path $_ -PathType Leaf})]
     [string]$setupExePath,
     [ValidateScript({Test-Path $_ -PathType Leaf})]
     [string]$previousSetupExePath,
+    [ValidateScript({Test-Path $_ -PathType Leaf})]
+    [string]$nextSetupExePath,
+    [ValidateScript({Test-Path $_ -PathType Leaf})]
+    [string]$v531SetupExePath,
     [ValidateSet("wsl", "hyperv")]
     [string]$provider="wsl",
     [switch]$installWSL=$false,
@@ -26,6 +39,8 @@ param (
     [switch]$skipWinVersionCheck=$false,
     [switch]$skipConfigFileCreation=$false
 )
+
+. $PSScriptRoot\utils.ps1
 
 $MachineConfPath = "$env:ProgramData\containers\containers.conf.d\99-podman-machine-provider.conf"
 $PodmanFolderPath = "$env:ProgramFiles\RedHat\Podman"
@@ -86,20 +101,8 @@ function Install-Podman-With-Defaults {
     Write-Host "Installation completed successfully!`n"
 }
 
-function Install-Previous-Podman {
-    Install-Podman -setupExePath $previousSetupExePath
-}
-
-function Install-Previous-Podman-With-Defaults {
-    Install-Podman-With-Defaults -setupExePath $previousSetupExePath
-}
-
 function Install-Current-Podman {
     Install-Podman -setupExePath $setupExePath
-}
-
-function Install-Current-Podman-With-Defaults {
-    Install-Podman-With-Defaults -setupExePath $setupExePath
 }
 
 function Test-Podman-Objects-Exist {
@@ -156,10 +159,6 @@ function Uninstall-Current-Podman {
     Uninstall-Podman -setupExePath $setupExePath
 }
 
-function Uninstall-Previous-Podman {
-    Uninstall-Podman -setupExePath $previousSetupExePath
-}
-
 function Test-Podman-Objects-Exist-Not {
     Write-Host "Verifying that podman files, folders and registry entries don't exist..."
     $WindowsPathsToTest | ForEach-Object {
@@ -212,18 +211,39 @@ function Get-Latest-Podman-Setup-From-GitHub {
     return $destinationPath
 }
 
+function Test-Installation {
+    param (
+        [ValidateSet("wsl", "hyperv")]
+        [string]$expectedConf
+    )
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist
+    if ($expectedConf) {
+        Test-Podman-Machine-Conf-Content -expected $expectedConf
+    } else {
+        Test-Podman-Machine-Conf-Content
+    }
+}
+
+function Test-Installation-No-Config {
+    Test-Podman-Objects-Exist
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
+function Test-Uninstallation {
+    Test-Podman-Objects-Exist-Not
+    Test-Podman-Machine-Conf-Exist-Not
+}
+
 # SCENARIOS
 function Start-Scenario-Installation-Green-Field {
     Write-Host "`n==========================================="
     Write-Host " Running scenario: Installation-Green-Field"
     Write-Host "==========================================="
     Install-Current-Podman
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist
-    Test-Podman-Machine-Conf-Content
+    Test-Installation
     Uninstall-Current-Podman
-    Test-Podman-Objects-Exist-Not
-    Test-Podman-Machine-Conf-Exist-Not
+    Test-Uninstallation
 }
 
 function Start-Scenario-Installation-Skip-Config-Creation-Flag {
@@ -232,11 +252,9 @@ function Start-Scenario-Installation-Skip-Config-Creation-Flag {
     Write-Host "========================================================="
     $skipConfigFileCreation = $true
     Install-Current-Podman
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist-Not
+    Test-Installation-No-Config
     Uninstall-Current-Podman
-    Test-Podman-Objects-Exist-Not
-    Test-Podman-Machine-Conf-Exist-Not
+    Test-Uninstallation
 }
 
 function Start-Scenario-Installation-With-Pre-Existing-Podman-Exe {
@@ -245,63 +263,98 @@ function Start-Scenario-Installation-With-Pre-Existing-Podman-Exe {
     Write-Host "============================================================"
     New-Fake-Podman-Exe
     Install-Current-Podman
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist-Not
+    Test-Installation-No-Config
     Uninstall-Current-Podman
-    Test-Podman-Objects-Exist-Not
-    Test-Podman-Machine-Conf-Exist-Not
+    Test-Uninstallation
 }
 
 function Start-Scenario-Update-Without-User-Changes {
-    Write-Host "`n=============================================="
-    Write-Host " Running scenario: Update-Without-User-Changes"
-    Write-Host "=============================================="
-    Install-Previous-Podman
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist
-    Test-Podman-Machine-Conf-Content
-    Install-Current-Podman-With-Defaults
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist
-    Test-Podman-Machine-Conf-Content
-    Uninstall-Current-Podman
-    Test-Podman-Objects-Exist-Not
-    Test-Podman-Machine-Conf-Exist-Not
+    param (
+        [ValidateSet("From-Previous", "From-531", "To-Next")]
+        [string]$mode="From-Previous"
+    )
+    Write-Host "`n======================================================"
+    Write-Host " Running scenario: Update-Without-User-Changes-$mode"
+    Write-Host "======================================================"
+    switch ($mode) {
+        'From-Previous' {$i = $previousSetupExePath; $u = $setupExePath}
+        'From-531' {$i = $v531SetupExePath; $u = $setupExePath}
+        'To-Next' {$i = $setupExePath; $u = $nextSetupExePath}
+    }
+    Install-Podman -setupExePath $i
+    Test-Installation
+    Install-Podman-With-Defaults -setupExePath $u
+    Test-Installation
+    Uninstall-Podman -setupExePath $u
+    Test-Uninstallation
+}
+
+function Start-Scenario-Update-Without-User-Changes-From-531 {
+    Start-Scenario-Update-Without-User-Changes -mode "From-531"
+}
+
+function Start-Scenario-Update-Without-User-Changes-To-Next {
+    Start-Scenario-Update-Without-User-Changes -mode "To-Next"
 }
 
 function Start-Scenario-Update-With-User-Changed-Config-File {
-    Write-Host "`n======================================================="
-    Write-Host " Running scenario: Update-With-User-Changed-Config-File"
-    Write-Host "======================================================="
-    Install-Previous-Podman
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist
-    Test-Podman-Machine-Conf-Content
+    param (
+        [ValidateSet("From-Previous", "From-531", "To-Next")]
+        [string]$mode="From-Previous"
+    )
+    Write-Host "`n=============================================================="
+    Write-Host " Running scenario: Update-With-User-Changed-Config-File-$mode"
+    Write-Host "=============================================================="
+    switch ($mode) {
+        'From-Previous' {$i = $previousSetupExePath; $u = $setupExePath}
+        'From-531' {$i = $v531SetupExePath; $u = $setupExePath}
+        'To-Next' {$i = $setupExePath; $u = $nextSetupExePath}
+    }
+    Install-Podman -setupExePath $i
+    Test-Installation
     $newProvider = Switch-Podman-Machine-Conf-Content
-    Install-Current-Podman-With-Defaults
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist
-    Test-Podman-Machine-Conf-Content -expected $newProvider
-    Uninstall-Current-Podman
-    Test-Podman-Objects-Exist-Not
-    Test-Podman-Machine-Conf-Exist-Not
+    Install-Podman-With-Defaults -setupExePath $u
+    Test-Installation -expectedConf $newProvider
+    Uninstall-Podman -setupExePath $u
+    Test-Uninstallation
+}
+
+function Start-Scenario-Update-With-User-Changed-Config-File-From-531 {
+    Start-Scenario-Update-With-User-Changed-Config-File -mode "From-531"
+}
+
+function Start-Scenario-Update-With-User-Changed-Config-File-To-Next {
+    Start-Scenario-Update-With-User-Changed-Config-File -mode "To-Next"
 }
 
 function Start-Scenario-Update-With-User-Removed-Config-File {
-    Write-Host "`n======================================================="
-    Write-Host " Running scenario: Update-With-User-Removed-Config-File"
-    Write-Host "======================================================="
-    Install-Previous-Podman
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist
-    Test-Podman-Machine-Conf-Content
+    param (
+        [ValidateSet("From-Previous", "From-531", "To-Next")]
+        [string]$mode="From-Previous"
+    )
+    Write-Host "`n=============================================================="
+    Write-Host " Running scenario: Update-With-User-Removed-Config-File-$mode"
+    Write-Host "=============================================================="
+    switch ($mode) {
+        'From-Previous' {$i = $previousSetupExePath; $u = $setupExePath}
+        'From-531' {$i = $v531SetupExePath; $u = $setupExePath}
+        'To-Next' {$i = $setupExePath; $u = $nextSetupExePath}
+    }
+    Install-Podman -setupExePath $i
+    Test-Installation
     Remove-Podman-Machine-Conf
-    Install-Current-Podman-With-Defaults
-    Test-Podman-Objects-Exist
-    Test-Podman-Machine-Conf-Exist-Not
-    Uninstall-Current-Podman
-    Test-Podman-Objects-Exist-Not
-    Test-Podman-Machine-Conf-Exist-Not
+    Install-Podman-With-Defaults -setupExePath $u
+    Test-Installation-No-Config
+    Uninstall-Podman -setupExePath $u
+    Test-Uninstallation
+}
+
+function Start-Scenario-Update-With-User-Removed-Config-File-From-531 {
+    Start-Scenario-Update-With-User-Removed-Config-File -mode "From-531"
+}
+
+function Start-Scenario-Update-With-User-Removed-Config-File-To-Next {
+    Start-Scenario-Update-With-User-Removed-Config-File -mode "To-Next"
 }
 
 switch ($scenario) {
@@ -326,11 +379,35 @@ switch ($scenario) {
         }
         Start-Scenario-Update-Without-User-Changes
     }
+    'update-without-user-changes-from-531' {
+        if (!$v531SetupExePath) {
+            $v531SetupExePath = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
+        }
+        Start-Scenario-Update-Without-User-Changes-From-531
+    }
+    'update-without-user-changes-to-next' {
+        if (!$nextSetupExePath) {
+            throw "Next version installer path is not defined. Use '-nextSetupExePath <setup-exe-path>' to define it."
+        }
+        Start-Scenario-Update-Without-User-Changes-To-Next
+    }
     'update-with-user-changed-config-file' {
         if (!$previousSetupExePath) {
             $previousSetupExePath = Get-Latest-Podman-Setup-From-GitHub
         }
         Start-Scenario-Update-With-User-Changed-Config-File
+    }
+    'update-with-user-changed-config-file-from-531' {
+        if (!$v531SetupExePath) {
+            $v531SetupExePath = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
+        }
+        Start-Scenario-Update-With-User-Changed-Config-File-From-531
+    }
+    'update-with-user-changed-config-file-to-next' {
+        if (!$nextSetupExePath) {
+            throw "Next version installer path is not defined. Use '-nextSetupExePath <setup-exe-path>' to define it."
+        }
+        Start-Scenario-Update-With-User-Changed-Config-File-To-Next
     }
     'update-with-user-removed-config-file' {
         if (!$previousSetupExePath) {
@@ -338,15 +415,39 @@ switch ($scenario) {
         }
         Start-Scenario-Update-With-User-Removed-Config-File
     }
+    'update-with-user-removed-config-file-from-531' {
+        if (!$v531SetupExePath) {
+            $v531SetupExePath = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
+        }
+        Start-Scenario-Update-With-User-Removed-Config-File-From-531
+    }
+    'update-with-user-removed-config-file-to-next' {
+        if (!$nextSetupExePath) {
+            throw "Next version installer path is not defined. Use '-nextSetupExePath <setup-exe-path>' to define it."
+        }
+        Start-Scenario-Update-With-User-Removed-Config-File-To-Next
+    }
     'all' {
+        if (!$nextSetupExePath) {
+            throw "Next version installer path is not defined. Use '-nextSetupExePath <setup-exe-path>' to define it."
+        }
         if (!$previousSetupExePath) {
             $previousSetupExePath = Get-Latest-Podman-Setup-From-GitHub
+        }
+        if (!$v531SetupExePath) {
+            $v531SetupExePath = Get-Podman-Setup-From-GitHub -version "tags/v5.3.1"
         }
         Start-Scenario-Installation-Green-Field
         Start-Scenario-Installation-Skip-Config-Creation-Flag
         Start-Scenario-Installation-With-Pre-Existing-Podman-Exe
         Start-Scenario-Update-Without-User-Changes
+        Start-Scenario-Update-Without-User-Changes-From-531
+        Start-Scenario-Update-Without-User-Changes-To-Next
         Start-Scenario-Update-With-User-Changed-Config-File
+        Start-Scenario-Update-With-User-Changed-Config-File-From-531
+        Start-Scenario-Update-With-User-Changed-Config-File-To-Next
         Start-Scenario-Update-With-User-Removed-Config-File
+        Start-Scenario-Update-With-User-Removed-Config-File-From-531
+        Start-Scenario-Update-With-User-Removed-Config-File-To-Next
     }
 }

--- a/contrib/win-installer/test-installer.ps1
+++ b/contrib/win-installer/test-installer.ps1
@@ -1,6 +1,11 @@
 #!/usr/bin/env pwsh
 
-# Example usage:
+# Usage examples:
+#
+# 1) Build a v9.9.9 installer and run `update-without-user-chages`
+#    scenario without specifying the previous setup exe (it will download from
+#    GitHub):
+#
 # rm .\contrib\win-installer\*.log &&
 # rm .\contrib\win-installer\*.exe &&
 # rm .\contrib\win-installer\*.wixpdb &&
@@ -92,10 +97,10 @@ function Install-Podman-With-Defaults {
     $ret = Start-Process -Wait `
                             -PassThru "$setupExePath" `
                             -ArgumentList "/install /quiet `
-                                /log $PSScriptRoot\podman-setup.log"
+                                /log $PSScriptRoot\podman-setup-default.log"
     if ($ret.ExitCode -ne 0) {
         Write-Host "Install failed, dumping log"
-        Get-Content $PSScriptRoot\podman-setup.log
+        Get-Content $PSScriptRoot\podman-setup-default.log
         throw "Exit code is $($ret.ExitCode)"
     }
     Write-Host "Installation completed successfully!`n"

--- a/contrib/win-installer/utils.ps1
+++ b/contrib/win-installer/utils.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+function Get-Latest-Podman-Setup-From-GitHub {
+    return Get-Podman-Setup-From-GitHub "latest"
+}
+
+function Get-Podman-Setup-From-GitHub {
+    param(
+        [Parameter(Mandatory)]
+        [string] $version
+    )
+
+    Write-Host "Downloading the $version Podman windows setup from GitHub..."
+    $apiUrl = "https://api.github.com/repos/containers/podman/releases/$version"
+    $response = Invoke-RestMethod -Uri $apiUrl -Headers @{"User-Agent"="PowerShell"} -ErrorAction Stop
+    $downloadUrl = $response.assets[0].browser_download_url
+    Write-Host "Downloading URL: $downloadUrl"
+    $latestTag = $response.tag_name
+    $destinationPath = "$PSScriptRoot\podman-$latestTag-setup.exe"
+    Write-Host "Destination Path: $destinationPath"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $destinationPath
+    Write-Host "Command completed successfully!`n"
+    return $destinationPath
+}


### PR DESCRIPTION
### The problem

When upgrading from v5.3.1 to a new version on a Windows machine without WSL, the installer asks to reboot. This problem doesn't impact users because v5.3.1 is the last release, but it is blocking the release v5.3.2.

### Why it happens

The `ForceReboot` action in the v5.3.1 package is executed during a "major upgrade" to a new version (if WSL is not installed).

### Changes introduced by this PR

- Fix the `ForceReboot` action condition to avoid it during updates
- Add a [Windows Installer patch](https://wixtoolset.org/docs/tools/patches/) for the already released `v5.3.1` so that updates from that version don't trigger an unrequested reboot.
- Bump the WiX version to 5.0.2
- Add tests for upgrades to next version
- Add tests for upgrades from v5.3.1 (minor upgrade)

⚠️ To build the Windows installer from this PR branch (to test the PR), build the `v5.3.1` locally first because of [this issue](https://github.com/containers/podman/issues/24833) and change the Product ID in `podman.wxs` (as described in this PR `contrib/win-installer/README.md` preparation section).

This PR supersedes #24778

Reference:  https://github.com/orgs/wixtoolset/discussions/8854
Fixes #24735

#### Does this PR introduce a user-facing change?

```release-note
None
```
