### PR TITLE
Add --env and --unsetenv to podman update.

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -114,21 +114,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(envMergeFlagName, completion.AutocompleteNone)
 
-		envFlagName := "env"
-		createFlags.StringArrayP(
-			envFlagName, "e", Env(),
-			"Set environment variables in container",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(envFlagName, completion.AutocompleteNone)
-
-		unsetenvFlagName := "unsetenv"
-		createFlags.StringArrayVar(
-			&cf.UnsetEnv,
-			unsetenvFlagName, []string{},
-			"Unset environment default variables in container",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(unsetenvFlagName, completion.AutocompleteNone)
-
 		createFlags.BoolVar(
 			&cf.UnsetEnvAll,
 			"unsetenv-all", false,
@@ -554,6 +539,21 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"no-healthcheck", false,
 			"Disable healthchecks on container",
 		)
+
+		envFlagName := "env"
+		createFlags.StringArrayP(
+			envFlagName, "e", Env(),
+			"Set environment variables in container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(envFlagName, completion.AutocompleteNone)
+
+		unsetenvFlagName := "unsetenv"
+		createFlags.StringArrayVar(
+			&cf.UnsetEnv,
+			unsetenvFlagName, []string{},
+			"Unset environment default variables in container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(unsetenvFlagName, completion.AutocompleteNone)
 
 		healthCmdFlagName := "health-cmd"
 		createFlags.StringVar(

--- a/cmd/podman/containers/update.go
+++ b/cmd/podman/containers/update.go
@@ -163,6 +163,22 @@ func update(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if cmd.Flags().Changed("env") {
+		env, err := cmd.Flags().GetStringArray("env")
+		if err != nil {
+			return err
+		}
+		opts.Env = env
+	}
+
+	if cmd.Flags().Changed("unsetenv") {
+		env, err := cmd.Flags().GetStringArray("unsetenv")
+		if err != nil {
+			return err
+		}
+		opts.UnsetEnv = env
+	}
+
 	rep, err := registry.ContainerEngine().ContainerUpdate(context.Background(), opts)
 	if err != nil {
 		return err

--- a/docs/source/markdown/options/env.update.md
+++ b/docs/source/markdown/options/env.update.md
@@ -1,0 +1,13 @@
+####> This option file is used in:
+####>   podman update
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--env**, **-e**=*env*
+
+Add a value (e.g. env=*value*) to the container. Can be used multiple times.
+If the value already exists in the container, it is overridden.
+To remove an environment variable from the container, use the `--unsetenv`
+option.
+
+Note that the env updates only affect the main container process after
+the next start.

--- a/docs/source/markdown/options/unsetenv.update.md
+++ b/docs/source/markdown/options/unsetenv.update.md
@@ -1,0 +1,10 @@
+####> This option file is used in:
+####>   podman update
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--unsetenv**=*env*
+
+Unset environment variables from the container.
+
+Note that the env updates only affect the main container process after
+the next start.

--- a/docs/source/markdown/podman-update.1.md.in
+++ b/docs/source/markdown/podman-update.1.md.in
@@ -42,6 +42,8 @@ Updates the configuration of an existing container, allowing changes to resource
 
 @@option device-write-iops
 
+@@option env.update
+
 @@option health-cmd
 
 @@option health-interval
@@ -89,6 +91,8 @@ Changing this setting resets the timer, depending on the state of the container.
 @@option pids-limit
 
 @@option restart
+
+@@option unsetenv.update
 
 
 ## EXAMPLEs

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -782,7 +782,14 @@ func UpdateContainer(w http.ResponseWriter, r *http.Request) {
 		restartRetries = &localRetries
 	}
 
-	if err := ctr.Update(resources, restartPolicy, restartRetries, &define.UpdateHealthCheckConfig{}); err != nil {
+	updateOptions := &entities.ContainerUpdateOptions{
+		Resources:                       resources,
+		ChangedHealthCheckConfiguration: &define.UpdateHealthCheckConfig{},
+		RestartPolicy:                   restartPolicy,
+		RestartRetries:                  restartRetries,
+	}
+
+	if err := ctr.Update(updateOptions); err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("updating container: %w", err))
 		return
 	}

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -455,7 +455,16 @@ func UpdateContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = ctr.Update(resourceLimits, restartPolicy, restartRetries, &options.UpdateHealthCheckConfig)
+	updateOptions := &entities.ContainerUpdateOptions{
+		Resources:                       resourceLimits,
+		ChangedHealthCheckConfiguration: &options.UpdateHealthCheckConfig,
+		RestartPolicy:                   restartPolicy,
+		RestartRetries:                  restartRetries,
+		Env:                             options.Env,
+		UnsetEnv:                        options.UnsetEnv,
+	}
+
+	err = ctr.Update(updateOptions)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -79,6 +79,8 @@ type UpdateEntities struct {
 	specs.LinuxResources
 	define.UpdateHealthCheckConfig
 	define.UpdateContainerDevicesLimits
+	Env      []string
+	UnsetEnv []string
 }
 
 type Info struct {

--- a/pkg/bindings/containers/update.go
+++ b/pkg/bindings/containers/update.go
@@ -30,6 +30,8 @@ func Update(ctx context.Context, options *types.ContainerUpdateOptions) (string,
 		LinuxResources:               *options.Resources,
 		UpdateHealthCheckConfig:      *options.ChangedHealthCheckConfiguration,
 		UpdateContainerDevicesLimits: *options.DevicesLimits,
+		Env:                          options.Env,
+		UnsetEnv:                     options.UnsetEnv,
 	}
 	requestData, err := jsoniter.MarshalToString(updateEntities)
 	if err != nil {

--- a/pkg/domain/entities/types/containers.go
+++ b/pkg/domain/entities/types/containers.go
@@ -51,12 +51,16 @@ type ContainerUpdateOptions struct {
 	// - DevicesLimits to Limit device
 	// - RestartPolicy to change restart policy
 	// - RestartRetries to change restart retries
+	// - Env to change the environment variables.
+	// - UntsetEnv to unset the environment variables.
 	Specgen                         *specgen.SpecGenerator
 	Resources                       *specs.LinuxResources
 	DevicesLimits                   *define.UpdateContainerDevicesLimits
 	ChangedHealthCheckConfiguration *define.UpdateHealthCheckConfig
 	RestartPolicy                   *string
 	RestartRetries                  *uint
+	Env                             []string
+	UnsetEnv                        []string
 }
 
 func (u *ContainerUpdateOptions) ProcessSpecgen() {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1803,12 +1803,12 @@ func (ic *ContainerEngine) ContainerUpdate(ctx context.Context, updateOptions *e
 	}
 	container := containers[0].Container
 
-	resourceLimits, err := specgenutil.UpdateMajorAndMinorNumbers(updateOptions.Resources, updateOptions.DevicesLimits)
+	updateOptions.Resources, err = specgenutil.UpdateMajorAndMinorNumbers(updateOptions.Resources, updateOptions.DevicesLimits)
 	if err != nil {
 		return "", err
 	}
 
-	if err = container.Update(resourceLimits, updateOptions.RestartPolicy, updateOptions.RestartRetries, updateOptions.ChangedHealthCheckConfiguration); err != nil {
+	if err = container.Update(updateOptions); err != nil {
 		return "", err
 	}
 	return containers[0].ID(), nil


### PR DESCRIPTION
The --env is used to add new environment variable to container or override the existing one. The --unsetenv is used to remove the environment variable.

It is done by sharing "env" and "unsetenv" flags between both "update" and "create" commands and later handling these flags in the "update" command handler.

The lists of environment variables to add/remove are stored in newly added variables in the ContainerUpdateOptions.

The Container.Update API call is extended to take these two lists of environment variables and handle them in the internal update method using the envLib package.

Fixes: #24875

#### Does this PR introduce a user-facing change?

```release-note
The `podman update` command now supports `--env` and `--unsetenv` arguments.
```
