### PR TITLE
Update winmake.ps1 to build arm64 artifacts

### DIFF
--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -55,6 +55,7 @@ if ($args.Count -lt 1 -or $args[0].Length -lt 1) {
     Write-Host 'Uses Env Vars: '
     Write-Host '   $ENV:FETCH_BASE_URL - GitHub Repo Address to locate release on'
     Write-Host '   $ENV:V531_SETUP_EXE_PATH - Path to v5.3.1 setup.exe used to build the patch'
+    Write-Host '   $ENV:PODMAN_ARCH - Installer target platform (x64 or arm64)'
     Write-Host 'Env Settings for signing (optional)'
     Write-Host '   $ENV:VAULT_ID'
     Write-Host '   $ENV:APP_ID'
@@ -103,6 +104,16 @@ if ($ENV:INSTVER -eq "") {
     Exit 1
 }
 
+$installerPlatform = ""
+if ($null -eq $ENV:PODMAN_ARCH -or $ENV:PODMAN_ARCH -eq "amd64") {
+    $installerPlatform = "x64"
+} elseif ($ENV:PODMAN_ARCH -eq "arm64") {
+    $installerPlatform = "arm64"
+} else {
+    Write-Host "Unknown architecture $ENV:PODMAN_ARCH. Valid options are amd64 or arm64."
+    Exit 1
+}
+
 SignItem @("artifacts/win-sshproxy.exe",
           "artifacts/podman.exe")
 $gvExists = Test-Path "artifacts/gvproxy.exe"
@@ -123,10 +134,10 @@ if ($gvExists) {
 if (Test-Path ./obj) {
     Remove-Item ./obj -Recurse -Force -Confirm:$false
 }
-dotnet build podman.wixproj /property:DefineConstants="VERSION=$ENV:INSTVER" -o .; ExitOnError
+dotnet build podman.wixproj /property:DefineConstants="VERSION=$ENV:INSTVER" /property:InstallerPlatform="$installerPlatform" -o .; ExitOnError
 SignItem @("en-US\podman.msi")
 
-dotnet build podman-setup.wixproj /property:DefineConstants="VERSION=$ENV:INSTVER" -o .; ExitOnError
+dotnet build podman-setup.wixproj /property:DefineConstants="VERSION=$ENV:INSTVER" /property:InstallerPlatform="$installerPlatform" -o .; ExitOnError
 wix burn detach podman-setup.exe -engine engine.exe; ExitOnError
 SignItem @("engine.exe")
 

--- a/contrib/win-installer/podman-setup.wixproj
+++ b/contrib/win-installer/podman-setup.wixproj
@@ -1,6 +1,5 @@
 <Project Sdk="WixToolset.Sdk/5.0.2">
     <PropertyGroup>
-		<InstallerPlatform>x64</InstallerPlatform>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<OutputType>Bundle</OutputType>
 	</PropertyGroup>

--- a/contrib/win-installer/podman.wixproj
+++ b/contrib/win-installer/podman.wixproj
@@ -1,6 +1,5 @@
 <Project Sdk="WixToolset.Sdk/5.0.2">
 	<PropertyGroup>
-		<InstallerPlatform>x64</InstallerPlatform>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	</PropertyGroup>
 	<ItemGroup>

--- a/contrib/win-installer/podman.wxs
+++ b/contrib/win-installer/podman.wxs
@@ -51,7 +51,7 @@
 		-->
 		<SetProperty Id="HIDE_PROVIDER_CHOICE" After="AppSearch" Value="1" Sequence="first" Condition="(SKIP_CONFIG_FILE_CREATION = 1) OR (MACHINE_PROVIDER_CONFIG_FILE_PATH) OR (MAIN_EXECUTABLE_FILE_PATH)" />
 
-		<CustomAction Id="OpenGuide" DllEntry="WixShellExec" Impersonate="yes" BinaryRef="Wix4UtilCA_X86" />
+		<CustomAction Id="OpenGuide" DllEntry="WixShellExec" Impersonate="yes" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
 		<util:BroadcastEnvironmentChange />
 		<Feature Id="Complete" Level="1">
 			<ComponentRef Id="INSTALLDIR_Component" />


### PR DESCRIPTION
Winmake could only build AMD64 artifacts (podman-remote, gvproxy, win-sshproxy, podman.msi and podman-setup.exe).

This commit makes the necessary change to winmake so that it:
1) builds ARM64 artifacts when executed on arm64
2) cross-compiles to ARM64/AMD64 with the  `-architecture` (or `-arch`) parameter

It depends on https://github.com/containers/podman/pull/26023, which removes the need to build `check.c` code (which is not used anyway).

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
