### PR TITLE
docs: Update `podman build` security options

### DIFF
--- a/docs/source/markdown/options/security-opt.image.md
+++ b/docs/source/markdown/options/security-opt.image.md
@@ -16,7 +16,7 @@ container
 - `label=level:LEVEL`   : Set the label level for the container processes
 - `label=filetype:TYPE` : Set the label file type for the container files
 - `label=disable`       : Turn off label separation for the container
-- `no-new-privileges`   : Not supported
+- `no-new-privileges`   : Disable container processes from gaining additional privileges
 
 - `seccomp=unconfined` : Turn off seccomp confinement for the container
 - `seccomp=profile.json` :  JSON file to be used as the seccomp filter for the container.


### PR DESCRIPTION
It seems support was added into Buildah for no-new-privileges [1] however the Podman build documentation was not updated.

Fixes #25731

[1] https://github.com/containers/buildah/commit/d4c661a7746fd8e309bfa0b0b5fd7d13d05846ed

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
