### PR TITLE
podman system check: Fix error check logic

### DIFF
--- a/cmd/podman/system/check.go
+++ b/cmd/podman/system/check.go
@@ -64,8 +64,11 @@ func check(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if !checkOptions.Repair && !checkOptions.RepairLossy && response.Errors {
-		return errors.New("damage detected in local storage")
+	if !checkOptions.Repair && !checkOptions.RepairLossy {
+		if response.Errors {
+			return errors.New("damage detected in local storage")
+		}
+		return nil
 	}
 
 	recheckOptions := checkOptions


### PR DESCRIPTION
Previously there is a minor logic error, which causes podman system check to do the check twice although there is no repair flag.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
