### PR TITLE
Pod YAML: Add support for `lifecycle.stopSignal`

### DIFF
--- a/docs/kubernetes_support.md
+++ b/docs/kubernetes_support.md
@@ -112,6 +112,7 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | resources\.requests                                 | ✅      |
 | lifecycle\.postStart                                | no      |
 | lifecycle\.preStop                                  | no      |
+| lifecycle\.stopSignal                               | ✅      |
 | terminationMessagePath                              | no      |
 | terminationMessagePolicy                            | no      |
 | livenessProbe                                       | ✅      |

--- a/pkg/k8s.io/api/core/v1/types.go
+++ b/pkg/k8s.io/api/core/v1/types.go
@@ -1331,6 +1331,13 @@ type Lifecycle struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 	// +optional
 	PreStop *Handler `json:"preStop,omitempty"`
+	// StopSignal defines the signal to be sent to the container when stopping.
+	// This value is configured via the container's Lifecycle and overrides any
+	// stop signal defined in the container image. If no StopSignal is specified,
+	// the default signal (SIGTERM) will be used.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#defining-custom-stop-signals
+	// +optional
+	StopSignal *string `json:"stopSignal,omitempty"`
 }
 
 type ConditionStatus string

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -656,6 +656,14 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		s.StopTimeout = &timeout
 	}
 
+	if lifecycle := opts.Container.Lifecycle; lifecycle != nil && lifecycle.StopSignal != nil {
+		stopSignal, err := util.ParseSignal(*lifecycle.StopSignal)
+		if err != nil {
+			return nil, err
+		}
+		s.StopSignal = &stopSignal
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION
### What I did
- Fix #25389

### How I did it
1. Code Analysis:
![25389](https://github.com/user-attachments/assets/87a58f40-8e26-4f87-a3b8-56ee7d0f65f2)
add parsing signal logics inside `ToSpecGen`, and `StopSignal` is now recognized as a container option inside `CreateContainerOptions`

2. Docs: add support for lifecycle.stopSignal in Pod YAML

### How to verify it
Add three e2e test cases
1. Default Case: No StopSignal, defaults to `SIGTERM`
2. Positive Case: Pod YAML add StopSignal `SIGUSR1`
3. Negative Case: invalid signal string, and error is expected


### Release Note
```release-note
Support for `lifecycle.stopSignal` in Pod YAML
```
