### PR TITLE
Force use of iptables on Windows WSL

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -12,6 +12,11 @@ const containersConf = `[containers]
 
 [engine]
 cgroup_manager = "cgroupfs"
+
+# Using iptables until we fix nftables on WSL:
+# https://github.com/containers/podman/issues/25201
+[network]
+firewall_driver="iptables"
 `
 
 const registriesConf = `unqualified-search-registries=["docker.io"]


### PR DESCRIPTION
This is a workaround for #25201 and helps with
upgrading the WSL image to Fedora 41.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
