### PR TITLE
Correct units in init error message

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -249,7 +249,7 @@ func checkMaxMemory(newMem strongunits.MiB) error {
 		return err
 	}
 	if total := strongunits.B(memStat.Total); strongunits.B(memStat.Total) < newMem.ToBytes() {
-		return fmt.Errorf("requested amount of memory (%d MB) greater than total system memory (%d MB)", newMem, total)
+		return fmt.Errorf("requested amount of memory (%d MB) greater than total system memory (%d MB)", newMem, strongunits.ToMib(total))
 	}
 	return nil
 }

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -71,11 +71,12 @@ var _ = Describe("podman machine init", func() {
 		// this comes in bytes
 		memStat, err := mem.VirtualMemory()
 		Expect(err).ToNot(HaveOccurred())
-		total := strongunits.ToMib(strongunits.B(memStat.Total)) + 1024
+		systemMem := strongunits.ToMib(strongunits.B(memStat.Total))
 
 		badMem := initMachine{}
-		badMemSession, err := mb.setCmd(badMem.withMemory(uint(total))).run()
+		badMemSession, err := mb.setCmd(badMem.withMemory(uint(systemMem + 1024))).run()
 		Expect(err).ToNot(HaveOccurred())
+		Expect(badMemSession.errorToString()).To(ContainSubstring(fmt.Sprintf("greater than total system memory (%d MB)", systemMem)))
 		Expect(badMemSession).To(Exit(125))
 	})
 


### PR DESCRIPTION
When trying to initialize a machine with more memory that the system has we were outputting an error message in the wrong unit.  It should have been in MB and B. This was found as part of #25803 but is not the solution for that issue.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed error with `podman machine init` where the memory was reported in the wrong unit.
```
