### PR TITLE
system-tests: switch ls with getfattr for selinux tests

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -384,20 +384,21 @@ EOF
 
     mount --type tmpfs -o "context=\"$LABEL\"" tmpfs $tmpdir
 
-    run ls -dZ ${tmpdir}
-    is "$output" "${LABEL} ${tmpdir}" "No Relabel Correctly"
+    run getfattr --only-values --absolute-names -n security.selinux ${tmpdir}
+    is "$output" "${LABEL}" "No Relabel Correctly"
+
     run_podman run --rm -v $tmpdir:/test:z --privileged $IMAGE true
-    run ls -dZ $tmpdir
-    is "$output" "${LABEL} $tmpdir" "Ignored shared relabel Correctly"
+    run getfattr --only-values --absolute-names -n security.selinux ${tmpdir}
+    is "$output" "${LABEL}" "Ignored shared relabel Correctly"
 
     run_podman run --rm -v $tmpdir:/test:Z --privileged $IMAGE true
-    run ls -dZ $tmpdir
-    is "$output" "${LABEL} $tmpdir" "Ignored private relabel Correctly"}
+    run getfattr --only-values --absolute-names -n security.selinux ${tmpdir}
+    is "$output" "${LABEL}" "Ignored private relabel Correctly"
     umount $tmpdir
 
     run_podman run --rm -v $tmpdir:/test:z --privileged $IMAGE true
-    run ls -dZ $tmpdir
-    is "$output" "${RELABEL} $tmpdir" "Ignored private relabel Correctly"}
+    run getfattr --only-values --absolute-names -n security.selinux ${tmpdir}
+    is "$output" "${RELABEL}" "Ignored private relabel Correctly"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
The test `podman selinux: check unsupported relabel` has been failing recently on Fedora rawhide.

This is due to a regression in the `ls` command itself. Workaround for now is to switch to `getfattr -n security.selinux ...`.

Ref: https://github.com/containers/podman/issues/25132#issuecomment-2615744915

Fixes: #25132

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
