### PR TITLE
podman: remember hooks-dir on restarts

### DIFF
--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -285,6 +285,9 @@ func CreateExitCommandArgs(storageConfig storageTypes.StoreOptions, config *conf
 		"--db-backend", config.Engine.DBBackend,
 		fmt.Sprintf("--transient-store=%t", storageConfig.TransientStore),
 	}
+	for _, dir := range config.Engine.HooksDir.Get() {
+		command = append(command, []string{"--hooks-dir", dir}...)
+	}
 	if storageConfig.ImageStore != "" {
 		command = append(command, []string{"--imagestore", storageConfig.ImageStore}...)
 	}

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -968,27 +968,6 @@ EOF
      fi
 }
 
-function wait_for_restart_count() {
-    local cname="$1"
-    local count="$2"
-    local tname="$3"
-
-    local timeout=10
-    while :; do
-        # Previously this would fail as the container would run out of ips after 5 restarts.
-        run_podman inspect --format "{{.RestartCount}}" $cname
-        if [[ "$output" == "$2" ]]; then
-            break
-        fi
-
-        timeout=$((timeout - 1))
-        if [[ $timeout -eq 0 ]]; then
-            die "Timed out waiting for RestartCount with $tname"
-        fi
-        sleep 0.5
-    done
-}
-
 # Test for https://github.com/containers/podman/issues/18615
 # CANNOT BE PARALLELIZED due to strict checking of /run/netns
 @test "podman network cleanup --userns + --restart" {

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -1347,6 +1347,30 @@ function ensure_no_mountpoint() {
     fi
 }
 
+###########################
+# ensure container has been restarted requested times
+###########################
+function wait_for_restart_count() {
+    local cname="$1"
+    local count="$2"
+    local tname="$3"
+
+    local timeout=10
+    while :; do
+        # Previously this would fail as the container would run out of ips after 5 restarts.
+        run_podman inspect --format "{{.RestartCount}}" $cname
+        if [[ "$output" == "$2" ]]; then
+            break
+        fi
+
+        timeout=$((timeout - 1))
+        if [[ $timeout -eq 0 ]]; then
+            die "Timed out waiting for RestartCount with $tname"
+        fi
+        sleep 0.5
+    done
+}
+
 
 # END   miscellaneous tools
 ###############################################################################


### PR DESCRIPTION
When podman restarts config values within the Engine are lost. Add --hook-dirs arguments as appropriate to the cleanup command so that hooks are preserved on restarts due to the on-restart setting

Fixes: #17935

I've confirmed this works with my reproducer, and it's probably the smallest change that'd work for us so opening PR with that for feedback.
Thanks!

#### Does this PR introduce a user-facing change?

```release-note
Fix hooks not being run properly after first restart if a non-default --hooks-dir setting was used
```
(happy to remove this note as I don't think it's a critical bug, but it's technically user-facing so wrote it in doubt)
