### PR TITLE
Set the IDMappings also when RootfsOverlay is used.

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -536,12 +536,8 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		return fmt.Errorf("creating container storage: %w", containerInfoErr)
 	}
 
-	// Only reconfig IDMappings if layer was mounted from storage.
-	// If it's an external overlay do not reset IDmappings.
-	if !c.config.RootfsOverlay {
-		c.config.IDMappings.UIDMap = containerInfo.UIDMap
-		c.config.IDMappings.GIDMap = containerInfo.GIDMap
-	}
+	c.config.IDMappings.UIDMap = containerInfo.UIDMap
+	c.config.IDMappings.GIDMap = containerInfo.GIDMap
 
 	processLabel, err := c.processLabel(containerInfo.ProcessLabel)
 	if err != nil {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -322,6 +322,13 @@ var _ = Describe("Podman run", func() {
 		osession.WaitWithDefaultTimeout()
 		Expect(osession).Should(ExitCleanly())
 		Expect(osession.OutputToString()).To(Equal("0 1234 5678"))
+
+		// Test --rootfs with an external overlay with --userns=auto
+		osession = podmanTest.Podman([]string{"run", "--userns=auto", "--rm", "--security-opt", "label=disable",
+			"--rootfs", rootfs + ":O", "cat", "/proc/self/uid_map"})
+		osession.WaitWithDefaultTimeout()
+		Expect(osession).Should(ExitCleanly())
+		Expect(osession.OutputToString()).To(ContainSubstring("1024"))
 	})
 
 	It("podman run a container with --init", func() {


### PR DESCRIPTION
This is related to #23292 and is needed to replace pause image container with pause container based
on the rootfs.

Without this change, the GIDs and UIDs are not mapped in the rootfs container which use overlay if --userns=auto is used. This leads to an error mounting /dev/pts with gid=5, becuase GID 5 simply does not exist in the pause container using rootfs.

All the tests pass with this change, but I have to admit I did not find out why the original code has been introduced.



#### Does this PR introduce a user-facing change?

```release-note
None
```
