### PR TITLE
pkg/util: remove redundant min/max helper functions

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -428,20 +428,6 @@ func parseTriple(spec []string, parentMapping []ruser.IDMap, mapSetting string) 
 	return mappings, flags, nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Remove any conflicting mapping from mapping present in extension, so
 // extension can be appended to mapping without conflicts.
 // Returns the resulting mapping, with extension appended to it.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
