### PR TITLE
Fix windows path handling in `podman cp`

### DIFF
--- a/pkg/copy/parse.go
+++ b/pkg/copy/parse.go
@@ -2,6 +2,7 @@ package copy
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -37,6 +38,14 @@ func parseUserInput(input string) (container string, path string) {
 	// If the input starts with a dot or slash, it cannot refer to a
 	// container.
 	if input[0] == '.' || input[0] == '/' {
+		return
+	}
+
+	// If the input is an absolute path, it cannot refer to a container.
+	// This is necessary because absolute paths on Windows will include
+	// a colon, which would cause the drive letter to be parsed as a
+	// container name.
+	if filepath.IsAbs(input) {
 		return
 	}
 

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -1,11 +1,8 @@
 package e2e_test
 
 import (
-	"archive/tar"
-	"bytes"
 	"fmt"
 	"io"
-	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
@@ -287,87 +284,6 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(run).To(Exit(0))
 		Expect(build.outputToString()).To(ContainSubstring(name))
-	})
-
-	It("Copy ops", func() {
-		var (
-			stdinDirectory = "stdin-dir"
-			stdinFile      = "file.txt"
-		)
-
-		now := time.Now()
-
-		tarBuffer := &bytes.Buffer{}
-		tw := tar.NewWriter(tarBuffer)
-
-		// Write a directory header to the tar
-		err := tw.WriteHeader(&tar.Header{
-			Name:       stdinDirectory,
-			Mode:       int64(0640 | fs.ModeDir),
-			Gid:        1000,
-			ModTime:    now,
-			ChangeTime: now,
-			AccessTime: now,
-			Typeflag:   tar.TypeDir,
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		// Write a file header to the tar
-		err = tw.WriteHeader(&tar.Header{
-			Name:       path.Join(stdinDirectory, stdinFile),
-			Mode:       0755,
-			Uid:        1000,
-			ModTime:    now,
-			ChangeTime: now,
-			AccessTime: now,
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		err = tw.Close()
-		Expect(err).ToNot(HaveOccurred())
-
-		name := randomString()
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(session).To(Exit(0))
-
-		bm := basicMachine{}
-		newImgs, err := mb.setCmd(bm.withPodmanCommand([]string{"pull", TESTIMAGE})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(newImgs).To(Exit(0))
-		Expect(newImgs.outputToStringSlice()).To(HaveLen(1))
-
-		createAlp, err := mb.setCmd(bm.withPodmanCommand([]string{"create", TESTIMAGE, "top"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(createAlp).To(Exit(0))
-		Expect(createAlp.outputToStringSlice()).To(HaveLen(1))
-
-		// Testing stdin copy with archive mode disabled (ownership will be determined by the tar file)
-		containerID := createAlp.outputToStringSlice()[0]
-		cpTar, err := mb.setCmd(bm.withPodmanCommand([]string{"cp", "-a=false", "-", containerID + ":/tmp"})).setStdin(tarBuffer).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cpTar).To(Exit(0))
-
-		start, err := mb.setCmd(bm.withPodmanCommand([]string{"start", containerID})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(start).To(Exit(0))
-
-		// Check the directory is created with the appropriate mode, uid, gid
-		exec, err := mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", "/tmp/stdin-dir"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(exec).To(Exit(0))
-		execStdOut := exec.outputToStringSlice()
-		Expect(execStdOut).To(HaveLen(1))
-		Expect(execStdOut[0]).To(Equal("640 0 1000"))
-
-		// Check the file is created with the appropriate mode, uid, gid
-		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", "/tmp/stdin-dir/file.txt"})).run()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(exec).To(Exit(0))
-		execStdOut = exec.outputToStringSlice()
-		Expect(execStdOut).To(HaveLen(1))
-		Expect(execStdOut[0]).To(Equal("755 1000 0"))
 	})
 })
 

--- a/pkg/machine/e2e/cp_test.go
+++ b/pkg/machine/e2e/cp_test.go
@@ -1,18 +1,232 @@
 package e2e_test
 
 import (
+	"archive/tar"
+	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("podman machine cp", func() {
-	It("all tests", func() {
+var _ = Describe("run cp commands", func() {
+	It("podman cp", func() {
+		const (
+			file            = "foo.txt"
+			directory       = "foo-dir"
+			fileInDirectory = "bar.txt"
+			stdinFile       = "file.txt"
+			stdinDirectory  = "stdin-dir"
+			containerName   = "podman-cp-test"
+		)
+
+		sourceDir := GinkgoT().TempDir()
+		destinationDir := GinkgoT().TempDir()
+
+		f, err := os.Create(filepath.Join(sourceDir, file))
+		Expect(err).ToNot(HaveOccurred())
+		err = f.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the file stat to check permissions later
+		sourceFileStat, err := os.Stat(filepath.Join(sourceDir, file))
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.MkdirAll(filepath.Join(sourceDir, directory), 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the directory stat to check permissions later
+		sourceDirStat, err := os.Stat(filepath.Join(sourceDir, directory))
+		Expect(err).ToNot(HaveOccurred())
+
+		f, err = os.Create(filepath.Join(sourceDir, directory, fileInDirectory))
+		Expect(err).ToNot(HaveOccurred())
+		err = f.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the file in directory stat to check permissions later
+		sourceFileInDirStat, err := os.Stat(filepath.Join(sourceDir, directory, fileInDirectory))
+		Expect(err).ToNot(HaveOccurred())
+
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		bm := basicMachine{}
+		newImgs, err := mb.setCmd(bm.withPodmanCommand([]string{"pull", TESTIMAGE})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(newImgs).To(Exit(0))
+		Expect(newImgs.outputToStringSlice()).To(HaveLen(1))
+
+		createAlp, err := mb.setCmd(bm.withPodmanCommand([]string{"create", "--name", containerName, TESTIMAGE, "top"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createAlp).To(Exit(0))
+		Expect(createAlp.outputToStringSlice()).To(HaveLen(1))
+
+		containerID := createAlp.outputToStringSlice()[0]
+
+		// Create a second container to test copying between containers
+		// This container is named "C" to also test that Windows prefers
+		// to treat C:\ as a local file path instead of a container name
+		createAlp, err = mb.setCmd(bm.withPodmanCommand([]string{"create", "--name", "C", TESTIMAGE, "top"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createAlp).To(Exit(0))
+		Expect(createAlp.outputToStringSlice()).To(HaveLen(1))
+
+		destinationContainerID := createAlp.outputToStringSlice()[0]
+
+		By("copy from host to container by id")
+		// Copy a single file into the container
+		cpFile, err := mb.setCmd(bm.withPodmanCommand([]string{"cp", filepath.Join(sourceDir, file), containerID + ":/tmp/"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpFile).To(Exit(0))
+
+		// Copy a directory into the container
+		cpDir, err := mb.setCmd(bm.withPodmanCommand([]string{"cp", filepath.Join(sourceDir, directory), containerID + ":/tmp"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpDir).To(Exit(0))
+
+		start, err := mb.setCmd(bm.withPodmanCommand([]string{"start", containerID})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(start).To(Exit(0))
+
+		// Check the single file is created with the appropriate mode, uid, gid
+		exec, err := mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", path.Join("/tmp", file)})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(fmt.Sprintf("%o %d %d", sourceFileStat.Mode().Perm(), 0, 0)))
+
+		// Check the directory is created with the appropriate mode, uid, gid
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", path.Join("/tmp", directory)})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(fmt.Sprintf("%o %d %d", sourceDirStat.Mode().Perm(), 0, 0)))
+
+		// Check the file in the directory is created with the appropriate mode, uid, gid
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", path.Join("/tmp", directory, fileInDirectory)})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(fmt.Sprintf("%o %d %d", sourceFileInDirStat.Mode().Perm(), 0, 0)))
+
+		By("copy from host to container by name")
+		// Copy a single renamed file into the container
+		cpFile, err = mb.setCmd(bm.withPodmanCommand([]string{"cp", filepath.Join(sourceDir, file), containerName + ":/tmp/rename.txt"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpFile).To(Exit(0))
+
+		// Check the single file is created with the appropriate mode, uid, gid
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", "/tmp/rename.txt"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(fmt.Sprintf("%o %d %d", sourceFileStat.Mode().Perm(), 0, 0)))
+
+		By("copy from container to host")
+		// Copy the file back from the container to the host
+		cpFile, err = mb.setCmd(bm.withPodmanCommand([]string{"cp", containerID + ":" + path.Join("/tmp", file), destinationDir + string(os.PathSeparator)})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpFile).To(Exit(0))
+
+		// Get the file stat of the copied file to compare against the original
+		destinationFileStat, err := os.Stat(filepath.Join(destinationDir, file))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(destinationFileStat.Mode()).To(Equal(sourceFileStat.Mode()))
+		// Compare the modification time of the file in the container and the host (with second level precision)
+		Expect(destinationFileStat.ModTime()).To(BeTemporally("~", sourceFileStat.ModTime(), time.Second))
+
+		// Copy a directory back from the container to the host
+		cpDir, err = mb.setCmd(bm.withPodmanCommand([]string{"cp", containerID + ":" + path.Join("/tmp", directory), destinationDir + string(os.PathSeparator)})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpDir).To(Exit(0))
+
+		// Get the stat of the copied directory to compare against the original
+		destinationDirStat, err := os.Stat(filepath.Join(destinationDir, directory))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(destinationDirStat.Mode()).To(Equal(sourceDirStat.Mode()))
+		// Compare the modification time of the folder in the container and the host (with second level precision)
+		Expect(destinationDirStat.ModTime()).To(BeTemporally("~", sourceDirStat.ModTime(), time.Second))
+
+		// Get the stat of the copied file in the directory to compare against the original
+		destinationFileInDirStat, err := os.Stat(filepath.Join(sourceDir, directory, fileInDirectory))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(destinationFileInDirStat.Mode()).To(Equal(sourceFileInDirStat.Mode()))
+		// Compare the modification time of the file in the container and the host (with second level precision)
+		Expect(destinationFileInDirStat.ModTime()).To(BeTemporally("~", sourceFileInDirStat.ModTime(), time.Second))
+
+		By("copy stdin to container")
+		now := time.Now()
+		tarBuffer := &bytes.Buffer{}
+		tw := tar.NewWriter(tarBuffer)
+
+		// Write a directory header to the tar
+		err = tw.WriteHeader(&tar.Header{
+			Name:       stdinDirectory,
+			Mode:       int64(0640 | fs.ModeDir),
+			Gid:        1000,
+			ModTime:    now,
+			ChangeTime: now,
+			AccessTime: now,
+			Typeflag:   tar.TypeDir,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Write a file header to the tar
+		err = tw.WriteHeader(&tar.Header{
+			Name:       path.Join(stdinDirectory, stdinFile),
+			Mode:       0755,
+			Uid:        1000,
+			ModTime:    now,
+			ChangeTime: now,
+			AccessTime: now,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		err = tw.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Testing stdin copy with archive mode disabled (ownership will be determined by the tar file)
+		cpTar, err := mb.setCmd(bm.withPodmanCommand([]string{"cp", "-a=false", "-", containerID + ":/tmp"})).setStdin(tarBuffer).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpTar).To(Exit(0))
+
+		// Check the directory is created with the appropriate mode, uid, gid
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", "/tmp/stdin-dir"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal("640 0 1000"))
+
+		// Check the file is created with the appropriate mode, uid, gid
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", containerID, "stat", "-c", "%a %u %g", "/tmp/stdin-dir/file.txt"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal("755 1000 0"))
+
+		By("copy from container to container")
+		// Copy the file from the first container to the second container (with renaming)
+		cpFile, err = mb.setCmd(bm.withPodmanCommand([]string{"cp", containerID + ":" + path.Join("/tmp", file), destinationContainerID + ":" + path.Join("/tmp", "destination.txt")})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cpFile).To(Exit(0))
+
+		start, err = mb.setCmd(bm.withPodmanCommand([]string{"start", destinationContainerID})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(start).To(Exit(0))
+
+		// Check the single file is created with the appropriate mode, uid, gid
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", destinationContainerID, "stat", "-c", "%a %u %g", path.Join("/tmp", "destination.txt")})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(fmt.Sprintf("%o %d %d", sourceFileStat.Mode().Perm(), 0, 0)))
+	})
+
+	It("podman machine cp", func() {
 		// HOST FILE SYSTEM
 		// ~/<ginkgo_tmp>
 		//   * foo.txt


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

This PR fixes a handful of Windows path bugs in `podman container cp` that prevented copying files from (or to) a Windows host.

* The Windows drive letter was being treated as a container ID/name, which is fixed by using `filepath.IsAbs` to determine if a given path is an absolute path on the system (on Windows, this is true for paths starting with a single drive letter and a colon).
* The code used `/` as the root folder path, even on Windows (should be `<drive letter>:\` (i.e. `C:\`), which caused `copier` to reject the given path. This was fixed by depending on the behavior of `filepath.VolumeName` and `os.PathSeparator` to build the correct root path for a given OS.
* There was logic that was hardcoded to use `/` as the path separator rather than `os.PathSeparator` which caused path normalization to fail. Fixed by using the os specific separator.
* There was a bug (now fixed) in the `copier` package in `containers/buildah` that would cause an infinite loop when trying to process files from a Windows path. I updated the vendored dependency to the latest version of `buildah`.
* Some methods in `cp.go` used `filepath` for parsing paths within containers, which causes issues on Windows. Switched to using `path` for processing paths within containers to force Linux style conventions.

I also refactored the e2e test coverage that was added for `podman container cp` (moved the existing test from `basic_test.go` to `cp_test.go` alongside the `podman machine cp` test coverage) and added a few new test cases.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
