### PR TITLE
Allow not specifying type with --mount flag

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -13,7 +13,7 @@ Options common to all mount types:
 - *src*, *source*: mount source spec for **bind**, **glob**, and **volume**.
   Mandatory for **artifact**, **bind**, **glob**, **image** and **volume**.
 
-- *dst*, *destination*, *target*: mount destination spec.
+- *dst*, *dest*, *destination*, *target*: mount destination spec.
 
 When source globs are specified without the destination directory,
 the files and directories are mounted with their complete path

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -446,7 +446,7 @@ func parseMountOptions(mountType string, args []string) (*universalMount, error)
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
 			}
 			mnt.subPath = value
-		case "target", "dst", "destination":
+		case "target", "dst", "dest", "destination":
 			if mnt.mount.Destination != "" {
 				return nil, fmt.Errorf("cannot pass %q option more than once: %w", name, errOptionArg)
 			}
@@ -617,7 +617,7 @@ func getDevptsMount(args []string) (spec.Mount, error) {
 		switch name {
 		case "uid", "gid", "mode", "ptmxmode", "newinstance", "max":
 			newMount.Options = append(newMount.Options, arg)
-		case "target", "dst", "destination":
+		case "target", "dst", "dest", "destination":
 			if !hasValue {
 				return newMount, fmt.Errorf("%v: %w", name, errOptionArg)
 			}
@@ -674,7 +674,7 @@ func getImageVolume(args []string) (*specgen.ImageVolume, error) {
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
 			}
 			newVolume.Source = value
-		case "target", "dst", "destination":
+		case "target", "dst", "dest", "destination":
 			if !hasValue {
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
 			}
@@ -728,7 +728,7 @@ func getArtifactVolume(args []string) (*specgen.ArtifactVolume, error) {
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
 			}
 			newVolume.Source = value
-		case "target", "dst", "destination":
+		case "target", "dst", "dest", "destination":
 			if !hasValue {
 				return nil, fmt.Errorf("%v: %w", name, errOptionArg)
 			}

--- a/pkg/specgenutilexternal/mount.go
+++ b/pkg/specgenutilexternal/mount.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 )
 
-var (
-	errInvalidSyntax = errors.New("incorrect mount format: should be --mount type=<bind|glob|tmpfs|volume>,[src=<host-dir|volume-name>,]target=<ctr-dir>[,options]")
-)
-
 // FindMountType parses the input and extracts the type of the mount type and
 // the remaining non-type tokens.
 func FindMountType(input string) (mountType string, tokens []string, err error) {
@@ -22,7 +18,7 @@ func FindMountType(input string) (mountType string, tokens []string, err error) 
 		return "", nil, err
 	}
 	if len(records) != 1 {
-		return "", nil, errInvalidSyntax
+		return "", nil, errors.New("incorrect mount format: should be --mount type=<bind|glob|tmpfs|volume>,[src=<host-dir|volume-name>,]target=<ctr-dir>[,options]")
 	}
 	for _, s := range records[0] {
 		kv := strings.Split(s, "=")
@@ -34,7 +30,7 @@ func FindMountType(input string) (mountType string, tokens []string, err error) 
 		found = true
 	}
 	if !found {
-		err = errInvalidSyntax
+		mountType = "volume"
 	}
 	return
 }

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -1122,4 +1122,13 @@ RUN chmod 755 /test1 /test2 /test3`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})
+
+	It("--mount flag defaults to volume if no type given", func() {
+		volName := "testvol"
+		podmanTest.PodmanExitCleanly("volume", "create", volName)
+
+		podmanTest.PodmanExitCleanly("run", "--rm", "--mount", fmt.Sprintf("src=%s,dest=/mnt", volName), ALPINE, "touch", "/mnt/testfile")
+		outTest := podmanTest.PodmanExitCleanly("run", "--rm", "--mount", fmt.Sprintf("type=volume,src=%s,dest=/mnt", volName), ALPINE, "ls", "/mnt")
+		Expect(outTest.OutputToString()).To(ContainSubstring("testfile"))
+	})
 })


### PR DESCRIPTION
Docker does not require `--type` to be passed, defaulting to `type=volume` in cases where it's not passed. Do the same in our volume parsing, and add a test to verify this works as expected.

Fixes #26101

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `--mount` option to `podman create` and `podman run` now supports `dest=` as a valid alias for `destination=`.
Fixed a bug where the `--mount` option to `podman create` and `podman run`  required the `type=` option to be specified, instead of defaulting to `volume` when it was not present.
```
