### PR TITLE
podman run: fix --pids-limit -1 wrt runc

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -212,10 +212,6 @@ func replaceContainer(name string) error {
 func createOrUpdateFlags(cmd *cobra.Command, vals *entities.ContainerCreateOptions) error {
 	if cmd.Flags().Changed("pids-limit") {
 		val := cmd.Flag("pids-limit").Value.String()
-		// Convert -1 to 0, so that -1 maps to unlimited pids limit
-		if val == "-1" {
-			val = "0"
-		}
 		pidsLimit, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
 			return err


### PR DESCRIPTION
gSince commit c25cc7230 ("Allow a value of -1 to set unlimited pids limit", PR #11794) podman converts the pids-limit value of -1 to 0 for OCI spec.

Unfortunately, different runtimes (crun and runc) treat pids.limit=0 differently, and the runtime-spec definition is somewhat vague (see [1]).

Long term fix belongs to runtime-spec and then runtimes should follow it.

Short term fix is do not convert -1 to 0 (as all runtimes treat -1 as unlimited).
   
[NO TESTS NEEDED] -- this is covered by test added in commit 553e53d44.
    
Fixes: https://issues.redhat.com/browse/RHEL-80973

```release-note
podman run/update: fix --pid-limit -1 for runc case
```
