### PR TITLE
e2e tests: fix desired network backend checking

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,6 +59,7 @@ env:
     CI_DESIRED_RUNTIME: crun    # As of 2024-05-28 there are no other supported runtimes
     CI_DESIRED_DATABASE: sqlite # 'sqlite' or 'boltdb'
     CI_DESIRED_STORAGE: overlay # overlay, vfs, or composefs (which is actually overlay)
+    CI_DESIRED_NETWORK_BACKEND: netavark # 'netavark' or 'cni'
 
     # Curl-command prefix for downloading task artifacts, simply add the
     # the url-encoded task name, artifact name, and path as a suffix.

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -154,15 +154,23 @@ var _ = Describe("Podman Info", func() {
 	})
 
 	It("Podman info: check desired network backend", func() {
+		// defined in .cirrus.yml
+		want := os.Getenv("CI_DESIRED_NETWORK_BACKEND")
+		if want == "" {
+			if os.Getenv("CIRRUS_CI") == "" {
+				Skip("CI_DESIRED_NETWORK_BACKEND is not set--this is OK because we're not running under Cirrus")
+			}
+			Fail("CIRRUS_CI is set, but CI_DESIRED_NETWORK_BACKEND is not!")
+		}
 		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.NetworkBackend}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal("netavark"))
+		Expect(session.OutputToString()).To(Equal(want))
 
 		session = podmanTest.Podman([]string{"info", "--format", "{{.Host.NetworkBackendInfo.Backend}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal("netavark"))
+		Expect(session.OutputToString()).To(Equal(want))
 	})
 
 	It("Podman info: check desired database backend", func() {


### PR DESCRIPTION
Setting 'cni' as the network backend then run e2e tests, the following test failure will be hit w/o this patch.

\# ./test/tools/build/ginkgo -v -focus "Podman info: check desired network backend" test/e2e/ ...
Podman Info [It] Podman info: check desired network backend /root/podman/test/e2e/info_test.go:156

  [FAILED] Expected
      \<string\>: cni
  to equal
      \<string\>: netavark

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

It's only for testing.

```
[root@dell-r730-059 ~]# cat /etc/redhat-release 
Red Hat Enterprise Linux release 9.6 Beta (Plow)

[root@dell-r730-059 ~]# rpm -q podman crun criu kernel
podman-5.4.0-1.el9.x86_64
crun-1.19.1-1.el9.x86_64
criu-3.19-1.el9.x86_64
kernel-5.14.0-570.3.1.el9_6.x86_64
```
