### PR TITLE
[skip-ci] Packit: Ignore ELN and CS jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,8 +37,9 @@ jobs:
       - fedora-development-x86_64
       - fedora-development-aarch64
 
+  # Ignore until golang is updated in distro buildroot to go 1.23.3+
   - job: copr_build
-    trigger: pull_request
+    trigger: ignore
     packages: [podman-eln]
     notifications: *packit_generic_failure_notification
     enable_net: true
@@ -50,8 +51,9 @@ jobs:
         additional_repos:
           - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
 
+  # Ignore until golang is updated in distro buildroot to go 1.23.3+
   - job: copr_build
-    trigger: pull_request
+    trigger: ignore
     packages: [podman-centos]
     notifications: *packit_generic_failure_notification
     enable_net: true


### PR DESCRIPTION
ELN and CS buildroots currently have an older golang build causing lots of annoyance.
Ref: https://github.com/containers/podman/pull/25694#discussion_r2016587671

This commit disables those jobs until golang is updated on them.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
