### PR TITLE
Fix: Compat API in rootless mode ignores ulimits

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -486,15 +486,15 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
 		HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
 	}
-	if !rootless.IsRootless() {
-		var ulimits []string
-		if len(cc.HostConfig.Ulimits) > 0 {
-			for _, ul := range cc.HostConfig.Ulimits {
-				ulimits = append(ulimits, ul.String())
-			}
-			cliOpts.Ulimit = ulimits
+
+	var ulimits []string
+	if len(cc.HostConfig.Ulimits) > 0 {
+		for _, ul := range cc.HostConfig.Ulimits {
+			ulimits = append(ulimits, ul.String())
 		}
+		cliOpts.Ulimit = ulimits
 	}
+
 	if cc.HostConfig.Resources.NanoCPUs > 0 {
 		if cliOpts.CPUPeriod != 0 || cliOpts.CPUQuota != 0 {
 			return nil, nil, fmt.Errorf("NanoCpus conflicts with CpuPeriod and CpuQuota")

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -419,6 +419,21 @@ t GET containers/$cid/json 200 \
 
 t DELETE containers/$cid?v=true 204
 
+
+# test compact API in rootless mode ignores ulimits https://github.com/containers/podman/issues/25881
+t POST containers/create \
+  Image=$IMAGE           \
+  HostConfig='{"Ulimits":[{"Name":"cpu","Soft":1,"Hard":2}]}' \
+  201                    \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .HostConfig.Ulimits[0].Name="RLIMIT_CPU" \
+  .HostConfig.Ulimits[0].Hard=2            \
+  .HostConfig.Ulimits[0].Soft=1            \
+
+t DELETE containers/$cid 204
+
 # test port mapping
 podman run -d --rm --name bar -p 8080:9090 $IMAGE top
 


### PR DESCRIPTION
This PR fixes a bug where the Compat API ignores ulimits in rootless mode.

Fixes: https://github.com/containers/podman/issues/25881

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the Compat API API ignores ulimits in rootless mode.
```
