### PR TITLE
Improve podman build secrets docs / Makefile validatepr description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ validate: validate-source validate-binaries
 # not automated right now.  The hope is that eventually the quay.io/libpod/fedora_podman is multiarch and can replace this
 # image in the future.
 .PHONY: validatepr
-validatepr:
+validatepr: ## Go Format and lint, which all code changes must pass
 	$(PODMANCMD) run --rm \
 		-v $(CURDIR):/go/src/github.com/containers/podman \
 		--security-opt label=disable \

--- a/docs/source/markdown/options/secret.image.md
+++ b/docs/source/markdown/options/secret.image.md
@@ -2,12 +2,22 @@
 ####>   podman build, farm build
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--secret**=**id=id,src=path**
+#### **--secret**=**id=id[,src=*envOrFile*][,env=*ENV*][,type=*file* | *env*]**
 
-Pass secret information used in the Containerfile for building images
-in a safe way that are not stored in the final image, or be seen in other stages.
-The secret is mounted in the container at the default location of `/run/secrets/id`.
+Pass secret information to be used in the Containerfile for building images
+in a safe way that will not end up stored in the final image, or be seen in other stages.
+The value of the secret will be read from an environment variable or file named
+by the "id" option, or named by the "src" option if it is specified, or from an
+environment variable specified by the "env" option. See [EXAMPLES](#examples).
+The secret will be mounted in the container at `/run/secrets/id` by default.
 
-To later use the secret, use the --mount option in a `RUN` instruction within a `Containerfile`:
+To later use the secret, use the --mount flag in a `RUN` instruction within a `Containerfile`:
 
 `RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`
+
+The location of the secret in the container can be overridden using the
+"target", "dst", or "destination" option of the `RUN --mount` flag.
+
+`RUN --mount=type=secret,id=mysecret,target=/run/secrets/myothersecret cat /run/secrets/myothersecret`
+
+Note: changing the contents of secret files will not trigger a rebuild of layers that use said secrets.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -566,6 +566,23 @@ Build image using the specified network when running containers during the build
 $ podman build --network mynet .
 ```
 
+Build an image using a secret stored in an environment variable or file named `mysecret` to be used with the instruction `RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`:
+```
+$ podman build --secret=id=mysecret .
+```
+
+Build an image using a secret stored in an environment variable named `MYSECRET` to be used with the instruction `RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`:
+```
+$ podman build --secret=id=mysecret,env=MYSECRET .
+$ podman build --secret=id=mysecret,src=MYSECRET,type=env .
+```
+
+Build an image using a secret stored in a file named `.mysecret` to be used with the instruction `RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`:
+```
+$ podman build --secret=id=mysecret,src=.mysecret .
+$ podman build --secret=id=mysecret,src=.mysecret,type=file .
+```
+
 ### Building a multi-architecture image using the --manifest option (requires emulation software)
 
 Build image using the specified architectures and link to a single manifest on successful completion:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
## Description

**TL;DR:**
1. Enhance the `podman build --secret` documentation and add examples.
2. Add `validatepr` to `make help` output.

<details>

**Details:** After struggling to find a way to build an image without writing a secret to disk first, I did some hunting. This PR is basically a copy/paste from [buildah-build.1], with some tweaks to appease the podman project linter and with the addition of some Examples. (I plan to submit a similar PR to [containers/buildah] to update the `--secret` help output and add the examples there as well).

**Note:** This "Fixes" #23388 if you go strictly by the Title. However, if you read the comments, it looks like the OP is looking for something more along the lines of using `--secret` WITHOUT needing `--mount=type=secret` modifications to a Containerfile. This is why I omitted the issue number from the commit description. I am more than willing to modify this if requested.
</details>

## Testing

- [x] `make binaries` passes
- [x] `make docs` passes and edits to `secret.image.md` appear in `podman-build.1.md` and `podman-farm-build.1.md`.
    <details>
    
    ![Screenshot from 2025-01-23 20-57-05](https://github.com/user-attachments/assets/65643e33-381e-408d-bfb9-c87c0d659cad)
    
    ![Screenshot from 2025-01-23 20-58-19](https://github.com/user-attachments/assets/f5521d99-ecda-414e-a557-ff901822410a)
    
    ![Screenshot from 2025-01-23 22-31-52](https://github.com/user-attachments/assets/2e491ec0-3e23-4954-ae88-bbfa9687364a)
    
    ![image](https://github.com/user-attachments/assets/bbcab4d2-9132-4f57-a701-5e75b9bfe2be)

    </details>
- [x] `make validatepr` passes
- [x] `make help` shows `validatepr`
    <details>
    
    ![Screenshot from 2025-01-23 22-07-59](https://github.com/user-attachments/assets/86247168-c14a-423e-b65e-a2948480e772)
    </details>

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

<!-- Links -->
[containers/buildah]: https://github.com/containers/buildah
[buildah-build.1]: https://github.com/containers/buildah/blob/main/docs/buildah-build.1.md
