### PR TITLE
Add kube play support for CDI resource allocation

### DIFF
--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v5/pkg/k8s.io/apimachinery/pkg/util/intstr"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/docker/docker/pkg/meminfo"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
 )
@@ -1396,6 +1397,70 @@ func TestTCPLivenessProbe(t *testing.T) {
 				assert.Equal(t, int(test.specGenerator.ContainerHealthCheckConfig.HealthCheckOnFailureAction), define.HealthCheckOnFailureActionRestart)
 				assert.Contains(t, test.specGenerator.ContainerHealthCheckConfig.HealthConfig.Test, test.expectedHost)
 				assert.Contains(t, test.specGenerator.ContainerHealthCheckConfig.HealthConfig.Test, test.expectedPort)
+			}
+		})
+	}
+}
+
+func TestDeviceResource(t *testing.T) {
+	tests := []struct {
+		name          string
+		specGenerator specgen.SpecGenerator
+		container     v1.Container
+		succeed       bool
+		devices       []spec.LinuxDevice
+	}{
+		{
+			"ParseQualifiedCDI",
+			specgen.SpecGenerator{},
+			v1.Container{
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						"nvidia.com/gpu=0": resource.MustParse("1"),
+					},
+				},
+			},
+			true,
+			[]spec.LinuxDevice{
+				{Path: "nvidia.com/gpu=0"},
+			},
+		},
+		{
+			"ParsePodmanDeviceResource",
+			specgen.SpecGenerator{},
+			v1.Container{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						"podman.io/device=/dev/kmsg": resource.MustParse("1"),
+					},
+				},
+			},
+			true,
+			[]spec.LinuxDevice{
+				{Path: "/dev/kmsg"},
+			},
+		},
+		{
+			"InvalidCDI",
+			specgen.SpecGenerator{},
+			v1.Container{
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						"foobar.net/class=///": resource.MustParse("1"),
+					},
+				},
+			},
+			false,
+			[]spec.LinuxDevice{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := setupContainerDevices(&test.specGenerator, test.container)
+			assert.Equal(t, err == nil, test.succeed)
+			if err == nil {
+				assert.Equal(t, test.specGenerator.Devices, test.devices)
 			}
 		})
 	}


### PR DESCRIPTION
We now handle CDI qualified names being passed to resources.limits. The
support for that was already in libpod as of ab7f6095a17bd50477c30fc8c127a8604b5693a6
when passed via the devices list. this just hooks the kube yaml parser
up to it.

Additionally we introduce `podman.io/device` that accepts device paths
as names and is transparently translated to mimick --device. This allows
bringing arbitrary devices into the container via similar, although
incompatible with, k8s mechanics:

```yaml
resources:
  requests:
    podman.io/device=/dev/kmsg: 1
```

Fixes: https://github.com/containers/podman/issues/17833

```release-note
kube-play now supports CDI strings
```

Signed-off-by: Robert Günzler <r@gnzler.io>
