### PR TITLE
[skip-ci] packit: fix missing fedora arches

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,6 +33,8 @@ jobs:
     enable_net: true
     targets:
       - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-development-x86_64
       - fedora-development-aarch64
 
   - job: copr_build


### PR DESCRIPTION
Silly mistake on my end, of course we want to build on both arches.

Fixes: 9eb4d27c5c ("packit: only build F41+")

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
