### PR TITLE
Use UnparsedInstance.Manifest instead of ImageSource.GetManifest

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/signature"
@@ -716,7 +717,7 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 					logrus.Errorf("Unable to close %s image source %q", srcRef.DockerReference().Name(), err)
 				}
 			}()
-			topManifestBlob, manifestType, err := rawSource.GetManifest(ctx, nil)
+			topManifestBlob, manifestType, err := image.UnparsedInstance(rawSource, nil).Manifest(ctx)
 			if err != nil {
 				return fmt.Errorf("getting manifest blob: %w", err)
 			}
@@ -757,7 +758,7 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 				instanceDigests := list.Instances()
 				for _, instanceDigest := range instanceDigests {
 					digest := instanceDigest
-					man, _, err := rawSource.GetManifest(ctx, &digest)
+					man, _, err := image.UnparsedInstance(rawSource, &digest).Manifest(ctx)
 					if err != nil {
 						return err
 					}

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/common/libimage/define"
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/pkg/shortnames"
@@ -148,7 +149,7 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string, o
 		}
 		defer src.Close()
 
-		manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
+		manifestBytes, manifestType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 		if err != nil {
 			appendErr(fmt.Errorf("loading manifest %q: %w", transports.ImageName(ref), err))
 			continue
@@ -429,7 +430,7 @@ func (ir *ImageEngine) digestFromDigestOrManifestListMember(ctx context.Context,
 		return "", fmt.Errorf("reading local image %q to check if it's in the manifest list: %w", name, err)
 	}
 	defer src.Close()
-	manifestBytes, _, err := src.GetManifest(ctx, nil)
+	manifestBytes, _, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 	if err != nil {
 		return "", fmt.Errorf("locating image named %q to check if it's in the manifest list: %w", name, err)
 	}

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/containers/common/libimage"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -545,7 +546,7 @@ func (as ArtifactStore) getArtifacts(ctx context.Context, _ *libartTypes.GetArti
 // getManifest takes an imgSrc and returns the manifest for the imgSrc.
 // A OCI index list is not supported and will return an error.
 func getManifest(ctx context.Context, imgSrc types.ImageSource) (*manifest.OCI1, error) {
-	b, manifestType, err := imgSrc.GetManifest(ctx, nil)
+	b, manifestType, err := image.UnparsedInstance(imgSrc, nil).Manifest(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -371,7 +371,7 @@ func (as ArtifactStore) Extract(ctx context.Context, nameOrDigest string, target
 			digest = arty.Manifest.Layers[0].Digest
 		}
 
-		return copyImageBlobToFile(ctx, imgSrc, digest, target)
+		return copyTrustedImageBlobToFile(ctx, imgSrc, digest, target)
 	}
 
 	if len(options.Digest) > 0 || len(options.Title) > 0 {
@@ -387,7 +387,7 @@ func (as ArtifactStore) Extract(ctx context.Context, nameOrDigest string, target
 		if err != nil {
 			return err
 		}
-		return copyImageBlobToFile(ctx, imgSrc, digest, filepath.Join(target, filename))
+		return copyTrustedImageBlobToFile(ctx, imgSrc, digest, filepath.Join(target, filename))
 	}
 
 	for _, l := range arty.Manifest.Layers {
@@ -396,7 +396,7 @@ func (as ArtifactStore) Extract(ctx context.Context, nameOrDigest string, target
 		if err != nil {
 			return err
 		}
-		err = copyImageBlobToFile(ctx, imgSrc, l.Digest, filepath.Join(target, filename))
+		err = copyTrustedImageBlobToFile(ctx, imgSrc, l.Digest, filepath.Join(target, filename))
 		if err != nil {
 			return err
 		}
@@ -454,7 +454,11 @@ func findDigest(arty *libartifact.Artifact, options *libartTypes.ExtractOptions)
 	return digest, nil
 }
 
-func copyImageBlobToFile(ctx context.Context, imgSrc types.ImageSource, digest digest.Digest, target string) error {
+// copyTrustedImageBlobToFile copies blob identified by digest in imgSrc to file target.
+//
+// WARNING: This does not validate the contents against the expected digest, so it should only
+// be used to read from trusted sources!
+func copyTrustedImageBlobToFile(ctx context.Context, imgSrc types.ImageSource, digest digest.Digest, target string) error {
 	src, _, err := imgSrc.GetBlob(ctx, types.BlobInfo{Digest: digest}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get artifact file: %w", err)

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v5/pkg/machine/compression"
@@ -310,7 +311,7 @@ func (o *OCIArtifactDisk) decompress() error {
 }
 
 func getOriginalFileName(ctx context.Context, imgSrc types.ImageSource, artifactDigest digest.Digest) (string, error) {
-	v1RawMannyfest, _, err := imgSrc.GetManifest(ctx, &artifactDigest)
+	v1RawMannyfest, _, err := image.UnparsedInstance(imgSrc, &artifactDigest).Manifest(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/machine/ocipull/source.go
+++ b/pkg/machine/ocipull/source.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/types"
@@ -45,7 +46,7 @@ func GetLocalBlob(ctx context.Context, path string) (*types.BlobInfo, error) {
 }
 
 func GetDiskArtifactReference(ctx context.Context, imgSrc types.ImageSource, opts *DiskArtifactOpts) (digest.Digest, error) {
-	rawMannyFest, mannyType, err := imgSrc.GetManifest(ctx, nil)
+	rawMannyFest, mannyType, err := image.UnparsedInstance(imgSrc, nil).Manifest(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -92,7 +93,7 @@ func GetDiskArtifactReference(ctx context.Context, imgSrc types.ImageSource, opt
 	if artifactDigest == "" {
 		return "", fmt.Errorf("no valid disk artifact found")
 	}
-	v1RawMannyfest, _, err := imgSrc.GetManifest(ctx, &artifactDigest)
+	v1RawMannyfest, _, err := image.UnparsedInstance(imgSrc, &artifactDigest).Manifest(ctx)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
... to validate that the manifests match expected digests, if any.
    
Do this everywhere, even where we read local storage which is mostly trusted, because it is cheap enough and being consistent makes it less likely for the code to be copied into other contexts where the sources are not trusted.

#### Does this PR introduce a user-facing change?
```release-note
None
```
