### PR TITLE
test: Fix expected output for runc on namespaces

### DIFF
--- a/test/system/195-run-namespaces.bats
+++ b/test/system/195-run-namespaces.bats
@@ -38,7 +38,13 @@ uts    | uts
             run_podman logs $cname
             con1_ns="$output"
 
-            assert "$con1_ns" == "$con2_ns" "($name) namespace matches (type: $type)"
+            if [[ "$option" = "pid" ]] && is_rootless && ! is_remote && [[ "$(podman_runtime)" = "runc" ]]; then
+                # Replace "pid:[1234567]" with "pid:\[1234567\]"
+                con1_ns_esc="${con1_ns//[\[\]]/\\&}"
+                assert "$con2_ns" =~ "${con1_ns_esc}.*warning .*" "($name) namespace matches (type: $type)"
+            else
+                assert "$con1_ns" == "$con2_ns" "($name) namespace matches (type: $type)"
+            fi
             local matcher="=="
             if [[ "$type" != "host" ]]; then
                 matcher="!="


### PR DESCRIPTION
Fix issue with 195-run-namespaces test with runc. When run as rootless, runc issues an extra warning on podman:

https://github.com/opencontainers/runc/issues/4732

Verification run: https://openqa.opensuse.org/tests/5002299/file/podman-bats-user-local.tap