### PR TITLE
Set network ID if available during container inspect. Fixes #24910

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -383,7 +383,7 @@ case "$TEST_FLAVOR" in
         ;;
     compose_v2)
         showrun dnf -y remove docker-compose
-        showrun curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+        showrun curl -SL https://github.com/docker/compose/releases/download/v2.32.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
         showrun chmod +x /usr/local/bin/docker-compose
         ;& # Continue with next item
     apiv2)

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -212,11 +212,19 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 		return nil, err
 	}
 
+	getNetworkID := func(nameOrID string) string {
+		network, err := c.runtime.network.NetworkInspect(nameOrID)
+		if err == nil && network.ID != "" {
+			return network.ID
+		}
+		return nameOrID
+	}
+
 	setDefaultNetworks := func() {
 		settings.Networks = make(map[string]*define.InspectAdditionalNetwork, 1)
 		name := c.NetworkMode()
 		addedNet := new(define.InspectAdditionalNetwork)
-		addedNet.NetworkID = name
+		addedNet.NetworkID = getNetworkID(name)
 		settings.Networks[name] = addedNet
 	}
 
@@ -244,7 +252,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 			settings.Networks = make(map[string]*define.InspectAdditionalNetwork, len(networks))
 			for net, opts := range networks {
 				cniNet := new(define.InspectAdditionalNetwork)
-				cniNet.NetworkID = net
+				cniNet.NetworkID = getNetworkID(net)
 				cniNet.Aliases = opts.Aliases
 				settings.Networks[net] = cniNet
 			}
@@ -275,7 +283,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 		for name, opts := range networks {
 			result := netStatus[name]
 			addedNet := new(define.InspectAdditionalNetwork)
-			addedNet.NetworkID = name
+			addedNet.NetworkID = getNetworkID(name)
 			addedNet.Aliases = opts.Aliases
 			addedNet.InspectBasicNetworkConfig = resultToBasicNetworkConfig(result)
 

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -74,7 +74,7 @@ t GET libpod/containers/json?all=true 200 \
 # Test compat API for Network Settings (.Network is N/A when rootless)
 network_expect="Networks.pasta.NetworkID=pasta"
 if root; then
-    network_expect="Networks.podman.NetworkID=podman"
+    network_expect="Networks.podman.NetworkID=2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9"
 fi
 t GET /containers/json?all=true 200 \
   length=1 \
@@ -335,7 +335,7 @@ t GET containers/${cid_top}/json 200 \
   .Config.Cmd='[]' \
   .Config.StopTimeout="10" \
   .Path="top" \
-  .NetworkSettings.Networks.podman.NetworkID=podman
+  .NetworkSettings.Networks.podman.NetworkID=2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9
 t POST  containers/${cid_top}/start 204
 # make sure the container is running
 t GET containers/${cid_top}/json 200 \

--- a/test/apiv2/python/rest_api/test_v2_0_0_network.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_network.py
@@ -14,6 +14,7 @@ class NetworkTestCase(APITestCase):
             self.podman_url + "/v1.40/networks/create", json={"Name": "TestDefaultNetwork"}
         )
         self.assertEqual(net_default.status_code, 201, net_default.text)
+        net_id = net_default.json()["Id"]
 
         create = requests.post(
             self.podman_url + "/v1.40/containers/create?name=postCreateConnect",
@@ -59,7 +60,7 @@ class NetworkTestCase(APITestCase):
         self.assertFalse(payload["Config"].get("NetworkDisabled", False))
 
         self.assertEqual(
-            "TestDefaultNetwork",
+            net_id,
             payload["NetworkSettings"]["Networks"]["TestDefaultNetwork"]["NetworkID"],
         )
         # TODO restore this to test, when joining multiple networks possible
@@ -79,6 +80,7 @@ class NetworkTestCase(APITestCase):
             self.podman_url + "/v1.40/networks/create", json={"Name": "TestNetwork"}
         )
         self.assertEqual(net.status_code, 201, net.text)
+        net_id = net.json()["Id"]
 
         create = requests.post(
             self.podman_url + "/v1.40/containers/create?name=postCreate",
@@ -99,7 +101,7 @@ class NetworkTestCase(APITestCase):
         payload = inspect.json()
         self.assertFalse(payload["Config"].get("NetworkDisabled", False))
         self.assertEqual(
-            "TestNetwork",
+            net_id,
             payload["NetworkSettings"]["Networks"]["TestNetwork"]["NetworkID"],
         )
     def test_inspect(self):

--- a/test/compose/ipam_set_ip/docker-compose.yml
+++ b/test/compose/ipam_set_ip/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   test:
     image: alpine

--- a/test/compose/uptwice/docker-compose.yml
+++ b/test/compose/uptwice/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     app:
         build: .

--- a/test/compose/uptwice/tests.sh
+++ b/test/compose/uptwice/tests.sh
@@ -1,6 +1,5 @@
 # -*- bash -*-
 
-CR=$'\r'
 NL=$'\n'
 
 cp docker-compose.yml docker-compose.yml.bak
@@ -10,5 +9,5 @@ output=$(podman_compose up -d 2>&1)
 # Horrible output check here but we really want to make sure that there are
 # no unexpected warning/errors and the normal messages are send on stderr as
 # well so we cannot check for an empty stderr.
-expected="Container uptwice-app-1  Recreate${NL}Container uptwice-app-1  Recreated${NL}Container uptwice-app-1  Starting${NL}Container uptwice-app-1  Started"
+expected=" Container uptwice-app-1  Recreate${NL} Container uptwice-app-1  Recreated${NL} Container uptwice-app-1  Starting${NL} Container uptwice-app-1  Started"
 is "$output" "$expected" "no error output in compose up (#15580)"

--- a/test/compose/uptwice_idempotent/docker-compose.yml
+++ b/test/compose/uptwice_idempotent/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine
+    command: top

--- a/test/compose/uptwice_idempotent/tests.sh
+++ b/test/compose/uptwice_idempotent/tests.sh
@@ -1,0 +1,9 @@
+# -*- bash -*-
+
+output=$(podman_compose up -d 2>&1)
+
+# Horrible output check here but we really want to make sure that there are
+# no unexpected warning/errors and the normal messages are send on stderr as
+# well so we cannot check for an empty stderr.
+expected=" Container uptwice_idempotent-app-1  Running"
+is "$output" "$expected" "no container recreation in compose up (#24950)"

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -275,6 +275,10 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(network).Should(ExitCleanly())
 
+		session := podmanTest.Podman([]string{"network", "inspect", netName, "--format", "{{.Id}}"})
+		session.WaitWithDefaultTimeout()
+		netID := session.OutputToString()
+
 		ctrName := "testCtr"
 		container := podmanTest.Podman([]string{"run", "-dt", "--network", netName, "--name", ctrName, ALPINE, "top"})
 		container.WaitWithDefaultTimeout()
@@ -288,7 +292,7 @@ var _ = Describe("Podman network", func() {
 		Expect(conData[0].NetworkSettings.Networks).To(HaveLen(1))
 		Expect(conData[0].NetworkSettings.Networks).To(HaveKey(netName))
 		net := conData[0].NetworkSettings.Networks[netName]
-		Expect(net).To(HaveField("NetworkID", netName))
+		Expect(net).To(HaveField("NetworkID", netID))
 		Expect(net).To(HaveField("IPPrefixLen", 24))
 		Expect(net.IPAddress).To(HavePrefix("10.50.50."))
 
@@ -332,6 +336,14 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(netName2)
 		Expect(network2).Should(ExitCleanly())
 
+		session := podmanTest.Podman([]string{"network", "inspect", netName1, "--format", "{{.Id}}"})
+		session.WaitWithDefaultTimeout()
+		netID1 := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"network", "inspect", netName2, "--format", "{{.Id}}"})
+		session.WaitWithDefaultTimeout()
+		netID2 := session.OutputToString()
+
 		ctrName := "testCtr"
 		container := podmanTest.Podman([]string{"create", "--network", fmt.Sprintf("%s,%s", netName1, netName2), "--name", ctrName, ALPINE, "top"})
 		container.WaitWithDefaultTimeout()
@@ -346,9 +358,9 @@ var _ = Describe("Podman network", func() {
 		Expect(conData[0].NetworkSettings.Networks).To(HaveKey(netName1))
 		Expect(conData[0].NetworkSettings.Networks).To(HaveKey(netName2))
 		net1 := conData[0].NetworkSettings.Networks[netName1]
-		Expect(net1).To(HaveField("NetworkID", netName1))
+		Expect(net1).To(HaveField("NetworkID", netID1))
 		net2 := conData[0].NetworkSettings.Networks[netName2]
-		Expect(net2).To(HaveField("NetworkID", netName2))
+		Expect(net2).To(HaveField("NetworkID", netID2))
 
 		// Necessary to ensure the CNI network is removed cleanly
 		rmAll := podmanTest.Podman([]string{"rm", "-t", "0", "-f", ctrName})
@@ -369,6 +381,14 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(netName2)
 		Expect(network2).Should(ExitCleanly())
 
+		session := podmanTest.Podman([]string{"network", "inspect", netName1, "--format", "{{.Id}}"})
+		session.WaitWithDefaultTimeout()
+		netID1 := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"network", "inspect", netName2, "--format", "{{.Id}}"})
+		session.WaitWithDefaultTimeout()
+		netID2 := session.OutputToString()
+
 		ctrName := "testCtr"
 		container := podmanTest.Podman([]string{"run", "-dt", "--network", fmt.Sprintf("%s,%s", netName1, netName2), "--name", ctrName, ALPINE, "top"})
 		container.WaitWithDefaultTimeout()
@@ -383,11 +403,11 @@ var _ = Describe("Podman network", func() {
 		Expect(conData[0].NetworkSettings.Networks).To(HaveKey(netName1))
 		Expect(conData[0].NetworkSettings.Networks).To(HaveKey(netName2))
 		net1 := conData[0].NetworkSettings.Networks[netName1]
-		Expect(net1).To(HaveField("NetworkID", netName1))
+		Expect(net1).To(HaveField("NetworkID", netID1))
 		Expect(net1).To(HaveField("IPPrefixLen", 25))
 		Expect(net1.IPAddress).To(HavePrefix("10.50.51."))
 		net2 := conData[0].NetworkSettings.Networks[netName2]
-		Expect(net2).To(HaveField("NetworkID", netName2))
+		Expect(net2).To(HaveField("NetworkID", netID2))
 		Expect(net2).To(HaveField("IPPrefixLen", 26))
 		Expect(net2.IPAddress).To(HavePrefix("10.50.51."))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Properly return NetworkID during container inspect reports for docker-compose compatibility.
```
