### PR TITLE
Replace podman pause image with rootfs.

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1266,6 +1266,11 @@ func (c *Container) IsInfra() bool {
 	return c.config.IsInfra
 }
 
+// IsDefaultInfra returns whether the container is a default infra container generated directly by podman
+func (c *Container) IsDefaultInfra() bool {
+	return c.config.IsDefaultInfra
+}
+
 // IsInitCtr returns whether the container is an init container
 func (c *Container) IsInitCtr() bool {
 	return len(c.config.InitContainerType) > 0

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -404,6 +404,9 @@ type ContainerMiscConfig struct {
 	// IsInfra is a bool indicating whether this container is an infra container used for
 	// sharing kernel namespaces in a pod
 	IsInfra bool `json:"pause"`
+	// IsDefaultInfra is a bool indicating whether this container is a default infra container
+	// using the default rootfs with catatonit bind-mounted into it.
+	IsDefaultInfra bool `json:"defaultPause"`
 	// IsService is a bool indicating whether this container is a service container used for
 	// tracking the life cycle of K8s service.
 	IsService bool `json:"isService"`

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -183,6 +183,10 @@ func (c *Container) validate() error {
 		}
 	}
 
+	if c.config.IsDefaultInfra && !c.config.IsInfra {
+		return fmt.Errorf("default rootfs-based infra container is set for non-infra container")
+	}
+
 	return nil
 }
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1648,6 +1648,20 @@ func withIsInfra() CtrCreateOption {
 	}
 }
 
+// withIsDefaultInfra allows us to differentiate between the default infra containers generated
+// directly by podman and custom infra containers within the container config
+func withIsDefaultInfra() CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.IsDefaultInfra = true
+
+		return nil
+	}
+}
+
 // WithIsService allows us to differentiate between service containers and other container
 // within the container config.  It also sets the exit-code propagation of the
 // service container.

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -301,9 +301,13 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 
 	// TODO: We don't understand why specgen does not take of this, but
 	// integration tests clearly pointed out that it was required.
-	imageData, err := opts.Image.Inspect(ctx, nil)
-	if err != nil {
-		return nil, err
+	var imageData *libimage.ImageData
+	if opts.Image != nil {
+		var err error
+		imageData, err = opts.Image.Inspect(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 	s.WorkDir = "/"
 	// Entrypoint/Command handling is based off of

--- a/pkg/specgen/generate/pause_image.go
+++ b/pkg/specgen/generate/pause_image.go
@@ -4,18 +4,15 @@ package generate
 
 import (
 	"context"
-	"fmt"
-	"os"
 
-	buildahDefine "github.com/containers/buildah/define"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v5/libpod"
-	"github.com/containers/podman/v5/libpod/define"
 )
 
-// PullOrBuildInfraImage pulls down the specified image or the one set in
-// containers.conf.  If none is set, it builds a local pause image.
-func PullOrBuildInfraImage(rt *libpod.Runtime, imageName string) (string, error) {
+// PullInfraImage pulls down the specified image or the one set in
+// containers.conf. If none is set, it returns an empty string. In this
+// case, the rootfs-based pause image is used by libpod.
+func PullInfraImage(rt *libpod.Runtime, imageName string) (string, error) {
 	rtConfig, err := rt.GetConfigNoCopy()
 	if err != nil {
 		return "", err
@@ -33,64 +30,5 @@ func PullOrBuildInfraImage(rt *libpod.Runtime, imageName string) (string, error)
 		return imageName, nil
 	}
 
-	name, err := buildPauseImage(rt, rtConfig)
-	if err != nil {
-		return "", fmt.Errorf("building local pause image: %w", err)
-	}
-	return name, nil
-}
-
-func buildPauseImage(rt *libpod.Runtime, rtConfig *config.Config) (string, error) {
-	version, err := define.GetVersion()
-	if err != nil {
-		return "", err
-	}
-	imageName := fmt.Sprintf("localhost/podman-pause:%s-%d", version.Version, version.Built)
-
-	// First check if the image has already been built.
-	if _, _, err := rt.LibimageRuntime().LookupImage(imageName, nil); err == nil {
-		return imageName, nil
-	}
-
-	// Also look into the path as some distributions install catatonit in
-	// /usr/bin.
-	catatonitPath, err := rtConfig.FindInitBinary()
-	if err != nil {
-		return "", fmt.Errorf("finding pause binary: %w", err)
-	}
-
-	buildContent := fmt.Sprintf(`FROM scratch
-COPY %s /catatonit
-ENTRYPOINT ["/catatonit", "-P"]`, catatonitPath)
-
-	tmpF, err := os.CreateTemp("", "pause.containerfile")
-	if err != nil {
-		return "", err
-	}
-	if _, err := tmpF.WriteString(buildContent); err != nil {
-		return "", err
-	}
-	if err := tmpF.Close(); err != nil {
-		return "", err
-	}
-	defer os.Remove(tmpF.Name())
-
-	buildOptions := buildahDefine.BuildOptions{
-		CommonBuildOpts: &buildahDefine.CommonBuildOptions{},
-		Output:          imageName,
-		Quiet:           true,
-		IgnoreFile:      "/dev/null", // makes sure to not read a local .ignorefile (see #13529)
-		IIDFile:         "/dev/null", // prevents Buildah from writing the ID on stdout
-		IDMappingOptions: &buildahDefine.IDMappingOptions{
-			// Use the host UID/GID mappings for the build to avoid issues when
-			// running with a custom mapping (BZ #2083997).
-			HostUIDMapping: true,
-			HostGIDMapping: true,
-		},
-	}
-	if _, _, err := rt.Build(context.Background(), buildOptions, tmpF.Name()); err != nil {
-		return "", err
-	}
-
-	return imageName, nil
+	return "", nil
 }

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -38,12 +38,14 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (_ *libpod.Pod, finalErr e
 	}
 
 	if !p.PodSpecGen.NoInfra {
-		imageName, err := PullOrBuildInfraImage(rt, p.PodSpecGen.InfraImage)
+		imageName, err := PullInfraImage(rt, p.PodSpecGen.InfraImage)
 		if err != nil {
 			return nil, err
 		}
-		p.PodSpecGen.InfraImage = imageName
-		p.PodSpecGen.InfraContainerSpec.RawImageName = imageName
+		if len(imageName) > 0 {
+			p.PodSpecGen.InfraImage = imageName
+			p.PodSpecGen.InfraContainerSpec.RawImageName = imageName
+		}
 	}
 
 	spec, err := MapSpec(&p.PodSpecGen)

--- a/test/system/020-tag.bats
+++ b/test/system/020-tag.bats
@@ -57,6 +57,7 @@ function _tag_and_check() {
 
 # CANNOT BE PARALLELIZED: temporarily removes $IMAGE
 @test "podman untag all" {
+    _prefetch $IMAGE
     # First get the image ID
     run_podman inspect --format '{{.ID}}' $IMAGE
     iid=$output

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -237,7 +237,6 @@ load helpers
     is "$output" "$rand_value"
 
     run_podman pod rm -t 0 -f test
-    run_podman rmi $(pause_image)
 }
 
 @test "podman ps --format PodName" {
@@ -252,7 +251,6 @@ load helpers
 
     run_podman rm -t 0 -f $cid
     run_podman pod rm -t 0 -f $rand_value
-    run_podman rmi $(pause_image)
 }
 
 # vim: filetype=sh

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -563,7 +563,7 @@ EOF
 
     # Clean up
     systemctl stop $service_name
-    run_podman rmi -f $(pause_image) $local_image $newID $oldID
+    run_podman rmi -f $local_image $newID $oldID
     run_podman network rm podman-default-kube-network
     rm -f $UNIT_DIR/$unit_name
 }
@@ -630,7 +630,7 @@ EOF
     assert $status -eq 0 "Error stopping pod systemd unit: $output"
 
     run_podman pod rm -f $podname
-    run_podman rmi $local_image $(pause_image)
+    run_podman rmi $local_image
     rm -f $podunit $ctrunit
     systemctl daemon-reload
 }

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -117,12 +117,6 @@ RELABEL="system_u:object_r:container_file_t:s0"
        is "$output" "${RELABEL} $TESTDIR" "selinux relabel should have happened"
     fi
 
-    # Make sure that the K8s pause image isn't pulled but the local podman-pause is built.
-    run_podman images
-    run_podman 1 image exists k8s.gcr.io/pause
-    run_podman 1 image exists registry.k8s.io/pause
-    run_podman image exists $(pause_image)
-
     run_podman pod rm -t 0 -f $PODNAME
 }
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -452,21 +452,6 @@ function clean_setup() {
     if [[ -z "$found_needed_image" ]]; then
         _prefetch $PODMAN_TEST_IMAGE_FQN
     fi
-
-    # Load (create, actually) the pause image. This way, all pod tests will
-    # have it available. Without this, pod tests run in parallel will leave
-    # behind <none>:<none> images.
-    # FIXME: only do this when running parallel! Otherwise, we may break
-    #        test expectations.
-    #        SUB-FIXME: there's no actual way to tell if we're running bats
-    #                   in parallel (see bats-core#998). Use undocumented hack.
-    # FIXME: #23292 -- this should not be necessary.
-    if [[ -n "$BATS_SEMAPHORE_DIR" ]]; then
-        run_podman pod create mypod
-        run_podman pod rm mypod
-        # And now, we have a pause image, and each test does not
-        # need to build their own.
-    fi
 }
 
 # END   setup/teardown tools
@@ -810,15 +795,6 @@ function journald_unavailable() {
     echo "WEIRD: 'journalctl -n 1' failed with a non-permission error:"
     echo "$output"
     return 1
-}
-
-# Returns the name of the local pause image.
-function pause_image() {
-    # This function is intended to be used as '$(pause_image)', i.e.
-    # our caller wants our output. run_podman() messes with output because
-    # it emits the command invocation to stdout, hence the redirection.
-    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}" >/dev/null
-    echo "localhost/podman-pause:$output"
 }
 
 # Wait for the pod (1st arg) to transition into the state (2nd arg)


### PR DESCRIPTION
This commit removes the code to build a local pause image from the Containerfile and keeps just a code to PullInfraImage.

In case the user-defined infra image is not set, the PrepareInfraSpec is called to find out the catatonit binary and use it using the rootfs with overlay.

This removes the need to build a local pause container image.

The same logic is also applied to createServiceContainer which is originally also based on the pause image.

Fixes: #23292


#### Does this PR introduce a user-facing change?

```release-note
None
```
