### PR TITLE
When generating host volumes for k8s, force to lowercase

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -1188,14 +1188,15 @@ func generateKubePersistentVolumeClaim(v *ContainerNamedVolume) (v1.VolumeMount,
 	ro := slices.Contains(v.Options, "ro")
 
 	// To avoid naming conflicts with any host path mounts, add a unique suffix to the volume's name.
-	name := v.Name + "-pvc"
+	vName := strings.ToLower(v.Name)
+	name := vName + "-pvc"
 
 	vm := v1.VolumeMount{}
 	vm.Name = name
 	vm.MountPath = v.Dest
 	vm.ReadOnly = ro
 
-	pvc := v1.PersistentVolumeClaimVolumeSource{ClaimName: v.Name, ReadOnly: ro}
+	pvc := v1.PersistentVolumeClaimVolumeSource{ClaimName: vName, ReadOnly: ro}
 	vs := v1.VolumeSource{}
 	vs.PersistentVolumeClaim = &pvc
 	vo := v1.Volume{Name: name, VolumeSource: vs}
@@ -1274,7 +1275,7 @@ func convertVolumePathToName(hostSourcePath string) (string, error) {
 	}
 	// First, trim trailing slashes, then replace slashes with dashes.
 	// Thus, /mnt/data/ will become mnt-data
-	return strings.ReplaceAll(strings.Trim(hostSourcePath, "/"), "/", "-"), nil
+	return strings.ToLower(strings.ReplaceAll(strings.Trim(hostSourcePath, "/"), "/", "-")), nil
 }
 
 func determineCapAddDropFromCapabilities(defaultCaps, containerCaps []string) *v1.Capabilities {

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -94,6 +94,19 @@ status                           | =  | null
       run_podman rm $cname
 }
 
+@test "podman kube generate volumes" {
+      cname=c-$(safename)
+      KUBE=$PODMAN_TMPDIR/kube.yaml
+      source=$PODMAN_TMPDIR/Upper/Case/Path
+      mkdir -p ${source}
+      run_podman create --name $cname -v $source:/mnt -v UPPERCASEVolume:/volume $IMAGE
+      run_podman kube generate $cname -f $KUBE
+      assert "$(< $KUBE)" =~ "name: uppercasevolume-pvc" "Lowercase volume name"
+      assert "$(< $KUBE)" =~ "upper-case-path" "Lowercase volume paths"
+      run_podman rm $cname
+      run_podman volume rm UPPERCASEVolume
+}
+
 @test "podman kube generate - pod" {
     local pname=p-$(safename)
     local cname1=c1-$(safename)


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/16542

Kubernetes only allows lower case persistent volume names.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Persistent volume names will be lowercase with podman kube generate
```
