### PR TITLE
fix network DB desync after failed connect/disconnect

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -583,6 +583,14 @@ load helpers.network
     run_podman network connect $netname $background_cid
     is "$output" "" "(re)connect of container with no open ports"
 
+    # connect a network with an intentional error (bad mac address)
+    run_podman 125 network connect --mac-address 00:00:00:00:00:00 $netname2 $cid
+    assert "$output" =~ "Cannot assign requested address" "mac address error"
+
+    # podman inspect must still work correctly and not error due network desync
+    run_podman inspect --format '{{ range $index, $value := .NetworkSettings.Networks }}{{$index}}{{end}}' $cid
+    assert "$output" == "$netname" "only network1 must be connected"
+
     # connect a second network
     run_podman network connect $netname2 $cid
     is "$output" "" "Output should be empty (no errors)"


### PR DESCRIPTION
Networks are stored in two ways in the DB, first a static network list which holds all the network with its option for the container. Second, the network status which hold the actual network result from netavark but only when the container is running.

If the container is running they must be in sync and podman inspect has checks to ensure that as well it errors out of there is a desync between the two.

As the adding to the db and doing actual networking configuration are diffeent parts it possible that one worked while the other failed which triggers the desync. To avoid this make the network connect/disconnect code more robust against partial failures. When the network calls fail we update the db again to remove/add the network back.

Fixes: https://issues.redhat.com/browse/RHEL-78037

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where errors during podman network connect/disconnect could cause a DB mismatch which caused podman inspect on the container to fail.
```
