### PR TITLE
Update podman ps --watch to use a default value

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -47,6 +47,7 @@ var (
 		Example:           strings.ReplaceAll(psCommand.Example, "podman ps", "podman container ps"),
 	}
 )
+
 var (
 	listOpts = entities.ContainerListOptions{
 		Filters: make(map[string][]string),
@@ -97,7 +98,8 @@ func listFlagSet(cmd *cobra.Command) {
 	flags.BoolVar(&listOpts.Sync, "sync", false, "Sync container state with OCI runtime")
 
 	watchFlagName := "watch"
-	flags.UintVarP(&listOpts.Watch, watchFlagName, "w", 0, "Watch the ps output on an interval in seconds")
+	flags.UintVarP(&listOpts.Watch, watchFlagName, "w", 0, "Watch the ps output on an interval in seconds (-w=5|--watch=5)")
+	flags.Lookup(watchFlagName).NoOptDefVal = "2"
 	_ = cmd.RegisterFlagCompletionFunc(watchFlagName, completion.AutocompleteNone)
 
 	sort := validate.Value(&listOpts.Sort, "command", "created", "id", "image", "names", "runningfor", "size", "status")
@@ -107,6 +109,7 @@ func listFlagSet(cmd *cobra.Command) {
 
 	flags.SetNormalizeFunc(utils.AliasFlags)
 }
+
 func checkFlags(c *cobra.Command) error {
 	// latest, and last are mutually exclusive.
 	if listOpts.Last >= 0 && listOpts.Latest {

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -151,7 +151,9 @@ Forcibly syncing is much slower, but can resolve inconsistent state issues.
 
 #### **--watch**, **-w**
 
-Refresh the output with current containers on an interval in seconds.
+Refresh the output with current containers on an interval in seconds. When
+passed with no value a default of 2 seconds is used. A custom interval value can
+be passed using `--watch=5` or `-w=5`.
 
 ## EXAMPLES
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -1033,4 +1033,24 @@ var _ = Describe("Podman ps", func() {
 		Expect(output).To(HaveLen(1))
 		Expect(output).Should(ContainElement(ContainSubstring("late")))
 	})
+
+	It("podman ps --watch without value", func() {
+		options := PodmanExecOptions{
+			Wrapper: []string{"timeout", "--preserve-status", "3s"},
+		}
+
+		session := podmanTest.PodmanWithOptions(options, "ps", "--watch")
+		session.WaitWithDefaultTimeout()
+		Eventually(session, 4).Should(Exit(1))
+	})
+
+	It("podman ps --watch with value", func() {
+		options := PodmanExecOptions{
+			Wrapper: []string{"timeout", "--preserve-status", "3s"},
+		}
+
+		session := podmanTest.PodmanWithOptions(options, "ps", "--watch=1")
+		session.WaitWithDefaultTimeout()
+		Eventually(session, 4).Should(Exit(1))
+	})
 })


### PR DESCRIPTION
When running `podman ps --watch` an error is returned as an interval value must be passed. This patch updates the --watch flag to use a default of 2 seconds if no value is passed.

Fixes: https://github.com/containers/podman/issues/26005

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman ps` --watch flag now has a default interval of 2 seconds.
```
