### PR TITLE
Stop setting btrfs_noversion build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,10 @@ SYSTEMDDIR ?= ${LIBDIR}/systemd/system
 USERSYSTEMDDIR ?= ${LIBDIR}/systemd/user
 SYSTEMDGENERATORSDIR ?= ${LIBDIR}/systemd/system-generators
 USERSYSTEMDGENERATORSDIR ?= ${LIBDIR}/systemd/user-generators
-REMOTETAGS ?= remote exclude_graphdriver_btrfs btrfs_noversion containers_image_openpgp
+REMOTETAGS ?= remote exclude_graphdriver_btrfs containers_image_openpgp
 BUILDTAGS ?= \
 	$(shell hack/apparmor_tag.sh) \
 	$(shell hack/btrfs_installed_tag.sh) \
-	$(shell hack/btrfs_tag.sh) \
 	$(shell hack/systemd_tag.sh) \
 	$(shell hack/libsubid_tag.sh) \
 	$(if $(filter linux,$(GOOS)), seccomp,)

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
-#include <btrfs/version.h>
-EOF
-if test $? -ne 0 ; then
-	echo btrfs_noversion
-fi

--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -26,7 +26,7 @@ the same result:
 To focus on one specific test on windows, run `ginkgo` manually:
 
 ```pwsh
-$remotetags = "remote exclude_graphdriver_btrfs btrfs_noversion containers_image_openpgp"
+$remotetags = "remote exclude_graphdriver_btrfs containers_image_openpgp"
 $focus_file = "basic_test.go"
 $focus_test = "podman build contexts"
 ./test/tools/build/ginkgo.exe `

--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -258,19 +258,19 @@ export BASEBUILDTAGS="$BASEBUILDTAGS libtrust_openssl"
 %endif
 
 # build %%{name}
-export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) $(hack/libdm_tag.sh)"
+export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/libdm_tag.sh)"
 %gobuild -o bin/%{name} ./cmd/%{name}
 
 # build %%{name}-remote
-export BUILDTAGS="$BASEBUILDTAGS exclude_graphdriver_btrfs btrfs_noversion remote"
+export BUILDTAGS="$BASEBUILDTAGS exclude_graphdriver_btrfs remote"
 %gobuild -o bin/%{name}-remote ./cmd/%{name}
 
 # build quadlet
-export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh)"
+export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh)"
 %gobuild -o bin/quadlet ./cmd/quadlet
 
 # build %%{name}-testing
-export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh)"
+export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh)"
 %gobuild -o bin/podman-testing ./cmd/podman-testing
 
 # reset LDFLAGS for plugins binaries

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -288,7 +288,7 @@ function Get-Podman-Version{
 # Init script
 $target = $args[0]
 
-$remotetags = "remote exclude_graphdriver_btrfs btrfs_noversion containers_image_openpgp"
+$remotetags = "remote exclude_graphdriver_btrfs containers_image_openpgp"
 
 switch ($target) {
     {$_ -in '', 'podman-remote', 'podman'} {


### PR DESCRIPTION
c/storage no longer uses this tag after
https://github.com/containers/storage/pull/2308.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
