### PR TITLE
Secret create - add ignore option to allow noop

### DIFF
--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -57,6 +57,8 @@ func init() {
 
 	flags.BoolVar(&createOpts.Replace, "replace", false, "If a secret with the same name exists, replace it")
 
+	flags.BoolVar(&createOpts.Ignore, "ignore", false, "If a secret with the same name exists, ignore and do not create a new secret")
+
 	labelFlagName := "label"
 	flags.StringArrayVarP(&labels, labelFlagName, "l", nil, "Specify labels on the secret")
 	_ = createCmd.RegisterFlagCompletionFunc(labelFlagName, completion.AutocompleteNone)
@@ -64,6 +66,11 @@ func init() {
 
 func create(cmd *cobra.Command, args []string) error {
 	name := args[0]
+
+	// Validate that --ignore and --replace are not used together
+	if createOpts.Ignore && createOpts.Replace {
+		return errors.New("cannot use --ignore and --replace flags together")
+	}
 
 	var err error
 	path := args[1]

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -38,6 +38,12 @@ Read secret data from environment variable.
 
 Print usage statement.
 
+#### **--ignore**=*false*
+
+If a secret with the same name already exists, do not return an error and return the existing secret's ID instead of creating a new one.
+Cannot be used with `--replace`.
+The default is **false**.
+
 #### **--label**, **-l**=*key=val1,key2=val2*
 
 Add label to secret. These labels can be viewed in podman secrete inspect or ls.
@@ -46,6 +52,7 @@ Add label to secret. These labels can be viewed in podman secrete inspect or ls.
 
 If existing secret with the same name already exists, update the secret.
 The `--replace` option does not change secrets within existing containers, only newly created containers.
+Cannot be used with `--ignore`.
  The default is **false**.
 
 ## SECRET DRIVERS

--- a/pkg/api/handlers/libpod/secrets.go
+++ b/pkg/api/handlers/libpod/secrets.go
@@ -27,6 +27,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 		DriverOpts map[string]string `schema:"driveropts"`
 		Labels     map[string]string `schema:"labels"`
 		Replace    bool              `schema:"replace"`
+		Ignore     bool              `schema:"ignore"`
 	}{
 		// override any golang type defaults
 	}
@@ -40,6 +41,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	opts.DriverOpts = query.DriverOpts
 	opts.Labels = query.Labels
 	opts.Replace = query.Replace
+	opts.Ignore = query.Ignore
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.SecretCreate(r.Context(), query.Name, r.Body, opts)

--- a/pkg/bindings/secrets/types.go
+++ b/pkg/bindings/secrets/types.go
@@ -29,4 +29,5 @@ type CreateOptions struct {
 	DriverOpts map[string]string
 	Labels     map[string]string
 	Replace    *bool
+	Ignore     *bool
 }

--- a/pkg/bindings/secrets/types_create_options.go
+++ b/pkg/bindings/secrets/types_create_options.go
@@ -91,3 +91,18 @@ func (o *CreateOptions) GetReplace() bool {
 	}
 	return *o.Replace
 }
+
+// WithIgnore set field Ignore to given value
+func (o *CreateOptions) WithIgnore(value bool) *CreateOptions {
+	o.Ignore = &value
+	return o
+}
+
+// GetIgnore returns value of field Ignore
+func (o *CreateOptions) GetIgnore() bool {
+	if o.Ignore == nil {
+		var z bool
+		return z
+	}
+	return *o.Ignore
+}

--- a/pkg/domain/entities/secrets.go
+++ b/pkg/domain/entities/secrets.go
@@ -12,6 +12,7 @@ type SecretCreateOptions struct {
 	DriverOpts map[string]string
 	Labels     map[string]string
 	Replace    bool
+	Ignore     bool
 }
 
 type SecretInspectOptions struct {

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -24,6 +24,22 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 		return nil, err
 	}
 
+	// If ignore flag is set, check if secret already exists
+	if options.Ignore {
+		secret, err := manager.Lookup(name)
+		if err == nil {
+			// Secret exists, return its ID without error
+			return &entities.SecretCreateReport{
+				ID: secret.ID,
+			}, nil
+		}
+		if !errors.Is(err, secrets.ErrNoSuchSecret) {
+			// Some other error occurred during lookup
+			return nil, err
+		}
+		// Secret doesn't exist, continue with creation
+	}
+
 	// set defaults from config for the case they are not set by an upper layer
 	// (-> i.e. tests that talk directly to the api)
 	cfg, err := ic.Libpod.GetConfigNoCopy()

--- a/pkg/domain/infra/tunnel/secrets.go
+++ b/pkg/domain/infra/tunnel/secrets.go
@@ -16,7 +16,8 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 		WithDriverOpts(options.DriverOpts).
 		WithName(name).
 		WithLabels(options.Labels).
-		WithReplace(options.Replace)
+		WithReplace(options.Replace).
+		WithIgnore(options.Ignore)
 	created, err := secrets.Create(ic.ClientCtx, reader, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Add --ignore flag to secret create command to allow noop in case the secret already exists 
```
