### PR TITLE
Clean up after unexpectedly terminated build

### DIFF
--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -48,6 +48,7 @@ func init() {
 	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation.  The default is false")
 	flags.BoolVarP(&pruneOptions.All, "all", "a", false, "Remove all unused data")
 	flags.BoolVar(&pruneOptions.External, "external", false, "Remove container data in storage not controlled by podman")
+	flags.BoolVar(&pruneOptions.Build, "build", false, "Remove build containers")
 	flags.BoolVar(&pruneOptions.Volume, "volumes", false, "Prune volumes")
 	filterFlagName := "filter"
 	flags.StringArrayVar(&filters, filterFlagName, []string{}, "Provide filter values (e.g. 'label=<key>=<value>')")
@@ -64,8 +65,12 @@ func prune(cmd *cobra.Command, args []string) error {
 			volumeString = `
 	- all volumes not used by at least one container`
 		}
-
-		fmt.Printf(createPruneWarningMessage(pruneOptions), volumeString, "Are you sure you want to continue? [y/N] ")
+		buildString := ""
+		if pruneOptions.Build {
+			buildString = `
+	- all build containers`
+		}
+		fmt.Printf(createPruneWarningMessage(pruneOptions), volumeString, buildString, "Are you sure you want to continue? [y/N] ")
 
 		answer, err := reader.ReadString('\n')
 		if err != nil {
@@ -124,7 +129,7 @@ func createPruneWarningMessage(pruneOpts entities.SystemPruneOptions) string {
 	if pruneOpts.All {
 		return `WARNING! This command removes:
 	- all stopped containers
-	- all networks not used by at least one container%s
+	- all networks not used by at least one container%s%s
 	- all images without at least one container associated with them
 	- all build cache
 
@@ -132,7 +137,7 @@ func createPruneWarningMessage(pruneOpts entities.SystemPruneOptions) string {
 	}
 	return `WARNING! This command removes:
 	- all stopped containers
-	- all networks not used by at least one container%s
+	- all networks not used by at least one container%s%s
 	- all dangling images
 	- all dangling build cache
 

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -7,20 +7,28 @@ podman\-system\-prune - Remove all unused pods, containers, images, networks, an
 **podman system prune** [*options*]
 
 ## DESCRIPTION
-**podman system prune** removes all unused containers (both dangling and unreferenced), pods, networks, and optionally, volumes from local storage.
+**podman system prune** removes all unused containers (both dangling and unreferenced), build containers, pods, networks, and optionally, volumes from local storage.
 
 Use the **--all** option to delete all unused images.  Unused images are dangling images as well as any image that does not have any containers based on it.
 
 By default, volumes are not removed to prevent important data from being deleted if there is currently no container using the volume. Use the **--volumes** flag when running the command to prune volumes as well.
+
+By default, build containers are not removed to prevent interference with builds in progress. Use the **--build** flag when running the command to remove build containers as well.
 
 ## OPTIONS
 #### **--all**, **-a**
 
 Recursively remove all unused pods, containers, images, networks, and volume data. (Maximum 50 iterations.)
 
+#### **--build**
+
+Removes any build containers that were created during the build, but were not removed because the build was unexpectedly terminated.
+
+Note: **This is not safe operation and should be executed only when no builds are in progress. It can interfere with builds in progress.**
+
 #### **--external**
 
-Removes all leftover container storage files from local storage not managed by Podman. In normal circumstances, no such data exists, but in case of an unclean shutdown, the Podman database may be corrupted and cause this.
+Tries to clean up remainders of previous containers or layers that are not references in the storage json files. These can happen in the case of unclean shutdowns or regular restarts in transient storage mode.
 
 However, when using transient storage mode, the Podman database does not persist. This means containers leave the writable layers on disk after a reboot. When using a transient store, it is recommended that the **podman system prune --external** command is run during boot.
 

--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -25,6 +25,7 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 		All      bool `schema:"all"`
 		Volumes  bool `schema:"volumes"`
 		External bool `schema:"external"`
+		Build    bool `schema:"build"`
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -46,6 +47,7 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 		Volume:   query.Volumes,
 		Filters:  *filterMap,
 		External: query.External,
+		Build:    query.Build,
 	}
 	report, err := containerEngine.SystemPrune(r.Context(), pruneOptions)
 	if err != nil {

--- a/pkg/bindings/system/types.go
+++ b/pkg/bindings/system/types.go
@@ -18,6 +18,7 @@ type PruneOptions struct {
 	Filters  map[string][]string
 	Volumes  *bool
 	External *bool
+	Build    *bool
 }
 
 // VersionOptions are optional options for getting version info

--- a/pkg/bindings/system/types_prune_options.go
+++ b/pkg/bindings/system/types_prune_options.go
@@ -76,3 +76,18 @@ func (o *PruneOptions) GetExternal() bool {
 	}
 	return *o.External
 }
+
+// WithBuild set field Build to given value
+func (o *PruneOptions) WithBuild(value bool) *PruneOptions {
+	o.Build = &value
+	return o
+}
+
+// GetBuild returns value of field Build
+func (o *PruneOptions) GetBuild() bool {
+	if o.Build == nil {
+		var z bool
+		return z
+	}
+	return *o.Build
+}

--- a/pkg/domain/entities/types/system.go
+++ b/pkg/domain/entities/types/system.go
@@ -43,6 +43,7 @@ type SystemPruneOptions struct {
 	Volume   bool
 	Filters  map[string][]string `json:"filters" schema:"filters"`
 	External bool
+	Build    bool
 }
 
 // SystemPruneReport provides report after system prune is executed.

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -19,7 +19,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool, 
 
 // SystemPrune prunes unused data from the system.
 func (ic *ContainerEngine) SystemPrune(ctx context.Context, opts entities.SystemPruneOptions) (*entities.SystemPruneReport, error) {
-	options := new(system.PruneOptions).WithAll(opts.All).WithVolumes(opts.Volume).WithFilters(opts.Filters).WithExternal(opts.External)
+	options := new(system.PruneOptions).WithAll(opts.All).WithVolumes(opts.Volume).WithFilters(opts.Filters).WithExternal(opts.External).WithBuild(opts.Build)
 	return system.Prune(ic.ClientCtx, options)
 }
 


### PR DESCRIPTION
The `podman system prune` command can remove build containers that were created during the build but were not removed because the build terminated unexpectedly. 

By default, build containers are not removed to prevent interference with builds in progress. Use the **--build** flag when running the command to remove build containers as well.

### Reproducer:
- Containerfile:
```Dockerfile
FROM ubi8/ubi
RUN truncate -s 10G out
RUN echo "Hi"
RUN sleep infinity
```
- Test script `run.sh`:
```bash
#!/usr/bin/env bash

podman build -f Containerfile -t podmanleaker &
sleep 60 && kill -9 $! 
```
- measure the size of current images, containers, etc... Before build
```bash
podman unshare du -sh ~/.local/share/containers/
```
- Test script (Note: requires disk space of about 32 GB)
```bash
./run.sh
```
- measure the size of current images, containers, etc... After termination of build
```bash
podman unshare du -sh ~/.local/share/containers/
```
- Clean up leftovers after build
```bash
podman system prune --build -f
```
- measure the size of current images, containers, etc... After cleanup build
```bash
podman unshare du -sh ~/.local/share/containers/
```
> The size should be the same as the first measurement but could be different if a base image is present in the system. 

Fixes: https://github.com/containers/podman/issues/14523
Fixes: https://github.com/containers/podman/issues/23683
Fixes: https://issues.redhat.com/browse/RHEL-62009

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman system prune` command now supports removing build containers with the new `--build` option. 
```
