### PR TITLE
podman logs: allow options after argument

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -118,7 +118,6 @@ func logsFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&logsOptions.Colors, "color", "", false, "Output the containers with different colors in the log.")
 	flags.BoolVarP(&logsOptions.Names, "names", "n", false, "Output the container name in the log")
 
-	flags.SetInterspersed(false)
 	_ = flags.MarkHidden("details")
 }
 

--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -92,7 +92,6 @@ func logsFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&logsPodOptions.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")
 	flags.BoolVarP(&logsPodOptions.Colors, "color", "", false, "Output the containers within a pod with different colors in the log")
 
-	flags.SetInterspersed(false)
 	_ = flags.MarkHidden("details")
 }
 

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -122,7 +122,9 @@ var _ = Describe("Podman logs", func() {
 			Expect(wait).To(ExitCleanly())
 
 			Eventually(func(g Gomega) {
-				results := podmanTest.Podman([]string{"logs", "--tail", "99", name})
+				// Options after name should work as well
+				// https://github.com/containers/podman/issues/25653
+				results := podmanTest.Podman([]string{"logs", name, "--tail", "99"})
 				results.WaitWithDefaultTimeout()
 				g.Expect(results).To(ExitCleanly())
 				g.Expect(results.OutputToStringArray()).To(HaveLen(3))

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -341,7 +341,8 @@ function _log_test_follow_since() {
     sleep 0.2
 
     # Make sure podman logs actually follows by giving a low timeout and check that the command times out
-    PODMAN_TIMEOUT=3 run_podman 124 ${events_backend} logs --since 0.1s -f $cname
+    # Option after container name should work as well: https://github.com/containers/podman/issues/25653
+    PODMAN_TIMEOUT=3 run_podman 124 ${events_backend} logs --since 0.1s $cname -f
     assert "$output" =~ "$content
 timeout: sending signal TERM to command.*" "logs --since -f on running container works"
 


### PR DESCRIPTION
Do not use the interspersed option for logs, it is not needed and just restricts valid use cases.

Fixes #25653

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
