### PR TITLE
Update Neil Smith's GitHub username in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,7 +17,7 @@ Maintainers and Reviewers for the Skopeo and Buildah projects are found in their
 | Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Mohan Boddu       | [mohanboddu](https://github.com/mohanboddu)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
-| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [actionmancan](https://github.com/actionmancan)          | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
 | Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
 | Ygal Blum         | [ygalblum](https://github.com/ygalblum)                  | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
 | Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |


### PR DESCRIPTION
This PR updates Neil Smith's GitHub username from 'Neil-Smith' to 'actionmancan' in the MAINTAINERS.md file.

- Changed GitHub username from 'Neil-Smith' to 'actionmancan'
- Maintains Neil Smith's role as Community Manager
- No functional changes, just updating the GitHub handle

Does this PR introduce a user-facing change?
None

```release-note
None
```

Signed-off-by: G A Neil Smith <nesmith@redhat.com>