### PR TITLE
pkg/bindings: fix infinite loop/memory leak in image pull

### DIFF
--- a/pkg/bindings/images/push.go
+++ b/pkg/bindings/images/push.go
@@ -74,7 +74,7 @@ LOOP:
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return err
+			return fmt.Errorf("failed to decode message from stream: %w", err)
 		}
 
 		select {


### PR DESCRIPTION
In the case of an Decoder error which is not EOF we loop forever, as the
Decoder stores some errors each next Decode() call will keep returning
the same error. Thus we loop forever until we run out of memory as each
error was stored in pullErrors array as described in [1].

Note this does not actually fix whatever causes the underlying
connection error in the issue, it just fixes the loop/memory leak.


---

pkg/bindings: wrap image push decode error

If this fails we should know exactly what failed. The underlying
connection error might just be unexpected EOF or somthing which is not
helpful.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes potential infinite loop/memory leak in podman-remote pull when the server connection is closed unexpectedly 
```
