### PR TITLE
test/e2e: fix "with unsafe hostPath subpaths" test

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5549,7 +5549,7 @@ spec:
 	})
 
 	It("with unsafe hostPath subpaths", func() {
-		hostPathLocation := podmanTest.TempDir
+		hostPathLocation := filepath.Join(podmanTest.TempDir, "vol")
 
 		Expect(os.MkdirAll(filepath.Join(hostPathLocation, "testing"), 0755)).To(Succeed())
 		Expect(os.Symlink("/", filepath.Join(hostPathLocation, "testing", "symlink"))).To(Succeed())


### PR DESCRIPTION
A recent pasta update changed the selinux rules and we now run pasta under pasta_t and no longer the container_runtime_t type. The pasta type has much stricter type rules on what the file we hand it must be labelled. This test tries to mount the runroot which gets relabeled with the container_file_t type but that means pasta can no longer access its pid file we give it. To fix this test here simply mount a subdir.

see #26473

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
