### PR TITLE
[v5.4-rhel] podman run: fix --pids-limit -1 wrt runc

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -212,10 +212,6 @@ func replaceContainer(name string) error {
 func createOrUpdateFlags(cmd *cobra.Command, vals *entities.ContainerCreateOptions) error {
 	if cmd.Flags().Changed("pids-limit") {
 		val := cmd.Flag("pids-limit").Value.String()
-		// Convert -1 to 0, so that -1 maps to unlimited pids limit
-		if val == "-1" {
-			val = "0"
-		}
 		pidsLimit, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
 			return err


### PR DESCRIPTION
Since commit c25cc7230 ("Allow a value of -1 to set unlimited pids limit") podman converts the pids-limit value of -1 to 0 for OCI spec.

Unfortunately, different runtimes (crun and runc) treat pids.limit=0 differently, and the runtime-spec definition is somewhat vague (see [1]).

Long term fix belongs to runtime-spec and then runtimes should follow it.

Short term fix is do not convert -1 to 0 (as all runtimes treat -1 as unlimited).

[NO NEW TESTS NEEDED] -- this is covered by test added in commit 553e53d44.

Fixes: https://issues.redhat.com/browse/RHEL-80973

[1]: https://github.com/opencontainers/runc/issues/4014#issuecomment-1888185352

Fixes: https://issues.redhat.com/browse/RHEL-82424, https://issues.redhat.com/browse/RHEL-82425
In the RHEL 9.6 and 10.0 ZeroDay streams

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
