### PR TITLE
[skip-ci] Packit/RPM: Display upstream commit SHA in all rpm builds

### DIFF
--- a/.packit-copr-rpm.sh
+++ b/.packit-copr-rpm.sh
@@ -4,15 +4,9 @@
 # action in .packit.yaml. These steps only work on copr builds, not on official
 # Fedora builds.
 
-set -eox pipefail
+set -exo pipefail
 
-PACKAGE=podman
-
-# Set path to rpm spec file
-SPEC_FILE=rpm/$PACKAGE.spec
-
-# Get short sha
-GIT_COMMIT=$(git rev-parse HEAD)
+. .packit-rpm-git-commit.sh
 
 # Get Version from HEAD
 VERSION=$(grep '^const RawVersion' version/rawversion/version.go | cut -d\" -f2)
@@ -40,6 +34,3 @@ sed -i "s/^Source0:.*.tar.gz/Source0: $PACKAGE-$VERSION.tar.gz/" $SPEC_FILE
 
 # Update setup macro to use the correct build dir
 sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$VERSION/" $SPEC_FILE
-
-# Update LDFLAGS to show commit id for Copr builds
-sed -i "s/##GIT_COMMIT##/$GIT_COMMIT/" $SPEC_FILE

--- a/.packit-rpm-git-commit.sh
+++ b/.packit-rpm-git-commit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Updates the rpm spec with the upstream git SHA. Works for both copr and koji
+# builds via Packit actions. See .packit.yaml for usage.
+
+set -exo pipefail
+
+PACKAGE=podman
+
+# Set path to rpm spec file
+SPEC_FILE=rpm/$PACKAGE.spec
+
+# Get short sha
+GIT_COMMIT=$(git rev-parse HEAD)
+
+# Update LDFLAGS to show commit id for Copr builds
+sed -i "s/^GIT_COMMIT=*/GIT_COMMIT=\"$GIT_COMMIT\"/" $SPEC_FILE

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,8 +20,8 @@ srpm_build_deps:
   - make
 
 actions:
-  fix-spec-file:
-    - "bash .packit.sh"
+  fix-spec-file: "bash .packit-copr-rpm.sh"
+  pre-sync: "bash .packit-rpm-git-commit.sh"
 
 jobs:
   - job: copr_build

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -238,12 +238,10 @@ LDFLAGS="-X %{ld_libpod}/define.buildInfo=${SOURCE_DATE_EPOCH:-$(date +%s)} \
          -X %{ld_libpod}/config._etcDir=%{_sysconfdir} \
          -X %{ld_project}/pkg/systemd/quadlet._binDir=%{_bindir}"
 
-%if %{defined copr_build}
-# ##GIT_COMMIT## is set by `.packit.sh` in Packit's Copr RPM build jobs.
-# Has no effect on Koji builds.
-GIT_COMMIT="##GIT_COMMIT##"
+# This variable will be set by Packit actions. See .packit.yaml in the root dir
+# of the repo (upstream as well as Fedora dist-git).
+GIT_COMMIT=""
 LDFLAGS="$LDFLAGS -X %{ld_libpod}/define.gitCommit=$GIT_COMMIT"
-%endif
 
 # build rootlessport first
 %gobuild -o bin/rootlessport ./cmd/rootlessport


### PR DESCRIPTION
Packit's `pre-sync` action allows modification of spec file prior to dist-git PR creation. This is already being done on containers-common rpm to update c/storage and c/image verions tags in spec.

This commit will allow `podman version` to show `Git Commit: $SHA` for all copr as well as koji builds.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
