### PR TITLE
do not set the CreateCommand for API users

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -161,6 +161,9 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	s.RawImageName = rawImageName
 
+	// Include the command used to create the container.
+	s.ContainerCreateCommand = os.Args
+
 	if err := createPodIfNecessary(cmd, s, cliVals.Net); err != nil {
 		return err
 	}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -206,6 +206,10 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	s.RawImageName = rawImageName
+
+	// Include the command used to create the container.
+	s.ContainerCreateCommand = os.Args
+
 	s.ImageOS = cliVals.OS
 	s.ImageArch = cliVals.Arch
 	s.ImageVariant = cliVals.Variant

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -73,7 +73,6 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 		// a few extra that do not have the same json tags
 		psg.InfraContainerSpec.Name = psg.InfraName
 		psg.InfraContainerSpec.ConmonPidFile = psg.InfraConmonPidFile
-		psg.InfraContainerSpec.ContainerCreateCommand = psg.InfraCommand
 		psg.InfraContainerSpec.Image = psg.InfraImage
 		psg.InfraContainerSpec.RawImageName = psg.InfraImage
 	}

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -550,12 +550,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.Entrypoint = entrypoint
 	}
 
-	// Include the command used to create the container.
-
-	if len(s.ContainerCreateCommand) == 0 {
-		s.ContainerCreateCommand = os.Args
-	}
-
 	if len(inputCommand) > 0 {
 		s.Command = inputCommand
 	}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -191,12 +191,15 @@ cid=$(jq -r '.Id' <<<"$output")
 t POST   libpod/containers/${cid}/start 204
 # Container should exit almost immediately. Wait for it, confirm successful run
 t POST   "libpod/containers/${cid}/wait?condition=stopped&condition=exited"  200 '0'
+
+# Regression check for #15036 (Umask) and #25026 (CreateCommand)
 t GET    libpod/containers/${cid}/json 200 \
   .Id=$cid \
   .State.Status~\\\(exited\\\|stopped\\\) \
   .State.Running=false \
   .State.ExitCode=0 \
-  .Config.Umask=0022 # regression check for #15036
+  .Config.Umask=0022 \
+  .Config.CreateCommand=null
 t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 CNAME=myfoo
@@ -309,6 +312,11 @@ t GET containers/$cid/json 200 \
   .Path="echo" \
   .Args[0]="param1" \
   .Args[1]="param2"
+# Regression check for #25026 (CreateCommand)
+t GET    libpod/containers/${cid}/json 200 \
+  .Id=$cid \
+  .Config.CreateCommand=null
+
 t DELETE containers/$cid 204
 
 # test only set the entrypoint, Cmd should be []


### PR DESCRIPTION
This should be set only by podman as it is used for the podman generate systemd --new command. For the api it was set to the system service command which is simply pointless. It must be empty in these cases.

Fixes #25026

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
