### PR TITLE
cirrus: figure out DEST_BRANCH automatically

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,8 +5,6 @@ env:
     ####
     #### Global variables used for all tasks
     ####
-    # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "main"
     # Sane (default) value for GOPROXY and GOSUMDB.
     GOPROXY: "https://proxy.golang.org,direct"
     GOSUMDB: "sum.golang.org"
@@ -106,6 +104,11 @@ validate-source_task:
           cd /
           rm -rf $CIRRUS_WORKING_DIR
           mkdir -p $CIRRUS_WORKING_DIR
+          if [[ -z "$CIRRUS_PR" ]]; then
+            DEST_BRANCH="$CIRRUS_BRANCH"
+          else
+            DEST_BRANCH="$CIRRUS_BASE_BRANCH"
+          fi
           git clone --recursive --branch=$DEST_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
           cd $CIRRUS_WORKING_DIR
           git remote update origin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -775,7 +775,7 @@ podman_machine_windows_task:
         <<: *windows
         type: m5zn.metal
         platform: windows
-    timeout_in: 45m
+    timeout_in: 60m
     env: *winenv
     matrix:
       - env:
@@ -798,7 +798,7 @@ podman_machine_mac_task:
     skip: *skip_rhel_release
     depends_on: *build
     persistent_worker: *mac_pw
-    timeout_in: 45m
+    timeout_in: 60m
     env:
         <<: *mac_env
         DISTRO_NV: "darwin"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -36,6 +36,25 @@ fi
 # Managed by setup_environment.sh; holds task-specific definitions.
 if [[ -r "/etc/ci_environment" ]]; then source /etc/ci_environment; fi
 
+# Set DEST_BRANCH automatically, this var used for many checks,
+# i.e. to find out the merge base to do build/commit checks.
+# To avoid having to set it manually for each branch try to
+# generate based of the CIRRUS env.
+# shellcheck disable=SC2154
+if [[ -z "$CIRRUS_PR" ]]; then
+    # shellcheck disable=SC2154
+    DEST_BRANCH="$CIRRUS_BRANCH"
+else
+    # shellcheck disable=SC2154
+    DEST_BRANCH="$CIRRUS_BASE_BRANCH"
+fi
+if [[ -z "${DEST_BRANCH}" ]]; then
+    die "DEST_BRANCH is undefined, not running under cirrus?"
+fi
+msg "DEST_BRANCH is $DEST_BRANCH"
+export DEST_BRANCH
+
+
 # This is normally set from .cirrus.yml but default is necessary when
 # running under hack/get_ci_vm.sh since it cannot infer the value.
 DISTRO_NV="${DISTRO_NV:-$OS_REL_VER}"

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -12,6 +12,8 @@ set -eo pipefail
 set -a
 source /etc/automation_environment
 source $AUTOMATION_LIB_PATH/common_lib.sh
+# shellcheck source=contrib/cirrus/lib.sh
+source $(dirname $0)/lib.sh
 set +a
 
 req_env_vars CI DEST_BRANCH IMAGE_SUFFIX TEST_FLAVOR TEST_ENVIRON \


### PR DESCRIPTION
Instead of us forgetting to update it on each new branch push.


Also bump the mac machine timeout to try to avoid the timeout flakes.

```release-note
None
```
