### PR TITLE
Allow generate-bindings on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,9 +478,7 @@ podman-testing: bin/podman-testing
 
 .PHONY: generate-bindings
 generate-bindings: .install.golangci-lint
-ifneq ($(GOOS),darwin)
 	$(GOCMD) generate ./pkg/bindings/... ;
-endif
 
 # DO NOT USE: use local-cross instead
 bin/podman.cross.%:


### PR DESCRIPTION
This exclusion has been there since the make target was added[1]. I wasn't able to find the reason but this runs on Darwin today and is useful to be able to run when you are developing bindings on a Mac.

[1] https://github.com/containers/podman/pull/8956

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
