### PR TITLE
Don't try to resolve host path if copying from stdin

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -339,16 +339,18 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 		return err
 	}
 
+	hostInfo := &copy.FileInfo{}
+	var err error
+
 	isStdin := false
 	if hostPath == "-" {
-		hostPath = os.Stdin.Name()
 		isStdin = true
-	}
-
-	// Make sure that host path exists.
-	hostInfo, err := copy.ResolveHostPath(hostPath)
-	if err != nil {
-		return fmt.Errorf("%q could not be found on the host: %w", hostPath, err)
+	} else {
+		// Make sure that host path exists if not copying from stdin.
+		hostInfo, err = copy.ResolveHostPath(hostPath)
+		if err != nil {
+			return fmt.Errorf("%q could not be found on the host: %w", hostPath, err)
+		}
 	}
 
 	containerBaseName, containerInfo, containerResolvedToParentDir, err := resolvePathOnDestinationContainer(container, containerPath, isStdin)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Resolves #25472

Calling `copy.ResolveHostPath` fails when copying from stdin on Windows as /dev/stdin isn't a real folder. The result of `copy.ResolveHostPath` isn't actually used in the stdin code flow, so an easy fix is to condition the call on whether isStdin is true or false. The only potential behavior change is that, if for some unlikely reason /dev/stdin was missing on Linux or MacOS, the copy command would fail with a different error than it did previously.