### PR TITLE
Quadlet - Error when units define User, Group, or DynamicUser in Serv…

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -78,6 +78,12 @@ session gets started. For unit files placed in subdirectories within
 /etc/containers/systemd/user/${UID}/ and the other user unit search paths,
 Quadlet will recursively search and run the unit files present in these subdirectories.
 
+Note that Quadlet units do not support running as a non-root user by defining the
+[User, Group](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#User=),
+or [DynamicUser](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#DynamicUser=)
+systemd options. If you want to run a rootless Quadlet, you will need to create the user
+and add the unit file to one of the above rootless unit search paths.
+
 Note: When a Quadlet is starting, Podman often pulls or builds one more container images which may take a considerable amount of time.
 Systemd defaults service start time to 90 seconds, or fails the service. Pre-pulling the image or extending
 the systemd timeout time for the service using the *TimeoutStartSec* Service option can fix the problem.

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -2248,14 +2248,6 @@ func initServiceUnitFile(quadletUnitFile *parser.UnitFile, isUser bool, unitsInf
 		return nil, nil, err
 	}
 
-	// These Service keys cannot be used in a Quadlet unit
-	for _, key := range UnsupportedServiceKeys {
-		_, hasKey := quadletUnitFile.Lookup(ServiceGroup, key)
-		if hasKey {
-			return nil, nil, fmt.Errorf("using key %s in the Service group is not supported", key)
-		}
-	}
-
 	service := quadletUnitFile.Dup()
 	service.Filename = unitInfo.ServiceFileName()
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -186,6 +186,9 @@ const (
 	KeyYaml                  = "Yaml"
 )
 
+// Unsupported keys in the Service group. Defined here so we can error when they are found
+var UnsupportedServiceKeys = [...]string{"User", "Group", "DynamicUser"}
+
 type UnitInfo struct {
 	// The name of the generated systemd service unit
 	ServiceName string
@@ -2243,6 +2246,14 @@ func initServiceUnitFile(quadletUnitFile *parser.UnitFile, isUser bool, unitsInf
 
 	if err := checkForUnknownKeys(quadletUnitFile, group, groupsInfo[group].SupportedKeys); err != nil {
 		return nil, nil, err
+	}
+
+	// These Service keys cannot be used in a Quadlet unit
+	for _, key := range UnsupportedServiceKeys {
+		_, hasKey := quadletUnitFile.Lookup(ServiceGroup, key)
+		if hasKey {
+			return nil, nil, fmt.Errorf("using key %s in the Service group is not supported", key)
+		}
 	}
 
 	service := quadletUnitFile.Dup()

--- a/test/e2e/quadlet/service-dynamicuser.build
+++ b/test/e2e/quadlet/service-dynamicuser.build
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.build
+++ b/test/e2e/quadlet/service-dynamicuser.build
@@ -1,4 +1,8 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.container
+++ b/test/e2e/quadlet/service-dynamicuser.container
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.container
+++ b/test/e2e/quadlet/service-dynamicuser.container
@@ -1,4 +1,7 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+
+[Container]
+Image=localhost/imagename
+
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.image
+++ b/test/e2e/quadlet/service-dynamicuser.image
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.image
+++ b/test/e2e/quadlet/service-dynamicuser.image
@@ -1,4 +1,7 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+
+[Image]
+Image=localhost/imagename
+
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.kube
+++ b/test/e2e/quadlet/service-dynamicuser.kube
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.kube
+++ b/test/e2e/quadlet/service-dynamicuser.kube
@@ -1,4 +1,7 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+
+[Kube]
+Yaml=deployment.yml
+
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.network
+++ b/test/e2e/quadlet/service-dynamicuser.network
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.network
+++ b/test/e2e/quadlet/service-dynamicuser.network
@@ -1,4 +1,3 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.pod
+++ b/test/e2e/quadlet/service-dynamicuser.pod
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.pod
+++ b/test/e2e/quadlet/service-dynamicuser.pod
@@ -1,4 +1,3 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.volume
+++ b/test/e2e/quadlet/service-dynamicuser.volume
@@ -1,0 +1,4 @@
+## assert-failed
+## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
+[Service]
+DynamicUser=foobar

--- a/test/e2e/quadlet/service-dynamicuser.volume
+++ b/test/e2e/quadlet/service-dynamicuser.volume
@@ -1,4 +1,3 @@
-## assert-failed
 ## assert-stderr-contains "using key DynamicUser in the Service group is not supported"
 [Service]
 DynamicUser=foobar

--- a/test/e2e/quadlet/service-group.container
+++ b/test/e2e/quadlet/service-group.container
@@ -1,0 +1,9 @@
+## assert-failed
+## assert-stderr-contains "using key Group in the Service group is not supported"
+[Container]
+# This is fine
+Group=1000
+
+[Service]
+# This isn't
+Group=1000

--- a/test/e2e/quadlet/service-group.container
+++ b/test/e2e/quadlet/service-group.container
@@ -1,7 +1,8 @@
-## assert-failed
 ## assert-stderr-contains "using key Group in the Service group is not supported"
 [Container]
+Image=localhost/imagename
 # This is fine
+User=1000
 Group=1000
 
 [Service]

--- a/test/e2e/quadlet/service-user.container
+++ b/test/e2e/quadlet/service-user.container
@@ -1,0 +1,9 @@
+## assert-failed
+## assert-stderr-contains "using key User in the Service group is not supported"
+[Container]
+# This is fine
+User=1000
+
+[Service]
+# This isn't
+User=1000

--- a/test/e2e/quadlet/service-user.container
+++ b/test/e2e/quadlet/service-user.container
@@ -1,6 +1,6 @@
-## assert-failed
 ## assert-stderr-contains "using key User in the Service group is not supported"
 [Container]
+Image=localhost/imagename
 # This is fine
 User=1000
 

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1096,6 +1096,16 @@ BOGUS=foo
 		runWarningQuadletTestCase,
 		Entry("label-unsupported-escape.container", "label-unsupported-escape.container", "unsupported escape char"),
 		Entry("shortname.container", "shortname.container", "Warning: shortname.container specifies the image \"shortname\" which not a fully qualified image name. This is not ideal for performance and security reasons. See the podman-pull manpage discussion of short-name-aliases.conf for details."),
+
+		Entry("Unsupported Service Key - User", "service-user.container", "Warning: using key User in the Service group is not supported"),
+		Entry("Unsupported Service Key - Group", "service-group.container", "Warning: using key Group in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.build", "service-dynamicuser.build", "Warning: using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.container", "service-dynamicuser.container", "Warning: using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.image", "service-dynamicuser.image", "Warning: using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.kube", "service-dynamicuser.kube", "Warning: using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.network", "service-dynamicuser.network", "Warning: using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.pod", "service-dynamicuser.pod", "Warning: using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.volume", "service-dynamicuser.volume", "Warning: using key DynamicUser in the Service group is not supported"),
 	)
 
 	DescribeTable("Running expected error quadlet test case",
@@ -1126,16 +1136,6 @@ BOGUS=foo
 		Entry("Build - Neither WorkingDirectory nor File Key", "neither-workingdirectory-nor-file.build", "converting \"neither-workingdirectory-nor-file.build\": neither SetWorkingDirectory, nor File key specified"),
 		Entry("Build - No ImageTag Key", "no-imagetag.build", "converting \"no-imagetag.build\": no ImageTag key specified"),
 		Entry("emptyline.container", "emptyline.container", "converting \"emptyline.container\": no Image or Rootfs key specified"),
-
-		Entry("Unsupported Service Key - User", "service-user.container", "converting \"service-user.container\": using key User in the Service group is not supported"),
-		Entry("Unsupported Service Key - Group", "service-group.container", "converting \"service-group.container\": using key Group in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.build", "service-dynamicuser.build", "converting \"service-dynamicuser.build\": using key DynamicUser in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.container", "service-dynamicuser.container", "converting \"service-dynamicuser.container\": using key DynamicUser in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.image", "service-dynamicuser.image", "converting \"service-dynamicuser.image\": using key DynamicUser in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.kube", "service-dynamicuser.kube", "converting \"service-dynamicuser.kube\": using key DynamicUser in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.network", "service-dynamicuser.network", "converting \"service-dynamicuser.network\": using key DynamicUser in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.pod", "service-dynamicuser.pod", "converting \"service-dynamicuser.pod\": using key DynamicUser in the Service group is not supported"),
-		Entry("Unsupported Service Key - DynamicUser.volume", "service-dynamicuser.volume", "converting \"service-dynamicuser.volume\": using key DynamicUser in the Service group is not supported"),
 	)
 
 	DescribeTable("Running success quadlet with ServiceName test case",

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1126,6 +1126,16 @@ BOGUS=foo
 		Entry("Build - Neither WorkingDirectory nor File Key", "neither-workingdirectory-nor-file.build", "converting \"neither-workingdirectory-nor-file.build\": neither SetWorkingDirectory, nor File key specified"),
 		Entry("Build - No ImageTag Key", "no-imagetag.build", "converting \"no-imagetag.build\": no ImageTag key specified"),
 		Entry("emptyline.container", "emptyline.container", "converting \"emptyline.container\": no Image or Rootfs key specified"),
+
+		Entry("Unsupported Service Key - User", "service-user.container", "converting \"service-user.container\": using key User in the Service group is not supported"),
+		Entry("Unsupported Service Key - Group", "service-group.container", "converting \"service-group.container\": using key Group in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.build", "service-dynamicuser.build", "converting \"service-dynamicuser.build\": using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.container", "service-dynamicuser.container", "converting \"service-dynamicuser.container\": using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.image", "service-dynamicuser.image", "converting \"service-dynamicuser.image\": using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.kube", "service-dynamicuser.kube", "converting \"service-dynamicuser.kube\": using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.network", "service-dynamicuser.network", "converting \"service-dynamicuser.network\": using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.pod", "service-dynamicuser.pod", "converting \"service-dynamicuser.pod\": using key DynamicUser in the Service group is not supported"),
+		Entry("Unsupported Service Key - DynamicUser.volume", "service-dynamicuser.volume", "converting \"service-dynamicuser.volume\": using key DynamicUser in the Service group is not supported"),
 	)
 
 	DescribeTable("Running success quadlet with ServiceName test case",


### PR DESCRIPTION
…ice group

Fixes: #26543

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added: Quadlet generator will now fail with a descriptive error message if a unit defines User, Group, or DynamicUser in its Service group.
	Users created by systemd in this way this way cannot run podman, so this is an improvement over the current behavior - generating a systemd service that will fail.
```
