### PR TITLE
[v5.4] Backport linter update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,7 @@ linters:
     - nonamedreturns
     - exhaustruct
     # deprecated linters
-    - exportloopref
+    - tenv
 linters-settings:
   errcheck:
     check-blank: false

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 1.63.4
+GOLANGCI_LINT_VERSION := 1.64.2
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 1.64.2
+GOLANGCI_LINT_VERSION := 1.64.4
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems

--- a/cmd/podman/artifact/inspect.go
+++ b/cmd/podman/artifact/inspect.go
@@ -43,7 +43,7 @@ func init() {
 
 func inspect(cmd *cobra.Command, args []string) error {
 	artifactOptions := entities.ArtifactInspectOptions{}
-	inspectData, err := registry.ImageEngine().ArtifactInspect(registry.GetContext(), args[0], artifactOptions)
+	inspectData, err := registry.ImageEngine().ArtifactInspect(registry.Context(), args[0], artifactOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 func list(cmd *cobra.Command, _ []string) error {
-	reports, err := registry.ImageEngine().ArtifactList(registry.GetContext(), entities.ArtifactListOptions{})
+	reports, err := registry.ImageEngine().ArtifactList(registry.Context(), entities.ArtifactListOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/artifact/pull.go
+++ b/cmd/podman/artifact/pull.go
@@ -157,6 +157,6 @@ func artifactPull(cmd *cobra.Command, args []string) error {
 		pullOptions.Writer = os.Stdout
 	}
 
-	_, err = registry.ImageEngine().ArtifactPull(registry.GetContext(), args[0], pullOptions.ArtifactPullOptions)
+	_, err = registry.ImageEngine().ArtifactPull(registry.Context(), args[0], pullOptions.ArtifactPullOptions)
 	return err
 }

--- a/cmd/podman/artifact/push.go
+++ b/cmd/podman/artifact/push.go
@@ -224,6 +224,6 @@ func artifactPush(cmd *cobra.Command, args []string) error {
 			}
 	*/
 
-	_, err = registry.ImageEngine().ArtifactPush(registry.GetContext(), source, pushOptions.ArtifactPushOptions)
+	_, err = registry.ImageEngine().ArtifactPush(registry.Context(), source, pushOptions.ArtifactPushOptions)
 	return err
 }

--- a/cmd/podman/artifact/rm.go
+++ b/cmd/podman/artifact/rm.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func rm(cmd *cobra.Command, args []string) error {
-	artifactRemoveReport, err := registry.ImageEngine().ArtifactRm(registry.GetContext(), args[0], entities.ArtifactRemoveOptions{})
+	artifactRemoveReport, err := registry.ImageEngine().ArtifactRm(registry.Context(), args[0], entities.ArtifactRemoveOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -77,7 +77,7 @@ func autoUpdate(cmd *cobra.Command, args []string) error {
 		autoUpdateOptions.InsecureSkipTLSVerify = types.NewOptionalBool(!autoUpdateOptions.tlsVerify)
 	}
 
-	allReports, failures := registry.ContainerEngine().AutoUpdate(registry.GetContext(), autoUpdateOptions.AutoUpdateOptions)
+	allReports, failures := registry.ContainerEngine().AutoUpdate(registry.Context(), autoUpdateOptions.AutoUpdateOptions)
 	if allReports == nil {
 		return errorhandling.JoinErrors(failures)
 	}

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -103,7 +103,7 @@ func getContainers(cmd *cobra.Command, toComplete string, cType completeType, st
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	containers, err := engine.ContainerList(registry.GetContext(), listOpts)
+	containers, err := engine.ContainerList(registry.Context(), listOpts)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -138,7 +138,7 @@ func getPods(cmd *cobra.Command, toComplete string, cType completeType, statuses
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	pods, err := engine.PodPs(registry.GetContext(), listOpts)
+	pods, err := engine.PodPs(registry.Context(), listOpts)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -168,7 +168,7 @@ func getVolumes(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellCom
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	volumes, err := engine.VolumeList(registry.GetContext(), lsOpts)
+	volumes, err := engine.VolumeList(registry.Context(), lsOpts)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -191,7 +191,7 @@ func getImages(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellComp
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	images, err := engine.List(registry.GetContext(), listOptions)
+	images, err := engine.List(registry.Context(), listOptions)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -235,7 +235,7 @@ func getManifestListMembers(cmd *cobra.Command, list, toComplete string) ([]stri
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	listData, err := engine.ManifestInspect(registry.GetContext(), list, inspectOptions)
+	listData, err := engine.ManifestInspect(registry.Context(), list, inspectOptions)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -257,7 +257,7 @@ func getSecrets(cmd *cobra.Command, toComplete string, cType completeType) ([]st
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	secrets, err := engine.SecretList(registry.GetContext(), entities.SecretListRequest{})
+	secrets, err := engine.SecretList(registry.Context(), entities.SecretListRequest{})
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -327,7 +327,7 @@ func getArtifacts(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellC
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	artifacts, err := engine.ArtifactList(registry.GetContext(), listOptions)
+	artifacts, err := engine.ArtifactList(registry.Context(), listOptions)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -84,5 +84,5 @@ func attach(cmd *cobra.Command, args []string) error {
 	}
 	attachOpts.Stdout = os.Stdout
 	attachOpts.Stderr = os.Stderr
-	return registry.ContainerEngine().ContainerAttach(registry.GetContext(), name, attachOpts)
+	return registry.ContainerEngine().ContainerAttach(registry.Context(), name, attachOpts)
 }

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -77,7 +77,7 @@ func cleanup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	responses, err := registry.ContainerEngine().ContainerCleanup(registry.GetContext(), args, cleanupOptions)
+	responses, err := registry.ContainerEngine().ContainerCleanup(registry.Context(), args, cleanupOptions)
 	if err != nil {
 		// `podman container cleanup` is almost always run in the
 		// background. Our only way of relaying information to the user

--- a/cmd/podman/containers/clone.go
+++ b/cmd/podman/containers/clone.go
@@ -77,7 +77,7 @@ func clone(cmd *cobra.Command, args []string) error {
 
 	ctrClone.ID = args[0]
 	ctrClone.CreateOpts.IsClone = true
-	rep, err := registry.ContainerEngine().ContainerClone(registry.GetContext(), ctrClone)
+	rep, err := registry.ContainerEngine().ContainerClone(registry.Context(), ctrClone)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -98,7 +98,7 @@ func cp(cmd *cobra.Command, args []string) error {
 // containerMustExist returns an error if the specified container does not
 // exist.
 func containerMustExist(container string) error {
-	exists, err := registry.ContainerEngine().ContainerExists(registry.GetContext(), container, entities.ContainerExistsOptions{})
+	exists, err := registry.ContainerEngine().ContainerExists(registry.Context(), container, entities.ContainerExistsOptions{})
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 		return err
 	}
 
-	sourceContainerInfo, err := registry.ContainerEngine().ContainerStat(registry.GetContext(), sourceContainer, sourcePath)
+	sourceContainerInfo, err := registry.ContainerEngine().ContainerStat(registry.Context(), sourceContainer, sourcePath)
 	if err != nil {
 		return fmt.Errorf("%q could not be found on container %s: %w", sourcePath, sourceContainer, err)
 	}
@@ -166,7 +166,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 
 	sourceContainerCopy := func() error {
 		defer writer.Close()
-		copyFunc, err := registry.ContainerEngine().ContainerCopyToArchive(registry.GetContext(), sourceContainer, sourceContainerTarget, writer)
+		copyFunc, err := registry.ContainerEngine().ContainerCopyToArchive(registry.Context(), sourceContainer, sourceContainerTarget, writer)
 		if err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 			copyOptions.Rename = map[string]string{filepath.Base(sourceContainerTarget): destContainerBaseName}
 		}
 
-		copyFunc, err := registry.ContainerEngine().ContainerCopyFromArchive(registry.GetContext(), destContainer, destContainerTarget, reader, copyOptions)
+		copyFunc, err := registry.ContainerEngine().ContainerCopyFromArchive(registry.Context(), destContainer, destContainerTarget, reader, copyOptions)
 		if err != nil {
 			return err
 		}
@@ -211,7 +211,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 		hostPath = os.Stdout.Name()
 	}
 
-	containerInfo, err := registry.ContainerEngine().ContainerStat(registry.GetContext(), container, containerPath)
+	containerInfo, err := registry.ContainerEngine().ContainerStat(registry.Context(), container, containerPath)
 	if err != nil {
 		return fmt.Errorf("%q could not be found on container %s: %w", containerPath, container, err)
 	}
@@ -321,7 +321,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 
 	containerCopy := func() error {
 		defer writer.Close()
-		copyFunc, err := registry.ContainerEngine().ContainerCopyToArchive(registry.GetContext(), container, containerTarget, writer)
+		copyFunc, err := registry.ContainerEngine().ContainerCopyToArchive(registry.Context(), container, containerTarget, writer)
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 			target = filepath.Dir(target)
 		}
 
-		copyFunc, err := registry.ContainerEngine().ContainerCopyFromArchive(registry.GetContext(), container, target, reader, entities.CopyOptions{Chown: chown, NoOverwriteDirNonDir: !cpOpts.OverwriteDirNonDir})
+		copyFunc, err := registry.ContainerEngine().ContainerCopyFromArchive(registry.Context(), container, target, reader, entities.CopyOptions{Chown: chown, NoOverwriteDirNonDir: !cpOpts.OverwriteDirNonDir})
 		if err != nil {
 			return err
 		}
@@ -456,7 +456,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 // container.  If the path does not exist, it attempts to use the parent
 // directory.
 func resolvePathOnDestinationContainer(container string, containerPath string, isStdin bool) (baseName string, containerInfo *entities.ContainerStatReport, resolvedToParentDir bool, err error) {
-	containerInfo, err = registry.ContainerEngine().ContainerStat(registry.GetContext(), container, containerPath)
+	containerInfo, err = registry.ContainerEngine().ContainerStat(registry.Context(), container, containerPath)
 	if err == nil {
 		baseName = filepath.Base(containerInfo.LinkTarget)
 		return //nolint: nilerr
@@ -488,7 +488,7 @@ func resolvePathOnDestinationContainer(container string, containerPath string, i
 		return
 	}
 
-	containerInfo, err = registry.ContainerEngine().ContainerStat(registry.GetContext(), container, parentDir)
+	containerInfo, err = registry.ContainerEngine().ContainerStat(registry.Context(), container, parentDir)
 	if err != nil {
 		err = fmt.Errorf("%q could not be found on container %s: %w", containerPath, container, err)
 		return
@@ -505,7 +505,7 @@ func containerParentDir(container string, containerPath string) (string, error) 
 	if filepath.IsAbs(containerPath) {
 		return filepath.Dir(containerPath), nil
 	}
-	inspectData, _, err := registry.ContainerEngine().ContainerInspect(registry.GetContext(), []string{container}, entities.InspectOptions{})
+	inspectData, _, err := registry.ContainerEngine().ContainerInspect(registry.Context(), []string{container}, entities.InspectOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -174,7 +174,7 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	report, err := registry.ContainerEngine().ContainerCreate(registry.GetContext(), s)
+	report, err := registry.ContainerEngine().ContainerCreate(registry.Context(), s)
 	if err != nil {
 		// if pod was created as part of run
 		// remove it in case ctr creation fails
@@ -401,7 +401,7 @@ func pullImage(cmd *cobra.Command, imageName string, cliVals *entities.Container
 		pullOptions.RetryDelay = val
 	}
 
-	pullReport, pullErr := registry.ImageEngine().Pull(registry.GetContext(), imageName, pullOptions)
+	pullReport, pullErr := registry.ImageEngine().Pull(registry.Context(), imageName, pullOptions)
 	if pullErr != nil {
 		return "", pullErr
 	}

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -178,12 +178,12 @@ func exec(cmd *cobra.Command, args []string) error {
 		streams.AttachOutput = true
 		streams.AttachError = true
 
-		exitCode, err := registry.ContainerEngine().ContainerExec(registry.GetContext(), nameOrID, execOpts, streams)
+		exitCode, err := registry.ContainerEngine().ContainerExec(registry.Context(), nameOrID, execOpts, streams)
 		registry.SetExitCode(exitCode)
 		return err
 	}
 
-	id, err := registry.ContainerEngine().ContainerExecDetached(registry.GetContext(), nameOrID, execOpts)
+	id, err := registry.ContainerEngine().ContainerExecDetached(registry.Context(), nameOrID, execOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -68,7 +68,7 @@ func init() {
 func initContainer(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	args = utils.RemoveSlash(args)
-	report, err := registry.ContainerEngine().ContainerInit(registry.GetContext(), args, initOptions)
+	report, err := registry.ContainerEngine().ContainerInit(registry.Context(), args, initOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -142,5 +142,5 @@ func logs(_ *cobra.Command, args []string) error {
 	}
 	logsOptions.StdoutWriter = os.Stdout
 	logsOptions.StderrWriter = os.Stderr
-	return registry.ContainerEngine().ContainerLogs(registry.GetContext(), args, logsOptions.ContainerLogsOptions)
+	return registry.ContainerEngine().ContainerLogs(registry.Context(), args, logsOptions.ContainerLogsOptions)
 }

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -87,7 +87,7 @@ func mount(cmd *cobra.Command, args []string) error {
 	}
 	args = utils.RemoveSlash(args)
 
-	reports, err := registry.ContainerEngine().ContainerMount(registry.GetContext(), args, mountOpts)
+	reports, err := registry.ContainerEngine().ContainerMount(registry.Context(), args, mountOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -108,7 +108,7 @@ func port(_ *cobra.Command, args []string) error {
 		userProto = fields[1]
 	}
 
-	reports, err := registry.ContainerEngine().ContainerPort(registry.GetContext(), container, portOpts)
+	reports, err := registry.ContainerEngine().ContainerPort(registry.Context(), container, portOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -173,7 +173,7 @@ func quietOut(responses []entities.ListContainer) {
 }
 
 func getResponses() ([]entities.ListContainer, error) {
-	responses, err := registry.ContainerEngine().ContainerList(registry.GetContext(), listOpts)
+	responses, err := registry.ContainerEngine().ContainerList(registry.Context(), listOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/podman/containers/rename.go
+++ b/cmd/podman/containers/rename.go
@@ -52,5 +52,5 @@ func rename(cmd *cobra.Command, args []string) error {
 	renameOpts := entities.ContainerRenameOptions{
 		NewName: args[1],
 	}
-	return registry.ContainerEngine().ContainerRename(registry.GetContext(), args[0], renameOpts)
+	return registry.ContainerEngine().ContainerRename(registry.Context(), args[0], renameOpts)
 }

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -105,7 +105,7 @@ func restore(cmd *cobra.Command, args []string) error {
 	// Check if the container exists (#15055)
 	exists := &entities.BoolReport{Value: false}
 	for _, ctr := range args {
-		exists, e = registry.ContainerEngine().ContainerExists(registry.GetContext(), ctr, entities.ContainerExistsOptions{})
+		exists, e = registry.ContainerEngine().ContainerExists(registry.Context(), ctr, entities.ContainerExistsOptions{})
 		if e != nil {
 			return e
 		}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -225,7 +225,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	report, err := registry.ContainerEngine().ContainerRun(registry.GetContext(), runOpts)
+	report, err := registry.ContainerEngine().ContainerRun(registry.Context(), runOpts)
 	// report.ExitCode is set by ContainerRun even it returns an error
 	if report != nil {
 		registry.SetExitCode(report.ExitCode)
@@ -248,7 +248,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if runRmi {
-		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{imageName}, entities.ImageRemoveOptions{Ignore: true})
+		_, rmErrors := registry.ImageEngine().Remove(registry.Context(), []string{imageName}, entities.ImageRemoveOptions{Ignore: true})
 		for _, err := range rmErrors {
 			logrus.Warnf("Failed to remove image: %v", err)
 		}

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -131,7 +131,7 @@ func start(cmd *cobra.Command, args []string) error {
 		startOptions.Filters[fname] = append(startOptions.Filters[fname], filter)
 	}
 
-	responses, err := registry.ContainerEngine().ContainerStart(registry.GetContext(), containers, startOptions)
+	responses, err := registry.ContainerEngine().ContainerStart(registry.Context(), containers, startOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -79,7 +79,7 @@ func init() {
 func unmount(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	args = utils.RemoveSlash(args)
-	reports, err := registry.ContainerEngine().ContainerUnmount(registry.GetContext(), args, unmountOpts)
+	reports, err := registry.ContainerEngine().ContainerUnmount(registry.Context(), args, unmountOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/diff/diff.go
+++ b/cmd/podman/diff/diff.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Diff(_ *cobra.Command, args []string, options entities.DiffOptions) error {
-	results, err := registry.ContainerEngine().Diff(registry.GetContext(), args, options)
+	results, err := registry.ContainerEngine().Diff(registry.Context(), args, options)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/generate/spec.go
+++ b/cmd/podman/generate/spec.go
@@ -51,7 +51,7 @@ func init() {
 
 func spec(cmd *cobra.Command, args []string) error {
 	opts.ID = args[0]
-	report, err := registry.ContainerEngine().GenerateSpec(registry.GetContext(), opts)
+	report, err := registry.ContainerEngine().GenerateSpec(registry.Context(), opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -170,7 +170,7 @@ func systemd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s and %s are redundant and cannot be used together", stopTimeoutFlagName, stopTimeoutCompatFlagName)
 	}
 
-	reports, err := registry.ContainerEngine().GenerateSystemd(registry.GetContext(), args[0], systemdOptions)
+	reports, err := registry.ContainerEngine().GenerateSystemd(registry.Context(), args[0], systemdOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -96,7 +96,7 @@ func build(cmd *cobra.Command, args []string) error {
 			}
 		}()
 	}
-	report, err := registry.ImageEngine().Build(registry.GetContext(), apiBuildOpts.ContainerFiles, *apiBuildOpts)
+	report, err := registry.ImageEngine().Build(registry.Context(), apiBuildOpts.ContainerFiles, *apiBuildOpts)
 
 	if err != nil {
 		exitCode := buildahCLI.ExecErrorCodeGeneric

--- a/cmd/podman/images/exists.go
+++ b/cmd/podman/images/exists.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func exists(cmd *cobra.Command, args []string) error {
-	found, err := registry.ImageEngine().Exists(registry.GetContext(), args[0])
+	found, err := registry.ImageEngine().Exists(registry.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -123,7 +123,7 @@ func images(cmd *cobra.Command, args []string) error {
 			listFlag.sort, sortFields.String())
 	}
 
-	summaries, err := registry.ImageEngine().List(registry.GetContext(), listOptions)
+	summaries, err := registry.ImageEngine().List(registry.Context(), listOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/mount.go
+++ b/cmd/podman/images/mount.go
@@ -65,7 +65,7 @@ func mount(cmd *cobra.Command, args []string) error {
 		return errors.New("when using the --all switch, you may not pass any image names or IDs")
 	}
 
-	reports, err := registry.ImageEngine().Mount(registry.GetContext(), args, mountOpts)
+	reports, err := registry.ImageEngine().Mount(registry.Context(), args, mountOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -76,7 +76,7 @@ func prune(cmd *cobra.Command, args []string) error {
 			pruneOpts.Filter = append(pruneOpts.Filter, fmt.Sprintf("%s=%s", k, val))
 		}
 	}
-	results, err := registry.ImageEngine().Prune(registry.GetContext(), pruneOpts)
+	results, err := registry.ImageEngine().Prune(registry.Context(), pruneOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -208,7 +208,7 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	// scattering logic across (too) many parts of the code.
 	var errs utils.OutputErrors
 	for _, arg := range args {
-		pullReport, err := registry.ImageEngine().Pull(registry.GetContext(), arg, pullOptions.ImagePullOptions)
+		pullReport, err := registry.ImageEngine().Pull(registry.Context(), arg, pullOptions.ImagePullOptions)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -251,7 +251,7 @@ func imagePush(cmd *cobra.Command, args []string) error {
 
 	// Let's do all the remaining Yoga in the API to prevent us from scattering
 	// logic across (too) many parts of the code.
-	report, err := registry.ImageEngine().Push(registry.GetContext(), source, destination, pushOptions.ImagePushOptions)
+	report, err := registry.ImageEngine().Push(registry.Context(), source, destination, pushOptions.ImagePushOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -75,7 +75,7 @@ func rm(cmd *cobra.Command, args []string) error {
 
 	// Note: certain image-removal errors are non-fatal.  Hence, the report
 	// might be set even if err != nil.
-	report, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), args, imageOpts)
+	report, rmErrors := registry.ImageEngine().Remove(registry.Context(), args, imageOpts)
 	if report != nil {
 		for _, u := range report.Untagged {
 			fmt.Println("Untagged: " + u)

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -153,7 +153,7 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 		searchOptions.Password = creds.Password
 	}
 
-	searchReport, err := registry.ImageEngine().Search(registry.GetContext(), searchTerm, searchOptions.ImageSearchOptions)
+	searchReport, err := registry.ImageEngine().Search(registry.Context(), searchTerm, searchOptions.ImageSearchOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/tag.go
+++ b/cmd/podman/images/tag.go
@@ -45,5 +45,5 @@ func init() {
 }
 
 func tag(cmd *cobra.Command, args []string) error {
-	return registry.ImageEngine().Tag(registry.GetContext(), args[0], args[1:], entities.ImageTagOptions{})
+	return registry.ImageEngine().Tag(registry.Context(), args[0], args[1:], entities.ImageTagOptions{})
 }

--- a/cmd/podman/images/unmount.go
+++ b/cmd/podman/images/unmount.go
@@ -58,7 +58,7 @@ func unmount(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && unmountOpts.All {
 		return errors.New("when using the --all switch, you may not pass any image names or IDs")
 	}
-	reports, err := registry.ImageEngine().Unmount(registry.GetContext(), args, unmountOpts)
+	reports, err := registry.ImageEngine().Unmount(registry.Context(), args, unmountOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/untag.go
+++ b/cmd/podman/images/untag.go
@@ -44,5 +44,5 @@ func init() {
 }
 
 func untag(cmd *cobra.Command, args []string) error {
-	return registry.ImageEngine().Untag(registry.GetContext(), args[0], args[1:], entities.ImageUntagOptions{})
+	return registry.ImageEngine().Untag(registry.Context(), args[0], args[1:], entities.ImageUntagOptions{})
 }

--- a/cmd/podman/kube/apply.go
+++ b/cmd/podman/kube/apply.go
@@ -89,7 +89,7 @@ func apply(cmd *cobra.Command, args []string) error {
 		reader = f
 	} else {
 		generateOptions.Service = applyOptions.Service
-		report, err := registry.ContainerEngine().GenerateKube(registry.GetContext(), args, generateOptions)
+		report, err := registry.ContainerEngine().GenerateKube(registry.Context(), args, generateOptions)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func apply(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Deploying to cluster...")
 
-	if err = registry.ContainerEngine().KubeApply(registry.GetContext(), reader, applyOptions); err != nil {
+	if err = registry.ContainerEngine().KubeApply(registry.Context(), reader, applyOptions); err != nil {
 		return err
 	}
 

--- a/cmd/podman/kube/generate.go
+++ b/cmd/podman/kube/generate.go
@@ -93,7 +93,7 @@ func generateFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 }
 
 func generateKube(cmd *cobra.Command, args []string) error {
-	report, err := registry.ContainerEngine().GenerateKube(registry.GetContext(), args, generateOptions)
+	report, err := registry.ContainerEngine().GenerateKube(registry.Context(), args, generateOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -398,7 +398,7 @@ func teardown(body io.Reader, options entities.PlayKubeDownOptions) error {
 		volRmErrors   utils.OutputErrors
 		secRmErrors   utils.OutputErrors
 	)
-	reports, err := registry.ContainerEngine().PlayKubeDown(registry.GetContext(), body, options)
+	reports, err := registry.ContainerEngine().PlayKubeDown(registry.Context(), body, options)
 	if err != nil {
 		return err
 	}
@@ -465,7 +465,7 @@ func teardown(body io.Reader, options entities.PlayKubeDownOptions) error {
 }
 
 func kubeplay(body io.Reader) error {
-	report, err := registry.ContainerEngine().PlayKube(registry.GetContext(), body, playOptions.PlayKubeOptions)
+	report, err := registry.ContainerEngine().PlayKube(registry.Context(), body, playOptions.PlayKubeOptions)
 	if err != nil {
 		return err
 	}
@@ -478,7 +478,7 @@ func kubeplay(body io.Reader) error {
 
 	// If --wait=true, we need wait for the service container to exit so that we know that the pod has exited and we can clean up
 	if playOptions.Wait {
-		_, err := registry.ContainerEngine().ContainerWait(registry.GetContext(), []string{report.ServiceContainerID}, entities.WaitOptions{})
+		_, err := registry.ContainerEngine().ContainerWait(registry.Context(), []string{report.ServiceContainerID}, entities.WaitOptions{})
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/manifest/exists.go
+++ b/cmd/podman/manifest/exists.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func exists(cmd *cobra.Command, args []string) error {
-	found, err := registry.ImageEngine().ManifestExists(registry.GetContext(), args[0])
+	found, err := registry.ImageEngine().ManifestExists(registry.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/networks/exists.go
+++ b/cmd/podman/networks/exists.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func networkExists(cmd *cobra.Command, args []string) error {
-	response, err := registry.ContainerEngine().NetworkExists(registry.GetContext(), args[0])
+	response, err := registry.ContainerEngine().NetworkExists(registry.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -126,5 +126,5 @@ func logs(_ *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		podName = args[0]
 	}
-	return registry.ContainerEngine().PodLogs(registry.GetContext(), podName, logsPodOptions.PodLogsOptions)
+	return registry.ContainerEngine().PodLogs(registry.Context(), podName, logsPodOptions.PodLogsOptions)
 }

--- a/cmd/podman/registry/registry.go
+++ b/cmd/podman/registry/registry.go
@@ -21,7 +21,7 @@ type CliCommand struct {
 }
 
 var (
-	cliCtx          context.Context
+	cliCtx          = context.Background()
 	containerEngine entities.ContainerEngine
 	exitCode        = 0
 	imageEngine     entities.ImageEngine
@@ -81,28 +81,8 @@ func NewContainerEngine(cmd *cobra.Command, args []string) (entities.ContainerEn
 	return containerEngine, nil
 }
 
-type PodmanOptionsKey struct{}
-
 func Context() context.Context {
-	if cliCtx == nil {
-		cliCtx = ContextWithOptions(context.Background())
-	}
 	return cliCtx
-}
-
-func ContextWithOptions(ctx context.Context) context.Context {
-	cliCtx = context.WithValue(ctx, PodmanOptionsKey{}, podmanOptions)
-	return cliCtx
-}
-
-// GetContextWithOptions deprecated, use  NewContextWithOptions()
-func GetContextWithOptions() context.Context {
-	return ContextWithOptions(context.Background())
-}
-
-// GetContext deprecated, use  Context()
-func GetContext() context.Context {
-	return Context()
 }
 
 func DefaultAPIAddress() string {

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -116,7 +116,7 @@ func init() {
 }
 
 func Execute() {
-	if err := rootCmd.ExecuteContext(registry.GetContextWithOptions()); err != nil {
+	if err := rootCmd.ExecuteContext(registry.Context()); err != nil {
 		if registry.GetExitCode() == 0 {
 			registry.SetExitCode(define.ExecErrorCodeGeneric)
 		}

--- a/cmd/podman/secrets/exists.go
+++ b/cmd/podman/secrets/exists.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func exists(cmd *cobra.Command, args []string) error {
-	found, err := registry.ContainerEngine().SecretExists(registry.GetContext(), args[0])
+	found, err := registry.ContainerEngine().SecretExists(registry.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -75,7 +75,7 @@ func infoFlags(cmd *cobra.Command) {
 }
 
 func info(cmd *cobra.Command, args []string) error {
-	info, err := registry.ContainerEngine().Info(registry.GetContext())
+	info, err := registry.ContainerEngine().Info(registry.Context())
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/volumes/exists.go
+++ b/cmd/podman/volumes/exists.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func volumeExists(cmd *cobra.Command, args []string) error {
-	response, err := registry.ContainerEngine().VolumeExists(registry.GetContext(), args[0])
+	response, err := registry.ContainerEngine().VolumeExists(registry.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/volumes/mount.go
+++ b/cmd/podman/volumes/mount.go
@@ -36,7 +36,7 @@ func init() {
 
 func volumeMount(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
-	reports, err := registry.ContainerEngine().VolumeMount(registry.GetContext(), args)
+	reports, err := registry.ContainerEngine().VolumeMount(registry.Context(), args)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/volumes/unmount.go
+++ b/cmd/podman/volumes/unmount.go
@@ -32,7 +32,7 @@ func init() {
 
 func volumeUnmount(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
-	reports, err := registry.ContainerEngine().VolumeUnmount(registry.GetContext(), args)
+	reports, err := registry.ContainerEngine().VolumeUnmount(registry.Context(), args)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/define/vmfile_test.go
+++ b/pkg/machine/define/vmfile_test.go
@@ -55,9 +55,7 @@ func TestNewMachineFile(t *testing.T) {
 
 	homedir := t.TempDir()
 	longTemp := t.TempDir()
-	oldhome := os.Getenv("HOME")
-	os.Setenv("HOME", homedir) //nolint: tenv
-	defer os.Setenv("HOME", oldhome)
+	t.Setenv("HOME", homedir)
 
 	p := "/var/tmp/podman/my.sock"
 	longp := filepath.Join(longTemp, utils.RandomString(100), "my.sock")

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -60,7 +60,6 @@ var _ = Describe("Podman logs", func() {
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results = podmanTest.Podman([]string{"logs", cid})
 				results.WaitWithDefaultTimeout()
@@ -82,7 +81,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "2", cid})
 				results.WaitWithDefaultTimeout()
@@ -123,7 +121,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "99", name})
 				results.WaitWithDefaultTimeout()
@@ -156,7 +153,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "800", cid})
 				results.WaitWithDefaultTimeout()
@@ -177,7 +173,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "2", "-t", cid})
 				results.WaitWithDefaultTimeout()
@@ -198,7 +193,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--since", "2017-08-07T10:10:09.056611202-04:00", cid})
 				results.WaitWithDefaultTimeout()
@@ -219,7 +213,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--since", "10m", cid})
 				results.WaitWithDefaultTimeout()
@@ -240,7 +233,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--until", "10m", cid})
 				results.WaitWithDefaultTimeout()
@@ -261,7 +253,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				now := time.Now()
 				now = now.Add(time.Minute * 1)
@@ -400,7 +391,6 @@ var _ = Describe("Podman logs", func() {
 			Expect(inspect).To(ExitCleanly())
 			Expect(inspect.OutputToString()).To(Equal("10kB"))
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", cid})
 				results.WaitWithDefaultTimeout()
@@ -420,7 +410,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "test"})
 				results.WaitWithDefaultTimeout()
@@ -444,7 +433,6 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", cname})
 				results.WaitWithDefaultTimeout()
@@ -467,7 +455,6 @@ var _ = Describe("Podman logs", func() {
 			// However this test must make sure that there is no such extra newline.
 			Expect(string(logc.Out.Contents())).To(Equal(content))
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				logs := podmanTest.Podman([]string{"logs", cname})
 				logs.WaitWithDefaultTimeout()
@@ -502,7 +489,6 @@ var _ = Describe("Podman logs", func() {
 			ctr.WaitWithDefaultTimeout()
 			Expect(ctr).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"pod", "logs", "-l"})
 				results.WaitWithDefaultTimeout()
@@ -538,7 +524,6 @@ var _ = Describe("Podman logs", func() {
 			log2.WaitWithDefaultTimeout()
 			Expect(log2).To(ExitCleanly())
 
-			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"pod", "logs", "-l"})
 				results.WaitWithDefaultTimeout()
@@ -561,7 +546,6 @@ var _ = Describe("Podman logs", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).To(ExitCleanly())
 
-		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_TAG", fmt.Sprintf("CONTAINER_ID_FULL=%s", cid))
 			out, err := cmd.CombinedOutput()
@@ -582,7 +566,6 @@ var _ = Describe("Podman logs", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).To(ExitCleanly())
 
-		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_NAME", fmt.Sprintf("CONTAINER_ID_FULL=%s", cid))
 			out, err := cmd.CombinedOutput()
@@ -649,7 +632,6 @@ var _ = Describe("Podman logs", func() {
 		log2.WaitWithDefaultTimeout()
 		Expect(log2).To(ExitCleanly())
 
-		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			results := podmanTest.Podman([]string{"pod", "logs", "--names", podName})
 			results.WaitWithDefaultTimeout()
@@ -676,7 +658,6 @@ var _ = Describe("Podman logs", func() {
 		log2.WaitWithDefaultTimeout()
 		Expect(log2).To(ExitCleanly())
 
-		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			results := podmanTest.Podman([]string{"pod", "logs", "--color", podName})
 			results.WaitWithDefaultTimeout()

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -60,6 +60,7 @@ var _ = Describe("Podman logs", func() {
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results = podmanTest.Podman([]string{"logs", cid})
 				results.WaitWithDefaultTimeout()
@@ -81,6 +82,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "2", cid})
 				results.WaitWithDefaultTimeout()
@@ -121,6 +123,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "99", name})
 				results.WaitWithDefaultTimeout()
@@ -153,6 +156,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "800", cid})
 				results.WaitWithDefaultTimeout()
@@ -173,6 +177,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--tail", "2", "-t", cid})
 				results.WaitWithDefaultTimeout()
@@ -193,6 +198,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--since", "2017-08-07T10:10:09.056611202-04:00", cid})
 				results.WaitWithDefaultTimeout()
@@ -213,6 +219,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--since", "10m", cid})
 				results.WaitWithDefaultTimeout()
@@ -233,6 +240,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "--until", "10m", cid})
 				results.WaitWithDefaultTimeout()
@@ -253,6 +261,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				now := time.Now()
 				now = now.Add(time.Minute * 1)
@@ -391,6 +400,7 @@ var _ = Describe("Podman logs", func() {
 			Expect(inspect).To(ExitCleanly())
 			Expect(inspect.OutputToString()).To(Equal("10kB"))
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", cid})
 				results.WaitWithDefaultTimeout()
@@ -410,6 +420,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", "test"})
 				results.WaitWithDefaultTimeout()
@@ -433,6 +444,7 @@ var _ = Describe("Podman logs", func() {
 			wait.WaitWithDefaultTimeout()
 			Expect(wait).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"logs", cname})
 				results.WaitWithDefaultTimeout()
@@ -455,6 +467,7 @@ var _ = Describe("Podman logs", func() {
 			// However this test must make sure that there is no such extra newline.
 			Expect(string(logc.Out.Contents())).To(Equal(content))
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				logs := podmanTest.Podman([]string{"logs", cname})
 				logs.WaitWithDefaultTimeout()
@@ -489,6 +502,7 @@ var _ = Describe("Podman logs", func() {
 			ctr.WaitWithDefaultTimeout()
 			Expect(ctr).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"pod", "logs", "-l"})
 				results.WaitWithDefaultTimeout()
@@ -524,6 +538,7 @@ var _ = Describe("Podman logs", func() {
 			log2.WaitWithDefaultTimeout()
 			Expect(log2).To(ExitCleanly())
 
+			//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 			Eventually(func(g Gomega) {
 				results := podmanTest.Podman([]string{"pod", "logs", "-l"})
 				results.WaitWithDefaultTimeout()
@@ -546,6 +561,7 @@ var _ = Describe("Podman logs", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).To(ExitCleanly())
 
+		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_TAG", fmt.Sprintf("CONTAINER_ID_FULL=%s", cid))
 			out, err := cmd.CombinedOutput()
@@ -566,6 +582,7 @@ var _ = Describe("Podman logs", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).To(ExitCleanly())
 
+		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_NAME", fmt.Sprintf("CONTAINER_ID_FULL=%s", cid))
 			out, err := cmd.CombinedOutput()
@@ -632,6 +649,7 @@ var _ = Describe("Podman logs", func() {
 		log2.WaitWithDefaultTimeout()
 		Expect(log2).To(ExitCleanly())
 
+		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			results := podmanTest.Podman([]string{"pod", "logs", "--names", podName})
 			results.WaitWithDefaultTimeout()
@@ -658,6 +676,7 @@ var _ = Describe("Podman logs", func() {
 		log2.WaitWithDefaultTimeout()
 		Expect(log2).To(ExitCleanly())
 
+		//nolint:ginkgolinter // false positive https://github.com/golangci/golangci-lint/issues/5398
 		Eventually(func(g Gomega) {
 			results := podmanTest.Podman([]string{"pod", "logs", "--color", podName})
 			results.WaitWithDefaultTimeout()


### PR DESCRIPTION
Macos build task is failing in the lint step currently, I suspect because the macos workers were updated to go 1.24 but the older golangci-lint version did not support it yet. As such we have to update to the new version here.
clean cherry picks from #25304 and #25315

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
