### PR TITLE
Remove using `rw` as a default mount option

### DIFF
--- a/pkg/util/mount_opts.go
+++ b/pkg/util/mount_opts.go
@@ -191,9 +191,6 @@ func processOptionsInternal(options []string, isTmpfs bool, sourcePath string, g
 		newOptions = append(newOptions, opt)
 	}
 
-	if !foundWrite {
-		newOptions = append(newOptions, "rw")
-	}
 	if !foundProp {
 		if recursiveBind {
 			newOptions = append(newOptions, "rprivate")

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -802,13 +802,13 @@ func TestProcessOptions(t *testing.T) {
 		{
 			name:       "default bind mount",
 			sourcePath: "/path/to/source",
-			expected:   []string{"nodev", "nosuid", "rbind", "rprivate", "rw"},
+			expected:   []string{"nodev", "nosuid", "rbind", "rprivate"},
 		},
 		{
 			name:       "default bind mount with bind",
 			sourcePath: "/path/to/source",
 			options:    []string{"bind"},
-			expected:   []string{"nodev", "nosuid", "bind", "private", "rw"},
+			expected:   []string{"nodev", "nosuid", "bind", "private"},
 		},
 	}
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5818,7 +5818,7 @@ spec:
 		podmanTest.PodmanExitCleanly("kube", "play", outputFile)
 
 		inspectCtr2 := podmanTest.PodmanExitCleanly("inspect", "-f", "'{{ .HostConfig.Binds }}'", ctrNameInKubePod)
-		Expect(inspectCtr2.OutputToString()).To(ContainSubstring(":" + vol1 + ":rw"))
+		Expect(inspectCtr2.OutputToString()).To(ContainSubstring(":" + vol1))
 
 		inspectCtr1 := podmanTest.PodmanExitCleanly("inspect", "-f", "'{{ .HostConfig.Binds }}'", ctr1)
 		Expect(inspectCtr2.OutputToString()).To(Equal(inspectCtr1.OutputToString()))

--- a/test/python/docker/compat/test_containers.py
+++ b/test/python/docker/compat/test_containers.py
@@ -265,7 +265,7 @@ class TestContainers(common.DockerTestCase):
                 has_tried_pull = True
         self.assertFalse(has_tried_pull, "the build process has tried tried to pull the base image")
 
-    def test_mount_rw_by_default(self):
+    def test_mount_options_by_default(self):
         ctr: Optional[Container] = None
         vol: Optional[Volume] = None
 
@@ -282,7 +282,7 @@ class TestContainers(common.DockerTestCase):
             ctr_inspect = self.docker.api.inspect_container(ctr.id)
             binds: List[str] = ctr_inspect["HostConfig"]["Binds"]
             self.assertEqual(len(binds), 1)
-            self.assertEqual(binds[0], "test-volume:/vol-mnt:rw,rprivate,nosuid,nodev,rbind")
+            self.assertEqual(binds[0], "test-volume:/vol-mnt:rprivate,nosuid,nodev,rbind")
         finally:
             if ctr is not None:
                 ctr.remove()

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -988,7 +988,7 @@ EOF
     service_setup $QUADLET_SERVICE_NAME
 
     run_podman container inspect  --format '{{index .HostConfig.Tmpfs "/tmpfs1"}}' $QUADLET_CONTAINER_NAME
-    is "$output" "rw,rprivate,nosuid,nodev,tmpcopyup" "regular tmpfs mount"
+    is "$output" "rprivate,nosuid,nodev,tmpcopyup" "regular tmpfs mount"
 
     run_podman container inspect  --format '{{index .HostConfig.Tmpfs "/tmpfs2"}}' $QUADLET_CONTAINER_NAME
     is "$output" "ro,rprivate,nosuid,nodev,tmpcopyup" "read-only tmpfs mount"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
Podman is currently using the default mount option for the volumes as `rw` if not specified by the user. This can lead to the permission issues if the mount point is `ro`. In this PR, I removed setting up any default mount flag, so the underlying run time can handle it.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
