### PR TITLE
docs: add three examples to podman-generate-spec man page

### DIFF
--- a/docs/source/markdown/podman-generate-spec.1.md
+++ b/docs/source/markdown/podman-generate-spec.1.md
@@ -24,3 +24,147 @@ Output to the given file.
 #### **--name**, **-n**
 
 Rename the pod or container, so that it does not conflict with the existing entity. This is helpful when the JSON is to be used before the source pod or container is deleted.
+
+## EXAMPLES
+
+Generate Specgen JSON based on a container.
+```
+$ podman generate spec container1
+{
+ "name": "container1-clone",
+ "command": [
+  "/bin/sh"
+ ],
+ "env": {
+  "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+  "container": "podman"
+ },
+ "sdnotifyMode": "container",
+ "pidns": {
+  "nsmode": "default"
+ },
+ "utsns": {
+  "nsmode": "private"
+ },
+ "containerCreateCommand": [
+  "podman",
+  "run",
+  "--name",
+  "container1",
+  "cea2ff433c61"
+ ],
+ "init_container_type": "",
+ "image": "cea2ff433c610f5363017404ce989632e12b953114fefc6f597a58e813c15d61",
+ "ipcns": {
+  "nsmode": "default"
+ },
+ "shm_size": 65536000,
+ "shm_size_systemd": 0,
+ "selinux_opts": [
+  "disable"
+ ],
+ "userns": {
+  "nsmode": "default"
+ },
+ "idmappings": {
+  "HostUIDMapping": true,
+  "HostGIDMapping": true,
+  "UIDMap": null,
+  "GIDMap": null,
+  "AutoUserNs": false,
+  "AutoUserNsOpts": {
+   "Size": 0,
+   "InitialSize": 0,
+   "PasswdFile": "",
+   "GroupFile": "",
+   "AdditionalUIDMappings": null,
+   "AdditionalGIDMappings": null
+  }
+ },
+ "umask": "0022",
+ "cgroupns": {
+  "nsmode": "default"
+ },
+ "netns": {
+  "nsmode": "slirp4netns"
+ },
+ "Networks": null,
+ "use_image_hosts": false,
+ "resource_limits": {}
+}
+```
+
+Generate Specgen JSON based on a container. The output is single line.
+```
+$ podman generate spec --compact container1
+{"name":"container1-clone","command":["/bin/sh"],...
+```
+
+Generate Specgen JSON based on a container, writing the output to the specified file.
+```
+$ podman generate spec --filename output.json container1
+output.json
+$ cat output.json
+{
+ "name": "container1-clone",
+ "command": [
+  "/bin/sh"
+ ],
+ "env": {
+  "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+  "container": "podman"
+ },
+ "sdnotifyMode": "container",
+ "pidns": {
+  "nsmode": "default"
+ },
+ "utsns": {
+  "nsmode": "private"
+ },
+ "containerCreateCommand": [
+  "podman",
+  "run",
+  "--name",
+  "container1",
+  "cea2ff433c61"
+ ],
+ "init_container_type": "",
+ "image": "cea2ff433c610f5363017404ce989632e12b953114fefc6f597a58e813c15d61",
+ "ipcns": {
+  "nsmode": "default"
+ },
+ "shm_size": 65536000,
+ "shm_size_systemd": 0,
+ "selinux_opts": [
+  "disable"
+ ],
+ "userns": {
+  "nsmode": "default"
+ },
+ "idmappings": {
+  "HostUIDMapping": true,
+  "HostGIDMapping": true,
+  "UIDMap": null,
+  "GIDMap": null,
+  "AutoUserNs": false,
+  "AutoUserNsOpts": {
+   "Size": 0,
+   "InitialSize": 0,
+   "PasswdFile": "",
+   "GroupFile": "",
+   "AdditionalUIDMappings": null,
+   "AdditionalGIDMappings": null
+  }
+ },
+ "umask": "0022",
+ "cgroupns": {
+  "nsmode": "default"
+ },
+ "netns": {
+  "nsmode": "slirp4netns"
+ },
+ "Networks": null,
+ "use_image_hosts": false,
+ "resource_limits": {}
+}
+```


### PR DESCRIPTION
This patch adds three examples to the podman-generate-spec.1 man page:

- Example of executed without any options
- Example of executed with the `--compact` option
- Example of executed with the `--filename` option

Fixes: #26377

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
