### PR TITLE
Fix container clone with configured Healthcheck

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1733,6 +1733,11 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 		}
 	}
 
+	ctrCloneOpts.CreateOpts.HealthOnFailure = spec.HealthCheckOnFailureAction.String()
+	ctrCloneOpts.CreateOpts.HealthLogDestination = spec.HealthLogDestination
+	ctrCloneOpts.CreateOpts.HealthMaxLogCount = spec.HealthMaxLogCount
+	ctrCloneOpts.CreateOpts.HealthMaxLogSize = spec.HealthMaxLogSize
+
 	err = specgenutil.FillOutSpecGen(spec, &ctrCloneOpts.CreateOpts, []string{})
 	if err != nil {
 		return nil, err

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -462,6 +462,10 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 		specg.HealthMaxLogSize = define.DefaultHealthMaxLogSize
 	}
 
+	specg.HealthConfig = conf.HealthCheckConfig
+	specg.StartupHealthConfig = conf.StartupHealthCheckConfig
+	specg.HealthCheckOnFailureAction = conf.HealthCheckOnFailureAction
+
 	specg.IDMappings = &conf.IDMappings
 	specg.ContainerCreateCommand = conf.CreateCommand
 	if len(specg.Rootfs) == 0 {


### PR DESCRIPTION
This PR fixes a bug where the Healthcheck was not copied to the cloned container.

Fixes: https://github.com/containers/podman/issues/21630
Fixes: https://issues.redhat.com/browse/RUN-2632

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed: `podman container clone` now correctly copies health check settings.
```
