### PR TITLE
play kube: never add empty alias

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -890,7 +890,9 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	// the podName appended to it, but this is a breaking change and will be done in podman 5.0
 	ctrNameAliases := make([]string, 0, len(podYAML.Spec.Containers))
 	for _, container := range podYAML.Spec.Containers {
-		ctrNameAliases = append(ctrNameAliases, container.Name)
+		if container.Name != "" {
+			ctrNameAliases = append(ctrNameAliases, container.Name)
+		}
 	}
 	for k, v := range podSpec.PodSpecGen.Networks {
 		v.Aliases = append(v.Aliases, ctrNameAliases...)


### PR DESCRIPTION
Netavark v1.15 added new warnings on some invalid names and that triggerd a new test failure in podman e2e test.

The "Podman kube play with disabled cgroup" case now complains about an empty name:
```
podman [options] kube play /tmp/CI_aM20/podman-e2e-3156601197/subtest-3441376193/p/kube.yaml
[WARN  netavark::network::bridge] invalid network alias "": name is empty, ignoring this name
```
This is because this test does not set a container name thus the code was adding an empty string so to fix it check if the name is not empty first.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Kube play will no longer add an empty network alias when no container name was specified
```
