### PR TITLE
Add isolation-specific skips for runtime flag test

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -124,6 +124,7 @@ EOF
 
 @test "podman build - global runtime flags test" {
     skip_if_remote "--runtime-flag flag not supported for remote"
+    skip_if_chroot "--runtime-flag flag not used for chroot isolation"
 
     rand_content=$(random_string 50)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
runtime-flag test fails when the isolation is chroot, because it doesn't use oci-runtime.
This PR fixes the test failure when it runs in `BUILDAH_ISOLATION=chroot` environment (e.g. nested container with https://github.com/containers/image_build/blob/main/podman/Containerfile) 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
