### PR TITLE
Bump to v5.4.1

### DIFF
--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "5.4.1"
+const RawVersion = "5.4.2-dev"

--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "5.4.1-dev"
+const RawVersion = "5.4.1"


### PR DESCRIPTION
As the title says. All backports already complete, so this is just a version number change.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
