### PR TITLE
Remove unused code and data structures

### DIFF
--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -248,12 +248,6 @@ type PodSpecGenerator struct {
 type PodResourceConfig struct {
 	// ResourceLimits contains linux specific CPU data for the pod
 	ResourceLimits *spec.LinuxResources `json:"resource_limits,omitempty"`
-	// CPU period of the cpuset, determined by --cpus
-	CPUPeriod uint64 `json:"cpu_period,omitempty"`
-	// CPU quota of the cpuset, determined by --cpus
-	CPUQuota int64 `json:"cpu_quota,omitempty"`
-	// ThrottleReadBpsDevice contains the rate at which the devices in the pod can be read from/accessed
-	ThrottleReadBpsDevice map[string]spec.LinuxThrottleDevice `json:"throttleReadBpsDevice,omitempty"`
 }
 
 type PodSecurityConfig struct {


### PR DESCRIPTION
No change in functionality.

I might be missing something here, but it appears to be either unfinished or abandoned.

Fixes: bbd085ad1e ("Podman Pod Create --cpus and --cpuset-cpus flags", PR #10716)
Fixes: 2d86051893 ("Pod Device-Read-BPS support", PR #11686)

Cc @cdoern 

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
