### PR TITLE
[v5.4-rhel] wire up --retry-delay for artifact pull

### DIFF
--- a/cmd/podman/artifact/pull.go
+++ b/cmd/podman/artifact/pull.go
@@ -116,28 +116,6 @@ func artifactPull(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// TODO Once we have a decision about the flag removal above, this should be safe to delete
-	/*
-		platform, err := cmd.Flags().GetString("platform")
-		if err != nil {
-			return err
-		}
-		if platform != "" {
-			if pullOptions.Arch != "" || pullOptions.OS != "" {
-				return errors.New("--platform option can not be specified with --arch or --os")
-			}
-
-			specs := strings.Split(platform, "/")
-			pullOptions.OS = specs[0] // may be empty
-			if len(specs) > 1 {
-				pullOptions.Arch = specs[1]
-				if len(specs) > 2 {
-					pullOptions.Variant = specs[2]
-				}
-			}
-		}
-	*/
-
 	if pullOptions.CredentialsCLI != "" {
 		creds, err := util.ParseRegistryCreds(pullOptions.CredentialsCLI)
 		if err != nil {

--- a/pkg/domain/infra/abi/artifact.go
+++ b/pkg/domain/infra/abi/artifact.go
@@ -63,12 +63,18 @@ func (ir *ImageEngine) ArtifactPull(ctx context.Context, name string, opts entit
 	pullOptions.CertDirPath = opts.CertDirPath
 	pullOptions.Username = opts.Username
 	pullOptions.Password = opts.Password
-	// pullOptions.Architecture = opts.Arch
 	pullOptions.SignaturePolicyPath = opts.SignaturePolicyPath
 	pullOptions.InsecureSkipTLSVerify = opts.InsecureSkipTLSVerify
 	pullOptions.Writer = opts.Writer
 	pullOptions.OciDecryptConfig = opts.OciDecryptConfig
 	pullOptions.MaxRetries = opts.MaxRetries
+	if opts.RetryDelay != "" {
+		duration, err := time.ParseDuration(opts.RetryDelay)
+		if err != nil {
+			return nil, err
+		}
+		pullOptions.RetryDelay = &duration
+	}
 
 	if !opts.Quiet && pullOptions.Writer == nil {
 		pullOptions.Writer = os.Stderr

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -132,6 +132,13 @@ var _ = Describe("Podman artifact", func() {
 	})
 
 	It("podman artifact push and pull", func() {
+		// Before starting a registry, try to pull a bogus image from a bogus registry
+		// using retry-delay
+		retrySession := podmanTest.Podman([]string{"artifact", "pull", "--retry", "1", "--retry-delay", "100ms", "127.0.0.1/mybadimagename"})
+		retrySession.WaitWithDefaultTimeout()
+		Expect(retrySession).Should(ExitWithError(125, "connect: connection refused"))
+		Expect(retrySession.ErrorToString()).To(ContainSubstring("retrying in 100ms ..."))
+
 		artifact1File, err := createArtifactFile(1024)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
fixed a bug in the artifact code where --retry-delay was being discarded.

Fixes: https://issues.redhat.com/browse/RUN-2511
Fixes: https://issues.redhat.com/browse/RHEL-80259, https://issues.redhat.com/browse/RHEL-80260

This was initially put into the v5.4 branch, but it also needs to be in this branch.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
