### PR TITLE
compat: fix ContainerState.Status JSON values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ It’s important to describe the change in plain English for the reviewer to ver
 Solve only one problem per patch.
 If your description starts to get long, that’s a sign that you probably need to split up your patch.
 
-If the patch fixes a logged bug entry, refer to that bug entry by number and URL.
+If the patch fixes a logged bug entry, refer to that bug entry by number or URL.
 If the patch follows from a mailing list discussion, give a URL to the mailing list archive.
 Please format these lines as `Fixes:` followed by the URL or, for Github bugs, the bug number preceded by a #.
 For example:

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -463,9 +463,20 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*container.InspectResp
 		state.Running = true
 	}
 
-	// Dockers created state is our configured state
-	if state.Status == define.ContainerStateCreated.String() {
-		state.Status = define.ContainerStateConfigured.String()
+	// map our statuses to Docker's statuses
+	switch state.Status {
+	case define.ContainerStateConfigured.String(), define.ContainerStateCreated.String():
+		state.Status = "created"
+	case define.ContainerStateRunning.String(), define.ContainerStateStopping.String():
+		state.Status = "running"
+	case define.ContainerStatePaused.String():
+		state.Status = "paused"
+	case define.ContainerStateRemoving.String():
+		state.Status = "removing"
+	case define.ContainerStateStopped.String(), define.ContainerStateExited.String():
+		state.Status = "exited"
+	default:
+		state.Status = "" // unknown state
 	}
 
 	if l.HasHealthCheck() && state.Status != "created" {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -698,7 +698,7 @@ t GET containers/status-test/json 200 .State.Status="running"
 
 podman stop status-test &
 sleep 1
-t GET containers/status-test/json 200 .State.Status="stopping"
+t GET containers/status-test/json 200 .State.Status="running"
 
 sleep 3
 t GET containers/status-test/json 200 .State.Status="exited"


### PR DESCRIPTION
This mirrors the conversion currently being done in `LibpodToContainer` into `LibpodToContainerJSON`, converting podman style statuses to docker style statuses as defined in their OpenAPI definition:

https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerInspect

Fixes: #17728
Fixes: https://github.com/containers/podman/issues/17728

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the Compat endpoints for Containers would return `ContainerState.Status` using podman statuses instead of docker statuses (#17728).
```