### PR TITLE
compat: GET /images/json returns [] instead of <none>:<none> in RepoTags and RepoDigest

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -468,6 +468,15 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 		// docker adds sha256: in front of the ID
 		for _, s := range summaries {
 			s.ID = "sha256:" + s.ID
+			// Ensure RepoTags and RepoDigests are empty arrays instead of null for Docker compatibility
+			// as per https://docs.docker.com/reference/api/engine/version-history/#v143-api-changes
+			// Relates to https://issues.redhat.com/browse/RUN-2699
+			if s.RepoTags == nil {
+				s.RepoTags = []string{}
+			}
+			if s.RepoDigests == nil {
+				s.RepoDigests = []string{}
+			}
 		}
 	}
 	utils.WriteResponse(w, http.StatusOK, summaries)

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -440,4 +440,19 @@ t GET "libpod/events?stream=false&since=$START"  200  \
   .Actor.Attributes.name="localhost:5000/idonotexist" \
   .Actor.Attributes.error~".*connection refused"
 
+# test empty RepoTags and RepoDigests is an empty array
+IIDFILE=$(mktemp)
+podman image build --iidfile $IIDFILE -<<EOF
+FROM $IMAGE
+RUN :
+EOF
+
+t GET images/json 200 \
+  .[1].RepoTags=[] \
+  .[1].RepoDigests=[] \
+  .[1].Id=$(< $IIDFILE)
+
+podman rmi -f $(< $IIDFILE)
+rm -f $IIDFILE
+
 # vim: filetype=sh


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
compat: GET /images/json returns [] instead of <none>:<none> in RepoTags and RepoDigest
```
