### PR TITLE
Add --all to artifact rm

### DIFF
--- a/cmd/podman/artifact/rm.go
+++ b/cmd/podman/artifact/rm.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containers/podman/v5/cmd/podman/common"
@@ -11,40 +12,67 @@ import (
 
 var (
 	rmCmd = &cobra.Command{
-		Use:               "rm ARTIFACT",
-		Short:             "Remove an OCI artifact",
-		Long:              "Remove an OCI from local storage",
-		RunE:              rm,
-		Aliases:           []string{"remove"},
-		Args:              cobra.ExactArgs(1),
+		Use:     "rm [options] ARTIFACT",
+		Short:   "Remove an OCI artifact",
+		Long:    "Remove an OCI artifact from local storage",
+		RunE:    rm,
+		Aliases: []string{"remove"},
+		Args: func(cmd *cobra.Command, args []string) error { //nolint: gocritic
+			return checkAllAndArgs(cmd, args)
+		},
 		ValidArgsFunction: common.AutocompleteArtifacts,
-		Example:           `podman artifact rm quay.io/myimage/myartifact:latest`,
-		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},
+		Example: `podman artifact rm quay.io/myimage/myartifact:latest
+podman artifact rm -a`,
+		Annotations: map[string]string{registry.EngineMode: registry.ABIMode},
 	}
-	// The lint avoid here is because someday soon we will need flags for
-	// this command
-	rmFlag = rmFlagType{} //nolint:unused
+
+	rmOptions = entities.ArtifactRemoveOptions{}
 )
 
-// TODO at some point force will be a required option; but this cannot be
-// until we have artifacts being consumed by other parts of libpod like
-// volumes
-type rmFlagType struct { //nolint:unused
-	force bool
+func rmFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.BoolVarP(&rmOptions.All, "all", "a", false, "Remove all artifacts")
 }
-
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: rmCmd,
 		Parent:  artifactCmd,
 	})
+	rmFlags(rmCmd)
 }
 
 func rm(cmd *cobra.Command, args []string) error {
-	artifactRemoveReport, err := registry.ImageEngine().ArtifactRm(registry.Context(), args[0], entities.ArtifactRemoveOptions{})
+	var nameOrID string
+	if len(args) > 0 {
+		nameOrID = args[0]
+	}
+	artifactRemoveReport, err := registry.ImageEngine().ArtifactRm(registry.Context(), nameOrID, rmOptions)
 	if err != nil {
 		return err
 	}
-	fmt.Println(artifactRemoveReport.ArtfactDigest.Encoded())
+	for _, d := range artifactRemoveReport.ArtifactDigests {
+		fmt.Println(d.Encoded())
+	}
+	return nil
+}
+
+// checkAllAndArgs takes a cobra command and args and checks if
+// all is used, then no args can be passed. note: this was created
+// as an unexported local func for now and could be moved to pkg
+// validate.  if we add "--latest" to the command, then perhaps
+// one of the existing plg validate funcs would be appropriate.
+func checkAllAndArgs(c *cobra.Command, args []string) error {
+	all, _ := c.Flags().GetBool("all")
+	if all && len(args) > 0 {
+		return fmt.Errorf("when using the --all switch, you may not pass any artifact names or digests")
+	}
+	if !all {
+		if len(args) < 1 {
+			return errors.New("a single artifact name or digest must be specified")
+		}
+		if len(args) > 1 {
+			return errors.New("too many arguments: only accepts one artifact name or digest ")
+		}
+	}
 	return nil
 }

--- a/docs/source/markdown/podman-artifact-rm.1.md
+++ b/docs/source/markdown/podman-artifact-rm.1.md
@@ -9,7 +9,7 @@ subject to change.*
 podman\-artifact\-rm - Remove an OCI from local storage
 
 ## SYNOPSIS
-**podman artifact rm** *name*
+**podman artifact rm** [*options*] *name*
 
 ## DESCRIPTION
 
@@ -17,6 +17,11 @@ Remove an artifact from the local artifact store.  The input may be the fully
 qualified artifact name or a full or partial artifact digest.
 
 ## OPTIONS
+
+#### **--all**, **-a**
+
+Remove all artifacts in the local store.  The use of this option conflicts with
+providing a name or digest of the artifact.
 
 #### **--help**
 
@@ -29,14 +34,21 @@ Remove an artifact by name
 
 ```
 $ podman artifact rm quay.io/artifact/foobar2:test
-e7b417f49fc24fc7ead6485da0ebd5bc4419d8a3f394c169fee5a6f38faa4056
+Deleted: e7b417f49fc24fc7ead6485da0ebd5bc4419d8a3f394c169fee5a6f38faa4056
 ```
 
 Remove an artifact by partial digest
 
 ```
 $ podman artifact rm e7b417f49fc
-e7b417f49fc24fc7ead6485da0ebd5bc4419d8a3f394c169fee5a6f38faa4056
+Deleted: e7b417f49fc24fc7ead6485da0ebd5bc4419d8a3f394c169fee5a6f38faa4056
+```
+
+Remove all artifacts in local storage
+```
+$ podman artifact rm -a
+Deleted: cee15f7c5ce3e86ae6ce60d84bebdc37ad34acfa9a2611cf47501469ac83a1ab
+Deleted: 72875f8f6f78d5b8ba98b2dd2c0a6f395fde8f05ff63a1df580d7a88f5afa97b
 ```
 
 ## SEE ALSO

--- a/pkg/domain/entities/artifact.go
+++ b/pkg/domain/entities/artifact.go
@@ -59,6 +59,8 @@ type ArtifactPushOptions struct {
 }
 
 type ArtifactRemoveOptions struct {
+	// Remove all artifacts
+	All bool
 }
 
 type ArtifactPullReport struct{}
@@ -79,5 +81,5 @@ type ArtifactAddReport struct {
 }
 
 type ArtifactRemoveReport struct {
-	ArtfactDigest *digest.Digest
+	ArtifactDigests []*digest.Digest
 }


### PR DESCRIPTION
Add the ability to remove all artifacts with a --all|-a option in podman artifact rm.

Fixes: https://issues.redhat.com/browse/RUN-2512

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add ability to remove all artifacts in the local store
```
