### PR TITLE
support recursive read only (`rro`) option for mounts

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/common/pkg/resize"
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
 )
 
 // OCIRuntime is an implementation of an OCI runtime.
@@ -130,6 +131,9 @@ type OCIRuntime interface { //nolint:interfacebloat
 	// SupportsKVM os whether the OCI runtime supports running containers
 	// without KVM separation
 	SupportsKVM() bool
+
+	// Features returns the features struct from the OCI runtime
+	Features() *features.Features
 
 	// AttachSocketPath is the path to the socket to attach to a given
 	// container.

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/common/pkg/resize"
 	"github.com/containers/podman/v5/libpod/define"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
 	"github.com/sirupsen/logrus"
 )
 
@@ -192,6 +193,11 @@ func (r *MissingRuntime) SupportsNoCgroups() bool {
 // without KVM separation
 func (r *MissingRuntime) SupportsKVM() bool {
 	return false
+}
+
+// Features returns nil since this is a missing runtime
+func (r *MissingRuntime) Features() *features.Features {
+	return nil
 }
 
 // AttachSocketPath does not work as there is no runtime to attach to.

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -43,8 +43,7 @@ type OverlayVolume struct {
 }
 
 // ImageVolume is a volume based on a container image.  The container image is
-// first mounted on the host and is then bind-mounted into the container.  An
-// ImageVolume is always mounted read-only.
+// first mounted on the host and is then bind-mounted into the container.
 type ImageVolume struct {
 	// Source is the source of the image volume.  The image can be referred
 	// to by name and by ID.

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -345,34 +345,38 @@ func parseMountOptions(mountType string, args []string) (*universalMount, error)
 			} else {
 				mnt.mount.Options = append(mnt.mount.Options, "idmap")
 			}
-		case "readonly", "ro", "rw":
+		case "readonly", "ro", "recursivereadonly", "rro", "rw":
 			if setRORW {
-				return nil, fmt.Errorf("cannot pass 'readonly', 'ro', or 'rw' mnt.Options more than once: %w", errOptionArg)
+				return nil, fmt.Errorf("cannot pass 'readonly', 'ro', 'rro', 'recursivereadonly' or 'rw' options more than once: %w", errOptionArg)
 			}
 			setRORW = true
+
 			// Can be formatted as one of:
 			// readonly
 			// readonly=[true|false]
 			// ro
 			// ro=[true|false]
+			// recursivereadonly
+			// recursivereadonly=[true|false]
+			// rro
+			// rro=[true|false]
 			// rw
 			// rw=[true|false]
-			if name == "readonly" {
-				name = "ro"
-			}
-			if hasValue {
-				switch strings.ToLower(value) {
-				case "true":
-					mnt.mount.Options = append(mnt.mount.Options, name)
-				case "false":
-					// Set the opposite only for rw
-					// ro's opposite is the default
-					if name == "rw" {
-						mnt.mount.Options = append(mnt.mount.Options, "ro")
+			switch name {
+			case "rro", "recursivereadonly":
+				mnt.mount.Options = append(mnt.mount.Options, "rro")
+			case "ro", "readonly":
+				mnt.mount.Options = append(mnt.mount.Options, "ro")
+			case "rw":
+				if hasValue {
+					switch strings.ToLower(value) {
+					case "true":
+						mnt.mount.Options = append(mnt.mount.Options, name)
+					case "false":
+						// default to rro instead of ro
+						mnt.mount.Options = append(mnt.mount.Options, "rro")
 					}
 				}
-			} else {
-				mnt.mount.Options = append(mnt.mount.Options, name)
 			}
 		case "nodev", "dev":
 			if setDev {

--- a/pkg/util/mount_opts.go
+++ b/pkg/util/mount_opts.go
@@ -94,7 +94,7 @@ func processOptionsInternal(options []string, isTmpfs bool, sourcePath string, g
 				return nil, fmt.Errorf("only one of 'nodev' and 'dev' can be used: %w", ErrDupeMntOption)
 			}
 			foundDev = true
-		case "rw", "ro":
+		case "rw", "ro", "rro":
 			if foundWrite {
 				return nil, fmt.Errorf("only one of 'rw' and 'ro' can be used: %w", ErrDupeMntOption)
 			}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
@@ -1,0 +1,145 @@
+// Package features provides the Features struct.
+package features
+
+// Features represents the supported features of the runtime.
+type Features struct {
+	// OCIVersionMin is the minimum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.0".
+	OCIVersionMin string `json:"ociVersionMin,omitempty"`
+
+	// OCIVersionMax is the maximum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.2-dev".
+	OCIVersionMax string `json:"ociVersionMax,omitempty"`
+
+	// Hooks is the list of the recognized hook names, e.g., "createRuntime".
+	// Nil value means "unknown", not "no support for any hook".
+	Hooks []string `json:"hooks,omitempty"`
+
+	// MountOptions is the list of the recognized mount options, e.g., "ro".
+	// Nil value means "unknown", not "no support for any mount option".
+	// This list does not contain filesystem-specific options passed to mount(2) syscall as (const void *).
+	MountOptions []string `json:"mountOptions,omitempty"`
+
+	// Linux is specific to Linux.
+	Linux *Linux `json:"linux,omitempty"`
+
+	// Annotations contains implementation-specific annotation strings,
+	// such as the implementation version, and third-party extensions.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// PotentiallyUnsafeConfigAnnotations the list of the potential unsafe annotations
+	// that may appear in `config.json`.
+	//
+	// A value that ends with "." is interpreted as a prefix of annotations.
+	PotentiallyUnsafeConfigAnnotations []string `json:"potentiallyUnsafeConfigAnnotations,omitempty"`
+}
+
+// Linux is specific to Linux.
+type Linux struct {
+	// Namespaces is the list of the recognized namespaces, e.g., "mount".
+	// Nil value means "unknown", not "no support for any namespace".
+	Namespaces []string `json:"namespaces,omitempty"`
+
+	// Capabilities is the list of the recognized capabilities , e.g., "CAP_SYS_ADMIN".
+	// Nil value means "unknown", not "no support for any capability".
+	Capabilities []string `json:"capabilities,omitempty"`
+
+	Cgroup          *Cgroup          `json:"cgroup,omitempty"`
+	Seccomp         *Seccomp         `json:"seccomp,omitempty"`
+	Apparmor        *Apparmor        `json:"apparmor,omitempty"`
+	Selinux         *Selinux         `json:"selinux,omitempty"`
+	IntelRdt        *IntelRdt        `json:"intelRdt,omitempty"`
+	MountExtensions *MountExtensions `json:"mountExtensions,omitempty"`
+}
+
+// Cgroup represents the "cgroup" field.
+type Cgroup struct {
+	// V1 represents whether Cgroup v1 support is compiled in.
+	// Unrelated to whether the host uses cgroup v1 or not.
+	// Nil value means "unknown", not "false".
+	V1 *bool `json:"v1,omitempty"`
+
+	// V2 represents whether Cgroup v2 support is compiled in.
+	// Unrelated to whether the host uses cgroup v2 or not.
+	// Nil value means "unknown", not "false".
+	V2 *bool `json:"v2,omitempty"`
+
+	// Systemd represents whether systemd-cgroup support is compiled in.
+	// Unrelated to whether the host uses systemd or not.
+	// Nil value means "unknown", not "false".
+	Systemd *bool `json:"systemd,omitempty"`
+
+	// SystemdUser represents whether user-scoped systemd-cgroup support is compiled in.
+	// Unrelated to whether the host uses systemd or not.
+	// Nil value means "unknown", not "false".
+	SystemdUser *bool `json:"systemdUser,omitempty"`
+
+	// Rdma represents whether RDMA cgroup support is compiled in.
+	// Unrelated to whether the host supports RDMA or not.
+	// Nil value means "unknown", not "false".
+	Rdma *bool `json:"rdma,omitempty"`
+}
+
+// Seccomp represents the "seccomp" field.
+type Seccomp struct {
+	// Enabled is true if seccomp support is compiled in.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Actions is the list of the recognized actions, e.g., "SCMP_ACT_NOTIFY".
+	// Nil value means "unknown", not "no support for any action".
+	Actions []string `json:"actions,omitempty"`
+
+	// Operators is the list of the recognized operators, e.g., "SCMP_CMP_NE".
+	// Nil value means "unknown", not "no support for any operator".
+	Operators []string `json:"operators,omitempty"`
+
+	// Archs is the list of the recognized archs, e.g., "SCMP_ARCH_X86_64".
+	// Nil value means "unknown", not "no support for any arch".
+	Archs []string `json:"archs,omitempty"`
+
+	// KnownFlags is the list of the recognized filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// Nil value means "unknown", not "no flags are recognized".
+	KnownFlags []string `json:"knownFlags,omitempty"`
+
+	// SupportedFlags is the list of the supported filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// This list may be a subset of KnownFlags due to some flags
+	// not supported by the current kernel and/or libseccomp.
+	// Nil value means "unknown", not "no flags are supported".
+	SupportedFlags []string `json:"supportedFlags,omitempty"`
+}
+
+// Apparmor represents the "apparmor" field.
+type Apparmor struct {
+	// Enabled is true if AppArmor support is compiled in.
+	// Unrelated to whether the host supports AppArmor or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// Selinux represents the "selinux" field.
+type Selinux struct {
+	// Enabled is true if SELinux support is compiled in.
+	// Unrelated to whether the host supports SELinux or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// IntelRdt represents the "intelRdt" field.
+type IntelRdt struct {
+	// Enabled is true if Intel RDT support is compiled in.
+	// Unrelated to whether the host supports Intel RDT or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// MountExtensions represents the "mountExtensions" field.
+type MountExtensions struct {
+	// IDMap represents the status of idmap mounts support.
+	IDMap *IDMap `json:"idmap,omitempty"`
+}
+
+type IDMap struct {
+	// Enabled represents whether idmap mounts supports is compiled in.
+	// Unrelated to whether the host supports it or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -921,6 +921,7 @@ github.com/opencontainers/runc/libcontainer/utils
 # github.com/opencontainers/runtime-spec v1.2.1
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
+github.com/opencontainers/runtime-spec/specs-go/features
 # github.com/opencontainers/runtime-tools v0.9.1-0.20241108202711-f7e3563b0271
 ## explicit; go 1.19
 github.com/opencontainers/runtime-tools/generate


### PR DESCRIPTION
`ro` on linux kernel < 5.12 doesn't apply MT_RECURSIVE leading to submounts not respecting the readonly option.

crun/runc achieve this by calling mount_setattr(2) when passed the `rro` mount option. This change check whether the runtime in use supports `rro` and the kernel supports mount_setattr(2) and passes `rro` to the runtime. It defaults to `rro` when supported and when `ro` is specified. If `rro` is specified and unsupported, it returns an error.

Closes #24229

Signed-off-by: Danish Prakash <contact@danishpraka.sh>
