### PR TITLE
[v4.9-rhel][DO NOT MERGE] Fix: Ensure HealthCheck exec session terminates on timeout

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -206,7 +206,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.StringVar(
 			&cf.HealthTimeout,
 			healthTimeoutFlagName, define.DefaultHealthCheckTimeout,
-			"the maximum time allowed to complete the healthcheck before an interval is considered failed",
+			"the maximum time allowed to complete the healthcheck before an interval is considered failed and SIGKILL is sent to the healthcheck process",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthTimeoutFlagName, completion.AutocompleteNone)
 

--- a/docs/source/markdown/options/health-timeout.md
+++ b/docs/source/markdown/options/health-timeout.md
@@ -6,3 +6,6 @@
 
 The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
 value can be expressed in a time format such as **1m22s**. The default value is **30s**.
+
+Note: A timeout marks the healthcheck as failed. If the healthcheck command itself runs longer than the specified *timeout*,
+it will be sent a `SIGKILL` signal.

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -156,34 +156,20 @@ type legacyExecSession struct {
 	PID     int      `json:"pid"`
 }
 
-// ExecCreate creates a new exec session for the container.
-// The session is not started. The ID of the new exec session will be returned.
-func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
-	if !c.batched {
-		c.lock.Lock()
-		defer c.lock.Unlock()
-
-		if err := c.syncContainer(); err != nil {
-			return "", err
-		}
-	}
-
-	// Verify our config
+func (c *Container) verifyExecConfig(config *ExecConfig) error {
 	if config == nil {
-		return "", fmt.Errorf("must provide a configuration to ExecCreate: %w", define.ErrInvalidArg)
+		return fmt.Errorf("must provide a configuration to ExecCreate: %w", define.ErrInvalidArg)
 	}
 	if len(config.Command) == 0 {
-		return "", fmt.Errorf("must provide a non-empty command to start an exec session: %w", define.ErrInvalidArg)
+		return fmt.Errorf("must provide a non-empty command to start an exec session: %w", define.ErrInvalidArg)
 	}
 	if config.ExitCommandDelay > 0 && len(config.ExitCommand) == 0 {
-		return "", fmt.Errorf("must provide a non-empty exit command if giving an exit command delay: %w", define.ErrInvalidArg)
+		return fmt.Errorf("must provide a non-empty exit command if giving an exit command delay: %w", define.ErrInvalidArg)
 	}
+	return nil
+}
 
-	// Verify that we are in a good state to continue
-	if !c.ensureState(define.ContainerStateRunning) {
-		return "", fmt.Errorf("can only create exec sessions on running containers: %w", define.ErrCtrStateInvalid)
-	}
-
+func (c *Container) getUniqueExecSessionID() string {
 	// Generate an ID for our new exec session
 	sessionID := stringid.GenerateRandomID()
 	found := true
@@ -200,19 +186,51 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 			sessionID = stringid.GenerateRandomID()
 		}
 	}
+	return sessionID
+}
 
-	// Make our new exec session
+func (c *Container) createExecSession(config *ExecConfig) (*ExecSession, error) {
 	session := new(ExecSession)
-	session.Id = sessionID
+	session.Id = c.getUniqueExecSessionID()
 	session.ContainerId = c.ID()
 	session.State = define.ExecStateCreated
 	session.Config = new(ExecConfig)
 	if err := JSONDeepCopy(config, session.Config); err != nil {
-		return "", fmt.Errorf("copying exec configuration into exec session: %w", err)
+		return nil, fmt.Errorf("copying exec configuration into exec session: %w", err)
 	}
 
 	if len(session.Config.ExitCommand) > 0 {
 		session.Config.ExitCommand = append(session.Config.ExitCommand, []string{session.ID(), c.ID()}...)
+	}
+	return session, nil
+}
+
+// ExecCreate creates a new exec session for the container.
+// The session is not started. The ID of the new exec session will be returned.
+func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
+	if !c.batched {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		if err := c.syncContainer(); err != nil {
+			return "", err
+		}
+	}
+
+	// Verify our config
+	if err := c.verifyExecConfig(config); err != nil {
+		return "", err
+	}
+
+	// Verify that we are in a good state to continue
+	if !c.ensureState(define.ContainerStateRunning) {
+		return "", fmt.Errorf("can only create exec sessions on running containers: %w", define.ErrCtrStateInvalid)
+	}
+
+	// Make our new exec session
+	session, err := c.createExecSession(config)
+	if err != nil {
+		return "", err
 	}
 
 	if c.state.ExecSessions == nil {
@@ -230,7 +248,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 
 	logrus.Infof("Created exec session %s in container %s", session.ID(), c.ID())
 
-	return sessionID, nil
+	return session.Id, nil
 }
 
 // ExecStart starts an exec session in the container, but does not attach to it.
@@ -753,6 +771,68 @@ func (c *Container) ExecResize(sessionID string, newSize resize.TerminalSize) er
 	// Make sure the exec session is still running.
 
 	return c.ociRuntime.ExecAttachResize(c, sessionID, newSize)
+}
+
+func (c *Container) healthCheckExec(config *ExecConfig, streams *define.AttachStreams) (int, error) {
+	unlock := true
+	if !c.batched {
+		c.lock.Lock()
+		defer func() {
+			if unlock {
+				c.lock.Unlock()
+			}
+		}()
+
+		if err := c.syncContainer(); err != nil {
+			return -1, err
+		}
+	}
+
+	if err := c.verifyExecConfig(config); err != nil {
+		return -1, err
+	}
+
+	if !c.ensureState(define.ContainerStateRunning) {
+		return -1, fmt.Errorf("can only create exec sessions on running containers: %w", define.ErrCtrStateInvalid)
+	}
+
+	session, err := c.createExecSession(config)
+	if err != nil {
+		return -1, err
+	}
+
+	if c.state.ExecSessions == nil {
+		c.state.ExecSessions = make(map[string]*ExecSession)
+	}
+	c.state.ExecSessions[session.ID()] = session
+	defer delete(c.state.ExecSessions, session.ID())
+
+	opts, err := prepareForExec(c, session)
+	if err != nil {
+		return -1, err
+	}
+	defer func() {
+		if err := c.cleanupExecBundle(session.ID()); err != nil {
+			logrus.Errorf("Container %s light exec session cleanup error: %v", c.ID(), err)
+		}
+	}()
+
+	pid, attachErrChan, err := c.ociRuntime.ExecContainer(c, session.ID(), opts, streams, nil)
+	if err != nil {
+		return -1, err
+	}
+
+	if !c.batched {
+		c.lock.Unlock()
+		unlock = false
+	}
+
+	err = <-attachErrChan
+	if err != nil {
+		return -1, fmt.Errorf("container %s light exec session with pid: %d error: %v", c.ID(), pid, err)
+	}
+
+	return c.readExecExitCode(session.ID())
 }
 
 func (c *Container) Exec(config *ExecConfig, streams *define.AttachStreams, resize <-chan resize.TerminalSize) (int, error) {

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -215,4 +215,7 @@ var (
 	// ErrRemovingCtrs indicates that there was an error removing all
 	// containers from a pod.
 	ErrRemovingCtrs = errors.New("removing pod containers")
+
+	// ErrHealthCheckTimeout indicates that a HealthCheck timed out.
+	ErrHealthCheckTimeout = errors.New("healthcheck command exceeded timeout")
 )

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -113,19 +113,23 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	}()
 
 	logrus.Debugf("executing health check command %s for %s", strings.Join(newCommand, " "), c.ID())
-	timeStart := time.Now()
 	hcResult := define.HealthCheckSuccess
 	config := new(ExecConfig)
 	config.Command = newCommand
-	exitCode, hcErr := c.healthCheckExec(config, streams)
+	timeStart := time.Now()
+	exitCode, hcErr := c.healthCheckExec(config, c.HealthCheckConfig().Timeout, streams)
+	timeEnd := time.Now()
 	if hcErr != nil {
 		hcResult = define.HealthCheckFailure
-		if errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||
+		switch {
+		case errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||
 			errors.Is(hcErr, define.ErrOCIRuntimePermissionDenied) ||
-			errors.Is(hcErr, define.ErrOCIRuntime) {
+			errors.Is(hcErr, define.ErrOCIRuntime):
 			returnCode = 1
 			hcErr = nil
-		} else {
+		case errors.Is(hcErr, define.ErrHealthCheckTimeout):
+			returnCode = -1
+		default:
 			returnCode = 125
 		}
 	} else if exitCode != 0 {
@@ -144,7 +148,6 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 		}
 	}
 
-	timeEnd := time.Now()
 	if c.HealthCheckConfig().StartPeriod > 0 {
 		// there is a start-period we need to honor; we add startPeriod to container start time
 		startPeriodTime := c.state.StartedTime.Add(c.HealthCheckConfig().StartPeriod)
@@ -158,12 +161,6 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	eventLog := strings.Join(stdout, "\n")
 	if len(eventLog) > MaxHealthCheckLogLength {
 		eventLog = eventLog[:MaxHealthCheckLogLength]
-	}
-
-	if timeEnd.Sub(timeStart) > c.HealthCheckConfig().Timeout {
-		returnCode = -1
-		hcResult = define.HealthCheckFailure
-		hcErr = fmt.Errorf("healthcheck command exceeded timeout of %s", c.HealthCheckConfig().Timeout.String())
 	}
 
 	hcl := newHealthCheckLog(timeStart, timeEnd, returnCode, eventLog)

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -117,7 +117,7 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	hcResult := define.HealthCheckSuccess
 	config := new(ExecConfig)
 	config.Command = newCommand
-	exitCode, hcErr := c.exec(config, streams, nil, true)
+	exitCode, hcErr := c.healthCheckExec(config, streams)
 	if hcErr != nil {
 		hcResult = define.HealthCheckFailure
 		if errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -252,7 +252,7 @@ func (r *ConmonOCIRuntime) ExecStopContainer(ctr *Container, sessionID string, t
 
 	// SIGTERM did not work. On to SIGKILL.
 	logrus.Debugf("Killing exec session %s (PID %d) of container %s with SIGKILL", sessionID, pid, ctr.ID())
-	if err := unix.Kill(pid, unix.SIGTERM); err != nil {
+	if err := unix.Kill(pid, unix.SIGKILL); err != nil {
 		if err == unix.ESRCH {
 			return nil
 		}

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -372,4 +372,16 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		Expect(ps.OutputToStringArray()).To(HaveLen(2))
 		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})
+
+	It("podman healthcheck - health timeout", func() {
+		ctrName := "c-h-" + RandomString(6)
+		run := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--health-cmd", "top", "--health-timeout=3s", ALPINE, "top"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(ExitCleanly())
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", ctrName})
+		hc.WaitWithTimeout(10)
+		Expect(hc).To(ExitWithError())
+		Expect(hc.ErrorToString()).To(ContainSubstring("Error: healthcheck command exceeded timeout of 3s"))
+	})
 })


### PR DESCRIPTION
Previously, the HealthCheck exec session would not terminate on timeout, allowing the healthcheck to run indefinitely.
Because Docker does that, Podman should kill the HealthCheck when it reaches the timeout.

In order to backport this patch, you need to backport this patch as well (It is included in this PR):
- https://github.com/containers/podman/pull/25003 

Fixes: https://issues.redhat.com/browse/RHEL-86096



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where healthchecks exceeding their timeout were not properly terminated; they now receive SIGTERM then SIGKILL, aligning with Docker and preventing indefinite execution.
The HelathCheck is executed without writing to the database. 
```
