### PR TITLE
[skip-ci] RPM: set BUILD_ORIGIN

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -45,6 +45,12 @@
 # podman-machine subpackage will be present only on these architectures
 %global machine_arches x86_64 aarch64
 
+%if %{defined copr_build}
+%define build_origin Copr: %{?copr_username}/%{?copr_projectname}
+%else
+%define build_origin %{?packager}
+%endif
+
 Name: podman
 %if %{defined copr_build}
 Epoch: 102
@@ -242,6 +248,7 @@ export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 export GOPROXY=direct
 
 LDFLAGS="-X %{ld_libpod}/define.buildInfo=${SOURCE_DATE_EPOCH:-$(date +%s)} \
+         -X "%{ld_libpod}/define.buildOrigin=%{build_origin}" \
          -X %{ld_libpod}/config._installPrefix=%{_prefix} \
          -X %{ld_libpod}/config._etcDir=%{_sysconfdir} \
          -X %{ld_project}/pkg/systemd/quadlet._binDir=%{_bindir}"

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -248,7 +248,7 @@ export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 export GOPROXY=direct
 
 LDFLAGS="-X %{ld_libpod}/define.buildInfo=${SOURCE_DATE_EPOCH:-$(date +%s)} \
-         -X "%{ld_libpod}/define.buildOrigin=%{build_origin}" \
+         -X \"%{ld_libpod}/define.buildOrigin=%{build_origin}\" \
          -X %{ld_libpod}/config._installPrefix=%{_prefix} \
          -X %{ld_libpod}/config._etcDir=%{_sysconfdir} \
          -X %{ld_project}/pkg/systemd/quadlet._binDir=%{_bindir}"


### PR DESCRIPTION
For Copr builds, it will mention the Copr info from where the rpm is
installed.

For non-copr builds, it will mention the value of the packager macro
if set, and skip this field altogether if not.

On local rpm builds, this shows:
```
Build Origin:  Lokesh Mandvekar <lsm5@fedoraproject.org>
```

On koji rpm builds, this shows:
```
Build Origin: Fedora Project
```

On copr rpm builds (for eg. rhcontainerbot/playground), this shows:
```
Build Origin: Copr: rhcontainerbot/playground
```
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
