### PR TITLE
volumes: add new --uid and --gid option

### DIFF
--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -28,6 +28,10 @@ An overlay filesystem is created, which allows changes to the volume to be commi
 Using a value other than **local** or **image**, Podman attempts to create the volume using a volume plugin with the given name.
 Such plugins must be defined in the **volume_plugins** section of the **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)** configuration file.
 
+#### **--gid**=*gid*
+
+Set the GID that the volume will be created as. Differently than `--opt o=gid=*gid*`, the specified value is not passed to the mount operation. The specified GID will own the volume's mount point directory and affects the volume chown operation.
+
 #### **--help**
 
 Print usage statement
@@ -68,6 +72,10 @@ For the **image** driver, the only supported option is `image`, which specifies 
 This option is mandatory when using the **image** driver.
 
 When not using the **local** and **image** drivers, the given options are passed directly to the volume plugin. In this case, supported options are dictated by the plugin in question, not Podman.
+
+#### **--uid**=*uid*
+
+Set the UID that the volume will be created as. Differently than `--opt o=uid=*uid*`, the specified value is not passed to the mount operation. The specified UID will own the volume's mount point directory and affects the volume chown operation.
 
 ## QUOTAS
 
@@ -122,6 +130,11 @@ Create tmpfs named volume with specified size and mount options.
 Create tmpfs named volume testvol with specified options.
 ```
 # podman volume create --opt device=tmpfs --opt type=tmpfs --opt o=uid=1000,gid=1000 testvol
+```
+
+Create volume overriding the owner UID and GID.
+```
+# podman volume create --uid 1000 --gid 1000 myvol
 ```
 
 Create image named volume using the specified local image in containers/storage.

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -77,6 +77,13 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeIgnoreIfExist())
 	}
 
+	if input.UID != nil {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeUID(*input.UID), libpod.WithVolumeNoChown())
+	}
+	if input.GID != nil {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeGID(*input.GID), libpod.WithVolumeNoChown())
+	}
+
 	vol, err := runtime.NewVolume(r.Context(), volumeOptions...)
 	if err != nil {
 		utils.InternalServerError(w, err)

--- a/pkg/domain/entities/types/volumes.go
+++ b/pkg/domain/entities/types/volumes.go
@@ -18,6 +18,10 @@ type VolumeCreateOptions struct {
 	Options map[string]string `schema:"opts"`
 	// Ignore existing volumes
 	IgnoreIfExists bool `schema:"ignoreIfExist"`
+	// UID that the volume will be created as
+	UID *int `schema:"uid"`
+	// GID that the volume will be created as
+	GID *int `schema:"gid"`
 }
 
 type VolumeRmReport struct {

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -40,6 +40,13 @@ func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.Volum
 		volumeOptions = append(volumeOptions, libpod.WithVolumeIgnoreIfExist())
 	}
 
+	if opts.UID != nil {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeUID(*opts.UID), libpod.WithVolumeNoChown())
+	}
+	if opts.GID != nil {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeGID(*opts.GID), libpod.WithVolumeNoChown())
+	}
+
 	vol, err := ic.Libpod.NewVolume(ctx, volumeOptions...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
they allow to override the owner of the volume.  Differently from -o=uid= and -o=gid= they are not passed down to the mount operation.

Closes: https://issues.redhat.com/browse/RHEL-76452

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman volume create supports --uid and --gid to change the owner of the volume
```
