### PR TITLE
libpod: Don't exclude running deps from the container graph inputs

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -923,7 +923,7 @@ func (c *Container) startDependencies(ctx context.Context) error {
 
 	// Traverse the graph beginning at nodes with no dependencies
 	for _, node := range graph.noDepNodes {
-		startNode(ctx, node, false, ctrErrors, ctrsVisited, true)
+		startNode(ctx, node, false, ctrErrors, ctrsVisited, false)
 	}
 
 	if len(ctrErrors) > 0 {
@@ -957,17 +957,9 @@ func (c *Container) getAllDependencies(visited map[string]*Container) error {
 			if err != nil {
 				return err
 			}
-			status, err := dep.State()
-			if err != nil {
+			visited[depID] = dep
+			if err := dep.getAllDependencies(visited); err != nil {
 				return err
-			}
-			// if the dependency is already running, we can assume its dependencies are also running
-			// so no need to add them to those we need to start
-			if status != define.ContainerStateRunning {
-				visited[depID] = dep
-				if err := dep.getAllDependencies(visited); err != nil {
-					return err
-				}
 			}
 		}
 	}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2269,6 +2269,19 @@ WORKDIR /madethis`, BB)
 		running.WaitWithDefaultTimeout()
 		Expect(running).Should(ExitCleanly())
 		Expect(running.OutputToStringArray()).To(HaveLen(2))
+
+		podmanTest.StopContainer("--all")
+
+		indirectName := "ctr3"
+		indirectContainer := podmanTest.Podman([]string{"create", "--name", indirectName, "--requires", mainName, ALPINE, "top"})
+		indirectContainer.WaitWithDefaultTimeout()
+		Expect(indirectContainer).Should(ExitCleanly())
+
+		for _, name := range []string{depName, indirectName} {
+			start := podmanTest.Podman([]string{"start", name})
+			start.WaitWithDefaultTimeout()
+			Expect(start).Should(ExitCleanly())
+		}
 	})
 
 	It("podman run with pidfile", func() {


### PR DESCRIPTION
getAllDependencies() skips recursing into dependencies that are already running, but BuildContainerGraph() expects a *complete* set of inputs and returns an error if any are missing. Thus, podman will fail to start a container with already-running direct dependencies that, in turn, have their own dependencies.

None of the other callers of BuildContainerGraph() omit anything from their list of containers, so follow the same approach here, and just let startNode figure out if a start is actually needed.

Fixes: containers/podman-compose#921

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where starting a container with already-running dependencies would fail with `container [...] depends on container [...] not found in input list`.
```
