### PR TITLE
docs: Add quadlet debug method systemd-analyze

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -224,6 +224,14 @@ View the generated files and/or error messages with:
 /usr/lib/systemd/system-generators/podman-system-generator {--user} --dryrun
 ```
 
+Alternatively, show only the errors with:
+```
+systemd-analyze {--user} --generators=true verify example.service
+```
+
+That command also performs additional checks on the generated service unit.
+For details, see systemd-analyze(1) man page.
+
 #### Debugging a limited set of unit files
 
 If you would like to debug a limited set of unit files, you can copy them to a separate directory and set the
@@ -2086,7 +2094,7 @@ Options=iam_role,endpoint=${AWS_REGION},use_xattr,listobjectsv2,del_cache,use_ca
 ## SEE ALSO
 **[systemd.unit(5)](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)**,
 **[systemd.service(5)](https://www.freedesktop.org/software/systemd/man/systemd.service.html)**,
+**[systemd-analyze(1)](https://www.freedesktop.org/software/systemd/man/latest/systemd-analyze.html)**,
 **[podman-run(1)](podman-run.1.md)**,
 **[podman-network-create(1)](podman-network-create.1.md)**,
 **[podman-auto-update(1)](podman-auto-update.1.md)**
-**[systemd.unit(5)]**


### PR DESCRIPTION
Reference: https://github.com/containers/podman/discussions/24891

I could also have mentioned

```
QUADLET_UNIT_DIRS=<Directory> systemd-analyze {--user} --generators=true verify example.service
```
but I left it out as I didn't come up with a good way to document it. 


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
