### PR TITLE
cirrus: save/restore golangci-lint cache for linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -120,6 +120,12 @@ validate-source_task:
           fi
     # Standard setup stage call, used by nearly every task in CI.
     setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'
+    golangci-lint_cache:
+        folder: /root/.cache/golangci-lint
+        reupload_on_changes: true
+        fingerprint_script:
+            - go version
+            - grep GOLANGCI_LINT_VERSION Makefile | head -1
     # Standard main execution stage call, used by nearly every task in CI.
     main_script: &main '/usr/bin/time --verbose --output="$STATS_LOGFILE" $GOSRC/$SCRIPT_BASE/runner.sh'
 


### PR DESCRIPTION
This shaves off some time from golangci-lint run.
    
For linux, it's down from 5 to 3 minutes (for the whole task, not just
the golangci-lint runs), and the cache is only ~7MB (according to
golangci-lint, probably uncompressed) or ~2MB (according to cirrus CI,
probably compressed).
    
For Mac, due to remote build tag we don't lint much so linting takes
less than a minute, so it is not worth optimizing.
    
For Windows, similar.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
