### PR TITLE
test/system: remove pasta conditional

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -778,11 +778,7 @@ nameserver 8.8.8.8" "nameserver order is correct"
     fi
     # pasta only works rootless
     if is_rootless; then
-        if has_pasta; then
-            netmodes+=("pasta")
-        else
-            echo "# WARNING: pasta unavailable!" >&3
-        fi
+        netmodes+=("pasta")
     fi
 
     for netmode in "${netmodes[@]}"; do
@@ -1112,7 +1108,6 @@ function wait_for_restart_count() {
 @test "Podman unshare --rootless-netns with Pasta" {
     skip_if_remote "unshare is local-only"
     skip_if_not_rootless "pasta networking only available in rootless mode"
-    skip_if_no_pasta "pasta not found; this test requires pasta"
 
     pasta_iface=$(default_ifname 4)
     assert "$pasta_iface" != "" "pasta_iface is set"

--- a/test/system/505-networking-pasta.bats
+++ b/test/system/505-networking-pasta.bats
@@ -16,7 +16,6 @@ load helpers.network
 function setup() {
     basic_setup
     skip_if_not_rootless "pasta networking only available in rootless mode"
-    skip_if_no_pasta "pasta not found: install pasta(1) to run these tests"
 
     XFER_FILE="${PODMAN_TMPDIR}/pasta.bin"
 }

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -1,6 +1,5 @@
 # -*- bash -*-
 
-_cached_has_pasta=
 _cached_has_slirp4netns=
 
 ### Feature Checks #############################################################
@@ -44,28 +43,6 @@ function has_slirp4netns() {
     fi
     test "$_cached_has_slirp4netns" = "y"
 }
-
-# has_pasta() - Check if the pasta(1) command is available
-function has_pasta() {
-    if [[ -z "$_cached_has_pasta" ]]; then
-        _cached_has_pasta=n
-        run_podman info --format '{{.Host.Pasta.Executable}}'
-        if [[ -n "$output" ]]; then
-            _cached_has_pasta=y
-        fi
-    fi
-    test "$_cached_has_pasta" = "y"
-}
-
-# skip_if_no_pasta() - Skip current test if pasta(1) is not available
-# $1:	Optional message to display
-function skip_if_no_pasta() {
-    if ! has_pasta; then
-        local msg=$(_add_label_if_missing "$1" "pasta")
-        skip "${msg:-not applicable with no pasta binary}"
-    fi
-}
-
 
 ### procfs access ##############################################################
 


### PR DESCRIPTION
Sinc v5.0 pasta is the default and if it would not be installed a ton of tests would already fail. As such these conditional checks are pointless and can be removed to simplify the tests.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
