### PR TITLE
libpod: add `pullprogress` to /libpod/images/pull

### DIFF
--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -31,14 +31,15 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		AllTags    bool   `schema:"allTags"`
-		CompatMode bool   `schema:"compatMode"`
-		PullPolicy string `schema:"policy"`
-		Quiet      bool   `schema:"quiet"`
-		Reference  string `schema:"reference"`
-		Retry      uint   `schema:"retry"`
-		RetryDelay string `schema:"retrydelay"`
-		TLSVerify  bool   `schema:"tlsVerify"`
+		AllTags      bool   `schema:"allTags"`
+		CompatMode   bool   `schema:"compatMode"`
+		PullProgress bool   `schema:"pullProgress"`
+		PullPolicy   string `schema:"policy"`
+		Quiet        bool   `schema:"quiet"`
+		Reference    string `schema:"reference"`
+		Retry        uint   `schema:"retry"`
+		RetryDelay   string `schema:"retrydelay"`
+		TLSVerify    bool   `schema:"tlsVerify"`
 		// Platform fields below:
 		Arch    string `schema:"Arch"`
 		OS      string `schema:"OS"`
@@ -129,6 +130,10 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if query.PullProgress {
+		utils.PullProgress(r.Context(), w, runtime, query.Reference, pullPolicy, pullOptions)
+		return
+	}
 	if query.CompatMode {
 		utils.CompatPull(r.Context(), w, runtime, query.Reference, pullPolicy, pullOptions)
 		return

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -147,6 +147,57 @@ type ImagePullReport struct {
 	ID string `json:"id,omitempty"`
 }
 
+// ImagePullReportV2 provides a detailed status of a container image pull operation.
+type ImagePullReportV2 struct {
+	// Status indicates the current state of the image pull operation.
+	// Possible values are:
+	// - "error":   An error occurred during the pull.
+	// - "pulling": The image pull is in progress.
+	// - "success": The image pull completed successfully.
+	Status string `json:"status,omitempty"`
+
+	// Images contains the unique identifiers of the successfully pulled images.
+	// This field is only populated when the Status is "success".
+	Images []string `json:"images,omitempty"`
+
+	// Stream provides a human-readable stream of events from the containers/image
+	// library. This data is intended for display purposes and should not be parsed
+	// by software.
+	Stream string `json:"stream,omitempty"`
+
+	// Progress provides detailed information about the download progress of an
+	// image layer. This field is only populated when the Status is "pulling".
+	Progress *ImagePullProgress `json:"progress,omitempty"`
+}
+
+// ImagePullProgress details the download progress of a single image layer.
+type ImagePullProgress struct {
+	// Current is the number of bytes of the current artifact that have been
+	// downloaded so far.
+	Current uint64 `json:"current,omitempty"`
+
+	// Total is the total size of the artifact in bytes. A value of -1
+	// indicates that the total size is unknown.
+	Total int64 `json:"total,omitempty"`
+
+	// Completed indicates whether the pull of the associated layer has finished.
+	// This is particularly useful for tracking the status of "partial pulls"
+	// where only a portion of the layers may be downloaded.
+	Completed bool `json:"completed,omitempty"`
+
+	// ProgressComponentID is the unique identifier for the artifact being downloaded.
+	// When the status is `PullComplete`, this field will contain the digest of the blobs at the source.
+	// If the status is `Success`, indicating that the entire PullOperation is complete,
+	// this field will contain the digest or ID of the artifact in local storage.
+	// Note: The values in this field may change in future updates of podman.
+	ProgressComponentID string `json:"progressComponentID,omitempty"`
+
+	// ProgressText is a human-readable string that represents the current
+	// progress, often as a progress bar or status message. This text is for
+	// display purposes only and should not be parsed.
+	ProgressText string `json:"progressText,omitempty"`
+}
+
 type ImagePushStream struct {
 	// ManifestDigest is the digest of the manifest of the pushed image.
 	ManifestDigest string `json:"manifestdigest,omitempty"`

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -514,4 +514,43 @@ t POST libpod/local/images/load?path="" 400
 
 t POST libpod/local/images/load?path="../../../etc/passwd" 404
 
+# Test pullProgress parameter on /libpod/images/pull endpoint
+# Remove the image first to ensure we actually pull it
+podman rmi -f quay.io/libpod/alpine:latest >/dev/null 2>&1 || true
+
+# Test pullProgress=true - should return ImagePullReportV2 format with progress info
+t POST "libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true" 200 \
+  .status~".*success.*" \
+  .stream~".*Pull complete.*"
+
+
+# Test pullProgress=true with invalid image - should return error status
+t POST "libpod/images/pull?reference=localhost:5000/idonotexist:latest&pullProgress=true" 200 \
+  .status~".*error.*" \
+  .stream~".*"
+
+# Test pullProgress=true shows layer IDs during pull
+# Remove the image first to ensure we actually pull it
+podman rmi -f quay.io/libpod/alpine:latest >/dev/null 2>&1 || true
+
+# Get layer digests using skopeo inspect
+layer_digests=$(skopeo inspect docker://quay.io/libpod/alpine:latest | jq -r '.Layers[]' | sed 's/sha256://' | head -5)
+
+# Pull image with pullProgress=true and verify layer IDs are in the stream
+t POST "libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true" 200 \
+  .status~".*success.*" \
+  .stream~".*Pull complete.*"
+
+# Verify each layer digest appears in the stream output
+for layer_id in $layer_digests; do
+    if [[ $output =~ $layer_id ]]; then
+        _show_ok 1 "pullProgress shows layer ID $layer_id"
+    else
+        _show_ok 0 "pullProgress shows layer ID $layer_id" "[layer ID $layer_id not found in output]"
+    fi
+done
+
+# Clean up
+podman rmi -f quay.io/libpod/alpine:latest >/dev/null 2>&1 || true
+
 # vim: filetype=sh


### PR DESCRIPTION
Following PR attempts to expose `pull progress` of images while a user attempts to pull image using `libpod`'s API endpoint `/images/pull` using a newly introduced flag called `pullprogress`.

Output is similar to `compatMode` but not exactly same. Idea is to maintain a new endpoint which does not have to adhere with `docker` compatibility and can be extended for new features easily.

Following flag will expose some new fields to pullprogress and will be slowly extended with more features.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
libpod adds support for showing `pull progress` over images/pull API endpoint.
```
