### PR TITLE
Handle "Entrypoint":[] in compat containers/create API.

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -209,6 +209,12 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 			jsonString := string(b)
 			entrypoint = &jsonString
 		}
+	} else if cc.Config.Entrypoint != nil {
+		// Entrypoint in HTTP request is set, but it is an empty slice.
+		// Set the entrypoint to empty string slice, because keeping it set to nil
+		// would later fallback to default entrypoint.
+		emptySlice := "[]"
+		entrypoint = &emptySlice
 	}
 
 	// expose ports

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -811,6 +811,26 @@ if root && test -e /dev/nullb0; then
   podman rm -f updateCtr
 fi
 
+# test apiv2 create container with empty entrypoint
+# --data '{"Image":"quay.io/libpod/some:thing","Entrypoint": []}'
+# Fixes #26078
+podman image build -t test1:latest -<<EOF
+from alpine
+ENTRYPOINT ["echo", "test"]
+EOF
+
+t POST containers/create \
+  Image=test1:latest \
+  Entrypoint=[] \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Config.Entrypoint[0]=null
+
+t DELETE containers/$cid 204
+podman rmi test1
+
 
 # test if API support -1 for ulimits https://github.com/containers/podman/issues/24886
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -221,7 +221,7 @@ function jsonify() {
         local rhs
         IFS='=' read lhs rhs <<<"$i"
 
-        if [[ $rhs =~ \" || $rhs == true || $rhs == false || $rhs =~ ^-?[0-9]+$ ]]; then
+        if [[ $rhs =~ \" || $rhs == true || $rhs == false || $rhs == "[]" || $rhs =~ ^-?[0-9]+$ ]]; then
             # rhs has been pre-formatted for JSON or a non-string, do not change it
             :
         elif [[ $rhs == False ]]; then


### PR DESCRIPTION
When using `docker compose run --entrypoint ''`, docker sends `"Entrypoint": []` in the JSON. Podman currently treats that as `nil` and fallbacks to default image entrypoint.

This is not what is expected by the user. Instead, it should not use any entrypoint.

This commit fixes it by properly propagating the `[]` downstream to libpod.

Fixes: #26078


#### Does this PR introduce a user-facing change?


```release-note
None
```
