### PR TITLE
Network aliases cannot contain spaces

### DIFF
--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -85,6 +85,15 @@ func (c *Container) validate() error {
 		return fmt.Errorf("cannot set static IP or MAC address if not creating a network namespace: %w", define.ErrInvalidArg)
 	}
 
+	// issue #25927 network-aliases cannot have spaces
+	for _, net := range c.config.Networks {
+		for _, alias := range net.Aliases {
+			if strings.Contains(alias, " ") {
+				return fmt.Errorf("invalid alias %q: contains white space", alias)
+			}
+		}
+	}
+
 	// Cannot set static IP or MAC if joining >1 network.
 	if len(c.config.Networks) > 1 && (c.config.StaticIP != nil || c.config.StaticMAC != nil) {
 		return fmt.Errorf("cannot set static IP or MAC address if joining more than one network: %w", define.ErrInvalidArg)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -510,6 +510,11 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(ExitCleanly())
 
+		// Issue https://github.com/containers/podman/issues/25927
+		failed := podmanTest.Podman([]string{"create", "--rm", "--network=" + netName, "--network-alias", "a b", NGINX_IMAGE})
+		failed.WaitWithDefaultTimeout()
+		Expect(failed).Should(ExitWithError(125, fmt.Sprintf("invalid alias %q: contains white space", "a b")))
+
 		interval := 250 * time.Millisecond
 		for i := 0; i < 6; i++ {
 			n := podmanTest.Podman([]string{"network", "exists", netName})


### PR DESCRIPTION
Issue #25927 points out that `--network-alias "a b"` is accepted on the command line but dns names cannot have whitespaces in them.

Fixes: https://github.com/containers/podman/issues/25927

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where network aliases accepted white space in its input
```
