### PR TITLE
[WIP] Verify images in manifest list are not dangling and pruned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ $(IN_CONTAINER): %-in-container:
 	$(PODMANCMD) run --rm --env HOME=/root \
 		-v $(CURDIR):/src -w /src \
 		--security-opt label=disable \
-		docker.io/library/golang:1.22 \
+		docker.io/library/golang:1.23 \
 		make $(*)
 
 

--- a/go.mod
+++ b/go.mod
@@ -235,3 +235,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )
+
+replace github.com/containers/common => github.com/rhatdan/common v0.47.1-0.20250318135319-2242b2e1f465

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/containernetworking/plugins v1.6.2 h1:pqP8Mq923TLyef5g97XfJ/xpDeVek4y
 github.com/containernetworking/plugins v1.6.2/go.mod h1:SP5UG3jDO9LtmfbBJdP+nl3A1atOtbj2MBOYsnaxy64=
 github.com/containers/buildah v1.39.1-0.20250321123219-bc4d7eb70fe3 h1:F5qpz8HsQ/nxhArveDEgskbyOjFuSsEahevt4JHAePQ=
 github.com/containers/buildah v1.39.1-0.20250321123219-bc4d7eb70fe3/go.mod h1:kCk5Le5CiMazPfGhF8yg43LQa1YLKqBZNnI4PTq+W/U=
-github.com/containers/common v0.62.3-0.20250321171839-dbeb17e40c80 h1:U605lFaEyA0zsy4+gqZxth9V2Dl1UXBfcamA3cnQ33E=
-github.com/containers/common v0.62.3-0.20250321171839-dbeb17e40c80/go.mod h1:IW8fUkTIwJkeclyROeASOV5FvFBpHjtQj/XBXffhuBk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.4 h1:z7MqcldnXYGaU6uTaKVl7RFxTmbhNsd2UL0CyM3fdBs=
@@ -438,6 +436,8 @@ github.com/prometheus/common v0.57.0 h1:Ro/rKjwdq9mZn1K5QPctzh+MA4Lp0BuYk5ZZEVho
 github.com/prometheus/common v0.57.0/go.mod h1:7uRPFSUTbfZWsJ7MHY56sqt7hLQu3bxXHDnNhl8E9qI=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/rhatdan/common v0.47.1-0.20250318135319-2242b2e1f465 h1:aV/PjGzklc+iNdy86HriZ/yQ25h5sctFOFIy8O9inIs=
+github.com/rhatdan/common v0.47.1-0.20250318135319-2242b2e1f465/go.mod h1:l7TYE/GilpOcGkrErMCRHfvUnftyhjUGrSL/0gYad0M=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -597,7 +597,7 @@ func (ir *ImageEngine) Tree(ctx context.Context, nameOrID string, opts entities.
 	if err != nil {
 		return nil, err
 	}
-	tree, err := image.Tree(opts.WhatRequires)
+	tree, err := image.Tree(ctx, opts.WhatRequires)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/common/libimage/copier.go
+++ b/vendor/github.com/containers/common/libimage/copier.go
@@ -21,10 +21,8 @@ import (
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/signature/signer"
 	storageTransport "github.com/containers/image/v5/storage"
-	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	encconfig "github.com/containers/ocicrypt/config"
-	"github.com/containers/storage"
 	"github.com/sirupsen/logrus"
 )
 
@@ -177,8 +175,8 @@ type Copier struct {
 // newCopier creates a Copier based on a runtime's system context.
 // Note that fields in options *may* overwrite the counterparts of
 // the specified system context.  Please make sure to call `(*Copier).Close()`.
-func (r *Runtime) newCopier(options *CopyOptions) (*Copier, error) {
-	return NewCopier(options, r.SystemContext(), nil)
+func (r *Runtime) newCopier(options *CopyOptions, reportResolvedReference *types.ImageReference) (*Copier, error) {
+	return NewCopier(options, r.SystemContext(), reportResolvedReference)
 }
 
 // storageAllowedPolicyScopes overrides the policy for local storage
@@ -352,12 +350,6 @@ func (c *Copier) Close() error {
 // Copy the source to the destination.  Returns the bytes of the copied
 // manifest which may be used for digest computation.
 func (c *Copier) Copy(ctx context.Context, source, destination types.ImageReference) ([]byte, error) {
-	return c.copyInternal(ctx, source, destination, nil)
-}
-
-// Copy the source to the destination.  Returns the bytes of the copied
-// manifest which may be used for digest computation.
-func (c *Copier) copyInternal(ctx context.Context, source, destination types.ImageReference, reportResolvedReference *types.ImageReference) ([]byte, error) {
 	logrus.Debugf("Copying source image %s to destination image %s", source.StringWithinTransport(), destination.StringWithinTransport())
 
 	// Avoid running out of time when running inside a systemd unit by
@@ -462,11 +454,6 @@ func (c *Copier) copyInternal(ctx context.Context, source, destination types.Ima
 	var returnManifest []byte
 	f := func() error {
 		opts := c.imageCopyOptions
-		// This is already set when `newCopier` was called but there is an option
-		// to override it by callers if needed.
-		if reportResolvedReference != nil {
-			opts.ReportResolvedReference = reportResolvedReference
-		}
 		if sourceInsecure != nil {
 			value := types.NewOptionalBool(*sourceInsecure)
 			opts.SourceCtx.DockerInsecureSkipTLSVerify = value
@@ -483,22 +470,6 @@ func (c *Copier) copyInternal(ctx context.Context, source, destination types.Ima
 		return err
 	}
 	return returnManifest, retry.IfNecessary(ctx, f, &c.retryOptions)
-}
-
-func (c *Copier) copyToStorage(ctx context.Context, source, destination types.ImageReference) (*storage.Image, error) {
-	var resolvedReference types.ImageReference
-	_, err := c.copyInternal(ctx, source, destination, &resolvedReference)
-	if err != nil {
-		return nil, fmt.Errorf("internal error: unable to copy from source %s: %w", source, err)
-	}
-	if resolvedReference == nil {
-		return nil, fmt.Errorf("internal error: After attempting to copy %s, resolvedReference is nil", source)
-	}
-	_, image, err := storageTransport.ResolveReference(resolvedReference)
-	if err != nil {
-		return nil, fmt.Errorf("resolving an already-resolved reference %q to the pulled image: %w", transports.ImageName(resolvedReference), err)
-	}
-	return image, nil
 }
 
 // checkRegistrySourcesAllows checks the $BUILD_REGISTRY_SOURCES environment

--- a/vendor/github.com/containers/common/libimage/history.go
+++ b/vendor/github.com/containers/common/libimage/history.go
@@ -25,7 +25,7 @@ func (i *Image) History(ctx context.Context) ([]ImageHistory, error) {
 		return nil, err
 	}
 
-	layerTree, err := i.runtime.newFreshLayerTree()
+	layerTree, err := i.runtime.newFreshLayerTree(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/common/libimage/image_tree.go
+++ b/vendor/github.com/containers/common/libimage/image_tree.go
@@ -3,6 +3,7 @@
 package libimage
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 // Tree generates a tree for the specified image and its layers.  Use
 // `traverseChildren` to traverse the layers of all children.  By default, only
 // layers of the image are printed.
-func (i *Image) Tree(traverseChildren bool) (string, error) {
+func (i *Image) Tree(ctx context.Context, traverseChildren bool) (string, error) {
 	// NOTE: a string builder prevents us from copying to much data around
 	// and compile the string when and where needed.
 	sb := &strings.Builder{}
@@ -37,7 +38,7 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 		fmt.Fprintf(sb, "No Image Layers")
 	}
 
-	layerTree, err := i.runtime.newFreshLayerTree()
+	layerTree, err := i.runtime.newFreshLayerTree(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/containers/common/libimage/import.go
+++ b/vendor/github.com/containers/common/libimage/import.go
@@ -104,7 +104,7 @@ func (r *Runtime) Import(ctx context.Context, path string, options *ImportOption
 		return "", err
 	}
 
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.newCopier(&options.CopyOptions, nil)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/containers/common/libimage/layer_tree.go
+++ b/vendor/github.com/containers/common/libimage/layer_tree.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/storage"
 	storageTypes "github.com/containers/storage/types"
+	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -22,6 +23,10 @@ type layerTree struct {
 	// emptyImages do not have any top-layer so we cannot create a
 	// *layerNode for them.
 	emptyImages []*Image
+	// manifestList keep track of images based on their digest.
+	// Library will use this map when checking if a image is dangling.
+	// If an image is used in a manifestList it is NOT dangling
+	manifestListDigests map[digest.Digest]struct{}
 }
 
 // node returns a layerNode for the specified layerID.
@@ -90,20 +95,21 @@ func (l *layerNode) repoTags() ([]string, error) {
 }
 
 // newFreshLayerTree extracts a layerTree from consistent layers and images in the local storage.
-func (r *Runtime) newFreshLayerTree() (*layerTree, error) {
+func (r *Runtime) newFreshLayerTree(ctx context.Context) (*layerTree, error) {
 	images, layers, err := r.getImagesAndLayers()
 	if err != nil {
 		return nil, err
 	}
-	return r.newLayerTreeFromData(images, layers)
+	return r.newLayerTreeFromData(ctx, images, layers, false)
 }
 
 // newLayerTreeFromData extracts a layerTree from the given the layers and images.
 // The caller is responsible for (layers, images) being consistent.
-func (r *Runtime) newLayerTreeFromData(images []*Image, layers []storage.Layer) (*layerTree, error) {
+func (r *Runtime) newLayerTreeFromData(ctx context.Context, images []*Image, layers []storage.Layer, generateManifestDigestList bool) (*layerTree, error) {
 	tree := layerTree{
-		nodes:    make(map[string]*layerNode),
-		ociCache: make(map[string]*ociv1.Image),
+		nodes:               make(map[string]*layerNode),
+		ociCache:            make(map[string]*ociv1.Image),
+		manifestListDigests: make(map[digest.Digest]struct{}),
 	}
 
 	// First build a tree purely based on layer information.
@@ -124,6 +130,21 @@ func (r *Runtime) newLayerTreeFromData(images []*Image, layers []storage.Layer) 
 		topLayer := img.TopLayer()
 		if topLayer == "" {
 			tree.emptyImages = append(tree.emptyImages, img)
+			// When img is a manifest list, cache the lists of
+			// digests refereenced in manifest list. Digests can
+			// be used to check for dangling images.
+			if !generateManifestDigestList {
+				continue
+			}
+			if manifestList, _ := img.IsManifestList(ctx); manifestList {
+				mlist, err := img.ToManifestList()
+				if err != nil {
+					return nil, err
+				}
+				for _, digest := range mlist.list.Instances() {
+					tree.manifestListDigests[digest] = struct{}{}
+				}
+			}
 			continue
 		}
 		node, exists := tree.nodes[topLayer]

--- a/vendor/github.com/containers/common/libimage/load.go
+++ b/vendor/github.com/containers/common/libimage/load.go
@@ -30,7 +30,7 @@ func (r *Runtime) doLoadReference(ctx context.Context, ref types.ImageReference,
 	case dockerArchiveTransport.Transport.Name():
 		images, err = r.loadMultiImageDockerArchive(ctx, ref, &options.CopyOptions)
 	default:
-		_, images, err = r.copyFromDefault(ctx, ref, &options.CopyOptions)
+		images, err = r.copyFromDefault(ctx, ref, &options.CopyOptions)
 	}
 	return images, ref.Transport().Name(), err
 }
@@ -49,9 +49,6 @@ func (r *Runtime) LoadReference(ctx context.Context, ref types.ImageReference, o
 // Load loads one or more images (depending on the transport) from the
 // specified path.  The path may point to an image the following transports:
 // oci, oci-archive, dir, docker-archive.
-//
-// Load returns a string slice with names of recently loaded images.
-// If images are unnamed in the source, it returns a string slice of image IDs instead.
 func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) ([]string, error) {
 	logrus.Debugf("Loading image from %q", path)
 
@@ -145,8 +142,7 @@ func (r *Runtime) loadMultiImageDockerArchive(ctx context.Context, ref types.Ima
 	// should.
 	path := ref.StringWithinTransport()
 	if err := fileutils.Exists(path); err != nil {
-		_, names, err := r.copyFromDockerArchive(ctx, ref, options)
-		return names, err
+		return r.copyFromDockerArchive(ctx, ref, options)
 	}
 
 	reader, err := dockerArchiveTransport.NewReader(r.systemContextCopy(), path)
@@ -167,7 +163,7 @@ func (r *Runtime) loadMultiImageDockerArchive(ctx context.Context, ref types.Ima
 	var copiedImages []string
 	for _, list := range refLists {
 		for _, listRef := range list {
-			_, names, err := r.copyFromDockerArchiveReaderReference(ctx, reader, listRef, options)
+			names, err := r.copyFromDockerArchiveReaderReference(ctx, reader, listRef, options)
 			if err != nil {
 				return nil, err
 			}

--- a/vendor/github.com/containers/common/libimage/manifest_list.go
+++ b/vendor/github.com/containers/common/libimage/manifest_list.go
@@ -794,7 +794,7 @@ func (m *ManifestList) Push(ctx context.Context, destination string, options *Ma
 	// NOTE: we're using the logic in copier to create a proper
 	// types.SystemContext. This prevents us from having an error prone
 	// code duplicate here.
-	copier, err := m.image.runtime.newCopier(&options.CopyOptions)
+	copier, err := m.image.runtime.newCopier(&options.CopyOptions, nil)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/containers/common/libimage/push.go
+++ b/vendor/github.com/containers/common/libimage/push.go
@@ -118,7 +118,7 @@ func (r *Runtime) Push(ctx context.Context, source, destination string, options 
 		}
 	}
 
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.newCopier(&options.CopyOptions, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/common/libimage/runtime.go
+++ b/vendor/github.com/containers/common/libimage/runtime.go
@@ -634,7 +634,7 @@ func (r *Runtime) ListImages(ctx context.Context, options *ListImagesOptions) ([
 
 	var tree *layerTree
 	if needsLayerTree {
-		tree, err = r.newLayerTreeFromData(images, snapshot.Layers)
+		tree, err = r.newLayerTreeFromData(ctx, images, snapshot.Layers, true)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/common/libimage/save.go
+++ b/vendor/github.com/containers/common/libimage/save.go
@@ -119,7 +119,7 @@ func (r *Runtime) saveSingleImage(ctx context.Context, name, format, path string
 		return err
 	}
 
-	c, err := r.newCopier(&options.CopyOptions)
+	c, err := r.newCopier(&options.CopyOptions, nil)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (r *Runtime) saveDockerArchive(ctx context.Context, names []string, path st
 		copyOpts := options.CopyOptions
 		copyOpts.dockerArchiveAdditionalTags = local.tags
 
-		c, err := r.newCopier(&copyOpts)
+		c, err := r.newCopier(&copyOpts, nil)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/containers/common/libnetwork/internal/util/create.go
+++ b/vendor/github.com/containers/common/libnetwork/internal/util/create.go
@@ -39,13 +39,6 @@ func CommonNetworkCreate(n NetUtil, network *types.Network) error {
 			network.NetworkInterface = name
 		}
 	}
-
-	// Validate interface name if specified
-	if network.NetworkInterface != "" {
-		if err := ValidateInterfaceName(network.NetworkInterface); err != nil {
-			return fmt.Errorf("network interface name %s invalid: %w", network.NetworkInterface, err)
-		}
-	}
 	return nil
 }
 

--- a/vendor/github.com/containers/common/libnetwork/internal/util/validate.go
+++ b/vendor/github.com/containers/common/libnetwork/internal/util/validate.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
-	"unicode"
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/libnetwork/util"
@@ -158,26 +156,6 @@ func validatePerNetworkOpts(network *types.Network, netOpts *types.PerNetworkOpt
 			}
 			return fmt.Errorf("requested static ip %s not in any subnet on network %s", ip.String(), network.Name)
 		}
-	}
-	return nil
-}
-
-// ValidateInterfaceName validates the interface name based on the following rules:
-// 1. The name must be less than MaxInterfaceNameLength characters
-// 2. The name must not be "." or ".."
-// 3. The name must not contain / or : or any whitespace characters
-// ref to https://github.com/torvalds/linux/blob/81e4f8d68c66da301bb881862735bd74c6241a19/include/uapi/linux/if.h#L33C18-L33C20
-func ValidateInterfaceName(ifName string) error {
-	if len(ifName) > types.MaxInterfaceNameLength {
-		return fmt.Errorf("interface name is too long: interface names must be %d characters or less: %w", types.MaxInterfaceNameLength, types.ErrInvalidArg)
-	}
-	if ifName == "." || ifName == ".." {
-		return fmt.Errorf("interface name is . or ..: %w", types.ErrInvalidArg)
-	}
-	if strings.ContainsFunc(ifName, func(r rune) bool {
-		return r == '/' || r == ':' || unicode.IsSpace(r)
-	}) {
-		return fmt.Errorf("interface name contains / or : or whitespace characters: %w", types.ErrInvalidArg)
 	}
 	return nil
 }

--- a/vendor/github.com/containers/common/libnetwork/types/define.go
+++ b/vendor/github.com/containers/common/libnetwork/types/define.go
@@ -30,7 +30,4 @@ var (
 	// NotHexRegex is a regular expression to check if a string is
 	// a hexadecimal string.
 	NotHexRegex = regexp.Delayed(`[^0-9a-fA-F]`)
-
-	// MaxInterfaceNameLength is the maximum length of a network interface name
-	MaxInterfaceNameLength = 15
 )

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/containers/common/internal/attributedstring"
 	nettypes "github.com/containers/common/libnetwork/types"
@@ -37,8 +36,8 @@ const (
 	defaultInitName = "catatonit"
 )
 
-func getMaskedPaths() ([]string, error) {
-	maskedPaths := []string{
+var (
+	DefaultMaskedPaths = []string{
 		"/proc/acpi",
 		"/proc/kcore",
 		"/proc/keys",
@@ -50,34 +49,8 @@ func getMaskedPaths() ([]string, error) {
 		"/sys/devices/virtual/powercap",
 		"/sys/firmware",
 		"/sys/fs/selinux",
-		"/proc/interrupts",
-	}
-	maskedPathsToGlob := []string{
-		"/sys/devices/system/cpu/cpu*/thermal_throttle",
 	}
 
-	for _, p := range maskedPathsToGlob {
-		matches, err := filepath.Glob(p)
-		if err != nil {
-			return nil, err
-		}
-		maskedPaths = append(maskedPaths, matches...)
-	}
-	return maskedPaths, nil
-}
-
-var DefaultMaskedPaths = sync.OnceValue(func() []string {
-	maskedPaths, err := getMaskedPaths()
-	// this should never happen, the only error possible
-	// is ErrBadPattern and the patterns that were added must be valid
-	if err != nil {
-		panic(err)
-	}
-
-	return maskedPaths
-})
-
-var (
 	DefaultReadOnlyPaths = []string{
 		"/proc/asound",
 		"/proc/bus",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,7 +179,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.62.3-0.20250321171839-dbeb17e40c80
+# github.com/containers/common v0.62.3-0.20250321171839-dbeb17e40c80 => github.com/rhatdan/common v0.47.1-0.20250318135319-2242b2e1f465
 ## explicit; go 1.23.0
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring
@@ -1423,3 +1423,4 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v1.0.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
+# github.com/containers/common => github.com/rhatdan/common v0.47.1-0.20250318135319-2242b2e1f465


### PR DESCRIPTION
Vendor in latest containers/common

Currently if you create an un tagged image and add it to a manifest list, podman image prune will remove the image, and leave you with a broken manifest list. This PR removes the image from dangling in this situation and prevents the pruning.

We have seen this trigger issues with RamaLama which is creating manifest lists in this manner, and then users pruning the images.

Verifing: https://github.com/containers/common/pull/2360

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
