### PR TITLE
Add GODEBUG option to use legacy filepath.EvalSymlinks()

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -1,3 +1,4 @@
+//go:debug winsymlink=0
 package main
 
 import (


### PR DESCRIPTION
In go 1.23 filepath.EvalSymlink(path) behavior has changed and now it returns an error if path is a Windows junction. The new behavior breaks some functionalities (see #24557).

With the GODEBUG option `winsymlink=0`, `EvalSymlink` uses its legacy behavior on Windows.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
