### PR TITLE
Add cdi-spec-dir option to top level options

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -247,6 +247,9 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		if cmd.Flag("hooks-dir").Changed {
 			podmanConfig.ContainersConf.Engine.HooksDir.Set(podmanConfig.HooksDir)
 		}
+		if cmd.Flag("cdi-spec-dir").Changed {
+			podmanConfig.ContainersConf.Engine.CdiSpecDirs.Set(podmanConfig.CdiSpecDirs)
+		}
 
 		// Currently it is only possible to restore a container with the same runtime
 		// as used for checkpointing. It should be possible to make crun and runc
@@ -565,6 +568,10 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		hooksDirFlagName := "hooks-dir"
 		pFlags.StringArrayVar(&podmanConfig.HooksDir, hooksDirFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.HooksDir.Get(), "Set the OCI hooks directory path (may be set multiple times)")
 		_ = cmd.RegisterFlagCompletionFunc(hooksDirFlagName, completion.AutocompleteDefault)
+
+		cdiSpecDirFlagName := "cdi-spec-dir"
+		pFlags.StringArrayVar(&podmanConfig.CdiSpecDirs, cdiSpecDirFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.CdiSpecDirs.Get(), "Set the CDI spec directory path (may be set multiple times)")
+		_ = cmd.RegisterFlagCompletionFunc(cdiSpecDirFlagName, completion.AutocompleteDefault)
 
 		pFlags.IntVar(&podmanConfig.MaxWorks, "max-workers", (runtime.NumCPU()*3)+1, "The maximum number of workers for parallel operations")
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -25,6 +25,10 @@ man pages.
 
 ## GLOBAL OPTIONS
 
+#### **--cdi-spec-dir**=*path*
+
+The CDI spec directory path (may be set multiple times). Default path is `/etc/cdi`.
+
 #### **--cgroup-manager**=*manager*
 
 The CGroup manager to use for container cgroups. Supported values are __cgroupfs__ or __systemd__. Default is _systemd_ unless overridden in the containers.conf file.

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -639,6 +639,7 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	// Warning: CDI may alter g.Config in place.
 	if len(c.config.CDIDevices) > 0 {
 		registry, err := cdi.NewCache(
+			cdi.WithSpecDirs(c.runtime.config.Engine.CdiSpecDirs.Get()...),
 			cdi.WithAutoRefresh(false),
 		)
 		if err != nil {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -328,6 +328,17 @@ func WithCDI(devices []string) CtrCreateOption {
 	}
 }
 
+func WithCDISpecDirs(cdiSpecDirs []string) RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return define.ErrRuntimeFinalized
+		}
+
+		rt.config.Engine.CdiSpecDirs.Set(cdiSpecDirs)
+		return nil
+	}
+}
+
 // WithStorageOpts sets the devices to check for CDI configuration.
 func WithStorageOpts(storageOpts map[string]string) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -35,6 +35,7 @@ type PodmanConfig struct {
 	CPUProfile               string         // Hidden: Should CPU profile be taken
 	EngineMode               EngineMode     // ABI or Tunneling mode
 	HooksDir                 []string
+	CdiSpecDirs              []string
 	Identity                 string   // ssh identity for connecting to server
 	IsRenumber               bool     // Is this a system renumber command? If so, a number of checks will be relaxed
 	IsReset                  bool     // Is this a system reset command? If so, a number of checks will be skipped/omitted

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -212,6 +212,10 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		options = append(options, libpod.WithDatabaseBackend(cfg.ContainersConf.Engine.DBBackend))
 	}
 
+	if cfg.CdiSpecDirs != nil {
+		options = append(options, libpod.WithCDISpecDirs(cfg.CdiSpecDirs))
+	}
+
 	if cfg.Syslog {
 		options = append(options, libpod.WithSyslog())
 	}

--- a/pkg/specgen/generate/config_freebsd.go
+++ b/pkg/specgen/generate/config_freebsd.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/common/pkg/config"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -16,9 +17,10 @@ import (
 )
 
 // DevicesFromPath computes a list of devices
-func DevicesFromPath(g *generate.Generator, devicePath string) error {
+func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Config) error {
 	if isCDIDevice(devicePath) {
 		registry, err := cdi.NewCache(
+			cdi.WithSpecDirs(config.Engine.CdiSpecDirs.Get()...),
 			cdi.WithAutoRefresh(false),
 		)
 		if err != nil {

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -24,9 +24,10 @@ import (
 )
 
 // DevicesFromPath computes a list of devices
-func DevicesFromPath(g *generate.Generator, devicePath string) error {
+func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Config) error {
 	if isCDIDevice(devicePath) {
 		registry, err := cdi.NewCache(
+			cdi.WithSpecDirs(config.Engine.CdiSpecDirs.Get()...),
 			cdi.WithAutoRefresh(false),
 		)
 		if err != nil {

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -56,7 +56,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	if !s.IsPrivileged() {
 		// add default devices from containers.conf
 		for _, device := range rtc.Containers.Devices.Get() {
-			if err = DevicesFromPath(&g, device); err != nil {
+			if err = DevicesFromPath(&g, device, rtc); err != nil {
 				return nil, err
 			}
 		}
@@ -67,7 +67,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		}
 		// add default devices specified by caller
 		for _, device := range userDevices {
-			if err = DevicesFromPath(&g, device.Path); err != nil {
+			if err = DevicesFromPath(&g, device.Path, rtc); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -256,7 +256,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	var userDevices []spec.LinuxDevice
 	// add default devices from containers.conf
 	for _, device := range rtc.Containers.Devices.Get() {
-		if err = DevicesFromPath(&g, device); err != nil {
+		if err = DevicesFromPath(&g, device, rtc); err != nil {
 			return nil, err
 		}
 	}
@@ -267,7 +267,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 	// add default devices specified by caller
 	for _, device := range userDevices {
-		if err = DevicesFromPath(&g, device.Path); err != nil {
+		if err = DevicesFromPath(&g, device.Path, rtc); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Based on PR #21448. I've just fixed the propagation of --cdi-spec-dir to container image and added tests and documentation.

Original PR description:

One of the primary benefits of podman is that its possible run without altering the host system. By allowing cdi directories to be passed via command line it maintains this feature.

I'm particularly interested in running podman in a nix-shell with nvidia GPU passthough. Podman and all its dependencies (including nvidia-container-toolkit) come from nix and the host system again doesn't need altering. The one problem with that right now is that I have to write /etc/cdi/nvidia.yaml to be able to use the GPU. Note that the old nvidia-runtime-hook does not work for my use case (which involves vulkan passthrough).

With this change it will be possible to generate a user nvidia.yaml and point podman at that user-specific mount instructions there.

Fixes: #18292.
Fixes: #25691.

#### Does this PR introduce a user-facing change?

```release-note
- Add cdi-spec-dir option to insert additional CDI Spec search paths into the CDI loader.
```
