### PR TITLE
quadlet: add InterfaceName option to network unit

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1393,6 +1393,7 @@ Valid options for `[Network]` are listed below:
 | Driver=bridge                       | --driver bridge                                                 |
 | Gateway=192.168.55.3                | --gateway 192.168.55.3                                          |
 | GlobalArgs=--log-level=debug        | --log-level=debug                                               |
+| InterfaceName=enp1                  | --interface-name enp1                                           |
 | Internal=true                       | --internal                                                      |
 | IPAMDriver=dhcp                     | --ipam-driver dhcp                                              |
 | IPRange=192.168.55.128/25           | --ip-range 192.168.55.128/25                                    |
@@ -1449,6 +1450,14 @@ The format of this is a space separated list of arguments, which can optionally 
 escaped to allow inclusion of whitespace and other control characters.
 
 This key can be listed multiple times.
+
+### `InterfaceName=`
+
+This option maps the *network_interface* option in the network config, see **podman network inspect**.
+Depending on the driver, this can have different effects; for `bridge`, it uses the bridge interface name.
+For `macvlan` and `ipvlan`, it is the parent device on the host. It is the same as `--opt parent=...`.
+
+This is equivalent to the Podman `--interface-name` option.
 
 ### `Internal=` (defaults to `false`)
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -111,6 +111,7 @@ const (
 	KeyHostName              = "HostName"
 	KeyImage                 = "Image"
 	KeyImageTag              = "ImageTag"
+	KeyInterfaceName         = "InterfaceName"
 	KeyInternal              = "Internal"
 	KeyIP                    = "IP"
 	KeyIP6                   = "IP6"
@@ -372,6 +373,7 @@ var (
 				KeyIPAMDriver:           true,
 				KeyIPRange:              true,
 				KeyIPv6:                 true,
+				KeyInterfaceName:        true,
 				KeyInternal:             true,
 				KeyNetworkName:          true,
 				KeyNetworkDeleteOnStop:  true,
@@ -975,8 +977,9 @@ func ConvertNetwork(network *parser.UnitFile, name string, unitsInfoMap map[stri
 	lookupAndAddBoolean(network, NetworkGroup, boolKeys, podman)
 
 	stringKeys := map[string]string{
-		KeyDriver:     "--driver",
-		KeyIPAMDriver: "--ipam-driver",
+		KeyDriver:        "--driver",
+		KeyIPAMDriver:    "--ipam-driver",
+		KeyInterfaceName: "--interface-name",
 	}
 	lookupAndAddString(network, NetworkGroup, stringKeys, podman)
 

--- a/test/e2e/quadlet/interface-name.network
+++ b/test/e2e/quadlet/interface-name.network
@@ -1,0 +1,5 @@
+## assert-podman-final-args systemd-interface-name
+## assert-podman-args "--interface-name" "enp1"
+
+[Network]
+InterfaceName=enp1

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1005,6 +1005,7 @@ BOGUS=foo
 		Entry("Network - Gateway", "gateway.network"),
 		Entry("Network - IPAM Driver", "ipam-driver.network"),
 		Entry("Network - IPv6", "ipv6.network"),
+		Entry("Network - InterfaceName network", "interface-name.network"),
 		Entry("Network - Internal network", "internal.network"),
 		Entry("Network - Label", "label.network"),
 		Entry("Network - Multiple Options", "options.multiple.network"),


### PR DESCRIPTION
I noticed this was missing, its a simple 1 to 1 mapping to --interface-name.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added the InterfaceName option to the quadlet network unit type.
```
