### PR TITLE
Replace deprecated Docker types

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -6,9 +6,11 @@ import (
 	docker "github.com/docker/docker/api/types"
 	dockerBackend "github.com/docker/docker/api/types/backend"
 	dockerContainer "github.com/docker/docker/api/types/container"
+	dockerImage "github.com/docker/docker/api/types/image"
 	dockerNetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/api/types/volume"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -45,7 +47,7 @@ type LibpodImagesResolveReport struct {
 }
 
 type ContainersPruneReport struct {
-	docker.ContainersPruneReport
+	dockerContainer.PruneReport
 }
 
 type ContainersPruneReportLibpod struct {
@@ -101,11 +103,11 @@ type DiskUsage struct {
 }
 
 type VolumesPruneReport struct {
-	docker.VolumesPruneReport
+	volume.PruneReport
 }
 
 type ImagesPruneReport struct {
-	docker.ImagesPruneReport
+	dockerImage.PruneReport
 }
 
 type BuildCachePruneReport struct {
@@ -113,7 +115,7 @@ type BuildCachePruneReport struct {
 }
 
 type NetworkPruneReport struct {
-	docker.NetworksPruneReport
+	dockerNetwork.PruneReport
 }
 
 type ConfigCreateResponse struct {
@@ -166,7 +168,7 @@ type HistoryResponse struct {
 }
 
 type ExecCreateConfig struct {
-	docker.ExecConfig
+	dockerContainer.ExecOptions
 }
 
 type ExecStartConfig struct {


### PR DESCRIPTION
Docker has removed the temporary aliases for these types in their latest releases. 

Example: https://github.com/moby/moby/commit/e0156f0f160f695ee31e9ceb9ccb96300bcab22f
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".
