### PR TITLE
Fix `podman system reset` deletes the `podman.sock`

### DIFF
--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -20,6 +20,7 @@ var (
 	systemResetDescription = `Reset podman storage back to default state
 
   All containers will be stopped and removed, and all images, volumes, networks and container content will be removed.
+  This command does not restart podman.service and podman.socket systemd units. You may need to manually restart it after running this command.
 `
 	systemResetCommand = &cobra.Command{
 		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -67,7 +67,7 @@ func resetMachine() error {
 		logrus.Errorf("unable to remove machine data dir %q: %q", dirs.DataDir.GetPath(), err)
 	}
 
-	if err := utils.GuardedRemoveAll(dirs.RuntimeDir.GetPath()); err != nil {
+	if err := utils.RemoveFilesExcept(dirs.RuntimeDir.GetPath(), "podman.sock"); err != nil {
 		logrus.Errorf("unable to remove machine runtime dir %q: %q", dirs.RuntimeDir.GetPath(), err)
 	}
 

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -19,6 +19,8 @@ or `volume_path`.
 of the relevant configurations. If the administrator modified the configuration files first,
 `podman system reset` might not be able to clean up the previous storage.
 
+`podman system reset` does not restart podman.service and podman.socket systemd units. You may need to manually restart it after running this command.
+
 ## OPTIONS
 #### **--force**, **-f**
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -117,6 +118,27 @@ func GuardedRemoveAll(path string) error {
 		return fmt.Errorf("refusing to recursively delete `%s`", path)
 	}
 	return os.RemoveAll(path)
+}
+
+// RemoveFilesExcept removes all files in a directory except for the one specified
+// by excludeFile and will not delete certain catastrophic paths.
+func RemoveFilesExcept(path string, excludeFile string) error {
+	if path == "" || path == "/" {
+		return fmt.Errorf("refusing to recursively delete `%s`", path)
+	}
+
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if file.Name() != excludeFile {
+			if err := os.RemoveAll(filepath.Join(path, file.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func ProgressBar(prefix string, size int64, onComplete string) (*mpb.Progress, *mpb.Bar) {


### PR DESCRIPTION
This PR prevents the removal of the `podman.sock` file using the `podman system reset` command.

The `podman system reset` removes the `RunDirectory` directory as part of the podman machine reset, where `podman.sock` is usually stored.  
 
Fixes: https://issues.redhat.com/browse/RHEL-71320

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman system reset` command does not remove the `podman.sock` file.
```
