### PR TITLE
build: pass ignore file to buildah to consider empty ignore files

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -697,6 +697,14 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 			return nil, fmt.Errorf("unable to parse ignore file: %w", err)
 		}
 		opts.Excludes = excludes
+
+		// Always pass ignore file to force buildah to consider
+		// an empty ignore file if passed.
+		absIgnoreFile, err := filepath.Abs(flags.IgnoreFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve ignore file path: %w", err)
+		}
+		opts.IgnoreFile = absIgnoreFile
 	}
 
 	if flags.SourceDateEpoch != "" { // could be explicitly specified, or passed via the environment, tricking .Changed()

--- a/internal/localapi/utils.go
+++ b/internal/localapi/utils.go
@@ -234,6 +234,21 @@ func CheckIfImageBuildPathsOnRunningMachine(ctx context.Context, containerFiles 
 			context.Value = mapping.RemotePath
 		}
 	}
+
+	// Ignore file
+	if options.IgnoreFile != "" {
+		if err := fileutils.Lexists(options.IgnoreFile); errors.Is(err, fs.ErrNotExist) {
+			logrus.Debugf("Path %q does not exist locally, skipping machine check", options.IgnoreFile)
+			return nil, options, false
+		}
+		mapping, found := IsPathAvailableOnMachine(mounts, vmType, options.IgnoreFile)
+		if !found {
+			logrus.Debugf("Path %q is not available on the running machine", options.IgnoreFile)
+			return nil, options, false
+		}
+		options.IgnoreFile = mapping.RemotePath
+	}
+
 	return translatedContainerFiles, options, true
 }
 

--- a/internal/localapi/utils_test.go
+++ b/internal/localapi/utils_test.go
@@ -138,6 +138,19 @@ func TestIsPathAvailableOnMachine_Unix(t *testing.T) {
 			wantRemotePath: "/mnt/home/user/file.txt",
 			wantFound:      true,
 		},
+		{
+			name: "QEMU - Ignore file within mount",
+			mounts: []*vmconfigs.Mount{
+				{
+					Source: "/home/test",
+					Target: "/mnt/host",
+				},
+			},
+			vmType:         define.QemuVirt,
+			localPath:      "/home/test/project/.containerignore",
+			wantRemotePath: "/mnt/host/project/.containerignore",
+			wantFound:      true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/buildah"
@@ -84,6 +85,7 @@ type BuildQuery struct {
 	IDMappingOptions        string             `schema:"idmappingoptions"`
 	IdentityLabel           bool               `schema:"identitylabel"`
 	Ignore                  bool               `schema:"ignore"`
+	IgnoreFile              string             `schema:"ignorefile"`
 	InheritLabels           types.OptionalBool `schema:"inheritlabels"`
 	InheritAnnotations      types.OptionalBool `schema:"inheritannotations"`
 	Isolation               string             `schema:"isolation"`
@@ -167,6 +169,12 @@ func (b *BuildContext) validateLocalAPIPaths() error {
 			continue
 		}
 		if err := localapi.ValidatePathForLocalAPI(ctx.Value); err != nil {
+			return err
+		}
+	}
+
+	if b.IgnoreFile != "" {
+		if err := localapi.ValidatePathForLocalAPI(b.IgnoreFile); err != nil {
 			return err
 		}
 	}
@@ -293,6 +301,36 @@ func processBuildContext(query url.Values, r *http.Request, buildContext *BuildC
 				}
 			}
 		}
+	}
+
+	// Process dockerignore only if no explicit ignorefile was specified
+	if ignorefile := query.Get("ignorefile"); ignorefile != "" {
+		if filepath.IsAbs(ignorefile) {
+			ignoreFilePath := filepath.Clean(ignorefile)
+			// In remote builds, the client may send an absolute path that exists
+			// only on the client filesystem. The file is bundled in the tarball
+			// and unpacked under the context directory at the same absolute path,
+			// so fall back to looking it up there if the absolute path is missing.
+			if err := fileutils.Exists(ignoreFilePath); err != nil {
+				ignoreFilePath, err = securejoin.SecureJoin(buildContext.ContextDirectory, ignoreFilePath)
+				if err != nil {
+					return nil, utils.GetInternalServerError(fmt.Errorf("processing ignore file path: %w", err))
+				}
+			}
+			buildContext.IgnoreFile = ignoreFilePath
+		} else {
+			ignoreFilePath, err := securejoin.SecureJoin(buildContext.ContextDirectory, ignorefile)
+			if err != nil {
+				return nil, utils.GetInternalServerError(fmt.Errorf("processing ignore file path: %w", err))
+			}
+			buildContext.IgnoreFile = ignoreFilePath
+		}
+	} else {
+		_, ignoreFile, err := util.ParseDockerignore(buildContext.ContainerFiles, buildContext.ContextDirectory)
+		if err != nil {
+			return nil, utils.GetInternalServerError(fmt.Errorf("processing ignore file: %w", err))
+		}
+		buildContext.IgnoreFile = ignoreFile
 	}
 
 	return buildContext, nil
@@ -1013,13 +1051,6 @@ func getLocalBuildContext(r *http.Request, query url.Values, anchorDir string, _
 		return nil, utils.GetGenericBadRequestError(err)
 	}
 
-	// Process dockerignore
-	_, ignoreFile, err := util.ParseDockerignore(buildContext.ContainerFiles, buildContext.ContextDirectory)
-	if err != nil {
-		return nil, utils.GetInternalServerError(fmt.Errorf("processing ignore file: %w", err))
-	}
-	buildContext.IgnoreFile = ignoreFile
-
 	return buildContext, nil
 }
 
@@ -1119,13 +1150,6 @@ func getBuildContext(r *http.Request, query url.Values, anchorDir string, multip
 	if err != nil {
 		return nil, err
 	}
-
-	// Process dockerignore
-	_, ignoreFile, err := util.ParseDockerignore(buildContext.ContainerFiles, buildContext.ContextDirectory)
-	if err != nil {
-		return nil, utils.GetInternalServerError(fmt.Errorf("processing ignore file: %w", err))
-	}
-	buildContext.IgnoreFile = ignoreFile
 
 	return buildContext, nil
 }

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -541,6 +541,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      Path within the build context to the `Dockerfile`.
 	//      This is ignored if remote is specified and points to an external `Dockerfile`.
 	//  - in: query
+	//    name: ignorefile
+	//    type: string
+	//    description: |
+	//      Path to an alternate ignore file (e.g. `.containerignore`) within the build context.
+	//      When set, this file is used instead of the default `.containerignore`/`.dockerignore`,
+	//      and an empty ignore file is honored, overriding any default ignore file.
+	//  - in: query
 	//    name: t
 	//    type: string
 	//    default: latest
@@ -1575,6 +1582,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      Path within the build context to the `Dockerfile`.
 	//      This is ignored if remote is specified and points to an external `Dockerfile`.
 	//  - in: query
+	//    name: ignorefile
+	//    type: string
+	//    description: |
+	//      Path to an alternate ignore file (e.g. `.containerignore`) within the build context.
+	//      When set, this file is used instead of the default `.containerignore`/`.dockerignore`,
+	//      and an empty ignore file is honored, overriding any default ignore file.
+	//  - in: query
 	//    name: t
 	//    type: string
 	//    default: latest
@@ -1931,6 +1945,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      Absolute path within the build context to the `Dockerfile`.
 	//      This is ignored if remote is specified and points to an external `Dockerfile`.
+	//  - in: query
+	//    name: ignorefile
+	//    type: string
+	//    description: |
+	//      Path to an alternate ignore file (e.g. `.containerignore`) within the build context.
+	//      When set, this file is used instead of the default `.containerignore`/`.dockerignore`,
+	//      and an empty ignore file is honored, overriding any default ignore file.
 	//  - in: query
 	//    name: t
 	//    type: string

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -200,6 +200,15 @@ func prepareParams(options types.BuildOptions) (url.Values, error) {
 		}
 		params.Set("excludes", bArgs)
 	}
+	if options.IgnoreFile != "" {
+		ignoreFile := options.IgnoreFile
+		if absIgnore, err := filepath.Abs(ignoreFile); err == nil {
+			if relPath, ok := strings.CutPrefix(absIgnore, options.ContextDirectory+string(filepath.Separator)); ok {
+				ignoreFile = relPath
+			}
+		}
+		params.Set("ignorefile", ignoreFile)
+	}
 	if cpuPeriod := options.CommonBuildOpts.CPUPeriod; cpuPeriod > 0 {
 		params.Set("cpuperiod", strconv.Itoa(int(cpuPeriod)))
 	}
@@ -1050,7 +1059,7 @@ func build(ctx context.Context, containerFiles []string, options types.BuildOpti
 	}
 
 	buildFilePaths.excludes = options.Excludes
-	if len(buildFilePaths.excludes) == 0 {
+	if len(buildFilePaths.excludes) == 0 && options.IgnoreFile == "" {
 		buildFilePaths.excludes, _, err = util.ParseDockerignore(buildFilePaths.newContainerFiles, options.ContextDirectory)
 		if err != nil {
 			return nil, err
@@ -1071,6 +1080,19 @@ func build(ctx context.Context, containerFiles []string, options types.BuildOpti
 		}
 		requestParts.Params.Add("secrets", c)
 		buildFilePaths.tarContent = append(buildFilePaths.tarContent, secretsTarContent...)
+	}
+
+	// If ignorefile is outside the context directory, add it to tarball (same as containerfile)
+	if options.IgnoreFile != "" {
+		absIgnore, err := filepath.Abs(options.IgnoreFile)
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve ignore file path: %w", err)
+		}
+		if _, ok := strings.CutPrefix(absIgnore, contextDirAbs+string(filepath.Separator)); !ok {
+			if err := fileutils.Lexists(absIgnore); err == nil {
+				buildFilePaths.tarContent = append(buildFilePaths.tarContent, absIgnore)
+			}
+		}
 	}
 
 	requestParts, err = prepareRequestBody(ctx, requestParts, buildFilePaths, options)

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -1298,4 +1298,39 @@ function teardown() {
     assert "$output" =~ "--pull.*(default \"missing\")" "pull should default to missing"
 }
 
+@test "podman build --ignorefile overrides .dockerignore" {
+    local contextdir=$PODMAN_TMPDIR/build-test-$(random_string 10)
+    mkdir -p $contextdir
+
+    local testfile=testfile-$(random_string 12)
+    echo "test content" > $contextdir/$testfile
+
+    cat >$contextdir/.dockerignore <<EOF
+$testfile
+EOF
+
+    cat >$contextdir/Containerfile <<EOF
+FROM $IMAGE
+COPY . /testdir/
+RUN find /testdir/
+EOF
+
+    # Empty ignorefile inside context dir
+    local emptyignore=$contextdir/.emptyignore
+    touch $emptyignore
+
+    imgname="b-$(safename)"
+    run_podman build -t $imgname --ignorefile $emptyignore $contextdir
+    assert "$output" =~ "$testfile" "empty ignorefile inside context dir should override .dockerignore"
+    run_podman rmi -f $imgname
+
+    # Empty ignorefile outside context dir
+    local outsideignore=$PODMAN_TMPDIR/.outside-emptyignore
+    touch $outsideignore
+
+    run_podman build -t $imgname --ignorefile $outsideignore $contextdir
+    assert "$output" =~ "$testfile" "empty ignorefile outside context dir should override .dockerignore"
+    run_podman rmi -f $imgname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
We currently only pass parsed excludes from the ignore file to buildah and not the ignorefile path. This causes buildah to ignore `--ignorefile` if the specified file is empty.

Fixes #25147
