### PR TITLE
Update CONTRIBUTING for main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,10 @@ PRs for new features should include some background on what use cases the new co
 When possible and when it makes sense, try to break-up larger PRs into smaller ones - it's easier to review smaller code changes.
 But only if those smaller ones make sense as stand-alone PRs.
 
+Pull requests should be submitted to the main branch of the Podman repository.  Bug fixes may be cherry-picked or back-ported
+to Podman release branches but must first be merged upstream.  Maintainers reserve the right to not accept any pull requests
+to previous release branches.
+
 Regardless of the type of PR, all PRs should include:
 * Well-documented code changes, both through comments in the code itself and high-quality commit messages.
 * Additional tests. Ideally, they should fail w/o your code change applied.


### PR DESCRIPTION
We want contributors to submit to the main branch of podman and not branches without maintainer involvement.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
