### PR TITLE
Add support for --pids-limit in podman kube play.

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -55,6 +55,8 @@ by `podman kube play` to create them.
 
 Note: To customize the name of the infra container created during `podman kube play`, use the **io.podman.annotations.infra.name** annotation in the pod definition. This annotation is automatically set when generating a kube yaml from a pod that was created with the `--infra-name` flag set.
 
+Note: Use the **io.podman.annotations.pids-limit/$ctrname** annotation to configure the pod's pids limit.
+
 `Kubernetes PersistentVolumeClaims`
 
 A Kubernetes PersistentVolumeClaim represents a Podman named volume. Only the PersistentVolumeClaim name is required by Podman to create a volume. Kubernetes annotations can be used to make use of the available options for Podman volumes.

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -169,6 +169,9 @@ const (
 	// KubeImageAutomountAnnotation
 	KubeImageAutomountAnnotation = "io.podman.annotations.kube.image.volumes.mount"
 
+	// PIDsLimitAnnotation is used to limit the number of PIDs
+	PIDsLimitAnnotation = "io.podman.annotations.pids-limit"
+
 	// TotalAnnotationSizeLimitB is the max length of annotations allowed by Kubernetes.
 	TotalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
 )

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -375,6 +375,20 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		s.Annotations[define.InspectAnnotationApparmor] = apparmor
 	}
 
+	if pidslimit, ok := annotations[define.PIDsLimitAnnotation+"/"+opts.Container.Name]; ok {
+		s.Annotations[define.PIDsLimitAnnotation] = pidslimit
+		pidslimitAsInt, err := strconv.ParseInt(pidslimit, 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		if s.ResourceLimits == nil {
+			s.ResourceLimits = &spec.LinuxResources{}
+		}
+		s.ResourceLimits.Pids = &spec.LinuxPids{
+			Limit: pidslimitAsInt,
+		}
+	}
+
 	if label, ok := opts.Annotations[define.InspectAnnotationLabel+"/"+opts.Container.Name]; ok {
 		if label == "nested" {
 			s.ContainerSecurityConfig.LabelNested = &localTrue

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -527,6 +527,10 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.Annotations[define.UserNsAnnotation] = c.UserNS
 	}
 
+	if c.PIDsLimit != nil {
+		s.Annotations[define.PIDsLimitAnnotation] = strconv.FormatInt(*c.PIDsLimit, 10)
+	}
+
 	if len(c.StorageOpts) > 0 {
 		opts := make(map[string]string, len(c.StorageOpts))
 		for _, opt := range c.StorageOpts {


### PR DESCRIPTION
This commit adds new annotation called:

io.podman.annotations.pids-limit/$ctrname

This annotation is used to define the PIDsLimit for a particular pod. It is also automatically defined when newly added --pids-limit option is used.

Fixes: #24418

#### Does this PR introduce a user-facing change?

```release-note
The `podman kube play` now supports the `--pids-limit` command line option to define the PIDsLimit for pod.
```
