### PR TITLE
libpod: make hasCapSysResource platform-specific

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -18,7 +18,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -53,7 +52,6 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	stypes "github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/moby/sys/capability"
 	runcuser "github.com/moby/sys/user"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -178,18 +176,6 @@ func getOverlayUpperAndWorkDir(options []string) (string, string, error) {
 	}
 	return upperDir, workDir, nil
 }
-
-// hasCapSysResource returns whether the current process has CAP_SYS_RESOURCE.
-var hasCapSysResource = sync.OnceValues(func() (bool, error) {
-	currentCaps, err := capability.NewPid2(0)
-	if err != nil {
-		return false, err
-	}
-	if err = currentCaps.Load(); err != nil {
-		return false, err
-	}
-	return currentCaps.Get(capability.EFFECTIVE, capability.CAP_SYS_RESOURCE), nil
-})
 
 // Generate spec for a container
 // Accepts a map of the container's dependencies

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -410,3 +410,8 @@ func (c *Container) hasPrivateUTS() bool {
 	// specification.
 	return true
 }
+
+// hasCapSysResource returns whether the current process has CAP_SYS_RESOURCE.
+func hasCapSysResource() (bool, error) {
+	return true, nil
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/libpod/shutdown"
 	"github.com/containers/podman/v5/pkg/rootless"
+	"github.com/moby/sys/capability"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -835,3 +836,15 @@ func (c *Container) hasPrivateUTS() bool {
 	}
 	return privateUTS
 }
+
+// hasCapSysResource returns whether the current process has CAP_SYS_RESOURCE.
+var hasCapSysResource = sync.OnceValues(func() (bool, error) {
+	currentCaps, err := capability.NewPid2(0)
+	if err != nil {
+		return false, err
+	}
+	if err = currentCaps.Load(); err != nil {
+		return false, err
+	}
+	return currentCaps.Get(capability.EFFECTIVE, capability.CAP_SYS_RESOURCE), nil
+})


### PR DESCRIPTION
I'm not sure if there is an equivalent to CAP_SYS_RESOURCE on FreeBSD but for now, I have added a no-op stub which returns false.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
