### PR TITLE
Fix: 26365 Add examples for `rm` with `--force` & `--time`

### DIFF
--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -70,6 +70,17 @@ already been removed along with the container.
 
 The --force option must be specified to use the --time option.
 
+## EXAMPLES
+Forcefully kill container immediately:
+```
+$ podman rm mywebserver --force --time 0
+```
+
+Forcefully kill container after 1 minute:
+```
+$ podman rm mywebserver --force --time 60
+```
+
 #### **--volumes**, **-v**
 
 Remove anonymous volumes associated with the container. This does not include named volumes


### PR DESCRIPTION
The following manpage was missing examples for --force & --time flags:
- podman rm

Fixes [#26365](https://github.com/containers/podman/issues/26365)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
