### PR TITLE
docs: quadlet can translate names now

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -136,11 +136,6 @@ separate drop-in file as described above. The latter allows you to
 install an non-enabled unit and then later enabling it by installing
 the drop-in.
 
-
-**NOTE:** To express dependencies between containers, use the generated names of the services. In other
-words `WantedBy=other.service`, not `WantedBy=other.container`. The same is
-true for other kinds of dependencies, too, like `After=other.service`.
-
 ### Template files
 
 Systemd supports a concept of [template files](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Service%20Templates).


### PR DESCRIPTION
Remove no longer correct statement that quadlet that does not translate our own custom unit types

Fixes: e498c652 ("Quadlet - translate dependencies on other quadlet units")
Fixes: #26243

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
