### PR TITLE
Quadlet - remove the usage of cid and podid for container and pod files

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -604,6 +604,9 @@ func generateUnitsInfoMap(units []*parser.UnitFile) map[string]*quadlet.UnitInfo
 		case strings.HasSuffix(unit.Filename, ".pod"):
 			serviceName = quadlet.GetPodServiceName(unit)
 			containers = make([]string, 0)
+			// Prefill resouceNames for .pod files.
+			// This is requires for referencing the pod from .container files
+			resourceName = quadlet.GetPodResourceName(unit)
 		default:
 			Logf("Unsupported file type %q", unit.Filename)
 			continue

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args run --name systemd-%N --cidfile=%t/%N.cid --replace --rm --cgroups=split --sdnotify=conmon  -d localhost/imagename
+## assert-podman-final-args run --name systemd-%N --replace --rm --cgroups=split --sdnotify=conmon  -d localhost/imagename
 
 [Container]
 Image=localhost/imagename

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -1,6 +1,5 @@
 ## assert-podman-final-args localhost/imagename
 ## assert-podman-args "--name" "systemd-%N"
-## assert-podman-args "--cidfile=%t/%N.cid"
 ## assert-podman-args "--rm"
 ## assert-podman-args "--replace"
 ## assert-podman-args "-d"
@@ -12,8 +11,8 @@
 ## assert-key-is "Service" "Type" "notify"
 ## assert-key-is "Service" "NotifyAccess" "all"
 ## assert-key-is "Service" "SyslogIdentifier" "%N"
-## assert-key-is-regex "Service" "ExecStopPost" "-[/S].*/podman rm -v -f -i --cidfile=%t/%N.cid"
-## assert-key-is-regex "Service" "ExecStop" ".*/podman rm -v -f -i --cidfile=%t/%N.cid"
+## assert-key-is-regex "Service" "ExecStopPost" "-[/S].*/podman rm -v -f -i systemd-%N"
+## assert-key-is-regex "Service" "ExecStop" ".*/podman rm -v -f -i systemd-%N"
 ## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
 ## assert-key-is-regex "Unit" "After" "network-online.target|podman-user-wait-network-online.service"
 ## assert-key-is-regex "Unit" "Wants" "network-online.target|podman-user-wait-network-online.service"

--- a/test/e2e/quadlet/basic.pod
+++ b/test/e2e/quadlet/basic.pod
@@ -1,9 +1,9 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type forking
 ## assert-key-is Service SyslogIdentifier "%N"
-## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --pod-id-file=%t/%N.pod-id --exit-policy=stop --replace --infra-name systemd-basic-infra --name systemd-basic"
-## assert-key-is-regex Service ExecStart ".*/podman pod start --pod-id-file=%t/%N.pod-id"
-## assert-key-is-regex Service ExecStop ".*/podman pod stop --pod-id-file=%t/%N.pod-id --ignore --time=10"
-## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --pod-id-file=%t/%N.pod-id --ignore --force"
+## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --exit-policy=stop --replace --infra-name systemd-basic-infra --name systemd-basic"
+## assert-key-is-regex Service ExecStart ".*/podman pod start systemd-basic"
+## assert-key-is-regex Service ExecStop ".*/podman pod stop --ignore --time=10 systemd-basic"
+## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --ignore --force systemd-basic"
 
 [Pod]

--- a/test/e2e/quadlet/reloadcmd.container
+++ b/test/e2e/quadlet/reloadcmd.container
@@ -1,5 +1,5 @@
 ## assert-podman-reload-args "exec"
-## assert-podman-reload-args "--cidfile=%t/%N.cid"
+## assert-podman-reload-args "systemd-%N"
 ## assert-podman-reload-final-args "/some/binary file" "--arg1" "arg 2"
 
 [Container]

--- a/test/e2e/quadlet/reloadsignal.container
+++ b/test/e2e/quadlet/reloadsignal.container
@@ -1,5 +1,5 @@
 ## assert-podman-reload-args "kill"
-## assert-podman-reload-args "--cidfile=%t/%N.cid"
+## assert-podman-reload-args "systemd-%N"
 ## assert-podman-reload-args "--signal" "SIGHUP"
 
 [Container]


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - remove the usage of cid and podid, stop the container or pod by their names instead
```
