### PR TITLE
quadlet: add support for the UpheldBy option in the Install section

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -129,7 +129,7 @@ For example, to start a container on boot, add something like this to the file:
 WantedBy=default.target
 ```
 
-Currently, only the `Alias`, `WantedBy` and `RequiredBy` keys are supported.
+Currently, only the `Alias`, `WantedBy`, `RequiredBy`, and `UpheldBy` keys are supported.
 
 The Install section can be part of the main file, or it can be in a
 separate drop-in file as described above. The latter allows you to

--- a/test/e2e/quadlet/install.container
+++ b/test/e2e/quadlet/install.container
@@ -7,6 +7,9 @@
 ## assert-symlink req1.service.requires/install.service ../install.service
 ## assert-symlink req2.service.requires/install.service ../install.service
 ## assert-symlink req3.service.requires/install.service ../install.service
+## assert-symlink up1.service.upholds/install.service ../install.service
+## assert-symlink up2.service.upholds/install.service ../install.service
+## assert-symlink up3.service.upholds/install.service ../install.service
 
 [Container]
 Image=localhost/imagename
@@ -19,3 +22,5 @@ WantedBy=want1.service want2.service
 WantedBy=want3.service
 RequiredBy=req1.service req2.service
 RequiredBy=req3.service
+UpheldBy=up1.service up2.service
+UpheldBy=up3.service


### PR DESCRIPTION
This adds support for the UpheldBy option in quadlet files. The UpheldBy option is the counterpart to the Upholds option added in systemd v249 and is similar to the existing WantedBy and RequiredBy options.

See https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Upholds=.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Quadlet files now support the `UpheldBy` key in the `Install` section.
```
