### PR TITLE
Add remote support for `podman volume import` and `podman volume export`

### DIFF
--- a/cmd/podman/volumes/export.go
+++ b/cmd/podman/volumes/export.go
@@ -3,15 +3,11 @@ package volumes
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v5/cmd/podman/common"
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/pkg/domain/entities"
-	"github.com/containers/podman/v5/pkg/errorhandling"
-	"github.com/containers/podman/v5/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +17,6 @@ podman volume export
 
 Allow content of volume to be exported into external tar.`
 	exportCommand = &cobra.Command{
-		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},
 		Use:               "export [options] VOLUME",
 		Short:             "Export volumes",
 		Args:              cobra.ExactArgs(1),
@@ -32,10 +27,7 @@ Allow content of volume to be exported into external tar.`
 )
 
 var (
-	// Temporary struct to hold cli values.
-	cliExportOpts = struct {
-		Output string
-	}{}
+	cliExportOpts entities.VolumeExportOptions
 )
 
 func init() {
@@ -46,54 +38,20 @@ func init() {
 	flags := exportCommand.Flags()
 
 	outputFlagName := "output"
-	flags.StringVarP(&cliExportOpts.Output, outputFlagName, "o", "/dev/stdout", "Write to a specified file (default: stdout, which must be redirected)")
+	flags.StringVarP(&cliExportOpts.OutputPath, outputFlagName, "o", "/dev/stdout", "Write to a specified file (default: stdout, which must be redirected)")
 	_ = exportCommand.RegisterFlagCompletionFunc(outputFlagName, completion.AutocompleteDefault)
 }
 
 func export(cmd *cobra.Command, args []string) error {
-	var inspectOpts entities.InspectOptions
 	containerEngine := registry.ContainerEngine()
 	ctx := context.Background()
 
-	if cliExportOpts.Output == "" {
+	if cliExportOpts.OutputPath == "" {
 		return errors.New("expects output path, use --output=[path]")
 	}
-	inspectOpts.Type = common.VolumeType
-	volumeData, errs, err := containerEngine.VolumeInspect(ctx, args, inspectOpts)
-	if err != nil {
+
+	if err := containerEngine.VolumeExport(ctx, args[0], cliExportOpts); err != nil {
 		return err
 	}
-	if len(errs) > 0 {
-		return errorhandling.JoinErrors(errs)
-	}
-	if len(volumeData) < 1 {
-		return errors.New("no volume data found")
-	}
-	mountPoint := volumeData[0].VolumeConfigResponse.Mountpoint
-	driver := volumeData[0].VolumeConfigResponse.Driver
-	volumeOptions := volumeData[0].VolumeConfigResponse.Options
-	volumeMountStatus, err := containerEngine.VolumeMounted(ctx, args[0])
-	if err != nil {
-		return err
-	}
-	if mountPoint == "" {
-		return errors.New("volume is not mounted anywhere on host")
-	}
-	// Check if volume is using external plugin and export only if volume is mounted
-	if driver != "" && driver != "local" {
-		if !volumeMountStatus.Value {
-			return fmt.Errorf("volume is using a driver %s and volume is not mounted on %s", driver, mountPoint)
-		}
-	}
-	// Check if volume is using `local` driver and has mount options type other than tmpfs
-	if driver == "local" {
-		if mountOptionType, ok := volumeOptions["type"]; ok {
-			if mountOptionType != "tmpfs" && !volumeMountStatus.Value {
-				return fmt.Errorf("volume is using a driver %s and volume is not mounted on %s", driver, mountPoint)
-			}
-		}
-	}
-	logrus.Debugf("Exporting volume data from %s to %s", mountPoint, cliExportOpts.Output)
-	err = utils.CreateTarFromSrc(mountPoint, cliExportOpts.Output)
-	return err
+	return nil
 }

--- a/cmd/podman/volumes/import.go
+++ b/cmd/podman/volumes/import.go
@@ -1,23 +1,17 @@
 package volumes
 
 import (
-	"errors"
-	"fmt"
-	"os"
+	"context"
 
 	"github.com/containers/podman/v5/cmd/podman/common"
-	"github.com/containers/podman/v5/cmd/podman/parse"
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/pkg/domain/entities"
-	"github.com/containers/podman/v5/pkg/errorhandling"
-	"github.com/containers/podman/v5/utils"
 	"github.com/spf13/cobra"
 )
 
 var (
 	importDescription = `Imports contents into a podman volume from specified tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz).`
 	importCommand     = &cobra.Command{
-		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},
 		Use:               "import VOLUME [SOURCE]",
 		Short:             "Import a tarball contents into a podman volume",
 		Long:              importDescription,
@@ -37,65 +31,20 @@ func init() {
 }
 
 func importVol(cmd *cobra.Command, args []string) error {
-	var inspectOpts entities.InspectOptions
-	var tarFile *os.File
+	filePath := args[1]
+	if filePath == "-" {
+		filePath = "/dev/stdin"
+	}
+
 	containerEngine := registry.ContainerEngine()
-	ctx := registry.Context()
-	// create a slice of volumes since inspect expects slice as arg
-	volumes := []string{args[0]}
-	tarPath := args[1]
+	ctx := context.Background()
 
-	if tarPath != "-" {
-		err := parse.ValidateFileName(tarPath)
-		if err != nil {
-			return err
-		}
-
-		// open tar file
-		tarFile, err = os.Open(tarPath)
-		if err != nil {
-			return err
-		}
-	} else {
-		tarFile = os.Stdin
+	opts := entities.VolumeImportOptions{
+		InputPath: filePath,
 	}
 
-	inspectOpts.Type = common.VolumeType
-	inspectOpts.Type = common.VolumeType
-	volumeData, errs, err := containerEngine.VolumeInspect(ctx, volumes, inspectOpts)
-	if err != nil {
+	if err := containerEngine.VolumeImport(ctx, args[0], opts); err != nil {
 		return err
 	}
-	if len(errs) > 0 {
-		return errorhandling.JoinErrors(errs)
-	}
-	if len(volumeData) < 1 {
-		return errors.New("no volume data found")
-	}
-	mountPoint := volumeData[0].VolumeConfigResponse.Mountpoint
-	driver := volumeData[0].VolumeConfigResponse.Driver
-	volumeOptions := volumeData[0].VolumeConfigResponse.Options
-	volumeMountStatus, err := containerEngine.VolumeMounted(ctx, args[0])
-	if err != nil {
-		return err
-	}
-	if mountPoint == "" {
-		return errors.New("volume is not mounted anywhere on host")
-	}
-	// Check if volume is using external plugin and export only if volume is mounted
-	if driver != "" && driver != "local" {
-		if !volumeMountStatus.Value {
-			return fmt.Errorf("volume is using a driver %s and volume is not mounted on %s", driver, mountPoint)
-		}
-	}
-	// Check if volume is using `local` driver and has mount options type other than tmpfs
-	if driver == "local" {
-		if mountOptionType, ok := volumeOptions["type"]; ok {
-			if mountOptionType != "tmpfs" && !volumeMountStatus.Value {
-				return fmt.Errorf("volume is using a driver %s and volume is not mounted on %s", driver, mountPoint)
-			}
-		}
-	}
-	// dont care if volume is mounted or not we are gonna import everything to mountPoint
-	return utils.UntarToFileSystem(mountPoint, tarFile, nil)
+	return nil
 }

--- a/docs/source/markdown/podman-volume-export.1.md
+++ b/docs/source/markdown/podman-volume-export.1.md
@@ -12,8 +12,6 @@ podman\-volume\-export - Export volume to external tar
 on the local machine. **podman volume export** writes to STDOUT by default and can be
 redirected to a file using the `--output` flag.
 
-Note: Following command is not supported by podman-remote.
-
 **podman volume export [OPTIONS] VOLUME**
 
 ## OPTIONS

--- a/docs/source/markdown/podman-volume-import.1.md
+++ b/docs/source/markdown/podman-volume-import.1.md
@@ -14,8 +14,6 @@ The contents of the volume is merged with the content of the tarball with the la
 
 The given volume must already exist and is not created by podman volume import.
 
-Note: Following command is not supported by podman-remote.
-
 #### **--help**
 
 Print usage statement

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -299,10 +299,12 @@ func (v *Volume) NeedsMount() bool {
 	return v.needsMount()
 }
 
+// Export volume to tar.
 // Returns a ReadCloser which points to a tar of all the volume's contents.
-func (v *Volume) ExportVolume() (io.ReadCloser, error) {
+func (v *Volume) Export() (io.ReadCloser, error) {
 	v.lock.Lock()
 	err := v.mount()
+	mountPoint := v.mountPoint()
 	v.lock.Unlock()
 	if err != nil {
 		return nil, err
@@ -316,10 +318,35 @@ func (v *Volume) ExportVolume() (io.ReadCloser, error) {
 		}
 	}()
 
-	volContents, err := utils.TarWithChroot(v.mountPoint())
+	volContents, err := utils.TarWithChroot(mountPoint)
 	if err != nil {
 		return nil, fmt.Errorf("creating tar of volume %s contents: %w", v.Name(), err)
 	}
 
 	return volContents, nil
+}
+
+// Import a volume from a tar file, provided as an io.Reader.
+func (v *Volume) Import(r io.Reader) error {
+	v.lock.Lock()
+	err := v.mount()
+	mountPoint := v.mountPoint()
+	v.lock.Unlock()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		v.lock.Lock()
+		defer v.lock.Unlock()
+
+		if err := v.unmount(false); err != nil {
+			logrus.Errorf("Error unmounting volume %s: %v", v.Name(), err)
+		}
+	}()
+
+	if err := utils.UntarToFileSystem(mountPoint, r, nil); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -215,3 +215,22 @@ func ExistsVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")
 }
+
+// ExportVolume exports a volume
+func ExportVolume(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	name := utils.GetName(r)
+
+	vol, err := runtime.GetVolume(name)
+	if err != nil {
+		utils.Error(w, http.StatusNotFound, err)
+		return
+	}
+
+	contents, err := vol.ExportVolume()
+	if err != nil {
+		utils.Error(w, http.StatusInternalServerError, err)
+		return
+	}
+	utils.WriteResponse(w, http.StatusOK, contents)
+}

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -5,8 +5,10 @@ package libpod
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	"errors"
 
@@ -227,10 +229,44 @@ func ExportVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contents, err := vol.ExportVolume()
+	contents, err := vol.Export()
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, contents)
+}
+
+// ImportVolume imports a volume
+func ImportVolume(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	name := utils.GetName(r)
+
+	vol, err := runtime.GetVolume(name)
+	if err != nil {
+		utils.Error(w, http.StatusNotFound, err)
+		return
+	}
+
+	tmpfile, err := os.CreateTemp("", "podman-volume-import-")
+	if err != nil {
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("creating temporary file: %w", err))
+		return
+	}
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name())
+	}()
+
+	if _, err := io.Copy(tmpfile, r.Body); err != nil {
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("copying archive to temporary file: %w", err))
+		return
+	}
+
+	if err := vol.Import(tmpfile); err != nil {
+		utils.Error(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	utils.WriteResponse(w, http.StatusNoContent, "")
 }

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -148,6 +148,31 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/internalError"
 	r.Handle(VersionedPath("/libpod/volumes/{name}"), s.APIHandler(libpod.RemoveVolume)).Methods(http.MethodDelete)
 
+	// swagger:operation GET /libpod/volumes/{name}/export libpod VolumeExportLibpod
+	// ---
+	// tags:
+	//  - volumes
+	// summary: Export a volume
+	// parameters:
+	//  - in: path
+	//    name: name
+	//    type: string
+	//    required: true
+	//    description: the name or ID of the volume
+	// produces:
+	// - application/x-tar
+        // responses:
+        //   200:
+	//     description: no error
+	//     schema:
+	//      type: string
+        //      format: binary
+	//   404:
+	//     $ref: "#/responses/volumeNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/volumes/{name}/export"), s.APIHandler(libpod.ExportVolume)).Methods(http.MethodGet)
+
 	/*
 	 * Docker compatibility endpoints
 	 */

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -173,6 +173,35 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/internalError"
 	r.Handle(VersionedPath("/libpod/volumes/{name}/export"), s.APIHandler(libpod.ExportVolume)).Methods(http.MethodGet)
 
+	// swagger:operation PUT /libpod/volumes/{name}/import libpod VolumeImportLibpod
+	// ---
+	// tags:
+	//  - volumes
+	// summary: Populate a volume by importing provided tar
+	// parameters:
+	//  - in: path
+	//    name: name
+	//    type: string
+	//    required: true
+	//    description: the name or ID of the volume
+	//  - in: body
+	//    name: inputStream
+	//    description: |
+	//      An uncompressed tar archive
+	//    schema:
+	//      type: string
+	//      format: binary
+	// produces:
+	// - application/json
+	// responses:
+	//   204:
+	//     description: Successful import
+	//   404:
+	//     $ref: "#/responses/volumeNotFound"
+	//   500:
+	//     $ref: "#/responses/internalError"
+	r.Handle(VersionedPath("/libpod/volumes/{name}/import"), s.APIHandler(libpod.ImportVolume)).Methods(http.MethodPut)
+
 	/*
 	 * Docker compatibility endpoints
 	 */

--- a/pkg/bindings/volumes/volumes.go
+++ b/pkg/bindings/volumes/volumes.go
@@ -174,3 +174,29 @@ func Export(ctx context.Context, nameOrID string, options entities.VolumeExportO
 	}
 	return response.Process(nil)
 }
+
+// Import imports the given tar into the given volume
+func Import(ctx context.Context, nameOrID string, options entities.VolumeImportOptions) error {
+	if options.InputPath == "" {
+		return errors.New("must provide valid path for file to write to")
+	}
+
+	targetFile, err := os.Create(options.InputPath)
+	if err != nil {
+		return fmt.Errorf("unable to create target file path %q: %w", options.InputPath, err)
+	}
+	defer targetFile.Close()
+
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	response, err := conn.DoRequest(ctx, targetFile, http.MethodPut, "/volumes/%s/import", nil, nil, nameOrID)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	return response.Process(nil)
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -117,4 +117,5 @@ type ContainerEngine interface { //nolint:interfacebloat
 	VolumeUnmount(ctx context.Context, namesOrIds []string) ([]*VolumeUnmountReport, error)
 	VolumeReload(ctx context.Context) (*VolumeReloadReport, error)
 	VolumeExport(ctx context.Context, nameOrID string, options VolumeExportOptions) error
+	VolumeImport(ctx context.Context, nameOrID string, options VolumeImportOptions) error
 }

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -116,4 +116,5 @@ type ContainerEngine interface { //nolint:interfacebloat
 	VolumeRm(ctx context.Context, namesOrIds []string, opts VolumeRmOptions) ([]*VolumeRmReport, error)
 	VolumeUnmount(ctx context.Context, namesOrIds []string) ([]*VolumeUnmountReport, error)
 	VolumeReload(ctx context.Context) (*VolumeReloadReport, error)
+	VolumeExport(ctx context.Context, nameOrID string, options VolumeExportOptions) error
 }

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -37,12 +37,13 @@ type VolumeListReport = types.VolumeListReport
 // VolumeReloadReport describes the response from reload volume plugins
 type VolumeReloadReport = types.VolumeReloadReport
 
-/*
- * Docker API compatibility types
- */
-
 // VolumeMountReport describes the response from volume mount
 type VolumeMountReport = types.VolumeMountReport
 
 // VolumeUnmountReport describes the response from umounting a volume
 type VolumeUnmountReport = types.VolumeUnmountReport
+
+// VolumeExportOptions describes the options required to export a volume.
+type VolumeExportOptions struct {
+	OutputPath string
+}

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -47,3 +47,8 @@ type VolumeUnmountReport = types.VolumeUnmountReport
 type VolumeExportOptions struct {
 	OutputPath string
 }
+
+// VolumeImportOptions describes the options required to import a volume
+type VolumeImportOptions struct {
+	InputPath string
+}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -258,7 +258,7 @@ func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, op
 		return err
 	}
 
-	contents, err := vol.ExportVolume()
+	contents, err := vol.Export()
 	if err != nil {
 		return err
 	}
@@ -266,6 +266,29 @@ func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, op
 
 	if _, err := io.Copy(targetFile, contents); err != nil {
 		return fmt.Errorf("writing volume %s to file: %w", vol.Name(), err)
+	}
+
+	return nil
+}
+
+func (ic *ContainerEngine) VolumeImport(ctx context.Context, nameOrID string, options entities.VolumeImportOptions) error {
+	if options.InputPath == "" {
+		return errors.New("must provide valid path to import from")
+	}
+
+	inputFile, err := os.Open(options.InputPath)
+	if err != nil {
+		return fmt.Errorf("opening import file %q: %w", options.InputPath, err)
+	}
+	defer inputFile.Close()
+
+	vol, err := ic.Libpod.GetVolume(nameOrID)
+	if err != nil {
+		return err
+	}
+
+	if err := vol.Import(inputFile); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -113,3 +113,7 @@ func (ic *ContainerEngine) VolumeUnmount(ctx context.Context, nameOrIDs []string
 func (ic *ContainerEngine) VolumeReload(ctx context.Context) (*entities.VolumeReloadReport, error) {
 	return nil, errors.New("volume reload is not supported for remote clients")
 }
+
+func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, options entities.VolumeExportOptions) error {
+	return volumes.Export(ic.ClientCtx, nameOrID, options)
+}

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -117,3 +117,7 @@ func (ic *ContainerEngine) VolumeReload(ctx context.Context) (*entities.VolumeRe
 func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, options entities.VolumeExportOptions) error {
 	return volumes.Export(ic.ClientCtx, nameOrID, options)
 }
+
+func (ic *ContainerEngine) VolumeImport(ctx context.Context, nameOrID string, options entities.VolumeImportOptions) error {
+	return volumes.Import(ic.ClientCtx, nameOrID, options)
+}

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -65,10 +65,6 @@ var _ = Describe("Podman volume create", func() {
 	})
 
 	It("podman create and export volume", func() {
-		if podmanTest.RemoteTest {
-			Skip("Volume export check does not work with a remote client")
-		}
-
 		volName := "my_vol_" + RandomString(10)
 		session := podmanTest.Podman([]string{"volume", "create", volName})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -92,10 +92,6 @@ var _ = Describe("Podman volume create", func() {
 	})
 
 	It("podman create and import volume", func() {
-		if podmanTest.RemoteTest {
-			Skip("Volume export check does not work with a remote client")
-		}
-
 		volName := "my_vol_" + RandomString(10)
 		session := podmanTest.Podman([]string{"volume", "create", volName})
 		session.WaitWithDefaultTimeout()

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -242,7 +242,6 @@ EOF
 
 # Podman volume import test
 @test "podman volume import test" {
-    skip_if_remote "volumes import is not applicable on podman-remote"
     run_podman volume create --driver local my_vol
     run_podman run --rm -v my_vol:/data $IMAGE sh -c "echo hello >> /data/test"
     run_podman volume create my_vol2

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -260,8 +260,6 @@ EOF
 
 # stdout with NULs is easier to test here than in ginkgo
 @test "podman volume export to stdout" {
-    skip_if_remote "N/A on podman-remote"
-
     local volname="myvol_$(random_string 10)"
     local mountpoint="/data$(random_string 8)"
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -51,8 +51,7 @@ func ExecCmdWithStdStreams(stdin io.Reader, stdout, stderr io.Writer, env []stri
 }
 
 // UntarToFileSystem untars an os.file of a tarball to a destination in the filesystem
-func UntarToFileSystem(dest string, tarball *os.File, options *archive.TarOptions) error {
-	logrus.Debugf("untarring %s", tarball.Name())
+func UntarToFileSystem(dest string, tarball io.Reader, options *archive.TarOptions) error {
 	return archive.Untar(tarball, dest, options)
 }
 


### PR DESCRIPTION
These were coded up entirely in cmd/, which meant no API support. Refactor them into libpod/, add API endpoints, all that fun stuff!

Fixes #26409

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman volume import` and `podman volume export` commands are now available in the remote Podman client.
```
