### PR TITLE
GHA: Open PR to podman-machine-os on releases

### DIFF
--- a/.github/workflows/machine-os-pr.yml
+++ b/.github/workflows/machine-os-pr.yml
@@ -1,0 +1,145 @@
+name: "Machine OS PR"
+
+on:
+  pull_request_target:
+    # prevent action from running on older release-process branches
+    # TODO: remove when we move to new release flow
+    branches:
+      - 'v5.5'
+      - 'main'
+    paths:
+      - 'version/rawversion/version.go'
+
+concurrency:
+  # Cancel other in-progress runs on re-pushes
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  podman-image-build-pr:
+    name: Open PR on podman-machine-os
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      SHA: ${{github.event.pull_request.head.sha}}
+      UPSTREAM_MACHINE_OS: "containers/podman-machine-os"
+      PODMAN_REPO: "containers/podman"
+    steps:
+
+      - name: Get version
+        id: getversion
+        run: |
+          VERSION=$(curl "https://raw.githubusercontent.com/$PODMAN_REPO/$SHA/version/rawversion/version.go" | sed -n 's/^const RawVersion = \"\(.*\)\"$/\1/p')
+          # ignore -dev version bumps unless on main
+          if [[ ${{github.base_ref}} != "main" ]] && [[ $VERSION == *-dev ]] ; then
+            echo "::warning:: SKIPPING: dev bump not on main"
+          elif [[ ${{github.base_ref}} == *-rhel ]] ; then
+            echo "::warning:: SKIPPING: rhel branch"
+          else
+            echo "update=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check machine-os-branch
+        if: steps.getversion.outputs.update == 'true'
+        run: |
+          if ! (curl -s https://api.github.com/repos/$UPSTREAM_MACHINE_OS/branches| jq -e --arg branch "${{github.base_ref}}" '.[] | select(.name==$branch)') ; then
+            echo "::error:: Release branch does not exist."
+            echo "::error:: Please push $branch to $UPSTREAM_MACHINE_OS, then re-run this task."
+            exit 1
+          fi
+
+      - name: Label
+        if: steps.getversion.outputs.update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh pr edit --add-label do-not-merge/wait-machine-os-build ${{github.event.number}}
+
+      - name: Install wait-for-copr
+        if: steps.getversion.outputs.update == 'true'
+        run: |
+          pip3 install git+https://github.com/packit/wait-for-copr.git@main
+
+      - uses: actions/checkout@v4
+        if: steps.getversion.outputs.update == 'true'
+        id: checkout
+        with:
+          repository: containers/podman-machine-os
+          ref: ${{github.base_ref}}
+          token: ${{secrets.PODMANBOT_TOKEN}}
+
+      - name: Bump version
+        if: steps.getversion.outputs.update == 'true'
+        run: |
+          echo ${{steps.getversion.outputs.version}}
+          sed -i 's/export PODMAN_VERSION=".*"/export PODMAN_VERSION="${{steps.getversion.outputs.version}}"/g' podman-rpm-info-vars.sh
+          sed -i 's/export PODMAN_PR_NUM=".*"/export PODMAN_PR_NUM="${{github.event.number}}"/g' podman-rpm-info-vars.sh
+          echo "Updated file:"
+          cat podman-rpm-info-vars.sh
+
+      - name: Wait for COPR build
+        if: steps.getversion.outputs.update == 'true'
+        run: |
+          wait-for-copr \
+          --owner packit \
+          --project containers-podman-${{github.event.number}} \
+          podman \
+          ${SHA::9}
+
+      - name: Push
+        if: steps.getversion.outputs.update == 'true'
+        run: |
+          # Make committer the user who triggered the action, either through cutting a release or manual trigger
+          # GitHub gives everyone a noreply email associated with their account, use that email for the sign-off
+          git config --local user.name ${{ github.actor }}
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          bumpbranch="pr${{github.event.number}}"
+          git checkout -b $bumpbranch
+          git add podman-rpm-info-vars.sh
+          git commit --signoff -m "Bump Podman to v${{ steps.getversion.outputs.version }}"
+          git remote add podmanbot https://github.com/podmanbot/podman-machine-os
+          git push -f podmanbot "$bumpbranch"
+
+      - name: Check open PRs
+        id: checkpr
+        if: steps.getversion.outputs.update == 'true'
+        run: |
+          prs=$(gh pr list \
+            --repo $UPSTREAM_MACHINE_OS \
+            --head "pr${{github.event.number}}" \
+            --state open \
+            --json title \
+            --jq 'length')
+          if ((prs > 0)); then
+            echo "::notice:: SKIPPING: PR already exists. Re-pushed to re-trigger build."
+          else
+            echo "openpr=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+
+      - name: Open PR
+        if: steps.getversion.outputs.update == 'true' && steps.checkpr.outputs.openpr == 'true'
+        id: pr
+        run: |
+          bumpbranch="pr${{github.event.number}}"
+          uri=`gh pr create \
+            --title "Bump Podman to v${{ steps.getversion.outputs.version }}" \
+            --body  "Triggered by https://github.com/$PODMAN_REPO/pull/${{github.event.number}}" \
+            --head "podmanbot:$bumpbranch" \
+            --base "${{github.base_ref}}" \
+            --repo $UPSTREAM_MACHINE_OS`
+          echo "uri=$uri" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+
+      - name: Comment PR link
+        if: steps.getversion.outputs.update == 'true' && steps.checkpr.outputs.openpr == 'true'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: "Building images at: ${{ steps.pr.outputs.uri }}"


### PR DESCRIPTION
When we do a release, we need to ensure that machine images are built before the release PR can merge.

This GitHub action is triggered on version bumps, waits for our COPR builds to finish, and then opens a PR on the podman-machine-os repo to build the required machine-os images there. Note that dev bumps, unless on main, will not open a PR

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
