### PR TITLE
libpod: fix mount order for "/" volume

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -46,26 +46,28 @@ func MountExists(specMounts []spec.Mount, dest string) bool {
 	return false
 }
 
-type byDestination []spec.Mount
-
-func (m byDestination) Len() int {
-	return len(m)
-}
-
-func (m byDestination) Less(i, j int) bool {
-	return m.parts(i) < m.parts(j)
-}
-
-func (m byDestination) Swap(i, j int) {
-	m[i], m[j] = m[j], m[i]
-}
-
-func (m byDestination) parts(i int) int {
-	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
+func parts(m spec.Mount) int {
+	// We must special case a root mount /.
+	// The count of "/" and "/proc" are both 1 but of course logically "/" must
+	// be mounted before "/proc" as such set the count to 0.
+	if m.Destination == "/" {
+		return 0
+	}
+	return strings.Count(filepath.Clean(m.Destination), string(os.PathSeparator))
 }
 
 func sortMounts(m []spec.Mount) []spec.Mount {
-	sort.Sort(byDestination(m))
+	slices.SortStableFunc(m, func(a, b spec.Mount) int {
+		aLen := parts(a)
+		bLen := parts(b)
+		if aLen < bLen {
+			return -1
+		}
+		if aLen == bLen {
+			return 0
+		}
+		return 1
+	})
 	return m
 }
 

--- a/libpod/util_test.go
+++ b/libpod/util_test.go
@@ -1,0 +1,69 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"testing"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_sortMounts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []spec.Mount
+		want []spec.Mount
+	}{
+		{
+			name: "simple nested mounts",
+			args: []spec.Mount{
+				{
+					Destination: "/abc/123",
+				},
+				{
+					Destination: "/abc",
+				},
+			},
+			want: []spec.Mount{
+				{
+					Destination: "/abc",
+				},
+				{
+					Destination: "/abc/123",
+				},
+			},
+		},
+		{
+			name: "root mount",
+			args: []spec.Mount{
+				{
+					Destination: "/abc",
+				},
+				{
+					Destination: "/",
+				},
+				{
+					Destination: "/def",
+				},
+			},
+			want: []spec.Mount{
+				{
+					Destination: "/",
+				},
+				{
+					Destination: "/abc",
+				},
+				{
+					Destination: "/def",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortMounts(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
The count function for / and /proc results in the same value so the order is not guaranteed. We must ensure that a / mount is always first in the spec so that other mounts are not overshadowed by it.

Fixes: #26161

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a bug when mounting a volume to / where the mount order of the volumes was not correct and it would overmount important directories such as /proc causing start and/or runtime failures.
```
