### PR TITLE
test: Fix runc error message

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1665,7 +1665,7 @@ search               | $IMAGE           |
     runtime=$(podman_runtime)
     case "$runtime" in
         crun) expect='\(executable file `` not found in $PATH\|cannot find `` in $PATH\): No such file or directory: OCI runtime attempted to invoke a command that was not found' ;;
-        runc) expect='runc: runc create failed: unable to start container process: exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found' ;;
+        runc) expect='runc: runc create failed: unable to start container process:.* exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found' ;;
         *)    skip "Unknown runtime '$runtime'" ;;
     esac
 


### PR DESCRIPTION
Fix issue with 030-run test on systems with runc on openSUSE Tumbleweed 20250326 with podman 5.4.1 & runc 1.2.5.

```
#not ok 122 [030] podman run - no entrypoint
# tags: ci:parallel
# (from function `bail-now' in file test/system/helpers.bash, line 187,
#  from function `is' in file test/system/helpers.bash, line 1136,
#  in test file test/system/030-run.bats, line 1667)
#   `is "$output" "Error.*: $expect" "podman emits useful diagnostic when no entrypoint is set"' failed
#
# [05:55:11.331450725] # /usr/bin/podman run --rm --rootfs /tmp/podman_bats.5EavKY
# [05:55:11.626195689] Error: runc: runc create failed: unable to start container process: error during container init: exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found
# [05:55:11.629611105] [ rc=127 (expected) ]
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: podman emits useful diagnostic when no entrypoint is set
# #| expected: 'Error.*: runc: runc create failed: unable to start container process: exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found' (using expr)
# #|   actual: 'Error: runc: runc create failed: unable to start container process: error during container init: exec: "": executable file not found in $PATH: OCI runtime attempted to invoke a command that was not found'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # [teardown]
```

