### PR TITLE
Wait race with rm

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -771,6 +771,12 @@ func (c *Container) WaitForConditionWithInterval(ctx context.Context, waitTimeou
 						// This allows callers to actually wait for the ctr to be removed.
 						if wantedStates[define.ContainerStateRemoving] &&
 							(errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved)) {
+							// check if the exit code was recorded in the db to return it
+							exitCode, err := c.runtime.state.GetContainerExitCode(c.ID())
+							if err == nil {
+								trySend(exitCode, nil)
+							}
+
 							trySend(-1, nil)
 							return
 						}

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -602,7 +602,7 @@ func (c *Container) WaitForExit(ctx context.Context, pollInterval time.Duration)
 		defer c.lock.Unlock()
 
 		if err := c.syncContainer(); err != nil {
-			if errors.Is(err, define.ErrNoSuchCtr) {
+			if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved) {
 				// if the container is not valid at this point as it was deleted,
 				// check if the exit code was recorded in the db.
 				exitCode, err := c.runtime.state.GetContainerExitCode(id)
@@ -649,7 +649,7 @@ func (c *Container) WaitForExit(ctx context.Context, pollInterval time.Duration)
 
 	// we locked again so we must sync the state
 	if err := c.syncContainer(); err != nil {
-		if errors.Is(err, define.ErrNoSuchCtr) {
+		if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved) {
 			// if the container is not valid at this point as it was deleted,
 			// check if the exit code was recorded in the db.
 			exitCode, err := c.runtime.state.GetContainerExitCode(id)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a race condition between wait and remove for containers started with autoremove
```
