### PR TITLE
libpod: --user works with  --hostuser entries

### DIFF
--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -47,16 +47,16 @@ func TestGenerateUserGroupEntry(t *testing.T) {
 			Mountpoint: "/does/not/exist/tmp/",
 		},
 	}
-	group, err := c.generateUserGroupEntry(0)
+	group, err := c.generateUserGroupEntry(-1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, group, "456789:x:456789:123456\n")
 
 	c.config.User = "567890"
-	group, err = c.generateUserGroupEntry(0)
+	group, err = c.generateUserGroupEntry(-1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, group, "567890:x:567890:567890\n")
+	assert.Equal(t, group, "0:x:0:567890\n")
 }

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -90,13 +90,6 @@ USER 1000`, ALPINE)
 		Expect(session.OutputToString()).To(ContainSubstring("/etc/group"))
 	})
 
-	It("podman run numeric user not specified in container modifies group", func() {
-		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "20001", BB, "mount"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(ContainSubstring("/etc/group"))
-	})
-
 	It("podman run numeric group from image and no group file", func() {
 		dockerfile := fmt.Sprintf(`FROM %s
 RUN rm -f /etc/passwd /etc/shadow /etc/group

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -906,6 +906,17 @@ EOF
     fi
 
     user=$(id -u)
+
+    userspec=$(id -un):$(id -g)
+    run_podman run --hostuser=$user --user $userspec --rm $IMAGE sh -c 'echo $(id -un):$(id -g)'
+    is "$output" "$userspec"
+
+    run_podman run --hostuser=$user --user $userspec --group-entry="$(id -gn):x:$(id -g):" --rm $IMAGE sh -c 'echo $(id -un):$(id -gn)'
+    is "$output" "$(id -un):$(id -gn)"
+
+    run_podman 126 run --hostuser=$user --user "$(id -un):$(id -gn)" --rm $IMAGE sh -c 'echo $(id -un):$(id -gn)'
+    is "$output" "Error:.* no matching entries in group file"
+
     run_podman run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
     run_podman run --hostuser=$user --user $user --rm $IMAGE grep $user /etc/passwd
     user=bogus


### PR DESCRIPTION
create the /etc/passwd and /etc/group files before any user/group lookup so that the entries added dynamically are found by --user.

Closes: https://github.com/containers/podman/issues/25805

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now --user finds groups added by --hostuser
```
