### PR TITLE
Kube volumes can not contain _

### DIFF
--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -99,12 +99,12 @@ status                           | =  | null
       KUBE=$PODMAN_TMPDIR/kube.yaml
       source=$PODMAN_TMPDIR/Upper/Case/Path
       mkdir -p ${source}
-      run_podman create --name $cname -v $source:/mnt -v UPPERCASEVolume:/volume $IMAGE
+      run_podman create --name $cname -v $source:/mnt -v UPPERCASE_Volume:/volume $IMAGE
       run_podman kube generate $cname -f $KUBE
-      assert "$(< $KUBE)" =~ "name: uppercasevolume-pvc" "Lowercase volume name"
+      assert "$(< $KUBE)" =~ "name: uppercase-volume-pvc" "Lowercase volume name"
       assert "$(< $KUBE)" =~ "upper-case-path" "Lowercase volume paths"
       run_podman rm $cname
-      run_podman volume rm UPPERCASEVolume
+      run_podman volume rm UPPERCASE_Volume
 }
 
 @test "podman kube generate - pod" {


### PR DESCRIPTION
Need to substiture all _ to - for k8s support.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
