### PR TITLE
Windows installer test: hardcode the ID of the latest GH release

### DIFF
--- a/contrib/cirrus/win-installer-main.ps1
+++ b/contrib/cirrus/win-installer-main.ps1
@@ -12,6 +12,7 @@ if ($Env:CI -eq "true") {
     $RELEASE_DIR = "$PSScriptRoot\..\..\contrib\win-installer\current"
     if ($null -eq $ENV:CONTAINERS_MACHINE_PROVIDER) { $ENV:CONTAINERS_MACHINE_PROVIDER = 'wsl' }
 }
+$ENV:LATEST_GH_RELEASE_ID = "199677288" # v5.4.0
 
 Push-Location $WIN_INST_FOLDER
 
@@ -20,7 +21,7 @@ Push-Location $WIN_INST_FOLDER
 # Download the previous installer to test a major update
 
 if (!$env:PREV_SETUP_EXE_PATH) {
-    $env:PREV_SETUP_EXE_PATH = Get-Latest-Podman-Setup-From-GitHub
+    $env:PREV_SETUP_EXE_PATH = Get-Podman-Setup-From-GitHub $ENV:LATEST_GH_RELEASE_ID
 }
 
 # Note: consumes podman-remote-release-windows_amd64.zip from repo.tar.zst


### PR DESCRIPTION
To avoid problems when automatically downloading `latest` podman windows installer (e.g. the windows installer hasn't been included in the GH release because of an issue with the keys to sign it), we are now hardcoding the version of Podman that is
used to test the upgrade from latest to current version.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
