### PR TITLE
[v5.4-rhel] Fix: Ensure HealthCheck exec session terminates on timeout

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -623,7 +623,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.StringVar(
 			&cf.HealthTimeout,
 			healthTimeoutFlagName, define.DefaultHealthCheckTimeout,
-			"the maximum time allowed to complete the healthcheck before an interval is considered failed",
+			"the maximum time allowed to complete the healthcheck before an interval is considered failed and SIGKILL is sent to the healthcheck process",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthTimeoutFlagName, completion.AutocompleteNone)
 

--- a/docs/source/markdown/options/health-timeout.md
+++ b/docs/source/markdown/options/health-timeout.md
@@ -6,3 +6,6 @@
 
 The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
 value can be expressed in a time format such as **1m22s**. The default value is **30s**.
+
+Note: A timeout marks the healthcheck as failed. If the healthcheck command itself runs longer than the specified *timeout*,
+it will be sent a `SIGKILL` signal.

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -793,7 +793,7 @@ func (c *Container) ExecResize(sessionID string, newSize resize.TerminalSize) er
 	return c.ociRuntime.ExecAttachResize(c, sessionID, newSize)
 }
 
-func (c *Container) healthCheckExec(config *ExecConfig, streams *define.AttachStreams) (int, error) {
+func (c *Container) healthCheckExec(config *ExecConfig, timeout time.Duration, streams *define.AttachStreams) (int, error) {
 	unlock := true
 	if !c.batched {
 		c.lock.Lock()
@@ -841,15 +841,23 @@ func (c *Container) healthCheckExec(config *ExecConfig, streams *define.AttachSt
 	if err != nil {
 		return -1, err
 	}
+	session.PID = pid
 
 	if !c.batched {
 		c.lock.Unlock()
 		unlock = false
 	}
 
-	err = <-attachErrChan
-	if err != nil {
-		return -1, fmt.Errorf("container %s light exec session with pid: %d error: %v", c.ID(), pid, err)
+	select {
+	case err = <-attachErrChan:
+		if err != nil {
+			return -1, fmt.Errorf("container %s light exec session with pid: %d error: %v", c.ID(), pid, err)
+		}
+	case <-time.After(timeout):
+		if err := c.ociRuntime.ExecStopContainer(c, session.ID(), 0); err != nil {
+			return -1, err
+		}
+		return -1, fmt.Errorf("%v of %s", define.ErrHealthCheckTimeout, c.HealthCheckConfig().Timeout.String())
 	}
 
 	return c.readExecExitCode(session.ID())

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -217,4 +217,7 @@ var (
 	// ErrRemovingCtrs indicates that there was an error removing all
 	// containers from a pod.
 	ErrRemovingCtrs = errors.New("removing pod containers")
+
+	// ErrHealthCheckTimeout indicates that a HealthCheck timed out.
+	ErrHealthCheckTimeout = errors.New("healthcheck command exceeded timeout")
 )

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -97,7 +97,7 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	hcResult := define.HealthCheckSuccess
 	config := new(ExecConfig)
 	config.Command = newCommand
-	exitCode, hcErr := c.exec(config, streams, nil, true)
+	exitCode, hcErr := c.healthCheckExec(config, streams)
 	if hcErr != nil {
 		hcResult = define.HealthCheckFailure
 		if errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -93,19 +93,23 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	streams.AttachInput = true
 
 	logrus.Debugf("executing health check command %s for %s", strings.Join(newCommand, " "), c.ID())
-	timeStart := time.Now()
 	hcResult := define.HealthCheckSuccess
 	config := new(ExecConfig)
 	config.Command = newCommand
-	exitCode, hcErr := c.healthCheckExec(config, streams)
+	timeStart := time.Now()
+	exitCode, hcErr := c.healthCheckExec(config, c.HealthCheckConfig().Timeout, streams)
+	timeEnd := time.Now()
 	if hcErr != nil {
 		hcResult = define.HealthCheckFailure
-		if errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||
+		switch {
+		case errors.Is(hcErr, define.ErrOCIRuntimeNotFound) ||
 			errors.Is(hcErr, define.ErrOCIRuntimePermissionDenied) ||
-			errors.Is(hcErr, define.ErrOCIRuntime) {
+			errors.Is(hcErr, define.ErrOCIRuntime):
 			returnCode = 1
 			hcErr = nil
-		} else {
+		case errors.Is(hcErr, define.ErrHealthCheckTimeout):
+			returnCode = -1
+		default:
 			returnCode = 125
 		}
 	} else if exitCode != 0 {
@@ -124,7 +128,6 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 		}
 	}
 
-	timeEnd := time.Now()
 	if c.HealthCheckConfig().StartPeriod > 0 {
 		// there is a start-period we need to honor; we add startPeriod to container start time
 		startPeriodTime := c.state.StartedTime.Add(c.HealthCheckConfig().StartPeriod)
@@ -138,12 +141,6 @@ func (c *Container) runHealthCheck(ctx context.Context, isStartup bool) (define.
 	eventLog := output.String()
 	if c.HealthCheckMaxLogSize() != 0 && len(eventLog) > int(c.HealthCheckMaxLogSize()) {
 		eventLog = eventLog[:c.HealthCheckMaxLogSize()]
-	}
-
-	if timeEnd.Sub(timeStart) > c.HealthCheckConfig().Timeout {
-		returnCode = -1
-		hcResult = define.HealthCheckFailure
-		hcErr = fmt.Errorf("healthcheck command exceeded timeout of %s", c.HealthCheckConfig().Timeout.String())
 	}
 
 	hcl := newHealthCheckLog(timeStart, timeEnd, returnCode, eventLog)

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -250,7 +250,7 @@ func (r *ConmonOCIRuntime) ExecStopContainer(ctr *Container, sessionID string, t
 
 	// SIGTERM did not work. On to SIGKILL.
 	logrus.Debugf("Killing exec session %s (PID %d) of container %s with SIGKILL", sessionID, pid, ctr.ID())
-	if err := unix.Kill(pid, unix.SIGTERM); err != nil {
+	if err := unix.Kill(pid, unix.SIGKILL); err != nil {
 		if err == unix.ESRCH {
 			return nil
 		}

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -390,4 +390,13 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		Expect(ps.OutputToStringArray()).To(HaveLen(2))
 		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})
+
+	It("podman healthcheck - health timeout", func() {
+		ctrName := "c-h-" + RandomString(6)
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--health-cmd", "top", "--health-timeout=3s", ALPINE, "top")
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", ctrName})
+		hc.WaitWithTimeout(10)
+		Expect(hc).Should(ExitWithError(125, "Error: healthcheck command exceeded timeout of 3s"))
+	})
 })

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -418,4 +418,35 @@ function _check_health_log {
     run_podman rm -t 0 -f $ctrname
 }
 
+@test "podman healthcheck - stop container when healthcheck runs" {
+    ctr="c-h-$(safename)"
+    msg="hc-msg-$(random_string)"
+
+    run_podman run -d --name $ctr             \
+           --health-cmd "sleep 20; echo $msg" \
+           $IMAGE /home/podman/pause
+
+    timeout --foreground -v --kill=10 60 \
+        $PODMAN healthcheck run $ctr &
+    hc_pid=$!
+
+    run_podman inspect $ctr --format "{{.State.Status}}"
+    assert "$output" == "running" "Container is running"
+
+    run_podman stop $ctr
+
+    # Wait for background healthcheck to finish and make sure the exit status is 1
+    rc=0
+    wait -n $hc_pid || rc=$?
+    assert $rc -eq 1 "exit status check of healthcheck command"
+
+    run_podman inspect $ctr --format "{{.State.Status}}"
+    assert "$output" == "exited" "Container is stopped"
+
+    run_podman inspect $ctr --format "{{.State.Health.Log}}"
+    assert "$output" !~ "$msg" "Health log message not found"
+
+    run_podman rm -f -t0 $ctr
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Previously, the HealthCheck exec session would not terminate on timeout, allowing the healthcheck to run indefinitely.
Because Docker does that, Podman should kill the HealthCheck when it reaches the timeout.

In order to backport this patch, you need to backport this patch as well (It is included in this PR):
- https://github.com/containers/podman/pull/25003 

This Backport contains: 
- https://github.com/containers/podman/pull/25003
- https://github.com/containers/podman/pull/26086 [commit](https://github.com/containers/podman/pull/26086/commits/499ea1168bd52a36e98927222a987a6b959f0b50)
- https://github.com/containers/podman/pull/26086 [commit](https://github.com/containers/podman/pull/26086/commits/077649f9d0c53583654a61c94ebca0f4fa15b877)

> Comparing https://github.com/containers/podman/commit/499ea1168bd52a36e98927222a987a6b959f0b50#diff-bf52e0a2dfcea051750fa86d05c8a2ce247c66a92a8562570f4d3555d76664a6R872
this line`session.PIDData = getPidData(pid)` is removed because we would have to backport this PR #25906.


Fixes: https://issues.redhat.com/browse/RHEL-96916
Fixes: https://issues.redhat.com/browse/RHEL-96917


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where healthchecks exceeding their timeout were not properly terminated; they now receive SIGTERM then SIGKILL, aligning with Docker and preventing indefinite execution.
The HelathCheck is executed without writing to the database. 
```
