### PR TITLE
quadlet: support `Memory=` in `[Container]` sections

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -319,6 +319,7 @@ Valid options for `[Container]` are listed below:
 | LogDriver=journald                   | --log-driver journald                                |
 | LogOpt=path=/var/log/mykube\.json    | --log-opt path=/var/log/mykube\.json                 |
 | Mask=/proc/sys/foo\:/proc/sys/bar    | --security-opt mask=/proc/sys/foo:/proc/sys/bar      |
+| Memory=20g                           | --memory 20g                                         |
 | Mount=type=...                       | --mount type=...                                     |
 | Network=host                         | --network host                                       |
 | NetworkAlias=name                    | --network-alias name                                 |
@@ -658,6 +659,10 @@ This key can be listed multiple times.
 ### `Mask=`
 
 Specify the paths to mask separated by a colon. `Mask=/path/1:/path/2`. A masked path cannot be accessed inside the container.
+
+### `Memory=`
+
+Specify the amount of memory for the container.
 
 ### `Mount=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -122,6 +122,7 @@ const (
 	KeyLogDriver             = "LogDriver"
 	KeyLogOpt                = "LogOpt"
 	KeyMask                  = "Mask"
+	KeyMemory                = "Memory"
 	KeyMount                 = "Mount"
 	KeyNetwork               = "Network"
 	KeyNetworkAlias          = "NetworkAlias"
@@ -240,6 +241,7 @@ var (
 		KeyLogDriver:             true,
 		KeyLogOpt:                true,
 		KeyMask:                  true,
+		KeyMemory:                true,
 		KeyMount:                 true,
 		KeyNetwork:               true,
 		KeyNetworkAlias:          true,
@@ -635,6 +637,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool, unitsInfoMap map[
 		KeyStopSignal:  "--stop-signal",
 		KeyStopTimeout: "--stop-timeout",
 		KeyPull:        "--pull",
+		KeyMemory:      "--memory",
 	}
 	lookupAndAddString(container, ContainerGroup, stringKeys, podman)
 

--- a/test/e2e/quadlet/memory.container
+++ b/test/e2e/quadlet/memory.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --memory 20g
+
+[Container]
+Image=localhost/imagename
+Memory=20g

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -876,6 +876,7 @@ BOGUS=foo
 		Entry("logdriver.container", "logdriver.container"),
 		Entry("logopt.container", "logopt.container"),
 		Entry("mask.container", "mask.container"),
+		Entry("memory.container", "memory.container"),
 		Entry("name.container", "name.container"),
 		Entry("nestedselinux.container", "nestedselinux.container"),
 		Entry("network.container", "network.container"),


### PR DESCRIPTION
Maps to the `--memory=` flag.

#### Does this PR introduce a user-facing change?

```release-note
Support for `Memory=` in `[Container]` units.
```
