### PR TITLE
test: Pass OCI_RUNTIME environment variable to BATS tests

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -8,7 +8,7 @@ QUADLET=${QUADLET:-/usr/libexec/podman/quadlet}
 PODMAN_TESTING=${PODMAN_TESTING:-$(dirname ${BASH_SOURCE})/../../bin/podman-testing}
 
 # crun or runc, unlikely to change. Cache, because it's expensive to determine.
-PODMAN_RUNTIME=
+PODMAN_RUNTIME="$OCI_RUNTIME"
 
 # Standard image to use for most tests
 PODMAN_TEST_IMAGE_REGISTRY=${PODMAN_TEST_IMAGE_REGISTRY:-"quay.io"}


### PR DESCRIPTION
The `OCI_RUNTIME` environment variable is not being passed to the BATS tests even though:
- The [test documentation](https://github.com/containers/podman/blob/main/test/README.md) mentions it.
- [hack/bats](https://github.com/containers/podman/blob/main/hack/bats#L140) supports it.

With this change we no longer needed to edit [helpers.bash](https://github.com/containers/podman/blob/main/test/system/helpers.bash#L11)