### PR TITLE
Refactor Podman E2E helpers to allow passing/adding more options to the low-level executor

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1559,8 +1559,8 @@ var _ = Describe("Podman checkpoint", func() {
 		// Prevent --runtime arg from being set to force using default
 		// runtime unless explicitly set through passed args.
 		preservedMakeOptions := podmanTest.PodmanMakeOptions
-		podmanTest.PodmanMakeOptions = func(args []string, noEvents, noCache bool) []string {
-			defaultArgs := preservedMakeOptions(args, noEvents, noCache)
+		podmanTest.PodmanMakeOptions = func(args []string, options PodmanExecOptions) []string {
+			defaultArgs := preservedMakeOptions(args, options)
 			for i := range args {
 				// Runtime is set explicitly, so we should keep --runtime arg.
 				if args[i] == "--runtime" {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1060,7 +1060,12 @@ func SkipIfNetavark(p *PodmanTestIntegration) {
 
 // PodmanAsUser is the exec call to podman on the filesystem with the specified uid/gid and environment
 func (p *PodmanTestIntegration) PodmanAsUser(args []string, uid, gid uint32, cwd string, env []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanAsUserBase(args, uid, gid, cwd, env, false, false, nil, nil)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		UID: uid,
+		GID: gid,
+		CWD: cwd,
+		Env: env,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -441,7 +441,10 @@ func (p *PodmanTestIntegration) pullImage(image string, toCache bool) {
 		}()
 	}
 	for try := 0; try < 3; try++ {
-		podmanSession := p.PodmanBase([]string{"pull", image}, toCache, true)
+		podmanSession := p.PodmanExecBaseWithOptions([]string{"pull", image}, PodmanExecOptions{
+			NoEvents: toCache,
+			NoCache:  true,
+		})
 		pull := PodmanSessionIntegration{podmanSession}
 		pull.Wait(440)
 		if pull.ExitCode() == 0 {
@@ -1124,7 +1127,9 @@ func rmAll(podmanBin string, path string) {
 
 // PodmanNoCache calls the podman command with no configured imagecache
 func (p *PodmanTestIntegration) PodmanNoCache(args []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanBase(args, false, true)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		NoCache: true,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 
@@ -1135,7 +1140,10 @@ func PodmanTestSetup(tempDir string) *PodmanTestIntegration {
 // PodmanNoEvents calls the Podman command without an imagecache and without an
 // events backend. It is used mostly for caching and uncaching images.
 func (p *PodmanTestIntegration) PodmanNoEvents(args []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanBase(args, true, true)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		NoEvents: true,
+		NoCache:  true,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -679,7 +679,7 @@ func (p *PodmanTestIntegration) BuildImageWithLabel(dockerfile, imageName string
 
 // PodmanPID execs podman and returns its PID
 func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegration, int) {
-	podmanOptions := p.MakeOptions(args, false, false)
+	podmanOptions := p.MakeOptions(args, PodmanExecOptions{})
 	GinkgoWriter.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
 
 	command := exec.Command(p.PodmanBinary, podmanOptions...)
@@ -1140,7 +1140,7 @@ func (p *PodmanTestIntegration) PodmanNoEvents(args []string) *PodmanSessionInte
 }
 
 // MakeOptions assembles all the podman main options
-func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache bool) []string {
+func (p *PodmanTestIntegration) makeOptions(args []string, options PodmanExecOptions) []string {
 	if p.RemoteTest {
 		if !slices.Contains(args, "--remote") {
 			return append([]string{"--remote", "--url", p.RemoteSocket}, args...)
@@ -1154,7 +1154,7 @@ func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache boo
 	}
 
 	eventsType := "file"
-	if noEvents {
+	if options.NoEvents {
 		eventsType = "none"
 	}
 
@@ -1162,7 +1162,7 @@ func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache boo
 		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.NetworkConfigDir, p.NetworkBackend.ToString(), p.CgroupManager, p.TmpDir, eventsType, p.DatabaseBackend), " ")
 
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
-	if !noCache {
+	if !options.NoCache {
 		cacheOptions := []string{"--storage-opt",
 			fmt.Sprintf("%s.imagestore=%s", p.PodmanTest.ImageCacheFS, p.PodmanTest.ImageCacheDir)}
 		podmanOptions = append(cacheOptions, podmanOptions...)

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -492,7 +492,14 @@ func (s *PodmanSessionIntegration) InspectImageJSON() []inspect.ImageData {
 // It returns the session (to allow consuming output if desired).
 func (p *PodmanTestIntegration) PodmanExitCleanly(args ...string) *PodmanSessionIntegration {
 	GinkgoHelper()
-	session := p.Podman(args)
+	return p.PodmanExitCleanlyWithOptions(PodmanExecOptions{}, args...)
+}
+
+// PodmanExitCleanlyWithOptions runs a podman command with (optinos, args), and expects it to ExitCleanly within the default timeout.
+// It returns the session (to allow consuming output if desired).
+func (p *PodmanTestIntegration) PodmanExitCleanlyWithOptions(options PodmanExecOptions, args ...string) *PodmanSessionIntegration {
+	GinkgoHelper()
+	session := p.PodmanWithOptions(options, args...)
 	session.WaitWithDefaultTimeout()
 	Expect(session).Should(ExitCleanly())
 	return session

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -457,7 +457,9 @@ var _ = Describe("Podman exec", func() {
 		files := []*os.File{
 			devNull,
 		}
-		session := podmanTest.PodmanExtraFiles([]string{"exec", "--preserve-fds", "1", "test1", "ls"}, files)
+		session := podmanTest.PodmanWithOptions(PodmanExecOptions{
+			ExtraFiles: files,
+		}, "exec", "--preserve-fds", "1", "test1", "ls")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -457,11 +457,9 @@ var _ = Describe("Podman exec", func() {
 		files := []*os.File{
 			devNull,
 		}
-		session := podmanTest.PodmanWithOptions(PodmanExecOptions{
+		podmanTest.PodmanExitCleanlyWithOptions(PodmanExecOptions{
 			ExtraFiles: files,
 		}, "exec", "--preserve-fds", "1", "test1", "ls")
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman exec preserves --group-add groups", func() {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -24,32 +24,34 @@ func IsRemote() bool {
 
 // Podman is the exec call to podman on the filesystem
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
-	args = p.makeOptions(args, PodmanExecOptions{})
-	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{})
+	options := PodmanExecOptions{}
+	args = p.makeOptions(args, options)
+	podmanSession := p.PodmanExecBaseWithOptions(args, options)
 	return &PodmanSessionIntegration{podmanSession}
 }
 
 // PodmanSystemdScope runs the podman command in a new systemd scope
 func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSessionIntegration {
-	args = p.makeOptions(args, PodmanExecOptions{})
-
 	wrapper := []string{"systemd-run", "--scope"}
 	if isRootless() {
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
-
-	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+	options := PodmanExecOptions{
 		Wrapper: wrapper,
-	})
+	}
+
+	args = p.makeOptions(args, options)
+	podmanSession := p.PodmanExecBaseWithOptions(args, options)
 	return &PodmanSessionIntegration{podmanSession}
 }
 
 // PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
 func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	args = p.makeOptions(args, PodmanExecOptions{})
-	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+	options := PodmanExecOptions{
 		ExtraFiles: extraFiles,
-	})
+	}
+	args = p.makeOptions(args, options)
+	podmanSession := p.PodmanExecBaseWithOptions(args, options)
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -34,17 +34,6 @@ func (p *PodmanTestIntegration) PodmanWithOptions(options PodmanExecOptions, arg
 	return &PodmanSessionIntegration{podmanSession}
 }
 
-// PodmanSystemdScope runs the podman command in a new systemd scope
-func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSessionIntegration {
-	wrapper := []string{"systemd-run", "--scope"}
-	if isRootless() {
-		wrapper = []string{"systemd-run", "--scope", "--user"}
-	}
-	return p.PodmanWithOptions(PodmanExecOptions{
-		Wrapper: wrapper,
-	}, args...)
-}
-
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 	defaultFile := "registries.conf"
 	if UsingCacheRegistry() {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -24,14 +24,14 @@ func IsRemote() bool {
 
 // Podman is the exec call to podman on the filesystem
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
-	args = p.makeOptions(args, false, false)
+	args = p.makeOptions(args, PodmanExecOptions{})
 	podmanSession := p.PodmanBase(args, false, false)
 	return &PodmanSessionIntegration{podmanSession}
 }
 
 // PodmanSystemdScope runs the podman command in a new systemd scope
 func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSessionIntegration {
-	args = p.makeOptions(args, false, false)
+	args = p.makeOptions(args, PodmanExecOptions{})
 
 	wrapper := []string{"systemd-run", "--scope"}
 	if isRootless() {
@@ -46,7 +46,7 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 
 // PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
 func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	args = p.makeOptions(args, false, false)
+	args = p.makeOptions(args, PodmanExecOptions{})
 	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
 		ExtraFiles: extraFiles,
 	})

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -45,13 +45,6 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 	}, args...)
 }
 
-// PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
-func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	return p.PodmanWithOptions(PodmanExecOptions{
-		ExtraFiles: extraFiles,
-	}, args...)
-}
-
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 	defaultFile := "registries.conf"
 	if UsingCacheRegistry() {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -25,7 +25,7 @@ func IsRemote() bool {
 // Podman is the exec call to podman on the filesystem
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
 	args = p.makeOptions(args, PodmanExecOptions{})
-	podmanSession := p.PodmanBase(args, false, false)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{})
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -22,9 +22,13 @@ func IsRemote() bool {
 	return true
 }
 
-// Podman is the exec call to podman on the filesystem
+// Podman executes podman on the filesystem with default options.
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
-	options := PodmanExecOptions{}
+	return p.PodmanWithOptions(PodmanExecOptions{}, args...)
+}
+
+// PodmanWithOptions executes podman on the filesystem with the supplied options.
+func (p *PodmanTestIntegration) PodmanWithOptions(options PodmanExecOptions, args ...string) *PodmanSessionIntegration {
 	args = p.makeOptions(args, options)
 	podmanSession := p.PodmanExecBaseWithOptions(args, options)
 	return &PodmanSessionIntegration{podmanSession}
@@ -36,23 +40,16 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 	if isRootless() {
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
-	options := PodmanExecOptions{
+	return p.PodmanWithOptions(PodmanExecOptions{
 		Wrapper: wrapper,
-	}
-
-	args = p.makeOptions(args, options)
-	podmanSession := p.PodmanExecBaseWithOptions(args, options)
-	return &PodmanSessionIntegration{podmanSession}
+	}, args...)
 }
 
 // PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
 func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	options := PodmanExecOptions{
+	return p.PodmanWithOptions(PodmanExecOptions{
 		ExtraFiles: extraFiles,
-	}
-	args = p.makeOptions(args, options)
-	podmanSession := p.PodmanExecBaseWithOptions(args, options)
-	return &PodmanSessionIntegration{podmanSession}
+	}, args...)
 }
 
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -37,14 +38,18 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
 
-	podmanSession := p.PodmanAsUserBase(args, 0, 0, "", nil, false, false, wrapper, nil)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		Wrapper: wrapper,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 
 // PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
 func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
 	args = p.makeOptions(args, false, false)
-	podmanSession := p.PodmanAsUserBase(args, 0, 0, "", nil, false, false, nil, extraFiles)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		ExtraFiles: extraFiles,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -26,17 +26,6 @@ func (p *PodmanTestIntegration) PodmanWithOptions(options PodmanExecOptions, arg
 	return &PodmanSessionIntegration{podmanSession}
 }
 
-// PodmanSystemdScope runs the podman command in a new systemd scope
-func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSessionIntegration {
-	wrapper := []string{"systemd-run", "--scope"}
-	if isRootless() {
-		wrapper = []string{"systemd-run", "--scope", "--user"}
-	}
-	return p.PodmanWithOptions(PodmanExecOptions{
-		Wrapper: wrapper,
-	}, args...)
-}
-
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 	defaultFile := "registries.conf"
 	if UsingCacheRegistry() {

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -37,13 +37,6 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 	}, args...)
 }
 
-// PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
-func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	return p.PodmanWithOptions(PodmanExecOptions{
-		ExtraFiles: extraFiles,
-	}, args...)
-}
-
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 	defaultFile := "registries.conf"
 	if UsingCacheRegistry() {

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -26,13 +27,17 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 	if isRootless() {
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
-	podmanSession := p.PodmanAsUserBase(args, 0, 0, "", nil, false, false, wrapper, nil)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		Wrapper: wrapper,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 
 // PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
 func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	podmanSession := p.PodmanAsUserBase(args, 0, 0, "", nil, false, false, nil, extraFiles)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+		ExtraFiles: extraFiles,
+	})
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -17,7 +17,7 @@ func IsRemote() bool {
 
 // Podman is the exec call to podman on the filesystem
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanBase(args, false, false)
+	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{})
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -15,9 +15,14 @@ func IsRemote() bool {
 	return false
 }
 
-// Podman is the exec call to podman on the filesystem
+// Podman executes podman on the filesystem with default options.
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{})
+	return p.PodmanWithOptions(PodmanExecOptions{}, args...)
+}
+
+// PodmanWithOptions executes podman on the filesystem with the supplied options.
+func (p *PodmanTestIntegration) PodmanWithOptions(options PodmanExecOptions, args ...string) *PodmanSessionIntegration {
+	podmanSession := p.PodmanExecBaseWithOptions(args, options)
 	return &PodmanSessionIntegration{podmanSession}
 }
 
@@ -27,18 +32,16 @@ func (p *PodmanTestIntegration) PodmanSystemdScope(args []string) *PodmanSession
 	if isRootless() {
 		wrapper = []string{"systemd-run", "--scope", "--user"}
 	}
-	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+	return p.PodmanWithOptions(PodmanExecOptions{
 		Wrapper: wrapper,
-	})
-	return &PodmanSessionIntegration{podmanSession}
+	}, args...)
 }
 
 // PodmanExtraFiles is the exec call to podman on the filesystem and passes down extra files
 func (p *PodmanTestIntegration) PodmanExtraFiles(args []string, extraFiles []*os.File) *PodmanSessionIntegration {
-	podmanSession := p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
+	return p.PodmanWithOptions(PodmanExecOptions{
 		ExtraFiles: extraFiles,
-	})
-	return &PodmanSessionIntegration{podmanSession}
+	}, args...)
 }
 
 func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -618,7 +618,7 @@ RUN touch /file
 	It("authenticated push", func() {
 		registryOptions := &podmanRegistry.Options{
 			PodmanPath: podmanTest.PodmanBinary,
-			PodmanArgs: podmanTest.MakeOptions(nil, false, false),
+			PodmanArgs: podmanTest.MakeOptions(nil, PodmanExecOptions{}),
 			Image:      "docker-archive:" + imageTarPath(REGISTRY_IMAGE),
 		}
 

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Podman mount", func() {
 
 		// command: podman <options> unshare podman <options> mount cid
 		args := []string{"unshare", podmanTest.PodmanBinary}
-		opts := podmanTest.PodmanMakeOptions([]string{"mount", cid}, false, false)
+		opts := podmanTest.PodmanMakeOptions([]string{"mount", cid}, PodmanExecOptions{})
 		args = append(args, opts...)
 
 		// container root file system location is podmanTest.TempDir/...
@@ -59,7 +59,7 @@ var _ = Describe("Podman mount", func() {
 
 		// command: podman <options> unshare podman <options> image mount IMAGE
 		args := []string{"unshare", podmanTest.PodmanBinary}
-		opts := podmanTest.PodmanMakeOptions([]string{"image", "mount", CITEST_IMAGE}, false, false)
+		opts := podmanTest.PodmanMakeOptions([]string{"image", "mount", CITEST_IMAGE}, PodmanExecOptions{})
 		args = append(args, opts...)
 
 		// image location is podmanTest.TempDir/... because "--root podmanTest.TempDir/..."

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Podman run exit", func() {
 
 		// command: podman <options> unshare podman <options> image mount ALPINE
 		args := []string{"unshare", podmanTest.PodmanBinary}
-		opts := podmanTest.PodmanMakeOptions([]string{"mount", "--no-trunc"}, false, false)
+		opts := podmanTest.PodmanMakeOptions([]string{"mount", "--no-trunc"}, PodmanExecOptions{})
 		args = append(args, opts...)
 
 		pmount := podmanTest.Podman(args)

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1849,7 +1849,9 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		files := []*os.File{
 			devNull,
 		}
-		session := podmanTest.PodmanExtraFiles([]string{"run", "--preserve-fds", "1", ALPINE, "ls"}, files)
+		session := podmanTest.PodmanWithOptions(PodmanExecOptions{
+			ExtraFiles: files,
+		}, "run", "--preserve-fds", "1", ALPINE, "ls")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})

--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Systemd activate", func() {
 		Expect(err).ToNot(HaveOccurred())
 		addr := net.JoinHostPort(host, strconv.Itoa(port))
 
-		podmanOptions := podmanTest.makeOptions(nil, false, false)
+		podmanOptions := podmanTest.makeOptions(nil, testUtils.PodmanExecOptions{})
 
 		systemdArgs := []string{
 			"-E", "http_proxy", "-E", "https_proxy", "-E", "no_proxy",

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -55,7 +55,7 @@ var (
 // PodmanTestCommon contains common functions will be updated later in
 // the inheritance structs
 type PodmanTestCommon interface {
-	MakeOptions(args []string, noEvents, noCache bool) []string
+	MakeOptions(args []string, options PodmanExecOptions) []string
 	WaitForContainer() bool
 	WaitContainerReady(id string, expStr string, timeout int, step int) bool
 }
@@ -67,7 +67,7 @@ type PodmanTest struct {
 	NetworkBackend     NetworkBackend
 	DatabaseBackend    string
 	PodmanBinary       string
-	PodmanMakeOptions  func(args []string, noEvents, noCache bool) []string
+	PodmanMakeOptions  func(args []string, options PodmanExecOptions) []string
 	RemoteCommand      *exec.Cmd
 	RemotePodmanBinary string
 	RemoteSession      *os.Process
@@ -90,8 +90,8 @@ type HostOS struct {
 }
 
 // MakeOptions assembles all podman options
-func (p *PodmanTest) MakeOptions(args []string, noEvents, noCache bool) []string {
-	return p.PodmanMakeOptions(args, noEvents, noCache)
+func (p *PodmanTest) MakeOptions(args []string, options PodmanExecOptions) []string {
+	return p.PodmanMakeOptions(args, options)
 }
 
 // PodmanExecOptions modify behavior of PodmanTest.PodmanExecBaseWithOptions and its callers.
@@ -109,7 +109,7 @@ type PodmanExecOptions struct {
 // PodmanExecBaseWithOptions execs podman with the specified args, and in an environment defined by options
 func (p *PodmanTest) PodmanExecBaseWithOptions(args []string, options PodmanExecOptions) *PodmanSession {
 	var command *exec.Cmd
-	podmanOptions := p.MakeOptions(args, options.NoEvents, options.NoCache)
+	podmanOptions := p.MakeOptions(args, options)
 	podmanBinary := p.PodmanBinary
 	if p.RemoteTest {
 		podmanBinary = p.RemotePodmanBinary

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -157,14 +157,6 @@ func (p *PodmanTest) PodmanExecBaseWithOptions(args []string, options PodmanExec
 	return &PodmanSession{session}
 }
 
-// PodmanBase exec podman with default env.
-func (p *PodmanTest) PodmanBase(args []string, noEvents, noCache bool) *PodmanSession {
-	return p.PodmanExecBaseWithOptions(args, PodmanExecOptions{
-		NoEvents: noEvents,
-		NoCache:  noCache,
-	})
-}
-
 // WaitForContainer waits on a started container
 func (p *PodmanTest) WaitForContainer() bool {
 	for i := 0; i < 10; i++ {
@@ -181,7 +173,9 @@ func (p *PodmanTest) WaitForContainer() bool {
 // containers are currently running.
 func (p *PodmanTest) NumberOfContainersRunning() int {
 	var containers []string
-	ps := p.PodmanBase([]string{"ps", "-q"}, false, true)
+	ps := p.PodmanExecBaseWithOptions([]string{"ps", "-q"}, PodmanExecOptions{
+		NoCache: true,
+	})
 	ps.WaitWithDefaultTimeout()
 	Expect(ps).Should(Exit(0))
 	for _, i := range ps.OutputToStringArray() {
@@ -196,7 +190,9 @@ func (p *PodmanTest) NumberOfContainersRunning() int {
 // containers are currently defined.
 func (p *PodmanTest) NumberOfContainers() int {
 	var containers []string
-	ps := p.PodmanBase([]string{"ps", "-aq"}, false, true)
+	ps := p.PodmanExecBaseWithOptions([]string{"ps", "-aq"}, PodmanExecOptions{
+		NoCache: true,
+	})
 	ps.WaitWithDefaultTimeout()
 	Expect(ps.ExitCode()).To(Equal(0))
 	for _, i := range ps.OutputToStringArray() {
@@ -211,7 +207,9 @@ func (p *PodmanTest) NumberOfContainers() int {
 // pods are currently defined.
 func (p *PodmanTest) NumberOfPods() int {
 	var pods []string
-	ps := p.PodmanBase([]string{"pod", "ps", "-q"}, false, true)
+	ps := p.PodmanExecBaseWithOptions([]string{"pod", "ps", "-q"}, PodmanExecOptions{
+		NoCache: true,
+	})
 	ps.WaitWithDefaultTimeout()
 	Expect(ps.ExitCode()).To(Equal(0))
 	for _, i := range ps.OutputToStringArray() {
@@ -227,7 +225,9 @@ func (p *PodmanTest) NumberOfPods() int {
 func (p *PodmanTest) GetContainerStatus() string {
 	var podmanArgs = []string{"ps"}
 	podmanArgs = append(podmanArgs, "--all", "--format={{.Status}}")
-	session := p.PodmanBase(podmanArgs, false, true)
+	session := p.PodmanExecBaseWithOptions(podmanArgs, PodmanExecOptions{
+		NoCache: true,
+	})
 	session.WaitWithDefaultTimeout()
 	return session.OutputToString()
 }
@@ -235,7 +235,9 @@ func (p *PodmanTest) GetContainerStatus() string {
 // WaitContainerReady waits process or service inside container start, and ready to be used.
 func (p *PodmanTest) WaitContainerReady(id string, expStr string, timeout int, step int) bool {
 	startTime := time.Now()
-	s := p.PodmanBase([]string{"logs", id}, false, true)
+	s := p.PodmanExecBaseWithOptions([]string{"logs", id}, PodmanExecOptions{
+		NoCache: true,
+	})
 	s.WaitWithDefaultTimeout()
 
 	for {
@@ -248,7 +250,9 @@ func (p *PodmanTest) WaitContainerReady(id string, expStr string, timeout int, s
 			return false
 		}
 		time.Sleep(time.Duration(step) * time.Second)
-		s = p.PodmanBase([]string{"logs", id}, false, true)
+		s = p.PodmanExecBaseWithOptions([]string{"logs", id}, PodmanExecOptions{
+			NoCache: true,
+		})
 		s.WaitWithDefaultTimeout()
 	}
 }

--- a/test/utils/utils_suite_test.go
+++ b/test/utils/utils_suite_test.go
@@ -31,7 +31,7 @@ func FakePodmanTestCreate() *FakePodmanTest {
 	return p
 }
 
-func (p *FakePodmanTest) makeOptions(args []string, noEvents, noCache bool) []string {
+func (p *FakePodmanTest) makeOptions(args []string, options PodmanExecOptions) []string {
 	return FakeOutputs[strings.Join(args, " ")]
 }
 


### PR DESCRIPTION
This, primarily, replaces `PodmanAsUserBase` (called with 9 parameters) with `PodmanExecBaseWithOptions` called with `PodmanExecOptions`, where the caller can only specify the relevant options, and by name; and it threads `PodmanExecOptions` through the call stack, so that E2E tests can set these options directly.

This simplifies the call stack and eliminates the need for various helpers. My primary motivation is that, for https://github.com/containers/podman/pull/25007#discussion_r1925240002 , I want to add a “do not log Podman output to the Ginkgo log” option, and this will allow doing that without adding a one more (unnamed) boolean parameter, or perhaps a new set of helpers, throughout the call stack.

Tests can now, in addition to `Podman()`, call `PodmanWithOptions()`, and also (following the theme of #24977 ), `PodmanExitCleanlyWithOptions`.

And, in the future, maybe `PodmanExecOptions` could be extended with an expected exit code, or perhaps even an expected log output, making the test invocation even more declarative — but that’s not this PR.

---

Warning: I don’t fully understand the current code.
- I don’t know why the remote code manually calls `makeOptions` when the non-remote code relies on setting the `PodmanMakeOptions` upcall (which _also_ seems to be involved in the remote code?)
- I don’t know why various helpers in `common_test.go` and in `test/utils/utils.go`  bypass the difference above (e.g. don’t call `.Podman()`, and call `PodmanAsUserBase` directly and perhaps directly construct a `PodmanSessionIntegration`

There is quite likely a deeper logic to this which I couldn’t figure out. Or maybe these are just inconsistencies accrued over time with copy&paste. This PR is intended to be a refactoring with no change to how tests operate; it doesn’t have the ambition to clean these questions up.

#### Does this PR introduce a user-facing change?

```release-note
None
```
