### PR TITLE
Fix the fd leaking to aardvark-dns.

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -440,7 +440,7 @@ func (c *Container) getOCICgroupPath() (string, error) {
 }
 
 func openDirectory(path string) (fd int, err error) {
-	return unix.Open(path, unix.O_RDONLY|unix.O_PATH, 0)
+	return unix.Open(path, unix.O_RDONLY|unix.O_PATH|unix.O_CLOEXEC, 0)
 }
 
 func (c *Container) addNetworkNamespace(g *generate.Generator) error {


### PR DESCRIPTION
The openDirectory function is missing the unix.O_CLOEXEC flag. As a result, this file descriptor can leak into the aardvark-dns process which can then block the umount of rootfs - in this case, the umount fails with "Device or Resource busy" error message.

This commits adds the unix.O_CLOEXEC to unix.Open call, resulting in this fd to be closed on aardvark-dns exec.

#### Does this PR introduce a user-facing change?

```release-note
None
```
