### PR TITLE
test/system: add prefetch users to use cache image

### DIFF
--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -134,10 +134,12 @@ function setup() {
 @test "podman checkpoint --export, with volumes" {
     skip_if_remote "Test uses --root/--runroot, which are N/A over remote"
 
-    # To avoid network pull, copy $IMAGE straight to temp root
     local p_opts="$(podman_isolation_opts ${PODMAN_TMPDIR}) --events-backend file"
-    run_podman         save -o $PODMAN_TMPDIR/image.tar $IMAGE
-    run_podman $p_opts load -i $PODMAN_TMPDIR/image.tar
+    # prefetch image to avoid registry pulls because this is using a
+    # unique root which does not have the image already present.
+    # _PODMAN_TEST_OPTS is used to overwrite the podman options to
+    # make the function aware of the custom --root.
+    _PODMAN_TEST_OPTS="$p_opts --storage-driver $(podman_storage_driver)" _prefetch $IMAGE
 
     # Create a volume, find unused network port, and create a webserv container
     volname=v-$(safename)


### PR DESCRIPTION
When using a custom --root it will not have the image present and as such cause a pull. We can however use our own local cache if present to avoid the pull if we give the right podman options via _PODMAN_TEST_OPTS.

I saw the volume quota test fail during the pull in openQA thus I noticed this issue.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
