### PR TITLE
pkg/systemd: expose [Pod] ExitPolicy key for pod create --exit-policy

### DIFF
--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -76,7 +76,7 @@ Set the exit policy of the pod when the last container exits.  Supported policie
 | Exit Policy        | Description                                                                                                                |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | *continue*         | The pod continues running, by keeping its infra container alive, when the last container exits. Used by default.           |
-| *stop*             | The pod (including its infra container) is stopped when the last container exits. Used in `kube play`.                     |
+| *stop*             | The pod (including its infra container) is stopped when the last container exits. Used in `kube play` and quadlets.        |
 
 @@option gidmap.pod
 

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1006,6 +1006,7 @@ Valid options for `[Pod]` are listed below:
 | DNS=192.168.55.1                    | --dns=192.168.55.1                     |
 | DNSOption=ndots:1                   | --dns-option=ndots:1                   |
 | DNSSearch=example.com               | --dns-search example.com               |
+| ExitPolicy=stop                     | --exit-policy stop                     |
 | GIDMap=0:10000:10                   | --gidmap=0:10000:10                    |
 | GlobalArgs=--log-level=debug        | --log-level=debug                      |
 | HostName=name                       | --hostname=name                        |
@@ -1058,6 +1059,12 @@ This key can be listed multiple times.
 Set custom DNS search domains. Use **DNSSearch=.** to remove the search domain.
 
 This key can be listed multiple times.
+
+### `ExitPolicy=`
+
+Set the exit policy of the pod when the last container exits. Default for quadlets is **stop**.
+
+To keep the pod active, set `ExitPolicy=continue`.
 
 ### `GIDMap=`
 
@@ -2173,6 +2180,39 @@ PodName=test
 Image=quay.io/centos/centos:latest
 Exec=sh -c "sleep inf"
 Pod=test.pod
+```
+
+Example for a Pod with a oneshot Startup Task:
+
+`test.pod`
+```
+[Pod]
+PodName=test
+ExitPolicy=continue
+```
+
+`startup-task.container`
+```
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+[Container]
+Pod=test.pod
+Image=quay.io/centos/centos:latest
+Exec=sh -c "echo 'setup starting'; sleep 2; echo 'setup complete'"
+```
+
+`app.container`
+```
+[Unit]
+Requires=startup-task.container
+After=startup-task.container
+
+[Container]
+Pod=test.pod
+Image=quay.io/centos/centos:latest
+Exec=sh -c "echo 'app running.'; sleep 30"
 ```
 
 Example `s3fs.volume`:

--- a/test/e2e/quadlet/basic.pod
+++ b/test/e2e/quadlet/basic.pod
@@ -1,7 +1,7 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type forking
 ## assert-key-is Service SyslogIdentifier "%N"
-## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --exit-policy=stop --replace --infra-name systemd-basic-infra --name systemd-basic"
+## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --replace --exit-policy stop --infra-name systemd-basic-infra --name systemd-basic"
 ## assert-key-is-regex Service ExecStart ".*/podman pod start systemd-basic"
 ## assert-key-is-regex Service ExecStop ".*/podman pod stop --ignore --time=10 systemd-basic"
 ## assert-key-is-regex Service ExecStopPost ".*/podman pod rm --ignore --force systemd-basic"

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1693,6 +1693,11 @@ EOF
     # Pod should exist
     run_podman pod exists ${test_pod_name}
 
+    # Pod exit policy should be stop by default
+    run_podman pod inspect --format "{{.ExitPolicy}}" ${test_pod_name}
+    assert "$output" = "stop" \
+            "quadlet - pod: default ExitPolicy should be stop"
+
     # Wait for systemd to activate the container service
     wait_for_command_output "systemctl show --property=ActiveState $container_service" "ActiveState=active"
 


### PR DESCRIPTION
Add ExitPolicy key to pod quadlets with logic to default to stop.

Docs updated with clarifcation on default value and usage example.

Simple assert added to bats to verify default constraint exists.

Addresses #25596

See Also: https://github.com/containers/podman/discussions/26453

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added ExitPolicy for [Pod] in systemd quadlets
```
