### PR TITLE
Default podman machine list --all-providers to true

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -62,7 +62,7 @@ func init() {
 	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.ListReporter{}))
 	flags.BoolVarP(&listFlag.noHeading, "noheading", "n", false, "Do not print headers")
 	flags.BoolVarP(&listFlag.quiet, "quiet", "q", false, "Show only machine names")
-	flags.BoolVar(&listFlag.allProviders, "all-providers", false, "Show machines from all providers")
+	flags.BoolVar(&listFlag.allProviders, "all-providers", true, "Show machines from all providers")
 }
 
 func list(cmd *cobra.Command, args []string) error {

--- a/docs/source/markdown/podman-machine-list.1.md.in
+++ b/docs/source/markdown/podman-machine-list.1.md.in
@@ -26,9 +26,10 @@ environment variable while the machines are running can lead to unexpected behav
 
 ## OPTIONS
 
-#### **--all-providers**
+#### **--all-providers**=**true|false**
 
-Show machines from all providers
+Show machines from all providers.
+The default is **true**.
 
 #### **--format**=*format*
 

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -210,7 +210,13 @@ function check_help() {
         is "${lines[0]}" "Manage pods, containers and images" \
            "podman $helpopt: first line of output"
     done
+}
 
+# bats test_tags=ci:parallel
+@test "podman machine list --help tests" {
+    skip_if_remote
+    run_podman machine list --help
+    is "$output" ".*--all-providers   Show machines from all providers (default true)" "All providers default to true"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
Podman Desktop would like this to be the default, and I see little reason why it would not be the default.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman machine --list will now default to showing all machines for all profiles.
```
