### PR TITLE
e2e: skip pre-checkpoint tests on aarch64

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -977,6 +977,9 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with --pre-checkpoint", func() {
+		if podmanTest.Host.Arch == "arm64" {
+			Skip("skip on arm64/aarch64, checkpoint-restore/criu GH issue #2676")
+		}
 		SkipIfContainerized("FIXME: #24230 - no longer works in container testing")
 		if !criu.MemTrack() {
 			Skip("system (architecture/kernel/CRIU) does not support memory tracking")
@@ -1010,6 +1013,9 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with --pre-checkpoint and export (migration)", func() {
+		if podmanTest.Host.Arch == "arm64" {
+			Skip("skip on arm64/aarch64, checkpoint-restore/criu GH issue #2676")
+		}
 		SkipIfContainerized("FIXME: #24230 - no longer works in container testing")
 		SkipIfRemote("--import-previous is not yet supported on the remote client")
 		if !criu.MemTrack() {


### PR DESCRIPTION
Per Adrian Reber, the aarch64 kernel doesn't support the soft dirty bit and support isn't expected anytime soon.

Ref: https://github.com/checkpoint-restore/criu/issues/2676

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
