### PR TITLE
feat: Add OCI Artifact support to the Podman REST API

### DIFF
--- a/cmd/podman/artifact/add.go
+++ b/cmd/podman/artifact/add.go
@@ -2,6 +2,7 @@ package artifact
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v5/cmd/podman/common"
@@ -61,6 +62,8 @@ func init() {
 }
 
 func add(cmd *cobra.Command, args []string) error {
+	artifactName := args[0]
+	blobs := args[1:]
 	opts := new(entities.ArtifactAddOptions)
 
 	annots, err := utils.ParseAnnotations(addOpts.Annotations)
@@ -72,7 +75,18 @@ func add(cmd *cobra.Command, args []string) error {
 	opts.Append = addOpts.Append
 	opts.FileType = addOpts.FileType
 
-	report, err := registry.ImageEngine().ArtifactAdd(registry.Context(), args[0], args[1:], opts)
+	artifactBlobs := make([]entities.ArtifactBlob, 0, len(blobs))
+
+	for _, blobPath := range blobs {
+		artifactBlob := entities.ArtifactBlob{
+			BlobFilePath: blobPath,
+			FileName:     filepath.Base(blobPath),
+		}
+
+		artifactBlobs = append(artifactBlobs, artifactBlob)
+	}
+
+	report, err := registry.ImageEngine().ArtifactAdd(registry.Context(), artifactName, artifactBlobs, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/handlers/libpod/artifacts.go
+++ b/pkg/api/handlers/libpod/artifacts.go
@@ -1,0 +1,336 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/podman/v5/libpod"
+	"github.com/containers/podman/v5/pkg/api/handlers/utils"
+	api "github.com/containers/podman/v5/pkg/api/types"
+	"github.com/containers/podman/v5/pkg/auth"
+	"github.com/containers/podman/v5/pkg/domain/entities"
+	"github.com/containers/podman/v5/pkg/domain/infra/abi"
+	domain_utils "github.com/containers/podman/v5/pkg/domain/utils"
+	libartifact_types "github.com/containers/podman/v5/pkg/libartifact/types"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/gorilla/schema"
+)
+
+func InspectArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+
+	name := utils.GetName(r)
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	report, err := imageEngine.ArtifactInspect(r.Context(), name, entities.ArtifactInspectOptions{})
+	if err != nil {
+		if errors.Is(err, libartifact_types.ErrArtifactNotExist) {
+			utils.ArtifactNotFound(w, name, err)
+			return
+		} else {
+			utils.InternalServerError(w, err)
+			return
+		}
+	}
+
+	utils.WriteResponse(w, http.StatusOK, report)
+}
+
+func ListArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	artifacts, err := imageEngine.ArtifactList(r.Context(), entities.ArtifactListOptions{})
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	utils.WriteResponse(w, http.StatusOK, artifacts)
+}
+
+func PullArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
+
+	query := struct {
+		Name       string             `schema:"name"`
+		Retry      uint               `schema:"retry"`
+		RetryDelay string             `schema:"retryDelay"`
+		TLSVerify  types.OptionalBool `schema:"tlsVerify"`
+	}{}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
+		return
+	}
+
+	if query.Name == "" {
+		utils.Error(w, http.StatusBadRequest, errors.New("name parameter is required"))
+		return
+	}
+
+	artifactsPullOptions := entities.ArtifactPullOptions{}
+
+	// If TLS verification is explicitly specified (True or False) in the query,
+	// set the InsecureSkipTLSVerify option accordingly.
+	// If TLSVerify was not set in the query, OptionalBoolUndefined is used and
+	// handled later based off the target registry configuration.
+	switch query.TLSVerify {
+	case types.OptionalBoolTrue:
+		artifactsPullOptions.InsecureSkipTLSVerify = types.NewOptionalBool(false)
+	case types.OptionalBoolFalse:
+		artifactsPullOptions.InsecureSkipTLSVerify = types.NewOptionalBool(true)
+	case types.OptionalBoolUndefined:
+		// If the user doesn't define TLSVerify in the query, do nothing and pass
+		// it to the backend code to handle.
+	default: // Should never happen
+		panic("Unexpected handling occurred for TLSVerify")
+	}
+
+	if _, found := r.URL.Query()["retry"]; found {
+		artifactsPullOptions.MaxRetries = &query.Retry
+	}
+
+	if len(query.RetryDelay) != 0 {
+		artifactsPullOptions.RetryDelay = query.RetryDelay
+	}
+
+	authConf, authfile, err := auth.GetCredentials(r)
+	if err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+	defer auth.RemoveAuthfile(authfile)
+
+	artifactsPullOptions.AuthFilePath = authfile
+	if authConf != nil {
+		artifactsPullOptions.Username = authConf.Username
+		artifactsPullOptions.Password = authConf.Password
+		artifactsPullOptions.IdentityToken = authConf.IdentityToken
+	}
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	artifacts, err := imageEngine.ArtifactPull(r.Context(), query.Name, artifactsPullOptions)
+	if err != nil {
+		var errcd errcode.ErrorCoder
+		// Check to see if any of the wrapped errors is an errcode.ErrorCoder returned from the registry
+		if errors.As(err, &errcd) {
+			rc := errcd.ErrorCode().Descriptor().HTTPStatusCode
+			// Check if the returned error is 401 StatusUnauthorized indicating the request was unauthorized
+			if rc == http.StatusUnauthorized {
+				utils.Error(w, http.StatusUnauthorized, errcd.ErrorCode())
+				return
+			}
+			// Check if the returned error is 404 StatusNotFound indicating the artifact was not found
+			if rc == http.StatusNotFound {
+				utils.Error(w, http.StatusNotFound, errcd.ErrorCode())
+				return
+			}
+		}
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	utils.WriteResponse(w, http.StatusOK, artifacts)
+}
+
+func RemoveArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	name := utils.GetName(r)
+
+	artifacts, err := imageEngine.ArtifactRm(r.Context(), name, entities.ArtifactRemoveOptions{})
+	if err != nil {
+		if errors.Is(err, libartifact_types.ErrArtifactNotExist) {
+			utils.ArtifactNotFound(w, name, err)
+			return
+		}
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	utils.WriteResponse(w, http.StatusOK, artifacts)
+}
+
+func AddArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
+
+	query := struct {
+		Name             string   `schema:"name"`
+		FileName         string   `schema:"fileName"`
+		FileMIMEType     string   `schema:"fileMIMEType"`
+		Annotations      []string `schema:"annotations"`
+		ArtifactMIMEType string   `schema:"artifactMIMEType"`
+		Append           bool     `schema:"append"`
+	}{}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
+		return
+	}
+
+	if query.Name == "" || query.FileName == "" {
+		utils.Error(w, http.StatusBadRequest, errors.New("name and file parameters are required"))
+		return
+	}
+
+	annotations, err := domain_utils.ParseAnnotations(query.Annotations)
+	if err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+
+	artifactAddOptions := &entities.ArtifactAddOptions{
+		Append:       query.Append,
+		Annotations:  annotations,
+		ArtifactType: query.ArtifactMIMEType,
+		FileType:     query.FileMIMEType,
+	}
+
+	artifactBlobs := []entities.ArtifactBlob{{
+		BlobReader: r.Body,
+		FileName:   query.FileName,
+	}}
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	artifacts, err := imageEngine.ArtifactAdd(r.Context(), query.Name, artifactBlobs, artifactAddOptions)
+	if err != nil {
+		if errors.Is(err, libartifact_types.ErrArtifactNotExist) {
+			utils.ArtifactNotFound(w, query.Name, err)
+			return
+		}
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	utils.WriteResponse(w, http.StatusCreated, artifacts)
+}
+
+func PushArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
+
+	query := struct {
+		Retry      uint               `schema:"retry"`
+		RetryDelay string             `schema:"retrydelay"`
+		TLSVerify  types.OptionalBool `schema:"tlsVerify"`
+	}{}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusBadRequest, errors.New("name parameter is required"))
+		return
+	}
+
+	name := utils.GetName(r)
+
+	artifactsPushOptions := entities.ArtifactPushOptions{}
+
+	// If TLS verification is explicitly specified (True or False) in the query,
+	// set the SkipTLSVerify option accordingly.
+	// If TLSVerify was not set in the query, OptionalBoolUndefined is used and
+	// handled later based off the target registry configuration.
+	switch query.TLSVerify {
+	case types.OptionalBoolTrue:
+		artifactsPushOptions.SkipTLSVerify = types.NewOptionalBool(false)
+	case types.OptionalBoolFalse:
+		artifactsPushOptions.SkipTLSVerify = types.NewOptionalBool(true)
+	case types.OptionalBoolUndefined:
+		// If the user doesn't define TLSVerify in the query, do nothing and pass
+		// it to the backend code to handle.
+	default: // Should never happen
+		panic("Unexpected handling occurred for TLSVerify")
+	}
+
+	if _, found := r.URL.Query()["retry"]; found {
+		artifactsPushOptions.Retry = &query.Retry
+	}
+
+	if len(query.RetryDelay) != 0 {
+		artifactsPushOptions.RetryDelay = query.RetryDelay
+	}
+
+	authConf, authfile, err := auth.GetCredentials(r)
+	if err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+	defer auth.RemoveAuthfile(authfile)
+
+	if authConf != nil {
+		artifactsPushOptions.Username = authConf.Username
+		artifactsPushOptions.Password = authConf.Password
+	}
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	artifacts, err := imageEngine.ArtifactPush(r.Context(), name, artifactsPushOptions)
+	if err != nil {
+		var errcd errcode.ErrorCoder
+		// Check to see if any of the wrapped errors is an errcode.ErrorCoder returned from the registry
+		if errors.As(err, &errcd) {
+			rc := errcd.ErrorCode().Descriptor().HTTPStatusCode
+			// Check if the returned error is 401 indicating the request was unauthorized
+			if rc == 401 {
+				utils.Error(w, 401, errcd.ErrorCode())
+				return
+			}
+		}
+
+		var notFoundErr layout.ImageNotFoundError
+		if errors.As(err, &notFoundErr) {
+			utils.ArtifactNotFound(w, name, notFoundErr)
+			return
+		}
+
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	utils.WriteResponse(w, http.StatusOK, artifacts)
+}
+
+func ExtractArtifact(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
+
+	query := struct {
+		Digest string `schema:"digest"`
+		Title  string `schema:"title"`
+	}{}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
+		return
+	}
+
+	extractOpts := entities.ArtifactExtractOptions{
+		Title:  query.Title,
+		Digest: query.Digest,
+	}
+
+	name := utils.GetName(r)
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	err := imageEngine.ArtifactExtractTarStream(r.Context(), w, name, &extractOpts)
+	if err != nil {
+		if errors.Is(err, libartifact_types.ErrArtifactNotExist) {
+			utils.ArtifactNotFound(w, name, err)
+			return
+		}
+		utils.InternalServerError(w, err)
+		return
+	}
+}

--- a/pkg/api/handlers/swagger/errors.go
+++ b/pkg/api/handlers/swagger/errors.go
@@ -23,6 +23,20 @@ type containerNotFound struct {
 	Body errorhandling.ErrorModel
 }
 
+// No such artifact
+// swagger:response
+type artifactNotFound struct {
+	// in:body
+	Body errorhandling.ErrorModel
+}
+
+// error in authentication
+// swagger:response
+type artifactBadAuth struct {
+	// in:body
+	Body errorhandling.ErrorModel
+}
+
 // No such network
 // swagger:response
 type networkNotFound struct {

--- a/pkg/api/handlers/swagger/responses.go
+++ b/pkg/api/handlers/swagger/responses.go
@@ -478,3 +478,45 @@ type networkPruneResponse struct {
 	// in:body
 	Body []entities.NetworkPruneReport
 }
+
+// Inspect Artifact
+// swagger:response
+type inspectArtifactResponse struct {
+	// in:body
+	Body entities.ArtifactInspectReport
+}
+
+// Artifact list
+// swagger:response
+type artifactListResponse struct {
+	// in:body
+	Body []entities.ArtifactListReport
+}
+
+// Artifact Pull
+// swagger:response
+type artifactPullResponse struct {
+	// in:body
+	Body entities.ArtifactPullReport
+}
+
+// Artifact Remove
+// swagger:response
+type artifactRemoveResponse struct {
+	// in:body
+	Body entities.ArtifactRemoveReport
+}
+
+// Artifact Add
+// swagger:response
+type artifactAddResponse struct {
+	// in:body
+	Body entities.ArtifactAddReport
+}
+
+// Artifact Push
+// swagger:response
+type artifactPushResponse struct {
+	// in:body
+	Body entities.ArtifactPushReport
+}

--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -59,6 +59,10 @@ func ImageNotFound(w http.ResponseWriter, name string, err error) {
 	Error(w, http.StatusNotFound, err)
 }
 
+func ArtifactNotFound(w http.ResponseWriter, name string, err error) {
+	Error(w, http.StatusNotFound, err)
+}
+
 func NetworkNotFound(w http.ResponseWriter, name string, err error) {
 	if !errors.Is(err, define.ErrNoSuchNetwork) {
 		InternalServerError(w, err)

--- a/pkg/api/server/register_artifacts.go
+++ b/pkg/api/server/register_artifacts.go
@@ -1,0 +1,256 @@
+//go:build !remote
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/containers/podman/v5/pkg/api/handlers/libpod"
+	"github.com/gorilla/mux"
+)
+
+func (s *APIServer) registerArtifactHandlers(r *mux.Router) error {
+	// swagger:operation GET /libpod/artifacts/{name}/json libpod ArtifactInspectLibpod
+	// ---
+	// tags:
+	//   - artifacts
+	// summary: Inspect an artifact
+	// description: Obtain low-level information about an artifact
+	// produces:
+	//   - application/json
+	// parameters:
+	//   - name: name
+	//     in: path
+	//     description: The name or ID of the artifact
+	//     required: true
+	//     type: string
+	// responses:
+	//   200:
+	//     $ref: "#/responses/inspectArtifactResponse"
+	//   404:
+	//     $ref: "#/responses/artifactNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.HandleFunc(VersionedPath("/libpod/artifacts/{name:.*}/json"), s.APIHandler(libpod.InspectArtifact)).Methods(http.MethodGet)
+	// swagger:operation GET /libpod/artifacts/json libpod ArtifactListLibpod
+	// ---
+	// tags:
+	//   - artifacts
+	// summary: List artifacts
+	// description: Returns a list of artifacts on the server.
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: "#/responses/artifactListResponse"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.HandleFunc(VersionedPath("/libpod/artifacts/json"), s.APIHandler(libpod.ListArtifact)).Methods(http.MethodGet)
+	// swagger:operation POST /libpod/artifacts/pull libpod ArtifactPullLibpod
+	// ---
+	// tags:
+	//  - artifacts
+	// summary: Pull an OCI artifact
+	// description: Pulls an artifact from a registry and stores it locally.
+	// produces:
+	// - application/json
+	// parameters:
+	//   - name: name
+	//     in: query
+	//     description: Mandatory reference to the artifact (e.g., quay.io/image/artifact:tag)
+	//     required: true
+	//     type: string
+	//   - name: retry
+	//     in: query
+	//     description: Number of times to retry in case of failure when performing pull
+	//     type: integer
+	//     default: 3
+	//   - name: retryDelay
+	//     in: query
+	//     description: Delay between retries in case of pull failures (e.g., 10s)
+	//     type: string
+	//     default: 1s
+	//   - name: tlsVerify
+	//     in: query
+	//     description: Require TLS verification.
+	//     type: boolean
+	//     default: true
+	//   - name: X-Registry-Auth
+	//     in: header
+	//     description: |
+	//       base-64 encoded auth config.
+	//       Must include the following four values: username, password, email and server address
+	//       OR simply just an identity token.
+	//     type: string
+	// responses:
+	//   200:
+	//     $ref: "#/responses/artifactPullResponse"
+	//   400:
+	//     $ref: "#/responses/badParamError"
+	//   401:
+	//     $ref: "#/responses/artifactBadAuth"
+	//   404:
+	//     $ref: "#/responses/artifactNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/artifacts/pull"), s.APIHandler(libpod.PullArtifact)).Methods(http.MethodPost)
+	// swagger:operation DELETE /libpod/artifacts/{name} libpod ArtifactDeleteLibpod
+	// ---
+	// tags:
+	//  - artifacts
+	// summary: Remove Artifact
+	// description: Delete an Artifact from local storage
+	// produces:
+	//  - application/json
+	// parameters:
+	//  - name: name
+	//    in: path
+	//    description: name or ID of artifact to delete
+	//    required: true
+	//    type: string
+	// responses:
+	//   200:
+	//     $ref: "#/responses/artifactRemoveResponse"
+	//   404:
+	//     $ref: "#/responses/artifactNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/artifacts/{name:.*}"), s.APIHandler(libpod.RemoveArtifact)).Methods(http.MethodDelete)
+	// swagger:operation POST /libpod/artifacts/add libpod ArtifactAddLibpod
+	// ---
+	// tags:
+	//  - artifacts
+	// summary: Add an OCI artifact to the local store
+	// description: Add an OCI artifact to the local store from the local filesystem
+	// produces:
+	//   - application/json
+	// consumes:
+	//   - application/octet-stream
+	// parameters:
+	//   - name: name
+	//     in: query
+	//     description: Mandatory reference to the artifact (e.g., quay.io/image/artifact:tag)
+	//     required: true
+	//     type: string
+	//   - name: fileName
+	//     in: query
+	//     description: File to be added to the artifact
+	//     required: true
+	//     type: string
+	//   - name: fileMIMEType
+	//     in: query
+	//     description: Optionally set the type of file
+	//     type: string
+	//   - name: annotations
+	//     in: query
+	//     description: Array of annotation strings e.g "test=true"
+	//     type: array
+	//     items:
+	//       type: string
+	//   - name: artifactMIMEType
+	//     in: query
+	//     description: Use type to describe an artifact
+	//     type: string
+	//   - name: append
+	//     in: query
+	//     description: Append files to an existing artifact
+	//     type: boolean
+	//     default: false
+	//   - name: inputStream
+	//     in: body
+	//     description: A binary stream of the blob to add to artifact
+	//     schema:
+	//       type: string
+	//       format: binary
+	// responses:
+	//   201:
+	//     $ref: "#/responses/artifactAddResponse"
+	//   400:
+	//     $ref: "#/responses/badParamError"
+	//   404:
+	//     $ref: "#/responses/artifactNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/artifacts/add"), s.APIHandler(libpod.AddArtifact)).Methods(http.MethodPost)
+	// swagger:operation POST /libpod/artifacts/{name}/push libpod ArtifactPushLibpod
+	// ---
+	// tags:
+	//  - artifacts
+	// summary: Push an OCI artifact
+	// description: Push an OCI artifact from local storage to an image registry.
+	// produces:
+	//   - application/json
+	// parameters:
+	//   - name: name
+	//     in: path
+	//     description: Mandatory reference to the artifact (e.g., quay.io/image/artifact:tag)
+	//     required: true
+	//     type: string
+	//   - name: retry
+	//     in: query
+	//     description: Number of times to retry in case of failure when performing pull
+	//     type: integer
+	//     default: 3
+	//   - name: retryDelay
+	//     in: query
+	//     description: Delay between retries in case of pull failures (e.g., 10s)
+	//     type: string
+	//     default: 1s
+	//   - name: tlsVerify
+	//     in: query
+	//     description: Require TLS verification.
+	//     type: boolean
+	//     default: true
+	//   - name: X-Registry-Auth
+	//     in: header
+	//     description: |
+	//       base-64 encoded auth config.
+	//       Must include the following four values: username, password, email and server address
+	//       OR simply just an identity token.
+	//     type: string
+	// responses:
+	//   200:
+	//     $ref: "#/responses/artifactPushResponse"
+	//   400:
+	//     $ref: "#/responses/badParamError"
+	//   401:
+	//     $ref: "#/responses/artifactBadAuth"
+	//   404:
+	//     $ref: "#/responses/artifactNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/artifacts/{name:.*}/push"), s.APIHandler(libpod.PushArtifact)).Methods(http.MethodPost)
+	// swagger:operation GET /libpod/artifacts/{name}/extract libpod ArtifactExtractLibpod
+	// ---
+	// tags:
+	//  - artifacts
+	// summary: Extract an OCI artifact to a local path
+	// description: Extract the blobs of an OCI artifact to a local file or directory
+	// produces:
+	//   - application/x-tar
+	// parameters:
+	//  - name: name
+	//    in: path
+	//    description: The name or digest of artifact
+	//    required: true
+	//    type: string
+	//  - name: title
+	//    in: query
+	//    description: Only extract blob with the given title
+	//    type: string
+	//  - name: digest
+	//    in: query
+	//    description: Only extract blob with the given digest
+	//    type: string
+	// responses:
+	//   200:
+	//     description: Extract successful
+	//   400:
+	//     $ref: "#/responses/badParamError"
+	//   404:
+	//     $ref: "#/responses/artifactNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/artifacts/{name:.*}/extract"), s.APIHandler(libpod.ExtractArtifact)).Methods(http.MethodGet)
+	return nil
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -119,6 +119,7 @@ func newServer(runtime *libpod.Runtime, listener net.Listener, opts entities.Ser
 
 	for _, fn := range []func(*mux.Router) error{
 		server.registerAuthHandlers,
+		server.registerArtifactHandlers,
 		server.registerArchiveHandlers,
 		server.registerContainersHandlers,
 		server.registerDistributionHandlers,

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -2,6 +2,7 @@ package entities
 
 import (
 	"context"
+	"io"
 
 	"github.com/containers/common/libimage/define"
 	"github.com/containers/common/pkg/config"
@@ -9,8 +10,9 @@ import (
 )
 
 type ImageEngine interface { //nolint:interfacebloat
-	ArtifactAdd(ctx context.Context, name string, paths []string, opts *ArtifactAddOptions) (*ArtifactAddReport, error)
+	ArtifactAdd(ctx context.Context, name string, artifactBlobs []ArtifactBlob, opts *ArtifactAddOptions) (*ArtifactAddReport, error)
 	ArtifactExtract(ctx context.Context, name string, target string, opts *ArtifactExtractOptions) error
+	ArtifactExtractTarStream(ctx context.Context, w io.Writer, name string, opts *ArtifactExtractOptions) error
 	ArtifactInspect(ctx context.Context, name string, opts ArtifactInspectOptions) (*ArtifactInspectReport, error)
 	ArtifactList(ctx context.Context, opts ArtifactListOptions) ([]*ArtifactListReport, error)
 	ArtifactPull(ctx context.Context, name string, opts ArtifactPullOptions) (*ArtifactPullReport, error)

--- a/pkg/domain/entities/types/artifacts.go
+++ b/pkg/domain/entities/types/artifacts.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/containers/podman/v5/pkg/libartifact"
+
+type ArtifactInspectReport struct {
+	*libartifact.Artifact
+	Digest string
+}

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
@@ -10,6 +11,10 @@ import (
 // TODO For now, no remote support has been added. We need the API to firm up first.
 
 func (ir *ImageEngine) ArtifactExtract(ctx context.Context, name string, target string, opts *entities.ArtifactExtractOptions) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (ir *ImageEngine) ArtifactExtractTarStream(ctx context.Context, w io.Writer, name string, opts *entities.ArtifactExtractOptions) error {
 	return fmt.Errorf("not implemented")
 }
 
@@ -33,6 +38,6 @@ func (ir *ImageEngine) ArtifactPush(ctx context.Context, name string, opts entit
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (ir *ImageEngine) ArtifactAdd(ctx context.Context, name string, paths []string, opts *entities.ArtifactAddOptions) (*entities.ArtifactAddReport, error) {
+func (ir *ImageEngine) ArtifactAdd(ctx context.Context, name string, artifactBlob []entities.ArtifactBlob, opts *entities.ArtifactAddOptions) (*entities.ArtifactAddReport, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/test/apiv2/python/rest_api/test_v2_0_0_artifact.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_artifact.py
@@ -1,0 +1,582 @@
+import os
+import tarfile
+import unittest
+from typing import cast
+
+import requests
+
+from .fixtures import APITestCase
+from .fixtures.api_testcase import Artifact, ArtifactFile
+
+
+class ArtifactTestCase(APITestCase):
+    def test_add(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+        }
+
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        # Assert return response is json and contains digest
+        add_response_json = add_response.json()
+        self.assertIn("sha256:", cast(str, add_response_json["ArtifactDigest"]))
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+        artifact_layer = inspect_response_json["Manifest"]["layers"][0]
+
+        # Assert uploaded artifact blob is expected size
+        self.assertEqual(artifact_layer["size"], file.size)
+
+        # Assert uploaded artifact blob has expected title annotation
+        self.assertEqual(
+            artifact_layer["annotations"]["org.opencontainers.image.title"], file.name
+        )
+
+        # Assert blob media type fallback detection is working
+        self.assertEqual(artifact_layer["mediaType"], "application/octet-stream")
+
+    def test_add_with_append(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+        file = ArtifactFile(name="test_file_2")
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+            "append": "true",
+        }
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        # Assert return response is json and contains digest
+        add_response_json = add_response.json()
+        self.assertIn("sha256:", cast(str, add_response_json["ArtifactDigest"]))
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+        artifact_layers = inspect_response_json["Manifest"]["layers"]
+
+        # Assert artifact now has two layers
+        self.assertEqual(len(artifact_layers), 2)
+
+    def test_add_with_artifactMIMEType_override(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact_artifactType:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+            "artifactMIMEType": "application/testType",
+        }
+
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+
+        # Assert added artifact has correct mediaType
+        self.assertEqual(
+            inspect_response_json["Manifest"]["artifactType"], "application/testType"
+        )
+
+    def test_add_with_annotations(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact_annotation:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+            "annotations": ["test=test", "foo=bar"],
+        }
+
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+        artifact_layer = inspect_response_json["Manifest"]["layers"][0]
+
+        # Assert artifactBlobAnnotation is set correctly
+        anno = {
+            "foo": "bar",
+            "org.opencontainers.image.title": artifact.file.name,
+            "test": "test",
+        }
+        self.assertEqual(artifact_layer["annotations"], anno)
+
+    def test_add_with_empty_file(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact_empty_file:latest"
+        file = ArtifactFile(size=0)
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+        }
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        # Assert return response is json and contains digest
+        add_response_json = add_response.json()
+        self.assertIn("sha256:", cast(str, add_response_json["ArtifactDigest"]))
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+        artifact_layer = inspect_response_json["Manifest"]["layers"][0]
+
+        # Assert uploaded artifact blob is expected size
+        self.assertEqual(artifact_layer["size"], file.size)
+
+        # Assert uploaded artifact blob has expected title annotation
+        self.assertEqual(
+            artifact_layer["annotations"]["org.opencontainers.image.title"], file.name
+        )
+
+    def test_add_with_fileMIMEType_override(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact_mime_type:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+            "fileMIMEType": "fake/type",
+        }
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        # Assert return response is json and contains digest
+        add_response_json = add_response.json()
+        self.assertIn("sha256:", cast(str, add_response_json["ArtifactDigest"]))
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+        artifact_layer = inspect_response_json["Manifest"]["layers"][0]
+
+        # Assert uploaded artifact blob is expected MIME type
+        self.assertEqual(artifact_layer["mediaType"], "fake/type")
+
+    def test_add_with_auto_fileMIMEType_discovery(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact_image_blob:latest"
+        FILE_SIG = bytes([137, 80, 78, 71, 13, 10, 26, 10])
+        file = ArtifactFile(sig=FILE_SIG)
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+        }
+
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        add_response = artifact.add()
+
+        # Assert correct response code
+        self.assertEqual(add_response.status_code, 201, add_response.text)
+
+        # Assert return response is json and contains digest
+        add_response_json = add_response.json()
+        self.assertIn("sha256:", cast(str, add_response_json["ArtifactDigest"]))
+
+        inspect_response_json = artifact.do_artifact_inspect_request().json()
+        artifact_layer = inspect_response_json["Manifest"]["layers"][0]
+
+        # Assert uploaded artifact blob is automatically recognised as image
+        self.assertEqual(artifact_layer["mediaType"], "image/png")
+
+    def test_add_append_with_type_fails(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+            "artifactMIMEType": "application/octet-stream",
+            "append": "true",
+        }
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        r = artifact.add()
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 500, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "append option is not compatible with ArtifactType option",
+        )
+
+    def test_add_with_append_to_missing_artifact_fails(self):
+        ARTIFACT_NAME = "quay.io/myimage/missing:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {
+            "name": ARTIFACT_NAME,
+            "fileName": file.name,
+            "append": "true",
+        }
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        r = artifact.add()
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 404, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(rjson["cause"], "artifact does not exist")
+
+    def test_add_without_name_and_filename_fails(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+        file = ArtifactFile()
+        parameters: dict[str, str | list[str]] = {"fake": "fake"}
+        artifact = Artifact(self.uri(""), ARTIFACT_NAME, parameters, file)
+
+        r = artifact.add()
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 400, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "name and file parameters are required",
+        )
+
+    def test_inspect(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact_mime_type:latest"
+
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/json",
+        )
+        r = requests.get(url)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 200, r.text)
+
+        # Define expected layout keys
+        expected_top_level = {"Manifest", "Name", "Digest"}
+        expected_manifest = {
+            "schemaVersion",
+            "mediaType",
+            "config",
+            "layers",
+        }
+        expected_config = {"mediaType", "digest", "size", "data"}
+        expected_layer = {"mediaType", "digest", "size", "annotations"}
+
+        # Compare returned keys with expected
+        missing_top = expected_top_level - rjson.keys()
+        manifest = rjson.get("Manifest", {})
+        missing_manifest = expected_manifest - manifest.keys()
+        config = manifest.get("config", {})
+        missing_config = expected_config - config.keys()
+
+        layers = manifest.get("layers", [])
+        for i, layer in enumerate(layers):
+            missing_layer = expected_layer - layer.keys()
+            self.assertFalse(missing_layer)
+
+        # Assert all missing dicts are empty meaning all expected keys were present
+        self.assertFalse(missing_top)
+        self.assertFalse(missing_manifest)
+        self.assertFalse(missing_config)
+
+    def test_inspect_absent_artifact_fails(self):
+        ARTIFACT_NAME = "fake_artifact"
+        url = self.uri("/artifacts/" + ARTIFACT_NAME + "/json")
+        r = requests.get(url)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 404, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "artifact does not exist",
+        )
+
+    def test_list(self):
+        url = self.uri("/artifacts/json")
+        r = requests.get(url)
+        rjson = r.json()
+
+        self.assertEqual(r.status_code, 200, r.text)
+
+        expected_top_level = {"Manifest", "Name"}
+        expected_manifest = {"schemaVersion", "mediaType", "config", "layers"}
+        expected_config = {"mediaType", "digest", "size", "data"}
+        expected_layer = {"mediaType", "digest", "size", "annotations"}
+
+        for data in rjson:
+            missing_top = expected_top_level - data.keys()
+            manifest = data.get("Manifest", {})
+            missing_manifest = expected_manifest - manifest.keys()
+            config = manifest.get("config", {})
+            missing_config = expected_config - config.keys()
+
+            layers = manifest.get("layers", [])
+            for _, layer in enumerate(layers):
+                missing_layer = expected_layer - layer.keys()
+                self.assertFalse(missing_layer)
+
+            # assert all missing dicts are empty
+            self.assertFalse(missing_top)
+            self.assertFalse(missing_manifest)
+            self.assertFalse(missing_config)
+
+    def test_pull(self):
+        ARTIFACT_NAME = "quay.io/libpod/testartifact:20250206-single"
+        url = self.uri("/artifacts/pull")
+        parameters = {
+            "name": ARTIFACT_NAME,
+        }
+        r = requests.post(url, params=parameters)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 200, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertIn("sha256:", rjson["ArtifactDigest"])
+
+    def test_pull_with_retry(self):
+        ARTIFACT_NAME = "localhost/fake/artifact:latest"
+
+        # Note: Default retry is 3 attempts with 1s delay.
+        url = self.uri("/artifacts/pull")
+        parameters = {
+            "name": ARTIFACT_NAME,
+            "retryDelay": "3s",
+            "retry": "2",
+        }
+        r = requests.post(url, params=parameters)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 500, r.text)
+
+        # Assert request took expected time with retries
+        self.assertTrue(5 < r.elapsed.total_seconds() < 7)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "connection refused",
+        )
+
+    def test_pull_unauthorised_fails(self):
+        ARTIFACT_NAME = "quay.io/libpod_secret/testartifact:latest"
+        url = self.uri("/artifacts/pull")
+        parameters = {
+            "name": ARTIFACT_NAME,
+        }
+        r = requests.post(url, params=parameters)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 401, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "unauthorized",
+        )
+
+    def test_pull_missing_fails(self):
+        ARTIFACT_NAME = "quay.io/libpod/testartifact:superfake"
+        url = self.uri("/artifacts/pull")
+        parameters = {
+            "name": ARTIFACT_NAME,
+        }
+        r = requests.post(url, params=parameters)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 404, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "manifest unknown",
+        )
+
+    def test_remove(self):
+        ARTIFACT_NAME = "quay.io/libpod/testartifact:20250206-single"
+        url = self.uri("/artifacts/" + ARTIFACT_NAME)
+        r = requests.delete(url)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 200, r.text)
+
+        # Assert return response is json and contains digest
+        self.assertIn("sha256:", rjson["ArtifactDigests"][0])
+
+    def test_remove_absent_artifact_fails(self):
+        ARTIFACT_NAME = "localhost/fake/artifact:latest"
+        url = self.uri("/artifacts/" + ARTIFACT_NAME)
+
+        r = requests.delete(url)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 404, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "artifact does not exist",
+        )
+
+    def test_push_unauthorised(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/push",
+        )
+        r = requests.post(url)
+        rjson = r.json()
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(r.status_code, 401, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "unauthorized",
+        )
+
+    def test_push_bad_param(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+        parameters = {
+            "retry": "abc",
+        }
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/push",
+        )
+        r = requests.post(
+            url,
+            params=parameters,
+        )
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 400, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "name parameter is required",
+        )
+
+    def test_push_missing_artifact(self):
+        ARTIFACT_NAME = "localhost/fake/artifact:latest"
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/push",
+        )
+        r = requests.post(
+            url,
+        )
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 404, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertIn(
+            "no descriptor found for reference",
+            rjson["cause"],
+        )
+
+    def test_extract(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/extract",
+        )
+        r = requests.get(url)
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 200, r.text)
+
+        tar_file = "test.tar"
+        tar_file_sizes = None
+
+        with open(tar_file, "wb") as f:
+            _ = f.write(r.content)
+
+        with tarfile.open(tar_file, "r") as tar:
+            tar_file_sizes = {m.name: m.size for m in tar.getmembers() if m.isfile()}
+
+        self.assertEqual(
+            tar_file_sizes, {"test_file_1": 1048576, "test_file_2": 1048576}
+        )
+
+        os.remove(tar_file)
+
+    def test_extract_with_title(self):
+        ARTIFACT_NAME = "quay.io/myimage/myartifact:latest"
+
+        parameters: dict[str, str] = {
+            "title": "test_file_1",
+        }
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/extract",
+        )
+        r = requests.get(url, parameters)
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 200, r.text)
+
+        tar_file = "test.tar"
+        tar_file_sizes = None
+
+        with open(tar_file, "wb") as f:
+            _ = f.write(r.content)
+
+        with tarfile.open(tar_file, "r") as tar:
+            tar_file_sizes = {m.name: m.size for m in tar.getmembers() if m.isfile()}
+
+        self.assertEqual(tar_file_sizes, {"test_file_1": 1048576})
+
+        os.remove(tar_file)
+
+    def test_extract_absent_fails(self):
+        ARTIFACT_NAME = "localhost/fake/artifact:latest"
+
+        url = self.uri(
+            "/artifacts/" + ARTIFACT_NAME + "/extract",
+        )
+        r = requests.get(url)
+        rjson = r.json()
+
+        # Assert correct response code
+        self.assertEqual(r.status_code, 404, r.text)
+
+        # Assert return error response is json and contains correct message
+        self.assertEqual(
+            rjson["cause"],
+            "artifact does not exist",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This patch adds a new endpoint to the REST API called "artifacts" with the following methods:
- Add
- Extract
- Inspect
- List
- Pull
- Push
- Remove

This API will be utilised by the Podman bindings to add OCI Artifact support to our remote clients.

Jira: https://issues.redhat.com/browse/RUN-2711
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added artifacts endpoint to Podman REST API
```