### PR TITLE
Do not allow mounting to machine dir /tmp

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -149,6 +149,12 @@ options are:
 * **rw**: mount volume read/write (default)
 * **security_model=[model]**: specify 9p security model (see below)
 
+Note: The following destinations are forbidden for volumes: `/bin`, `/boot`, `/dev`, `/etc`,
+`/home`, `/proc`, `/root`, `/run`, `/sbin`, `/sys`, `/tmp`, `/usr`, and `/var`. Subdirectories
+of these destinations are allowed but users should be careful to not mount to important directories
+as unexpected results may occur.
+
+
 The 9p security model [determines] https://wiki.qemu.org/Documentation/9psetup#Starting_the_Guest_directly
 if and how the 9p filesystem translates some filesystem operations before
 actual storage on the host.

--- a/pkg/machine/shim/host_test.go
+++ b/pkg/machine/shim/host_test.go
@@ -1,0 +1,61 @@
+package shim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateDestinationPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		dest    string
+		wantErr bool
+	}{
+		{
+			name:    "Expect fail - /tmp",
+			dest:    "/tmp",
+			wantErr: true,
+		},
+		{
+			name:    "Expect fail trailing /",
+			dest:    "/tmp/",
+			wantErr: true,
+		},
+		{
+			name:    "Expect fail double /",
+			dest:    "//tmp",
+			wantErr: true,
+		},
+		{
+			name:    "/var should fail",
+			dest:    "/var",
+			wantErr: true,
+		},
+		{
+			name:    "/etc should fail",
+			dest:    "/etc",
+			wantErr: true,
+		},
+		{
+			name:    "/tmp subdir OK",
+			dest:    "/tmp/foobar",
+			wantErr: false,
+		},
+		{
+			name:    "/foobar OK",
+			dest:    "/foobar",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDestinationPaths(tt.dest)
+			if tt.wantErr {
+				assert.ErrorContainsf(t, err, "onsider another location or a subdirectory of an existing location", "illegal mount target")
+			} else {
+				assert.NoError(t, err, "mounts to subdirs or non-critical dirs should succeed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
the destination machine mount overwrote /tmp.  Here I have added a sanity check.  I also moved the volume parsing and check earlier in the init function so that one does not have to endure the decompression and clean up of the machine image for cli parsing.

Fixes: #18230

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug #18230 where mounting to machine mount to /tmp causes unexpected results.
```
