### PR TITLE
Do not error on tz detection

### DIFF
--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -151,7 +151,7 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 		if ign.TimeZone == "local" {
 			tz, err = getLocalTimeZone()
 			if err != nil {
-				return err
+				return fmt.Errorf("error getting local timezone: %q", err)
 			}
 		} else {
 			tz = ign.TimeZone


### PR DESCRIPTION
In cases where systemd was not available, podman machine was erroring out using timedatectl (it requires systemd).  on other providers like windows, we don't do any timezone detection so it seems valid to return a "" for timezone.  This fixes the first problem described #25950.

Fixes: https://github.com/containers/podman/issues/25950

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
