### PR TITLE
RPM: Limit Epoch 102 to podman-next copr

### DIFF
--- a/rpm/podman.spec
+++ b/rpm/podman.spec
@@ -19,6 +19,9 @@
 
 %if %{defined copr_username}
 %define copr_build 1
+%if "%{copr_username}" == "rhcontainerbot" && "%{copr_projectname}" == "podman-next"
+%define next_build 1
+%endif
 %endif
 
 # Only RHEL and CentOS Stream rpms are built with fips-enabled go compiler
@@ -46,7 +49,7 @@
 %endif
 
 Name: podman
-%if %{defined copr_build}
+%if %{defined next_build}
 Epoch: 102
 %else
 Epoch: 5


### PR DESCRIPTION
Users of WSL images currently get podman from the copr rpm on the release PR with Epoch: 102. This is a problem if the user is looking to update the image with packages from official Fedora repos.

This commit limits Epoch: 102 to only the podman rpms on rhcontainerbot/podman-next copr. All other rpms, including other copr rpms, will use the default Epoch.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
