### PR TITLE
Bump to v5.4.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## 5.4.2
+### Bugfixes
+- Fixed a bug where the `podman import` command could not import images compressed with algorithms other than gzip ([#25593](https://github.com/containers/podman/issues/25593)).
+- Fixed a bug where the `podman cp` command could deadlock when copying into a non-empty volume on a container that is not running ([#25585](https://github.com/containers/podman/issues/25585)).
+
+### API
+- Fixed a bug where the default values for some fields in the Libpod Create endpoint for Containers did not have sensible defaults for some healthcheck fields, causing unrestricted log growth for containers which did not set these fields ([#25473](https://github.com/containers/podman/issues/25473)).
+
+### Misc
+- Updated vendored Buildah to v1.39.4
+- Updated the containers/common library to v0.62.3
+- Updated the containers/image library to v5.34.3
+- Updated the containers/storage library to v1.57.2
+
 ## 5.4.1
 ### Bugfixes
 - Fixed a bug where volume quotas were not being applied ([#25368](https://github.com/containers/podman/issues/25368)).

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2916,6 +2916,10 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 	vol.lock.Lock()
 	defer vol.lock.Unlock()
 
+	return c.fixVolumePermissionsUnlocked(v, vol)
+}
+
+func (c *Container) fixVolumePermissionsUnlocked(v *ContainerNamedVolume, vol *Volume) error {
 	// The volume may need a copy-up. Check the state.
 	if err := vol.update(); err != nil {
 		return err

--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "5.4.2"
+const RawVersion = "5.4.3-dev"

--- a/version/rawversion/version.go
+++ b/version/rawversion/version.go
@@ -7,4 +7,4 @@ package rawversion
 //
 // NOTE: remember to bump the version at the top of the top-level README.md
 // file when this is bumped.
-const RawVersion = "5.4.2-dev"
+const RawVersion = "5.4.2"


### PR DESCRIPTION
As the title says

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
