### PR TITLE
[skip-ci] Packit: run .packit.sh only on post-commit copr builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,10 +19,6 @@ srpm_build_deps:
   - git-archive-all
   - make
 
-actions:
-  fix-spec-file:
-    - "bash .packit.sh"
-
 jobs:
   - job: copr_build
     trigger: pull_request
@@ -70,6 +66,9 @@ jobs:
     owner: rhcontainerbot
     project: podman-next
     enable_net: true
+    actions:
+      fix-spec-file:
+        - "bash .packit.sh"
 
   - job: tests
     identifier: cockpit-revdeps


### PR DESCRIPTION
The podman-machine-os tests fail on anything other than the version itself. So, appending the short SHA will not work for copr rpm builds fetched in podman-machine-os PRs.
    
Ref: https://github.com/containers/podman-machine-os/pull/87#issuecomment-2659477314
    
The short SHA is actually only required in post-commit builds posted to `rhcontainerbot/podman-next` Copr, as requested by Podman-Desktop.
    
This commit limits the relevant packit action to only the post-commit job.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
