### PR TITLE
docs: delete the duplicated phrase in introduction page

### DIFF
--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -36,7 +36,7 @@ Sometimes we can find a publicly available container image for the exact workloa
 
 Container Images aren’t actually images. They are repositories often made up of multiple layers. These layers can easily be added, saved, and shared with others by using a Containerfile (Dockerfile). This single file often contains all the instructions needed to build a new container image and can easily be shared with others publicly using tools like GitHub.
 
-Here's an example of how to build a build a container image from content that resides in a git repository::
+Here's an example of how to build a container image from content that resides in a git repository::
 
     podman build -t hello https://github.com/containers/PodmanHello.git
 


### PR DESCRIPTION
This PR removes the duplicated phrase 'build a' in the introduction page.
[https://docs.podman.io/en/latest/Introduction.html](https://docs.podman.io/en/latest/Introduction.html)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
