### PR TITLE
[v5.2-rhel] Fix HealthCheck log destination, count, and size defaults

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1252,6 +1252,27 @@ func (c *Container) HealthCheckConfig() *manifest.Schema2HealthConfig {
 	return c.config.HealthCheckConfig
 }
 
+func (c *Container) HealthCheckLogDestination() string {
+	if c.config.HealthLogDestination == nil {
+		return define.DefaultHealthCheckLocalDestination
+	}
+	return *c.config.HealthLogDestination
+}
+
+func (c *Container) HealthCheckMaxLogCount() uint {
+	if c.config.HealthMaxLogCount == nil {
+		return define.DefaultHealthMaxLogCount
+	}
+	return *c.config.HealthMaxLogCount
+}
+
+func (c *Container) HealthCheckMaxLogSize() uint {
+	if c.config.HealthMaxLogSize == nil {
+		return define.DefaultHealthMaxLogSize
+	}
+	return *c.config.HealthMaxLogSize
+}
+
 // AutoRemove indicates whether the container will be removed after it is executed
 func (c *Container) AutoRemove() bool {
 	spec := c.config.Spec

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -414,13 +414,16 @@ type ContainerMiscConfig struct {
 	// HealthCheckOnFailureAction defines an action to take once the container turns unhealthy.
 	HealthCheckOnFailureAction define.HealthCheckOnFailureAction `json:"healthcheck_on_failure_action"`
 	// HealthLogDestination defines the destination where the log is stored
-	HealthLogDestination string `json:"healthLogDestination,omitempty"`
+	// Nil value means the default value (local).
+	HealthLogDestination *string `json:"healthLogDestination,omitempty"`
 	// HealthMaxLogCount is maximum number of attempts in the HealthCheck log file.
 	// ('0' value means an infinite number of attempts in the log file)
-	HealthMaxLogCount uint `json:"healthMaxLogCount,omitempty"`
+	// Nil value means the default value (5).
+	HealthMaxLogCount *uint `json:"healthMaxLogCount,omitempty"`
 	// HealthMaxLogSize is the maximum length in characters of stored HealthCheck log
 	// ("0" value means an infinite log length)
-	HealthMaxLogSize uint `json:"healthMaxLogSize,omitempty"`
+	// Nil value means the default value (500).
+	HealthMaxLogSize *uint `json:"healthMaxLogSize,omitempty"`
 	// StartupHealthCheckConfig is the configuration of the startup
 	// healthcheck for the container. This will run before the regular HC
 	// runs, and when it passes the regular HC will be activated.

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -417,11 +417,11 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 
 	ctrConfig.HealthcheckOnFailureAction = c.config.HealthCheckOnFailureAction.String()
 
-	ctrConfig.HealthLogDestination = c.config.HealthLogDestination
+	ctrConfig.HealthLogDestination = c.HealthCheckLogDestination()
 
-	ctrConfig.HealthMaxLogCount = c.config.HealthMaxLogCount
+	ctrConfig.HealthMaxLogCount = c.HealthCheckMaxLogCount()
 
-	ctrConfig.HealthMaxLogSize = c.config.HealthMaxLogSize
+	ctrConfig.HealthMaxLogSize = c.HealthCheckMaxLogSize()
 
 	ctrConfig.CreateCommand = c.config.CreateCommand
 

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -50,7 +50,7 @@ func (c *Container) newContainerEventWithInspectData(status events.Status, healt
 	e.Image = c.config.RootfsImageName
 	e.Type = events.Container
 	e.HealthStatus = healthCheckResult.Status
-	if c.config.HealthLogDestination == define.HealthCheckEventsLoggerDestination {
+	if c.HealthCheckLogDestination() == define.HealthCheckEventsLoggerDestination {
 		if len(healthCheckResult.Log) > 0 {
 			logData, err := json.Marshal(healthCheckResult.Log[len(healthCheckResult.Log)-1])
 			if err != nil {

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -135,8 +135,8 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	}
 
 	eventLog := output.String()
-	if c.config.HealthMaxLogSize != 0 && len(eventLog) > int(c.config.HealthMaxLogSize) {
-		eventLog = eventLog[:c.config.HealthMaxLogSize]
+	if c.HealthCheckMaxLogSize() != 0 && len(eventLog) > int(c.HealthCheckMaxLogSize()) {
+		eventLog = eventLog[:c.HealthCheckMaxLogSize()]
 	}
 
 	if timeEnd.Sub(timeStart) > c.HealthCheckConfig().Timeout {
@@ -149,7 +149,7 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 
 	healthCheckResult, err := c.updateHealthCheckLog(hcl, inStartPeriod, isStartup)
 	if err != nil {
-		return hcResult, "", fmt.Errorf("unable to update health check log %s for %s: %w", c.config.HealthLogDestination, c.ID(), err)
+		return hcResult, "", fmt.Errorf("unable to update health check log %s for %s: %w", c.getHealthCheckLogDestination(), c.ID(), err)
 	}
 
 	// Write HC event with appropriate status as the last thing before we
@@ -387,7 +387,7 @@ func (c *Container) updateHealthCheckLog(hcl define.HealthCheckLog, inStartPerio
 		}
 	}
 	healthCheck.Log = append(healthCheck.Log, hcl)
-	if c.config.HealthMaxLogCount != 0 && len(healthCheck.Log) > int(c.config.HealthMaxLogCount) {
+	if c.HealthCheckMaxLogCount() != 0 && len(healthCheck.Log) > int(c.HealthCheckMaxLogCount()) {
 		healthCheck.Log = healthCheck.Log[1:]
 	}
 	return healthCheck, c.writeHealthCheckLog(healthCheck)
@@ -403,11 +403,11 @@ func (c *Container) witeToFileHealthCheckResults(path string, result define.Heal
 
 func (c *Container) getHealthCheckLogDestination() string {
 	var destination string
-	switch c.config.HealthLogDestination {
+	switch c.HealthCheckLogDestination() {
 	case define.DefaultHealthCheckLocalDestination, define.HealthCheckEventsLoggerDestination, "":
 		destination = filepath.Join(filepath.Dir(c.state.RunDir), "healthcheck.log")
 	default:
-		destination = filepath.Join(c.config.HealthLogDestination, c.ID()+"-healthcheck.log")
+		destination = filepath.Join(c.HealthCheckLogDestination(), c.ID()+"-healthcheck.log")
 	}
 	return destination
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1523,7 +1523,7 @@ func WithHealthCheckLogDestination(destination string) CtrCreateOption {
 		}
 		switch destination {
 		case define.HealthCheckEventsLoggerDestination, define.DefaultHealthCheckLocalDestination:
-			ctr.config.HealthLogDestination = destination
+			ctr.config.HealthLogDestination = &destination
 		default:
 			fileInfo, err := os.Stat(destination)
 			if err != nil {
@@ -1538,7 +1538,7 @@ func WithHealthCheckLogDestination(destination string) CtrCreateOption {
 			if err != nil {
 				return err
 			}
-			ctr.config.HealthLogDestination = absPath
+			ctr.config.HealthLogDestination = &absPath
 		}
 		return nil
 	}
@@ -1550,7 +1550,7 @@ func WithHealthCheckMaxLogCount(maxLogCount uint) CtrCreateOption {
 		if ctr.valid {
 			return define.ErrCtrFinalized
 		}
-		ctr.config.HealthMaxLogCount = maxLogCount
+		ctr.config.HealthMaxLogCount = &maxLogCount
 		return nil
 	}
 }
@@ -1561,7 +1561,7 @@ func WithHealthCheckMaxLogSize(maxLogSize uint) CtrCreateOption {
 		if ctr.valid {
 			return define.ErrCtrFinalized
 		}
-		ctr.config.HealthMaxLogSize = maxLogSize
+		ctr.config.HealthMaxLogSize = &maxLogSize
 		return nil
 	}
 }

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -45,6 +45,8 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		},
 		ContainerHealthCheckConfig: specgen.ContainerHealthCheckConfig{
 			HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+			HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+			HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
 		},
 	}
 

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	commonFlag "github.com/containers/common/pkg/flag"
+	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/containers/podman/v5/pkg/util"
@@ -275,9 +276,12 @@ type ContainerCreateOptions struct {
 
 func NewInfraContainerCreateOptions() ContainerCreateOptions {
 	options := ContainerCreateOptions{
-		IsInfra:          true,
-		ImageVolume:      "anonymous",
-		MemorySwappiness: -1,
+		IsInfra:              true,
+		ImageVolume:          "anonymous",
+		MemorySwappiness:     -1,
+		HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+		HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+		HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
 	}
 	return options
 }

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1736,10 +1736,6 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 		spec.Name = generate.CheckName(ic.Libpod, n, true)
 	}
 
-	spec.HealthLogDestination = define.DefaultHealthCheckLocalDestination
-	spec.HealthMaxLogCount = define.DefaultHealthMaxLogCount
-	spec.HealthMaxLogSize = define.DefaultHealthMaxLogSize
-
 	rtSpec, spec, opts, err := generate.MakeContainer(context.Background(), ic.Libpod, spec, true, c)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -59,7 +59,12 @@ func (ic *ContainerEngine) GenerateSpec(ctx context.Context, opts *entities.Gene
 	} else if p, err := ic.Libpod.LookupPod(opts.ID); err == nil {
 		pspec = &specgen.PodSpecGenerator{}
 		pspec.Name = p.Name()
-		_, err := generateUtils.PodConfigToSpec(ic.Libpod, pspec, &entities.ContainerCreateOptions{}, opts.ID)
+		_, err := generateUtils.PodConfigToSpec(ic.Libpod, pspec,
+			&entities.ContainerCreateOptions{
+				HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+				HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+				HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
+			}, opts.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -444,9 +444,23 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 		}
 	}
 
-	specg.HealthLogDestination = conf.HealthLogDestination
-	specg.HealthMaxLogCount = conf.HealthMaxLogCount
-	specg.HealthMaxLogSize = conf.HealthMaxLogSize
+	if conf.HealthLogDestination != nil {
+		specg.HealthLogDestination = *conf.HealthLogDestination
+	} else {
+		specg.HealthLogDestination = define.DefaultHealthCheckLocalDestination
+	}
+
+	if conf.HealthMaxLogCount != nil {
+		specg.HealthMaxLogCount = *conf.HealthMaxLogCount
+	} else {
+		specg.HealthMaxLogCount = define.DefaultHealthMaxLogCount
+	}
+
+	if conf.HealthMaxLogSize != nil {
+		specg.HealthMaxLogSize = *conf.HealthMaxLogSize
+	} else {
+		specg.HealthMaxLogSize = define.DefaultHealthMaxLogSize
+	}
 
 	specg.IDMappings = &conf.IDMappings
 	specg.ContainerCreateCommand = conf.CreateCommand

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -425,6 +425,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		s.Annotations[define.InspectAnnotationInit] = init
 	}
 
+	s.HealthLogDestination = define.DefaultHealthCheckLocalDestination
+	s.HealthMaxLogCount = define.DefaultHealthMaxLogCount
+	s.HealthMaxLogSize = define.DefaultHealthMaxLogSize
+
 	if publishAll, ok := opts.Annotations[define.InspectAnnotationPublishAll+"/"+opts.Container.Name]; ok {
 		if opts.IsInfra {
 			publishAllAsBool, err := strconv.ParseBool(publishAll)
@@ -438,9 +442,6 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	}
 
 	s.Annotations[define.KubeHealthCheckAnnotation] = "true"
-	s.HealthLogDestination = define.DefaultHealthCheckLocalDestination
-	s.HealthMaxLogCount = define.DefaultHealthMaxLogCount
-	s.HealthMaxLogSize = define.DefaultHealthMaxLogSize
 
 	// Environment Variables
 	envs := map[string]string{}

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -86,11 +86,6 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (_ *libpod.Pod, finalErr e
 		p.PodSpecGen.InfraContainerSpec.ResourceLimits = nil
 		p.PodSpecGen.InfraContainerSpec.WeightDevice = nil
 
-		// Set default for HealthCheck
-		p.PodSpecGen.InfraContainerSpec.HealthLogDestination = define.DefaultHealthCheckLocalDestination
-		p.PodSpecGen.InfraContainerSpec.HealthMaxLogCount = define.DefaultHealthMaxLogCount
-		p.PodSpecGen.InfraContainerSpec.HealthMaxLogSize = define.DefaultHealthMaxLogSize
-
 		rtSpec, spec, opts, err := MakeContainer(context.Background(), rt, p.PodSpecGen.InfraContainerSpec, false, nil)
 		if err != nil {
 			return nil, err

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -599,14 +599,17 @@ type ContainerHealthCheckConfig struct {
 	// Requires that HealthConfig be set.
 	// Optional.
 	StartupHealthConfig *define.StartupHealthCheck `json:"startupHealthConfig,omitempty"`
-	// HealthLogDestination defines the destination where the log is stored
-	HealthLogDestination string `json:"healthLogDestination,omitempty"`
+	// HealthLogDestination defines the destination where the log is stored.
+	// TODO (6.0): In next major release convert it to pointer and use omitempty
+	HealthLogDestination string `json:"healthLogDestination"`
 	// HealthMaxLogCount is maximum number of attempts in the HealthCheck log file.
-	// ('0' value means an infinite number of attempts in the log file)
-	HealthMaxLogCount uint `json:"healthMaxLogCount,omitempty"`
+	// ('0' value means an infinite number of attempts in the log file).
+	// TODO (6.0): In next major release convert it to pointer and use omitempty
+	HealthMaxLogCount uint `json:"healthMaxLogCount"`
 	// HealthMaxLogSize is the maximum length in characters of stored HealthCheck log
-	// ("0" value means an infinite log length)
-	HealthMaxLogSize uint `json:"healthMaxLogSize,omitempty"`
+	// ("0" value means an infinite log length).
+	// TODO (6.0): In next major release convert it to pointer and use omitempty
+	HealthMaxLogSize uint `json:"healthMaxLogSize"`
 }
 
 // SpecGenerator creates an OCI spec and Libpod configuration options to create

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -181,7 +181,10 @@ t GET    libpod/containers/${cid}/json 200 \
   .State.Status~\\\(exited\\\|stopped\\\) \
   .State.Running=false \
   .State.ExitCode=0 \
-  .Config.Umask=0022 # regression check for #15036
+  .Config.Umask=0022 \
+  .Config.HealthLogDestination=local \
+  .Config.HealthcheckMaxLogCount=5 \
+  .Config.HealthcheckMaxLogSize=500
 t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 CNAME=myfoo

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -274,6 +274,11 @@ failed    | exited     | 17
     done < <(parse_table "$tests")
 }
 
+@test "inspect - HealthCheck Defaults" {
+    run_podman inspect --format '{{.Config.HealthMaxLogSize}}--{{.Config.HealthMaxLogCount}}--{{.Config.HealthLogDestination}}' myrunningcontainer
+    assert "$output" == "500--5--local" "HealthCheck Default values of Log size, count and destination"
+}
+
 @test "network - curl" {
     run -0 curl --max-time 3 -s 127.0.0.1:$HOST_PORT/index.txt
     is "$output" "$RANDOM_STRING_1" "curl on running container"


### PR DESCRIPTION
This PR changes `HealthLogDestination`, `HealthMaxLogCount`, `HealthMaxLogSize` of `ContainerMiscConfig` to pointers.  And it removes omitempty from `HealthLogDestination`, `HealthMaxLogCount`, `HealthMaxLogSize` of `SpecGenerator.ContainerHealthCheckConfig`. 

GoLang sets unset values to the default value of the type. This means that the destination of the log is an empty string and the count and size are set to 0. However, this means that size and count are unbounded, and this is not the default behavior.

Fixes: https://github.com/containers/podman/issues/25473
Fixes: https://issues.redhat.com/browse/RHEL-83558


(cherry picked from commit fff42ac232ecdece93b0ea6053a84f5c3318ea72)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the default values of the HealthCheck logs were not set correctly, causing the logs to have no restrictions. 
```
