### PR TITLE
Clarified the consequences of --network=host

### DIFF
--- a/docs/source/markdown/options/network.md
+++ b/docs/source/markdown/options/network.md
@@ -27,7 +27,7 @@ Valid _mode_ values are:
 
 - **container:**_id_: Reuse another container's network stack.
 
-- **host**: Do not create a network namespace, the container uses the host's network. Note: The host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+- **host**: Use the host's network namespace for the container instead of creating an isolated namespace. Warning: This gives the container full access to abstract Unix domain sockets and to TCP/UDP sockets bound to localhost. Since these mechanisms are often used to prevent access to sensitive system services, isolating them from access by external entities, use of this option may be counted a security hole.
 
 - **ns:**_path_: Path to a network namespace to join.
 


### PR DESCRIPTION
The prior version talked about potential access to DBus, but this is a bogus warning: default OS setups do not bind DBus to localhost or to an abstract Unix socket.  It is possible that the original author was thinking of CVE-2020–15257, which affected containerd's abstract Unix socket; they fixed it by switching to a named socket, just as DBus always (?) has done.

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Clarified the documentation for the `--network=host` option accepted by `podman run/create`.
```
