### PR TITLE
CI: use z1d instance for windows machine testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -802,7 +802,7 @@ podman_machine_windows_task:
     depends_on: *build
     ec2_instance:
         <<: *windows
-        type: m5zn.metal
+        type: z1d.metal
         platform: windows
     timeout_in: 60m
     env: *winenv
@@ -812,6 +812,23 @@ podman_machine_windows_task:
       - env:
           TEST_FLAVOR: "machine-hyperv"
     clone_script: *winclone
+    # This depends on an instance with an local NVMe storage so we can make use of fast IO
+    # Our machine tests are IO bound so this is rather imporant to speed them up a lot.
+    setup_disk_script: |
+        echo "Get-Disk"
+        Get-Disk | Ft -autosize | out-string -width 4096
+        # Hard coded to disk 0, assume that this is always the case for our ec2 instance.
+        # It is not clear to me how I would filter by name because we still have two disks
+        # with the same name.
+        echo "Format and mount disk 0"
+        $disk = Get-Disk 0
+        $disk | Initialize-Disk -PartitionStyle MBR
+        $disk | New-Partition -UseMaximumSize -MbrType IFS
+        $Partition = Get-Partition -DiskNumber $disk.Number
+        $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
+        $Partition | Add-PartitionAccessPath -AccessPath "Z:\"
+        echo "Get-Volume"
+        Get-Volume
     main_script: ".\\repo\\contrib\\cirrus\\win-podman-machine-main.ps1"
     always:
         # Required for `contrib/cirrus/logformatter` to work properly

--- a/contrib/cirrus/win-podman-machine-test.ps1
+++ b/contrib/cirrus/win-podman-machine-test.ps1
@@ -33,5 +33,12 @@ Run-Command ".\bin\windows\podman.exe --version"
 New-Item -ItemType "directory" -Path "$env:AppData\containers"
 Copy-Item -Path pkg\machine\ocipull\policy.json -Destination "$env:AppData\containers"
 
+# Set TMPDIR to fast storage, see cirrus.yml setup_disk_script for setup Z:\
+# TMPDIR is used by the machine tests paths, while TMP and TEMP are the normal
+# windows temporary dirs. Just to ensure everything uses the fast disk.
+$Env:TMPDIR = 'Z:\'
+$Env:TMP = 'Z:\'
+$Env:TEMP = 'Z:\'
+
 Write-Host "`nRunning podman-machine e2e tests"
 Run-Command ".\winmake localmachine"

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -84,14 +84,14 @@ var _ = Describe("podman machine init", func() {
 		// Check that mounting to certain target directories like /tmp at the / level is NOT ok
 		tmpVol := initMachine{}
 		targetMount := "/tmp"
-		tmpVolSession, err := mb.setCmd(tmpVol.withVolume(fmt.Sprintf("/whatever:%s", targetMount))).run()
+		tmpVolSession, err := mb.setCmd(tmpVol.withImage(mb.imagePath).withVolume(fmt.Sprintf("/whatever:%s", targetMount))).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(tmpVolSession).To(Exit(125))
 		Expect(tmpVolSession.errorToString()).To(ContainSubstring(fmt.Sprintf("Error: machine mount destination cannot be %q: consider another location or a subdirectory of an existing location", targetMount)))
 
 		// Mounting to /tmp/foo (subdirectory) is OK
 		tmpSubdir := initMachine{}
-		tmpSubDirSession, err := mb.setCmd(tmpSubdir.withVolume("/whatever:/tmp/foo")).run()
+		tmpSubDirSession, err := mb.setCmd(tmpSubdir.withImage(mb.imagePath).withVolume("/whatever:/tmp/foo")).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(tmpSubDirSession).To(Exit(0))
 	})


### PR DESCRIPTION
This one has two local NVMe's attached so we should be able to use fast
local storage to hopefully speed the test up. The NVMe are not mounted
by default so we have to format and mount them. I have choosen Z as
drive letter as I guess it seems most likely that it is free.
Then we need to set the TMPDIR envs to make the machine tests use the
new location.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
