### PR TITLE
container: replace code with securejoin.OpenInRoot()

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5545,7 +5545,7 @@ spec:
 
 		playKube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
 		playKube.WaitWithDefaultTimeout()
-		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf(`subpath "testing/onlythis" is outside of the volume "%s/root/volumes/testvol/_data`, podmanTest.TempDir)))
+		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf("securejoin.OpenInRoot testing/onlythis: openat2 %s/root/volumes/testvol/_data/testing/onlythis: no such file or directory", podmanTest.TempDir)))
 	})
 
 	It("with unsafe hostPath subpaths", func() {
@@ -5559,9 +5559,7 @@ spec:
 		err = generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(Not(HaveOccurred()))
 
-		playKube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
-		playKube.WaitWithDefaultTimeout()
-		Expect(playKube).Should(ExitWithError(125, fmt.Sprintf(`subpath "testing/symlink" is outside of the volume "%s"`, hostPathLocation)))
+		podmanTest.PodmanExitCleanly("kube", "play", kubeYaml)
 	})
 
 	It("with configMap subpaths", func() {


### PR DESCRIPTION
when the code was first added, there was no securejoin.OpenInRoot(). Since there is a function already provided by a dependency and already used in libpod, replace the custom code with securejoin.OpenInRoot().

The new version does not report a symlink that points outside the root, but it is still resolved relative to the specified mountpoint, since that is the openat2 semantic.  It does not affect the security of the function.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
