### PR TITLE
docs: add an example to podman-secret-rm man page

### DIFF
--- a/docs/source/markdown/podman-secret-rm.1.md
+++ b/docs/source/markdown/podman-secret-rm.1.md
@@ -43,6 +43,13 @@ $ podman secret rm --all
 4ee314533b16a47d0d8c6e775
 ```
 
+Removes the specified secrets. No error is thrown if a non-existent secret is included.
+```
+$ podman secret rm --ignore mysecret1 mysecret2 non_existent_secret
+9bb0cad56c4a610da8ebca0cc
+3c497981215f1b5dd9ce19cde
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-secret(1)](podman-secret.1.md)**
 


### PR DESCRIPTION
This patch adds an example of using the `--ingore` option to the podman-secret-rm.1 man page.

Fixes: #26361

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
