### PR TITLE
test/system: do not check dns.podman

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -741,7 +741,6 @@ nameserver 8.8.8.8" "nameserver order is correct"
     fi
     # we should use the integrated dns server
     run_podman run --network $netname --rm $IMAGE cat /etc/resolv.conf
-    assert "$output" =~ "search dns.podman.*" "correct search domain"
     assert "$output" =~ ".*nameserver $subnet.1.*" \
            "integrated dns nameserver is set"
 


### PR DESCRIPTION
A recent change[1] in netavark makes it so we no longer set the default dns.podman search domain. As such we must no longer test for it.

[1] https://github.com/containers/netavark/pull/1214

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman custom networks when using netavark v1.15+ no longer set the default search domain dns.podman. Queries resolving such names will still work. 
```
