### PR TITLE
[v5.5] GHA Release: Fix windows installer uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,8 @@ jobs:
       run: |
         mv win-installer/* release-artifacts
         mv mac-installers/* release-artifacts
+        mv win-installer-amd64/* release-artifacts
+        mv win-installer-arm64/* release-artifacts
         pushd release-artifacts
         sha256sum * > shasums
         popd


### PR DESCRIPTION
The new arm and amd installers were left behind, upload them automatically to the GH release

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
