### PR TITLE
Fix flake on machine cp e2e test

### DIFF
--- a/pkg/machine/e2e/cp_test.go
+++ b/pkg/machine/e2e/cp_test.go
@@ -43,13 +43,17 @@ var _ = Describe("podman machine cp", func() {
 			guestToHostDir  = "guest-foo-dir"
 		)
 
-		_, err := os.Create(filePath)
+		f, err := os.Create(filePath)
+		Expect(err).ToNot(HaveOccurred())
+		err = f.Close()
 		Expect(err).ToNot(HaveOccurred())
 
 		err = os.MkdirAll(directoryPath, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = os.Create(fileInDirectoryPath)
+		f, err = os.Create(fileInDirectoryPath)
+		Expect(err).ToNot(HaveOccurred())
+		err = f.Close()
 		Expect(err).ToNot(HaveOccurred())
 
 		name := randomString()


### PR DESCRIPTION
Explicitly close file to avoid machine e2e test to fail on CI from time to time.

Fixes #25614

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
