### PR TITLE
compat API: respect base_hosts_file containers.conf option

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -120,8 +120,10 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	// moby always create the working directory
 	localTrue := true
 	sg.CreateWorkingDir = &localTrue
-	// moby doesn't inherit /etc/hosts from host
-	sg.BaseHostsFile = "none"
+	// moby doesn't inherit /etc/hosts from host, but only overwrite if not set in containers.conf
+	if rtc.Containers.BaseHostsFile == "" {
+		sg.BaseHostsFile = "none"
+	}
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -677,6 +677,35 @@ for endpoint in containers/create libpod/containers/create; do
 done
 
 stop_service
+# Create a temporary containers.conf with custom base_hosts_file set
+testdir=$(mktemp -d)
+cat > $testdir/containers.base_hosts_file.conf <<EOF
+[containers]
+base_hosts_file = "$testdir/hosts"
+EOF
+
+cat > $testdir/hosts <<EOF
+10.0.0.2 testname
+192.168.1.1 abc
+EOF
+
+CONTAINERS_CONF_OVERRIDE=$testdir/containers.base_hosts_file.conf start_service
+
+t POST containers/create \
+  Image=$IMAGE \
+  Cmd='["cat","/etc/hosts"]' \
+  Tty=true \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+t POST  containers/${cid}/start 204
+
+t GET "containers/${cid}/logs?follow=true&stdout=true&stderr=true" 200
+like "$(<$WORKDIR/curl.result.out)" ".*10.0.0.2[[:space:]]testname.*192.168.1.1[[:space:]]abc.*" "contains containers.conf base_hosts_file hosts"
+
+stop_service
+rm -rf "$testdir"
 start_service
 
 # Our states are different from Docker's.


### PR DESCRIPTION
Hard coding to none without checking containers.conf is not a good idea as users who liked the previous behavior and the podman default behavior of keeping the hosts entries can no longer do that.

With this commit they can set base_hosts_file = "/etc/hosts" to restore the previous behavior.

Fixes: https://issues.redhat.com/browse/RHEL-92995

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The docker compat API now respects the base_hosts_file option instead of hard coding it to none.
```
