### PR TITLE
Fix overlay volumes on Windows

### DIFF
--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -90,6 +90,13 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runAlp).To(Exit(0))
 
+		// Test overlay works on all platforms except Hyper-V (see #26210)
+		if !isVmtype(define.HyperVVirt) {
+			runAlp, err = mb.setCmd(bm.withPodmanCommand([]string{"run", "-v", tDir + ":/test:O", TESTIMAGE, "ls", "/test/attr-test-file"})).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(runAlp).To(Exit(0))
+		}
+
 		// Test build with --volume option
 		cf := filepath.Join(tDir, "Containerfile")
 		err = os.WriteFile(cf, []byte("FROM "+TESTIMAGE+"\nRUN ls /test/attr-test-file\n"), 0o644)

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -157,6 +157,11 @@ func parseVolumes(rtc *config.Config, volumeFlag, mountFlag, tmpfsFlag []string)
 	}
 	finalOverlayVolume := make([]*specgen.OverlayVolume, 0, len(overlayVolumes))
 	for _, volume := range overlayVolumes {
+		absSrc, err := specgen.ConvertWinMountPath(volume.Source)
+		if err != nil {
+			return nil, fmt.Errorf("getting absolute path of %s: %w", volume.Source, err)
+		}
+		volume.Source = absSrc
 		finalOverlayVolume = append(finalOverlayVolume, volume)
 	}
 	finalImageVolumes := make([]*specgen.ImageVolume, 0, len(unifiedContainerMounts.imageVolumes))


### PR DESCRIPTION
The Windows source folder path was not converted in the corresponding machine folder path when the volume was of type overlay as it does for other bind mount volumes.

Fix #25988

Overlay volumes provide faster I/O access to the local folder (but changes are ephemeral). For example, building podman from sources took 1m30s vs 2m48s with a normal volume.

```pwsh
> .\bin\windows\podman.exe build -t podman-build -f .\.devcontainer\Dockerfile .
> Measure-Command {Start-Process "C:\Users\mario\git\podman\bin\windows\podman.exe" -WorkingDirectory "C:\Users\mario\git\podman\" -ArgumentList "run -ti --rm -v C:\Users\mario\git\podman\:/podman:O -w /podman podman-build make podman" -NoNewWindow -Wait}
Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 30
Milliseconds      : 20
Ticks             : 900200105
TotalDays         : 0.00104189826967593
TotalHours        : 0.0250055584722222
TotalMinutes      : 1.50033350833333
TotalSeconds      : 90.0200105
TotalMilliseconds : 90020.0105
> Measure-Command {Start-Process "C:\Users\mario\git\podman\bin\windows\podman.exe" -WorkingDirectory "C:\Users\mario\git\podman\" -ArgumentList "run -ti --rm -v C:\Users\mario\git\podman\:/podman -w /podman podman-build make podman" -NoNewWindow -Wait}
Days              : 0
Hours             : 0
Minutes           : 2
Seconds           : 48
Milliseconds      : 26
Ticks             : 1680262632
TotalDays         : 0.00194474841666667
TotalHours        : 0.046673962
TotalMinutes      : 2.80043772
TotalSeconds      : 168.0262632
TotalMilliseconds : 168026.263
``` 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Mounting local folders in a container with the overlay option on Windows used to fail. The bug has been fixed, and it's now possible to mount overlay volumes on Windows too.
```
