### PR TITLE
Fix reporting summed image size for compat endpoint

### DIFF
--- a/pkg/api/handlers/compat/system.go
+++ b/pkg/api/handlers/compat/system.go
@@ -89,7 +89,7 @@ func GetDiskUsage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteResponse(w, http.StatusOK, handlers.DiskUsage{DiskUsage: docker.DiskUsage{
-		LayersSize:  0,
+		LayersSize:  df.ImagesSize,
 		Images:      imgs,
 		Containers:  ctnrs,
 		Volumes:     vols,

--- a/test/apiv2/45-system.at
+++ b/test/apiv2/45-system.at
@@ -34,6 +34,10 @@ t POST containers/create Image=$IMAGE Volumes='{"/test":{}}' HostConfig='{"Binds
   .Id~[0-9a-f]\\{64\\}
 cid=$(jq -r '.Id' <<<"$output")
 
+# Verify image takes size
+t GET system/df 200 '.LayersSize=12180391'
+t GET libpod/system/df 200 '.ImagesSize=12180391'
+
 # Verify that one container references the volume
 t GET system/df 200 '.Volumes[0].UsageData.RefCount=1'
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed reporting summed image size when using compat endpoint in disk usage
```
