### PR TITLE
[v5.5] Backports and c/common v0.63.1 bump

### DIFF
--- a/cmd/podman/system/check.go
+++ b/cmd/podman/system/check.go
@@ -64,8 +64,11 @@ func check(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if !checkOptions.Repair && !checkOptions.RepairLossy && response.Errors {
-		return errors.New("damage detected in local storage")
+	if !checkOptions.Repair && !checkOptions.RepairLossy {
+		if response.Errors {
+			return errors.New("damage detected in local storage")
+		}
+		return nil
 	}
 
 	recheckOptions := checkOptions

--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -275,7 +275,10 @@ func (d *dfContainer) ContainerID() string {
 }
 
 func (d *dfContainer) Image() string {
-	return d.SystemDfContainerReport.Image[0:12]
+	if len(d.SystemDfContainerReport.Image) >= 12 {
+		return d.SystemDfContainerReport.Image[0:12]
+	}
+	return ""
 }
 
 func (d *dfContainer) Command() string {

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -136,11 +136,6 @@ separate drop-in file as described above. The latter allows you to
 install an non-enabled unit and then later enabling it by installing
 the drop-in.
 
-
-**NOTE:** To express dependencies between containers, use the generated names of the services. In other
-words `WantedBy=other.service`, not `WantedBy=other.container`. The same is
-true for other kinds of dependencies, too, like `After=other.service`.
-
 ### Template files
 
 Systemd supports a concept of [template files](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Service%20Templates).

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.6.2
 	github.com/containers/buildah v1.40.0
-	github.com/containers/common v0.63.0
+	github.com/containers/common v0.63.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.6
 	github.com/containers/image/v5 v5.35.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/containernetworking/plugins v1.6.2 h1:pqP8Mq923TLyef5g97XfJ/xpDeVek4y
 github.com/containernetworking/plugins v1.6.2/go.mod h1:SP5UG3jDO9LtmfbBJdP+nl3A1atOtbj2MBOYsnaxy64=
 github.com/containers/buildah v1.40.0 h1:qCHTKnL/UEutxT6ZS8Zvhy7QUpe719jEIeGMSlcN3j4=
 github.com/containers/buildah v1.40.0/go.mod h1:U6qj0nseq6t97T2kkNpjgo0WBVRYIXASIOlS5eWvlhM=
-github.com/containers/common v0.63.0 h1:ox6vgUYX5TSvt4W+bE36sYBVz/aXMAfRGVAgvknSjBg=
-github.com/containers/common v0.63.0/go.mod h1:+3GCotSqNdIqM3sPs152VvW7m5+Mg8Kk+PExT3G9hZw=
+github.com/containers/common v0.63.1 h1:6g02gbW34PaRVH4Heb2Pk11x0SdbQ+8AfeKKeQGqYBE=
+github.com/containers/common v0.63.1/go.mod h1:+3GCotSqNdIqM3sPs152VvW7m5+Mg8Kk+PExT3G9hZw=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/gvisor-tap-vsock v0.8.6 h1:9SeAXK+K2o36CtrgYk6zRXbU3zrayjvkrI8b7/O6u5A=

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2260,13 +2260,16 @@ func (c *Container) addResolvConf() error {
 	}
 
 	// Set DNS search domains
-	search := networkSearchDomains
-
+	var search []string
+	keepHostSearches := false
 	if len(c.config.DNSSearch) > 0 || len(c.runtime.config.Containers.DNSSearches.Get()) > 0 {
 		customSearch := make([]string, 0, len(c.config.DNSSearch)+len(c.runtime.config.Containers.DNSSearches.Get()))
 		customSearch = append(customSearch, c.runtime.config.Containers.DNSSearches.Get()...)
 		customSearch = append(customSearch, c.config.DNSSearch...)
 		search = customSearch
+	} else {
+		search = networkSearchDomains
+		keepHostSearches = true
 	}
 
 	options := make([]string, 0, len(c.config.DNSOption)+len(c.runtime.config.Containers.DNSOptions.Get()))
@@ -2279,13 +2282,14 @@ func (c *Container) addResolvConf() error {
 	}
 
 	if err := resolvconf.New(&resolvconf.Params{
-		IPv6Enabled:     ipv6,
-		KeepHostServers: keepHostServers,
-		Nameservers:     nameservers,
-		Namespaces:      namespaces,
-		Options:         options,
-		Path:            destPath,
-		Searches:        search,
+		IPv6Enabled:      ipv6,
+		KeepHostServers:  keepHostServers,
+		KeepHostSearches: keepHostSearches,
+		Nameservers:      nameservers,
+		Namespaces:       namespaces,
+		Options:          options,
+		Path:             destPath,
+		Searches:         search,
 	}); err != nil {
 		return fmt.Errorf("building resolv.conf for container %s: %w", c.ID(), err)
 	}

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -207,6 +207,12 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 			jsonString := string(b)
 			entrypoint = &jsonString
 		}
+	} else if cc.Config.Entrypoint != nil {
+		// Entrypoint in HTTP request is set, but it is an empty slice.
+		// Set the entrypoint to empty string slice, because keeping it set to nil
+		// would later fallback to default entrypoint.
+		emptySlice := "[]"
+		entrypoint = &emptySlice
 	}
 
 	// expose ports

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -18,7 +19,27 @@ import (
 	"github.com/containers/podman/v5/pkg/specgen/generate"
 	"github.com/containers/podman/v5/pkg/specgenutil"
 	"github.com/containers/storage"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+// The JSON decoder correctly cannot decode (overflow) negative values (e.g., `-1`) for fields of type `uint64`,
+// as `-1` is used to represent `max` in `POSIXRlimit`. To address this, we use `tmpSpecGenerator` to decode the request body.
+// The `tmpSpecGenerator` overrides the `POSIXRlimit` type with a `tmpRlimit` type that uses the `json.Number` type for decoding values.
+// The `tmpRlimit` is then parsed into the `POSIXRlimit` type and assigned to the `SpecGenerator`.
+// This serves as a workaround for the issue (https://github.com/containers/podman/issues/24886).
+type tmpSpecGenerator struct {
+	specgen.SpecGenerator
+	Rlimits []tmpRlimit `json:"r_limits,omitempty"`
+}
+
+type tmpRlimit struct {
+	// Type of the rlimit to set
+	Type string `json:"type"`
+	// Hard is the hard limit for the specified type
+	Hard json.Number `json:"hard"`
+	// Soft is the soft limit for the specified type
+	Soft json.Number `json:"soft"`
+}
 
 // CreateContainer takes a specgenerator and makes a container. It returns
 // the new container ID on success along with any warnings.
@@ -35,25 +56,36 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	privileged := conf.Containers.Privileged
 
 	// we have to set the default before we decode to make sure the correct default is set when the field is unset
-	sg := specgen.SpecGenerator{
-		ContainerNetworkConfig: specgen.ContainerNetworkConfig{
-			UseImageHosts: &noHosts,
-		},
-		ContainerSecurityConfig: specgen.ContainerSecurityConfig{
-			Umask:      conf.Containers.Umask,
-			Privileged: &privileged,
-		},
-		ContainerHealthCheckConfig: specgen.ContainerHealthCheckConfig{
-			HealthLogDestination: define.DefaultHealthCheckLocalDestination,
-			HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
-			HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
+	tmpSg := tmpSpecGenerator{
+		SpecGenerator: specgen.SpecGenerator{
+			ContainerNetworkConfig: specgen.ContainerNetworkConfig{
+				UseImageHosts: &noHosts,
+			},
+			ContainerSecurityConfig: specgen.ContainerSecurityConfig{
+				Umask:      conf.Containers.Umask,
+				Privileged: &privileged,
+			},
+			ContainerHealthCheckConfig: specgen.ContainerHealthCheckConfig{
+				HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+				HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+				HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
+			},
 		},
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&sg); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&tmpSg); err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("decode(): %w", err))
 		return
 	}
+
+	sg := tmpSg.SpecGenerator
+	rLimits, err := parseRLimits(tmpSg.Rlimits)
+	if err != nil {
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("invalid rlimit: %w", err))
+		return
+	}
+	sg.Rlimits = rLimits
+
 	if sg.Passwd == nil {
 		t := true
 		sg.Passwd = &t
@@ -99,4 +131,43 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 
 	response := entities.ContainerCreateResponse{ID: ctr.ID(), Warnings: warn}
 	utils.WriteJSON(w, http.StatusCreated, response)
+}
+
+// parseRLimits parses slice of tmpLimit to slice of specs.POSIXRlimit.
+func parseRLimits(rLimits []tmpRlimit) ([]specs.POSIXRlimit, error) {
+	rl := []specs.POSIXRlimit{}
+
+	// The "soft" and "hard" values are expected to be of type uint64.
+	// The JSON decoder cannot cast -1 as to uint64.
+	// We need to convert them to uint64, and handle the special case of -1
+	// which indicates an max value.
+	parseLimitNumber := func(limit json.Number) (uint64, error) {
+		limitString := limit.String()
+		if limitString == "-1" {
+			// uint64(-1) overflow to max uint64 value
+			return math.MaxUint64, nil
+		}
+		return strconv.ParseUint(limitString, 10, 64)
+	}
+
+	for _, rLimit := range rLimits {
+		soft, err := parseLimitNumber(rLimit.Soft)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for POSIXRlimit.soft: %w", err)
+		}
+		hard, err := parseLimitNumber(rLimit.Hard)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for POSIXRlimit.hard: %w", err)
+		}
+		if rLimit.Type == "" {
+			return nil, fmt.Errorf("invalid value for POSIXRlimit.type: %w", err)
+		}
+
+		rl = append(rl, specs.POSIXRlimit{
+			Type: rLimit.Type,
+			Soft: soft,
+			Hard: hard,
+		})
+	}
+	return rl, nil
 }

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -890,7 +890,9 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	// the podName appended to it, but this is a breaking change and will be done in podman 5.0
 	ctrNameAliases := make([]string, 0, len(podYAML.Spec.Containers))
 	for _, container := range podYAML.Spec.Containers {
-		ctrNameAliases = append(ctrNameAliases, container.Name)
+		if container.Name != "" {
+			ctrNameAliases = append(ctrNameAliases, container.Name)
+		}
 	}
 	for k, v := range podSpec.PodSpecGen.Networks {
 		v.Aliases = append(v.Aliases, ctrNameAliases...)

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -90,6 +90,13 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runAlp).To(Exit(0))
 
+		// Test overlay works on all platforms except Hyper-V (see #26210)
+		if !isVmtype(define.HyperVVirt) {
+			runAlp, err = mb.setCmd(bm.withPodmanCommand([]string{"run", "-v", tDir + ":/test:O", TESTIMAGE, "ls", "/test/attr-test-file"})).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(runAlp).To(Exit(0))
+		}
+
 		// Test build with --volume option
 		cf := filepath.Join(tDir, "Containerfile")
 		err = os.WriteFile(cf, []byte("FROM "+TESTIMAGE+"\nRUN ls /test/attr-test-file\n"), 0o644)

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -338,7 +338,9 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 				s.LogConfiguration.Options = make(map[string]string)
 			}
 
-			s.LogConfiguration.Options["tag"] = rtc.Containers.LogTag
+			if _, exists := s.LogConfiguration.Options["tag"]; !exists {
+				s.LogConfiguration.Options["tag"] = rtc.Containers.LogTag
+			}
 		} else {
 			logrus.Warnf("log_tag %q is not allowed with %q log_driver", rtc.Containers.LogTag, define.JSONLogging)
 		}

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -157,6 +157,11 @@ func parseVolumes(rtc *config.Config, volumeFlag, mountFlag, tmpfsFlag []string)
 	}
 	finalOverlayVolume := make([]*specgen.OverlayVolume, 0, len(overlayVolumes))
 	for _, volume := range overlayVolumes {
+		absSrc, err := specgen.ConvertWinMountPath(volume.Source)
+		if err != nil {
+			return nil, fmt.Errorf("getting absolute path of %s: %w", volume.Source, err)
+		}
+		volume.Source = absSrc
 		finalOverlayVolume = append(finalOverlayVolume, volume)
 	}
 	finalImageVolumes := make([]*specgen.ImageVolume, 0, len(unifiedContainerMounts.imageVolumes))

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -782,6 +782,29 @@ if root && test -e /dev/nullb0; then
   podman rm -f updateCtr
 fi
 
+
+# test if API support -1 for ulimits https://github.com/containers/podman/issues/24886
+
+# Compat API
+t POST containers/create \
+  Image=$IMAGE           \
+  HostConfig='{"Ulimits":[{"Name":"memlock","Soft":-1,"Hard":-1}]}' \
+  201                    \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+t DELETE containers/$cid 204
+
+# Libpod API
+t POST libpod/containers/create \
+  Image=$IMAGE           \
+  r_limits='[{"type":"memlock","soft":-1,"hard":-1}]' \
+  201                    \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+t DELETE containers/$cid 204
+
 rm -rf $TMPD
 
 podman container rm -fa

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -782,6 +782,26 @@ if root && test -e /dev/nullb0; then
   podman rm -f updateCtr
 fi
 
+# test apiv2 create container with empty entrypoint
+# --data '{"Image":"quay.io/libpod/some:thing","Entrypoint": []}'
+# Fixes #26078
+podman image build -t test1:latest -<<EOF
+from alpine
+ENTRYPOINT ["echo", "test"]
+EOF
+
+t POST containers/create \
+  Image=test1:latest \
+  Entrypoint=[] \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Config.Entrypoint[0]=null
+
+t DELETE containers/$cid 204
+podman rmi test1
+
 
 # test if API support -1 for ulimits https://github.com/containers/podman/issues/24886
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -221,7 +221,7 @@ function jsonify() {
         local rhs
         IFS='=' read lhs rhs <<<"$i"
 
-        if [[ $rhs =~ \" || $rhs == true || $rhs == false || $rhs =~ ^-?[0-9]+$ ]]; then
+        if [[ $rhs =~ \" || $rhs == true || $rhs == false || $rhs == "[]" || $rhs =~ ^-?[0-9]+$ ]]; then
             # rhs has been pre-formatted for JSON or a non-string, do not change it
             :
         elif [[ $rhs == False ]]; then

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1152,24 +1152,27 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--name", "con1", "--network", net, CITEST_IMAGE, "nslookup", "con1"})
+		// Note apline nslookup tries to resolve all search domains always and returns an error if one does not resolve.
+		// Because we leak all host search domain into the container we have no control over if it resolves or not.
+		// Thus use "NAME." to indicate the name is full and no search domain should be tried.
+		session = podmanTest.Podman([]string{"run", "--name", "con1", "--network", net, CITEST_IMAGE, "nslookup", "con1."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--name", "con2", "--pod", pod, "--network", net, CITEST_IMAGE, "nslookup", "con2"})
+		session = podmanTest.Podman([]string{"run", "--name", "con2", "--pod", pod, "--network", net, CITEST_IMAGE, "nslookup", "con2."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--name", "con3", "--pod", pod2, CITEST_IMAGE, "nslookup", "con1"})
+		session = podmanTest.Podman([]string{"run", "--name", "con3", "--pod", pod2, CITEST_IMAGE, "nslookup", "con1."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitWithError(1, ""))
-		Expect(session.OutputToString()).To(ContainSubstring("server can't find con1.dns.podman: NXDOMAIN"))
+		Expect(session.OutputToString()).To(ContainSubstring("NXDOMAIN"))
 
 		session = podmanTest.Podman([]string{"run", "--name", "con4", "--network", net, CITEST_IMAGE, "nslookup", pod2 + ".dns.podman"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "--network", net, CITEST_IMAGE, "nslookup", hostname})
+		session = podmanTest.Podman([]string{"run", "--network", net, CITEST_IMAGE, "nslookup", hostname + "."})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -114,4 +114,14 @@ var _ = Describe("Podman volume rm", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">=", 2))
 	})
+
+	It("podman volume rm by unique partial name - case & underscore insensitive", func() {
+		volNames := []string{"test_volume", "test-volume", "test", "Test"}
+		for _, name := range volNames {
+			podmanTest.PodmanExitCleanly("volume", "create", name)
+		}
+
+		podmanTest.PodmanExitCleanly("volume", "rm", volNames[0])
+		podmanTest.PodmanExitCleanly("volume", "rm", volNames[2])
+	})
 })

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1315,6 +1315,14 @@ EOF
         fi
     fi
 
+    ctr="c-h-$(safename)"
+    run_podman run -d --name $ctr --ulimit core=-1:-1 $IMAGE /home/podman/pause
+
+    run_podman inspect $ctr --format "{{.HostConfig.Ulimits}}"
+    assert "$output" =~ "RLIMIT_CORE -1 -1" "ulimit core is not set to unlimited"
+
+    run_podman rm -f $ctr
+
     run_podman run --ulimit core=-1:-1 --rm $IMAGE grep core /proc/self/limits
     assert "$output" =~ " ${max}  * ${max}  * bytes"
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.63.0"
+const Version = "0.63.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,7 +142,7 @@ github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/pkg/volumes
 github.com/containers/buildah/util
-# github.com/containers/common v0.63.0
+# github.com/containers/common v0.63.1
 ## explicit; go 1.23.3
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
Backports of:
89b8e23385 75dc508e98 #26221
c87a761e05 #26252
da95bbdd5d #26264
f2d941b241 #26245
415668c802 #26225
a17f8afbbc #26237
e66ff395b7 #25986
3a981915f0 #26230
b276e7ef21 #26217
f25cefcb1b #26200

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
See release notes of the original PRs for each fix
```
