### PR TITLE
build: reuse `parse.ContainerIgnoreFile` from buildah

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/utils"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/env"
+	"github.com/openshift/imagebuilder"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -585,9 +586,9 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 	}
 
 	if flags.IgnoreFile != "" {
-		excludes, err := parseDockerignore(flags.IgnoreFile)
+		excludes, err := imagebuilder.ParseIgnore(flags.IgnoreFile)
 		if err != nil {
-			return nil, fmt.Errorf("unable to obtain decrypt config: %w", err)
+			return nil, fmt.Errorf("unable to parse ignore file: %w", err)
 		}
 		opts.Excludes = excludes
 	}
@@ -626,21 +627,6 @@ func getDecryptConfig(decryptionKeys []string) (*encconfig.DecryptConfig, error)
 	}
 
 	return decConfig, nil
-}
-
-func parseDockerignore(ignoreFile string) ([]string, error) {
-	excludes := []string{}
-	ignore, err := os.ReadFile(ignoreFile)
-	if err != nil {
-		return excludes, err
-	}
-	for _, e := range strings.Split(string(ignore), "\n") {
-		if len(e) == 0 || e[0] == '#' {
-			continue
-		}
-		excludes = append(excludes, e)
-	}
-	return excludes, nil
 }
 
 func areContainerfilesValid(contextDir string, containerFiles []string) error {

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -584,6 +584,7 @@ Labels.\"io.buildah.version\" | $buildah_version
          -subdir2/sub2 -subdir2/sub2.txt
          -subdir2/sub3 -subdir2/sub3.txt
          this-file-does-not-match-anything-in-ignore-file
+         -foo
          comment
     )
     for f in "${files[@]}"; do
@@ -613,6 +614,7 @@ subdir1
 subdir2
 !*/sub1*
 !subdir1/sub3*
+/foo
 EOF
 
         # Build an image. For .dockerignore


### PR DESCRIPTION
podman's logic to parse excludes from `--ignorefile` is not consistent with buildah, use code directly from buildah.

Closes: https://github.com/containers/podman/issues/25746

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: behavior of --ignorefile is consistent with buildah
```
