### PR TITLE
fix(ci): add ST1005 linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters:
       checks:
         - all
         - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier.
+        - -ST1005 # https://staticcheck.dev/docs/checks/#ST1005 Incorrectly formatted error string
         - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
     nolintlint:
       require-specific: true


### PR DESCRIPTION
Enable linter rule ST1005 - Incorrectly formatted error string

#### Does this PR introduce a user-facing change?
None

```release-note
None
```
