### PR TITLE
Update "check.c" to be C23 compliant

### DIFF
--- a/contrib/win-installer/podman-msihooks/check.c
+++ b/contrib/win-installer/podman-msihooks/check.c
@@ -3,7 +3,7 @@
 
 BOOL isWSLEnabled();
 BOOL isHyperVEnabled();
-LPCWSTR boolToNStr(BOOL bool);
+LPCWSTR boolToNStr(BOOL value);
 LPCSTR szSvcNameHyperv = TEXT("vmms");
 
 /**
@@ -43,8 +43,8 @@ LPCSTR szSvcNameHyperv = TEXT("vmms");
 	return 0;
 }
 
-LPCWSTR boolToNStr(BOOL bool) {
-	return bool ? L"1" : L"0";
+LPCWSTR boolToNStr(BOOL value) {
+	return value ? L"1" : L"0";
 }
 
 BOOL isWSLEnabled() {


### PR DESCRIPTION
Fixes compilation errors with GCC 15.

GCC 15 defaults to C23 standard, which introduced new keywords (including `bool`): https://gcc.gnu.org/gcc-15/porting_to.html#c23

Alternative fix would be to change build script to use lower C standard version.

It seems that at some point this file might be removed, because installer would not be responsible for installing dependencies anymore, but for now this fix would allow to build Podman installer with msys2 tooling (they upgraded
GCC to 15).

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
