### PR TITLE
[v5.4] Bump Buildah to v1.39.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.3.0
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.5.1
-	github.com/containers/buildah v1.38.1-0.20250125114111-92015b7f4301
+	github.com/containers/buildah v1.39.0
 	github.com/containers/common v0.62.0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.2

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8F
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
 github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
-github.com/containers/buildah v1.38.1-0.20250125114111-92015b7f4301 h1:eqHczpfbWOjyvQAkuCmzsZPds657cPXxXniXLcKFHdQ=
-github.com/containers/buildah v1.38.1-0.20250125114111-92015b7f4301/go.mod h1:UOhJzUS2A0uyZR/TygObcg2Og+nJ02pwMfVhIQBRIN8=
+github.com/containers/buildah v1.39.0 h1:/OpzH7eMQYLg6pyguk6vugqScoZm8fIiN6wgMre9nUY=
+github.com/containers/buildah v1.39.0/go.mod h1:PTC4lCOwVfT3esN7Kxf2j8Aa3uqxsyUZudECLeGJlkY=
 github.com/containers/common v0.62.0 h1:Sl9WE5h7Y/F3bejrMAA4teP1EcY9ygqJmW4iwSloZ10=
 github.com/containers/common v0.62.0/go.mod h1:Yec+z8mrSq4rydHofrnDCBqAcNA/BGrSg1kfFUL6F6s=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -234,6 +234,7 @@ integration_task:
 
     gce_instance:
         image_name: "$IMAGE_NAME"
+        cpu: 4
 
     # Separate scripts for separate outputs, makes debugging easier.
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
@@ -281,6 +282,7 @@ integration_rootless_task:
 
     gce_instance:
         image_name: "$IMAGE_NAME"
+        cpu: 4
 
     # Separate scripts for separate outputs, makes debugging easier.
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
@@ -298,6 +300,9 @@ in_podman_task:
     alias: in_podman
     skip: *not_build_docs
     depends_on: *smoke_vendor
+
+    gce_instance:
+        cpu: 4
 
     env:
         # This is key, cause the scripts to re-execute themselves inside a container.

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,97 @@
 
 # Changelog
 
+## v1.39.0 (2025-01-31)
+
+    Bump c/storage v1.57.1, c/image 5.34.0,  c/common v0.62.0
+    Update module github.com/containers/storage to v1.57.0
+    CI, .cirrus: parallelize containerized integration
+    ed's comment: cleanup
+    use seperate blobinfocache for flaky test
+    bump CI VMs to 4 CPUs (was: 2) for integration tests
+    cleanup, debug, and disable parallel in blobcache tests
+    bats tests - parallelize
+    pkg/overlay: cleanups
+    RPM: include check section to silence rpmlint
+    RPM: use default gobuild macro on RHEL
+    tests: remove masked /sys/dev/block check
+    vendor to latest c/{common,image,storage}
+    build, run: record hash or digest in image history
+    Accept image names as sources for cache mounts
+    Run(): always clean up options.ExternalImageMounts
+    refactor: replace golang.org/x/exp with stdlib
+    Update to c/image @main
+    fix broken doc link
+    run_freebsd.go: only import runtime-spec once
+    fix(deps): update module github.com/docker/docker to v27.5.1+incompatible
+    bump github.com/vbatts/tar-split
+    Add more checks to the --mount flag parsing logic
+    chroot mount flags integration test: copy binaries
+    fix(deps): update module github.com/moby/buildkit to v0.19.0
+    relabel(): correct a misleading parameter name
+    Fix TOCTOU error when bind and cache mounts use "src" values
+    define.TempDirForURL(): always use an intermediate subdirectory
+    internal/volume.GetBindMount(): discard writes in bind mounts
+    pkg/overlay: add a MountLabel flag to Options
+    pkg/overlay: add a ForceMount flag to Options
+    Add internal/volumes.bindFromChroot()
+    Add an internal/open package
+    fix(deps): update module github.com/containers/common to v0.61.1
+    fix(deps): update module github.com/containers/image/v5 to v5.33.1
+    [CI:DOCS] Touch up changelogs
+    fix(deps): update module github.com/docker/docker to v27.5.0+incompatible
+    copy-preserving-extended-attributes: use a different base image
+    fix(deps): update github.com/containers/luksy digest to a3a812d
+    chore(deps): update module golang.org/x/net to v0.33.0 [security]
+    fix(deps): update module golang.org/x/crypto to v0.32.0
+    New VM Images
+    fix(deps): update module github.com/opencontainers/runc to v1.2.4
+    fix(deps): update module github.com/docker/docker to v27.4.1+incompatible
+    fix(deps): update module github.com/containers/ocicrypt to v1.2.1
+    Add support for --security-opt mask and unmask
+    Allow cache mounts to be stages or additional build contexts
+    [skip-ci] RPM: cleanup changelog conditionals
+    fix(deps): update module github.com/cyphar/filepath-securejoin to v0.3.6
+    fix(deps): update module github.com/moby/buildkit to v0.18.2
+    Fix an error message in the chroot unit test
+    copier: use .PAXRecords instead of .Xattrs
+    chroot: on Linux, try to pivot_root before falling back to chroot
+    manifest add: add --artifact-annotation
+    Add context to an error message
+    Update module golang.org/x/crypto to v0.31.0
+    Update module github.com/opencontainers/runc to v1.2.3
+    Update module github.com/docker/docker to v27.4.0+incompatible
+    Update module github.com/cyphar/filepath-securejoin to v0.3.5
+    CI: don't build a binary in the unit tests task
+    CI: use /tmp for $GOCACHE
+    CI: remove dependencies on the cross-build task
+    CI: run cross-compile task with make -j
+    Update module github.com/docker/docker to v27.4.0-rc.4+incompatible
+    Update module github.com/moby/buildkit to v0.18.1
+    Update module golang.org/x/crypto to v0.30.0
+    Update golang.org/x/exp digest to 2d47ceb
+    Update github.com/opencontainers/runtime-tools digest to f7e3563
+    [skip-ci] Packit: remove rhel copr build jobs
+    [skip-ci] Packit: switch to fedora-all for copr
+    Update module github.com/stretchr/testify to v1.10.0
+    Update module github.com/moby/buildkit to v0.17.2
+    Makefile: use `find` to detect source files
+    Tests: make _prefetch() parallel-safe
+    Update module github.com/opencontainers/runc to v1.2.2
+    executor: allow to specify --no-pivot-root
+    Update module github.com/moby/sys/capability to v0.4.0
+    Makefile: mv codespell config to .codespellrc
+    Fix some codespell errors
+    Makefile,install.md: rm gopath stuff
+    Makefile: rm targets working on ..
+    build: rm exclude_graphdriver_devicemapper tag
+    Makefile: rm unused var
+    Finish updating to go 1.22
+    CI VMs: bump again
+    Bump to Buidah v1.39.0-dev
+    stage_executor: set avoidLookingCache only if mounting stage
+    imagebuildah: additionalContext is not a local built stage
+
 ## v1.38.0 (2024-11-08)
 
     Bump to c/common v0.61.0, c/image v5.33.0, c/storage v1.56.0

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,93 @@
+- Changelog for v1.39.0 (2025-01-31)
+  * Bump c/storage v1.57.1, c/image 5.34.0,  c/common v0.62.0
+  * Update module github.com/containers/storage to v1.57.0
+  * CI, .cirrus: parallelize containerized integration
+  * ed's comment: cleanup
+  * use seperate blobinfocache for flaky test
+  * bump CI VMs to 4 CPUs (was: 2) for integration tests
+  * cleanup, debug, and disable parallel in blobcache tests
+  * bats tests - parallelize
+  * pkg/overlay: cleanups
+  * RPM: include check section to silence rpmlint
+  * RPM: use default gobuild macro on RHEL
+  * tests: remove masked /sys/dev/block check
+  * vendor to latest c/{common,image,storage}
+  * build, run: record hash or digest in image history
+  * Accept image names as sources for cache mounts
+  * Run(): always clean up options.ExternalImageMounts
+  * refactor: replace golang.org/x/exp with stdlib
+  * Update to c/image @main
+  * fix broken doc link
+  * run_freebsd.go: only import runtime-spec once
+  * fix(deps): update module github.com/docker/docker to v27.5.1+incompatible
+  * bump github.com/vbatts/tar-split
+  * Add more checks to the --mount flag parsing logic
+  * chroot mount flags integration test: copy binaries
+  * fix(deps): update module github.com/moby/buildkit to v0.19.0
+  * relabel(): correct a misleading parameter name
+  * Fix TOCTOU error when bind and cache mounts use "src" values
+  * define.TempDirForURL(): always use an intermediate subdirectory
+  * internal/volume.GetBindMount(): discard writes in bind mounts
+  * pkg/overlay: add a MountLabel flag to Options
+  * pkg/overlay: add a ForceMount flag to Options
+  * Add internal/volumes.bindFromChroot()
+  * Add an internal/open package
+  * fix(deps): update module github.com/containers/common to v0.61.1
+  * fix(deps): update module github.com/containers/image/v5 to v5.33.1
+  * [CI:DOCS] Touch up changelogs
+  * fix(deps): update module github.com/docker/docker to v27.5.0+incompatible
+  * copy-preserving-extended-attributes: use a different base image
+  * fix(deps): update github.com/containers/luksy digest to a3a812d
+  * chore(deps): update module golang.org/x/net to v0.33.0 [security]
+  * fix(deps): update module golang.org/x/crypto to v0.32.0
+  * New VM Images
+  * fix(deps): update module github.com/opencontainers/runc to v1.2.4
+  * fix(deps): update module github.com/docker/docker to v27.4.1+incompatible
+  * fix(deps): update module github.com/containers/ocicrypt to v1.2.1
+  * Add support for --security-opt mask and unmask
+  * Allow cache mounts to be stages or additional build contexts
+  * [skip-ci] RPM: cleanup changelog conditionals
+  * fix(deps): update module github.com/cyphar/filepath-securejoin to v0.3.6
+  * fix(deps): update module github.com/moby/buildkit to v0.18.2
+  * Fix an error message in the chroot unit test
+  * copier: use .PAXRecords instead of .Xattrs
+  * chroot: on Linux, try to pivot_root before falling back to chroot
+  * manifest add: add --artifact-annotation
+  * Add context to an error message
+  * Update module golang.org/x/crypto to v0.31.0
+  * Update module github.com/opencontainers/runc to v1.2.3
+  * Update module github.com/docker/docker to v27.4.0+incompatible
+  * Update module github.com/cyphar/filepath-securejoin to v0.3.5
+  * CI: don't build a binary in the unit tests task
+  * CI: use /tmp for $GOCACHE
+  * CI: remove dependencies on the cross-build task
+  * CI: run cross-compile task with make -j
+  * Update module github.com/docker/docker to v27.4.0-rc.4+incompatible
+  * Update module github.com/moby/buildkit to v0.18.1
+  * Update module golang.org/x/crypto to v0.30.0
+  * Update golang.org/x/exp digest to 2d47ceb
+  * Update github.com/opencontainers/runtime-tools digest to f7e3563
+  * [skip-ci] Packit: remove rhel copr build jobs
+  * [skip-ci] Packit: switch to fedora-all for copr
+  * Update module github.com/stretchr/testify to v1.10.0
+  * Update module github.com/moby/buildkit to v0.17.2
+  * Makefile: use `find` to detect source files
+  * Tests: make _prefetch() parallel-safe
+  * Update module github.com/opencontainers/runc to v1.2.2
+  * executor: allow to specify --no-pivot-root
+  * Update module github.com/moby/sys/capability to v0.4.0
+  * Makefile: mv codespell config to .codespellrc
+  * Fix some codespell errors
+  * Makefile,install.md: rm gopath stuff
+  * Makefile: rm targets working on ..
+  * build: rm exclude_graphdriver_devicemapper tag
+  * Makefile: rm unused var
+  * Finish updating to go 1.22
+  * CI VMs: bump again
+  * Bump to Buidah v1.39.0-dev
+  * stage_executor: set avoidLookingCache only if mounting stage
+  * imagebuildah: additionalContext is not a local built stage
+
 - Changelog for v1.38.0 (2024-11-08)
   * Bump to c/common v0.61.0, c/image v5.33.0, c/storage v1.56.0
   * fix(deps): update module golang.org/x/crypto to v0.29.0

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.39.0-dev"
+	Version = "1.39.0"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,7 +147,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.5.1
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.38.1-0.20250125114111-92015b7f4301
+# github.com/containers/buildah v1.39.0
 ## explicit; go 1.22.8
 github.com/containers/buildah
 github.com/containers/buildah/bind


### PR DESCRIPTION
Bump Buildah to v1.39.0 in preparation for Podman v5.4.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
