### PR TITLE
compat: remove deprecated VirtualSize

### DIFF
--- a/pkg/api/handlers/compat/system.go
+++ b/pkg/api/handlers/compat/system.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/podman/v5/libpod"
 	"github.com/containers/podman/v5/pkg/api/handlers"
 	"github.com/containers/podman/v5/pkg/api/handlers/utils"
+	"github.com/containers/podman/v5/pkg/api/handlers/utils/apiutil"
 	api "github.com/containers/podman/v5/pkg/api/types"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/domain/infra/abi"
@@ -41,8 +42,12 @@ func GetDiskUsage(w http.ResponseWriter, r *http.Request) {
 			RepoTags:    []string{o.Tag},
 			SharedSize:  o.SharedSize,
 			Size:        o.Size,
-			VirtualSize: o.Size - o.UniqueSize,
 		}
+
+		if _, err := apiutil.SupportedVersion(r, "<1.44.0"); err == nil {
+			t.VirtualSize = o.Size - o.UniqueSize //nolint:staticcheck // Deprecated field
+		}
+
 		imgs[i] = &t
 	}
 

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -16,7 +16,7 @@ type ImageSummary struct {
 	Created     int64
 	Size        int64
 	SharedSize  int
-	VirtualSize int64
+	VirtualSize int64 `json:",omitempty"`
 	Labels      map[string]string
 	Containers  int
 	ReadOnly    bool `json:",omitempty"`

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -42,6 +42,14 @@ t GET images/json?filter=$IMAGE 200 \
   length=1 \
   .[0].Names[0]=$IMAGE
 
+# Test VirtualSize field is present in API v1.43 (backward compatibility)
+t GET /v1.43/images/json 200 \
+  .[0].VirtualSize~[0-9]\\+
+
+# Test VirtualSize field is no longer present in API v1.44+ (deprecated since API v1.43)
+t GET /v1.44/images/json 200 \
+  .[0].VirtualSize=null
+
 # Negative test case
 t GET images/json?filter=nonesuch 200 length=0
 
@@ -49,6 +57,14 @@ t GET images/json?filter=nonesuch 200 length=0
 t GET images/$iid/json 200 \
   .Id=sha256:$iid \
   .RepoTags[0]=$IMAGE
+
+# Test VirtualSize field is present in API v1.43 for single image inspect (backward compatibility)
+t GET /v1.43/images/$iid/json 200 \
+  .VirtualSize~[0-9]\\+
+
+# Test VirtualSize field is no longer present in API v1.44+ for single image inspect (deprecated since API v1.43)
+t GET /v1.44/images/$iid/json 200 \
+  .VirtualSize=null
 
 t POST "images/create?fromImage=alpine" 200 .error~null .status~".*Download complete.*"
 t POST "libpod/images/pull?reference=alpine&compatMode=true" 200 .error~null .status~".*Download complete.*"

--- a/test/apiv2/45-system.at
+++ b/test/apiv2/45-system.at
@@ -38,6 +38,27 @@ cid=$(jq -r '.Id' <<<"$output")
 t GET system/df 200 '.LayersSize=12180391'
 t GET libpod/system/df 200 '.ImagesSize=12180391'
 
+# VirtualSize was computed (somehow) in v1.43 so we need to
+# build an image to test that the value is returned
+# in API <= v1.43.
+IIDFILE=$(mktemp)
+podman build --iidfile $IIDFILE -<< EOF
+FROM $IMAGE
+RUN :
+EOF
+
+# Test VirtualSize field is present in API v1.43 for system/df (backward compatibility)
+t GET /v1.43/system/df 200 \
+    .Images[0].Size~[0-9]\\+ \
+    .Images[0].VirtualSize~[0-9]\\+
+
+# Test VirtualSize field is no longer present in API v1.44+ for system/df (deprecated since API v1.43)
+t GET /v1.44/system/df 200 \
+    .Images[0].Size~[0-9]\\+ \
+    .Images[0].VirtualSize=null
+
+podman rmi -f $(< $IIDFILE)
+
 # Verify that one container references the volume
 t GET system/df 200 '.Volumes[0].UsageData.RefCount=1'
 
@@ -91,3 +112,5 @@ t POST 'libpod/system/prune?volumes=true&filters={"label":["testlabel1"]}' param
 t POST 'libpod/system/prune?volumes=true' params='' 200 .VolumePruneReports[0].Id=foo1
 
 # TODO add other system prune tests for pods / images
+
+# vim: filetype=sh


### PR DESCRIPTION
Since compat version 1.43 the VirtualSize field in the GET /images/{name}/json, GET /images/json, and
GET /system/df responses is deprecated and will no longer be included in API v1.44. Use the Size field instead, which contains the same information.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
compat: deprecate VirtualSize in version 1.43 and remove it in 1.44
```
