### PR TITLE
Quadlet - support additional systemd unit relationship keys

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -213,15 +213,21 @@ var (
 	validPortRange = regexp.Delayed(`\d+(-\d+)?(/udp|/tcp)?$`)
 
 	unitDependencyKeys = []string{
-		"Wants",
+		"After",
+		"Before",
+		"BindsTo",
+		"Conflicts",
+		"OnFailure",
+		"OnSuccess",
+		"PartOf",
+		"PropagatesReloadTo",
+		"PropagatesStopTo",
+		"ReloadPropagatedFrom",
 		"Requires",
 		"Requisite",
-		"BindsTo",
-		"PartOf",
+		"StopPropagatedFrom",
 		"Upholds",
-		"Conflicts",
-		"Before",
-		"After",
+		"Wants",
 	}
 
 	// Supported keys in "Container" group

--- a/test/e2e/quadlet/dependent.container
+++ b/test/e2e/quadlet/dependent.container
@@ -1,9 +1,11 @@
 ## assert-key-is "Unit" "Requires" "basic-build.service basic.service basic-image.service basic.service basic-network.service basic-pod.service basic-volume.service"
 ## assert-key-is-regex "Unit" "After" "network-online.target|podman-user-wait-network-online.service" "basic-build.service basic.service basic-image.service basic.service basic-network.service basic-pod.service basic-volume.service"
+## assert-key-is "Unit" "PropagatesStopTo" "basic.service"
 
 [Unit]
 After=basic.build basic.container basic.image basic.kube basic.network basic.pod basic.volume
 Requires=basic.build basic.container basic.image basic.kube basic.network basic.pod basic.volume
+PropagatesStopTo=basic.container
 
 [Container]
 Image=localhost/imagename


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
No

```release-note
None
```

Not adding release notes because this PR is an addition to https://github.com/containers/podman/pull/25899
