### PR TITLE
Bump to Buildah v1.40.0

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -580,6 +580,10 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 		UnsetLabels:             flags.UnsetLabels,
 	}
 
+	if c.Flag("inherit-labels").Changed {
+		opts.InheritLabels = types.NewOptionalBool(flags.InheritLabels)
+	}
+
 	if flags.IgnoreFile != "" {
 		excludes, err := parseDockerignore(flags.IgnoreFile)
 		if err != nil {

--- a/docs/source/markdown/options/inherit-labels.md
+++ b/docs/source/markdown/options/inherit-labels.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman build, farm build
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--inherit-labels**
+
+Inherit the labels from the base image or base stages. (default true).

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -221,6 +221,8 @@ It does not affect _/etc/resolv.conf_ in the final image.
 
 @@option iidfile
 
+@@option inherit-labels
+
 @@option ipc.image
 
 @@option isolation

--- a/docs/source/markdown/podman-farm-build.1.md.in
+++ b/docs/source/markdown/podman-farm-build.1.md.in
@@ -123,6 +123,8 @@ This option specifies the name of the farm to be used in the build process.
 
 @@option iidfile
 
+@@option inherit-labels
+
 @@option ipc.image
 
 @@option isolation

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.3.0
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.6.2
-	github.com/containers/buildah v1.39.1-0.20250401180830-32d78c69be17
+	github.com/containers/buildah v1.40.0
 	github.com/containers/common v0.63.0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.5
@@ -27,7 +27,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.4.1
 	github.com/digitalocean/go-qemu v0.0.0-20250212194115-ee9b0668d242
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v28.1.1+incompatible
+	github.com/docker/docker v28.1.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-plugins-helpers v0.0.0-20240701071450-45e2431495c8
 	github.com/docker/go-units v0.5.0
@@ -151,7 +151,7 @@ require (
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mistifyio/go-zfs/v3 v3.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/moby/buildkit v0.20.2 // indirect
+	github.com/moby/buildkit v0.21.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
@@ -203,11 +203,10 @@ require (
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/oauth2 v0.29.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
-	golang.org/x/tools v0.31.0 // indirect
+	golang.org/x/tools v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/grpc v1.71.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,6 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
-	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEm
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.6.2 h1:pqP8Mq923TLyef5g97XfJ/xpDeVek4yF8A4mzy9Tc4U=
 github.com/containernetworking/plugins v1.6.2/go.mod h1:SP5UG3jDO9LtmfbBJdP+nl3A1atOtbj2MBOYsnaxy64=
-github.com/containers/buildah v1.39.1-0.20250401180830-32d78c69be17 h1:mfnd0BqHdV8p6+pol7SelIEgG7NbJQYW4IPywGakmCY=
-github.com/containers/buildah v1.39.1-0.20250401180830-32d78c69be17/go.mod h1:AvIRsFvWfSuMNGoMm8hXFaOGvzhsnujWz1C38rk+mk4=
+github.com/containers/buildah v1.40.0 h1:qCHTKnL/UEutxT6ZS8Zvhy7QUpe719jEIeGMSlcN3j4=
+github.com/containers/buildah v1.40.0/go.mod h1:U6qj0nseq6t97T2kkNpjgo0WBVRYIXASIOlS5eWvlhM=
 github.com/containers/common v0.63.0 h1:ox6vgUYX5TSvt4W+bE36sYBVz/aXMAfRGVAgvknSjBg=
 github.com/containers/common v0.63.0/go.mod h1:+3GCotSqNdIqM3sPs152VvW7m5+Mg8Kk+PExT3G9hZw=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
@@ -121,8 +121,8 @@ github.com/docker/cli v28.0.4+incompatible h1:pBJSJeNd9QeIWPjRcV91RVJihd/TXB77q1
 github.com/docker/cli v28.0.4+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.1.1+incompatible h1:49M11BFLsVO1gxY9UX9p/zwkE/rswggs8AdFmXQw51I=
-github.com/docker/docker v28.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.1.0+incompatible h1:4iqpcWQCt3Txcz7iWIb1U3SZ/n9ffo4U+ryY5/3eOp0=
+github.com/docker/docker v28.1.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -318,8 +318,8 @@ github.com/mistifyio/go-zfs/v3 v3.0.1 h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPn
 github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/moby/buildkit v0.20.2 h1:qIeR47eQ1tzI1rwz0on3Xx2enRw/1CKjFhoONVcTlMA=
-github.com/moby/buildkit v0.20.2/go.mod h1:DhaF82FjwOElTftl0JUAJpH/SUIUx4UvcFncLeOtlDI=
+github.com/moby/buildkit v0.21.0 h1:+z4vVqgt0spLrOSxi4DLedRbIh2gbNVlZ5q4rsnNp60=
+github.com/moby/buildkit v0.21.0/go.mod h1:mBq0D44uCyz2PdX8T/qym5LBbkBO3GGv0wqgX9ABYYw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=
@@ -551,8 +551,8 @@ golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ss
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c h1:KL/ZBHXgKGVmuZBZ01Lt57yE5ws8ZPSkkihmEyq7FXc=
-golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
+golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
+golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -668,8 +668,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
-golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
-golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
+golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=
+golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -130,6 +130,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		IDMappingOptions        string   `schema:"idmappingoptions"`
 		IdentityLabel           bool     `schema:"identitylabel"`
 		Ignore                  bool     `schema:"ignore"`
+		InheritLabels           bool     `schema:"inheritlabels"`
 		Isolation               string   `schema:"isolation"`
 		Jobs                    int      `schema:"jobs"`
 		LabelOpts               string   `schema:"labelopts"`
@@ -744,6 +745,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		IDMappingOptions:               &idMappingOptions,
 		IgnoreUnrecognizedInstructions: query.Ignore,
 		IgnoreFile:                     ignoreFile,
+		InheritLabels:                  types.NewOptionalBool(query.InheritLabels),
 		Isolation:                      isolation,
 		Jobs:                           &jobs,
 		Labels:                         labels,

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -567,6 +567,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      Contents of base images to be modified on ADD or COPY only
 	//      (As of Podman version v5.2)
 	//  - in: query
+	//    name: inheritlabels
+	//    type: boolean
+	//    default: true
+	//    description: |
+	//      Inherit the labels from the base image or base stages
+	//      (As of Podman version v5.5)
+	//  - in: query
 	//    name: nocache
 	//    type: boolean
 	//    default: false
@@ -1539,6 +1546,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      Contents of base images to be modified on ADD or COPY only
 	//      (As of Podman version v5.2)
+	//  - in: query
+	//    name: inheritlabels
+	//    type: boolean
+	//    default: true
+	//    description: |
+	//      Inherit the labels from the base image or base stages
+	//      (As of Podman version v5.5)
 	//  - in: query
 	//    name: nocache
 	//    type: boolean

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -237,6 +237,12 @@ func Build(ctx context.Context, containerFiles []string, options types.BuildOpti
 	if options.IgnoreUnrecognizedInstructions {
 		params.Set("ignore", "1")
 	}
+	if options.InheritLabels == imageTypes.OptionalBoolFalse {
+		params.Set("inheritlabels", "0")
+	} else {
+		params.Set("inheritlabels", "1")
+	}
+
 	params.Set("isolation", strconv.Itoa(int(options.Isolation)))
 	if options.CommonBuildOpts.HTTPProxy {
 		params.Set("httpproxy", "1")

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -341,6 +341,7 @@ success_task:
       - vendor
       - cross_build
       - integration
+      - integration_rootless
       - in_podman
 
     container:

--- a/vendor/github.com/containers/buildah/.golangci.yml
+++ b/vendor/github.com/containers/buildah/.golangci.yml
@@ -1,16 +1,29 @@
----
+version: "2"
+
 run:
   build-tags:
     - apparmor
     - seccomp
     - selinux
-  # Don't exceed number of threads available when running under CI
-  concurrency: 4
+
+formatters:
+  enable:
+    - gofumpt
+
 linters:
   enable:
-    - gofmt
-    - gofumpt
+    - nolintlint
     - revive
     - unconvert
     - unparam
+    - unused
     - whitespace
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,135 @@
 
 # Changelog
 
+## v1.40.0 (2025-04-17)
+
+    Bump c/storage to v1.58.0, c/image v5.35.0, c/common v0.63.0
+    fix(deps): update module github.com/docker/docker to v28.1.0+incompatible
+    fix(deps): update module github.com/containers/storage to v1.58.0
+    cirrus: make Total Success wait for rootless integration
+    chroot: use symbolic names when complaining about mount() errors
+    cli: hide the `completion` command instead of disabling it outright
+    Document rw and src options for --mount flag in buildah-run(1)
+    fix(deps): update module github.com/moby/buildkit to v0.21.0
+    build: add support for inherit-labels
+    chore(deps): update dependency golangci/golangci-lint to v2.1.0
+    .github: check_cirrus_cron work around github bug
+    stage_executor,getCreatedBy: expand buildArgs for sources correctly
+    Add a link to project governance and MAINTAINERS file
+    fix(deps): update github.com/containers/storage digest to b1d1b45
+    generateHostname: simplify
+    Use maps.Copy
+    Use slices.Concat
+    Use slices.Clone
+    Use slices.Contains
+    Use for range over integers
+    tests/testreport: don't copy os.Environ
+    Use any instead of interface{}
+    ci: add golangci-lint run with --tests=false
+    ci: add nolintlint, fix found issues
+    copier: rm nolint:unparam annotation
+    .golangci.yml: add unused linter
+    chroot: fix unused warnings
+    copier: fix unused warnings
+    tests/conformance: fix unused warning
+    ci: switch to golangci-lint v2
+    internal/mkcw: disable ST1003 warnings
+    tests/conformance: do not double import (fix ST1019)
+    cmd/buildah: don't double import (fix ST1019)
+    Do not capitalize error strings
+    cmd/buildah: do not capitalize error strings
+    tests/conformance: fix QF1012 warnings
+    tests/serve: fix QF1012 warning
+    Use strings.ReplaceAll to fix QF1004 warnings
+    Use switch to fix QF1003 warnings
+    Apply De Morgan's law to fix QF1001 warnings
+    Fix QF1007 staticcheck warnings
+    imagebuildah: fix revive warning
+    Rename max variable
+    tests/tools: install lint from binary, use renovate
+    fix(deps): update module github.com/containernetworking/cni to v1.3.0
+    Update Buildah issue template to new version and support podman build
+    fix(deps): update module golang.org/x/crypto to v0.37.0
+    stage_executor: reset platform in systemcontext for stages
+    fix(deps): update github.com/opencontainers/runtime-tools digest to 260e151
+    cmd/buildah: rm unused containerOutputUsingTemplate
+    cmd/buildah: rm unused getDateAndDigestAndSize
+    build: return ExecErrorCodeGeneric when git operation fails
+    add: report error while creating dir for URL source.
+    createPlatformContainer: drop MS_REMOUNT|MS_BIND
+    fix(deps): update module github.com/docker/docker to v28.0.3+incompatible
+    fix: bats won't fail on ! without cleverness
+    feat: use HistoryTimestamp, if set, for oci-archive entries
+    Allow extendedGlob to work with Windows paths
+    fix(deps): update module github.com/moby/buildkit to v0.20.2
+    fix(deps): update github.com/openshift/imagebuilder digest to e87e4e1
+    fix(deps): update module github.com/docker/docker to v28.0.2+incompatible
+    fix(deps): update module tags.cncf.io/container-device-interface to v1.0.1
+    chore(deps): update dependency containers/automation_images to v20250324
+    vendor: update github.com/opencontainers/selinux to v1.12.0
+    replace deprecated selinux/label calls
+    vendor: bump c/common to dbeb17e40c80
+    Use builtin arg defaults from imagebuilder
+    linux: accept unmask paths as glob values
+    vendor: update containers/common
+    Add --parents option for COPY in Dockerfiles
+    fix(deps): update module github.com/opencontainers/runc to v1.2.6
+    update go.sum from the previous commit
+    fix(deps): update module tags.cncf.io/container-device-interface to v1
+    chore(deps): update module golang.org/x/net to v0.36.0 [security]
+    packit: remove f40 from copr builds
+    cirrus: update to go 1.23 image
+    vendor bump to golang.org/x/crypto v0.36.0
+    cirrus: update PRIOR_FEDORA comment
+    github: remove cirrus rerun action
+    fix(deps): update module github.com/containers/common to v0.62.2
+    fix(deps): update module github.com/containers/image/v5 to v5.34.2
+    fix: close files properly when BuildDockerfiles exits
+    fix(deps): update module github.com/containers/storage to v1.57.2
+    stage_executor: history should include heredoc summary correctly
+    fix(deps): update module github.com/containers/common to v0.62.1
+    github: disable cron rerun action
+    fix(deps): update module github.com/moby/buildkit to v0.20.1
+    internal/mkcw.Archive(): use github.com/containers/storage/pkg/ioutils
+    [skip-ci] TMT: system tests
+    buildah-build.1.md: secret examples
+    fix(deps): update github.com/containers/luksy digest to 40bd943
+    fix(deps): update module github.com/opencontainers/image-spec to v1.1.1
+    fix(deps): update module github.com/containers/image/v5 to v5.34.1
+    Use UnparsedInstance.Manifest instead of ImageSource.GetManifest
+    fix(deps): update module github.com/opencontainers/runtime-spec to v1.2.1
+    tests/conformance/testdata/Dockerfile.add: update some URLs
+    Vendor imagebuilder
+    Fix source of OS, architecture and variant
+    chore(deps): update module github.com/go-jose/go-jose/v4 to v4.0.5 [security]
+    fix(deps): update module tags.cncf.io/container-device-interface to v0.8.1
+    fix(deps): update module github.com/moby/buildkit to v0.20.0
+    chroot createPlatformContainer: use MS_REMOUNT
+    conformance: make TestCommit and TestConformance parallel
+    cirrus: reduce task timeout
+    mkcw: mkcw_check_image use bats run_with_log
+    test: use /tmp as TMPDIR
+    heredoc: create temp subdirs for each build
+    test: heredoc remove python dependency from test
+    Support the containers.conf container_name_as_hostname option
+    fix(deps): update module github.com/opencontainers/runc to v1.2.5
+    fix(deps): update module github.com/spf13/cobra to v1.9.0
+    .cirrus: use more cores for smoke
+    Switch to the CNCF Code of Conduct
+    .cirrus: bump ci resources
+    fix(deps): update module golang.org/x/crypto to v0.33.0
+    Distinguish --mount=type=cache locations by ownership, too
+    fix(deps): update module golang.org/x/term to v0.29.0
+    .cirrus: run -race only on non-PR branch
+    unit: deparallize some tests
+    .cirrus: use multiple cpu for unit tests
+    Makefile: use -parallel for go test
+    unit_test: use Parallel test where possible
+    Update module golang.org/x/sys to v0.30.0
+    Update module golang.org/x/sync to v0.11.0
+    Update dependency containers/automation_images to v20250131
+    Bump to Buildah v1.40.0-dev
+
 ## v1.39.0 (2025-01-31)
 
     Bump c/storage v1.57.1, c/image 5.34.0,  c/common v0.62.0

--- a/vendor/github.com/containers/buildah/GOVERNANCE.md
+++ b/vendor/github.com/containers/buildah/GOVERNANCE.md
@@ -1,0 +1,3 @@
+## The Buildah Project Community Governance
+
+The Buildah project, as part of Podman Container Tools, follows the [Podman Project Governance](https://github.com/containers/podman/blob/main/GOVERNANCE.md).

--- a/vendor/github.com/containers/buildah/MAINTAINERS
+++ b/vendor/github.com/containers/buildah/MAINTAINERS
@@ -1,4 +1,0 @@
-Dan Walsh <dwalsh@redhat.com> (@rhatdan)
-Nalin Dahyabhai <nalin@redhat.com> (@nalind)
-Tom Sweeney <tsweeney@redhat.com> (@tomsweeneyredhat)
-Urvashi Mohnani <umohnani@redhat.com> (@umohnani8)

--- a/vendor/github.com/containers/buildah/MAINTAINERS.md
+++ b/vendor/github.com/containers/buildah/MAINTAINERS.md
@@ -1,0 +1,31 @@
+# Buildah Maintainers
+
+[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
+describes the project's governance and the Project Roles used below.
+
+## Maintainers
+
+| Maintainer        | GitHub ID                                                | Project Roles                    | Affiliation                                  |
+|-------------------|----------------------------------------------------------|----------------------------------|----------------------------------------------|
+| Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
+| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Aditya Rajan      | [flouthoc](https://github.com/flouthoc)                  | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Jan Rodák         | [Honny1](https://github.com/Honny1)                      | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+
+## Alumni
+
+None at present
+
+## Credits
+
+The structure of this document was based off of the equivalent one in the [CRI-O Project](https://github.com/cri-o/cri-o/blob/main/MAINTAINERS.md).

--- a/vendor/github.com/containers/buildah/Makefile
+++ b/vendor/github.com/containers/buildah/Makefile
@@ -52,6 +52,9 @@ ifeq ($(BUILDDEBUG), 1)
   override GOGCFLAGS += -N -l
 endif
 
+# Managed by renovate.
+export GOLANGCI_LINT_VERSION := 2.1.0
+
 #   make all BUILDDEBUG=1
 #     Note: Uses the -N -l go compiler options to disable compiler optimizations
 #           and inlining. Using these build options allows you to subsequently
@@ -192,6 +195,7 @@ vendor:
 .PHONY: lint
 lint: install.tools
 	./tests/tools/build/golangci-lint run $(LINTFLAGS)
+	./tests/tools/build/golangci-lint run --tests=false $(LINTFLAGS)
 
 # CAUTION: This is not a replacement for RPMs provided by your distro.
 # Only intended to build and test the latest unreleased changes.

--- a/vendor/github.com/containers/buildah/OWNERS
+++ b/vendor/github.com/containers/buildah/OWNERS
@@ -1,15 +1,24 @@
 approvers:
-  - TomSweeneyRedHat
+  - baude
+  - giuseppe
   - lsm5
+  - Luap99
+  - mheon
+  - mtrmac
   - nalind
   - rhatdan
-  - umohnani8
+  - TomSweeneyRedHat
 reviewers:
   - ashley-cui
   - baude
-  - edsantiago
   - flouthoc
   - giuseppe
   - Honny1
+  - lsm5
+  - Luap99
   - mheon
+  - mtrmac
+  - nalind
+  - rhatdan
+  - TomSweeneyRedHat
   - vrothberg

--- a/vendor/github.com/containers/buildah/add.go
+++ b/vendor/github.com/containers/buildah/add.go
@@ -454,10 +454,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	}
 
 	// if the destination is a directory that doesn't yet exist, let's copy it.
-	newDestDirFound := false
-	if (len(destStats) == 1 || len(destStats[0].Globbed) == 0) && destMustBeDirectory && !destCanBeFile {
-		newDestDirFound = true
-	}
+	newDestDirFound := (len(destStats) == 1 || len(destStats[0].Globbed) == 0) && destMustBeDirectory && !destCanBeFile
 
 	if len(destStats) == 1 && len(destStats[0].Globbed) == 1 && destStats[0].Results[destStats[0].Globbed[0]].IsRegular {
 		if destMustBeDirectory {
@@ -625,7 +622,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}
 			// Check for dockerignore-style exclusion of this item.
 			if rel != "." {
-				excluded, err := pm.Matches(filepath.ToSlash(rel)) // nolint:staticcheck
+				excluded, err := pm.Matches(filepath.ToSlash(rel)) //nolint:staticcheck
 				if err != nil {
 					return fmt.Errorf("checking if %q(%q) is excluded: %w", globbed, rel, err)
 				}

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,131 @@
+- Changelog for v1.40.0 (2025-04-17)
+  * Bump c/storage to v1.58.0, c/image v5.35.0, c/common v0.63.0
+  * fix(deps): update module github.com/docker/docker to v28.1.0+incompatible
+  * fix(deps): update module github.com/containers/storage to v1.58.0
+  * cirrus: make Total Success wait for rootless integration
+  * chroot: use symbolic names when complaining about mount() errors
+  * cli: hide the `completion` command instead of disabling it outright
+  * Document rw and src options for --mount flag in buildah-run(1)
+  * fix(deps): update module github.com/moby/buildkit to v0.21.0
+  * build: add support for inherit-labels
+  * chore(deps): update dependency golangci/golangci-lint to v2.1.0
+  * .github: check_cirrus_cron work around github bug
+  * stage_executor,getCreatedBy: expand buildArgs for sources correctly
+  * Add a link to project governance and MAINTAINERS file
+  * fix(deps): update github.com/containers/storage digest to b1d1b45
+  * generateHostname: simplify
+  * Use maps.Copy
+  * Use slices.Concat
+  * Use slices.Clone
+  * Use slices.Contains
+  * Use for range over integers
+  * tests/testreport: don't copy os.Environ
+  * Use any instead of interface{}
+  * ci: add golangci-lint run with --tests=false
+  * ci: add nolintlint, fix found issues
+  * copier: rm nolint:unparam annotation
+  * .golangci.yml: add unused linter
+  * chroot: fix unused warnings
+  * copier: fix unused warnings
+  * tests/conformance: fix unused warning
+  * ci: switch to golangci-lint v2
+  * internal/mkcw: disable ST1003 warnings
+  * tests/conformance: do not double import (fix ST1019)
+  * cmd/buildah: don't double import (fix ST1019)
+  * Do not capitalize error strings
+  * cmd/buildah: do not capitalize error strings
+  * tests/conformance: fix QF1012 warnings
+  * tests/serve: fix QF1012 warning
+  * Use strings.ReplaceAll to fix QF1004 warnings
+  * Use switch to fix QF1003 warnings
+  * Apply De Morgan's law to fix QF1001 warnings
+  * Fix QF1007 staticcheck warnings
+  * imagebuildah: fix revive warning
+  * Rename max variable
+  * tests/tools: install lint from binary, use renovate
+  * fix(deps): update module github.com/containernetworking/cni to v1.3.0
+  * Update Buildah issue template to new version and support podman build
+  * fix(deps): update module golang.org/x/crypto to v0.37.0
+  * stage_executor: reset platform in systemcontext for stages
+  * fix(deps): update github.com/opencontainers/runtime-tools digest to 260e151
+  * cmd/buildah: rm unused containerOutputUsingTemplate
+  * cmd/buildah: rm unused getDateAndDigestAndSize
+  * build: return ExecErrorCodeGeneric when git operation fails
+  * add: report error while creating dir for URL source.
+  * createPlatformContainer: drop MS_REMOUNT|MS_BIND
+  * fix(deps): update module github.com/docker/docker to v28.0.3+incompatible
+  * fix: bats won't fail on ! without cleverness
+  * feat: use HistoryTimestamp, if set, for oci-archive entries
+  * Allow extendedGlob to work with Windows paths
+  * fix(deps): update module github.com/moby/buildkit to v0.20.2
+  * fix(deps): update github.com/openshift/imagebuilder digest to e87e4e1
+  * fix(deps): update module github.com/docker/docker to v28.0.2+incompatible
+  * fix(deps): update module tags.cncf.io/container-device-interface to v1.0.1
+  * chore(deps): update dependency containers/automation_images to v20250324
+  * vendor: update github.com/opencontainers/selinux to v1.12.0
+  * replace deprecated selinux/label calls
+  * vendor: bump c/common to dbeb17e40c80
+  * Use builtin arg defaults from imagebuilder
+  * linux: accept unmask paths as glob values
+  * vendor: update containers/common
+  * Add --parents option for COPY in Dockerfiles
+  * fix(deps): update module github.com/opencontainers/runc to v1.2.6
+  * update go.sum from the previous commit
+  * fix(deps): update module tags.cncf.io/container-device-interface to v1
+  * chore(deps): update module golang.org/x/net to v0.36.0 [security]
+  * packit: remove f40 from copr builds
+  * cirrus: update to go 1.23 image
+  * vendor bump to golang.org/x/crypto v0.36.0
+  * cirrus: update PRIOR_FEDORA comment
+  * github: remove cirrus rerun action
+  * fix(deps): update module github.com/containers/common to v0.62.2
+  * fix(deps): update module github.com/containers/image/v5 to v5.34.2
+  * fix: close files properly when BuildDockerfiles exits
+  * fix(deps): update module github.com/containers/storage to v1.57.2
+  * stage_executor: history should include heredoc summary correctly
+  * fix(deps): update module github.com/containers/common to v0.62.1
+  * github: disable cron rerun action
+  * fix(deps): update module github.com/moby/buildkit to v0.20.1
+  * internal/mkcw.Archive(): use github.com/containers/storage/pkg/ioutils
+  * [skip-ci] TMT: system tests
+  * buildah-build.1.md: secret examples
+  * fix(deps): update github.com/containers/luksy digest to 40bd943
+  * fix(deps): update module github.com/opencontainers/image-spec to v1.1.1
+  * fix(deps): update module github.com/containers/image/v5 to v5.34.1
+  * Use UnparsedInstance.Manifest instead of ImageSource.GetManifest
+  * fix(deps): update module github.com/opencontainers/runtime-spec to v1.2.1
+  * tests/conformance/testdata/Dockerfile.add: update some URLs
+  * Vendor imagebuilder
+  * Fix source of OS, architecture and variant
+  * chore(deps): update module github.com/go-jose/go-jose/v4 to v4.0.5 [security]
+  * fix(deps): update module tags.cncf.io/container-device-interface to v0.8.1
+  * fix(deps): update module github.com/moby/buildkit to v0.20.0
+  * chroot createPlatformContainer: use MS_REMOUNT
+  * conformance: make TestCommit and TestConformance parallel
+  * cirrus: reduce task timeout
+  * mkcw: mkcw_check_image use bats run_with_log
+  * test: use /tmp as TMPDIR
+  * heredoc: create temp subdirs for each build
+  * test: heredoc remove python dependency from test
+  * Support the containers.conf container_name_as_hostname option
+  * fix(deps): update module github.com/opencontainers/runc to v1.2.5
+  * fix(deps): update module github.com/spf13/cobra to v1.9.0
+  * .cirrus: use more cores for smoke
+  * Switch to the CNCF Code of Conduct
+  * .cirrus: bump ci resources
+  * fix(deps): update module golang.org/x/crypto to v0.33.0
+  * Distinguish --mount=type=cache locations by ownership, too
+  * fix(deps): update module golang.org/x/term to v0.29.0
+  * .cirrus: run -race only on non-PR branch
+  * unit: deparallize some tests
+  * .cirrus: use multiple cpu for unit tests
+  * Makefile: use -parallel for go test
+  * unit_test: use Parallel test where possible
+  * Update module golang.org/x/sys to v0.30.0
+  * Update module golang.org/x/sync to v0.11.0
+  * Update dependency containers/automation_images to v20250131
+  * Bump to Buildah v1.40.0-dev
+
 - Changelog for v1.39.0 (2025-01-31)
   * Bump c/storage v1.57.1, c/image 5.34.0,  c/common v0.62.0
   * Update module github.com/containers/storage to v1.57.0

--- a/vendor/github.com/containers/buildah/chroot/seccomp.go
+++ b/vendor/github.com/containers/buildah/chroot/seccomp.go
@@ -4,15 +4,11 @@ package chroot
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/containers/common/pkg/seccomp"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	libseccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/sirupsen/logrus"
 )
-
-const seccompAvailable = true
 
 // setSeccomp sets the seccomp filter for ourselves and any processes that we'll start.
 func setSeccomp(spec *specs.Spec) error {
@@ -175,30 +171,6 @@ func setSeccomp(spec *specs.Spec) error {
 	filter.Release()
 	if err != nil {
 		return fmt.Errorf("activating seccomp filter: %w", err)
-	}
-	return nil
-}
-
-func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
-	switch seccompProfilePath {
-	case "unconfined":
-		spec.Linux.Seccomp = nil
-	case "":
-		seccompConfig, err := seccomp.GetDefaultProfile(spec)
-		if err != nil {
-			return fmt.Errorf("loading default seccomp profile failed: %w", err)
-		}
-		spec.Linux.Seccomp = seccompConfig
-	default:
-		seccompProfile, err := os.ReadFile(seccompProfilePath)
-		if err != nil {
-			return fmt.Errorf("opening seccomp profile failed: %w", err)
-		}
-		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
-		if err != nil {
-			return fmt.Errorf("loading seccomp profile (%s) failed: %w", seccompProfilePath, err)
-		}
-		spec.Linux.Seccomp = seccompConfig
 	}
 	return nil
 }

--- a/vendor/github.com/containers/buildah/chroot/seccomp_unsupported.go
+++ b/vendor/github.com/containers/buildah/chroot/seccomp_unsupported.go
@@ -8,19 +8,9 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-const seccompAvailable = false
-
 func setSeccomp(spec *specs.Spec) error {
 	if spec.Linux.Seccomp != nil {
 		return errors.New("configured a seccomp filter without seccomp support?")
-	}
-	return nil
-}
-
-func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
-	if spec.Linux != nil {
-		// runtime-tools may have supplied us with a default filter
-		spec.Linux.Seccomp = nil
 	}
 	return nil
 }

--- a/vendor/github.com/containers/buildah/config.go
+++ b/vendor/github.com/containers/buildah/config.go
@@ -26,7 +26,7 @@ import (
 // unmarshalConvertedConfig obtains the config blob of img valid for the wantedManifestMIMEType format
 // (either as it exists, or converting the image if necessary), and unmarshals it into dest.
 // NOTE: The MIME type is of the _manifest_, not of the _config_ that is returned.
-func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.Image, wantedManifestMIMEType string) error {
+func unmarshalConvertedConfig(ctx context.Context, dest any, img types.Image, wantedManifestMIMEType string) error {
 	_, actualManifestMIMEType, err := img.Manifest(ctx)
 	if err != nil {
 		return fmt.Errorf("getting manifest MIME type for %q: %w", transports.ImageName(img.Reference()), err)
@@ -96,9 +96,7 @@ func (b *Builder) initConfig(ctx context.Context, sys *types.SystemContext, img 
 				if b.ImageAnnotations == nil {
 					b.ImageAnnotations = make(map[string]string, len(v1Manifest.Annotations))
 				}
-				for k, v := range v1Manifest.Annotations {
-					b.ImageAnnotations[k] = v
-				}
+				maps.Copy(b.ImageAnnotations, v1Manifest.Annotations)
 			}
 		}
 	} else {

--- a/vendor/github.com/containers/buildah/copier/copier.go
+++ b/vendor/github.com/containers/buildah/copier/copier.go
@@ -331,7 +331,7 @@ func Stat(root string, directory string, options StatOptions, globs []string) ([
 		Request:     requestStat,
 		Root:        root,
 		Directory:   directory,
-		Globs:       append([]string{}, globs...),
+		Globs:       slices.Clone(globs),
 		StatOptions: options,
 	}
 	resp, err := copier(nil, nil, req)
@@ -382,7 +382,7 @@ func Get(root string, directory string, options GetOptions, globs []string, bulk
 		Request:   requestGet,
 		Root:      root,
 		Directory: directory,
-		Globs:     append([]string{}, globs...),
+		Globs:     slices.Clone(globs),
 		StatOptions: StatOptions{
 			CheckForArchives: options.ExpandArchives,
 		},
@@ -598,7 +598,7 @@ func copierWithoutSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req req
 	req.preservedRoot = req.Root
 	req.rootPrefix = string(os.PathSeparator)
 	req.preservedDirectory = req.Directory
-	req.preservedGlobs = append([]string{}, req.Globs...)
+	req.preservedGlobs = slices.Clone(req.Globs)
 	if !filepath.IsAbs(req.Directory) {
 		req.Directory = filepath.Join(req.Root, cleanerReldirectory(req.Directory))
 	}
@@ -701,9 +701,9 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	bulkReaderRead = nil
 	bulkWriterWrite.Close()
 	bulkWriterWrite = nil
-	killAndReturn := func(err error, step string) (*response, error) { // nolint: unparam
+	killAndReturn := func(err error, step string) error {
 		if err2 := cmd.Process.Kill(); err2 != nil {
-			return nil, fmt.Errorf("killing subprocess: %v; %s: %w", err2, step, err)
+			return fmt.Errorf("killing subprocess: %v; %s: %w", err2, step, err)
 		}
 		if errors.Is(err, io.ErrClosedPipe) || errors.Is(err, syscall.EPIPE) {
 			err2 := cmd.Wait()
@@ -711,22 +711,22 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 				err = fmt.Errorf("%s: %w", errorText, err)
 			}
 			if err2 != nil {
-				return nil, fmt.Errorf("waiting on subprocess: %v; %s: %w", err2, step, err)
+				return fmt.Errorf("waiting on subprocess: %v; %s: %w", err2, step, err)
 			}
 		}
-		return nil, fmt.Errorf("%v: %w", step, err)
+		return fmt.Errorf("%v: %w", step, err)
 	}
 	if err = encoder.Encode(req); err != nil {
-		return killAndReturn(err, "error encoding work request for copier subprocess")
+		return nil, killAndReturn(err, "error encoding work request for copier subprocess")
 	}
 	if err = decoder.Decode(&resp); err != nil {
 		if errors.Is(err, io.EOF) && errorBuffer.Len() > 0 {
-			return killAndReturn(errors.New(errorBuffer.String()), "error in copier subprocess")
+			return nil, killAndReturn(errors.New(errorBuffer.String()), "error in copier subprocess")
 		}
-		return killAndReturn(err, "error decoding response from copier subprocess")
+		return nil, killAndReturn(err, "error decoding response from copier subprocess")
 	}
 	if err = encoder.Encode(&request{Request: requestQuit}); err != nil {
-		return killAndReturn(err, "error encoding quit request for copier subprocess")
+		return nil, killAndReturn(err, "error encoding quit request for copier subprocess")
 	}
 	stdinWrite.Close()
 	stdinWrite = nil
@@ -850,7 +850,7 @@ func copierMain() {
 		req.preservedRoot = req.Root
 		req.rootPrefix = string(os.PathSeparator)
 		req.preservedDirectory = req.Directory
-		req.preservedGlobs = append([]string{}, req.Globs...)
+		req.preservedGlobs = slices.Clone(req.Globs)
 		if chrooted {
 			// We'll need to adjust some things now that the root
 			// directory isn't what it was.  Make the directory and
@@ -975,7 +975,7 @@ func pathIsExcluded(root, path string, pm *fileutils.PatternMatcher) (string, bo
 	// Matches uses filepath.FromSlash() to convert candidates before
 	// checking if they match the patterns it's been given, implying that
 	// it expects Unix-style paths.
-	matches, err := pm.Matches(filepath.ToSlash(rel)) // nolint:staticcheck
+	matches, err := pm.Matches(filepath.ToSlash(rel)) //nolint:staticcheck
 	if err != nil {
 		return rel, false, fmt.Errorf("copier: error checking if %q is excluded: %w", rel, err)
 	}
@@ -1009,7 +1009,7 @@ func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.P
 		}
 		excluded = excluded || thisExcluded
 		if !excluded {
-			if target, err := os.Readlink(filepath.Join(workingPath, components[0])); err == nil && !(len(components) == 1 && !evaluateFinalComponent) {
+			if target, err := os.Readlink(filepath.Join(workingPath, components[0])); err == nil && (len(components) != 1 || evaluateFinalComponent) {
 				followed++
 				if followed > maxLoopsFollowed {
 					return "", &os.PathError{
@@ -1052,7 +1052,7 @@ func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.P
 }
 
 func copierHandlerEval(req request) *response {
-	errorResponse := func(fmtspec string, args ...interface{}) *response {
+	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Eval: evalResponse{}}
 	}
 	resolvedTarget, err := resolvePath(req.Root, req.Directory, true, nil)
@@ -1063,7 +1063,7 @@ func copierHandlerEval(req request) *response {
 }
 
 func copierHandlerStat(req request, pm *fileutils.PatternMatcher) *response {
-	errorResponse := func(fmtspec string, args ...interface{}) *response {
+	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse{}}
 	}
 	if len(req.Globs) == 0 {
@@ -1233,7 +1233,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 	statRequest := req
 	statRequest.Request = requestStat
 	statResponse := copierHandlerStat(req, pm)
-	errorResponse := func(fmtspec string, args ...interface{}) (*response, func() error, error) {
+	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse.Stat, Get: getResponse{}}, nil, nil
 	}
 	if statResponse.Error != "" {
@@ -1661,14 +1661,15 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		return fmt.Errorf("getting fflags: %w", err)
 	}
 	var f *os.File
-	if hdr.Typeflag == tar.TypeReg {
+	switch hdr.Typeflag {
+	case tar.TypeReg:
 		// open the file first so that we don't write a header for it if we can't actually read it
 		f, err = os.Open(contentPath)
 		if err != nil {
 			return fmt.Errorf("opening file for adding its contents to archive: %w", err)
 		}
 		defer f.Close()
-	} else if hdr.Typeflag == tar.TypeDir {
+	case tar.TypeDir:
 		// open the directory file first to make sure we can access it.
 		f, err = os.Open(contentPath)
 		if err != nil {
@@ -1695,7 +1696,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 }
 
 func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
-	errorResponse := func(fmtspec string, args ...interface{}) (*response, func() error, error) {
+	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Put: putResponse{}}, nil, nil
 	}
 	dirUID, dirGID, defaultDirUID, defaultDirGID := 0, 0, 0, 0
@@ -2080,7 +2081,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			// set xattrs, including some that might have been reset by chown()
 			if !req.PutOptions.StripXattrs {
 				xattrs := mapWithPrefixedKeysWithoutKeyPrefix(hdr.PAXRecords, xattrPAXRecordNamespace)
-				if err = Lsetxattrs(path, xattrs); err != nil { // nolint:staticcheck
+				if err = Lsetxattrs(path, xattrs); err != nil {
 					if !req.PutOptions.IgnoreXattrErrors {
 						return fmt.Errorf("copier: put: error setting extended attributes on %q: %w", path, err)
 					}
@@ -2109,7 +2110,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 }
 
 func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
-	errorResponse := func(fmtspec string, args ...interface{}) (*response, func() error, error) {
+	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Mkdir: mkdirResponse{}}, nil, nil
 	}
 	dirUID, dirGID := 0, 0
@@ -2163,7 +2164,7 @@ func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response,
 }
 
 func copierHandlerRemove(req request) *response {
-	errorResponse := func(fmtspec string, args ...interface{}) *response {
+	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Remove: removeResponse{}}
 	}
 	resolvedTarget, err := resolvePath(req.Root, req.Directory, false, nil)

--- a/vendor/github.com/containers/buildah/copier/syscall_unix.go
+++ b/vendor/github.com/containers/buildah/copier/syscall_unix.go
@@ -84,8 +84,3 @@ func sameDevice(a, b os.FileInfo) bool {
 	}
 	return uA.Dev == uB.Dev
 }
-
-const (
-	testModeMask           = int64(os.ModePerm)
-	testIgnoreSymlinkDates = false
-)

--- a/vendor/github.com/containers/buildah/copier/syscall_windows.go
+++ b/vendor/github.com/containers/buildah/copier/syscall_windows.go
@@ -81,8 +81,3 @@ func lutimes(isSymlink bool, path string, atime, mtime time.Time) error {
 func sameDevice(a, b os.FileInfo) bool {
 	return true
 }
-
-const (
-	testModeMask           = int64(0o600)
-	testIgnoreSymlinkDates = true
-)

--- a/vendor/github.com/containers/buildah/define/build.go
+++ b/vendor/github.com/containers/buildah/define/build.go
@@ -187,7 +187,7 @@ type BuildOptions struct {
 	// Log is a callback that will print a progress message.  If no value
 	// is supplied, the message will be sent to Err (or os.Stderr, if Err
 	// is nil) by default.
-	Log func(format string, args ...interface{})
+	Log func(format string, args ...any)
 	// In is connected to stdin for RUN instructions.
 	In io.Reader
 	// Out is a place where non-error log messages are sent.
@@ -236,6 +236,9 @@ type BuildOptions struct {
 	// ID mapping options to use if we're setting up our own user namespace
 	// when handling RUN instructions.
 	IDMappingOptions *IDMappingOptions
+	// InheritLabels controls whether or not built images will retain the labels
+	// which were set in their base images
+	InheritLabels types.OptionalBool
 	// AddCapabilities is a list of capabilities to add to the default set when
 	// handling RUN instructions.
 	AddCapabilities []string

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.40.0-dev"
+	Version = "1.40.0"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/docker/types.go
+++ b/vendor/github.com/containers/buildah/docker/types.go
@@ -164,7 +164,7 @@ type V1Image struct {
 // V2Image stores the image configuration
 type V2Image struct {
 	V1Image
-	Parent     ID            `json:"parent,omitempty"` // nolint:govet
+	Parent     ID            `json:"parent,omitempty"`
 	RootFS     *V2S2RootFS   `json:"rootfs,omitempty"`
 	History    []V2S2History `json:"history,omitempty"`
 	OSVersion  string        `json:"os.version,omitempty"`

--- a/vendor/github.com/containers/buildah/imagebuildah/build.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/build.go
@@ -435,9 +435,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 		return "", nil, fmt.Errorf("creating build executor: %w", err)
 	}
 	b := imagebuilder.NewBuilder(options.Args)
-	for k, v := range builtinArgDefaults {
-		b.BuiltinArgDefaults[k] = v
-	}
+	maps.Copy(b.BuiltinArgDefaults, builtinArgDefaults)
 
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
@@ -451,7 +449,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 	if options.Target != "" {
 		stagesTargeted, ok := stages.ThroughTarget(options.Target)
 		if !ok {
-			return "", nil, fmt.Errorf("The target %q was not found in the provided Dockerfile", options.Target)
+			return "", nil, fmt.Errorf("the target %q was not found in the provided Dockerfile", options.Target)
 		}
 		stages = stagesTargeted
 	}

--- a/vendor/github.com/containers/buildah/import.go
+++ b/vendor/github.com/containers/buildah/import.go
@@ -19,7 +19,7 @@ import (
 
 func importBuilderDataFromImage(ctx context.Context, store storage.Store, systemContext *types.SystemContext, imageID, containerName, containerID string) (*Builder, error) {
 	if imageID == "" {
-		return nil, errors.New("Internal error: imageID is empty in importBuilderDataFromImage")
+		return nil, errors.New("internal error: imageID is empty in importBuilderDataFromImage")
 	}
 
 	storeopts, err := storage.DefaultStoreOptions()

--- a/vendor/github.com/containers/buildah/info.go
+++ b/vendor/github.com/containers/buildah/info.go
@@ -23,7 +23,7 @@ import (
 // InfoData holds the info type, i.e store, host etc and the data for each type
 type InfoData struct {
 	Type string
-	Data map[string]interface{}
+	Data map[string]any
 }
 
 // Info returns the store and host information
@@ -42,8 +42,8 @@ func Info(store storage.Store) ([]InfoData, error) {
 	return info, nil
 }
 
-func hostInfo() map[string]interface{} {
-	info := map[string]interface{}{}
+func hostInfo() map[string]any {
+	info := map[string]any{}
 	ps := internalUtil.NormalizePlatform(v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH})
 	info["os"] = ps.OS
 	info["arch"] = ps.Architecture
@@ -77,7 +77,7 @@ func hostInfo() map[string]interface{} {
 		info["SwapFree"] = mi.SwapFree
 	}
 	hostDistributionInfo := getHostDistributionInfo()
-	info["Distribution"] = map[string]interface{}{
+	info["Distribution"] = map[string]any{
 		"distribution": hostDistributionInfo["Distribution"],
 		"version":      hostDistributionInfo["Version"],
 	}
@@ -128,9 +128,9 @@ func hostInfo() map[string]interface{} {
 }
 
 // top-level "store" info
-func storeInfo(store storage.Store) (map[string]interface{}, error) {
+func storeInfo(store storage.Store) (map[string]any, error) {
 	// lets say storage driver in use, number of images, number of containers
-	info := map[string]interface{}{}
+	info := map[string]any{}
 	info["GraphRoot"] = store.GraphRoot()
 	info["RunRoot"] = store.RunRoot()
 	info["GraphDriverName"] = store.GraphDriverName()
@@ -148,7 +148,7 @@ func storeInfo(store storage.Store) (map[string]interface{}, error) {
 	if err != nil {
 		logrus.Error(err, "error getting number of images")
 	}
-	info["ImageStore"] = map[string]interface{}{
+	info["ImageStore"] = map[string]any{
 		"number": len(images),
 	}
 
@@ -156,7 +156,7 @@ func storeInfo(store storage.Store) (map[string]interface{}, error) {
 	if err != nil {
 		logrus.Error(err, "error getting number of containers")
 	}
-	info["ContainerStore"] = map[string]interface{}{
+	info["ContainerStore"] = map[string]any{
 		"number": len(containers),
 	}
 

--- a/vendor/github.com/containers/buildah/internal/config/convert.go
+++ b/vendor/github.com/containers/buildah/internal/config/convert.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/containers/image/v5/manifest"
@@ -25,9 +26,7 @@ func Schema2ConfigFromGoDockerclientConfig(config *dockerclient.Config) *manifes
 		}
 	}
 	labels := make(map[string]string)
-	for k, v := range config.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, config.Labels)
 	volumes := make(map[string]struct{})
 	for v := range config.Volumes {
 		volumes[v] = struct{}{}
@@ -82,9 +81,7 @@ func GoDockerclientConfigFromSchema2Config(s2config *manifest.Schema2Config) *do
 		}
 	}
 	labels := make(map[string]string)
-	for k, v := range s2config.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, s2config.Labels)
 	volumes := make(map[string]struct{})
 	for v := range s2config.Volumes {
 		volumes[v] = struct{}{}
@@ -101,17 +98,17 @@ func GoDockerclientConfigFromSchema2Config(s2config *manifest.Schema2Config) *do
 		Tty:             s2config.Tty,
 		OpenStdin:       s2config.OpenStdin,
 		StdinOnce:       s2config.StdinOnce,
-		Env:             append([]string{}, s2config.Env...),
-		Cmd:             append([]string{}, s2config.Cmd...),
+		Env:             slices.Clone(s2config.Env),
+		Cmd:             slices.Clone(s2config.Cmd),
 		Healthcheck:     healthCheck,
 		ArgsEscaped:     s2config.ArgsEscaped,
 		Image:           s2config.Image,
 		Volumes:         volumes,
 		WorkingDir:      s2config.WorkingDir,
-		Entrypoint:      append([]string{}, s2config.Entrypoint...),
+		Entrypoint:      slices.Clone(s2config.Entrypoint),
 		NetworkDisabled: s2config.NetworkDisabled,
 		MacAddress:      s2config.MacAddress,
-		OnBuild:         append([]string{}, s2config.OnBuild...),
+		OnBuild:         slices.Clone(s2config.OnBuild),
 		Labels:          labels,
 		StopSignal:      s2config.StopSignal,
 		Shell:           s2config.Shell,

--- a/vendor/github.com/containers/buildah/internal/config/override.go
+++ b/vendor/github.com/containers/buildah/internal/config/override.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/containers/buildah/docker"
@@ -24,9 +25,9 @@ func firstStringElseSecondString(first, second string) string {
 // slice of strings if it has contents, else the second slice
 func firstSliceElseSecondSlice(first, second []string) []string {
 	if len(first) > 0 {
-		return append([]string{}, first...)
+		return slices.Clone(first)
 	}
-	return append([]string{}, second...)
+	return slices.Clone(second)
 }
 
 // firstSlicePairElseSecondSlicePair takes two pairs of string slices, and
@@ -34,9 +35,9 @@ func firstSliceElseSecondSlice(first, second []string) []string {
 // pair
 func firstSlicePairElseSecondSlicePair(firstA, firstB, secondA, secondB []string) ([]string, []string) {
 	if len(firstA) > 0 || len(firstB) > 0 {
-		return append([]string{}, firstA...), append([]string{}, firstB...)
+		return slices.Clone(firstA), slices.Clone(firstB)
 	}
-	return append([]string{}, secondA...), append([]string{}, secondB...)
+	return slices.Clone(secondA), slices.Clone(secondB)
 }
 
 // mergeEnv combines variables from a and b into a single environment slice. if
@@ -45,7 +46,7 @@ func firstSlicePairElseSecondSlicePair(firstA, firstB, secondA, secondB []string
 func mergeEnv(a, b []string) []string {
 	index := make(map[string]int)
 	results := make([]string, 0, len(a)+len(b))
-	for _, kv := range append(append([]string{}, a...), b...) {
+	for _, kv := range slices.Concat(a, b) {
 		k, _, specifiesValue := strings.Cut(kv, "=")
 		if !specifiesValue {
 			if value, ok := os.LookupEnv(kv); ok {
@@ -134,7 +135,7 @@ func Override(dconfig *docker.Config, oconfig *v1.ImageConfig, overrideChanges [
 		oconfig.Entrypoint, oconfig.Cmd = firstSlicePairElseSecondSlicePair(overrideConfig.Entrypoint, overrideConfig.Cmd, oconfig.Entrypoint, oconfig.Cmd)
 		if overrideConfig.Healthcheck != nil {
 			dconfig.Healthcheck = &docker.HealthConfig{
-				Test:        append([]string{}, overrideConfig.Healthcheck.Test...),
+				Test:        slices.Clone(overrideConfig.Healthcheck.Test),
 				Interval:    overrideConfig.Healthcheck.Interval,
 				Timeout:     overrideConfig.Healthcheck.Timeout,
 				StartPeriod: overrideConfig.Healthcheck.StartPeriod,

--- a/vendor/github.com/containers/buildah/internal/mkcw/types/attest.go
+++ b/vendor/github.com/containers/buildah/internal/mkcw/types/attest.go
@@ -26,17 +26,18 @@ type TeeConfigFlags struct {
 // TeeConfigFlagBits are bits representing run-time expectations.
 type TeeConfigFlagBits int
 
+//nolint:revive,staticcheck // Don't warn about bad naming.
 const (
-	SEV_CONFIG_NO_DEBUG        TeeConfigFlagBits = 0b00000001 //revive:disable-line:var-naming no debugging of guests
-	SEV_CONFIG_NO_KEY_SHARING  TeeConfigFlagBits = 0b00000010 //revive:disable-line:var-naming no sharing keys between guests
-	SEV_CONFIG_ENCRYPTED_STATE TeeConfigFlagBits = 0b00000100 //revive:disable-line:var-naming requires SEV-ES
-	SEV_CONFIG_NO_SEND         TeeConfigFlagBits = 0b00001000 //revive:disable-line:var-naming no transferring the guest to another platform
-	SEV_CONFIG_DOMAIN          TeeConfigFlagBits = 0b00010000 //revive:disable-line:var-naming no transferring the guest out of the domain (?)
-	SEV_CONFIG_SEV             TeeConfigFlagBits = 0b00100000 //revive:disable-line:var-naming no transferring the guest to non-SEV platforms
-	SNP_CONFIG_SMT             TeeConfigFlagBits = 0b00000001 //revive:disable-line:var-naming SMT is enabled on the host machine
-	SNP_CONFIG_MANDATORY       TeeConfigFlagBits = 0b00000010 //revive:disable-line:var-naming reserved bit which should always be set
-	SNP_CONFIG_MIGRATE_MA      TeeConfigFlagBits = 0b00000100 //revive:disable-line:var-naming allowed to use a migration agent
-	SNP_CONFIG_DEBUG           TeeConfigFlagBits = 0b00001000 //revive:disable-line:var-naming allow debugging
+	SEV_CONFIG_NO_DEBUG        TeeConfigFlagBits = 0b00000001 // no debugging of guests
+	SEV_CONFIG_NO_KEY_SHARING  TeeConfigFlagBits = 0b00000010 // no sharing keys between guests
+	SEV_CONFIG_ENCRYPTED_STATE TeeConfigFlagBits = 0b00000100 // requires SEV-ES
+	SEV_CONFIG_NO_SEND         TeeConfigFlagBits = 0b00001000 // no transferring the guest to another platform
+	SEV_CONFIG_DOMAIN          TeeConfigFlagBits = 0b00010000 // no transferring the guest out of the domain (?)
+	SEV_CONFIG_SEV             TeeConfigFlagBits = 0b00100000 // no transferring the guest to non-SEV platforms
+	SNP_CONFIG_SMT             TeeConfigFlagBits = 0b00000001 // SMT is enabled on the host machine
+	SNP_CONFIG_MANDATORY       TeeConfigFlagBits = 0b00000010 // reserved bit which should always be set
+	SNP_CONFIG_MIGRATE_MA      TeeConfigFlagBits = 0b00000100 // allowed to use a migration agent
+	SNP_CONFIG_DEBUG           TeeConfigFlagBits = 0b00001000 // allow debugging
 )
 
 // TeeConfigFlagMinFW corresponds to a minimum version of the kernel+initrd

--- a/vendor/github.com/containers/buildah/internal/mkcw/types/workload.go
+++ b/vendor/github.com/containers/buildah/internal/mkcw/types/workload.go
@@ -28,7 +28,8 @@ type SnpWorkloadData struct {
 	Generation string `json:"gen"` // "milan" (naples=1, rome=2, milan=3, genoa/bergamo/siena=4, turin=5)
 }
 
+//nolint:revive,staticcheck // Don't warn about bad naming.
 const (
 	// SEV_NO_ES is a known trusted execution environment type: AMD-SEV (secure encrypted virtualization without encrypted state, requires epyc 1000 "naples")
-	SEV_NO_ES define.TeeType = "sev_no_es" //revive:disable-line:var-naming
+	SEV_NO_ES define.TeeType = "sev_no_es"
 )

--- a/vendor/github.com/containers/buildah/internal/mkcw/workload.go
+++ b/vendor/github.com/containers/buildah/internal/mkcw/workload.go
@@ -28,16 +28,21 @@ type (
 const (
 	maxWorkloadConfigSize    = 1024 * 1024
 	preferredPaddingBoundary = 4096
-	// SEV is a known trusted execution environment type: AMD-SEV
-	SEV = define.SEV
-	// SEV_NO_ES is a known trusted execution environment type: AMD-SEV without encrypted state
-	SEV_NO_ES = types.SEV_NO_ES //revive:disable-line:var-naming
-	// SNP is a known trusted execution environment type: AMD-SNP
-	SNP = define.SNP
+
 	// krun looks for its configuration JSON directly in a disk image if the last twelve bytes
 	// of the disk image are this magic value followed by a little-endian 64-bit
 	// length-of-the-configuration
 	krunMagic = "KRUN"
+)
+
+//nolint:revive,staticcheck
+const (
+	// SEV is a known trusted execution environment type: AMD-SEV
+	SEV = define.SEV
+	// SEV_NO_ES is a known trusted execution environment type: AMD-SEV without encrypted state
+	SEV_NO_ES = types.SEV_NO_ES
+	// SNP is a known trusted execution environment type: AMD-SNP
+	SNP = define.SNP
 )
 
 // ReadWorkloadConfigFromImage reads the workload configuration from the

--- a/vendor/github.com/containers/buildah/internal/sbom/presets.go
+++ b/vendor/github.com/containers/buildah/internal/sbom/presets.go
@@ -1,6 +1,10 @@
 package sbom
 
-import "github.com/containers/buildah/define"
+import (
+	"slices"
+
+	"github.com/containers/buildah/define"
+)
 
 // Preset returns a predefined SBOMScanOptions structure that has the passed-in
 // name as one of its "Type" values.
@@ -55,10 +59,8 @@ func Preset(name string) (preset *define.SBOMScanOptions, err error) {
 		},
 	}
 	for _, preset := range presets {
-		for _, presetName := range preset.Type {
-			if presetName == name {
-				return &preset, nil
-			}
+		if slices.Contains(preset.Type, name) {
+			return &preset, nil
 		}
 	}
 	return nil, nil

--- a/vendor/github.com/containers/buildah/new.go
+++ b/vendor/github.com/containers/buildah/new.go
@@ -99,10 +99,8 @@ func newContainerIDMappingOptions(idmapOptions *define.IDMappingOptions) storage
 
 func containerNameExist(name string, containers []storage.Container) bool {
 	for _, container := range containers {
-		for _, cname := range container.Names {
-			if cname == name {
-				return true
-			}
+		if slices.Contains(container.Names, name) {
+			return true
 		}
 	}
 	return false
@@ -246,11 +244,11 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	suffixDigitsModulo := 100
 	for {
-		var flags map[string]interface{}
+		var flags map[string]any
 		// check if we have predefined ProcessLabel and MountLabel
 		// this could be true if this is another stage in a build
 		if options.ProcessLabel != "" && options.MountLabel != "" {
-			flags = map[string]interface{}{
+			flags = map[string]any{
 				"ProcessLabel": options.ProcessLabel,
 				"MountLabel":   options.MountLabel,
 			}

--- a/vendor/github.com/containers/buildah/pkg/cli/build.go
+++ b/vendor/github.com/containers/buildah/pkg/cli/build.go
@@ -68,10 +68,8 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 			tags = tags[1:]
 		}
 		if c.Flag("manifest").Changed {
-			for _, tag := range tags {
-				if tag == iopts.Manifest {
-					return options, nil, nil, errors.New("the same name must not be specified for both '--tag' and '--manifest'")
-				}
+			if slices.Contains(tags, iopts.Manifest) {
+				return options, nil, nil, errors.New("the same name must not be specified for both '--tag' and '--manifest'")
 			}
 		}
 	}
@@ -378,6 +376,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		IIDFile:                 iopts.Iidfile,
 		IgnoreFile:              iopts.IgnoreFile,
 		In:                      stdin,
+		InheritLabels:           types.NewOptionalBool(iopts.InheritLabels),
 		Isolation:               isolation,
 		Jobs:                    &iopts.Jobs,
 		Labels:                  iopts.Label,

--- a/vendor/github.com/containers/buildah/pkg/cli/common.go
+++ b/vendor/github.com/containers/buildah/pkg/cli/common.go
@@ -6,6 +6,7 @@ package cli
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"runtime"
 	"strings"
@@ -71,6 +72,7 @@ type BudResults struct {
 	Format              string
 	From                string
 	Iidfile             string
+	InheritLabels       bool
 	Label               []string
 	LayerLabel          []string
 	Logfile             string
@@ -230,6 +232,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
 	fs.BoolVar(&flags.CompatVolumes, "compat-volumes", false, "preserve the contents of VOLUMEs during RUN instructions")
+	fs.BoolVar(&flags.InheritLabels, "inherit-labels", true, "inherit the labels from the base image or base stages.")
 	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.StringVarP(&flags.CWOptions, "cw", "", "", "confidential workload `options`")
@@ -455,13 +458,9 @@ func GetFromAndBudFlagsCompletions() commonComp.FlagCompletions {
 
 	// Add in the usernamespace and namespace flag completions
 	userNsComp := GetUserNSFlagsCompletions()
-	for name, comp := range userNsComp {
-		flagCompletion[name] = comp
-	}
+	maps.Copy(flagCompletion, userNsComp)
 	namespaceComp := GetNameSpaceFlagsCompletions()
-	for name, comp := range namespaceComp {
-		flagCompletion[name] = comp
-	}
+	maps.Copy(flagCompletion, namespaceComp)
 
 	return flagCompletion
 }

--- a/vendor/github.com/containers/buildah/pkg/jail/jail.go
+++ b/vendor/github.com/containers/buildah/pkg/jail/jail.go
@@ -29,7 +29,7 @@ const (
 )
 
 type config struct {
-	params map[string]interface{}
+	params map[string]any
 }
 
 var (
@@ -39,11 +39,11 @@ var (
 
 func NewConfig() *config {
 	return &config{
-		params: make(map[string]interface{}),
+		params: make(map[string]any),
 	}
 }
 
-func handleBoolSetting(key string, val bool) (string, interface{}) {
+func handleBoolSetting(key string, val bool) (string, any) {
 	// jail doesn't deal with booleans - it uses paired parameter
 	// names, e.g. "persist"/"nopersist". If the key contains '.',
 	// the "no" prefix is applied to the last element.
@@ -55,7 +55,7 @@ func handleBoolSetting(key string, val bool) (string, interface{}) {
 	return key, nil
 }
 
-func (c *config) Set(key string, value interface{}) {
+func (c *config) Set(key string, value any) {
 	// Normalise integer types to int32
 	switch v := value.(type) {
 	case int:

--- a/vendor/github.com/containers/buildah/pkg/parse/parse.go
+++ b/vendor/github.com/containers/buildah/pkg/parse/parse.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -705,11 +706,12 @@ func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
 				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", arr[0])
 			}
 			typeSelected = true
-			if arr[1] == "local" {
+			switch arr[1] {
+			case "local":
 				isDir = true
-			} else if arr[1] == "tar" {
+			case "tar":
 				isDir = false
-			} else {
+			default:
 				return define.BuildOutputOption{}, fmt.Errorf("invalid type %q selected for build output options %q", arr[1], buildOutput)
 			}
 		case "dest":
@@ -851,7 +853,7 @@ func SBOMScanOptionsFromFlagSet(flags *pflag.FlagSet, _ func(name string) *pflag
 	if image != "" || len(commands) > 0 || mergeStrategy != "" {
 		options = &define.SBOMScanOptions{
 			Image:         image,
-			Commands:      append([]string{}, commands...),
+			Commands:      slices.Clone(commands),
 			MergeStrategy: define.SBOMMergeStrategy(mergeStrategy),
 		}
 	}

--- a/vendor/github.com/containers/buildah/pkg/rusage/rusage_unix.go
+++ b/vendor/github.com/containers/buildah/pkg/rusage/rusage_unix.go
@@ -22,8 +22,8 @@ func get() (Rusage, error) {
 		Date:     time.Now(),
 		Utime:    mkduration(rusage.Utime),
 		Stime:    mkduration(rusage.Stime),
-		Inblock:  int64(rusage.Inblock), // nolint: unconvert
-		Outblock: int64(rusage.Oublock), // nolint: unconvert
+		Inblock:  int64(rusage.Inblock), //nolint:unconvert
+		Outblock: int64(rusage.Oublock), //nolint:unconvert
 	}
 	return r, nil
 }

--- a/vendor/github.com/containers/buildah/pkg/sshagent/sshagent.go
+++ b/vendor/github.com/containers/buildah/pkg/sshagent/sshagent.go
@@ -38,7 +38,7 @@ func NewAgentServer(source *Source) (*AgentServer, error) {
 }
 
 // newAgentServerKeyring creates a new agent from scratch and adds keys
-func newAgentServerKeyring(keys []interface{}) (*AgentServer, error) {
+func newAgentServerKeyring(keys []any) (*AgentServer, error) {
 	a := agent.NewKeyring()
 	for _, k := range keys {
 		if err := a.Add(agent.AddedKey{PrivateKey: k}); err != nil {
@@ -191,12 +191,12 @@ func (a *readOnlyAgent) Extension(_ string, _ []byte) ([]byte, error) {
 // The source of the forwarded agent can be from a socket on the host, or from individual key files
 type Source struct {
 	Socket string
-	Keys   []interface{}
+	Keys   []any
 }
 
 // NewSource takes paths and checks of they are keys or sockets, and creates a source
 func NewSource(paths []string) (*Source, error) {
-	var keys []interface{}
+	var keys []any
 	var socket string
 	if len(paths) == 0 {
 		socket = os.Getenv("SSH_AUTH_SOCK")

--- a/vendor/github.com/containers/buildah/scan.go
+++ b/vendor/github.com/containers/buildah/scan.go
@@ -107,7 +107,7 @@ func (b *Builder) sbomScan(ctx context.Context, options CommitOptions) (imageFil
 			// Start by assuming it's shell -c $whatever.
 			parsedCommand := []string{"/bin/sh", "-c", commandSpec}
 			if shell := scanBuilder.Shell(); len(shell) != 0 {
-				parsedCommand = append(append([]string{}, shell...), commandSpec)
+				parsedCommand = append(slices.Clone(shell), commandSpec)
 			}
 			if !strings.ContainsAny(commandSpec, "<>|") { // An imperfect check for shell redirection being used.
 				// If we can parse it ourselves, though, prefer to use that result,

--- a/vendor/github.com/containers/buildah/util/util.go
+++ b/vendor/github.com/containers/buildah/util/util.go
@@ -335,12 +335,8 @@ func logIfNotErrno(err error, what string, ignores ...syscall.Errno) (logged boo
 	if err == nil {
 		return false
 	}
-	if errno, isErrno := err.(syscall.Errno); isErrno {
-		for _, ignore := range ignores {
-			if errno == ignore {
-				return false
-			}
-		}
+	if errno, ok := err.(syscall.Errno); ok && slices.Contains(ignores, errno) {
+		return false
 	}
 	logrus.Error(what)
 	return true

--- a/vendor/github.com/docker/docker/api/types/registry/registry.go
+++ b/vendor/github.com/docker/docker/api/types/registry/registry.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.22
 
 package registry // import "github.com/docker/docker/api/types/registry"
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/directives.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/directives.go
@@ -148,14 +148,16 @@ func parseDirective(key string, dt []byte, anyFormat bool) (string, string, []Ra
 	}
 
 	// use json directive, and search for { "key": "..." }
-	jsonDirective := map[string]string{}
+	jsonDirective := map[string]any{}
 	if err := json.Unmarshal(dt, &jsonDirective); err == nil {
-		if v, ok := jsonDirective[key]; ok {
-			loc := []Range{{
-				Start: Position{Line: line},
-				End:   Position{Line: line},
-			}}
-			return v, v, loc, true
+		if vAny, ok := jsonDirective[key]; ok {
+			if v, ok := vAny.(string); ok {
+				loc := []Range{{
+					Start: Position{Line: line},
+					End:   Position{Line: line},
+				}}
+				return v, v, loc, true
+			}
 		}
 	}
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/line_parsers.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/line_parsers.go
@@ -281,7 +281,7 @@ func parseJSON(rest string) (*Node, map[string]bool, error) {
 		return nil, nil, errDockerfileNotJSONArray
 	}
 
-	var myJSON []interface{}
+	var myJSON []any
 	if err := json.Unmarshal([]byte(rest), &myJSON); err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/parser.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/parser.go
@@ -220,7 +220,7 @@ func init() {
 // based on the command and command arguments. A Node is created from the
 // result of the dispatch.
 func newNodeFromLine(line string, d *directives, comments []string) (*Node, error) {
-	cmd, flags, args, err := splitCommand(line)
+	cmd, flags, args, err := splitCommand(line, d)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/split_command.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/parser/split_command.go
@@ -7,7 +7,7 @@ import (
 
 // splitCommand takes a single line of text and parses out the cmd and args,
 // which are used for dispatching to more exact parsing functions.
-func splitCommand(line string) (string, []string, string, error) {
+func splitCommand(line string, d *directives) (string, []string, string, error) {
 	var args string
 	var flags []string
 
@@ -16,7 +16,7 @@ func splitCommand(line string) (string, []string, string, error) {
 
 	if len(cmdline) == 2 {
 		var err error
-		args, flags, err = extractBuilderFlags(cmdline[1])
+		args, flags, err = extractBuilderFlags(cmdline[1], d)
 		if err != nil {
 			return "", nil, "", err
 		}
@@ -25,7 +25,7 @@ func splitCommand(line string) (string, []string, string, error) {
 	return cmdline[0], flags, strings.TrimSpace(args), nil
 }
 
-func extractBuilderFlags(line string) (string, []string, error) {
+func extractBuilderFlags(line string, d *directives) (string, []string, error) {
 	// Parses the BuilderFlags and returns the remaining part of the line
 
 	const (
@@ -87,7 +87,7 @@ func extractBuilderFlags(line string) (string, []string, error) {
 				phase = inQuote
 				continue
 			}
-			if ch == '\\' {
+			if ch == d.escapeToken {
 				if pos+1 == len(line) {
 					continue // just skip \ at end
 				}
@@ -104,7 +104,7 @@ func extractBuilderFlags(line string) (string, []string, error) {
 				phase = inWord
 				continue
 			}
-			if ch == '\\' {
+			if ch == d.escapeToken {
 				if pos+1 == len(line) {
 					phase = inWord
 					continue // just skip \ at end

--- a/vendor/golang.org/x/tools/go/ast/inspector/inspector.go
+++ b/vendor/golang.org/x/tools/go/ast/inspector/inspector.go
@@ -10,6 +10,7 @@
 // builds a list of push/pop events and their node type. Subsequent
 // method calls that request a traversal scan this list, rather than walk
 // the AST, and perform type filtering using efficient bit sets.
+// This representation is sometimes called a "balanced parenthesis tree."
 //
 // Experiments suggest the inspector's traversals are about 2.5x faster
 // than ast.Inspect, but it may take around 5 traversals for this
@@ -50,6 +51,7 @@ type Inspector struct {
 //go:linkname events
 func events(in *Inspector) []event { return in.events }
 
+//go:linkname packEdgeKindAndIndex
 func packEdgeKindAndIndex(ek edge.Kind, index int) int32 {
 	return int32(uint32(index+1)<<7 | uint32(ek))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -723,8 +723,6 @@ github.com/moby/go-archive/tarheader
 # github.com/moby/patternmatcher v0.6.0
 ## explicit; go 1.19
 github.com/moby/patternmatcher
-# github.com/moby/sys/atomicwriter v0.1.0
-## explicit; go 1.18
 # github.com/moby/sys/capability v0.4.0
 ## explicit; go 1.21
 github.com/moby/sys/capability

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -110,8 +110,8 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.6.2
 ## explicit; go 1.23
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.39.1-0.20250401180830-32d78c69be17
-## explicit; go 1.23.0
+# github.com/containers/buildah v1.40.0
+## explicit; go 1.23.3
 github.com/containers/buildah
 github.com/containers/buildah/bind
 github.com/containers/buildah/chroot
@@ -428,7 +428,7 @@ github.com/distribution/reference
 ## explicit
 github.com/docker/distribution/registry/api/errcode
 github.com/docker/distribution/registry/api/v2
-# github.com/docker/docker v28.1.1+incompatible
+# github.com/docker/docker v28.1.0+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -706,8 +706,8 @@ github.com/mistifyio/go-zfs/v3
 # github.com/mitchellh/mapstructure v1.5.0
 ## explicit; go 1.14
 github.com/mitchellh/mapstructure
-# github.com/moby/buildkit v0.20.2
-## explicit; go 1.22.0
+# github.com/moby/buildkit v0.21.0
+## explicit; go 1.23.0
 github.com/moby/buildkit/frontend/dockerfile/command
 github.com/moby/buildkit/frontend/dockerfile/parser
 github.com/moby/buildkit/frontend/dockerfile/shell
@@ -1103,8 +1103,6 @@ golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/twofish
 golang.org/x/crypto/xts
-# golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
-## explicit; go 1.22.0
 # golang.org/x/mod v0.24.0
 ## explicit; go 1.23.0
 golang.org/x/mod/semver
@@ -1168,7 +1166,7 @@ golang.org/x/text/unicode/norm
 # golang.org/x/time v0.11.0
 ## explicit; go 1.23.0
 golang.org/x/time/rate
-# golang.org/x/tools v0.31.0
+# golang.org/x/tools v0.32.0
 ## explicit; go 1.23.0
 golang.org/x/tools/cover
 golang.org/x/tools/go/ast/inspector


### PR DESCRIPTION
Bumps to Buildah v1.40.0 and adds the `--inherits-labels` option to build and farm build man pages.

Also turn off the inherit-labels option test for now as it seems to be rather unhappy.

Issue for inherit-labels test failure: https://github.com/containers/podman/issues/25938

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
