### PR TITLE
Two small updates to the Governance model

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,6 +18,10 @@
 
 This document defines the governance of the Podman Project, including its subprojects. It defines the various roles our maintainers fill, how to become a maintainer, and how project-level decisions are made.
 
+The Podman project currently consists of the Podman project (the repository containing this file) and two subprojects:
+* [Buildah](https://github.com/containers/buildah)
+* [Skopeo](https://github.com/containers/skopeo/)
+
 # Contributor Ladder
 
 The Podman project has a number of maintainer roles arranged in a ladder. Each role is a rung on the ladder, with different responsibilities and privileges. Community members generally start at the first levels of the "ladder" and advance as their involvement in the project grows. Our project members are happy to help you advance along the contributor ladder. At all levels, contributors are required to follow the CNCF Code of Conduct (COC).
@@ -141,6 +145,7 @@ Description: Community managers are responsible for the project’s community in
     * Arranging, participating in, and leading, community meetings
     * Managing the project website and gathering associated metrics
     * Managing the project’s social media accounts and mailing lists and gathering associated metrics
+    * Creating and publishing minutes from Core Maintainer meetings
 * Requirements
     * Sustained high level of contribution to the community, including attending and engaging in community meetings, contributions to the website, and contributions to documentation, for at least six months
     * Is able to exercise judgment for the good of the project, independent of their employer, friends, or team


### PR DESCRIPTION
Firstly, include both subprojects in the model and link to them. Ensures complete clarity on what is part of the Podman Project in CNCF.

Secondly, add that Community Managers are expected to take notes on Core Maintainer meetings and make those notes available to the public.

Requires a 2/3 vote of Core Maintainers to merge.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
