### PR TITLE
[CI DOCS] Touchup buildah-bud README.md

### DIFF
--- a/test/buildah-bud/README.md
+++ b/test/buildah-bud/README.md
@@ -93,7 +93,7 @@ If the failure was in tests run, and you're vendoring, your only real choice is 
 
 * Identify the failing test(s)
 * File a new podman issue, e.g. "podman build fails buildah XYZ test"
-* Edit `test/buildah/bud/apply-podman-deltas`. Search for "actual podman bugs" near the bottom, and add a new `skip` line with the reason (INCLUDE THE ISSUE NUMBER!) and the test name.
+* Edit `test/buildah-bud/apply-podman-deltas`. Search for "actual podman bugs" near the bottom, and add a new `skip` line with the reason (INCLUDE THE ISSUE NUMBER!) and the test name.
 
 ### In all cases
 


### PR DESCRIPTION
The README.md in test/buildah-bud had the old directory name for the apply-podman-deltas file.  This change removes the `/` and adds a `-` in that file name.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
