### PR TITLE
Remove JSON tag from UseImageHosts in ContainerConfig

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -292,7 +292,7 @@ type ContainerNetworkConfig struct {
 	// UseImageHosts indicates that /etc/hosts should not be
 	// bind-mounted inside the container.
 	// Conflicts with HostAdd.
-	UseImageHosts bool `json:"useImageHosts"`
+	UseImageHosts bool
 	// BaseHostsFile is the base file to create the `/etc/hosts` file inside the container.
 	// This must either be an absolute path to a file on the host system, or one of the
 	// special flags `image` or `none`.


### PR DESCRIPTION
This did not have a JSON tag prior to being added by #25008. By adding one we risk a breaking change in the DB (particularly given the change in case - useImageHosts vs UseImageHosts) which we should try to avoid.

Remove the tag given this.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
