### PR TITLE
docs: add 'initialized' state to status filters

### DIFF
--- a/docs/source/markdown/podman-pause.1.md.in
+++ b/docs/source/markdown/podman-pause.1.md.in
@@ -28,21 +28,21 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container                         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] container created before the given duration or time.                  |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] Containers created before the given duration or time.                                |
 
 @@option latest
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -45,22 +45,22 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| label!     | [Key] or [Key=Value] Label NOT assigned to a container                           |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container (accepts regex)         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] container created before the given duration or time.                  |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container (accepts regex)                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] container created before the given duration or time.                                 |
 
 
 #### **--format**=*format*

--- a/docs/source/markdown/podman-restart.1.md.in
+++ b/docs/source/markdown/podman-restart.1.md.in
@@ -31,21 +31,21 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container                         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] Containers created before the given duration or time.                 |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] Containers created before the given duration or time.                                |
 
 @@option latest
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -35,21 +35,21 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container                         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] Containers created before the given duration or time.                 |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] Containers created before the given duration or time.                                |
 
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-start.1.md.in
+++ b/docs/source/markdown/podman-start.1.md.in
@@ -36,21 +36,21 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container                         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] Containers created before the given duration or time.                 |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] Containers created before the given duration or time.                                |
 
 @@option interactive
 

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -34,21 +34,21 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container                         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] Containers created before the given duration or time.                 |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] Containers created before the given duration or time.                                |
 
 @@option ignore
 

--- a/docs/source/markdown/podman-unpause.1.md.in
+++ b/docs/source/markdown/podman-unpause.1.md.in
@@ -28,21 +28,21 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                  |
-|------------|----------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                 |
-| name       | [Name] Container's name (accepts regex)                                          |
-| label      | [Key] or [Key=Value] Label assigned to a container                               |
-| exited     | [Int] Container's exit code                                                      |
-| status     | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container                         |
-| before     | [ID] or [Name] Containers created before this container                          |
-| since      | [ID] or [Name] Containers created since this container                           |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container              |
-| health     | [Status] healthy or unhealthy                                                    |
-| pod        | [Pod] name or full or partial ID of pod                                          |
-| network    | [Network] name or full ID of network                                             |
-| until      | [DateTime] Containers created before the given duration or time.                 |
+| **Filter** | **Description**                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------|
+| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name       | [Name] Container's name (accepts regex)                                                         |
+| label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| exited     | [Int] Container's exit code                                                                     |
+| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
+| ancestor   | [ImageName] Image or descendant used to create container                                        |
+| before     | [ID] or [Name] Containers created before this container                                         |
+| since      | [ID] or [Name] Containers created since this container                                          |
+| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health     | [Status] healthy or unhealthy                                                                   |
+| pod        | [Pod] name or full or partial ID of pod                                                         |
+| network    | [Network] name or full ID of network                                                            |
+| until      | [DateTime] Containers created before the given duration or time.                                |
 
 @@option latest
 


### PR DESCRIPTION
Previously, the 'initialized' state was not documented as an available filter for various Podman commands.

This commit documents 'initialized' as a valid state that can be used to filter the start, stop, restart, rm, pause, unpause, and ps commands.

Fixes #25017

I have quickly investigated the presence of other places (other than filters) where the 'initialized' status might be missing, but didn't find any.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
