### PR TITLE
Add hint to restart Podman machine to really accept new certificates

### DIFF
--- a/docs/tutorials/podman-install-certificate-authority.md
+++ b/docs/tutorials/podman-install-certificate-authority.md
@@ -52,6 +52,13 @@ If the "sudo su -" command was used to switch to a root shell as described above
 [core@localhost ~]$ exit
 ```
 
+If the certificates are still not accepted, it might be necessary to restart the Podman machine. To do this, issue the following commands on the host (and not inside the Podman machine):
+
+```
+podman machine stop
+podman machine start
+```
+
 ### Alternative Method
 
 If the above method is for some reason not practical or desirable, the certificate may be created using vi.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Add a small hint to the tutorial about Install Certificate Authority that a restart of the Podman machine might be necessary to really accept the newly added certificates.

This fixes #24593.