### PR TITLE
Quadlet 5 symlink bypass

### DIFF
--- a/docs/source/locale/ja/LC_MESSAGES/markdown.po
+++ b/docs/source/locale/ja/LC_MESSAGES/markdown.po
@@ -1108,14 +1108,14 @@ msgid ""
 "container or Kubernetes workloads must run inside a systemd unit. After a"
 " successful update of an image, the containers using the image get "
 "updated by restarting the systemd units they run in. Please refer to "
-"`quadlet(5)` on how to run Podman under systemd."
+"`podman-systemd.unit(5)` on how to run Podman under systemd."
 msgstr ""
 
 #: ../../source/markdown/podman-auto-update.1.md:16
 msgid ""
 "To configure a container for auto updates, it must be created with the "
 "`io.containers.autoupdate` label or the `AutoUpdate` field in "
-"`quadlet(5)` with one of the following two values:"
+"`podman-systemd.unit(5)` with one of the following two values:"
 msgstr ""
 
 #: ../../source/markdown/podman-auto-update.1.md:18
@@ -1148,7 +1148,7 @@ msgstr ""
 #: ../../source/markdown/podman-auto-update.1.md:31
 msgid ""
 "Podman supports auto updates for Kubernetes workloads.  The auto-update "
-"policy can be configured directly via `quadlet(5)` or inside the "
+"policy can be configured directly via `podman-systemd.unit(5)` or inside the "
 "Kubernetes YAML with the Podman-specific annotations mentioned below:"
 msgstr ""
 
@@ -32151,7 +32151,7 @@ msgstr ""
 #: ../../source/markdown/podmansh.1.md:130
 msgid ""
 "**[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, "
-"**quadlet(5)**"
+"**[podman-systemd.unit(5)](podman-systemd.unit.5.md)**"
 msgstr ""
 
 #: ../../source/markdown/podmansh.1.md:133

--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -10,9 +10,9 @@ podman\-auto-update - Auto update containers according to their auto-update poli
 **podman auto-update** pulls down new container images and restarts containers configured for auto updates.
 To make use of auto updates, the container or Kubernetes workloads must run inside a systemd unit.
 After a successful update of an image, the containers using the image get updated by restarting the systemd units they run in.
-Please refer to `quadlet(5)` on how to run Podman under systemd.
+Please refer to `podman-systemd.unit(5)` on how to run Podman under systemd.
 
-To configure a container for auto updates, it must be created with the `io.containers.autoupdate` label or the `AutoUpdate` field in `quadlet(5)` with one of the following two values:
+To configure a container for auto updates, it must be created with the `io.containers.autoupdate` label or the `AutoUpdate` field in `podman-systemd.unit(5)` with one of the following two values:
 
 * `registry`: If the label is present and set to `registry`, Podman reaches out to the corresponding registry to check if the image has been updated.
 The label `image` is an alternative to `registry` maintained for backwards compatibility.
@@ -27,7 +27,7 @@ If they differ, the local image is considered to be newer and the systemd unit g
 
 ### Auto Updates and Kubernetes YAML
 
-Podman supports auto updates for Kubernetes workloads.  The auto-update policy can be configured directly via `quadlet(5)` or inside the Kubernetes YAML with the Podman-specific annotations mentioned below:
+Podman supports auto updates for Kubernetes workloads.  The auto-update policy can be configured directly via `podman-systemd.unit(5)` or inside the Kubernetes YAML with the Podman-specific annotations mentioned below:
 
 * `io.containers.autoupdate`: "registry|local" to apply the auto-update policy to all containers
 * `io.containers.autoupdate/$container`: "registry|local" to apply the auto-update policy to `$container` only

--- a/docs/source/markdown/podmansh.1.md
+++ b/docs/source/markdown/podmansh.1.md
@@ -127,7 +127,7 @@ _EOF
 ```
 
 ## SEE ALSO
-**[containers.conf(5)](containers.conf.5.md)**, **[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, **quadlet(5)**
+**[containers.conf(5)](containers.conf.5.md)**, **[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, **[podman-systemd.unit(5)](podman-systemd.unit.5.md)**
 
 ## HISTORY
 May 2023, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
Fixes: #25063

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Documentation references to the quadlet(5) alias now point directly to the underlying podman-systemd.unit(5) page so that links will work in the HTML renderings where symlinks don't work and in distributions where the symlink isn't present at all, as with the current Brew `podman` package.
```
