### PR TITLE
Create `--append` flag to add file to existing artifact using `podman artifact add` command

### DIFF
--- a/cmd/podman/artifact/add.go
+++ b/cmd/podman/artifact/add.go
@@ -27,6 +27,7 @@ var (
 type artifactAddOptions struct {
 	ArtifactType string
 	Annotations  []string
+	Append       bool
 }
 
 var (
@@ -41,12 +42,15 @@ func init() {
 	flags := addCmd.Flags()
 
 	annotationFlagName := "annotation"
-	flags.StringArrayVar(&addOpts.Annotations, annotationFlagName, nil, "set an `annotation` for the specified artifact")
+	flags.StringArrayVar(&addOpts.Annotations, annotationFlagName, nil, "set an `annotation` for the specified files of artifact")
 	_ = addCmd.RegisterFlagCompletionFunc(annotationFlagName, completion.AutocompleteNone)
 
 	addTypeFlagName := "type"
 	flags.StringVar(&addOpts.ArtifactType, addTypeFlagName, "", "Use type to describe an artifact")
 	_ = addCmd.RegisterFlagCompletionFunc(addTypeFlagName, completion.AutocompleteNone)
+
+	appendFlagName := "append"
+	flags.BoolVarP(&addOpts.Append, appendFlagName, "a", false, "Append files to an existing artifact")
 }
 
 func add(cmd *cobra.Command, args []string) error {
@@ -58,6 +62,8 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 	opts.Annotations = annots
 	opts.ArtifactType = addOpts.ArtifactType
+	opts.Append = addOpts.Append
+
 	report, err := registry.ImageEngine().ArtifactAdd(registry.Context(), args[0], args[1:], opts)
 	if err != nil {
 		return err

--- a/docs/source/markdown/podman-artifact-add.1.md.in
+++ b/docs/source/markdown/podman-artifact-add.1.md.in
@@ -21,6 +21,12 @@ added.
 
 @@option annotation.manifest
 
+Note: Set annotations for each file being added.
+
+#### **--append**, **-a**
+
+Append files to an existing artifact. This option cannot be used with the **--type** option.
+
 #### **--help**
 
 Print usage statement.

--- a/pkg/domain/entities/artifact.go
+++ b/pkg/domain/entities/artifact.go
@@ -12,6 +12,7 @@ import (
 type ArtifactAddOptions struct {
 	Annotations  map[string]string
 	ArtifactType string
+	Append       bool
 }
 
 type ArtifactExtractOptions struct {

--- a/pkg/domain/infra/abi/artifact.go
+++ b/pkg/domain/infra/abi/artifact.go
@@ -162,6 +162,7 @@ func (ir *ImageEngine) ArtifactAdd(ctx context.Context, name string, paths []str
 	addOptions := types.AddOptions{
 		Annotations:  opts.Annotations,
 		ArtifactType: opts.ArtifactType,
+		Append:       opts.Append,
 	}
 
 	artifactDigest, err := artStore.Add(ctx, name, paths, &addOptions)

--- a/pkg/libartifact/types/config.go
+++ b/pkg/libartifact/types/config.go
@@ -8,6 +8,8 @@ type GetArtifactOptions struct{}
 type AddOptions struct {
 	Annotations  map[string]string `json:"annotations,omitempty"`
 	ArtifactType string            `json:",omitempty"`
+	// append option is not compatible with ArtifactType option
+	Append bool `json:",omitempty"`
 }
 
 type ExtractOptions struct {

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -3,17 +3,14 @@
 package integration
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/podman/v5/pkg/libartifact"
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 const (
@@ -36,19 +33,19 @@ var _ = Describe("Podman artifact", func() {
 		artifact1File, err := createArtifactFile(4192)
 		Expect(err).ToNot(HaveOccurred())
 		artifact1Name := "localhost/test/artifact1"
-		add1 := podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact1Name, artifact1File}...)
+		add1 := podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File)
 
 		artifact2File, err := createArtifactFile(10240)
 		Expect(err).ToNot(HaveOccurred())
 		artifact2Name := "localhost/test/artifact2"
-		podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact2Name, artifact2File}...)
+		podmanTest.PodmanExitCleanly("artifact", "add", artifact2Name, artifact2File)
 
 		// Should be three items in the list
-		listSession := podmanTest.PodmanExitCleanly([]string{"artifact", "ls"}...)
+		listSession := podmanTest.PodmanExitCleanly("artifact", "ls")
 		Expect(listSession.OutputToStringArray()).To(HaveLen(3))
 
 		// --format should work
-		listFormatSession := podmanTest.PodmanExitCleanly([]string{"artifact", "ls", "--format", "{{.Repository}}"}...)
+		listFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Repository}}")
 		output := listFormatSession.OutputToStringArray()
 
 		// There should be only 2 "lines" because the header should not be output
@@ -59,18 +56,18 @@ var _ = Describe("Podman artifact", func() {
 		Expect(output).To(ContainElement(artifact2Name))
 
 		// Check default digest length (should be 12)
-		defaultFormatSession := podmanTest.PodmanExitCleanly([]string{"artifact", "ls", "--format", "{{.Digest}}"}...)
+		defaultFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Digest}}")
 		defaultOutput := defaultFormatSession.OutputToStringArray()[0]
 		Expect(defaultOutput).To(HaveLen(12))
 
 		// Check with --no-trunc and verify the len of the digest is the same as the len what was returned when the artifact
 		// was added
-		noTruncSession := podmanTest.PodmanExitCleanly([]string{"artifact", "ls", "--no-trunc", "--format", "{{.Digest}}"}...)
+		noTruncSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--no-trunc", "--format", "{{.Digest}}")
 		truncOutput := noTruncSession.OutputToStringArray()[0]
 		Expect(truncOutput).To(HaveLen(len(add1.OutputToString())))
 
 		// check with --noheading and verify the header is not present through a line count AND substring match
-		noHeaderSession := podmanTest.PodmanExitCleanly([]string{"artifact", "ls", "--noheading"}...)
+		noHeaderSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--noheading")
 		noHeaderOutput := noHeaderSession.OutputToStringArray()
 		Expect(noHeaderOutput).To(HaveLen(2))
 		Expect(noHeaderOutput).ToNot(ContainElement("REPOSITORY"))
@@ -82,21 +79,16 @@ var _ = Describe("Podman artifact", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		artifact1Name := "localhost/test/artifact1"
-		podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact1Name, artifact1File}...)
+		podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File)
 
-		inspectSingleSession := podmanTest.PodmanExitCleanly([]string{"artifact", "inspect", artifact1Name}...)
+		a := podmanTest.InspectArtifact(artifact1Name)
 
-		a := libartifact.Artifact{}
-		inspectOut := inspectSingleSession.OutputToString()
-		err = json.Unmarshal([]byte(inspectOut), &a)
-		Expect(err).ToNot(HaveOccurred())
 		Expect(a.Name).To(Equal(artifact1Name))
 
 		// Adding an artifact with an existing name should fail
 		addAgain := podmanTest.Podman([]string{"artifact", "add", artifact1Name, artifact1File})
 		addAgain.WaitWithDefaultTimeout()
-		Expect(addAgain).ShouldNot(ExitCleanly())
-		Expect(addAgain.ErrorToString()).To(Equal(fmt.Sprintf("Error: artifact %s already exists", artifact1Name)))
+		Expect(addAgain).Should(ExitWithError(125, fmt.Sprintf("Error: artifact %s already exists", artifact1Name)))
 	})
 
 	It("podman artifact add with options", func() {
@@ -108,11 +100,9 @@ var _ = Describe("Podman artifact", func() {
 		annotation1 := "color=blue"
 		annotation2 := "flavor=lemon"
 
-		podmanTest.PodmanExitCleanly([]string{"artifact", "add", "--type", artifactType, "--annotation", annotation1, "--annotation", annotation2, artifact1Name, artifact1File}...)
-		inspectSingleSession := podmanTest.PodmanExitCleanly([]string{"artifact", "inspect", artifact1Name}...)
-		a := libartifact.Artifact{}
-		err = json.Unmarshal([]byte(inspectSingleSession.OutputToString()), &a)
-		Expect(err).ToNot(HaveOccurred())
+		podmanTest.PodmanExitCleanly("artifact", "add", "--type", artifactType, "--annotation", annotation1, "--annotation", annotation2, artifact1Name, artifact1File)
+
+		a := podmanTest.InspectArtifact(artifact1Name)
 		Expect(a.Name).To(Equal(artifact1Name))
 		Expect(a.Manifest.ArtifactType).To(Equal(artifactType))
 		Expect(a.Manifest.Layers[0].Annotations["color"]).To(Equal("blue"))
@@ -120,8 +110,7 @@ var _ = Describe("Podman artifact", func() {
 
 		failSession := podmanTest.Podman([]string{"artifact", "add", "--annotation", "org.opencontainers.image.title=foobar", "foobar", artifact1File})
 		failSession.WaitWithDefaultTimeout()
-		Expect(failSession).Should(Exit(125))
-		Expect(failSession.ErrorToString()).Should(Equal("Error: cannot override filename with org.opencontainers.image.title annotation"))
+		Expect(failSession).Should(ExitWithError(125, "Error: cannot override filename with org.opencontainers.image.title annotation"))
 	})
 
 	It("podman artifact add multiple", func() {
@@ -132,14 +121,9 @@ var _ = Describe("Podman artifact", func() {
 
 		artifact1Name := "localhost/test/artifact1"
 
-		podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact1Name, artifact1File1, artifact1File2}...)
+		podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File1, artifact1File2)
 
-		inspectSingleSession := podmanTest.PodmanExitCleanly([]string{"artifact", "inspect", artifact1Name}...)
-
-		a := libartifact.Artifact{}
-		inspectOut := inspectSingleSession.OutputToString()
-		err = json.Unmarshal([]byte(inspectOut), &a)
-		Expect(err).ToNot(HaveOccurred())
+		a := podmanTest.InspectArtifact(artifact1Name)
 		Expect(a.Name).To(Equal(artifact1Name))
 
 		Expect(a.Manifest.Layers).To(HaveLen(2))
@@ -156,20 +140,16 @@ var _ = Describe("Podman artifact", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		artifact1Name := fmt.Sprintf("localhost:%s/test/artifact1", port)
-		podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact1Name, artifact1File}...)
+		podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File)
 
-		podmanTest.PodmanExitCleanly([]string{"artifact", "push", "-q", "--tls-verify=false", artifact1Name}...)
+		podmanTest.PodmanExitCleanly("artifact", "push", "-q", "--tls-verify=false", artifact1Name)
 
-		podmanTest.PodmanExitCleanly([]string{"artifact", "rm", artifact1Name}...)
+		podmanTest.PodmanExitCleanly("artifact", "rm", artifact1Name)
 
-		podmanTest.PodmanExitCleanly([]string{"artifact", "pull", "--tls-verify=false", artifact1Name}...)
+		podmanTest.PodmanExitCleanly("artifact", "pull", "--tls-verify=false", artifact1Name)
 
-		inspectSingleSession := podmanTest.PodmanExitCleanly([]string{"artifact", "inspect", artifact1Name}...)
+		a := podmanTest.InspectArtifact(artifact1Name)
 
-		a := libartifact.Artifact{}
-		inspectOut := inspectSingleSession.OutputToString()
-		err = json.Unmarshal([]byte(inspectOut), &a)
-		Expect(err).ToNot(HaveOccurred())
 		Expect(a.Name).To(Equal(artifact1Name))
 	})
 
@@ -177,37 +157,35 @@ var _ = Describe("Podman artifact", func() {
 		// Trying to remove an image that does not exist should fail
 		rmFail := podmanTest.Podman([]string{"artifact", "rm", "foobar"})
 		rmFail.WaitWithDefaultTimeout()
-		Expect(rmFail).Should(Exit(125))
-		Expect(rmFail.ErrorToString()).Should(Equal(fmt.Sprintf("Error: no artifact found with name or digest of %s", "foobar")))
+		Expect(rmFail).Should(ExitWithError(125, fmt.Sprintf("Error: no artifact found with name or digest of %s", "foobar")))
 
 		// Add an artifact to remove later
 		artifact1File, err := createArtifactFile(4192)
 		Expect(err).ToNot(HaveOccurred())
 		artifact1Name := "localhost/test/artifact1"
-		addArtifact1 := podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact1Name, artifact1File}...)
+		addArtifact1 := podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File)
 
 		// Removing that artifact should work
-		rmWorks := podmanTest.PodmanExitCleanly([]string{"artifact", "rm", artifact1Name}...)
+		rmWorks := podmanTest.PodmanExitCleanly("artifact", "rm", artifact1Name)
 		// The digests printed by removal should be the same as the digest that was added
 		Expect(addArtifact1.OutputToString()).To(Equal(rmWorks.OutputToString()))
 
 		// Inspecting that the removed artifact should fail
 		inspectArtifact := podmanTest.Podman([]string{"artifact", "inspect", artifact1Name})
 		inspectArtifact.WaitWithDefaultTimeout()
-		Expect(inspectArtifact).Should(Exit(125))
-		Expect(inspectArtifact.ErrorToString()).To(Equal(fmt.Sprintf("Error: no artifact found with name or digest of %s", artifact1Name)))
+		Expect(inspectArtifact).Should(ExitWithError(125, fmt.Sprintf("Error: no artifact found with name or digest of %s", artifact1Name)))
 	})
 
 	It("podman artifact inspect with full or partial digest", func() {
 		artifact1File, err := createArtifactFile(4192)
 		Expect(err).ToNot(HaveOccurred())
 		artifact1Name := "localhost/test/artifact1"
-		addArtifact1 := podmanTest.PodmanExitCleanly([]string{"artifact", "add", artifact1Name, artifact1File}...)
+		addArtifact1 := podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File)
 
 		artifactDigest := addArtifact1.OutputToString()
 
-		podmanTest.PodmanExitCleanly([]string{"artifact", "inspect", artifactDigest}...)
-		podmanTest.PodmanExitCleanly([]string{"artifact", "inspect", artifactDigest[:12]}...)
+		podmanTest.PodmanExitCleanly("artifact", "inspect", artifactDigest)
+		podmanTest.PodmanExitCleanly("artifact", "inspect", artifactDigest[:12])
 
 	})
 


### PR DESCRIPTION
This PR creates a  `--append` flag to add a file to an existing artifact using the `podman artifact add` command.

Fixes: https://issues.redhat.com/browse/RUN-2444

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman artifact add` has new option: `--append`
```

