### PR TITLE
Update documentation for podman-machine-os-apply

### DIFF
--- a/docs/source/markdown/podman-machine-os-apply.1.md
+++ b/docs/source/markdown/podman-machine-os-apply.1.md
@@ -13,7 +13,16 @@ Apply machine OS changes from an OCI image.
 VM's that use OS's that use rpm-ostreee have the capability to rebase itself from the content of an OCI image.
 `podman machine image apply` takes an OCI image with container native ostree functionality and rebases itself on that image.
 
-By default, Podman machines on Mac and Linux use an rpm-ostree based distribution (Fedora CoreOS).
+By default, Podman machines on Mac, Linux, and Windows Hyper-V use a customized rpm-ostree based distribution (Fedora CoreOS). Machines based on Microsoft WSL use a
+customized Fedora distribution and cannot be updated with this command.
+
+Note: WSL-based machines are upgradable by using the `podman machine ssh <machine_name>` command followed by `sudo dnf update`.  This can, however, result in unexpected results in
+Podman client and server version differences.
+
+Podman machine images are stored as OCI images at `quay.io/podman/machine-os`. When applying an image using this
+command, the fully qualified OCI reference name must be used including tag where the tag is the
+version of Podman that is inside the VM. By default, Podman will attempt to pull only the statement
+version as itself.
 
 For more information, see the [rpm-ostree documentation](https://coreos.github.io/rpm-ostree/container/).
 
@@ -32,14 +41,21 @@ Restart VM after applying changes.
 
 ## EXAMPLES
 
-Update the default Podman machine to the specified bootable OCI image.
+Update the default Podman machine to the latest development version of the
+bootable OCI image.
+
+Note: This may result in having a newer Podman version inside the machine
+than the client.  Unexpected results may occur.
+
+Update the default Podman machine to the most recent Podman 5.4 bootable
+OCI image.
 ```
-$ podman machine os apply quay.io/podman_next
+$ podman machine os apply quay.io/podman/machine-os:5.4
 ```
 
-Update the specified Podman machine to the specified bootable OCI image.
+Update the specified Podman machine to latest Podman 5.3 bootable OCI image.
 ```
-$ podman machine os apply quay.io/podman_next podman-machine-default
+$ podman machine os apply quay.io/podman/machine-os:5.3 mymachine
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
A user reported that it was a surprise to receive an unsupported os error when trying to use `podman machine os apply` with WSL machines. This is intentional however the documentation needed to be updated to explicitly state why (it is not based on FCOS).

Fixes: #25435

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
