### PR TITLE
remote: don't print bogus error when starting container attached

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -806,7 +806,6 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 						logrus.Errorf("Failed to check if %s should restart: %v", ctr.ID, err)
 						return
 					}
-					logrus.Errorf("Should restart: %v", shouldRestart)
 
 					if !shouldRestart && ctr.AutoRemove {
 						removeContainer(ctr.ID, ctr.CIDFile)

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -149,4 +149,18 @@ load helpers
     run_podman rm -t 0 -f $ctrID $cname
 }
 
+# Regression test for https://github.com/containers/podman/issues/25965
+# bats test_tags=ci:parallel
+@test "podman start attach with created --rm container" {
+    local msg=c-$(safename)
+    run_podman create --rm $IMAGE echo "$msg"
+    cid="$output"
+
+    run_podman start -a $cid
+    assert "$output" == "$msg" "attach printed the expected output"
+
+    # container must be removed on its own as it was created with --rm
+    run_podman 1 container exists $cid
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
This looks like debug leftover, in any case this is not an error so simply remove the line.

Fixes #25965

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman-remote start --attach would print a bogus error when the container was created with --rm.
```
