### PR TITLE
add artifact mount support

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -6,12 +6,12 @@
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPEs are **bind**, **devpts**, **glob**, **image**, **ramfs**, **tmpfs** and **volume**.
+Current supported mount TYPEs are **artifact**, **bind**, **devpts**, **glob**, **image**, **ramfs**, **tmpfs** and **volume**.
 
 Options common to all mount types:
 
 - *src*, *source*: mount source spec for **bind**, **glob**, and **volume**.
-  Mandatory for **bind** and **glob**.
+  Mandatory for **artifact**, **bind**, **glob**, **image** and **volume**.
 
 - *dst*, *destination*, *target*: mount destination spec.
 
@@ -23,6 +23,25 @@ on the destination directory are mounted. The option
 `type=glob,src=/foo*,destination=/tmp/bar` tells container engines
 to mount host files matching /foo* to the /tmp/bar/
 directory in the container.
+
+Options specific to type=**artifact**:
+
+- *digest*: If the artifact source contains multiple blobs a digest can be
+  specified to only mount the one specific blob with the digest.
+
+- *title*: If the artifact source contains multiple blobs a title can be set
+  which is compared against `org.opencontainers.image.title` annotation.
+
+The *src* argument contains the name of the artifact, it must already exist locally.
+The *dst* argument contains the target path, if the path in the container is a
+directory or does not exist the blob title (`org.opencontainers.image.title`
+annotation) will be used as filename and joined to the path. If the annotation
+does not exist the digest will be used as filename instead. This results in all blobs
+of the artifact mounted into the container at the given path.
+
+However if the *dst* path is a existing file in the container then the blob will be
+mounted directly on it. This only works when the artifact contains of a single blob
+or when either *digest* or *title* are specified.
 
 Options specific to type=**volume**:
 
@@ -104,4 +123,6 @@ Examples:
 
 - `type=tmpfs,destination=/path/in/container,noswap`
 
-- `type=volume,source=vol1,destination=/path/in/container,ro=true`
+- `type=artifact,src=quay.io/libpod/testartifact:20250206-single,dst=/data`
+
+- `type=artifact,src=quay.io/libpod/testartifact:20250206-multi,dst=/data,title=test1`

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -280,6 +280,28 @@ type ContainerImageVolume struct {
 	SubPath string `json:"subPath,omitempty"`
 }
 
+// ContainerArtifactVolume is a volume based on a artifact. The artifact blobs will
+// be bind mounted directly as files and must always be read only.
+type ContainerArtifactVolume struct {
+	// Source is the name or digest of the artifact that should be mounted
+	Source string `json:"source"`
+	// Dest is the absolute path of the mount in the container.
+	// If path is a file in the container, then the artifact must consist of a single blob.
+	// Otherwise if it is a directory or does not exists all artifact blobs will be mounted
+	// into this path as files. As name the "org.opencontainers.image.title" will be used if
+	// available otherwise the digest is used as name.
+	Dest string `json:"dest"`
+	// Title can be used for multi blob artifacts to only mount the one specific blob that
+	// matches the "org.opencontainers.image.title" annotation.
+	// Optional. Conflicts with Digest.
+	Title string `json:"title"`
+	// Digest can be used to filter a single blob from a multi blob artifact by the given digest.
+	// When this option is set the file name in the container defaults to the digest even when
+	// the title annotation exist.
+	// Optional. Conflicts with Title.
+	Digest string `json:"digest"`
+}
+
 // ContainerSecret is a secret that is mounted in a container
 type ContainerSecret struct {
 	// Secret is the secret

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -162,6 +162,8 @@ type ContainerRootFSConfig struct {
 	// moved out of Libpod into pkg/specgen).
 	// Please DO NOT reuse the `imageVolumes` name in container JSON again.
 	ImageVolumes []*ContainerImageVolume `json:"ctrImageVolumes,omitempty"`
+	// ArtifactVolumes lists the artifact volumes to mount into the container.
+	ArtifactVolumes []*ContainerArtifactVolume `json:"artifactVolumes,omitempty"`
 	// CreateWorkingDir indicates that Libpod should create the container's
 	// working directory if it does not exist. Some OCI runtimes do this by
 	// default, but others do not.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1515,6 +1515,19 @@ func WithImageVolumes(volumes []*ContainerImageVolume) CtrCreateOption {
 	}
 }
 
+// WithImageVolumes adds the given image volumes to the container.
+func WithArtifactVolumes(volumes []*ContainerArtifactVolume) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.ArtifactVolumes = volumes
+
+		return nil
+	}
+}
+
 // WithHealthCheck adds the healthcheck to the container config
 func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/domain/infra/abi/artifact.go
+++ b/pkg/domain/infra/abi/artifact.go
@@ -5,22 +5,16 @@ package abi
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/containers/common/libimage"
 	"github.com/containers/podman/v5/pkg/domain/entities"
-	"github.com/containers/podman/v5/pkg/libartifact/store"
 	"github.com/containers/podman/v5/pkg/libartifact/types"
 	"github.com/opencontainers/go-digest"
 )
 
-func getDefaultArtifactStore(ir *ImageEngine) string {
-	return filepath.Join(ir.Libpod.StorageConfig().GraphRoot, "artifacts")
-}
-
 func (ir *ImageEngine) ArtifactInspect(ctx context.Context, name string, _ entities.ArtifactInspectOptions) (*entities.ArtifactInspectReport, error) {
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +35,7 @@ func (ir *ImageEngine) ArtifactInspect(ctx context.Context, name string, _ entit
 
 func (ir *ImageEngine) ArtifactList(ctx context.Context, _ entities.ArtifactListOptions) ([]*entities.ArtifactListReport, error) {
 	reports := make([]*entities.ArtifactListReport, 0)
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +74,7 @@ func (ir *ImageEngine) ArtifactPull(ctx context.Context, name string, opts entit
 	if !opts.Quiet && pullOptions.Writer == nil {
 		pullOptions.Writer = os.Stderr
 	}
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +86,7 @@ func (ir *ImageEngine) ArtifactRm(ctx context.Context, name string, opts entitie
 		namesOrDigests []string
 	)
 	artifactDigests := make([]*digest.Digest, 0, len(namesOrDigests))
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +127,7 @@ func (ir *ImageEngine) ArtifactRm(ctx context.Context, name string, opts entitie
 func (ir *ImageEngine) ArtifactPush(ctx context.Context, name string, opts entities.ArtifactPushOptions) (*entities.ArtifactPushReport, error) {
 	var retryDelay *time.Duration
 
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +183,7 @@ func (ir *ImageEngine) ArtifactPush(ctx context.Context, name string, opts entit
 	return &entities.ArtifactPushReport{}, err
 }
 func (ir *ImageEngine) ArtifactAdd(ctx context.Context, name string, paths []string, opts *entities.ArtifactAddOptions) (*entities.ArtifactAddReport, error) {
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +204,7 @@ func (ir *ImageEngine) ArtifactAdd(ctx context.Context, name string, paths []str
 }
 
 func (ir *ImageEngine) ArtifactExtract(ctx context.Context, name string, target string, opts *entities.ArtifactExtractOptions) error {
-	artStore, err := store.NewArtifactStore(getDefaultArtifactStore(ir), ir.Libpod.SystemContext())
+	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return err
 	}

--- a/pkg/domain/infra/abi/artifact.go
+++ b/pkg/domain/infra/abi/artifact.go
@@ -215,8 +215,10 @@ func (ir *ImageEngine) ArtifactExtract(ctx context.Context, name string, target 
 		return err
 	}
 	extractOpt := &types.ExtractOptions{
-		Digest: opts.Digest,
-		Title:  opts.Title,
+		FilterBlobOptions: types.FilterBlobOptions{
+			Digest: opts.Digest,
+			Title:  opts.Title,
+		},
 	}
 
 	return artStore.Extract(ctx, name, target, extractOpt)

--- a/pkg/domain/infra/abi/artifact.go
+++ b/pkg/domain/infra/abi/artifact.go
@@ -85,7 +85,6 @@ func (ir *ImageEngine) ArtifactRm(ctx context.Context, name string, opts entitie
 	var (
 		namesOrDigests []string
 	)
-	artifactDigests := make([]*digest.Digest, 0, len(namesOrDigests))
 	artStore, err := ir.Libpod.ArtifactStore()
 	if err != nil {
 		return nil, err
@@ -111,6 +110,7 @@ func (ir *ImageEngine) ArtifactRm(ctx context.Context, name string, opts entitie
 		namesOrDigests = append(namesOrDigests, name)
 	}
 
+	artifactDigests := make([]*digest.Digest, 0, len(namesOrDigests))
 	for _, namesOrDigest := range namesOrDigests {
 		artifactDigest, err := artStore.Remove(ctx, namesOrDigest)
 		if err != nil {

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -312,7 +312,7 @@ func (as ArtifactStore) Add(ctx context.Context, dest string, paths []string, op
 	return &artifactManifestDigest, nil
 }
 
-// Inspect an artifact in a local store
+// Extract an artifact to local file or directory
 func (as ArtifactStore) Extract(ctx context.Context, nameOrDigest string, target string, options *libartTypes.ExtractOptions) error {
 	if len(options.Digest) > 0 && len(options.Title) > 0 {
 		return errors.New("cannot specify both digest and title")

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -364,7 +364,7 @@ func (as ArtifactStore) Extract(ctx context.Context, nameOrDigest string, target
 			if len(options.Digest) == 0 && len(options.Title) == 0 {
 				return fmt.Errorf("the artifact consists of several blobs and the target %q is not a directory and neither digest or title was specified to only copy a single blob", target)
 			}
-			digest, err = findDigest(arty, options)
+			digest, err = findDigest(arty, &options.FilterBlobOptions)
 			if err != nil {
 				return err
 			}
@@ -376,7 +376,7 @@ func (as ArtifactStore) Extract(ctx context.Context, nameOrDigest string, target
 	}
 
 	if len(options.Digest) > 0 || len(options.Title) > 0 {
-		digest, err := findDigest(arty, options)
+		digest, err := findDigest(arty, &options.FilterBlobOptions)
 		if err != nil {
 			return err
 		}
@@ -427,7 +427,7 @@ func generateArtifactBlobName(title string, digest digest.Digest) (string, error
 	return filename, nil
 }
 
-func findDigest(arty *libartifact.Artifact, options *libartTypes.ExtractOptions) (digest.Digest, error) {
+func findDigest(arty *libartifact.Artifact, options *libartTypes.FilterBlobOptions) (digest.Digest, error) {
 	var digest digest.Digest
 	for _, l := range arty.Manifest.Layers {
 		if options.Digest == l.Digest.String() {

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -47,6 +47,10 @@ func NewArtifactStore(storePath string, sc *types.SystemContext) (*ArtifactStore
 	if storePath == "" {
 		return nil, errors.New("store path cannot be empty")
 	}
+	if !filepath.IsAbs(storePath) {
+		return nil, fmt.Errorf("store path %q must be absolute", storePath)
+	}
+
 	logrus.Debugf("Using artifact store path: %s", storePath)
 
 	artifactStore := &ArtifactStore{

--- a/pkg/libartifact/types/config.go
+++ b/pkg/libartifact/types/config.go
@@ -12,9 +12,16 @@ type AddOptions struct {
 	Append bool `json:",omitempty"`
 }
 
-type ExtractOptions struct {
-	// Title annotation value to extract only a single blob matching that name. Optional.
+// FilterBlobOptions options used to filter for a single blob in an artifact
+type FilterBlobOptions struct {
+	// Title annotation value to extract only a single blob matching that name.
+	// Optional. Conflicts with Digest.
 	Title string
-	// Digest of the blob to extract. Optional.
+	// Digest of the blob to extract.
+	// Optional. Conflicts with Title.
 	Digest string
+}
+
+type ExtractOptions struct {
+	FilterBlobOptions
 }

--- a/pkg/libartifact/types/config.go
+++ b/pkg/libartifact/types/config.go
@@ -25,3 +25,15 @@ type FilterBlobOptions struct {
 type ExtractOptions struct {
 	FilterBlobOptions
 }
+
+type BlobMountPathOptions struct {
+	FilterBlobOptions
+}
+
+// BlobMountPath contains the info on how the artifact must be mounted
+type BlobMountPath struct {
+	// Source path of the blob, i.e. full path in the blob dir.
+	SourcePath string
+	// Name of the file in the container.
+	Name string
+}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -507,6 +507,19 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		options = append(options, libpod.WithImageVolumes(vols))
 	}
 
+	if len(s.ArtifactVolumes) != 0 {
+		vols := make([]*libpod.ContainerArtifactVolume, 0, len(s.ArtifactVolumes))
+		for _, v := range s.ArtifactVolumes {
+			vols = append(vols, &libpod.ContainerArtifactVolume{
+				Dest:   v.Destination,
+				Source: v.Source,
+				Digest: v.Digest,
+				Title:  v.Title,
+			})
+		}
+		options = append(options, libpod.WithArtifactVolumes(vols))
+	}
+
 	if s.Command != nil {
 		options = append(options, libpod.WithCommand(s.Command))
 	}

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -305,6 +305,8 @@ type ContainerStorageConfig struct {
 	// Image volumes bind-mount a container-image mount into the container.
 	// Optional.
 	ImageVolumes []*ImageVolume `json:"image_volumes,omitempty"`
+	// ArtifactVolumes volumes based on an existing artifact.
+	ArtifactVolumes []*ArtifactVolume `json:"artifact_volumes,omitempty"`
 	// Devices are devices that will be added to the container.
 	// Optional.
 	Devices []spec.LinuxDevice `json:"devices,omitempty"`

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -58,6 +58,28 @@ type ImageVolume struct {
 	SubPath string `json:"subPath,omitempty"`
 }
 
+// ArtifactVolume is a volume based on a artifact. The artifact blobs will
+// be bind mounted directly as files and must always be read only.
+type ArtifactVolume struct {
+	// Source is the name or digest of the artifact that should be mounted
+	Source string `json:"source"`
+	// Destination is the absolute path of the mount in the container.
+	// If path is a file in the container, then the artifact must consist of a single blob.
+	// Otherwise if it is a directory or does not exists all artifact blobs will be mounted
+	// into this path as files. As name the "org.opencontainers.image.title" will be used if
+	// available otherwise the digest is used as name.
+	Destination string `json:"destination"`
+	// Title can be used for multi blob artifacts to only mount the one specific blob that
+	// matches the "org.opencontainers.image.title" annotation.
+	// Optional. Conflicts with Digest.
+	Title string `json:"title,omitempty"`
+	// Digest can be used to filter a single blob from a multi blob artifact by the given digest.
+	// When this option is set the file name in the container defaults to the digest even when
+	// the title annotation exist.
+	// Optional. Conflicts with Title.
+	Digest string `json:"digest,omitempty"`
+}
+
 // GenVolumeMounts parses user input into mounts, volumes and overlay volumes
 func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*NamedVolume, map[string]*OverlayVolume, error) {
 	mounts := make(map[string]spec.Mount)

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -790,6 +790,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if len(s.ImageVolumes) == 0 {
 		s.ImageVolumes = containerMounts.imageVolumes
 	}
+	if len(s.ArtifactVolumes) == 0 {
+		s.ArtifactVolumes = containerMounts.artifactVolumes
+	}
 
 	devices := c.Devices
 	for _, gpu := range c.GPUs {

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -762,15 +762,15 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 
 	// Only add read-only tmpfs mounts in case that we are read-only and the
 	// read-only tmpfs flag has been set.
-	mounts, volumes, overlayVolumes, imageVolumes, err := parseVolumes(rtc, c.Volume, c.Mount, c.TmpFS)
+	containerMounts, err := parseVolumes(rtc, c.Volume, c.Mount, c.TmpFS)
 	if err != nil {
 		return err
 	}
 	if len(s.Mounts) == 0 || len(c.Mount) != 0 {
-		s.Mounts = mounts
+		s.Mounts = containerMounts.mounts
 	}
 	if len(s.Volumes) == 0 || len(c.Volume) != 0 {
-		s.Volumes = volumes
+		s.Volumes = containerMounts.volumes
 	}
 
 	if s.LabelNested != nil && *s.LabelNested {
@@ -785,10 +785,10 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	}
 	// TODO make sure these work in clone
 	if len(s.OverlayVolumes) == 0 {
-		s.OverlayVolumes = overlayVolumes
+		s.OverlayVolumes = containerMounts.overlayVolumes
 	}
 	if len(s.ImageVolumes) == 0 {
-		s.ImageVolumes = imageVolumes
+		s.ImageVolumes = containerMounts.imageVolumes
 	}
 
 	devices := c.Devices

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -37,7 +37,7 @@ type universalMount struct {
 func parseVolumes(rtc *config.Config, volumeFlag, mountFlag, tmpfsFlag []string) ([]spec.Mount, []*specgen.NamedVolume, []*specgen.OverlayVolume, []*specgen.ImageVolume, error) {
 	// Get mounts from the --mounts flag.
 	// TODO: The runtime config part of this needs to move into pkg/specgen/generate to avoid querying containers.conf on the client.
-	unifiedMounts, unifiedVolumes, unifiedImageVolumes, err := Mounts(mountFlag, rtc.Mounts())
+	unifiedMounts, unifiedVolumes, unifiedImageVolumes, err := mounts(mountFlag, rtc.Mounts())
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -146,12 +146,12 @@ func parseVolumes(rtc *config.Config, volumeFlag, mountFlag, tmpfsFlag []string)
 	return finalMounts, finalVolumes, finalOverlayVolume, finalImageVolumes, nil
 }
 
-// Mounts takes user-provided input from the --mount flag as well as Mounts
+// mounts takes user-provided input from the --mount flag as well as mounts
 // specified in containers.conf and creates OCI spec mounts and Libpod named volumes.
 // podman run --mount type=bind,src=/etc/resolv.conf,target=/etc/resolv.conf ...
 // podman run --mount type=tmpfs,target=/dev/shm ...
 // podman run --mount type=volume,source=test-volume, ...
-func Mounts(mountFlag []string, configMounts []string) (map[string]spec.Mount, map[string]*specgen.NamedVolume, map[string]*specgen.ImageVolume, error) {
+func mounts(mountFlag []string, configMounts []string) (map[string]spec.Mount, map[string]*specgen.NamedVolume, map[string]*specgen.ImageVolume, error) {
 	finalMounts := make(map[string]spec.Mount)
 	finalNamedVolumes := make(map[string]*specgen.NamedVolume)
 	finalImageVolumes := make(map[string]*specgen.ImageVolume)

--- a/test/e2e/artifact_mount_test.go
+++ b/test/e2e/artifact_mount_test.go
@@ -1,0 +1,223 @@
+//go:build linux || freebsd
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/containers/podman/v5/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman artifact mount", func() {
+	BeforeEach(func() {
+		SkipIfRemote("artifacts are not supported on the remote client yet due to being in development still")
+	})
+
+	It("podman artifact mount single blob", func() {
+		podmanTest.PodmanExitCleanly("artifact", "pull", ARTIFACT_SINGLE)
+
+		const artifactContent = "mRuO9ykak1Q2j"
+
+		tests := []struct {
+			name          string
+			mountOpts     string
+			containerFile string
+		}{
+			{
+				name:          "single artifact mount",
+				mountOpts:     "dst=/test",
+				containerFile: "/test/testfile",
+			},
+			{
+				name:          "single artifact mount on existing file",
+				mountOpts:     "dst=/etc/os-release",
+				containerFile: "/etc/os-release",
+			},
+			{
+				name:          "single artifact mount with title",
+				mountOpts:     "dst=/tmp,title=testfile",
+				containerFile: "/tmp/testfile",
+			},
+			{
+				name:          "single artifact mount with digest",
+				mountOpts:     "dst=/data,digest=sha256:e9510923578af3632946ecf5ae479c1b5f08b47464e707b5cbab9819272a9752",
+				containerFile: "/data/sha256-e9510923578af3632946ecf5ae479c1b5f08b47464e707b5cbab9819272a9752",
+			},
+		}
+
+		for _, tt := range tests {
+			By(tt.name)
+			// FIXME: we need https://github.com/containers/container-selinux/pull/360 to fix the selinux access problem, until then disable it.
+			session := podmanTest.PodmanExitCleanly("run", "--security-opt=label=disable", "--rm", "--mount", "type=artifact,src="+ARTIFACT_SINGLE+","+tt.mountOpts, ALPINE, "cat", tt.containerFile)
+			Expect(session.OutputToString()).To(Equal(artifactContent))
+		}
+	})
+
+	It("podman artifact mount multi blob", func() {
+		podmanTest.PodmanExitCleanly("artifact", "pull", ARTIFACT_MULTI)
+		podmanTest.PodmanExitCleanly("artifact", "pull", ARTIFACT_MULTI_NO_TITLE)
+
+		const (
+			artifactContent1 = "xuHWedtC0ADST"
+			artifactContent2 = "tAyZczFlgFsi4"
+		)
+
+		type expectedFiles struct {
+			file    string
+			content string
+		}
+
+		tests := []struct {
+			name           string
+			mountOpts      string
+			containerFiles []expectedFiles
+		}{
+			{
+				name:      "multi blob with title",
+				mountOpts: "src=" + ARTIFACT_MULTI + ",dst=/test",
+				containerFiles: []expectedFiles{
+					{
+						file:    "/test/test1",
+						content: artifactContent1,
+					},
+					{
+						file:    "/test/test2",
+						content: artifactContent2,
+					},
+				},
+			},
+			{
+				name:      "multi blob without title",
+				mountOpts: "src=" + ARTIFACT_MULTI_NO_TITLE + ",dst=/test",
+				containerFiles: []expectedFiles{
+					{
+						file:    "/test/sha256-8257bba28b9d19ac353c4b713b470860278857767935ef7e139afd596cb1bb2d",
+						content: artifactContent1,
+					},
+					{
+						file:    "/test/sha256-63700c54129c6daaafe3a20850079f82d6d658d69de73d6158d81f920c6fbdd7",
+						content: artifactContent2,
+					},
+				},
+			},
+			{
+				name:      "multi blob filter by title",
+				mountOpts: "src=" + ARTIFACT_MULTI + ",dst=/test,title=test2",
+				containerFiles: []expectedFiles{
+					{
+						file:    "/test/test2",
+						content: artifactContent2,
+					},
+				},
+			},
+			{
+				name:      "multi blob filter by digest",
+				mountOpts: "src=" + ARTIFACT_MULTI + ",dst=/test,digest=sha256:8257bba28b9d19ac353c4b713b470860278857767935ef7e139afd596cb1bb2d",
+				containerFiles: []expectedFiles{
+					{
+						file:    "/test/sha256-8257bba28b9d19ac353c4b713b470860278857767935ef7e139afd596cb1bb2d",
+						content: artifactContent1,
+					},
+				},
+			},
+		}
+		for _, tt := range tests {
+			By(tt.name)
+			// FIXME: we need https://github.com/containers/container-selinux/pull/360 to fix the selinux access problem, until then disable it.
+			args := []string{"run", "--security-opt=label=disable", "--rm", "--mount", "type=artifact," + tt.mountOpts, ALPINE, "cat"}
+			for _, f := range tt.containerFiles {
+				args = append(args, f.file)
+			}
+			session := podmanTest.PodmanExitCleanly(args...)
+			outs := session.OutputToStringArray()
+			Expect(outs).To(HaveLen(len(tt.containerFiles)))
+			for i, f := range tt.containerFiles {
+				Expect(outs[i]).To(Equal(f.content))
+			}
+		}
+	})
+
+	It("podman artifact mount remove while in use", func() {
+		ctrName := "ctr1"
+		artifactName := "localhost/test"
+		artifactFileName := "somefile"
+
+		artifactFile := filepath.Join(podmanTest.TempDir, artifactFileName)
+		err := os.WriteFile(artifactFile, []byte("hello world\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("artifact", "add", artifactName, artifactFile)
+
+		// FIXME: we need https://github.com/containers/container-selinux/pull/360 to fix the selinux access problem, until then disable it.
+		podmanTest.PodmanExitCleanly("run", "--security-opt=label=disable", "--name", ctrName, "-d", "--mount", "type=artifact,src="+artifactName+",dst=/test", ALPINE, "sleep", "100")
+
+		podmanTest.PodmanExitCleanly("artifact", "rm", artifactName)
+
+		// file must sill be readable after artifact removal
+		session := podmanTest.PodmanExitCleanly("exec", ctrName, "cat", "/test/"+artifactFileName)
+		Expect(session.OutputToString()).To(Equal("hello world"))
+
+		// restart will fail if artifact does not exist
+		session = podmanTest.Podman([]string{"restart", "-t0", ctrName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError(125, artifactName+": artifact does not exist"))
+
+		// create a artifact with the same name again and add another file to ensure it picks up the changes
+		artifactFile2Name := "otherfile"
+		artifactFile2 := filepath.Join(podmanTest.TempDir, artifactFile2Name)
+		err = os.WriteFile(artifactFile2, []byte("second file"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		podmanTest.PodmanExitCleanly("artifact", "add", artifactName, artifactFile, artifactFile2)
+		podmanTest.PodmanExitCleanly("start", ctrName)
+
+		session = podmanTest.PodmanExitCleanly("exec", ctrName, "cat", "/test/"+artifactFileName, "/test/"+artifactFile2Name)
+		Expect(session.OutputToString()).To(Equal("hello world second file"))
+	})
+
+	It("podman artifact mount dest conflict", func() {
+		tests := []struct {
+			name  string
+			mount string
+		}{
+			{
+				name:  "bind mount --volume",
+				mount: "--volume=/tmp:/test",
+			},
+			{
+				name:  "overlay mount",
+				mount: "--volume=/tmp:/test:O",
+			},
+			{
+				name:  "named volume",
+				mount: "--volume=abc:/test:O",
+			},
+			{
+				name:  "bind mount --mount type=bind",
+				mount: "--mount=type=bind,src=/tmp,dst=/test",
+			},
+			{
+				name:  "image mount",
+				mount: "--mount=type=bind,src=someimage,dst=/test",
+			},
+			{
+				name:  "tmpfs mount",
+				mount: "--tmpfs=/test",
+			},
+			{
+				name:  "artifact mount",
+				mount: "--mount=type=artifact,src=abc,dst=/test",
+			},
+		}
+
+		for _, tt := range tests {
+			By(tt.name)
+			session := podmanTest.Podman([]string{"run", "--rm", "--mount", "type=artifact,src=someartifact,dst=/test", tt.mount, ALPINE})
+			session.WaitWithDefaultTimeout()
+			Expect(session).To(ExitWithError(125, "/test: duplicate mount destination"))
+		}
+	})
+})

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -475,7 +475,7 @@ var _ = Describe("Podman artifact", func() {
 		a := podmanTest.InspectArtifact(artifact1Name)
 
 		Expect(a.Manifest.Layers).To(HaveLen(1))
-		Expect(a.TotalSizeBytes()).To(Equal(int64(524288)))
+		Expect(a.TotalSizeBytes()).To(Equal(int64(1024)))
 	})
 
 	It("podman artifact add file already exists in artifact", func() {
@@ -506,7 +506,7 @@ var _ = Describe("Podman artifact", func() {
 		a := podmanTest.InspectArtifact(artifact1Name)
 
 		Expect(a.Manifest.Layers).To(HaveLen(1))
-		Expect(a.TotalSizeBytes()).To(Equal(int64(1048576)))
+		Expect(a.TotalSizeBytes()).To(Equal(int64(2048)))
 	})
 
 	It("podman artifact add with --append and --type", func() {


### PR DESCRIPTION
Add support for mounting artifacts with `type=artifact,src=quay.io/libpod/testartifact:20250206-single,dst=/data`

see commits

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The --mount option accepts a new mount type `artifact` to mount a artifact into a container. 
```
