### PR TITLE
Make podman.io update action reusable

### DIFF
--- a/.github/workflows/update-podmanio.yml
+++ b/.github/workflows/update-podmanio.yml
@@ -6,7 +6,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version to build and upload (e.g. "v9.8.7")'
+        description: 'Release version to bump on podman.io'
+        required: true
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version to bump on podman.io'
+        type: string
+        required: true
+    secrets:
+      PODMANBOT_TOKEN:
         required: true
 
 jobs:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
