### PR TITLE
Remove `.exe` suffix if any in completion

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -62,7 +62,10 @@ Options:
 
 var (
 	rootCmd = &cobra.Command{
-		Use:                   filepath.Base(os.Args[0]) + " [options]",
+		// In shell completion, there is `.exe` suffix on Windows.
+		// This does not provide the same experience across platforms
+		// and was mentioned in [#16499](https://github.com/containers/podman/issues/16499).
+		Use:                   strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe") + " [options]",
 		Long:                  "Manage pods, containers and images",
 		SilenceUsage:          true,
 		SilenceErrors:         true,

--- a/pkg/machine/e2e/config_help_test.go
+++ b/pkg/machine/e2e/config_help_test.go
@@ -1,0 +1,11 @@
+package e2e_test
+
+type helpMachine struct {
+	cmd []string
+}
+
+func (i *helpMachine) buildCmd(m *machineTestBuilder) []string {
+	cmd := []string{"help"}
+	i.cmd = cmd
+	return cmd
+}

--- a/pkg/machine/e2e/help_test.go
+++ b/pkg/machine/e2e/help_test.go
@@ -1,0 +1,23 @@
+package e2e_test
+
+import (
+	"regexp"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("podman help", func() {
+	It("podman usage base command is podman or podman-remote, without extension	", func() {
+		helpSession, err := mb.setCmd(new(helpMachine)).run()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(helpSession).Should(Exit(0))
+
+		// Verify `.exe` suffix doesn't present in the usage command string
+		helpMessages := helpSession.outputToStringSlice()
+		usageCmdIndex := slices.IndexFunc(helpMessages, func(helpMessage string) bool { return helpMessage == "Usage:" }) + 1
+		Expect(regexp.MustCompile(`\w\.exe\b`).MatchString(helpMessages[usageCmdIndex])).Should(BeFalse())
+	})
+})


### PR DESCRIPTION
In shell completion, there is `.exe` suffix on Windows and this break several shells.

Relates to #16499.
It seems didn't fix at the time but waiting for a fix in cobra.

```release-note
Fixed a bug that prevents shell completion on Windows under some circumstances.
```
