### PR TITLE
fix(pkg/rootless): avoid memleak during init() contructor

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -364,15 +364,12 @@ get_cmd_line_args (int *argc_out)
 static bool
 can_use_shortcut (char **argv)
 {
-  cleanup_free char *argv0 = NULL;
   bool ret = true;
   int argc;
 
 #ifdef DISABLE_JOIN_SHORTCUT
   return false;
 #endif
-
-  argv0 = argv[0];
 
   if (strstr (argv[0], "podman") == NULL)
     return false;
@@ -439,6 +436,7 @@ static void __attribute__((constructor)) init()
   const char *listen_fds;
   const char *listen_fdnames;
   cleanup_free char **argv = NULL;
+  cleanup_free char *argv0 = NULL;
   cleanup_dir DIR *d = NULL;
   int argc;
 
@@ -496,6 +494,8 @@ static void __attribute__((constructor)) init()
       fprintf(stderr, "cannot retrieve cmd line");
       _exit (EXIT_FAILURE);
     }
+  // Even if unused, this is needed to ensure we properly free the memory
+  argv0 = argv[0];
 
   if (geteuid () != 0 || getenv ("_CONTAINERS_USERNS_CONFIGURED") == NULL)
     do_preexec_hooks(argv, argc);


### PR DESCRIPTION
`argv[0]`, ie: the full buffer allocated by `get_cmd_line_args`, was going to be freed only if `can_use_shortcut()` was called. Since that is not always the case, add a fallback cleanup method.

Spotted using `-fsanitize=address`: 
```
==1050100==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x70591a2fd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x705915490406 in get_cmd_line_args /home/federico/go/pkg/mod/github.com/containers/podman/v5@v5.2.5/pkg/rootless/rootless_linux.c:313
```

Fix was tested by running once again (after applying the patch) with asan.

#### Does this PR introduce a user-facing change?

```release-note
None
```
