### PR TITLE
Add autocomment for `needs-info` label

### DIFF
--- a/.github/workflows/needs-info-labeler.yaml
+++ b/.github/workflows/needs-info-labeler.yaml
@@ -1,0 +1,28 @@
+name: Needs info labeler
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'needs-info'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        run: gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: |
+            A reviewer has determined we need more information to understand the reported issue.  A comment on what is missing should be provided. Be certain you:
+
+            * provide an exact reproducer where possible
+            * verify you have provided all relevant information - minimum is `podman info`
+            * answer any follow up questions
+
+            If no response to the `needs-info` is provided in 30 days, this issue may be closed by our stale bot.
+
+            For more information on reporting issues on this repository, consult our [issue guide](ISSUE.md).


### PR DESCRIPTION
When a reviewer of an issue determines that an issue is incompleted, a `needs-info` label can be added to the issue.  This will trigger a GH action with an automated response.  The reviewer should also have told the user what is needed or asked a question.  Also, we have no automated way to remove the label when a response is provided, so this still needs to be managed.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
