### PR TITLE
test: Fix for spurious runc error message

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -77,7 +77,12 @@ echo $rand        |   0 | $rand
     echo "$content" > $PODMAN_TMPDIR/tempfile
 
     run_podman run --rm -i --preserve-fds=2 $IMAGE sh -c "cat <&4" 4<$PODMAN_TMPDIR/tempfile
-    is "$output" "$content" "container read input from fd 4"
+
+    if [[ "$(podman_runtime)" = "runc" ]]; then
+        assert "$output" =~ "${content}(.* error .* already been removed.*)?"
+    else
+        is "$output" "$content" "container read input from fd 4"
+    fi
 }
 
 # 'run --preserve-fd' passes a list of additional file descriptors into the container


### PR DESCRIPTION
Fix issue with `030-run` test when using runc as OCI runtime.

OS: podman 5.4.2 / runc 1.2.6 on latest openSUSE Tumbleweed

Verification run: https://openqa.opensuse.org/tests/5029065/file/podman-bats-root-local.tap

```
not ok 56 [030] podman run --preserve-fds in 602ms
# tags: ci:parallel
# (from function `bail-now' in file test/system/helpers.bash, line 187,
#  from function `is' in file test/system/helpers.bash, line 1136,
#  in test file test/system/030-run.bats, line 80)
#   `is "$output" "$content" "container read input from fd 4"' failed
#
# [08:30:25.600046765] # /usr/bin/podman run --rm -i --preserve-fds=2 quay.io/libpod/testimage:20241011 sh -c cat <&4
# [08:30:26.002618716] sJ4RLO6n3iX4qiAEXG2X
# time="2025-04-29T08:30:25-04:00" level=error msg="forwarding signal 18 to container a84353502e8cc9ea1037a71acccb46c50c0aa0a1bcb2a70a559ff04244cd5e78: container has already been removed"
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: container read input from fd 4
# #| expected: 'sJ4RLO6n3iX4qiAEXG2X'
# #|   actual: 'sJ4RLO6n3iX4qiAEXG2X'
# #|         > 'time="2025-04-29T08:30:25-04:00" level=error msg="forwarding signal 18 to container a84353502e8cc9ea1037a71acccb46c50c0aa0a1bcb2a70a559ff04244cd5e78: container has already been removed"'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # [teardown]
```

```release-note
None
```
