### PR TITLE
Skip layer digests for podman system check --quick

### DIFF
--- a/docs/source/markdown/podman-system-check.1.md
+++ b/docs/source/markdown/podman-system-check.1.md
@@ -34,6 +34,8 @@ attempts to pull images, and should be treated as though they are damaged.
 Skip checks which are known to be time-consuming.  This will prevent some types
 of errors from being detected.
 
+The exact checks performed by this option are subject to change.
+
 #### **--repair**, **-r**
 
 Remove any images which are determined to have been damaged in some way, unless

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1316,7 +1316,18 @@ func (r *Runtime) PruneBuildContainers() ([]*reports.PruneReport, error) {
 func (r *Runtime) SystemCheck(ctx context.Context, options entities.SystemCheckOptions) (entities.SystemCheckReport, error) {
 	what := storage.CheckEverything()
 	if options.Quick {
-		what = storage.CheckMost()
+		// Turn off checking layer digests and layer contents to do quick check.
+		// This is not a complete check like storage.CheckEverything(), and may fail detecting
+		// whether a file is missing from the image or its content has changed.
+		// In some cases it's desirable to trade check thoroughness for speed.
+		what = &storage.CheckOptions{
+			LayerDigests:   false,
+			LayerMountable: true,
+			LayerContents:  false,
+			LayerData:      true,
+			ImageData:      true,
+			ContainerData:  true,
+		}
 	}
 	if options.UnreferencedLayerMaximumAge != nil {
 		tmp := *options.UnreferencedLayerMaximumAge


### PR DESCRIPTION
In some cases, it is useful to opt for a quicker check if we prioritize detecting and fixing severe corruption and can tolerate minor damage.

The check option is derived from CRI-O's internal repair: https://github.com/cri-o/cri-o/blob/9e4d86d82370ad44c14649f28ebdd8f94aaa28ca/internal/lib/container_server.go#L860

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman system check --quick` now also skips checking layer digests
```
