### PR TITLE
[skip-ci] RPM: Add riscv64 to ExclusiveArch-es

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -62,7 +62,7 @@ Release: %autorelease
 %if %{defined golang_arches_future}
 ExclusiveArch: %{golang_arches_future}
 %else
-ExclusiveArch: aarch64 ppc64le s390x x86_64
+ExclusiveArch: aarch64 ppc64le s390x x86_64 riscv64
 %endif
 Summary: Manage Pods, Containers and Container Images
 URL: https://%{name}.io/


### PR DESCRIPTION
podman-5.4.1 as found in rawhide , builds and seems to work without issues on currently available riscv64 machines

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
No

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
