### PR TITLE
podman machine: pull wsl image from machine-os

### DIFF
--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -27,7 +27,6 @@ const (
 	artifactRegistry     = "quay.io"
 	artifactRepo         = "podman"
 	artifactImageName    = "machine-os"
-	artifactImageNameWSL = "machine-os-wsl"
 	artifactOriginalName = "org.opencontainers.image.title"
 	machineOS            = "linux"
 )
@@ -95,13 +94,7 @@ func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, endpoint 
 
 	cache := false
 	if endpoint == "" {
-		// The OCI artifact containing the OS image for WSL has a different
-		// image name. This should be temporary and dropped as soon as the
-		// OS image for WSL is built from fedora-coreos too (c.f. RUN-2178).
 		imageName := artifactImageName
-		if vmType == define.WSLVirt {
-			imageName = artifactImageNameWSL
-		}
 		endpoint = fmt.Sprintf("docker://%s/%s/%s:%s", artifactRegistry, artifactRepo, imageName, artifactVersion.majorMinor())
 		cache = true
 	}


### PR DESCRIPTION
Starting with [1] we now build and publish the wsl image from the machine-os repo, as such this special case is no longer needed.

[1] https://github.com/containers/podman-machine-os/pull/142

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman machine for wsl pull now its image from quay.io/podman/machine-os just like the other providers.
```
