### PR TITLE
docs: drop --pre-checkpoint requirement

### DIFF
--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -128,7 +128,7 @@ The default is **false**.
 #### **--pre-checkpoint**, **-P**
 
 Dump the *container's* memory information only, leaving the *container* running. Later
-operations supersedes prior dumps. It only works on `runc 1.0-rc3` or `higher`.\
+operations supersedes prior dumps.\
 The default is **false**.
 
 The functionality to only checkpoint the memory of the container and in a second


### PR DESCRIPTION
runc is not the only runtime supporting --pre-checkpoint

crun commit 0683fec8b mentions

"This commit takes the interface as implemented in runc and implements it for crun. "

See also discussion thread:
https://github.com/containers/podman/discussions/26154

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
