### PR TITLE
fix(cmd): prevent adding connection with invalid identities file

### DIFF
--- a/cmd/podman/system/connection/add.go
+++ b/cmd/podman/system/connection/add.go
@@ -141,6 +141,16 @@ func add(cmd *cobra.Command, args []string) error {
 
 	switch uri.Scheme {
 	case "ssh":
+		// ensure the Identity provided is a valid file
+		if cmd.Flags().Changed("identity") {
+			info, err := os.Stat(entities.Identity)
+			switch {
+			case err != nil:
+				return err
+			case info.IsDir():
+				return fmt.Errorf("%q is a directory", entities.Identity)
+			}
+		}
 		return ssh.Create(entities, sshMode)
 	case "unix":
 		if cmd.Flags().Changed("identity") {

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -45,6 +45,19 @@ var _ = Describe("podman system connection", func() {
 	BeforeEach(setupConnectionsConf)
 
 	Context("without running API service", func() {
+		It("adding ssh connection with non-existing identity", func() {
+			identity := "~/foo/bar.txt"
+			cmd := []string{"system", "connection", "add",
+				"--default",
+				"--identity", identity,
+				"QA",
+				"ssh://root@podman.test:2222/run/podman/podman.sock",
+			}
+			session := podmanTest.Podman(cmd)
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitWithError(125, fmt.Sprintf("Error: stat %s: no such file or directory", identity)))
+		})
+
 		It("add ssh://", func() {
 			cmd := []string{"system", "connection", "add",
 				"--default",


### PR DESCRIPTION
Fixes https://github.com/containers/podman/issues/26016

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Ensure identities file exists when adding ssh connection
```
