### PR TITLE
[v3.2.3-rhel] Update EOL date + Simplify CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,22 +25,13 @@ env:
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
     FEDORA_NAME: "fedora-34"
-    PRIOR_FEDORA_NAME: "fedora-33"
-    UBUNTU_NAME: "ubuntu-2104"
-    PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     # Google-cloud VM Images
     IMAGE_SUFFIX: "c6737534580424704"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${IMAGE_SUFFIX}"
 
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
-    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CONTAINER_FQIN: "quay.io/libpod/prior-ubuntu_podman:${IMAGE_SUFFIX}"
 
     ####
     #### Control variables that determine what to run and how to run it.
@@ -60,66 +51,6 @@ timeout_in: 60m
 
 
 gcp_credentials: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e42f55e097e897ab63ee78369dae141dcf0b46a9d0cdd]
-
-
-# Attempt to prevent flakes by confirming all required external/3rd-party
-# services are available and functional.
-ext_svc_check_task:
-    alias: 'ext_svc_check'  # int. ref. name - required for depends_on reference
-    name: "Ext. services"  # Displayed Title - has no other significance
-    skip: &tags "$CIRRUS_TAG != ''"  # Don't run on tags
-    # Default/small container image to execute tasks with
-    container: &smallcontainer
-        image: ${CTR_FQIN}
-        # Resources are limited across ALL currently executing tasks
-        # ref: https://cirrus-ci.org/guide/linux/#linux-containers
-        cpu: 2
-        memory: 2
-    env:
-        TEST_FLAVOR: ext_svc
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    # NOTE: The default way Cirrus-CI clones is *NOT* compatible with
-    #       environment expectations in contrib/cirrus/lib.sh.  Specifically
-    #       the 'origin' remote must be defined, and all remote branches/tags
-    #       must be available for reference from CI scripts.
-    clone_script: &full_clone |
-          cd /
-          rm -rf $CIRRUS_WORKING_DIR
-          mkdir -p $CIRRUS_WORKING_DIR
-          git clone --recursive --branch=$DEST_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-          cd $CIRRUS_WORKING_DIR
-          git remote update origin
-          if [[ -n "$CIRRUS_PR" ]]; then # running for a PR
-              git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
-              git checkout pull/$CIRRUS_PR
-          else
-              git reset --hard $CIRRUS_CHANGE_IN_REPO
-          fi
-          make install.tools
-
-    setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'
-    main_script: &main '/usr/bin/time --verbose --output="$STATS_LOGFILE" $GOSRC/$SCRIPT_BASE/runner.sh'
-    always: &runner_stats
-        runner_stats_artifacts:
-            path: ./*-${STATS_LOGFILE_SFX}
-            type: text/plain
-
-
-# Execute some quick checks to confirm this YAML file and all
-# automation-related shell scripts are sane.
-automation_task:
-    alias: 'automation'
-    name: "Check Automation"
-    skip: &branches_and_tags "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run on branches/tags
-    container: *smallcontainer
-    env:
-        TEST_FLAVOR: automation
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        TEST_ENVIRON: container
-    clone_script: *full_clone
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
 
 
 # N/B: This task is critical.  It builds all binaries and release archives
@@ -142,44 +73,49 @@ build_task:
         # according to gcloud CLI tool warning messages.
         disk: 200
         image_name: "${VM_IMAGE_NAME}"  # from stdenvars
-    matrix: &platform_axis
+    matrix:
         # Ref: https://cirrus-ci.org/guide/writing-tasks/#matrix-modification
-        - env:  &stdenvars
+        - env: &stdenvars
               DISTRO_NV: ${FEDORA_NAME}
               # Not used here, is used in other tasks
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        - env:
-              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-              _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        - env:
-              DISTRO_NV: ${UBUNTU_NAME}
-              VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
-              _BUILD_CACHE_HANDLE: ${UBUNTU_NAME}-build-${CIRRUS_BUILD_ID}
-        - env:
-              DISTRO_NV: ${PRIOR_UBUNTU_NAME}
-              VM_IMAGE_NAME: ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_UBUNTU_CONTAINER_FQIN}
-              _BUILD_CACHE_HANDLE: ${PRIOR_UBUNTU_NAME}-build-${CIRRUS_BUILD_ID}
     env:
         TEST_FLAVOR: build
+    # NOTE: The default way Cirrus-CI clones is *NOT* compatible with
+    #       environment expectations in contrib/cirrus/lib.sh.  Specifically
+    #       the 'origin' remote must be defined, and all remote branches/tags
+    #       must be available for reference from CI scripts.
     # Ref: https://cirrus-ci.org/guide/writing-tasks/#cache-instruction
     gopath_cache:  &gopath_cache
         folder: *gopath  # Required hard-coded path, no variables.
         fingerprint_script: echo "$_BUILD_CACHE_HANDLE"
         # Cheat: Clone here when cache is empty, guaranteeing consistency.
-        populate_script: *full_clone
+        populate_script: |
+          cd /
+          rm -rf $CIRRUS_WORKING_DIR
+          mkdir -p $CIRRUS_WORKING_DIR
+          git clone --recursive --branch=$DEST_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+          cd $CIRRUS_WORKING_DIR
+          git remote update origin
+          if [[ -n "$CIRRUS_PR" ]]; then # running for a PR
+              git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+              git checkout pull/$CIRRUS_PR
+          else
+              git reset --hard $CIRRUS_CHANGE_IN_REPO
+          fi
+          make install.tools
+
     # A normal clone would invalidate useful cache
-    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
-    setup_script: *setup
-    main_script: *main
+    clone_script: &noop /bin/true
+    setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'
+    main_script: &main '/usr/bin/time --verbose --output="$STATS_LOGFILE" $GOSRC/$SCRIPT_BASE/runner.sh'
     always: &binary_artifacts
-        <<: *runner_stats
+        runner_stats_artifacts:
+            path: ./*-${STATS_LOGFILE_SFX}
+            type: text/plain
         gosrc_artifacts:
             path: ./*  # Grab everything in top-level $GOSRC
             type: application/octet-stream
@@ -199,172 +135,23 @@ validate_task:
     # automation reliability/speed in those contexts.  Any missed errors due
     # to nonsequential PR merging practices, will be caught on a future PR,
     # build or test task failures.
-    skip: *branches_and_tags
+    skip: "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run on branches/tags
     depends_on:
-        - ext_svc_check
-        - automation
         - build
     # golangci-lint is a very, very hungry beast.
-    gce_instance: &bigvm
+    gce_instance:
         <<: *standardvm
         cpu: 8
         memory: "16Gb"
     env:
         <<: *stdenvars
         TEST_FLAVOR: validate
-    gopath_cache: &ro_gopath_cache
+    gopath_cache:
         <<: *gopath_cache
         reupload_on_changes: false
     clone_script: *noop
     setup_script: *setup
     main_script: *main
-    always: *runner_stats
-
-
-# Exercise the "libpod" API with a small set of common
-# operations to ensure they are functional.
-bindings_task:
-    name: "Test Bindings"
-    alias: bindings
-    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
-    skip: *branches_and_tags
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: bindings
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-# Check that all included go modules from other sources match
-# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
-# make sure that the generated bindings in pkg/bindings/...
-# are in sync with the code.
-consistency_task:
-    name: "Test Code Consistency"
-    alias: consistency
-    skip: *tags
-    depends_on:
-        - build
-    container: *smallcontainer
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: consistency
-        TEST_ENVIRON: container
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    clone_script: *full_clone  # build-cache not available to container tasks
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-# There are several other important variations of podman which
-# must always build successfully.  Most of them are handled in
-# this task, though a few need dedicated tasks which follow.
-alt_build_task:
-    name: "$ALT_NAME"
-    alias: alt_build
-    only_if: *not_docs
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: "altbuild"
-    gce_instance: *standardvm
-    matrix:
-      #- env:
-      #      ALT_NAME: 'Build Each Commit'
-      - env:
-            ALT_NAME: 'Windows Cross'
-      - env:
-            ALT_NAME: 'Build Without CGO'
-      - env:
-            ALT_NAME: 'Test build RPM'
-      - env:
-            ALT_NAME: 'Alt Arch. Cross'
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# Does exactly what it says, execute the podman unit-tests on all primary
-# platforms and release versions.
-unit_test_task:
-    name: "Unit tests on $DISTRO_NV"
-    alias: unit_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-        - validate
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: unit
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-# Always run subsequent to integration tests.  While parallelism is lost
-# with runtime, debugging system-test failures can be more challenging
-# for some golang developers.  Otherwise the following tasks run across
-# the same matrix as the integration-tests (above).
-local_system_test_task: &local_system_test_task
-    name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
-    alias: local_system_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-      - unit_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: &logs_artifacts
-        <<: *runner_stats
-
-
-remote_system_test_task:
-    <<: *local_system_test_task
-    alias: remote_system_test
-    depends_on:
-      - unit_test
-    env:
-        TEST_FLAVOR: sys
-        PODBIN_NAME: remote
-
-
-rootless_system_test_task:
-    name: *std_name_fmt
-    alias: rootless_system_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-      - unit_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-        PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: &int_logs_artifacts
-        <<: *logs_artifacts
 
 
 # This task is critical.  It updates the "last-used by" timestamp stored
@@ -379,11 +166,7 @@ meta_task:
         image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
-        IMGNAMES: >-
-            ${FEDORA_CACHE_IMAGE_NAME}
-            ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-            ${UBUNTU_CACHE_IMAGE_NAME}
-            ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
+        IMGNAMES: ${FEDORA_CACHE_IMAGE_NAME}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_REPO_NAME}"
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]
@@ -401,64 +184,17 @@ success_task:
     alias: success
     # N/B: ALL tasks must be listed here, minus their '_task' suffix.
     depends_on:
-        - ext_svc_check
-        - automation
         - build
         - validate
-        - bindings
-        - consistency
-        - alt_build
-        - unit_test
-        - local_system_test
-        - remote_system_test
-        - rootless_system_test
         - meta
-    container: *smallcontainer
+    container:
+        image: ${CTR_FQIN}
+        # Resources are limited across ALL currently executing tasks
+        # ref: https://cirrus-ci.org/guide/linux/#linux-containers
+        cpu: 2
+        memory: 2
     env:
         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
         TEST_ENVIRON: container
     clone_script: *noop
     script: /bin/true
-
-
-# When a new tag is pushed, confirm that the code and commits
-# meet criteria for an official release.
-release_task:
-    name: "Verify Release"
-    alias: release
-    only_if: *tags
-    depends_on:
-        - success
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: release
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# When preparing to release a new version, this task may be manually
-# activated at the PR stage to verify the build is proper for a potential
-# podman release.
-#
-# Note: This cannot use a YAML alias on 'release_task' as of this
-# comment, it is incompatible with 'trigger_type: manual'
-release_test_task:
-    name: "Optional Release Test"
-    alias: release_test
-    only_if: $CIRRUS_PR != ''
-    trigger_type: manual
-    depends_on:
-        - success
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: release
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -19,10 +19,10 @@ die_unknown() {
     die "Unknown/unsupported \$$var_name '$var_value'"
 }
 
-_EOL=20231001
+_EOL=20250531
 if [[ $(date +%Y%m%d) -ge $_EOL ]]; then
     die "As of $_EOL this branch is probably
-no longer supported in RHEL 8.4.0.2, please
+no longer supported in RHEL 8.4.z, please
 confirm this with RHEL PM.  If so:
 
 It should be removed from Cirrus-Cron,


### PR DESCRIPTION
This RHEL release branch has a very short lifespan remaining, but the original date set in the CI scripts was wrong.  Fix that and reduce CI to the absolute bare-minimum needed for any remaining backports.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
