### PR TITLE
docs: add an example to podman-network-rm man page

### DIFF
--- a/docs/source/markdown/podman-network-rm.1.md
+++ b/docs/source/markdown/podman-network-rm.1.md
@@ -24,19 +24,19 @@ Seconds to wait before forcibly stopping the running containers that are using t
 Delete specified network:
 ```
 # podman network rm podman9
-Deleted: podman9
+podman9
 ```
 
 Delete specified network and all containers associated with the network:
 ```
 # podman network rm -f fred
-Deleted: fred
+fred
 ```
 
 Delete specified network and all containers associated with the network after waiting up to 15 seconds:
 ```
 # podman network rm --force --time 15 fred
-Deleted: fred
+fred
 ```
 
 ## Exit Status


### PR DESCRIPTION
This patch adds an example of using the `--time` option to the podman-network-rm.1 man page.

Fixes: #26373

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
