### PR TITLE
error with libkrun on intel-based machines

### DIFF
--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
 	"github.com/containers/podman/v5/libpod/events"
+	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	provider2 "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
@@ -56,6 +58,9 @@ func machinePreRunE(c *cobra.Command, args []string) error {
 	provider, err = provider2.Get()
 	if err != nil {
 		return err
+	}
+	if provider.VMType() == define.LibKrun && runtime.GOARCH == "amd64" {
+		return errors.New("libkrun is not supported on Intel based machines. Please revert to the applehv provider")
 	}
 	return rootlessOnly(c, args)
 }

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -43,10 +43,11 @@ func Get() (vmconfigs.VMProvider, error) {
 }
 
 func GetAll() []vmconfigs.VMProvider {
-	return []vmconfigs.VMProvider{
-		new(applehv.AppleHVStubber),
-		new(libkrun.LibKrunStubber),
+	configs := []vmconfigs.VMProvider{new(applehv.AppleHVStubber)}
+	if runtime.GOARCH == "arm64" {
+		configs = append(configs, new(libkrun.LibKrunStubber))
 	}
+	return configs
 }
 
 // SupportedProviders returns the providers that are supported on the host operating system


### PR DESCRIPTION
libkrun is not supported on Intel.  We should error.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Emit an error when trying to use libkrun on Intel-based Macs
```
