### PR TITLE
Add --no-trunc to artifact ls

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -1,4 +1,5 @@
 podman-artifact-add.1.md
+podman-artifact-ls.1.md
 podman-artifact-pull.1.md
 podman-artifact-push.1.md
 podman-attach.1.md

--- a/docs/source/markdown/options/no-trunc.md
+++ b/docs/source/markdown/options/no-trunc.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman artifact ls, images
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--no-trunc**
+
+Do not truncate the output (default *false*).

--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -29,23 +29,30 @@ Print results with a Go template.
 | .Tag            | Tag of the artifact name                       |
 
 
+@@option no-trunc
 
 ## EXAMPLES
 
 List artifacts in the local store
 ```
 $ podman artifact ls
-REPOSITORY                TAG         DIGEST                                                            SIZE
-quay.io/artifact/foobar1  latest      ab609fad386df1433f461b0643d9cf575560baf633809dcc9c190da6cc3a3c29  2.097GB
-quay.io/artifact/foobar2  special     cd734b558ceb8ccc0281ca76530e1dea1eb479407d3163f75fb601bffb6f73d0  12.58MB
-
-
+REPOSITORY                TAG         DIGEST             SIZE
+quay.io/artifact/foobar1  latest      ab609fad386d       2.097GB
+quay.io/artifact/foobar2  special     cd734b558ceb       12.58MB
 ```
+
+List artifacts in the local store without truncating the digest
+```
+REPOSITORY                TAG         DIGEST                                                              SIZE
+quay.io/artifact/foobar1  latest      ab609fad386df1433f461b0643d9cf575560baf633809dcc9c190da6cc3a3c29    2.097GB
+quay.io/artifact/foobar2  special     cd734b558ceb8ccc0281ca76530e1dea1eb479407d3163f75fb601bffb6f73d0    12.58MB
+```
+
 List artifact digests and size using a --format
 ```
 $ podman artifact ls --format "{{.Digest}} {{.Size}}"
-ab609fad386df1433f461b0643d9cf575560baf633809dcc9c190da6cc3a3c29 2.097GB
-cd734b558ceb8ccc0281ca76530e1dea1eb479407d3163f75fb601bffb6f73d0 12.58MB
+ab609fad386d 2.097GB
+cd734b558ceb 12.58MB
 ```
 
 

--- a/docs/source/markdown/podman-images.1.md.in
+++ b/docs/source/markdown/podman-images.1.md.in
@@ -106,9 +106,7 @@ Valid placeholders for the Go template are listed below:
 
 Display the history of image names.  If an image gets re-tagged or untagged, then the image name history gets prepended (latest image first).  This is especially useful when undoing a tag operation or an image does not contain any name because it has been untagged.
 
-#### **--no-trunc**
-
-Do not truncate the output (default *false*).
+@@option no-trunc
 
 @@option noheading
 


### PR DESCRIPTION
added a --no-trunc flag to artifact ls, which follows what images has done.  by default now, the ls output will have the shortened 12 character digest.  the --no-trunc will output the full digest.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `no-trunc` option to artifact ls and shortened digests in default ls output to 12 characters.
```
