### PR TITLE
fix 26348: add container diff --latest doc

### DIFF
--- a/docs/source/markdown/podman-container-diff.1.md.in
+++ b/docs/source/markdown/podman-container-diff.1.md.in
@@ -44,6 +44,11 @@ $ podman container diff --format json container1 container2
 }
 ```
 
+```
+$ podman container diff --latest
+C /etc
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**
 


### PR DESCRIPTION
Fixed #26348

Adding example for `container diff --latest`.

The remaining requested seem to be covered already:
```
podman pod pause
podman pod unpause
podman pod inspect
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
