### PR TITLE
add podman artifact extract

### DIFF
--- a/cmd/podman/artifact/extract.go
+++ b/cmd/podman/artifact/extract.go
@@ -1,0 +1,52 @@
+package artifact
+
+import (
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v5/cmd/podman/common"
+	"github.com/containers/podman/v5/cmd/podman/registry"
+	"github.com/containers/podman/v5/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	extractCmd = &cobra.Command{
+		Use:               "extract [options] ARTIFACT PATH",
+		Short:             "Extract an OCI artifact to a local path",
+		Long:              "Extract the blobs of an OCI artifact to a local file or directory",
+		RunE:              extract,
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: common.AutocompleteArtifactAdd,
+		Example: `podman artifact Extract quay.io/myimage/myartifact:latest /tmp/foobar.txt
+podman artifact Extract quay.io/myimage/myartifact:latest /home/paul/mydir`,
+		Annotations: map[string]string{registry.EngineMode: registry.ABIMode},
+	}
+)
+
+var (
+	extractOpts entities.ArtifactExtractOptions
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: extractCmd,
+		Parent:  artifactCmd,
+	})
+	flags := extractCmd.Flags()
+
+	digestFlagName := "digest"
+	flags.StringVar(&extractOpts.Digest, digestFlagName, "", "Only extract blob with the given digest")
+	_ = extractCmd.RegisterFlagCompletionFunc(digestFlagName, completion.AutocompleteNone)
+
+	titleFlagName := "title"
+	flags.StringVar(&extractOpts.Title, titleFlagName, "", "Only extract blob with the given title")
+	_ = extractCmd.RegisterFlagCompletionFunc(titleFlagName, completion.AutocompleteNone)
+}
+
+func extract(cmd *cobra.Command, args []string) error {
+	err := registry.ImageEngine().ArtifactExtract(registry.Context(), args[0], args[1], &extractOpts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/docs/source/markdown/podman-artifact-extract.1.md
+++ b/docs/source/markdown/podman-artifact-extract.1.md
@@ -1,0 +1,83 @@
+% podman-artifact-extract 1
+
+
+## WARNING: Experimental command
+*This command is considered experimental and still in development. Inputs, options, and outputs are all
+subject to change.*
+
+## NAME
+podman\-artifact\-extract - Extract an OCI artifact to a local path
+
+## SYNOPSIS
+**podman artifact extract** *artifact* *target*
+
+## DESCRIPTION
+
+Extract the blobs of an OCI artifact to a local file or directory.
+
+If the target path is a file or does not exist, the artifact must either consist
+of one blob (layer) or if it has multiple blobs (layers) then the **--digest** or
+**--title** option must be used to select only a single blob. If the file already
+exists it will be overwritten.
+
+If the target is a directory (it must exist), all blobs will be copied to the
+target directory. As the target file name the value from the `org.opencontainers.image.title`
+annotation is used. If the annotation is missing, the target file name will be the
+digest of the blob (with `:` replaced by `-` in the name).
+If the target file already exists in the directory, it will be overwritten.
+
+## OPTIONS
+
+#### **--digest**=**digest**
+
+When extracting blobs from the artifact only use the one with the specified digest.
+If the target is a directory then the digest is always used as file name instead even
+when the title annotation exists on the blob.
+Conflicts with **--title**.
+
+#### **--help**
+
+Print usage statement.
+
+#### **--title**=**title**
+
+When extracting blobs from the artifact only use the one with the specified title.
+It looks for the `org.opencontainers.image.title` annotation and compares that
+against the given title.
+Conflicts with **--digest**.
+
+## EXAMPLES
+
+Extract an artifact with a single blob
+
+```
+$ podman artifact extract quay.io/artifact/foobar1:test /tmp/myfile
+```
+
+Extract an artifact with multiple blobs
+
+```
+$ podman artifact extract quay.io/artifact/foobar2:test /tmp/mydir
+$ ls /tmp/mydir
+CONTRIBUTING.md  README.md
+```
+
+Extract only a single blob from an artifact with multiple blobs
+
+```
+$ podman artifact extract --title README.md quay.io/artifact/foobar2:test /tmp/mydir
+$ ls /tmp/mydir
+README.md
+```
+Or using the digest instead of the title
+```
+$ podman artifact extract --digest sha256:c0594e012b17fd9e6548355ceb571a79613f7bb988d7d883f112513601ac6e9a quay.io/artifact/foobar2:test /tmp/mydir
+$ ls /tmp/mydir
+README.md
+```
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-artifact(1)](podman-artifact.1.md)**
+
+## HISTORY
+Feb 2025, Originally compiled by Paul Holzinger <pholzing@redhat.com>

--- a/docs/source/markdown/podman-artifact.1.md
+++ b/docs/source/markdown/podman-artifact.1.md
@@ -22,6 +22,7 @@ from its local "artifact store".
 | Command | Man Page                                                   | Description                                                  |
 |---------|------------------------------------------------------------|--------------------------------------------------------------|
 | add     | [podman-artifact-add(1)](podman-artifact-add.1.md)         | Add an OCI artifact to the local store                       |
+| extract | [podman-artifact-extract(1)](podman-artifact-extract.1.md) | Extract an OCI artifact to a local path                      |
 | inspect | [podman-artifact-inspect(1)](podman-artifact-inspect.1.md) | Inspect an OCI artifact                                      |
 | ls      | [podman-artifact-ls(1)](podman-artifact-ls.1.md)           | List OCI artifacts in local store                            |
 | pull    | [podman-artifact-pull(1)](podman-artifact-pull.1.md)       | Pulls an artifact from a registry and stores it locally      |

--- a/pkg/domain/entities/artifact.go
+++ b/pkg/domain/entities/artifact.go
@@ -14,6 +14,15 @@ type ArtifactAddOptions struct {
 	ArtifactType string
 }
 
+type ArtifactExtractOptions struct {
+	// Title annotation value to extract only a single blob matching that name.
+	// Conflicts with Digest. Optional.
+	Title string
+	// Digest of the blob to extract.
+	// Conflicts with Title. Optional.
+	Digest string
+}
+
 type ArtifactInspectOptions struct {
 	Remote bool
 }

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -10,6 +10,7 @@ import (
 
 type ImageEngine interface { //nolint:interfacebloat
 	ArtifactAdd(ctx context.Context, name string, paths []string, opts *ArtifactAddOptions) (*ArtifactAddReport, error)
+	ArtifactExtract(ctx context.Context, name string, target string, opts *ArtifactExtractOptions) error
 	ArtifactInspect(ctx context.Context, name string, opts ArtifactInspectOptions) (*ArtifactInspectReport, error)
 	ArtifactList(ctx context.Context, opts ArtifactListOptions) ([]*ArtifactListReport, error)
 	ArtifactPull(ctx context.Context, name string, opts ArtifactPullOptions) (*ArtifactPullReport, error)

--- a/pkg/domain/infra/abi/artifact.go
+++ b/pkg/domain/infra/abi/artifact.go
@@ -172,3 +172,16 @@ func (ir *ImageEngine) ArtifactAdd(ctx context.Context, name string, paths []str
 		ArtifactDigest: artifactDigest,
 	}, nil
 }
+
+func (ir *ImageEngine) ArtifactExtract(ctx context.Context, name string, target string, opts *entities.ArtifactExtractOptions) error {
+	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	if err != nil {
+		return err
+	}
+	extractOpt := &types.ExtractOptions{
+		Digest: opts.Digest,
+		Title:  opts.Title,
+	}
+
+	return artStore.Extract(ctx, name, target, extractOpt)
+}

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -9,7 +9,7 @@ import (
 
 // TODO For now, no remote support has been added. We need the API to firm up first.
 
-func ArtifactAdd(ctx context.Context, path, name string, opts entities.ArtifactAddOptions) error {
+func (ir *ImageEngine) ArtifactExtract(ctx context.Context, name string, target string, opts *entities.ArtifactExtractOptions) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/libartifact/types/config.go
+++ b/pkg/libartifact/types/config.go
@@ -9,3 +9,10 @@ type AddOptions struct {
 	Annotations  map[string]string `json:"annotations,omitempty"`
 	ArtifactType string            `json:",omitempty"`
 }
+
+type ExtractOptions struct {
+	// Title annotation value to extract only a single blob matching that name. Optional.
+	Title string
+	// Digest of the blob to extract. Optional.
+	Digest string
+}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1610,3 +1610,10 @@ func createArtifactFile(numBytes int64) (string, error) {
 	}
 	return outFile, nil
 }
+
+func makeTempDirInDir(dir string) string {
+	GinkgoHelper()
+	path, err := os.MkdirTemp(dir, "podman-test")
+	Expect(err).ToNot(HaveOccurred())
+	return path
+}


### PR DESCRIPTION
Add a new command to extract the blob content of the artifact store to a local path.

Fixes https://issues.redhat.com/browse/RUN-2445

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a new podman artifact extract command.
```
