### PR TITLE
update gvproxy version to 0.8.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ endif
 
 # gvisor-tap-vsock version for gvproxy.exe and win-sshproxy.exe downloads
 # the upstream project ships pre-built binaries since version 0.7.1
-GV_VERSION=v0.8.1
+GV_VERSION=v0.8.4
 
 ###
 ### Primary entry-point targets

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -6,7 +6,7 @@ ifeq ($(ARCH), aarch64)
 else
 	GOARCH:=$(ARCH)
 endif
-GVPROXY_VERSION ?= 0.8.3
+GVPROXY_VERSION ?= 0.8.4
 VFKIT_VERSION ?= 0.6.0
 KRUNKIT_VERSION ?= 0.1.4
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containers/buildah v1.39.2
 	github.com/containers/common v0.62.1
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/gvisor-tap-vsock v0.8.3
+	github.com/containers/gvisor-tap-vsock v0.8.4
 	github.com/containers/image/v5 v5.34.1
 	github.com/containers/libhvee v0.10.0
 	github.com/containers/ocicrypt v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/containers/common v0.62.1 h1:durvu7Kelb8PYgX7bwuAg/d5LKj2hs3cAaqcU7Vn
 github.com/containers/common v0.62.1/go.mod h1:n9cEboBmY3AnTk1alkq4t7sLM4plwkDCiaWbsf67YxE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/gvisor-tap-vsock v0.8.3 h1:Am3VdjXTn8Mn+dNhgkiRcCFOTSM8u9aWKLW3KTHOGjk=
-github.com/containers/gvisor-tap-vsock v0.8.3/go.mod h1:46MvrqNuRNbjV4ZsZ3mHVJjR2Eh+fpyRh72EvWWFFjU=
+github.com/containers/gvisor-tap-vsock v0.8.4 h1:z7MqcldnXYGaU6uTaKVl7RFxTmbhNsd2UL0CyM3fdBs=
+github.com/containers/gvisor-tap-vsock v0.8.4/go.mod h1:Guh8d/SiuJ9jlnuIyUjcKkFKQ2qpLhNKPGD1jMoIt2Q=
 github.com/containers/image/v5 v5.34.1 h1:/m2bkFnuedTyNkzma8s7cFLjeefPIb4trjyafWhIlwM=
 github.com/containers/image/v5 v5.34.1/go.mod h1:/WnvUSEfdqC/ahMRd4YJDBLrpYWkGl018rB77iB3FDo=
 github.com/containers/libhvee v0.10.0 h1:7VLv8keWZpHuGmWvyY4c1mVH5V1JYb1G78VC+8AlrM0=

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/gvproxy_command.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/gvproxy_command.go
@@ -19,6 +19,9 @@ type GvproxyCommand struct {
 	// List of endpoints the user wants to listen to
 	endpoints []string
 
+	// List of service endpoints the user wants to listen to
+	servicesEndpoints []string
+
 	// Map of different sockets provided by user (socket-type flag:socket)
 	sockets map[string]string
 
@@ -60,6 +63,14 @@ func (c *GvproxyCommand) AddEndpoint(endpoint string) {
 	}
 
 	c.endpoints = append(c.endpoints, endpoint)
+}
+
+func (c *GvproxyCommand) AddServiceEndpoint(endpoint string) {
+	if len(c.servicesEndpoints) < 1 {
+		c.servicesEndpoints = []string{}
+	}
+
+	c.servicesEndpoints = append(c.servicesEndpoints, endpoint)
 }
 
 func (c *GvproxyCommand) AddVpnkitSocket(socket string) {
@@ -152,6 +163,18 @@ func (c *GvproxyCommand) endpointsToCmdline() []string {
 	return args
 }
 
+func (c *GvproxyCommand) servicesEndpointsToCmdline() []string {
+	args := []string{}
+
+	for _, endpoint := range c.servicesEndpoints {
+		if endpoint != "" {
+			args = append(args, "-services", endpoint)
+		}
+	}
+
+	return args
+}
+
 // ToCmdline converts Command to a properly formatted command for gvproxy based
 // on its fields
 func (c *GvproxyCommand) ToCmdline() []string {
@@ -159,6 +182,8 @@ func (c *GvproxyCommand) ToCmdline() []string {
 
 	// listen (endpoints)
 	args = append(args, c.endpointsToCmdline()...)
+
+	args = append(args, c.servicesEndpointsToCmdline()...)
 
 	// debug
 	if c.Debug {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/gvisor-tap-vsock v0.8.3
+# github.com/containers/gvisor-tap-vsock v0.8.4
 ## explicit; go 1.22.0
 github.com/containers/gvisor-tap-vsock/pkg/types
 # github.com/containers/image/v5 v5.34.1

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -64,7 +64,7 @@ function Win-SSHProxy {
 
     New-Item -ItemType Directory -Force -Path "./bin/windows"
     if (-Not $Version) {
-        $Version = "v0.8.3"
+        $Version = "v0.8.4"
     }
     curl.exe -sSL -o "./bin/windows/gvproxy.exe" --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windowsgui.exe"
     curl.exe -sSL -o "./bin/windows/win-sshproxy.exe" --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy.exe"


### PR DESCRIPTION
The 0.8.4 has one important fix[1], which could improve #25121.
Also it set all places to use same version of gvisor-tap-vsock 

[1]https://github.com/containers/gvisor-tap-vsock/issues/474

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update the bundled gvproxy version to 0.8.4
```
