### PR TITLE
fix: absolute path usage for kube play on Windows

### DIFF
--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -130,7 +130,7 @@ func importCon(cmd *cobra.Command, args []string) error {
 	}
 
 	errFileName := parse.ValidateFileName(source)
-	errURL := parse.ValidURL(source)
+	errURL := parse.ValidWebURL(source)
 	if errURL == nil {
 		importOpts.SourceIsURL = true
 	}

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -369,7 +369,7 @@ func readerFromArg(fileName string) (*bytes.Reader, error) {
 	switch {
 	case fileName == "-": // Read from stdin
 		reader = os.Stdin
-	case parse.ValidURL(fileName) == nil:
+	case parse.ValidWebURL(fileName) == nil:
 		response, err := http.Get(fileName)
 		if err != nil {
 			return nil, err

--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -157,14 +157,21 @@ func parseEnvOrLabelFile(envOrLabel map[string]string, filename, configType stri
 	return scanner.Err()
 }
 
-// ValidURL checks a string urlStr is a url or not
-func ValidURL(urlStr string) error {
-	url, err := url.ParseRequestURI(urlStr)
+// ValidWebURL checks a string urlStr is a url or not
+func ValidWebURL(urlStr string) error {
+	parsedURL, err := url.ParseRequestURI(urlStr)
 	if err != nil {
-		return fmt.Errorf("invalid url %q: %w", urlStr, err)
+		return fmt.Errorf("invalid URL %q: %w", urlStr, err)
 	}
-	if url.Scheme == "" {
-		return fmt.Errorf("invalid url %q: missing scheme", urlStr)
+
+	// to be a valid web url, scheme must be either http or https
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("invalid URL %q: unsupported scheme %q", urlStr, parsedURL.Scheme)
+	}
+
+	// ensure url contain a host
+	if parsedURL.Host == "" {
+		return fmt.Errorf("invalid URL %q: missing host", urlStr)
 	}
 	return nil
 }

--- a/cmd/podman/parse/net_test.go
+++ b/cmd/podman/parse/net_test.go
@@ -158,3 +158,69 @@ func TestGetAllLabelsFile(t *testing.T) {
 	result, _ := GetAllLabels(fileLabels, Var1)
 	assert.Equal(t, len(result), 3)
 }
+
+func TestValidWebURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "Valid HTTP URL",
+			input:   "http://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "Valid HTTPS URL",
+			input:   "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "Missing scheme",
+			input:   "example.com",
+			wantErr: true,
+		},
+		{
+			name:    "Unsupported scheme - FTP",
+			input:   "ftp://example.com",
+			wantErr: true,
+		},
+		{
+			name:    "Missing host",
+			input:   "https://",
+			wantErr: true,
+		},
+		{
+			name:    "Local file path - Windows style",
+			input:   "C:/hello/world",
+			wantErr: true,
+		},
+		{
+			name:    "Local file path - Unix style",
+			input:   "/usr/local/bin",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid URL characters",
+			input:   "https://example.com/%%%",
+			wantErr: true,
+		},
+		{
+			name:    "Valid URL with port",
+			input:   "https://example.com:8080",
+			wantErr: false,
+		},
+		{
+			name:    "Valid URL with path",
+			input:   "https://example.com/path/to/resource",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidWebURL(tt.input)
+			assert.Equal(t, tt.wantErr, err != nil, "ValidWebURL(%q) = %v, wantErr %v", tt.input, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

Fixes https://github.com/containers/podman/issues/26350

```release-note
Fixes absolute path usage for kube play on Windows
```

cc @l0rd 