### PR TITLE
docs: remove bogus markdown heading in podman-ps

### DIFF
--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -248,9 +248,6 @@ cache is in pod web-pod (1234567890ab)
 standalone-container is in pod  ()
 ```
 
-## ps
-Print a list of containers
-
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[buildah(1)](https://github.com/containers/buildah/blob/main/docs/buildah.1.md)**, **[crio(8)](https://github.com/cri-o/cri-o/blob/main/docs/crio.8.md)**
 


### PR DESCRIPTION
The prior commit that expanded the examples added an out of place heading to the manpage for podman-ps, which looks like a probable AI tool hallucination.

