### PR TITLE
make validate-in-container changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ $(IN_CONTAINER): %-in-container:
 	$(PODMANCMD) run --rm --env HOME=/root \
 		-v $(CURDIR):/src -w /src \
 		--security-opt label=disable \
-		docker.io/library/golang:1.22 \
+		quay.io/libpod/validatepr:latest \
 		make $(*)
 
 

--- a/contrib/validatepr/Containerfile
+++ b/contrib/validatepr/Containerfile
@@ -3,15 +3,15 @@ FROM registry.fedoraproject.org/fedora:latest
 WORKDIR /go/src/github.com/containers/podman
 
 RUN dnf install -y systemd-devel \
+	awk \
+	btrfs-progs-devel \
+	git \
+	golang \
+	gpgme-devel \
 	libassuan-devel \
 	libseccomp-devel \
-	gpgme-devel \
-	device-mapper-devel \
-	btrfs-progs-devel \
-	golang \
 	make \
 	man-db \
-	git \
 	perl-Clone \
 	perl-FindBin \
-	pre-commit  && dnf clean all
+	pre-commit && dnf clean all


### PR DESCRIPTION
changing the validate-in-container make target to use quay.io/libpod/validatepr:latest.  this allows `make validate` to run to completion doing linting, ed's perl checks, and pre-commit.]

The image is now based on F42 `awk` is not part of the base image, so I added `awk`.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
