### PR TITLE
Update gvproxy and vfkit binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ endif
 
 # gvisor-tap-vsock version for gvproxy.exe and win-sshproxy.exe downloads
 # the upstream project ships pre-built binaries since version 0.7.1
-GV_VERSION=v0.8.0
+GV_VERSION=v0.8.1
 
 ###
 ### Primary entry-point targets

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -7,7 +7,7 @@ else
 	GOARCH:=$(ARCH)
 endif
 GVPROXY_VERSION ?= 0.8.1
-VFKIT_VERSION ?= 0.5.1
+VFKIT_VERSION ?= 0.6.0
 KRUNKIT_VERSION ?= 0.1.4
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -6,7 +6,7 @@ ifeq ($(ARCH), aarch64)
 else
 	GOARCH:=$(ARCH)
 endif
-GVPROXY_VERSION ?= 0.8.0
+GVPROXY_VERSION ?= 0.8.1
 VFKIT_VERSION ?= 0.5.1
 KRUNKIT_VERSION ?= 0.1.4
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin


### PR DESCRIPTION
The gvisor-tap-vsock and vfkit binaries were updated to their latest version, but the binaries were still older ones.
This PR updates these binaries to the latest releases.
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman-machine now uses gvproxy 0.8.1 and vfkit 0.6.0
```