### PR TITLE
pkg/machine: more timezone fixes

### DIFF
--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -280,6 +280,12 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(timezoneSession).To(Exit(0))
 		Expect(timezoneSession.outputToString()).To(ContainSubstring("HST"))
+
+		sshTimezone = sshMachine{}
+		timezoneSession, err = mb.setName(name).setCmd(sshTimezone.withSSHCommand([]string{"timedatectl show --property Timezone"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(timezoneSession).To(Exit(0))
+		Expect(timezoneSession.outputToString()).To(ContainSubstring("Pacific/Honolulu"))
 	})
 
 	It("machine init with volume", func() {

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -147,9 +147,13 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 		// local means the same as the host
 		// look up where it is pointing to on the host
 		if ign.TimeZone == "local" {
-			tz, err = getLocalTimeZone()
-			if err != nil {
-				return fmt.Errorf("error getting local timezone: %q", err)
+			if env, ok := os.LookupEnv("TZ"); ok {
+				tz = env
+			} else {
+				tz, err = getLocalTimeZone()
+				if err != nil {
+					return fmt.Errorf("error getting local timezone: %q", err)
+				}
 			}
 		}
 		// getLocalTimeZone() can return empty string, do not add broken symlink in that case

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -166,10 +166,11 @@ func (ign *DynamicIgnition) GenerateIgnitionConfig() error {
 				},
 				LinkEmbedded1: LinkEmbedded1{
 					Hard: BoolToPtr(false),
-					// We always want this value in unix form (/path/to/something) because this is being
-					// set in the machine OS (always Linux).  However, filepath.join on windows will use a "\\"
-					// separator; therefore we use ToSlash to convert the path to unix style
-					Target: filepath.ToSlash(filepath.Join("/usr/share/zoneinfo", tz)),
+					// We always want this value in unix form (../usr/share/zoneinfo) because this is being
+					// set in the machine OS (always Linux) and systemd needs the relative symlink.  However,
+					// filepath.join on windows will use a "\\" separator so use path.Join() which always
+					// uses the slash.
+					Target: path.Join("../usr/share/zoneinfo", tz),
 				},
 			}
 			ignStorage.Links = append(ignStorage.Links, tzLink)


### PR DESCRIPTION
pkg/machine: do not add broken localtime symlink

The timezone might be empty so the zoneinfo link would then be invalid.

---

pkg/machine: properly setup zoneinfo symlink

If you run timedatectl inside it will not show the correct timezone, it
seems systemd really wants a relative link which is also documented by
coreos[1]. Also we can just use path.Join() directly and don't have to
convert the path again on windows.

[1] https://docs.fedoraproject.org/en-US/fedora-coreos/time-zone/#_setting_the_time_zone_via_ignition

---

pkg/machine: rework getLocalTimeZone on linux

Get the timezone off the localtime symlink like systemd does it.
It is more efficient then fork/exec another command for it that may or
may not exits and the /etc/timezone files doesn't exist on most distros
so that is not a great fallback.





#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix podman machine timezone handling so that systemd inside can see the right timezone.
```
