### PR TITLE
cmd: Fix help text. --config specifies a dir not a regular file

### DIFF
--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -29,7 +29,7 @@ type PodmanConfig struct {
 	ContainersConf           *config.Config
 	ContainersConfDefaultsRO *config.Config // The read-only! defaults from containers.conf.
 	DBBackend                string         // Hidden: change the database backend
-	DockerConfig             string         // Location of authentication config file
+	DockerConfig             string         // Path to directory containing authentication config file
 	CgroupUsage              string         // rootless code determines Usage message
 	ConmonPath               string         // --conmon flag will set Engine.ConmonPath
 	CPUProfile               string         // Hidden: Should CPU profile be taken


### PR DESCRIPTION
This `--config` option was initially added here:
https://github.com/containers/podman/commit/4e4c3e3dbffd6c8fc2c1a8674a581aed61f2d629

Under the hood this simply modifies env to set DOCKER_CONFIG=<passed in string>

The DOCKER_CONFIG env var is used as a directory that contains multiple config files... of which podman and container libs probably only use `$DIR/config.json`.
See: https://docs.docker.com/reference/cli/docker/#environment-variables

The old CMD and help text was misleading... if we point the at a regular file we can see errors like:
```
$ touch /tmp/foo/tmpcr9zrx71
$ /bin/podman --config /tmp/foo/tmpcr9zrx71 build -t foobar:latest
Error: creating build container: initializing source docker://quay.io/centos/centos:stream9: getting username and password: reading JSON file "/tmp/foo/tmpcr9zrx71/config.json": open /tmp/foo/tmpcr9zrx71/config.json: not a directory
```
^^ In this case we had created `/tmp/foo/tmpcr9zrx71` as a regular file.

```release-note
Clarify --config <str> CMD option help text
```
