### PR TITLE
Clarify behavior of --health-timeout in man page

### DIFF
--- a/docs/source/markdown/options/health-timeout.md
+++ b/docs/source/markdown/options/health-timeout.md
@@ -6,3 +6,7 @@
 
 The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
 value can be expressed in a time format such as **1m22s**. The default value is **30s**.
+
+Note: A timeout marks the healthcheck as failed but does not terminate the running process.
+This ensures that a slow but eventually successful healthcheck does not disrupt the container
+but is still accounted for in the health status.


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHEL-84682

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
