### PR TITLE
Avoid upgrading from v5.3.1 on Windows

### DIFF
--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -20,11 +20,7 @@ Push-Location $WIN_INST_FOLDER
 # Download the previous installer to test a major update
 
 if (!$env:PREV_SETUP_EXE_PATH) {
-    # After v5.3.2 is released we should replace
-    #     `Get-Podman-Setup-From-GitHub -version "tags/v5.3.0"`
-    # with
-    #     `Get-Latest-Podman-Setup-From-GitHub`
-    $env:PREV_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub -version "tags/v5.3.0"
+    $env:PREV_SETUP_EXE_PATH = Get-Latest-Podman-Setup-From-GitHub
 }
 
 # Note: consumes podman-remote-release-windows_amd64.zip from repo.tar.zst

--- a/contrib/win-installer/burn.wxs
+++ b/contrib/win-installer/burn.wxs
@@ -22,6 +22,11 @@
     <util:RegistrySearch Id="CurrentBuild" Variable="CBNumber" Result="value" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Value="CurrentBuildNumber" />
     <bal:Condition Message="Windows 10 (19041) or later is required to run this application." Condition="VersionNT &gt;= v10.0 AND (CBNumber &gt;= 19041 OR AllowOldWin = 1)" />
     <bal:Condition Message="You have an installed development, pre-release version, or alternative build identifying as the same version of this installer. You must uninstall the existing version of Podman first, before proceeding." Condition="WixBundleInstalled OR WixBundleForcedRestartPackage OR PreviousVersion &lt;&gt; VERSION" />
+    <!-- Next condition blocks upgrades from v5.3.1. That's because that version
+         of the installer has a bug (that got patched in v5.3.2) and upgrading
+         from v5.3.1 requires upgrading to v5.3.2 first.
+         c.f. https://github.com/containers/podman/issues/24735 -->
+    <bal:Condition Message="You have v5.3.1 of Podman installed and upgrading to this version is not allowed. You must upgrade to v5.3.2 first." Condition="PreviousVersion &lt;&gt; v5.3.1" />
     <Chain>
       <MsiPackage Id="Setup" SourceFile="en-US\podman.msi" Vital="yes">
         <MsiProperty Name="INSTALLDIR" Value="[InstallFolder]" />

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -10,7 +10,7 @@
 	<?define UseGVProxy = ""?>
 	<?endif?>
 
-	<Package Name="podman" Manufacturer="Red Hat Inc." Version="$(VERSION)" UpgradeCode="a6a9dd9c-0732-44ba-9279-ffe22ea50671" ProductCode="18107131-1820-4878-8AEE-65AAE37BC1E3">
+	<Package Name="podman" Manufacturer="Red Hat Inc." Version="$(VERSION)" UpgradeCode="a6a9dd9c-0732-44ba-9279-ffe22ea50671">
 		<Media Id="1" Cabinet="Podman.cab" EmbedCab="yes" />
 		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." RemoveFeatures="Complete" Schedule="afterInstallExecute" />
 		<Property Id="DiskPrompt" Value="Red Hat's Podman $(VERSION) Installation" />


### PR DESCRIPTION
This PR adds a condition in the Windows WiX bundle that prevents upgrades from v5.3.1 and recommends the user to upgrade to v5.3.2 first.

Version 5.3.1 of the installer had [a bug](https://github.com/containers/podman/issues/24735) that got patched in v5.3.x. The patch won't be included in the installer for v5.4.0 ([see here for details](https://github.com/containers/podman/pull/25021)), and we can't allow direct upgrades from v5.3.1 to v5.4.x anymore. 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
