### PR TITLE
Manpages: podman machine init add example with --now

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -199,6 +199,12 @@ Initialize a Podman machine for the specified name pulling the content from the 
 $ podman machine init myvm
 ```
 
+Initialize and start a new Podman machine in one step.
+
+```
+podman machine init --now
+```
+
 Initialize the default Podman machine pulling the content from the internet defaulting to rootful mode. The default is rootless.
 ```
 $ podman machine init --rootful


### PR DESCRIPTION
- Add `podman machine init --now` example in manpages. 

Fixes: https://github.com/containers/podman/issues/26376
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".
