### PR TITLE
compat: Partial implementatino of compat api to Docker v1.42

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -416,9 +416,10 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 	decoder := utils.GetDecoder(r)
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	query := struct {
-		All     bool
-		Digests bool
-		Filter  string // Docker 1.24 compatibility
+		All        bool
+		Digests    bool
+		Filter     string // Docker 1.24 compatibility
+		SharedSize bool   `schema:"shared-size"` // Docker 1.42 compatibility
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -476,6 +477,10 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 			}
 			if s.RepoDigests == nil {
 				s.RepoDigests = []string{}
+			}
+			// Docker 1.42 sets SharedSize to -1 if ont passed explicitly
+			if !query.SharedSize {
+				s.SharedSize = -1
 			}
 		}
 	}

--- a/pkg/api/handlers/compat/ping.go
+++ b/pkg/api/handlers/compat/ping.go
@@ -18,7 +18,8 @@ import (
 func Ping(w http.ResponseWriter, r *http.Request) {
 	// Note: API-Version and Libpod-API-Version are set in handler_api.go
 	w.Header().Set("BuildKit-Version", "")
-	w.Header().Set("Builder-Version", "")
+	// Docker uses Builder-Version 1 for classic builder and 2 for BuildKit
+	w.Header().Set("Builder-Version", "1")
 	w.Header().Set("Docker-Experimental", "true")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("OSType", runtime.GOOS)

--- a/pkg/api/handlers/compat/system.go
+++ b/pkg/api/handlers/compat/system.go
@@ -91,11 +91,13 @@ func GetDiskUsage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteResponse(w, http.StatusOK, handlers.DiskUsage{DiskUsage: docker.DiskUsage{
-		LayersSize:  df.ImagesSize,
-		Images:      imgs,
-		Containers:  ctnrs,
-		Volumes:     vols,
-		BuildCache:  []*build.CacheRecord{},
-		BuilderSize: 0,
+		// BuilderSize was explicitly omitted since Docker deprecated its in ver 1.42
+		// and suggests to use BuildCache.
+		// https://docs.docker.com/reference/api/engine/version-history/#v142-api-changes
+		LayersSize: df.ImagesSize,
+		Images:     imgs,
+		Containers: ctnrs,
+		Volumes:    vols,
+		BuildCache: []*build.CacheRecord{},
 	}})
 }

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -455,4 +455,11 @@ t GET images/json 200 \
 podman rmi -f $(< $IIDFILE)
 rm -f $IIDFILE
 
+# check that SharedSize returns -1 for compat api if not set
+# and 0 (or the correct shared size) if set
+t GET images/json 200 \
+    .[0].SharedSize=-1
+t GET images/json?shared-size=true 200 \
+    .[0].SharedSize=0
+
 # vim: filetype=sh


### PR DESCRIPTION
This PR introduces 3 changes:
`GET /images/json` now returns `SharedSize` when `shared-size` is passed. Returns -1 Otherwise
`GET /system/df` does not return `BuilderSize` 
`GET /_ping` now returns Builder-Version=1

Related: https://issues.redhat.com/browse/RUN-2698

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
compat: add SharedSize to GET /images/json
compat: remove GET /system/df BuilderSize
compat: GET /_ping return Builder-Version: 1
```
