### PR TITLE
chore: use another script to get the version of gvproxy + fix download link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ endif
 
 # gvisor-tap-vsock version for gvproxy.exe and win-sshproxy.exe downloads
 # the upstream project ships pre-built binaries since version 0.7.1
-GVPROXY_VERSION=$(shell grep github.com/containers/gvisor-tap-vsock go.mod  | cut -d" " -f2)
+GVPROXY_VERSION=$(shell $(GO) list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
 
 ###
 ### Primary entry-point targets

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -1,4 +1,5 @@
 SHELL := bash
+GO ?= go
 
 ARCH ?= aarch64
 ifeq ($(ARCH), aarch64)
@@ -6,10 +7,10 @@ ifeq ($(ARCH), aarch64)
 else
 	GOARCH:=$(ARCH)
 endif
-GVPROXY_VERSION ?= $(shell grep github.com/containers/gvisor-tap-vsock ../../go.mod  | cut -d" " -f2)
+GVPROXY_VERSION=$(shell $(GO) list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
 VFKIT_VERSION ?= 0.6.1
 KRUNKIT_VERSION ?= 0.2.0
-GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
+GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
 KRUNKIT_RELEASE_URL ?= https://github.com/containers/krunkit/releases/download/v$(KRUNKIT_VERSION)/krunkit-podman-unsigned-$(KRUNKIT_VERSION).tgz
 PACKAGE_DIR ?= out/packaging


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Trying to build the podman installer after https://github.com/containers/podman/pull/25688 I noticed that the gvproxy is not downloaded (there is a v in the VERSION property then as in the URL another v was added, it was fetching a "not found" content binary.

I saw that we should use another script, so switch to the new script. Need to add GO variable at the beginning of the Makefile as well to reuse the same script

I also tested `make win-gvproxy`

```
mkdir -p bin/windows/
curl -sSL -o bin/windows/gvproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/v0.8.5/gvproxy-windowsgui.exe
curl -sSL -o bin/windows/win-sshproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/v0.8.5/win-sshproxy.exe
```

and it fetches the right binary
