### PR TITLE
[CI] Bump FreeBSD version to 13.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -322,7 +322,7 @@ freebsd_alt_build_task:
         TEST_FLAVOR: "altbuild"
         ALT_NAME: 'FreeBSD Cross'
     freebsd_instance:
-        image_family: freebsd-13-3
+        image_family: freebsd-13-4
     setup_script:
         - pkg install -y gpgme bash go-md2man gmake gsed gnugrep go pkgconf zstd
     build_amd64_script:


### PR DESCRIPTION
The FreeBSD build is broken due to missing FreeBSD 13.3 image, for example https://cirrus-ci.com/task/4915570123997184
 
Version 13.3 is EOL. See https://www.freebsd.org/releases/

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
