### PR TITLE
Quadlet - fix pod name to depend on the name of the generate service

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1482,7 +1482,7 @@ func GetPodResourceName(podUnit *parser.UnitFile) string {
 	// Derive pod name from unit name (with added prefix), or use user-provided name.
 	podName, ok := podUnit.Lookup(PodGroup, KeyPodName)
 	if !ok || len(podName) == 0 {
-		podName = removeExtension(podUnit.Filename, "systemd-", "")
+		podName = "systemd-%N"
 	}
 	return podName
 }

--- a/test/e2e/quadlet/basic.pod
+++ b/test/e2e/quadlet/basic.pod
@@ -1,9 +1,9 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type forking
 ## assert-key-is Service SyslogIdentifier "%N"
-## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --exit-policy=stop --replace --infra-name systemd-basic-infra --name systemd-basic"
-## assert-key-is-regex Service ExecStart ".*/podman pod start systemd-basic"
-## assert-key-is-regex Service ExecStop ".*/podman pod stop --ignore --time=10 systemd-basic"
-## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --ignore --force systemd-basic"
+## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --exit-policy=stop --replace --infra-name systemd-%N-infra --name systemd-%N"
+## assert-key-is-regex Service ExecStart ".*/podman pod start systemd-%N"
+## assert-key-is-regex Service ExecStop ".*/podman pod stop --ignore --time=10 systemd-%N"
+## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --ignore --force systemd-%N"
 
 [Pod]


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet - Pod name is defined using the generated service name as documented
```

Resolves: #26062
