### PR TITLE
cmd/podman: add --latest option to update #26380

### DIFF
--- a/docs/source/markdown/options/latest.md
+++ b/docs/source/markdown/options/latest.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman attach, container diff, container inspect, diff, exec, init, inspect, kill, logs, mount, network reload, pause, pod inspect, pod kill, pod logs, pod rm, pod start, pod stats, pod stop, pod top, port, restart, rm, start, stats, stop, top, unmount, unpause, wait
+####>   podman attach, container diff, container inspect, diff, exec, init, inspect, kill, logs, mount, network reload, pause, pod inspect, pod kill, pod logs, pod rm, pod start, pod stats, pod stop, pod top, port, restart, rm, start, stats, stop, top, unmount, unpause, update, wait
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--latest**, **-l**

--- a/docs/source/markdown/podman-update.1.md.in
+++ b/docs/source/markdown/podman-update.1.md.in
@@ -78,6 +78,8 @@ Changing this setting resets the timer, depending on the state of the container.
 
 @@option health-timeout
 
+@@option latest
+
 @@option memory
 
 @@option memory-reservation
@@ -102,6 +104,11 @@ Update a container with a new cpu quota and period:
 podman update --cpus=0.5 ctrID
 ```
 
+Update the latest container with a new cpu value:
+```
+podman update --latest --cpus=1
+```
+
 Update a container with multiple options at ones:
 ```
 podman update --cpus 5 --cpuset-cpus 0 --cpu-shares 123 --cpuset-mems 0 \\
@@ -116,4 +123,5 @@ podman update --cpus 5 --cpuset-cpus 0 --cpu-shares 123 --cpuset-mems 0 \\
 **[podman(1)](podman.1.md)**, **[podman-create(1)](podman-create.1.md)**, **[podman-run(1)](podman-run.1.md)**
 
 ## HISTORY
+June 2025, Latest option added by Hayato Kihara <kai.21banana@gmail.com>
 August 2022, Originally written by Charlie Doern <cdoern@redhat.com>

--- a/pkg/domain/entities/types/containers.go
+++ b/pkg/domain/entities/types/containers.go
@@ -61,6 +61,7 @@ type ContainerUpdateOptions struct {
 	RestartRetries                  *uint
 	Env                             []string
 	UnsetEnv                        []string
+	Latest                          bool
 }
 
 func (u *ContainerUpdateOptions) ProcessSpecgen() {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1804,7 +1804,7 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 // ContainerUpdate finds and updates the given container's cgroup config with the specified options
 func (ic *ContainerEngine) ContainerUpdate(ctx context.Context, updateOptions *entities.ContainerUpdateOptions) (string, error) {
 	updateOptions.ProcessSpecgen()
-	containers, err := getContainers(ic.Libpod, getContainersOptions{names: []string{updateOptions.NameOrID}})
+	containers, err := getContainers(ic.Libpod, getContainersOptions{latest: updateOptions.Latest, names: []string{updateOptions.NameOrID}})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Allow users to target the most recently created container with `podman update --latest` (short `-l`). The same option already exists on many other commands, so this brings update in line with the rest of the CLI and saves users from typing or looking up the newest container.

Fixes: #26380

#### Does this PR introduce a user-facing change?

```release-note
Added `--latest` option to `podman update` saves users from typing or looking up the most recently created container.
```
