### PR TITLE
docs: fix container create mounts field

### DIFF
--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -230,6 +230,12 @@ type ContainerBasicConfig struct {
 	GroupEntry string `json:"group_entry,omitempty"`
 }
 
+
+// Embed the Mount type to make the Go Swagger resolve to the correct type
+type SpecMount struct {
+	spec.Mount
+}
+
 // ContainerStorageConfig contains information on the storage configuration of a
 // container.
 type ContainerStorageConfig struct {
@@ -293,7 +299,7 @@ type ContainerStorageConfig struct {
 	// These will supersede Image Volumes and VolumesFrom volumes where
 	// there are conflicts.
 	// Optional.
-	Mounts []spec.Mount `json:"mounts,omitempty"`
+	Mounts []SpecMount `json:"mounts,omitempty"`
 	// Volumes are named volumes that will be added to the container.
 	// These will supersede Image Volumes and VolumesFrom volumes where
 	// there are conflicts.


### PR DESCRIPTION
Name collision makes the Swagger confused about the types while the Go compiler handles the types correctly and is able to link the imports correctly.

Fixes: https://github.com/containers/podman/issues/13717
Fixes: https://github.com/containers/podman/issues/13092

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
mounts option for /libpod/containers/create
```

cc @mheon 