### PR TITLE
Run HealthCheck without saving the `ExecSession` to the database

### DIFF
--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -97,7 +97,7 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	hcResult := define.HealthCheckSuccess
 	config := new(ExecConfig)
 	config.Command = newCommand
-	exitCode, hcErr := c.exec(config, streams, nil, true)
+	exitCode, hcErr := c.healthCheckExec(config, streams)
 	if hcErr != nil {
 		hcResult = define.HealthCheckFailure
 		if errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -466,4 +466,35 @@ function _check_health_log {
     run_podman rm -t 0 -f $ctrname
 }
 
+@test "podman healthcheck - stop container when healthcheck runs" {
+    ctr="c-h-$(safename)"
+    msg="hc-msg-$(random_string)"
+
+    run_podman run -d --name $ctr             \
+           --health-cmd "sleep 20; echo $msg" \
+           $IMAGE /home/podman/pause
+
+    timeout --foreground -v --kill=10 60 \
+        $PODMAN healthcheck run $ctr &
+    hc_pid=$!
+
+    run_podman inspect $ctr --format "{{.State.Status}}"
+    assert "$output" == "running" "Container is running"
+
+    run_podman stop $ctr
+
+    # Wait for background healthcheck to finish and make sure the exit status is 1
+    rc=0
+    wait -n $hc_pid || rc=$?
+    assert $rc -eq 1 "exit status check of healthcheck command"
+
+    run_podman inspect $ctr --format "{{.State.Status}}"
+    assert "$output" == "exited" "Container is stopped"
+
+    run_podman inspect $ctr --format "{{.State.Health.Log}}"
+    assert "$output" !~ "$msg" "Health log message not found"
+
+    run_podman rm -f -t0 $ctr
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
This PR creates a method to run the HealthCheck command without creating and deleting an `ExecSession` in the database. 

When HealthCheck is run using the original `exec` method, an `ExecSession` is created and deleted. This approach causes unexpectedly higher IO usage when synchronizing the container and creating and deleting `ExecSession` in the database. 

The new `healthCheckExec` function locks the container and creates the `ExecSession` locally without writing to the database. Executes a local `ExecSession`.  As a result, the number of writes in the database has been reduced to zero. 

### Verify reduction
- Start 30 containers with `/bin/true` as a health check that runs every 10 seconds.
- Monitor writes for two mins: `timeout 120 stap check.stp 0x23 > stap.out` 
   - > Note: you will probably need to install debug symbols for the kernel: `dnf debuginfo-install kernel-$(uname -r)
`
   - Script `check.stp`:
```
#!/usr/bin/stap

global mydev

probe begin

{ dev = usrdev2kerndev($1) mydev = MKDEV(MAJOR(dev), MINOR(dev)) }
probe vfs.write.return

{ if (dev == mydev) printf ("%s(%d)[%s(%d)] %s 0x%x %s\n", execname(), pid(), pexecname(), ppid(), ppfunc(), dev, fullpath_struct_file(task_current(), @entry($file))) }
```
 - Process result: `sed -E 's/([0-9]+)//' stap.out | sort | uniq -c | sort -bn | tail -n 3`
   - The result before should look like this:
```
4179 podman()[systemd(1)] vfs_write 0x23 /var/lib/containers/storage/db.sql
16115 podman()[systemd(1)] vfs_write 0x23 /var/lib/containers/storage/db.sql-journal
29857374 stapio()[stap(195325)] vfs_write 0x23 /home/jrodak/dev/stap.out
```  
> The result after applying this change should not contain `/var/lib/containers/storage/db.sql` and `/var/lib/containers/storage/db.sql-journal` or have a smaller first number on the line.

Fixes: https://issues.redhat.com/browse/RHEL-69970

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The HelathCheck is executed without writing to the database. 
```
