### PR TITLE
[v5.4] some CI backports + test fixes for rawhide

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20250312t165422z-f41f40d13"
+    IMAGE_SUFFIX: "c20250324t111922z-f41f40d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -770,7 +770,7 @@ podman_machine_windows_task:
     depends_on: *build
     ec2_instance:
         <<: *windows
-        type: m5zn.metal
+        type: z1d.metal
         platform: windows
     timeout_in: 45m
     env: *winenv
@@ -780,6 +780,23 @@ podman_machine_windows_task:
       - env:
           TEST_FLAVOR: "machine-hyperv"
     clone_script: *winclone
+    # This depends on an instance with an local NVMe storage so we can make use of fast IO
+    # Our machine tests are IO bound so this is rather imporant to speed them up a lot.
+    setup_disk_script: |
+        echo "Get-Disk"
+        Get-Disk | Ft -autosize | out-string -width 4096
+        # Hard coded to disk 0, assume that this is always the case for our ec2 instance.
+        # It is not clear to me how I would filter by name because we still have two disks
+        # with the same name.
+        echo "Format and mount disk 0"
+        $disk = Get-Disk 0
+        $disk | Initialize-Disk -PartitionStyle MBR
+        $disk | New-Partition -UseMaximumSize -MbrType IFS
+        $Partition = Get-Partition -DiskNumber $disk.Number
+        $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
+        $Partition | Add-PartitionAccessPath -AccessPath "Z:\"
+        echo "Get-Volume"
+        Get-Volume
     main_script: ".\\repo\\contrib\\cirrus\\win-podman-machine-main.ps1"
     always:
         # Required for `contrib/cirrus/logformatter` to work properly

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -146,9 +146,11 @@ build_task:
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
         - env:
-              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+              # Note, this is changed to FEDORA_NAME temporarily as f40 contains a to old golang
+              # Once we bump our images to f42/41 this must be turned back to PRIOR_FEDORA_NAME
+              DISTRO_NV: ${FEDORA_NAME}
+              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               CI_DESIRED_DATABASE: boltdb
               CI_DESIRED_STORAGE: vfs
         - env:
@@ -663,18 +665,9 @@ container_integration_test_task:
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: *only_if_int_test
     depends_on: *build
-    matrix: &fedora_vm_axis
-        - env:
-              DISTRO_NV: ${FEDORA_NAME}
-              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        - env:
-              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-              CI_DESIRED_DATABASE: boltdb
     gce_instance: *fastvm
     env:
+        <<: *stdenvars
         TEST_FLAVOR: int
         TEST_ENVIRON: container
     clone_script: *get_gosrc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20250107t132430z-f41f40d13"
+    IMAGE_SUFFIX: "c20250312t165422z-f41f40d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/win-podman-machine-test.ps1
+++ b/contrib/cirrus/win-podman-machine-test.ps1
@@ -33,5 +33,12 @@ Run-Command ".\bin\windows\podman.exe --version"
 New-Item -ItemType "directory" -Path "$env:AppData\containers"
 Copy-Item -Path pkg\machine\ocipull\policy.json -Destination "$env:AppData\containers"
 
+# Set TMPDIR to fast storage, see cirrus.yml setup_disk_script for setup Z:\
+# TMPDIR is used by the machine tests paths, while TMP and TEMP are the normal
+# windows temporary dirs. Just to ensure everything uses the fast disk.
+$Env:TMPDIR = 'Z:\'
+$Env:TMP = 'Z:\'
+$Env:TEMP = 'Z:\'
+
 Write-Host "`nRunning podman-machine e2e tests"
 Run-Command ".\winmake localmachine"

--- a/test/compose/slirp4netns_opts/setup.sh
+++ b/test/compose/slirp4netns_opts/setup.sh
@@ -3,6 +3,6 @@
 # create tempfile to store nc output
 OUTFILE=$(mktemp)
 # listen on a port, the container will try to connect to it
-nc -l 5001 > $OUTFILE &
+ncat -l 5001 > $OUTFILE &
 
 nc_pid=$!

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -68,8 +69,8 @@ var _ = Describe("Podman pod create", func() {
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(ExitCleanly())
 
-		check := SystemExec("nc", []string{"-z", "localhost", "80"})
-		Expect(check).Should(ExitWithError(1, ""))
+		_, err := net.Dial("tcp", "localhost:80")
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("podman create pod with network portbindings", func() {
@@ -83,7 +84,7 @@ var _ = Describe("Podman pod create", func() {
 		webserver := podmanTest.Podman([]string{"run", "--pod", pod, "-dt", NGINX_IMAGE})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(ExitCleanly())
-		Expect(ncz(port)).To(BeTrue(), "port %d is up", port)
+		testPortConnection(port)
 	})
 
 	It("podman create pod with id file with network portbindings", func() {
@@ -97,7 +98,7 @@ var _ = Describe("Podman pod create", func() {
 		webserver := podmanTest.Podman([]string{"run", "--pod-id-file", file, "-dt", NGINX_IMAGE})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(ExitCleanly())
-		Expect(ncz(port)).To(BeTrue(), "port %d is up", port)
+		testPortConnection(port)
 	})
 
 	It("podman create pod with no infra but portbindings should fail", func() {

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1131,7 +1131,7 @@ spec:
 EOF
 
     # Bind the port to force a an error when starting the pod
-    timeout --foreground -v --kill=10 10 nc -l 127.0.0.1 $port &
+    timeout --foreground -v --kill=10 10 ncat -l 127.0.0.1 $port &
     nc_pid=$!
 
     # Create the Quadlet file

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -791,7 +791,7 @@ nameserver 8.8.8.8" "nameserver order is correct"
         cid="$output"
 
         # make sure binding the same port fails
-        run timeout 5 nc -l 127.0.0.1 $port
+        run timeout 5 ncat -l 127.0.0.1 $port
         assert "$status" -eq 2 "ncat unexpected exit code"
         assert "$output" =~ "127.0.0.1:$port: Address already in use" "ncat error message"
 
@@ -803,10 +803,7 @@ nameserver 8.8.8.8" "nameserver order is correct"
             # port is bound in the container, https://github.com/containers/podman/issues/21561.
             retries=5
             while [[ $retries -gt 0 ]]; do
-                # -w 1 adds a 1 second timeout. For some reason, ubuntu's ncat
-                # doesn't close the connection on EOF, and other options to
-                # change this are not portable across distros. -w seems to work.
-                run nc -w 1 127.0.0.1 $port <<<$random
+                run ncat 127.0.0.1 $port <<<$random
                 if [[ $status -eq 0 ]]; then
                     break
                 fi


### PR DESCRIPTION
Backports of
https://github.com/containers/podman/pull/25561
https://github.com/containers/podman/pull/25658
https://github.com/containers/podman/pull/25673 (Only one commit because the machine test does not exist here)

These should result in less flakes and faster windows machine testing so the next release should be able to get out a bit faster.
Also the ncat changes are needed to pass test in rawhide so we need them for gating as well.
 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
