### PR TITLE
libpod: don't force only network search domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.7.1
 	github.com/containers/buildah v1.40.1-0.20250523151639-b535d02d0ee1
-	github.com/containers/common v0.63.1-0.20250528122446-1a3b5ecec62f
+	github.com/containers/common v0.63.1-0.20250602154905-5a4ca2d5d355
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.6
 	github.com/containers/image/v5 v5.35.1-0.20250526152843-c64593da00e4

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/containernetworking/plugins v1.7.1 h1:CNAR0jviDj6FS5Vg85NTgKWLDzZPfi/
 github.com/containernetworking/plugins v1.7.1/go.mod h1:xuMdjuio+a1oVQsHKjr/mgzuZ24leAsqUYRnzGoXHy0=
 github.com/containers/buildah v1.40.1-0.20250523151639-b535d02d0ee1 h1:3bNWDmqh9tx0iAXPzBJugj/oC0nTD9yTXCyIu/Mj/LE=
 github.com/containers/buildah v1.40.1-0.20250523151639-b535d02d0ee1/go.mod h1:8BVLrM6nRl/dRMYxZ+TrmoWPXzkCY99rZOYvJoXpIyE=
-github.com/containers/common v0.63.1-0.20250528122446-1a3b5ecec62f h1:308Ex0+3+gBSpDPJrFCQIhALdD8YC7jzaXuxSFZgFiA=
-github.com/containers/common v0.63.1-0.20250528122446-1a3b5ecec62f/go.mod h1:efNRNweihnq5nXALnAPDXTpC7uJtnFV4pNuETTfvI8s=
+github.com/containers/common v0.63.1-0.20250602154905-5a4ca2d5d355 h1:vK7TVpONcQzWHR4dAEnLkLeCrKNB61UhLDpwAXFIIto=
+github.com/containers/common v0.63.1-0.20250602154905-5a4ca2d5d355/go.mod h1:efNRNweihnq5nXALnAPDXTpC7uJtnFV4pNuETTfvI8s=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.6 h1:9SeAXK+K2o36CtrgYk6zRXbU3zrayjvkrI8b7/O6u5A=

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2254,13 +2254,16 @@ func (c *Container) addResolvConf() error {
 	}
 
 	// Set DNS search domains
-	search := networkSearchDomains
-
+	var search []string
+	keepHostSearches := false
 	if len(c.config.DNSSearch) > 0 || len(c.runtime.config.Containers.DNSSearches.Get()) > 0 {
 		customSearch := make([]string, 0, len(c.config.DNSSearch)+len(c.runtime.config.Containers.DNSSearches.Get()))
 		customSearch = append(customSearch, c.runtime.config.Containers.DNSSearches.Get()...)
 		customSearch = append(customSearch, c.config.DNSSearch...)
 		search = customSearch
+	} else {
+		search = networkSearchDomains
+		keepHostSearches = true
 	}
 
 	options := make([]string, 0, len(c.config.DNSOption)+len(c.runtime.config.Containers.DNSOptions.Get()))
@@ -2273,13 +2276,14 @@ func (c *Container) addResolvConf() error {
 	}
 
 	if err := resolvconf.New(&resolvconf.Params{
-		IPv6Enabled:     ipv6,
-		KeepHostServers: keepHostServers,
-		Nameservers:     nameservers,
-		Namespaces:      namespaces,
-		Options:         options,
-		Path:            destPath,
-		Searches:        search,
+		IPv6Enabled:      ipv6,
+		KeepHostServers:  keepHostServers,
+		KeepHostSearches: keepHostSearches,
+		Nameservers:      nameservers,
+		Namespaces:       namespaces,
+		Options:          options,
+		Path:             destPath,
+		Searches:         search,
 	}); err != nil {
 		return fmt.Errorf("building resolv.conf for container %s: %w", c.ID(), err)
 	}

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1152,24 +1152,27 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--name", "con1", "--network", net, CITEST_IMAGE, "nslookup", "con1"})
+		// Note apline nslookup tries to resolve all search domains always and returns an error if one does not resolve.
+		// Because we leak all host search domain into the container we have no control over if it resolves or not.
+		// Thus use "NAME." to indicate the name is full and no search domain should be tried.
+		session = podmanTest.Podman([]string{"run", "--name", "con1", "--network", net, CITEST_IMAGE, "nslookup", "con1."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--name", "con2", "--pod", pod, "--network", net, CITEST_IMAGE, "nslookup", "con2"})
+		session = podmanTest.Podman([]string{"run", "--name", "con2", "--pod", pod, "--network", net, CITEST_IMAGE, "nslookup", "con2."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--name", "con3", "--pod", pod2, CITEST_IMAGE, "nslookup", "con1"})
+		session = podmanTest.Podman([]string{"run", "--name", "con3", "--pod", pod2, CITEST_IMAGE, "nslookup", "con1."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitWithError(1, ""))
-		Expect(session.OutputToString()).To(ContainSubstring("server can't find con1.dns.podman: NXDOMAIN"))
+		Expect(session.OutputToString()).To(ContainSubstring("NXDOMAIN"))
 
 		session = podmanTest.Podman([]string{"run", "--name", "con4", "--network", net, CITEST_IMAGE, "nslookup", pod2 + ".dns.podman"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--network", net, CITEST_IMAGE, "nslookup", hostname})
+		session = podmanTest.Podman([]string{"run", "--network", net, CITEST_IMAGE, "nslookup", hostname + "."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,7 +142,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.63.1-0.20250528122446-1a3b5ecec62f
+# github.com/containers/common v0.63.1-0.20250602154905-5a4ca2d5d355
 ## explicit; go 1.23.3
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
We like to append the host servers in that case so that we do not only
force dns.podman.

Fixes: https://github.com/containers/podman/issues/24713
Fixes: https://issues.redhat.com/browse/RHEL-83787

Also:
We should fully replace the options, now that we vendored the
libnetwork/resolvconf changes into podman this just works.

Fixes: https://github.com/containers/podman/issues/22399

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When using a network with dns enabled (i.e. aardvark-dns) the host search domains are now still appended. (#24713)
When using podman run/create --dns-option the options are now correctly replaced instead of appended. (#22399)
```
