### PR TITLE
artifact: only allow single manifest

### DIFF
--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -94,9 +94,9 @@ var _ = Describe("Podman artifact", func() {
 		err = json.Unmarshal([]byte(inspectSingleSession.OutputToString()), &a)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(a.Name).To(Equal(artifact1Name))
-		Expect(a.Manifests[0].ArtifactType).To(Equal(artifactType))
-		Expect(a.Manifests[0].Layers[0].Annotations["color"]).To(Equal("blue"))
-		Expect(a.Manifests[0].Layers[0].Annotations["flavor"]).To(Equal("lemon"))
+		Expect(a.Manifest.ArtifactType).To(Equal(artifactType))
+		Expect(a.Manifest.Layers[0].Annotations["color"]).To(Equal("blue"))
+		Expect(a.Manifest.Layers[0].Annotations["flavor"]).To(Equal("lemon"))
 
 		failSession := podmanTest.Podman([]string{"artifact", "add", "--annotation", "org.opencontainers.image.title=foobar", "foobar", artifact1File})
 		failSession.WaitWithDefaultTimeout()
@@ -122,11 +122,7 @@ var _ = Describe("Podman artifact", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(a.Name).To(Equal(artifact1Name))
 
-		var layerCount int
-		for _, layer := range a.Manifests {
-			layerCount += len(layer.Layers)
-		}
-		Expect(layerCount).To(Equal(2))
+		Expect(a.Manifest.Layers).To(HaveLen(2))
 	})
 
 	It("podman artifact push and pull", func() {


### PR DESCRIPTION
Allowing for multiple manifest per artifact just makes the code and cli design harder to work with it. It is not clear how mounting, extracting or edit on a multi manifest artifact should have worked.

A single manifest should make the code much easier to work with.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
