### PR TITLE
feat: Add support for configuring swap in Podman machine

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -83,6 +83,14 @@ func init() {
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
 
+	swapFlagName := "swap"
+	flags.Uint64VarP(
+		&initOpts.Swap,
+		swapFlagName, "s", 0,
+		"Swap in MiB",
+	)
+	_ = initCmd.RegisterFlagCompletionFunc(swapFlagName, completion.AutocompleteNone)
+
 	flags.BoolVar(
 		&now,
 		"now", false,

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -119,6 +119,7 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.ListReporter) erro
 		"CPUs":     "CPUS",
 		"Memory":   "MEMORY",
 		"DiskSize": "DISK SIZE",
+		"Swap":     "SWAP",
 	})
 
 	rpt := report.New(os.Stdout, cmd.Name())
@@ -182,6 +183,7 @@ func toMachineFormat(vms []*machine.ListResponse, defaultCon *config.Connection)
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
 		response.Memory = strUint(uint64(vm.Memory.ToBytes()))
+		response.Swap = strUint(uint64(vm.Swap.ToBytes()))
 		response.DiskSize = strUint(uint64(vm.DiskSize.ToBytes()))
 		response.Port = vm.Port
 		response.RemoteUsername = vm.RemoteUsername
@@ -225,6 +227,7 @@ func toHumanFormat(vms []*machine.ListResponse, defaultCon *config.Connection) [
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
 		response.Memory = units.BytesSize(float64(vm.Memory.ToBytes()))
+		response.Swap = units.BytesSize(float64(vm.Swap.ToBytes()))
 		response.DiskSize = units.BytesSize(float64(vm.DiskSize.ToBytes()))
 
 		humanResponses = append(humanResponses, response)

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -104,6 +104,12 @@ if there is no existing remote connection configurations.
 
 API forwarding, if available, follows this setting.
 
+#### **--swap**, **-s**=*number*
+
+Swap (in MiB). Note: 1024MiB = 1GiB.
+
+Renders a `zram-generator.conf` file with zram-size set to the value passed to --swap
+
 #### **--timezone**
 
 Set the timezone for the machine and containers.  Valid values are `local` or

--- a/docs/source/markdown/podman-machine-list.1.md.in
+++ b/docs/source/markdown/podman-machine-list.1.md.in
@@ -50,6 +50,7 @@ Valid placeholders for the Go template are listed below:
 | .RemoteUsername     | VM Username for rootless Podman           |
 | .Running            | Is machine running                        |
 | .Stream             | Stream name                               |
+| .Swap               | Allocated swap for machine               |
 | .UserModeNetworking | Whether machine uses user-mode networking |
 | .VMType             | VM type                                   |
 

--- a/pkg/domain/entities/machine.go
+++ b/pkg/domain/entities/machine.go
@@ -13,6 +13,7 @@ type ListReporter struct {
 	VMType             string
 	CPUs               uint64
 	Memory             string
+	Swap               string
 	DiskSize           string
 	Port               int
 	RemoteUsername     string

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -22,9 +22,7 @@ import (
 
 const apiUpTimeout = 20 * time.Second
 
-var (
-	ForwarderBinaryName = "gvproxy"
-)
+var ForwarderBinaryName = "gvproxy"
 
 type Download struct {
 	Arch                  string
@@ -55,6 +53,7 @@ type ListResponse struct {
 	VMType             string
 	CPUs               uint64
 	Memory             strongunits.MiB
+	Swap               strongunits.MiB
 	DiskSize           strongunits.GiB
 	Port               int
 	RemoteUsername     string

--- a/pkg/machine/define/initopts.go
+++ b/pkg/machine/define/initopts.go
@@ -11,6 +11,7 @@ type InitOptions struct {
 	Volumes            []string
 	IsDefault          bool
 	Memory             uint64
+	Swap               uint64
 	Name               string
 	TimeZone           string
 	URI                url.URL

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -28,6 +28,7 @@ type initMachine struct {
 	playbook           string
 	cpus               *uint
 	diskSize           *uint
+	swap               *uint
 	ignitionPath       string
 	username           string
 	image              string
@@ -81,6 +82,9 @@ func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
 	if i.userModeNetworking {
 		cmd = append(cmd, "--user-mode-networking")
 	}
+	if i.swap != nil {
+		cmd = append(cmd, "--swap", strconv.Itoa(int(*i.swap)))
+	}
 	name := m.name
 	cmd = append(cmd, name)
 
@@ -112,8 +116,14 @@ func (i *initMachine) withCPUs(num uint) *initMachine {
 	i.cpus = &num
 	return i
 }
+
 func (i *initMachine) withDiskSize(size uint) *initMachine {
 	i.diskSize = &size
+	return i
+}
+
+func (i *initMachine) withSwap(size uint) *initMachine {
+	i.swap = &size
 	return i
 }
 

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -30,9 +30,7 @@ import (
 // List is done at the host level to allow for a *possible* future where
 // more than one provider is used
 func List(vmstubbers []vmconfigs.VMProvider, _ machine.ListOptions) ([]*machine.ListResponse, error) {
-	var (
-		lrs []*machine.ListResponse
-	)
+	var lrs []*machine.ListResponse
 
 	for _, s := range vmstubbers {
 		dirs, err := env.GetMachineDirs(s.VMType())
@@ -49,15 +47,15 @@ func List(vmstubbers []vmconfigs.VMProvider, _ machine.ListOptions) ([]*machine.
 				return nil, err
 			}
 			lr := machine.ListResponse{
-				Name:      name,
-				CreatedAt: mc.Created,
-				LastUp:    mc.LastUp,
-				Running:   state == machineDefine.Running,
-				Starting:  mc.Starting,
-				//Stream:             "", // No longer applicable
+				Name:               name,
+				CreatedAt:          mc.Created,
+				LastUp:             mc.LastUp,
+				Running:            state == machineDefine.Running,
+				Starting:           mc.Starting,
 				VMType:             s.VMType().String(),
 				CPUs:               mc.Resources.CPUs,
 				Memory:             mc.Resources.Memory,
+				Swap:               mc.Swap,
 				DiskSize:           mc.Resources.DiskSize,
 				Port:               mc.SSH.Port,
 				RemoteUsername:     mc.SSH.RemoteUsername,
@@ -204,13 +202,13 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		VMType:    mp.VMType(),
 		WritePath: ignitionFile.GetPath(),
 		Rootful:   opts.Rootful,
+		Swap:      opts.Swap,
 	})
 
 	// If the user provides an ignition file, we need to
 	// copy it into the conf dir
 	if len(opts.IgnitionPath) > 0 {
 		err = ignBuilder.BuildWithIgnitionFile(opts.IgnitionPath)
-
 		if err != nil {
 			return err
 		}

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -27,6 +27,8 @@ type MachineConfig struct {
 	SSH       SSHConfig
 	Version   uint
 
+	Swap strongunits.MiB
+
 	// Image stuff
 	imageDescription machineImage //nolint:unused
 

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -81,6 +81,10 @@ func NewMachineConfig(opts define.InitOptions, dirs *define.MachineDirs, sshIden
 	}
 	mc.Resources = mrc
 
+	if opts.Swap > 0 {
+		mc.Swap = strongunits.MiB(opts.Swap)
+	}
+
 	sshPort, err := ports.AllocateMachinePort()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add `--swap` argument to `podman machine init` command.

Passing an int64 value to this flag will trigger the Podman machine
ignition file to be generated with a zram-generator.conf file containing
the --swap value as the zram-size argument.

This file is read by the zram-generator systemd service on boot
resulting in a zram swap device being created.

Fixes: https://github.com/containers/podman/issues/15980

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add new --swap argument to `podman machine init` command to enable and configure swap
```
