### PR TITLE
Add examples of `--all` flag

### DIFF
--- a/docs/source/markdown/podman-init.1.md.in
+++ b/docs/source/markdown/podman-init.1.md.in
@@ -24,22 +24,31 @@ Initialize all containers. Containers that have already initialized (including c
 
 @@option latest
 
-## EXAMPLE
+## EXAMPLES
 
 Initialize specified container with a given ID.
 ```
-podman init 35480fc9d568
+$ podman init 35480fc9d568
 ```
 
 Initialize specified container with a given name.
 ```
-podman init test1
+$ podman init test1
 ```
 
 Initialize the latest container. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 ```
-podman init --latest
+$ podman init --latest
 ```
+
+Initialize all containers.
+```
+$ podman init --all
+9d2629dda7b9d4ca35c1fc63fa56592a08b9d5ab988b4301fddf16b623f676cc
+a9b78bcac97e131236930e3fa0be576e95ab89c96a7cb6fb1c821b772db9f623
+9db345273719c14bc254f90ef2df24779193b42d68b1364c0914ca6f76cf5e9c
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-start(1)](podman-start.1.md)**
 

--- a/docs/source/markdown/podman-pod-pause.1.md
+++ b/docs/source/markdown/podman-pod-pause.1.md
@@ -19,16 +19,23 @@ Pause all pods.
 
 Instead of providing the pod name or ID, pause the last created pod. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-## EXAMPLE
+## EXAMPLES
 
 Pause a pod with a given name:
 ```
-podman pod pause mywebserverpod
+$ podman pod pause mywebserverpod
 ```
 
 Pause a pod with a given ID:
 ```
-podman pod pause 860a4b23
+$ podman pod pause 860a4b23
+```
+
+Pause all pods
+```
+$ podman pod pause --all
+817973d45404da08f1fe393a13c8eeb0948f4a259d8835f083370b4a63cb0431
+0793d692719c8ef1f983fd29d7568e817c5a8e865e2b3925201a75dce24cfe80
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-secret-rm.1.md
+++ b/docs/source/markdown/podman-secret-rm.1.md
@@ -36,6 +36,13 @@ Remove secrets mysecret1 and mysecret2.
 $ podman secret rm mysecret1 mysecret2
 ```
 
+Remove all secrets
+```
+$ podman secret rm --all
+3fa78977c813cca1d5b1a4570
+4ee314533b16a47d0d8c6e775
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-secret(1)](podman-secret.1.md)**
 

--- a/docs/source/markdown/podman-system-connection-remove.1.md
+++ b/docs/source/markdown/podman-system-connection-remove.1.md
@@ -21,6 +21,12 @@ Remove the specified system connection:
 ```
 $ podman system connection remove production
 ```
+
+Remove all system connections:
+```
+$ podman system connection remove --all
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-system(1)](podman-system.1.md)**, **[podman-system-connection(1)](podman-system-connection.1.md)**
 

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -63,6 +63,32 @@ Print usage statement
 
 Prune volumes currently unused by any container
 
+## EXAMPLES
+
+Prune all containers, pods, and networks that are not in use.
+```
+$ podman system prune --all
+WARNING! This command removes:
+	- all stopped containers
+	- all networks not used by at least one container
+	- all images without at least one container associated with them
+	- all build cache
+
+Are you sure you want to continue? [y/N] y
+Deleted Images
+ce21f047f73644dcb9cd55ad247433fb47ade48ad4f4e676881fbcb2d5735c76
+c874afc1f445044eaa821da0c32328707406e546a688d8c4c22587a5f88a1992
+2fce09cfad57c6de112654eeb6f6da1851f3ced1cff7ac0002378642c2c7ca84
+0cd6d2e072175191823999cd189f8d262ba5e460271095570d8cffb1d9072e9a
+172bdaffe628cc7b7f8b7b6695438afc612a9833382f5968a06740a3804c3b64
+bf07fec943ec23054f3b81c0e65926a1c83dc82c50933dc6372c60e09fdb2d4f
+b2f735cbb571dd6a28e66455af0623ecc81f9c5b74259d3e04b3bac3b178e965
+cea2ff433c610f5363017404ce989632e12b953114fefc6f597a58e813c15d61
+Deleted Networks
+podman-default-kube-network
+Total reclaimed space: 3.372GB
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-system(1)](podman-system.1.md)**
 


### PR DESCRIPTION
The following manpages were missing examples of the `--all` flag:
* podman init
* podman pod pause
* podman secret rm
* podman system connection remove
* podman system prune

Added examples of all.

Fixes #26354

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
