### PR TITLE
oci: report empty exec path as ENOENT

### DIFF
--- a/libpod/oci_util.go
+++ b/libpod/oci_util.go
@@ -152,7 +152,7 @@ func getOCIRuntimeError(name, runtimeMsg string) error {
 		}
 		return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrOCIRuntimePermissionDenied)
 	}
-	if match := regexp.MustCompile("(?i).*executable file not found in.*|.*no such file or directory.*").FindString(runtimeMsg); match != "" {
+	if match := regexp.MustCompile("(?i).*executable file not found in.*|.*no such file or directory.*|.*open executable.*").FindString(runtimeMsg); match != "" {
 		errStr := match
 		if includeFullOutput {
 			errStr = runtimeMsg

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -400,17 +400,14 @@ var _ = Describe("Podman exec", func() {
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(ExitCleanly())
 
-		expect := "chdir to `/missing`: No such file or directory"
-		if podmanTest.OCIRuntime == "runc" {
-			expect = "chdir to cwd"
-		}
+		expect := ".*(chdir to cwd|chdir to `/missing`: No such file or directory).*"
 		session := podmanTest.Podman([]string{"exec", "--workdir", "/missing", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(127, expect))
+		Expect(session).To(ExitWithErrorRegex(127, expect))
 
 		session = podmanTest.Podman([]string{"exec", "-w", "/missing", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(127, expect))
+		Expect(session).To(ExitWithErrorRegex(127, expect))
 	})
 
 	It("podman exec cannot be invoked", func() {

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -22,13 +22,15 @@ var _ = Describe("Podman run exit", func() {
 	It("podman run exit ExecErrorCodeCannotInvoke", func() {
 		result := podmanTest.Podman([]string{"run", ALPINE, "/etc"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(ExitWithErrorRegex(define.ExecErrorCodeCannotInvoke, ".*(open executable|the path `/etc` is not a regular file): Operation not permitted: OCI permission denied.*"))
+		expected := ".*(exec: \"/etc\": is a directory|(open executable|the path `/etc` is not a regular file): Operation not permitted: OCI permission denied).*"
+		Expect(result).Should(ExitWithErrorRegex(define.ExecErrorCodeCannotInvoke, expected))
 	})
 
 	It("podman run exit ExecErrorCodeNotFound", func() {
 		result := podmanTest.Podman([]string{"run", ALPINE, "foobar"})
 		result.WaitWithDefaultTimeout()
-		Expect(result).Should(ExitWithError(define.ExecErrorCodeNotFound, "executable file `foobar` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found"))
+		expected := ".*(executable file not found in \\$PATH|executable file `foobar` not found in \\$PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found).*"
+		Expect(result).Should(ExitWithErrorRegex(define.ExecErrorCodeNotFound, expected))
 	})
 
 	It("podman run exit 0", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1657,7 +1657,7 @@ search               | $IMAGE           |
     # runc and crun emit different diagnostics
     runtime=$(podman_runtime)
     case "$runtime" in
-        crun) expect='\(executable file `` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found\|executable path is empty\)' ;;
+        crun) expect='\(executable file `` not found in $PATH\|cannot find `` in $PATH\): No such file or directory: OCI runtime attempted to invoke a command that was not found' ;;
         runc) expect='runc: runc create failed: unable to start container process: exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found' ;;
         *)    skip "Unknown runtime '$runtime'" ;;
     esac


### PR DESCRIPTION
unify the error codes returned by runc and crun.

Fix the tests to work with both runtimes, as well as the https://github.com/containers/crun/pull/1672 changes in progress for crun.

Follow-up for https://github.com/containers/podman/pull/25340

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
