### PR TITLE
Don't BuildRequires: ostree-devel

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -93,7 +93,6 @@ BuildRequires: shadow-utils-subid-devel
 BuildRequires: pkgconfig
 BuildRequires: make
 BuildRequires: man-db
-BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: catatonit


### PR DESCRIPTION
We are not opting into the ostree backend, and it doesn't build: https://github.com/containers/image/pull/2821 . So, stop referencing the dependency.

Should not change behavior.

@lsm5 @jnovy PTAL.

#### Does this PR introduce a user-facing change?

```release-note
None
```
