### PR TITLE
CI: Fix directive `//nolint:revive` is unused for linter "revive" on ARM

### DIFF
--- a/test/e2e/config_arm64.go
+++ b/test/e2e/config_arm64.go
@@ -3,14 +3,14 @@
 package integration
 
 var (
-	STORAGE_FS          = "overlay"                                                                                                                                  //nolint:revive
-	STORAGE_OPTIONS     = "--storage-driver overlay"                                                                                                                 //nolint:revive
-	ROOTLESS_STORAGE_FS = "overlay"                                                                                                                                  //nolint:revive
-	CACHE_IMAGES        = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE} //nolint:revive
-	NGINX_IMAGE         = "quay.io/lsm5/alpine_nginx-aarch64:latest"                                                                                                 //nolint:revive
-	BB_GLIBC            = "docker.io/library/busybox:glibc"                                                                                                          //nolint:revive
-	REGISTRY_IMAGE      = "quay.io/libpod/registry:2.8.2"                                                                                                            //nolint:revive
-	CITEST_IMAGE        = "quay.io/libpod/testimage:20241011"                                                                                                        //nolint:revive
-	SYSTEMD_IMAGE       = "quay.io/libpod/systemd-image:20240124"                                                                                                    //nolint:revive
-	CIRROS_IMAGE        = "quay.io/libpod/cirros:latest"                                                                                                             //nolint:revive
+	STORAGE_FS          = "overlay"
+	STORAGE_OPTIONS     = "--storage-driver overlay"
+	ROOTLESS_STORAGE_FS = "overlay"
+	CACHE_IMAGES        = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, CITEST_IMAGE, HEALTHCHECK_IMAGE, SYSTEMD_IMAGE}
+	NGINX_IMAGE         = "quay.io/lsm5/alpine_nginx-aarch64:latest"
+	BB_GLIBC            = "docker.io/library/busybox:glibc"
+	REGISTRY_IMAGE      = "quay.io/libpod/registry:2.8.2"
+	CITEST_IMAGE        = "quay.io/libpod/testimage:20241011"
+	SYSTEMD_IMAGE       = "quay.io/libpod/systemd-image:20240124"
+	CIRROS_IMAGE        = "quay.io/libpod/cirros:latest"
 )


### PR DESCRIPTION
This PR fixes `golangci-lint` on ARM64 machines. 
Fixes:
- `directive `//nolint:revive` is unused for linter "revive" (nolintlint)`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
