### PR TITLE
[skip-ci] Packit/Copr: Fix `podman version` in rpm

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -12,7 +12,7 @@ PACKAGE=podman
 SPEC_FILE=rpm/$PACKAGE.spec
 
 # Get short sha
-SHORT_SHA=$(git rev-parse --short HEAD)
+GIT_COMMIT=$(git rev-parse HEAD)
 
 # Get Version from HEAD
 VERSION=$(grep '^const RawVersion' version/rawversion/version.go | cut -d\" -f2)
@@ -41,8 +41,5 @@ sed -i "s/^Source0:.*.tar.gz/Source0: $PACKAGE-$VERSION.tar.gz/" $SPEC_FILE
 # Update setup macro to use the correct build dir
 sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$VERSION/" $SPEC_FILE
 
-# Update relevant sed entries in spec file with the actual VERSION and SHORT_SHA
-# This allows podman --version to also show the SHORT_SHA along with the
-# VERSION
-sed -i "s/##VERSION##/$VERSION/" $SPEC_FILE
-sed -i "s/##SHORT_SHA##/$SHORT_SHA/" $SPEC_FILE
+# Update LDFLAGS to show commit id for Copr builds
+sed -i "s/##GIT_COMMIT##/$GIT_COMMIT/" $SPEC_FILE


### PR DESCRIPTION
Additional rpm patching to show upstream short sha in `podman --version` caused podman-machine-os tests to fail.

This commit gets rid of that patching and instead sets define.gitCommit LDFLAG for Copr rpms.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
