### PR TITLE
Add support to ShmSize in Pods with Quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -953,6 +953,7 @@ Valid options for `[Pod]` are listed below:
 | PodName=name                        | --name=name                            |
 | PublishPort=8080:80                 | --publish 8080:80                      |
 | ServiceName=name                    | Name the systemd unit `name.service`   |
+| ShmSize=100m                        | --shm-size=100m                        |
 | SubGIDMap=gtest                     | --subgidname=gtest                     |
 | SubUIDMap=utest                     | --subuidname=utest                     |
 | UIDMap=0:10000:10                   | --uidmap=0:10000:10                    |
@@ -1091,6 +1092,12 @@ By default, Quadlet will name the systemd service unit by appending `-pod` to th
 Setting this key overrides this behavior by instructing Quadlet to use the provided name.
 
 Note, the name should not include the `.service` file extension
+
+### `ShmSize=`
+
+Size of /dev/shm.
+
+This is equivalent to the Podman `--shm-size` option and generally has the form `number[unit]`
 
 ### `SubGIDMap=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -413,6 +413,7 @@ var (
 		KeyRemapUidSize:         true,
 		KeyRemapUsers:           true,
 		KeyServiceName:          true,
+		KeyShmSize:              true,
 		KeySubGIDMap:            true,
 		KeySubUIDMap:            true,
 		KeyUIDMap:               true,
@@ -1629,10 +1630,11 @@ func ConvertPod(podUnit *parser.UnitFile, name string, unitsInfoMap map[string]*
 	}
 
 	stringsKeys := map[string]string{
-		KeyIP:  "--ip",
-		KeyIP6: "--ip6",
+		KeyIP:      "--ip",
+		KeyIP6:     "--ip6",
+		KeyShmSize: "--shm-size",
 	}
-	lookupAndAddAllStrings(podUnit, PodGroup, stringsKeys, execStartPre)
+	lookupAndAddString(podUnit, PodGroup, stringsKeys, execStartPre)
 
 	allStringsKeys := map[string]string{
 		KeyNetworkAlias: "--network-alias",

--- a/test/e2e/quadlet/shmsize.pod
+++ b/test/e2e/quadlet/shmsize.pod
@@ -1,0 +1,4 @@
+## assert-podman-pre-args "--shm-size" "5g"
+
+[Pod]
+ShmSize=5g

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1042,6 +1042,7 @@ BOGUS=foo
 		Entry("Pod - Remap auto2", "remap-auto2.pod"),
 		Entry("Pod - Remap keep-id", "remap-keep-id.pod"),
 		Entry("Pod - Remap manual", "remap-manual.pod"),
+		Entry("Pod - Shm Size", "shmsize.pod"),
 	)
 
 	DescribeTable("Running expected warning quadlet test case",


### PR DESCRIPTION
This closes #22915

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Add support for ShmSize in Pods created with Quadlet.
Add e2e tests.
Add new Docs entry.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Users are now able to define the ShmSize value on Pod Units for containers created with quadlets.
```
