### PR TITLE
docs: Expand description of no-new-privileges

### DIFF
--- a/docs/source/markdown/options/security-opt.md
+++ b/docs/source/markdown/options/security-opt.md
@@ -22,7 +22,7 @@ Note: Labeling can be disabled for all <<|pods/>>containers by setting label=fal
 
 - **mask**=_/path/1:/path/2_: The paths to mask separated by a colon. A masked path cannot be accessed inside the container<<s within the pod|>>.
 
-- **no-new-privileges**: Disable container processes from gaining additional privileges.
+- **no-new-privileges**: Disable container processes from gaining additional privileges through the `execve(2)` system call (e.g. via setuid or setgid bits, or via file capabilities). Programs that rely on setuid/setgid bits set on their executable to change user id or group id are no longer able to do so, and any file capabilities added to the executable (e.g. via `setcap`) are not added to the permitted capability set. For more details, see: https://docs.kernel.org/userspace-api/no_new_privs.html.
 
 - **seccomp=unconfined**: Turn off seccomp confinement for the <<container|pod>>.
 - **seccomp=profile.json**: JSON file to be used as a seccomp filter. Note that the `io.podman.annotations.seccomp` annotation is set with the specified value as shown in `podman inspect`.


### PR DESCRIPTION
Fixes: #25853

The below is found on the matching [systemd docs](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#NoNewPrivileges=) which I don't think applies to Podman. Is it correct to leave it out?

> In case the service will be run in a new mount namespace anyway and SELinux is disabled, all file systems are mounted with MS_NOSUID flag. [...]
>
> Note that this setting only has an effect on the unit's processes themselves (or any processes directly or indirectly forked off them). It has no effect on processes potentially invoked on request of them through tools such as [at(1)](https://man7.org/linux/man-pages/man1/at.1.html), [crontab(1)](https://man7.org/linux/man-pages/man1/crontab.1.html), [systemd-run(1)](https://www.freedesktop.org/software/systemd/man/latest/systemd-run.html#), or arbitrary IPC services.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
