### PR TITLE
Make Go not panic on a partial update

### DIFF
--- a/pkg/bindings/containers/update.go
+++ b/pkg/bindings/containers/update.go
@@ -26,13 +26,21 @@ func Update(ctx context.Context, options *types.ContainerUpdateOptions) (string,
 			params.Set("restartRetries", strconv.Itoa(int(*options.RestartRetries)))
 		}
 	}
+
 	updateEntities := &handlers.UpdateEntities{
-		LinuxResources:               *options.Resources,
-		UpdateHealthCheckConfig:      *options.ChangedHealthCheckConfiguration,
-		UpdateContainerDevicesLimits: *options.DevicesLimits,
-		Env:                          options.Env,
-		UnsetEnv:                     options.UnsetEnv,
+		Env:      options.Env,
+		UnsetEnv: options.UnsetEnv,
 	}
+	if options.Resources != nil {
+		updateEntities.LinuxResources = *options.Resources
+	}
+	if options.ChangedHealthCheckConfiguration != nil {
+		updateEntities.UpdateHealthCheckConfig = *options.ChangedHealthCheckConfiguration
+	}
+	if options.DevicesLimits != nil {
+		updateEntities.UpdateContainerDevicesLimits = *options.DevicesLimits
+	}
+
 	requestData, err := jsoniter.MarshalToString(updateEntities)
 	if err != nil {
 		return "", err

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/podman/v5/pkg/bindings"
 	"github.com/containers/podman/v5/pkg/bindings/containers"
 	"github.com/containers/podman/v5/pkg/domain/entities/reports"
+	"github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/containers/podman/v5/pkg/specgen"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -801,5 +802,16 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(c).To(HaveLen(1))
 		Expect(c[0].PodName).To(Equal(podName))
+	})
+
+	It("Update container allows for partial updates", func() {
+		var name = "top"
+		_, err := bt.RunTopContainer(&name, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = containers.Update(bt.conn, &types.ContainerUpdateOptions{
+			NameOrID: name,
+		})
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Right now, if you call Update with only part of the options struct added, it panics. This fixes that by only adding them if they are not nil.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md

```release-note
None
```
