### PR TITLE
RFC: Introduce PodmanTestIntegration.PodmanCleanly

### DIFF
--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -20,9 +20,7 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to non-running container", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test1", "-i", CITEST_IMAGE, "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("create", "--name", "test1", "-i", CITEST_IMAGE, "ls")
 
 		results := podmanTest.Podman([]string{"attach", "test1"})
 		results.WaitWithDefaultTimeout()
@@ -30,10 +28,7 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman container attach to non-running container", func() {
-		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-i", CITEST_IMAGE, "ls"})
-
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("container", "create", "--name", "test1", "-i", CITEST_IMAGE, "ls")
 
 		results := podmanTest.Podman([]string{"container", "attach", "test1"})
 		results.WaitWithDefaultTimeout()
@@ -55,9 +50,7 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to a running container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", "test", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done")
 
 		results := podmanTest.Podman([]string{"attach", "test"})
 		time.Sleep(2 * time.Second)
@@ -67,13 +60,8 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to the latest container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"run", "-d", "--name", "test2", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test2; sleep 1; done"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", "test1", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done")
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", "test2", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test2; sleep 1; done")
 
 		cid := "-l"
 		if IsRemote() {
@@ -87,9 +75,7 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to a container with --sig-proxy set to false", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", "test", CITEST_IMAGE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done")
 
 		results := podmanTest.Podman([]string{"attach", "--sig-proxy=false", "test"})
 		time.Sleep(2 * time.Second)

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -81,6 +81,7 @@ func (matcher *ExitMatcher) MatchMayChangeInTheFuture(actual interface{}) bool {
 }
 
 // ExitCleanly asserts that a PodmanSession exits 0 and with no stderr
+// Consider using PodmanTestIntegration.PodmanExitCleanly instead of directly using this matcher.
 func ExitCleanly() types.GomegaMatcher {
 	return &exitCleanlyMatcher{}
 }


### PR DESCRIPTION
This significantly simplifies the ceromony of running a Podman command in integration tests, from

```go
  session := p.Podman([]string{"stop", id})
  session.WaitWithDefaultTimeout()
  Expect(session).Should(ExitCleanly())
```

to
```go
  p.PodmanCleanly("stop", id)
```

There are >4650 instances of `ExitCleanly()` in the tests, and many could be migrated; this does not do that.

@containers/podman-maintainers RFC. While writing integration tests, I find the ever-present repetitive boilerplate hard to read/maintain, and generally off-putting; OTOH the `PodmanCleanly` call does not show explicitly that any testing is happening. I’m also, short-term, not able to migrate everything, so introducing this would make tests less consistent for now.

It’s also very possible there’s already a much better way to do things, and I just don’t know.

#### Does this PR introduce a user-facing change?

```release-note
None
```
