### PR TITLE
Assorted minor fixes to hack/install_golangci.sh

### DIFF
--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -3,9 +3,12 @@
 # This script is intended to be a convenience, to be called from the
 # Makefile `.install.golangci-lint` target.  Any other usage is not recommended.
 
-die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
+die() { echo "${1:-No error message given} (from $(basename "$0"))"; exit 1; }
 
 [ -n "$VERSION" ] || die "\$VERSION is empty or undefined"
+
+# Strip the leading v, if found.
+VERSION=${VERSION#v}
 
 function install() {
     local retry=$1
@@ -14,27 +17,20 @@ function install() {
     if [[ $retry -ne 0 ]]; then
         msg+=" - retry #$retry"
     fi
-    echo $msg
+    echo "$msg"
 
-    curl -sSL --retry 5 https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
+    curl -sSfL --retry 5 https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $BINDIR "v$VERSION"
 }
 
-# Undocumented behavior: golangci-lint installer requires $BINDIR in env,
-# will default to ./bin but we can't rely on that.
-export BINDIR="./bin"
+BINDIR="./bin"
 BIN="$BINDIR/golangci-lint"
-if [ ! -x "$BIN" ]; then
-    # This flakes much too frequently with "crit unable to find v1.51.1"
-    for retry in $(seq 0 5); do
-	install $retry && exit 0
-        sleep 5
-    done
-else
-    # Prints its own file name as part of --version output
-    $BIN --version | grep "$VERSION"
-    if [ $? -eq 0 ]; then
-        echo "Using existing $BINDIR/$($BIN --version)"
-    else
-        install
-    fi
+if [ -x "$BIN" ] && $BIN --version | grep "$VERSION"; then
+    echo "Using existing $BIN"
+    exit 0
 fi
+
+# This flakes much too frequently with "crit unable to find v1.51.1"
+for retry in $(seq 0 5); do
+    install "$retry" && exit 0
+    sleep 5
+done


### PR DESCRIPTION
_(Those used to be separate commits but are now squashed.)_

### 1. Strip leading v from VERSION.
 
This will allow to simplify renovate rule at [1].
 
### 2. Fix git branch in the URL.
 
In golangci-lint v2 they've switched from master to main,
and it's not clear what will happen to master over time,
so let's just switch to main prophylactically.
 
### 3. Use -b option instead of undocumented hack.
 
Instead of relying on an undocumented feature of having BINDIR,
let's use -b option as recommended by the official docs at [2].
 
### 4. Avoid stuttering in the output.
 
Before:
 
        [kir@kir-tp1 podman]$ VERSION=2.0.2 ./hack/install_golangci.sh
        golangci-lint has version 2.0.2 built with go1.24.1 from 2b224c2c on 2025-03-25T21:36:18Z
        Using existing ./bin/golangci-lint has version 2.0.2 built with go1.24.1 from 2b224c2c on 2025-03-25T21:36:18Z
 
After:
 
        [kir@kir-tp1 podman]$ VERSION=2.0.2 ./hack/install_golangci.sh
        golangci-lint has version 2.0.2 built with go1.24.1 from 2b224c2c on 2025-03-25T21:36:18Z
        Using existing ./bin/golangci-lint
 
### 5. Fix shellcheck warnings.
 
### 6. Also retry when reinstalling.
 
The code logic to retry install for up to 5 times when installation
fails was introduced by commit dd8574022d ("CI: retry the golangci
install").
 
For some reason, the above commit only uses the logic when the binary is
not found. In a situation when the binary is found but is of the wrong
version, no retries are done.
 
Fix that.
 
### 7. Add -f option to curl.
 
As recommended by the official installation docs at [2].
 
[1]: https://github.com/containers/automation/blame/16f757f69956514006cc26b4d0a78f9f252171c6/renovate/defaults.json5#L106-L108
[2]: https://golangci-lint.run/welcome/install/#binaries

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
