### PR TITLE
pkg/machine: remove some unsused services and add the /etc/environment.d SSL vars back

### DIFF
--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -480,7 +480,7 @@ func prepareCertFile(fpath string, name string) (File, error) {
 
 const (
 	systemdSSLConf = "/etc/systemd/system.conf.d/podman-machine-ssl.conf"
-	// envdSSLConf    = "/etc/environment.d/podman-machine-ssl.conf"
+	envdSSLConf    = "/etc/environment.d/podman-machine-ssl.conf"
 	profileSSLConf = "/etc/profile.d/podman-machine-ssl.sh"
 	sslCertFile    = "SSL_CERT_FILE"
 	sslCertDir     = "SSL_CERT_DIR"
@@ -488,7 +488,7 @@ const (
 
 func getSSLEnvironmentFiles(sslFileName, sslDirName string) []File {
 	systemdFileContent := "[Manager]\n"
-	// envdFileContent := ""
+	envdFileContent := ""
 	profileFileContent := ""
 	if sslFileName != "" {
 		// certs are written to UserCertsTargetPath see prepareCertFile()
@@ -496,21 +496,19 @@ func getSSLEnvironmentFiles(sslFileName, sslDirName string) []File {
 		// a path on the client (i.e. windows) but then join to linux path that will be used inside the VM.
 		env := fmt.Sprintf("%s=%q\n", sslCertFile, path.Join(define.UserCertsTargetPath, filepath.Base(sslFileName)))
 		systemdFileContent += "DefaultEnvironment=" + env
-		// envdFileContent += env
+		envdFileContent += env
 		profileFileContent += "export " + env
 	}
 	if sslDirName != "" {
 		// certs are written to UserCertsTargetPath see prepareCertFile()
 		env := fmt.Sprintf("%s=%q\n", sslCertDir, define.UserCertsTargetPath)
 		systemdFileContent += "DefaultEnvironment=" + env
-		// envdFileContent += env
+		envdFileContent += env
 		profileFileContent += "export " + env
 	}
 	return []File{
 		getSSLFile(systemdSSLConf, systemdFileContent),
-		// FIXME: something is very broken with the environment.d systemd generator.
-		// When setting any var there the systemd fails to boot successfully.
-		// getSSLFile(envdSSLConf, envdFileContent),
+		getSSLFile(envdSSLConf, envdFileContent),
 		getSSLFile(profileSSLConf, profileFileContent),
 	}
 }


### PR DESCRIPTION
pkg/machine: remove old fw_cfg service

It has not been in use since commit https://github.com/containers/podman/commit/f218f8430aa092ec45c4b7868f6d51b0bba4052b and should have been
removed there. It seems somehow it is causing a bug since our env file
is empty. In that case it triggers a segfault and since that happens
from within pam we are unable to login in any way.

I reported the issue[1] but because we don't need this just remove it so
we don't have to wait for a fix.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2370858

Revert "podman machine: fix proxy test"

This reverts commit https://github.com/containers/podman/commit/0b8dd9084010b1d444d7362c5be6704843c21aba.

pkg/machine: remove unsused net recover file

This is not used in the code so it can be deleted.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
