### PR TITLE
ci: fix two issues, remove unused exceptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,8 +69,6 @@ linters:
     generated: strict
     presets:
       - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
     rules:
       - linters:

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -233,17 +233,17 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 	sort.Ints(vals)
+loop:
 	for ind, core := range vals {
 		switch {
 		case core > int(cpuSet):
 			if copy == "" {
 				copy = "0-" + strconv.Itoa(int(cpuSet))
 				infraOptions.CPUSetCPUs = copy
-				break
 			} else {
 				infraOptions.CPUSetCPUs = copy
-				break
 			}
+			break loop
 		case ind != 0:
 			copy += "," + strconv.Itoa(core)
 		default:
@@ -252,6 +252,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	createOptions.Cpus = infraOptions.CPUS
 	createOptions.CpusetCpus = infraOptions.CPUSetCPUs
+
 	podSpec := specgen.NewPodSpecGenerator()
 	podSpec, err = entities.ToPodSpecGen(*podSpec, &createOptions)
 	if err != nil {

--- a/pkg/bindings/containers/term_windows.go
+++ b/pkg/bindings/containers/term_windows.go
@@ -48,7 +48,6 @@ func notifyWinChange(ctx context.Context, winChange chan os.Signal, stdin *os.Fi
 			case <-ctx.Done():
 				return
 			case <-timer.C:
-				break
 			}
 
 			w, h, err := term.GetSize(int(stdout.Fd()))


### PR DESCRIPTION
This fixes ~~one~~ two issues caught by staticcheck, and removes two exception presets from .golangci.yml. See commits for details.

Makes sense to merge this one before #25874.

#### Does this PR introduce a user-facing change?

```release-note
none
```
