### PR TITLE
fix(pkg/rootless): fix `get_cmd_line_args` memleak in rootless_linux.

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -352,9 +352,6 @@ get_cmd_line_args (int *argc_out)
 
   argv[argc] = NULL;
 
-  /* Move ownership.  */
-  buffer = NULL;
-
   if (argc_out)
     *argc_out = argc;
 


### PR DESCRIPTION
The assignment to NULL was preventing gcc `cleanup` attribute to auto-free the pointer for us, since it received a pointer to a NULL pointer.

Spotted using `-fsanitize=address`: 
```
==1050100==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x70591a2fd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x705915490406 in get_cmd_line_args /home/federico/go/pkg/mod/github.com/containers/podman/v5@v5.2.5/pkg/rootless/rootless_linux.c:313
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
