### PR TITLE
Disable FS mount in volume only test

### DIFF
--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -100,16 +100,9 @@ var _ = Describe("run basic podman commands", func() {
 	})
 
 	It("Single character volume mount", func() {
-		// Get a tmp directory
-		tDir, err := filepath.Abs(GinkgoT().TempDir())
-		Expect(err).ToNot(HaveOccurred())
 		name := randomString()
 		i := new(initMachine).withImage(mb.imagePath).withNow()
 
-		// All other platforms have an implicit mount for the temp area
-		if isVmtype(define.QemuVirt) {
-			i.withVolume(tDir)
-		}
 		session, err := mb.setName(name).setCmd(i).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))


### PR DESCRIPTION
The test is checking that named volumes could be used. FS mount is not needed and there is no code testing anything around it.

This makes this test pass in env, where virtiofs is not available for QEMU.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
