### PR TITLE
Take WSL path from PATH instead of forcing it to WindowsApps

### DIFF
--- a/cmd/podman-wslkerninst/main.go
+++ b/cmd/podman-wslkerninst/main.go
@@ -48,7 +48,7 @@ func installWslKernel() error {
 	)
 	backoff := 500 * time.Millisecond
 	for i := 1; i < 6; i++ {
-		err = wutil.SilentExec(wutil.FindWSL(), "--update")
+		err = wutil.SilentExec("wsl", "--update")
 		if err == nil {
 			break
 		}

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -38,7 +38,8 @@ func getOtherProvider() string {
 	return ""
 }
 
-func runSystemCommand(binary string, cmdArgs []string) (*machineSession, error) {
+func runWslCommand(cmdArgs []string) (*machineSession, error) {
+	binary := "wsl"
 	GinkgoWriter.Println(binary + " " + strings.Join(cmdArgs, " "))
 	c := exec.Command(binary, cmdArgs...)
 	session, err := Start(c, GinkgoWriter, GinkgoWriter)

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Microsoft/go-winio/vhd"
 	"github.com/containers/libhvee/pkg/hypervctl"
 	"github.com/containers/podman/v5/pkg/machine/define"
-	"github.com/containers/podman/v5/pkg/machine/wsl/wutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -28,12 +27,12 @@ var _ = Describe("podman machine init - windows only", func() {
 		Expect(session).To(Exit(0))
 
 		defer func() {
-			_, err := runSystemCommand(wutil.FindWSL(), []string{"--terminate", "podman-net-usermode"})
+			_, err := runWslCommand([]string{"--terminate", "podman-net-usermode"})
 			if err != nil {
 				fmt.Println("unable to terminate podman-net-usermode")
 			}
 
-			_, err = runSystemCommand(wutil.FindWSL(), []string{"--unregister", "podman-net-usermode"})
+			_, err = runWslCommand([]string{"--unregister", "podman-net-usermode"})
 			if err != nil {
 				fmt.Println("unable to unregister podman-net-usermode")
 			}
@@ -106,17 +105,17 @@ var _ = Describe("podman machine init - windows only", func() {
 		// a vm outside the context of podman-machine and also
 		// so we dont have to download a distribution from microsoft
 		// servers
-		exportSession, err := runSystemCommand(wutil.FindWSL(), []string{"--export", "podman-foobarexport", exportedPath})
+		exportSession, err := runWslCommand([]string{"--export", "podman-foobarexport", exportedPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exportSession).To(Exit(0))
 
 		// importing the machine and creating a vm
-		importSession, err := runSystemCommand(wutil.FindWSL(), []string{"--import", distName, distrDir, exportedPath})
+		importSession, err := runWslCommand([]string{"--import", distName, distrDir, exportedPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(importSession).To(Exit(0))
 
 		defer func() {
-			_, err := runSystemCommand(wutil.FindWSL(), []string{"--unregister", distName})
+			_, err := runWslCommand([]string{"--unregister", distName})
 			if err != nil {
 				fmt.Println("unable to remove bogus wsl instance")
 			}

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -95,7 +95,7 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 
 	dist := env.WithPodmanPrefix(name)
 	fmt.Println(prompt)
-	if err = runCmdPassThrough(wutil.FindWSL(), "--import", dist, distTarget, imagePath, "--version", "2"); err != nil {
+	if err = runCmdPassThrough("wsl", "--import", dist, distTarget, imagePath, "--version", "2"); err != nil {
 		return "", fmt.Errorf("the WSL import of guest OS failed: %w", err)
 	}
 
@@ -427,7 +427,7 @@ func installWslKernel() error {
 
 	backoff := 500 * time.Millisecond
 	for i := 0; i < 5; i++ {
-		err = runCmdPassThroughTee(log, wutil.FindWSL(), "--update")
+		err = runCmdPassThroughTee(log, "wsl", "--update")
 		if err == nil {
 			break
 		}
@@ -537,18 +537,18 @@ func withUser(s string, user string) string {
 func wslInvoke(dist string, arg ...string) error {
 	newArgs := []string{"-u", "root", "-d", dist}
 	newArgs = append(newArgs, arg...)
-	return runCmdPassThrough(wutil.FindWSL(), newArgs...)
+	return runCmdPassThrough("wsl", newArgs...)
 }
 
 func wslPipe(input string, dist string, arg ...string) error {
 	newArgs := []string{"-u", "root", "-d", dist}
 	newArgs = append(newArgs, arg...)
-	return pipeCmdPassThrough(wutil.FindWSL(), input, newArgs...)
+	return pipeCmdPassThrough("wsl", input, newArgs...)
 }
 
 //nolint:unused
 func wslCreateKeys(identityPath string, dist string) (string, error) {
-	return machine.CreateSSHKeysPrefix(identityPath, true, true, wutil.FindWSL(), "-u", "root", "-d", dist)
+	return machine.CreateSSHKeysPrefix(identityPath, true, true, "wsl", "-u", "root", "-d", dist)
 }
 
 func runCmdPassThrough(name string, arg ...string) error {
@@ -645,7 +645,7 @@ func getAllWSLDistros(running bool) (map[string]struct{}, error) {
 	if running {
 		args = append(args, "--running")
 	}
-	cmd := exec.Command(wutil.FindWSL(), args...)
+	cmd := exec.Command("wsl", args...)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -674,7 +674,7 @@ func getAllWSLDistros(running bool) (map[string]struct{}, error) {
 }
 
 func isSystemdRunning(dist string) (bool, error) {
-	cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "sh")
+	cmd := exec.Command("wsl", "-u", "root", "-d", dist, "sh")
 	cmd.Stdin = strings.NewReader(sysdpid + "\necho $SYSDPID\n")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
@@ -704,7 +704,7 @@ func isSystemdRunning(dist string) (bool, error) {
 }
 
 func terminateDist(dist string) error {
-	cmd := exec.Command(wutil.FindWSL(), "--terminate", dist)
+	cmd := exec.Command("wsl", "--terminate", dist)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("command %s %v failed: %w (%s)", cmd.Path, cmd.Args, err, strings.TrimSpace(string(out)))
@@ -713,7 +713,7 @@ func terminateDist(dist string) error {
 }
 
 func unregisterDist(dist string) error {
-	cmd := exec.Command(wutil.FindWSL(), "--unregister", dist)
+	cmd := exec.Command("wsl", "--unregister", dist)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("command %s %v failed: %w (%s)", cmd.Path, cmd.Args, err, strings.TrimSpace(string(out)))
@@ -761,7 +761,7 @@ func getCPUs(name string) (uint64, error) {
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}
-	cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "nproc")
+	cmd := exec.Command("wsl", "-u", "root", "-d", dist, "nproc")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return 0, err
@@ -791,7 +791,7 @@ func getMem(name string) (strongunits.MiB, error) {
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}
-	cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "cat", "/proc/meminfo")
+	cmd := exec.Command("wsl", "-u", "root", "-d", dist, "cat", "/proc/meminfo")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return 0, err

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/containers/podman/v5/pkg/machine/env"
-	"github.com/containers/podman/v5/pkg/machine/wsl/wutil"
 
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/podman/v5/pkg/machine"
@@ -105,7 +104,7 @@ func (w WSLStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error,
 	// below if we wanted to hard error on the wsl unregister
 	// of the vm
 	wslRemoveFunc := func() error {
-		if err := runCmdPassThrough(wutil.FindWSL(), "--unregister", env.WithPodmanPrefix(mc.Name)); err != nil {
+		if err := runCmdPassThrough("wsl", "--unregister", env.WithPodmanPrefix(mc.Name)); err != nil {
 			return err
 		}
 		return nil
@@ -250,7 +249,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		fmt.Fprintf(os.Stderr, "Could not stop API forwarding service (win-sshproxy.exe): %s\n", err.Error())
 	}
 
-	cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "sh")
+	cmd := exec.Command("wsl", "-u", "root", "-d", dist, "sh")
 	cmd.Stdin = strings.NewReader(waitTerm)
 	out := &bytes.Buffer{}
 	cmd.Stderr = out
@@ -260,7 +259,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		return fmt.Errorf("executing wait command: %w", err)
 	}
 
-	exitCmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "/usr/local/bin/enterns", "systemctl", "exit", "0")
+	exitCmd := exec.Command("wsl", "-u", "root", "-d", dist, "/usr/local/bin/enterns", "systemctl", "exit", "0")
 	if err = exitCmd.Run(); err != nil {
 		return fmt.Errorf("stopping systemd: %w", err)
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

None

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman on Windows now prefers the WSL executable in “C:\Program Files\Windows Subsystem for Linux\wsl.exe” over the one in WindowsApps, avoiding common “access denied” issues.

```

According to issue https://github.com/containers/podman/issues/25787 podman is trying to use WindowsApps wsl.exe first, but that one can have access issues

We can first search on Program Files for the proper .exe for wsl, this corrects issues with WindowsApps folder executables not being accessible