### PR TITLE
docs: update `DefaultDependencies=` description

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2000,6 +2000,9 @@ Add Quadlet's default network dependencies to the unit (default is `true`).
 When set to false, Quadlet will **not** add a dependency (After=, Wants=) to
 `network-online.target`/`podman-user-wait-network-online.service` to the generated unit.
 
+Note, this option is set in the `[Quadlet]` section. The `[Unit]` section
+has an option with the same name but a different meaning.
+
 ## EXAMPLES
 
 Example `test.container`:


### PR DESCRIPTION


`DefaultDependencies=` in the [`[Quadlet]`](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#defaultdependencies) section
is not the same as `DefaultDependencies=` in the [`[Unit]`](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#DefaultDependencies=) section.
Setting the value of one of them will not impact the value of the other.
Mention the existence of the `[Unit]` section option and that they are different.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
