### PR TITLE
update gvproxy version to 0.8.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ endif
 
 # gvisor-tap-vsock version for gvproxy.exe and win-sshproxy.exe downloads
 # the upstream project ships pre-built binaries since version 0.7.1
-GV_VERSION=v0.8.4
+GV_VERSION=v0.8.5
 
 ###
 ### Primary entry-point targets

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -6,7 +6,7 @@ ifeq ($(ARCH), aarch64)
 else
 	GOARCH:=$(ARCH)
 endif
-GVPROXY_VERSION ?= 0.8.4
+GVPROXY_VERSION ?= 0.8.5
 VFKIT_VERSION ?= 0.6.0
 KRUNKIT_VERSION ?= 0.1.4
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -72,7 +72,7 @@ function Win-SSHProxy {
 
     New-Item -ItemType Directory -Force -Path "./bin/windows"
     if (-Not $Version) {
-        $Version = "v0.8.4"
+        $Version = "v0.8.5"
     }
     curl.exe -sSL -o "./bin/windows/gvproxy.exe" --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windowsgui.exe"
     curl.exe -sSL -o "./bin/windows/win-sshproxy.exe" --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy.exe"


### PR DESCRIPTION
Align gvproxy version to gvforwarder which has already been bumped in #25615 fa0e5af54282.
These versions should really be bumped together as they were previously in #25501 48662fa32b49.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update the bundled gvproxy version to 0.8.5
```
