### PR TITLE
Release win arm64 artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
 
   windows-installer:
     name: Build Windows Installer
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     runs-on: windows-latest
     needs: [check, build-artifacts]
     env:
@@ -198,13 +201,29 @@ jobs:
         }
         Pop-Location
         Exit $code
-    - name: Display structure of downloaded files
+      env:
+        PODMAN_ARCH: ${{ matrix.arch }}
+    - name: Display structure of built files
       run: |
         Push-Location contrib\win-installer
         Get-ChildItem
         Pop-Location
-    - name: Artifact
+    - name: Rename the installer
+      run: |
+        Push-Location contrib\win-installer
+        Copy-Item -Path podman-${{steps.getversion.outputs.version}}-setup.exe -Destination podman-installer-windows-${{ matrix.arch }}.exe
+        Pop-Location
+    - name: Upload the installer
       uses: actions/upload-artifact@v4
+      with:
+        name: win-installer-${{ matrix.arch }}
+        path: |
+          .\contrib\win-installer\podman-installer-windows-${{ matrix.arch }}.exe
+      # For backwards compatibility, we also upload the amd64 windows
+      # installer using the old name
+    - name: Upload the installer (legacy)
+      uses: actions/upload-artifact@v4
+      if: ${{ matrix.arch == 'amd64' }}
       with:
         name: win-installer
         path: |

--- a/Makefile
+++ b/Makefile
@@ -847,7 +847,7 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 		$(MAKE) $(GOPLAT) podman-remote; \
 	fi
 	if [[ "$(GOOS)" == "windows" ]]; then \
-		$(MAKE) $(GOPLAT) TMPDIR="" win-gvproxy; \
+		$(MAKE) $(GOPLAT) TMPDIR="" win-gvproxy-$(GOARCH); \
 	fi
 	if [[ "$(GOOS)" == "darwin" ]]; then \
 		$(MAKE) $(GOPLAT) podman-mac-helper;\
@@ -862,10 +862,15 @@ podman-remote-release-%.zip: test/version/version ## Build podman-remote for %=$
 
 # Downloads pre-built gvproxy and win-sshproxy helpers. See comment on GVPROXY_VERSION declaration
 .PHONY: win-gvproxy
-win-gvproxy: test/version/version
+win-gvproxy: win-gvproxy-amd64 # Keep this target for backwards compatibility
+
+win-gvproxy-%: test/version/version
+	$(eval GOARCH := $*)
+	$(eval GVPROXY_FILENAME := $(if $(filter arm64,$(GOARCH)), gvproxy-windows-arm64.exe,gvproxy-windowsgui.exe))
+	$(eval SSHPROXY_FILENAME :=  $(if $(filter arm64,$(GOARCH)), win-sshproxy-arm64.exe, win-sshproxy.exe))
 	mkdir -p bin/windows/
-	curl -sSL -o bin/windows/gvproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/gvproxy-windowsgui.exe
-	curl -sSL -o bin/windows/win-sshproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/win-sshproxy.exe
+	curl -sSL -o bin/windows/gvproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/$(GVPROXY_FILENAME)
+	curl -sSL -o bin/windows/win-sshproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/$(SSHPROXY_FILENAME)
 
 .PHONY: rpm
 rpm:  ## Build rpm packages
@@ -1059,6 +1064,8 @@ release-artifacts: clean-binaries
 	mv podman-remote-release-darwin_arm64.zip release/
 	$(MAKE) podman-remote-release-windows_amd64.zip
 	mv podman-remote-release-windows_amd64.zip release/
+	$(MAKE) podman-remote-release-windows_arm64.zip
+	mv podman-remote-release-windows_arm64.zip release/
 	$(MAKE) podman-remote-static-linux_amd64
 	tar -cvzf podman-remote-static-linux_amd64.tar.gz bin/podman-remote-static-linux_amd64
 	$(MAKE) podman-remote-static-linux_arm64

--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -105,7 +105,7 @@ if ($ENV:INSTVER -eq "") {
 }
 
 $installerPlatform = ""
-if ($null -eq $ENV:PODMAN_ARCH -or $ENV:PODMAN_ARCH -eq "amd64") {
+if ($null -eq $ENV:PODMAN_ARCH -or "" -eq $ENV:PODMAN_ARCH -or "amd64" -eq $ENV:PODMAN_ARCH) {
     $installerPlatform = "x64"
 } elseif ($ENV:PODMAN_ARCH -eq "arm64") {
     $installerPlatform = "arm64"

--- a/contrib/win-installer/process-release.ps1
+++ b/contrib/win-installer/process-release.ps1
@@ -97,10 +97,14 @@ try {
     $restore = 1
     $ProgressPreference = 'SilentlyContinue';
 
+    if ($null -eq $ENV:PODMAN_ARCH -or "" -eq $ENV:PODMAN_ARCH ) {
+        Write-Warning "PODMAN_ARCH not set, defaulting to amd64"
+        $ENV:PODMAN_ARCH = "amd64"
+    }
     if ($releaseDir.Length -gt 0) {
-        Copy-Item -Path "$releaseDir/podman-remote-release-windows_amd64.zip" "release.zip"
+        Copy-Item -Path "$releaseDir/podman-remote-release-windows_${ENV:PODMAN_ARCH}.zip" "release.zip"
     } else {
-        DownloadOrSkip "$base_url/releases/download/$version/podman-remote-release-windows_amd64.zip"  "release.zip"
+        DownloadOrSkip "$base_url/releases/download/$version/podman-remote-release-windows_${ENV:PODMAN_ARCH}.zip"  "release.zip"
         DownloadOptional "$base_url/releases/download/$version/shasums" ..\shasums
     }
     Expand-Archive -Path release.zip

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -14,6 +14,7 @@ param (
             Write-Warning "Unsupported architecture $arch. Using default ($defaultArchitecture)."
             return $defaultArchitecture
         }
+        return $arch
     ),
     [parameter(ValueFromRemainingArguments)][object[]]$params = @()
 )
@@ -108,7 +109,7 @@ function Installer{
         [string]$version,
         [string]$suffix = "dev"
     );
-    Write-Host "Building the windows installer"
+    Write-Host "Building the windows installer for $architecture"
 
     # Check for the files to include in the installer
     $requiredArtifacts = @(


### PR DESCRIPTION
Updates that are necessary to include the Windows arm64 installer in the release process.

The PR is split into 3 commits:
- an important fix to the `ps1` scripts to pick the right zip file (amd64/arm64) based on the value of `$PODMAN_ARCH`
- updates to the `Makefile` to build the `windows_arm64.zip` as part of `release-artifacts`
- updates to the `release` GitHub workflow to build and upload both AMD64 and ARM64 Windows installers

NOTE: to cherry-pick this to the 5.5 branch, we also need #26048 and #26023

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
