### PR TITLE
Add --noheading to artifact ls

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -31,8 +31,9 @@ var (
 )
 
 type listFlagType struct {
-	format  string
-	noTrunc bool
+	format    string
+	noHeading bool
+	noTrunc   bool
 }
 
 type artifactListOutput struct {
@@ -55,6 +56,7 @@ func init() {
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, defaultArtifactListOutputFormat, "Format volume output using JSON or a Go template")
 	_ = listCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&artifactListOutput{}))
+	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print column headings")
 	flags.BoolVar(&listFlag.noTrunc, "no-trunc", false, "Do not truncate output")
 }
 
@@ -132,7 +134,7 @@ func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) erro
 		return err
 	}
 
-	if rpt.RenderHeaders {
+	if rpt.RenderHeaders && !listFlag.noHeading {
 		if err := rpt.Execute(headers); err != nil {
 			return fmt.Errorf("failed to write report column headers: %w", err)
 		}

--- a/docs/source/markdown/options/noheading.md
+++ b/docs/source/markdown/options/noheading.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman image trust, images, machine list, network ls, pod ps, secret ls, volume ls
+####>   podman artifact ls, image trust, images, machine list, network ls, pod ps, secret ls, volume ls
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--noheading**, **-n**

--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -28,8 +28,9 @@ Print results with a Go template.
 | .Size           | Size artifact in human readable units          |
 | .Tag            | Tag of the artifact name                       |
 
-
 @@option no-trunc
+
+@@option noheading
 
 ## EXAMPLES
 
@@ -43,9 +44,17 @@ quay.io/artifact/foobar2  special     cd734b558ceb       12.58MB
 
 List artifacts in the local store without truncating the digest
 ```
+$ podman artifact ls --no-trunc
 REPOSITORY                TAG         DIGEST                                                              SIZE
 quay.io/artifact/foobar1  latest      ab609fad386df1433f461b0643d9cf575560baf633809dcc9c190da6cc3a3c29    2.097GB
 quay.io/artifact/foobar2  special     cd734b558ceb8ccc0281ca76530e1dea1eb479407d3163f75fb601bffb6f73d0    12.58MB
+```
+
+List artifacts in the local store without the title header
+```
+$ podman artifact ls --noheading
+quay.io/artifact/foobar1  latest      ab609fad386d       2.097GB
+quay.io/artifact/foobar2  special     cd734b558ceb       12.58MB
 ```
 
 List artifact digests and size using a --format

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -55,6 +55,12 @@ var _ = Describe("Podman artifact", func() {
 		truncOutput := noTruncSession.OutputToStringArray()[0]
 		Expect(truncOutput).To(HaveLen(len(add1.OutputToString())))
 
+		// check with --noheading and verify the header is not present through a line count AND substring match
+		noHeaderSession := podmanTest.PodmanExitCleanly([]string{"artifact", "ls", "--noheading"}...)
+		noHeaderOutput := noHeaderSession.OutputToStringArray()
+		Expect(noHeaderOutput).To(HaveLen(2))
+		Expect(noHeaderOutput).ToNot(ContainElement("REPOSITORY"))
+
 	})
 
 	It("podman artifact simple add", func() {


### PR DESCRIPTION
like images and containers, it could be handy to have a --noheading option that removes the headings on the output.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add --noheading to `podman artifact ls`
```
