### PR TITLE
Do not set arch for windows to amd64

### DIFF
--- a/contrib/cirrus/win-lib.ps1
+++ b/contrib/cirrus/win-lib.ps1
@@ -9,7 +9,6 @@ $ErrorActionPreference = 'Stop'
 
 # Any golang compilation needs to know what it's building for.
 $Env:GOOS = "windows"
-$Env:GOARCH = "amd64"
 
 # Unnecessary and intrusive.  They claim parameter/variable
 # values aren't collected, but there could be a bug leading


### PR DESCRIPTION
Setting the arch to amd64 breaks arm64 windows builds.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
