### PR TITLE
compat: Add CgroupnsMode to POST /containers/create

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -507,6 +507,14 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*container.InspectResp
 	}
 	sort.Strings(hc.Binds)
 
+	// Map CgroupMode to CgroupnsMode for Docker API compatibility
+	switch inspect.HostConfig.CgroupMode {
+	case "private":
+		hc.CgroupnsMode = container.CgroupnsModePrivate
+	case "host":
+		hc.CgroupnsMode = container.CgroupnsModeHost
+	}
+
 	// k8s-file == json-file
 	if hc.LogConfig.Type == define.KubernetesLogging {
 		hc.LogConfig.Type = define.JSONLogging

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -474,6 +474,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		User:                 cc.Config.User,
 		UserNS:               string(cc.HostConfig.UsernsMode),
 		UTS:                  string(cc.HostConfig.UTSMode),
+		CgroupNS:             string(cc.HostConfig.CgroupnsMode),
 		Mount:                mounts,
 		VolumesFrom:          cc.HostConfig.VolumesFrom,
 		Workdir:              cc.Config.WorkingDir,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
compat: POST /containers/create accepts HostConfig.CgroupnsMode
```

@Luap99 same here, I think I need some guidance with testing. (works locally though)