### PR TITLE
Checking for multiple registries when login/logout

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
@@ -99,6 +100,10 @@ func login(cmd *cobra.Command, args []string) error {
 		DockerInsecureSkipTLSVerify: skipTLS,
 	}
 	common.SetRegistriesConfPath(sysCtx)
+	registriesFromFile, _ := sysregistriesv2.UnqualifiedSearchRegistries(sysCtx)
+	if len(registriesFromFile) > 1 {
+		return errors.New("multiple registries in registry.conf, a registry must be provided")
+	}
 	loginOptions.GetLoginSet = cmd.Flag("get-login").Changed
 	return auth.Login(context.Background(), sysCtx, &loginOptions.LoginOptions, args)
 }

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
@@ -50,5 +52,9 @@ func init() {
 func logout(cmd *cobra.Command, args []string) error {
 	sysCtx := &types.SystemContext{}
 	common.SetRegistriesConfPath(sysCtx)
+	registriesFromFile, _ := sysregistriesv2.UnqualifiedSearchRegistries(sysCtx)
+	if len(registriesFromFile) > 1 {
+		return errors.New("multiple registries in registry.conf, a registry must be provided")
+	}
 	return auth.Logout(sysCtx, &logoutOptions, args)
 }


### PR DESCRIPTION
Creating a check for `podman login` if there is a multiple registries in the `registry.conf` to avoid any issues where credential getting replaced by `docker login`

Fixes #22400 