### PR TITLE
Remove bin/podman.cross Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,18 +482,6 @@ ifneq ($(GOOS),darwin)
 	$(GOCMD) generate ./pkg/bindings/... ;
 endif
 
-# DO NOT USE: use local-cross instead
-bin/podman.cross.%:
-	TARGET="$*"; \
-	GOOS="$${TARGET%%.*}"; \
-	GOARCH="$${TARGET##*.}"; \
-	CGO_ENABLED=0 \
-		$(GO) build \
-		$(BUILDFLAGS) \
-		$(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' \
-		-tags '$(BUILDTAGS_CROSS)' \
-		-o "$@" ./cmd/podman
-
 .PHONY: local-cross
 local-cross: $(CROSS_BUILD_TARGETS) ## Cross compile podman binary for multiple architectures
 


### PR DESCRIPTION
The local-cross Make target has superceeded this old Make target and the warning to not use it has been in place now for 4+ years.

Removing it to clean up the Makefile slightly.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
