### PR TITLE
libpod: Fix building the pause image rootfs on FreeBSD

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -214,7 +214,7 @@ func (c *Container) prepareInitRootfs() (spec.Mount, error) {
 	newMount.Destination = "/" + filepath.Base(catatonitPath)
 
 	c.config.Rootfs = tmpDir
-	c.config.RootfsOverlay = true
+	c.prepareInitRootfsPlatform()
 	if len(c.config.Entrypoint) == 0 {
 		c.config.Entrypoint = []string{"/" + filepath.Base(catatonitPath), "-P"}
 		c.config.Spec.Process.Args = c.config.Entrypoint

--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -435,3 +435,8 @@ func containerPathIsFile(unsafeRoot string, containerPath string) (bool, error) 
 	}
 	return false, err
 }
+
+// Platform-specific configuration for the pause image Rootfs. RootfsOverlay is
+// not supported on FreeBSD.
+func (c *Container) prepareInitRootfsPlatform() {
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -846,3 +846,9 @@ func containerPathIsFile(unsafeRoot string, containerPath string) (bool, error) 
 	}
 	return false, err
 }
+
+// Platform-specific configuration for the pause image Rootfs. Use RootfsOverlay
+// on Linux.
+func (c *Container) prepareInitRootfsPlatform() {
+	c.config.RootfsOverlay = true
+}


### PR DESCRIPTION
On FreeBSD, we don't have support for RootfsOverlay so make this part platform-specific.

An alternative to this might be to set the root filesystem to be readonly in the OCI config which is supported on FreeBSD and should give similar protection in the pause image.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
