### PR TITLE
[CI] Correct ST1005 staticcheck lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters:
       checks:
         - all
         - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier.
-        - -ST1005 # https://staticcheck.dev/docs/checks/#ST1005 Incorrectly formatted error string
         - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
     nolintlint:
       require-specific: true


### PR DESCRIPTION
This rule was incorrectly disabled in #26400

You can see here [1] adding "-" disables a rule and ST1005 is enabled by default.

[1] https://golangci-lint.run/usage/linters/#staticcheck

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
