### PR TITLE
MAINTAINERS.md: sort by role and add nalind to OWNERS

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,3 +6,8 @@ kind/api-change:
 machine:
   - changed-files:
     - any-glob-to-any-file: pkg/machine/**
+governance:
+  - changed-files:
+    - any-glob-to-any-file: OWNERS
+    - any-glob-to-any-file: MAINTAINERS.md
+    - any-glob-to-any-file: GOVERNANCE.md

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,24 +8,24 @@ describes the Podman project's governance and the Project Roles used below.
 | Maintainer        | GitHub ID                                                | Project Roles                    | Affiliation                                  |
 |-------------------|----------------------------------------------------------|----------------------------------|----------------------------------------------|
 | Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Ygal Blum         | [ygalblum](https://github.com/ygalblum)                  | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
-| Jake Correnti     | [jakecorrenti](https://github.com/jakecorrenti)          | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
-| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
 | Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Jason Greene      | [n1hility](https://github.com/n1hility)                  | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Jhon Honce        | [jwhonce](https://github.com/jwhonce)                    | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
+| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Ygal Blum         | [ygalblum](https://github.com/ygalblum)                  | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
 | Mario Loriedo     | [l0rd](https://github.com/l0rd/)                         | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
 | Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Jake Correnti     | [jakecorrenti](https://github.com/jakecorrenti)          | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Jason Greene      | [n1hility](https://github.com/n1hility)                  | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Jhon Honce        | [jwhonce](https://github.com/jwhonce)                    | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Urvashi Mohnani   | [umohnani8](https://github.com/umohnani8)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Aditya Rajan      | [flouthoc](https://github.com/flouthoc)                  | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Jan Rodák         | [Honny1](https://github.com/Honny1)                      | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
-| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
-| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
-| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 
 ## Alumni

--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - lsm5
   - mheon
   - mtrmac
+  - nalind
   - ygalblum
 reviewers:
   - Luap99
@@ -23,6 +24,7 @@ reviewers:
   - mheon
   - mtrmac
   - n1hility
+  - nalind
   - rhatdan
   - umohnani8
   - vrothberg


### PR DESCRIPTION
MAINTAINERS.md: sort by role 

This should make it easier to read, most people likely care about the
roles.

---

OWNERS: add nalind

He is a core maintainer and was not listed here by mistake.

---

.github/labeler: add governance label automatically

We don't have anything CI wise to enforce proper reviews for governance
changes but we can easily label a PR so that should raise more
awareness.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
