### PR TITLE
Fix flake test: `podman pause/unpause with HealthCheck interval`

### DIFF
--- a/test/system/080-pause.bats
+++ b/test/system/080-pause.bats
@@ -106,7 +106,11 @@ load helpers.systemd
     run_podman healthcheck run $ctrname
     is "$output" "" "output from 'podman healthcheck run'"
 
-    run -0 systemctl status $cid-*.{service,timer}
+    # We checking only timer because checking of service caused unexpected exit code 3 of systemctl status.
+    # Since the status check can be executed when HealthCheck was exited, this caused a termination error code 3
+    # for systemctl status. Because service was in dead state because HealthCheck exited.
+    # https://github.com/containers/podman/issues/25204
+    run -0 systemctl status $cid-*.timer
     assert "$output" =~ "active" "service should be running"
 
     run_podman --noout pause $ctrname
@@ -121,7 +125,7 @@ load helpers.systemd
     run_podman healthcheck run $ctrname
     is "$output" "" "output from 'podman healthcheck run'"
 
-    run -0 systemctl status $cid-*.{service,timer}
+    run -0 systemctl status $cid-*.timer
     assert "$output" =~ "active" "service should be running"
 
     run_podman rm -t 0 -f $ctrname


### PR DESCRIPTION
This PR fixes flake test: `podman pause/unpause with HealthCheck interval`. 


Checking of service and timer caused unexpected exit code `3` of `systemctl status`. Since the status check can be executed when HealthCheck was exited, this caused a termination error code `3` for `systemctl status`. Because service was in dead state because HealthCheck exited.

Fixes: https://github.com/containers/podman/issues/25204

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
