### PR TITLE
Testing WSL image based on Fedora 41 (don't merge)

### DIFF
--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -101,8 +101,10 @@ func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, endpoint 
 		imageName := artifactImageName
 		if vmType == define.WSLVirt {
 			imageName = artifactImageNameWSL
+			endpoint = fmt.Sprintf("docker://%s/%s/%s:%s", artifactRegistry, "mloriedo", imageName, "5.5-next")
+		} else {
+			endpoint = fmt.Sprintf("docker://%s/%s/%s:%s", artifactRegistry, artifactRepo, imageName, artifactVersion.majorMinor())
 		}
-		endpoint = fmt.Sprintf("docker://%s/%s/%s:%s", artifactRegistry, artifactRepo, imageName, artifactVersion.majorMinor())
 		cache = true
 	}
 


### PR DESCRIPTION
The goal of this PR is to check if [Fedora 41 based WSL image](https://github.com/containers/podman-machine-wsl-os/pull/13) breaks machine e2e tests. It's not supposed to be merged. 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
