### PR TITLE
OWNERS: Fix GitHub handle

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,7 +16,7 @@ reviewers:
   - baude
   - flouthoc
   - giuseppe
-  - honny1
+  - Honny1
   - jakecorrenti
   - jwhonce
   - l0rd


### PR DESCRIPTION
The `OWNERS` file contains an incorrect GitHub handle `honny1`. The correct GitHub handle is `Honny1`. This causes `/approve` comments to have no effect on PR. The `MAINTAINERS.md` file contains the correct GitHub handle.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
