### PR TITLE
[skip-ci] Packit: Fix action script for updating upstream commit id in rpm spec

### DIFF
--- a/.packit-rpm-git-commit.sh
+++ b/.packit-rpm-git-commit.sh
@@ -14,4 +14,4 @@ SPEC_FILE=rpm/$PACKAGE.spec
 GIT_COMMIT=$(git rev-parse HEAD)
 
 # Update LDFLAGS to show commit id for Copr builds
-sed -i "s/^GIT_COMMIT=*/GIT_COMMIT=\"$GIT_COMMIT\"/" $SPEC_FILE
+sed -i "s/^GIT_COMMIT=.*/GIT_COMMIT=\"$GIT_COMMIT\"/" $SPEC_FILE


### PR DESCRIPTION
This fixes multiple trailing quotes after the commit and also ensures the older commit id will be correctly replaced by the newer id.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
