### PR TITLE
Automatically bump to -dev after tag

### DIFF
--- a/.github/workflows/dev-bump.yml
+++ b/.github/workflows/dev-bump.yml
@@ -1,0 +1,158 @@
+name: Bump to -dev version
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  bump:
+    name: Bump to -dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.PODMANBOT_TOKEN }}
+      - name: Bump
+        id: bump
+        run: |
+          ref=${{ github.ref_name }}
+          version=${ref#v}
+          if [[ $version == *-rc* ]]; then
+              devbump="${version%-*}-dev"
+              echo "::notice:: is a rc - bumping z down to $devbump"
+          else
+              arr=($(echo "$version" | tr . '\n'))
+              arr[2]=$((${arr[2]}+1))
+              devbump="$(IFS=. ; echo "${arr[*]}")-dev"
+              echo "::notice:: bumping z up to $devbump"
+          fi
+
+          sed -i "s/const RawVersion = ".*"/const RawVersion = \"${devbump}\"/g" version/rawversion/version.go
+
+          echo "devbump=$devbump" >> $GITHUB_OUTPUT
+      - name: Push
+        run: |
+          # Make committer the user who triggered the action, either through cutting a release or manual trigger
+          # GitHub gives everyone a noreply email associated with their account, use that email for the sign-off
+          git config --local user.name ${{ github.actor }}
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          bumpbranch="bump-${{ steps.bump.outputs.devbump }}"
+          git checkout -b $bumpbranch
+          git add version/rawversion/version.go
+          git commit --signoff -m "Bump Podman to v${{ steps.bump.outputs.devbump }}"
+          git remote add podmanbot https://github.com/podmanbot/podman
+          git push -f podmanbot "$bumpbranch"
+      - name: Check open PRs
+        id: checkpr
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+        run: |
+          prs=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --head bump-${{ steps.bump.outputs.devbump }} \
+            --state open \
+            --json title \
+            --jq 'length')
+          if ((prs > 0)); then
+            echo "SKIPPING: PR already exists to update from ${{ github.ref_name }}."
+          else
+            echo "prexists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open PR
+        if: steps.checkpr.outputs.prexists == 'false'
+        id: pr
+        run: |
+          bumpbranch="bump-${{ steps.bump.outputs.devbump }}"
+          ref=${{ github.ref_name }}
+          base=${ref%.*}
+          body=$(printf '```release-note\nNone\n```\n')
+          gh pr create \
+            --title "Bump Podman to v${{ steps.bump.outputs.devbump }}" \
+            --body  "$body" \
+            --head "podmanbot:$bumpbranch" \
+            --base "$base" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+  mainbump:
+    name: Bump on main
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.PODMANBOT_TOKEN }}
+      - name: Check version on main
+        id: check
+        run: |
+          mainvers=`grep -P '(?<=const RawVersion = ")(\d.\d)' -o version/rawversion/version.go`
+          ref=${{ github.ref_name }}
+          releasevers=${ref#v}
+          if echo "${mainvers},${releasevers}" | tr ',' '\n' | sort -V -C
+          then
+              echo "bump=true" >> $GITHUB_OUTPUT
+              echo "Main is lower than release, so we need to bump main"
+          else
+              echo "::notice:: SKIPPING: Main is higher than release, no need to bump"
+          fi
+      - name: Bump main
+        id: bump
+        if: steps.check.outputs.bump == 'true'
+        run: |
+          ref=${{ github.ref_name }}
+          releasevers=${ref#v}
+
+          arr=($(echo "$releasevers" | tr . '\n'))
+          arr[1]=$((${arr[1]}+1))
+          arr[2]=0
+          devbump="$(IFS=. ; echo "${arr[*]}")-dev"
+          echo "::notice:: Bumping main to: $devbump"
+
+          sed -i "s/const RawVersion = \".*\"/const RawVersion = \"$devbump\"/g" version/rawversion/version.go
+
+          echo "devbump=$devbump" >> $GITHUB_OUTPUT
+      - name: Push
+        if: steps.check.outputs.bump == 'true'
+        run: |
+          # Make committer the user who triggered the action, either through cutting a release or manual trigger
+          # GitHub gisves everyone a noreply email associated with their account, use that email for the sign-off
+          git config --local user.name ${{ github.actor }}
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          bumpbranch="bump-main-${{ steps.bump.outputs.devbump }}"
+          git checkout -b $bumpbranch
+          git add version/rawversion/version.go
+          git commit --signoff -m "Bump main to v${{ steps.bump.outputs.devbump }}"
+          git remote add podmanbot https://github.com/podmanbot/podman
+          git push -f podmanbot "$bumpbranch"
+      - name: Check open PRs
+        id: checkpr
+        if: steps.check.outputs.bump == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}
+        run: |
+          prs=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --head bump-main-${{ steps.bump.outputs.devbump }} \
+            --state open \
+            --json title \
+            --jq 'length')
+          if ((prs > 0)); then
+            echo "SKIPPING: PR already exists to update to ${{ steps.bump.outputs.devbump }}."
+          else
+            echo "prexists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open PR
+        if: steps.check.outputs.bump == 'true' &&  steps.checkpr.outputs.prexists == 'false'
+        run: |
+          bumpbranch="bump-main-${{ steps.bump.outputs.devbump }}"
+          body=$(printf '```release-note\nNone\n```\n')
+          gh pr create \
+            --title "Bump main to v${{ steps.bump.outputs.devbump }}" \
+            --body  "$body" \
+            --head "podmanbot:$bumpbranch" \
+            --base "main" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.PODMANBOT_TOKEN }}


### PR DESCRIPTION
Create GitHub action to automatically bump to a -dev version after a release is tagged.

On a branch:
- The bump will always be a z bump on branches
- If the bump is to an RC, then the bump will be back down to dev (ie, 9.9.0-rc1 to 9.9.0-dev)
- If the bump is not an RC, the bump wil be up to dev (ie, 9.9.0 to 9.9.1-dev)

On main:
- If the X.Y version on main is smaller than the X.Y on the release tag, this action will open a PR to bump the version on main to the release tag's X.Y+1
- Major version (X) dev bumps will still need to be manual

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
