### PR TITLE
rootless: fix hang on s390x

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -658,7 +658,7 @@ create_pause_process (const char *pause_pid_file_path, char **argv)
   if (pipe (p) < 0)
     return -1;
 
-  pid = fork ();
+  pid = syscall_clone (SIGCHLD, NULL);
   if (pid < 0)
     {
       close (p[0]);
@@ -689,7 +689,7 @@ create_pause_process (const char *pause_pid_file_path, char **argv)
       close (p[0]);
 
       setsid ();
-      pid = fork ();
+      pid = syscall_clone (SIGCHLD, NULL);
       if (pid < 0)
         _exit (EXIT_FAILURE);
 


### PR DESCRIPTION
avoid using the glibc fork() function after using directly the clone() syscall, as it confuses glibc causing the fork() to hang in some cases.

The issue has been observed only on s390x, and the fix was confirmed in the issue discussion.

Closes: https://github.com/containers/podman/issues/25184

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a potential hang on s390x when running as rootless and Podman needs to reexecute itself
```
