### PR TITLE
Fix podman-restart.service when there are no containers

### DIFF
--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -10,7 +10,7 @@ Type=oneshot
 RemainAfterExit=true
 Environment=LOGGING="--log-level=info"
 ExecStart=@@PODMAN@@ $LOGGING start --all --filter restart-policy=always
-ExecStop=/bin/sh -c '@@PODMAN@@ $LOGGING stop $(@@PODMAN@@ container ls --filter restart-policy=always -q)'
+ExecStop=/bin/sh -c 'CONTAINERS="$(@@PODMAN@@ container ls --filter restart-policy=always -q)"; if [ -n "$CONTAINERS" ]; then @@PODMAN@@ $LOGGING stop $CONTAINERS; fi'
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
If no containers need to be restarted, podman-restart prints "Error: you must provide at least one name or id" then fails.

Update the shell script to handle that condition.

#### Does this PR introduce a user-facing change?

Yes

```release-note
Fixed podman-restart.service: now exits successfully when no containers need restarting
```
