### PR TITLE
test/compose: use --cdi-spec-dir not /etc/cdi

### DIFF
--- a/test/compose/cdi_device/setup.sh
+++ b/test/compose/cdi_device/setup.sh
@@ -1,9 +1,1 @@
-if is_rootless; then
-    reason=" - can't write to /etc/cdi"
-    _show_ok skip "$testname # skip$reason"
-    exit 0
-fi
-
-mkdir -p /etc/cdi
-mount -t tmpfs tmpfs /etc/cdi
-cp device.json /etc/cdi
+cp device.json $WORKDIR/cdi

--- a/test/compose/cdi_device/teardown.sh
+++ b/test/compose/cdi_device/teardown.sh
@@ -1,3 +1,0 @@
-if ! is_rootless; then
-    umount -l /etc/cdi
-fi

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -198,12 +198,12 @@ function start_service() {
 
     # FIXME: use ${testname} subdir but we can't: 50-char limit in runroot
     if ! is_rootless; then
-        rm -rf $WORKDIR/{root,runroot,cni}
+        rm -rf $WORKDIR/{root,runroot,networks}
     else
-        $PODMAN_BIN unshare rm -rf $WORKDIR/{root,runroot,cni}
+        $PODMAN_BIN unshare rm -rf $WORKDIR/{root,runroot,networks}
     fi
     rm -f $DOCKER_SOCK
-    mkdir --mode 0755 $WORKDIR/{root,runroot,cni}
+    mkdir --mode 0755 $WORKDIR/{root,runroot,networks}
     chcon --reference=/var/lib/containers $WORKDIR/root
 
     $PODMAN_BIN \
@@ -212,7 +212,7 @@ function start_service() {
         --root $WORKDIR/root \
         --runroot $WORKDIR/runroot \
         --cgroup-manager=systemd \
-        --network-config-dir $WORKDIR/cni \
+        --network-config-dir $WORKDIR/networks \
         system service \
         --time 0 unix://$DOCKER_SOCK \
         &> $WORKDIR/server.log &
@@ -239,7 +239,7 @@ function podman() {
 	--storage-driver=vfs \
         --root    $WORKDIR/root    \
         --runroot $WORKDIR/runroot \
-        --network-config-dir $WORKDIR/cni \
+        --network-config-dir $WORKDIR/networks \
         "$@")
     rc=$?
 

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -237,7 +237,7 @@ function start_service() {
 function podman() {
     echo "\$ podman $*"           >>$WORKDIR/output.log
     output=$($PODMAN_BIN \
-	--storage-driver=vfs \
+        --storage-driver=vfs \
         --root    $WORKDIR/root    \
         --runroot $WORKDIR/runroot \
         --network-config-dir $WORKDIR/networks \
@@ -403,7 +403,7 @@ for t in "${tests_to_run[@]}"; do
     fi
 
     # FIXME: run 'podman ps'?
-#    rm -rf $WORKDIR/${testname}
+    #    rm -rf $WORKDIR/${testname}
 done
 
 # END   entry handler

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -198,12 +198,12 @@ function start_service() {
 
     # FIXME: use ${testname} subdir but we can't: 50-char limit in runroot
     if ! is_rootless; then
-        rm -rf $WORKDIR/{root,runroot,networks}
+        rm -rf $WORKDIR/{root,runroot,networks,cdi}
     else
-        $PODMAN_BIN unshare rm -rf $WORKDIR/{root,runroot,networks}
+        $PODMAN_BIN unshare rm -rf $WORKDIR/{root,runroot,networks,cdi}
     fi
     rm -f $DOCKER_SOCK
-    mkdir --mode 0755 $WORKDIR/{root,runroot,networks}
+    mkdir --mode 0755 $WORKDIR/{root,runroot,networks,cdi}
     chcon --reference=/var/lib/containers $WORKDIR/root
 
     $PODMAN_BIN \
@@ -213,6 +213,7 @@ function start_service() {
         --runroot $WORKDIR/runroot \
         --cgroup-manager=systemd \
         --network-config-dir $WORKDIR/networks \
+        --cdi-spec-dir $WORKDIR/cdi \
         system service \
         --time 0 unix://$DOCKER_SOCK \
         &> $WORKDIR/server.log &
@@ -240,6 +241,7 @@ function podman() {
         --root    $WORKDIR/root    \
         --runroot $WORKDIR/runroot \
         --network-config-dir $WORKDIR/networks \
+        --cdi-spec-dir $WORKDIR/cdi \
         "$@")
     rc=$?
 


### PR DESCRIPTION
Don't mess with a system dir and some minor test script cleanups, see commits.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
