### PR TITLE
docs: Update description for completion

### DIFF
--- a/cmd/podman/completion/completion.go
+++ b/cmd/podman/completion/completion.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	completionDescription = `Generate shell autocompletions.
-  Valid arguments are bash, zsh, and fish.
+  Valid arguments are bash, zsh, fish, and powershell.
   Please refer to the man page to see how you can load these completions.`
 )
 


### PR DESCRIPTION
Update the description for completion command.

It misses `powershell` in the `valid arguments` list.

```release-note
None
```
