### PR TITLE
update golangci/golangci-lint to v1.63.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 1.62.2
+GOLANGCI_LINT_VERSION := 1.63.4
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems

--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -95,11 +95,7 @@ func TestUnitDirs(t *testing.T) {
 		unitDirs = getUnitDirs(false)
 		assert.Equal(t, []string{}, unitDirs)
 
-		name, err := os.MkdirTemp("", "dir")
-		assert.Nil(t, err)
-		// remove the temporary directory at the end of the program
-		defer os.RemoveAll(name)
-
+		name := t.TempDir()
 		t.Setenv("QUADLET_UNIT_DIRS", name)
 		unitDirs = getUnitDirs(false)
 		assert.Equal(t, []string{name}, unitDirs, "rootful should use environment variable")
@@ -107,10 +103,7 @@ func TestUnitDirs(t *testing.T) {
 		unitDirs = getUnitDirs(true)
 		assert.Equal(t, []string{name}, unitDirs, "rootless should use environment variable")
 
-		symLinkTestBaseDir, err := os.MkdirTemp("", "podman-symlinktest")
-		assert.Nil(t, err)
-		// remove the temporary directory at the end of the program
-		defer os.RemoveAll(symLinkTestBaseDir)
+		symLinkTestBaseDir := t.TempDir()
 
 		actualDir := filepath.Join(symLinkTestBaseDir, "actual")
 		err = os.Mkdir(actualDir, 0755)
@@ -152,10 +145,7 @@ func TestUnitDirs(t *testing.T) {
 			assert.Nil(t, err)
 		}
 
-		symLinkRecursiveTestBaseDir, err := os.MkdirTemp("", "podman-symlink-recursive-test")
-		assert.Nil(t, err)
-		// remove the temporary directory at the end of the program
-		defer os.RemoveAll(symLinkRecursiveTestBaseDir)
+		symLinkRecursiveTestBaseDir := t.TempDir()
 
 		expectedDirs := make([]string, 0)
 		// Create <BASE>/unitDir
@@ -214,9 +204,7 @@ func TestUnitDirs(t *testing.T) {
 	} else {
 		fmt.Println(os.Args)
 
-		symLinkTestBaseDir, err := os.MkdirTemp("", "podman-symlinktest2")
-		assert.Nil(t, err)
-		defer os.RemoveAll(symLinkTestBaseDir)
+		symLinkTestBaseDir := t.TempDir()
 		rootF, err := os.Open("/")
 		assert.Nil(t, err)
 		defer rootF.Close()

--- a/libpod/events/logfile_test.go
+++ b/libpod/events/logfile_test.go
@@ -30,10 +30,10 @@ func TestRotateLog(t *testing.T) {
 		{1000, 600, 1500, true},
 	}
 
+	tmpDir := t.TempDir()
 	for _, test := range tests {
-		tmp, err := os.CreateTemp("", "log-rotation-")
+		tmp, err := os.CreateTemp(tmpDir, "log-rotation-")
 		require.NoError(t, err)
-		defer os.Remove(tmp.Name())
 		defer tmp.Close()
 
 		// Create dummy file and content.
@@ -80,9 +80,8 @@ func TestTruncationOutput(t *testing.T) {
 10
 `
 	// Create dummy file
-	tmp, err := os.CreateTemp("", "log-rotation")
+	tmp, err := os.CreateTemp(t.TempDir(), "log-rotation")
 	require.NoError(t, err)
-	defer os.Remove(tmp.Name())
 	defer tmp.Close()
 
 	// Write content before truncation to dummy file
@@ -114,10 +113,11 @@ func TestRenameLog(t *testing.T) {
 4
 5
 `
+	tmpDir := t.TempDir()
 	// Create two dummy files
-	source, err := os.CreateTemp("", "removing")
+	source, err := os.CreateTemp(tmpDir, "removing")
 	require.NoError(t, err)
-	target, err := os.CreateTemp("", "renaming")
+	target, err := os.CreateTemp(tmpDir, "renaming")
 	require.NoError(t, err)
 
 	// Write to source dummy file

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -44,7 +45,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 )
 
 // Set up the JSON library for all of Libpod

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/domain/infra/abi"
 	"github.com/containers/podman/v5/pkg/util"
-	"golang.org/x/exp/maps"
 
 	dockerNetwork "github.com/docker/docker/api/types/network"
 	"github.com/sirupsen/logrus"

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -33,7 +34,6 @@ import (
 	"github.com/gorilla/schema"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/maps"
 )
 
 func ManifestCreate(w http.ResponseWriter, r *http.Request) {

--- a/pkg/ctime/ctime_test.go
+++ b/pkg/ctime/ctime_test.go
@@ -9,17 +9,16 @@ import (
 func TestCreated(t *testing.T) {
 	before := time.Now()
 
-	fileA, err := os.CreateTemp("", "ctime-test-")
+	tmpDir := t.TempDir()
+	fileA, err := os.CreateTemp(tmpDir, "ctime-test-")
 	if err != nil {
 		t.Error(err)
 	}
-	defer os.Remove(fileA.Name())
 
-	fileB, err := os.CreateTemp("", "ctime-test-")
+	fileB, err := os.CreateTemp(tmpDir, "ctime-test-")
 	if err != nil {
 		t.Error(err)
 	}
-	defer os.Remove(fileB.Name())
 
 	after := time.Now()
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -6,10 +6,9 @@ package env
 import (
 	"bufio"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
-
-	"golang.org/x/exp/maps"
 )
 
 const whiteSpaces = " \t"

--- a/pkg/machine/compression/copy_test.go
+++ b/pkg/machine/compression/copy_test.go
@@ -2,7 +2,6 @@ package compression
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	crcOs "github.com/crc-org/crc/v2/pkg/os"
@@ -11,11 +10,9 @@ import (
 func TestCopyFile(t *testing.T) {
 	testStr := "test-machine"
 
-	srcFile, err := os.CreateTemp("", "machine-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	srcFi, err := srcFile.Stat()
+	tmpDir := t.TempDir()
+
+	srcFile, err := os.CreateTemp(tmpDir, "machine-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,27 +20,18 @@ func TestCopyFile(t *testing.T) {
 	_, _ = srcFile.Write([]byte(testStr)) //nolint:mirror
 	srcFile.Close()
 
-	srcFilePath := filepath.Join(os.TempDir(), srcFi.Name())
-
-	destFile, err := os.CreateTemp("", "machine-copy-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	destFi, err := destFile.Stat()
+	destFile, err := os.CreateTemp(tmpDir, "machine-copy-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	destFile.Close()
 
-	destFilePath := filepath.Join(os.TempDir(), destFi.Name())
-
-	if err := crcOs.CopyFile(srcFilePath, destFilePath); err != nil {
+	if err := crcOs.CopyFile(srcFile.Name(), destFile.Name()); err != nil {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(destFilePath)
+	data, err := os.ReadFile(destFile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fix new issues found by usetesting, mainly we should use t.TempDir() in test which makes the code better as this will be removed on test end automatically so no need for defer or any error checking. Also fix issues reported by exptostd, these mainly show where we can switch the imports to the std maps/slices packages instead of the golang.org/x/exp/... packages.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
