### PR TITLE
fix: #23915 podman build is not parsing sbom command line arguments

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -515,6 +516,24 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 		}
 	}
 
+	var sbomScanOptions []buildahDefine.SBOMScanOptions
+	if c.Flag("sbom").Changed || c.Flag("sbom-scanner-command").Changed || c.Flag("sbom-scanner-image").Changed || c.Flag("sbom-image-output").Changed || c.Flag("sbom-merge-strategy").Changed || c.Flag("sbom-output").Changed || c.Flag("sbom-image-output").Changed || c.Flag("sbom-purl-output").Changed || c.Flag("sbom-image-purl-output").Changed {
+		sbomScanOption, err := parse.SBOMScanOptions(c)
+		if err != nil {
+			return nil, err
+		}
+		if !slices.Contains(sbomScanOption.ContextDir, contextDir) {
+			sbomScanOption.ContextDir = append(sbomScanOption.ContextDir, contextDir)
+		}
+		for _, abc := range additionalBuildContext {
+			if !abc.IsURL && !abc.IsImage {
+				sbomScanOption.ContextDir = append(sbomScanOption.ContextDir, abc.Value)
+			}
+		}
+		sbomScanOption.PullPolicy = pullPolicy
+		sbomScanOptions = append(sbomScanOptions, *sbomScanOption)
+	}
+
 	opts := buildahDefine.BuildOptions{
 		AddCapabilities:         flags.CapAdd,
 		AdditionalTags:          tags,
@@ -571,6 +590,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 		Runtime:                 podmanConfig.RuntimePath,
 		RuntimeArgs:             runtimeFlags,
 		RusageLogFile:           flags.RusageLogFile,
+		SBOMScanOptions:         sbomScanOptions,
 		SignBy:                  flags.SignBy,
 		SignaturePolicyPath:     flags.SignaturePolicy,
 		Squash:                  flags.Squash,

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -670,6 +670,42 @@ func prepareRequestBody(ctx context.Context, requestParts *RequestParts, buildFi
 		return nil, err
 	}
 
+	if len(options.SBOMScanOptions) > 0 {
+		for _, sbomScanOpts := range options.SBOMScanOptions {
+			if sbomScanOpts.SBOMOutput != "" {
+				requestParts.Params.Set("sbom-output", sbomScanOpts.SBOMOutput)
+			}
+
+			if sbomScanOpts.PURLOutput != "" {
+				requestParts.Params.Set("sbom-purl-output", sbomScanOpts.PURLOutput)
+			}
+
+			if sbomScanOpts.ImageSBOMOutput != "" {
+				requestParts.Params.Set("sbom-image-output", sbomScanOpts.ImageSBOMOutput)
+			}
+
+			if sbomScanOpts.ImagePURLOutput != "" {
+				requestParts.Params.Set("sbom-image-purl-output", sbomScanOpts.ImagePURLOutput)
+			}
+
+			if sbomScanOpts.Image != "" {
+				requestParts.Params.Set("sbom-scanner-image", sbomScanOpts.Image)
+			}
+
+			if commands := sbomScanOpts.Commands; len(commands) > 0 {
+				c, err := jsoniter.MarshalToString(commands)
+				if err != nil {
+					return nil, err
+				}
+				requestParts.Params.Add("sbom-scanner-command", c)
+			}
+
+			if sbomScanOpts.MergeStrategy != "" {
+				requestParts.Params.Set("sbom-merge-strategy", string(sbomScanOpts.MergeStrategy))
+			}
+		}
+	}
+
 	if len(options.AdditionalBuildContexts) == 0 {
 		requestParts.Body = tarfile
 		logrus.Debugf("Using main build context: %q", options.ContextDirectory)


### PR DESCRIPTION
# Issue Description
SBOM flags are not respected while podman build command.

At the same time buildah build command works as expected.

Fixes #23915 

## Steps to reproduce the issue
With the following Containerfile:
```
FROM ubuntu:22.04
WORKDIR /app
```

Run the following podman build:

```
podman build -t sbom-img --sbom=trivy-spdx \
        --sbom-image-output=/app/sbom-spdx.json \
        --sbom-output=sbom-spdx.json \
        --sbom-scanner-image=ghcr.io/aquasecurity/trivy \
        --sbom-scanner-command="trivy filesystem -q {ROOTFS} --format spdx-json --output {OUTPUT}" \
        --sbom-scanner-command="trivy filesystem -q {CONTEXT} --format spdx-json --output {OUTPUT}" \
        --sbom-merge-strategy=merge-spdx-by-package-name-and-versioninfo \
        -f Containerfile
```

Create a container with the image built in the previous step and check if the file sbom-spdx.json is inside of the container as requested:

```
podman run -it --rm sbom-img ls -al
```

Expected result:
```
drwxr-xr-x. 1 root root     28 Mar 21 13:06 .
dr-xr-xr-x. 1 root root     12 Mar 21 13:17 ..
-rw-r--r--. 1 root root 147729 Mar 21 13:06 sbom-spdx.json
```

Actual results:
```
drwxr-xr-x. 1 root root     28 Mar 21 13:06 .
dr-xr-xr-x. 1 root root     12 Mar 21 13:17 ..
```

Running the steps above with the code from this PR shows the expected result (the same as when using buildah), while running with the code from the main branch shows the actual result (with the bug).


#### Does this PR introduce a user-facing change?

```release-note
None
```
