### PR TITLE
Fix a shellcheck warning about word splitting

### DIFF
--- a/docker/podman-docker.sh
+++ b/docker/podman-docker.sh
@@ -1,7 +1,7 @@
 # DOCKER_HOST initialization
 
 if [ -z "${DOCKER_HOST-}" ]; then
-    if [ $(id -u) -eq 0 ]; then
+    if [ "$(id -u)" -eq 0 ]; then
 	export DOCKER_HOST=unix:///run/podman/podman.sock
     else
 	if [ -n "${XDG_RUNTIME_DIR-}" ]; then


### PR DESCRIPTION
Error: SHELLCHECK_WARNING (CWE-156): [#def2]
/etc/profile.d/podman-docker.sh:4:10: warning[SC2046]: Quote this to prevent word splitting.
    2|
    3|   if [ -z "${DOCKER_HOST-}" ]; then
    4|->     if [ $(id -u) -eq 0 ]; then
    5|   	export DOCKER_HOST=unix:///run/podman/podman.sock
    6|       else

Resolves: https://openscanhub.fedoraproject.org/task/52458/log/podman-5.4.2-1.fc43/scan-results.html#def2

#### Does this PR introduce a user-facing change?

```release-note
None
```
