### PR TITLE
rpm: add attr as dependency for podman-tests

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -144,6 +144,7 @@ Requires: %{name} = %{epoch}:%{version}-%{release}
 %if %{defined fedora}
 Requires: bats
 %endif
+Requires: attr
 Requires: jq
 Requires: skopeo
 Requires: nmap-ncat


### PR DESCRIPTION
Since commit 06c103469d we are using getfattr in system tests, that caused failures in gating tests[1] as getfattr was not installed. So add attr as dependency.

[1] https://artifacts.dev.testing-farm.io/d93b6849-e526-46e9-a7c3-874bad4217a9/work-tests.yml8_p4nfkf/tests-n75vnz0u/test.podman-root.bats.log

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
