### PR TITLE
Fix parsing of paths for unmask

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -739,9 +739,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 				return fmt.Errorf("invalid systempaths option %q, only `unconfined` is supported", val)
 			}
 		case "unmask":
-			if hasVal {
-				s.ContainerSecurityConfig.Unmask = append(s.ContainerSecurityConfig.Unmask, val)
-			}
+			s.ContainerSecurityConfig.Unmask = append(s.ContainerSecurityConfig.Unmask, strings.Split(val, ":")...)
 		case "no-new-privileges":
 			noNewPrivileges := true
 			if hasVal {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -437,7 +437,7 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(BeEmpty())
 
-		session = podmanTest.Podman([]string{"run", "-d", "--name=maskCtr2", "--security-opt", "unmask=/proc/acpi:/sys/firmware", ALPINE, "sleep", "200"})
+		session = podmanTest.Podman([]string{"run", "-d", "--name=maskCtr2", "--security-opt", "unmask=/proc/acpi:/sys/firmware:/sys/fs/cgroup", ALPINE, "sleep", "200"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		session = podmanTest.Podman([]string{"exec", "maskCtr2", "ls", "/sys/firmware"})
@@ -447,6 +447,9 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"exec", "maskCtr2", "ls", "/proc/acpi"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(Not(BeEmpty()))
+		Expect(session).Should(ExitCleanly())
+		session = podmanTest.Podman([]string{"exec", "maskCtr2", "sh", "-c", "awk '$5 ~ /\\/sys\\/fs\\/cgroup/ && $6 ~ /^rw,|,rw,|,rw$|^rw$/ { print }' /proc/self/mountinfo | grep ."})
+		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
 		session = podmanTest.Podman([]string{"run", "-d", "--name=maskCtr3", "--security-opt", "mask=/sys/power/disk", ALPINE, "sleep", "200"})


### PR DESCRIPTION
This fixes an issue where multiple paths separated by a colon were treated as a single path, contrary to what docs say and unlike how mask option works.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where multiple paths could not be set in --security-opt=unmask
```
