### PR TITLE
Move detection of libkrun and intel

### DIFF
--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
 	"github.com/containers/podman/v5/libpod/events"
-	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	provider2 "github.com/containers/podman/v5/pkg/machine/provider"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
@@ -58,9 +56,6 @@ func machinePreRunE(c *cobra.Command, args []string) error {
 	provider, err = provider2.Get()
 	if err != nil {
 		return err
-	}
-	if provider.VMType() == define.LibKrun && runtime.GOARCH == "amd64" {
-		return errors.New("libkrun is not supported on Intel based machines. Please revert to the applehv provider")
 	}
 	return rootlessOnly(c, args)
 }

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -36,6 +37,9 @@ func Get() (vmconfigs.VMProvider, error) {
 	case define.AppleHvVirt:
 		return new(applehv.AppleHVStubber), nil
 	case define.LibKrun:
+		if runtime.GOARCH == "amd64" {
+			return nil, errors.New("libkrun is not supported on Intel based machines. Please revert to the applehv provider")
+		}
 		return new(libkrun.LibKrunStubber), nil
 	default:
 		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())


### PR DESCRIPTION
A review comment post merge suggested I move the detection of libkrun and intel into the provider.Get()

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
