### PR TITLE
Fix SQLite volume lookup queries matching too liberally

### DIFF
--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -114,4 +114,14 @@ var _ = Describe("Podman volume rm", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">=", 2))
 	})
+
+	It("podman volume rm by unique partial name - case & underscore insensitive", func() {
+		volNames := []string{"test_volume", "test-volume", "test", "Test"}
+		for _, name := range volNames {
+			podmanTest.PodmanExitCleanly("volume", "create", name)
+		}
+
+		podmanTest.PodmanExitCleanly("volume", "rm", volNames[0])
+		podmanTest.PodmanExitCleanly("volume", "rm", volNames[2])
+	})
 })


### PR DESCRIPTION
Specifically, this does two things:

1. Turn on case-sensitive LIKE queries. Technically, this is not specific to volumes, as it will also affect container and pod lookups - but there, it only affects IDs. So `podman rm abc123` will not be the same as `podman rm ABC123` but I don't think anyone was manually entering uppercase SHA256 hash IDs so it shouldn't matter.

2. Escape the _ and % characters in volume lookup queries. These are SQLite wildcards, and meant that `podman volume rm test_1` would also match `podman volume rm testa2` (or any character in place of the underscore). This isn't done with pod and container lookups, but again those just use LIKE for IDs - so technically `podman volume rm abc_123` probably works and removes containers with an ID matching that pattern... I don't think that matters though.

Fixes #26168

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the `podman volume rm` and `podman volume inspect` commands would incorrectly handle volume names containing the _ character when the SQLite database backend was in use
```
