### PR TITLE
Explain using `--subuidname` with `--uidmap`

### DIFF
--- a/docs/source/markdown/options/gidmap.container.md
+++ b/docs/source/markdown/options/gidmap.container.md
@@ -2,11 +2,12 @@
 ####>   podman create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--gidmap**=*[flags]container_uid:from_uid[:amount]*
+#### **--gidmap**=*[flags]container_gid:from_gid[:amount]*
 
 Run the container in a new user namespace using the supplied GID mapping. This
-option conflicts with the **--userns** and **--subgidname** options. This
-option provides a way to map host GIDs to container GIDs in the same way as
-__--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
+option conflicts with the **--userns** option. It provides a way to map host
+GIDs to container GIDs in the same way as __--uidmap__ maps host UIDs to
+container UIDs. For details see __--uidmap__.
 
-Note: the **--gidmap** option cannot be called in conjunction with the **--pod** option as a gidmap cannot be set on the container level when in a pod.
+Note: **--gidmap** cannot be called in conjunction with the **--pod** option,
+because a gidmap cannot be set on the container level when in a pod.

--- a/docs/source/markdown/options/gidmap.pod.md
+++ b/docs/source/markdown/options/gidmap.pod.md
@@ -2,7 +2,9 @@
 ####>   podman pod clone, pod create
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--gidmap**=*pod_gid:host_gid:amount*
+#### **--gidmap**=*container_gid:from_gid[:amount]*
 
-GID map for the user namespace. Using this flag runs all containers in the pod with user namespace enabled.
-It conflicts with the **--userns** and **--subgidname** flags.
+Run all containers in the pod in a new user namespace using the supplied GID
+mapping. This option conflicts with the **--userns** option. It provides a way
+to map host GIDs to container GIDs. It can be passed several times to map
+different ranges.

--- a/docs/source/markdown/options/subgidname.md
+++ b/docs/source/markdown/options/subgidname.md
@@ -4,6 +4,8 @@
 ####> are applicable to all of those.
 #### **--subgidname**=*name*
 
-Run the container in a new user namespace using the map with _name_ in the _/etc/subgid_ file.
-If running rootless, the user needs to have the right to use the mapping. See **subgid**(5).
-This flag conflicts with **--userns** and **--gidmap**.
+Run the container in a new user namespace using the map with _name_ in the
+_/etc/subgid_ file. If running rootless, the user needs to have the right to
+use the mapping. See **subgid**(5). This flag conflicts with **--userns**.
+Together with **--gidmap** it acts as if **--gidmap** was passed with all
+mappings of the _name_ group in _/etc/subgid_.

--- a/docs/source/markdown/options/subuidname.md
+++ b/docs/source/markdown/options/subuidname.md
@@ -4,6 +4,8 @@
 ####> are applicable to all of those.
 #### **--subuidname**=*name*
 
-Run the container in a new user namespace using the map with _name_ in the _/etc/subuid_ file.
-If running rootless, the user needs to have the right to use the mapping. See **subuid**(5).
-This flag conflicts with **--userns** and **--uidmap**.
+Run the container in a new user namespace using the map with _name_ in the
+_/etc/subuid_ file. If running rootless, the user needs to have the right to
+use the mapping. See **subuid**(5). This flag conflicts with **--userns**.
+Together with **--uidmap** it acts as if **--uidmap** was passed with all
+mappings of the _name_ user in _/etc/subuid_.

--- a/docs/source/markdown/options/uidmap.container.md
+++ b/docs/source/markdown/options/uidmap.container.md
@@ -5,9 +5,8 @@
 #### **--uidmap**=*[flags]container_uid:from_uid[:amount]*
 
 Run the container in a new user namespace using the supplied UID mapping. This
-option conflicts with the **--userns** and **--subuidname** options. This
-option provides a way to map host UIDs to container UIDs. It can be passed
-several times to map different ranges.
+option conflicts with the **--userns** option. It provides a way to map host
+UIDs to container UIDs. It can be passed several times to map different ranges.
 
 The possible values of the optional *flags* are discussed further down on this page.
 The *amount* value is optional and assumed to be **1** if not given.
@@ -18,7 +17,6 @@ The *from_uid* value is based upon the user running the command, either rootful 
 * rootless user: [*flags*]*container_uid*:*intermediate_uid*[:*amount*]
 
   `Rootful mappings`
-
 
 When **podman <<subcommand>>** is called by a privileged user, the option **--uidmap**
 works as a direct mapping between host UIDs and container UIDs.

--- a/docs/source/markdown/options/uidmap.pod.md
+++ b/docs/source/markdown/options/uidmap.pod.md
@@ -2,9 +2,9 @@
 ####>   podman pod clone, pod create
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--uidmap**=*container_uid:from_uid:amount*
+#### **--uidmap**=*container_uid:from_uid[:amount]*
 
-Run all containers in the pod in a new user namespace using the supplied mapping. This
-option conflicts with the **--userns** and **--subuidname** options. This
-option provides a way to map host UIDs to container UIDs. It can be passed
-several times to map different ranges.
+Run all containers in the pod in a new user namespace using the supplied UID
+mapping. This option conflicts with the **--userns** option. It provides a way
+to map host UIDs to container UIDs. It can be passed several times to map
+different ranges.


### PR DESCRIPTION
In practice, passing `--subuidname` acts exactly as if one passes `--uidmap` with a 1:1 replication of `/etc/subuid` of that user. The options don't "conflict" - at least not in the sense of what one would consider a "conflict" (I'd consider `--userns` a conflict, because Podman actually bails if one attempts to use `--uidmap` with `--userns`) - they rather just both change the mappings in the user namespace.

Combining both options with rootless containers doesn't make much sense I think, but there's a use case with rootful containers: I commonly add 65536 subuids to `/etc/subuid` for some user and run a rootful container with `--subuidname` to create a user namespace resembling that of the given user, optionally adding more users with `--uidmap`.

To verify: "amount" of `--uidmap` (et. al.) is optional for pods, too, right? I don't use pods, just noticed the discrepancy...

#### Does this PR introduce a user-facing change?

```release-note
None
```
