### PR TITLE
quadlet: handle generate environment params that inherit from host

### DIFF
--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -839,9 +839,9 @@ func (f *UnitFile) LookupLastArgs(groupName string, key string) ([]string, bool)
 }
 
 // Look up 'Environment' style key-value keys
-func (f *UnitFile) LookupAllKeyVal(groupName string, key string) (map[string]string, error) {
+func (f *UnitFile) LookupAllKeyVal(groupName string, key string) (map[string]*string, error) {
 	var warnings error
-	res := make(map[string]string)
+	res := make(map[string]*string)
 	allKeyvals := f.LookupAll(groupName, key)
 	for _, keyvals := range allKeyvals {
 		assigns, err := splitString(keyvals, WhitespaceSeparators, SplitRelax|SplitUnquote|SplitCUnescape)
@@ -852,9 +852,9 @@ func (f *UnitFile) LookupAllKeyVal(groupName string, key string) (map[string]str
 		for _, assign := range assigns {
 			key, value, found := strings.Cut(assign, "=")
 			if found {
-				res[key] = value
+				res[key] = &value
 			} else {
-				warnings = errors.Join(warnings, fmt.Errorf("separator was not found for %s", assign))
+				res[key] = nil
 			}
 		}
 	}

--- a/pkg/systemd/quadlet/podmancmdline.go
+++ b/pkg/systemd/quadlet/podmancmdline.go
@@ -33,7 +33,7 @@ func (c *PodmanCmdline) addf(format string, a ...interface{}) {
 	c.add(fmt.Sprintf(format, a...))
 }
 
-func (c *PodmanCmdline) addKeys(arg string, keys map[string]string) {
+func (c *PodmanCmdline) addKeys(arg string, keys map[string]*string) {
 	ks := make([]string, 0, len(keys))
 	for k := range keys {
 		ks = append(ks, k)
@@ -41,7 +41,11 @@ func (c *PodmanCmdline) addKeys(arg string, keys map[string]string) {
 	sort.Strings(ks)
 
 	for _, k := range ks {
-		c.add(arg, fmt.Sprintf("%s=%s", k, keys[k]))
+		if keys[k] != nil {
+			c.add(arg, fmt.Sprintf("%s=%s", k, *keys[k]))
+		} else {
+			c.add(arg, k)
+		}
 	}
 }
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -810,8 +810,8 @@ func ConvertContainer(container *parser.UnitFile, isUser bool, unitsInfoMap map[
 	if ok && len(update) > 0 {
 		podman.addKeys(
 			"--label",
-			map[string]string{
-				autoUpdateLabel: update,
+			map[string]*string{
+				autoUpdateLabel: &update,
 			},
 		)
 	}

--- a/test/e2e/quadlet/env.container
+++ b/test/e2e/quadlet/env.container
@@ -4,9 +4,10 @@
 ## assert-podman-args --env "FOO3=foo3"
 ## assert-podman-args --env "REPLACE=replaced"
 ## assert-podman-args --env "FOO4=foo\\nfoo"
+## assert-podman-args --env "FOO5"
 
 [Container]
 Image=localhost/imagename
 Environment=FOO1=foo1 "FOO2=foo2 " \
                      FOO3=foo3 REPLACE=replace
-Environment=REPLACE=replaced 'FOO4=foo\nfoo'
+Environment=REPLACE=replaced 'FOO4=foo\nfoo' FOO5


### PR DESCRIPTION
Fixes: #26247

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
This fix allows the user to use Podman's default logic for propagating environment variables from the host to the container in the Quadlet generator
```
