### PR TITLE
pkg/api: honor cdi devices from the hostconfig

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -163,6 +163,11 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 	for _, dev := range cc.HostConfig.Devices {
 		devices = append(devices, fmt.Sprintf("%s:%s:%s", dev.PathOnHost, dev.PathInContainer, dev.CgroupPermissions))
 	}
+	for _, r := range cc.HostConfig.Resources.DeviceRequests {
+		if r.Driver == "cdi" {
+			devices = append(devices, r.DeviceIDs...)
+		}
+	}
 
 	// iterate blkreaddevicebps
 	readBps := make([]string, 0, len(cc.HostConfig.BlkioDeviceReadBps))

--- a/test/compose/cdi_device/README.md
+++ b/test/compose/cdi_device/README.md
@@ -1,0 +1,9 @@
+cdi devices
+===========
+
+This test copies a CDI device file on a tmpfs mounted on /etc/cdi, then checks that the CDI device in the compose file is present in a container.  The test is skipped when running as rootless.
+
+Validation
+------------
+
+* The CDI device is present in the container.

--- a/test/compose/cdi_device/device.json
+++ b/test/compose/cdi_device/device.json
@@ -1,0 +1,14 @@
+{
+  "cdiVersion": "0.3.0",
+  "kind": "vendor.com/device",
+  "devices": [
+    {
+      "name": "myKmsg",
+      "containerEdits": {
+        "mounts": [
+          {"hostPath": "/dev/kmsg", "containerPath": "/dev/kmsg1", "options": ["rw", "rprivate", "rbind"]}
+        ]
+      }
+    }
+  ]
+}

--- a/test/compose/cdi_device/docker-compose.yml
+++ b/test/compose/cdi_device/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  test:
+    image: alpine
+    command: ["top"]
+    volumes:
+      - /dev:/dev-host
+    security_opt:
+      - label=disable
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: cdi
+            device_ids: ['vendor.com/device=myKmsg']
+            capabilities: []

--- a/test/compose/cdi_device/setup.sh
+++ b/test/compose/cdi_device/setup.sh
@@ -1,0 +1,9 @@
+if is_rootless; then
+    reason=" - can't write to /etc/cdi"
+    _show_ok skip "$testname # skip$reason"
+    exit 0
+fi
+
+mkdir -p /etc/cdi
+mount -t tmpfs tmpfs /etc/cdi
+cp device.json /etc/cdi

--- a/test/compose/cdi_device/teardown.sh
+++ b/test/compose/cdi_device/teardown.sh
@@ -1,0 +1,3 @@
+if ! is_rootless; then
+    umount -l /etc/cdi
+fi

--- a/test/compose/cdi_device/tests.sh
+++ b/test/compose/cdi_device/tests.sh
@@ -1,0 +1,11 @@
+# -*- bash -*-
+
+ctr_name="cdi_device-test-1"
+
+podman exec "$ctr_name" sh -c 'stat -c "%t:%T" /dev-host/kmsg'
+
+expected=$output
+
+podman exec "$ctr_name" sh -c 'stat -c "%t:%T" /dev/kmsg1'
+
+is "$output" "$expected" "$testname : device /dev/kmsg1 has the same rdev as /dev/kmsg on the host"


### PR DESCRIPTION
Disclaimer: I am not very familiar with all the details of CDI, so there might still be something missing, but the following patch seems to be enough for the test cases that were reported so I open a PR to gather some feedback.

Pass down the devices specifies in the resources block so that CDI devices in the compose file are honored.

Tested manually with the following compose file:

services:
  testgpupodman_count:
    image: ubuntu:latest
    command: ["nvidia-smi"]
    profiles: [gpu]
    deploy:
      resources:
        reservations:
          devices:
          - driver: nvidia
            count: 1
            capabilities: [gpu]
  testgpupodman_deviceid:
      image: docker.io/ubuntu:latest
      command: ["nvidia-smi"]
      deploy:
        resources:
          reservations:
            devices:
            - driver: cdi
              device_ids: ['nvidia.com/gpu=all']
              capabilities: [gpu]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now Podman honors CDI devices passed from the api
```
