### PR TITLE
Fix `podman inspect` to correctly handle log_size_max

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -669,6 +669,14 @@ func (c *Container) LogTag() string {
 	return c.config.LogTag
 }
 
+// LogSizeMax returns the maximum size of the container's log file.
+func (c *Container) LogSizeMax() int64 {
+	if c.config.LogSize > 0 {
+		return c.config.LogSize
+	}
+	return c.runtime.config.Containers.LogSizeMax
+}
+
 // RestartPolicy returns the container's restart policy.
 func (c *Container) RestartPolicy() string {
 	return c.config.RestartPolicy

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -378,7 +378,7 @@ type ContainerMiscConfig struct {
 	LogPath string `json:"logPath"`
 	// LogTag is the tag used for logging
 	LogTag string `json:"logTag"`
-	// LogSize is the tag used for logging
+	// LogSize is the maximum size of the container's log file
 	LogSize int64 `json:"logSize"`
 	// LogDriver driver for logs
 	LogDriver string `json:"logDriver"`

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -498,7 +498,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	logConfig := new(define.InspectLogConfig)
 	logConfig.Type = c.config.LogDriver
 	logConfig.Path = c.config.LogPath
-	logConfig.Size = units.HumanSize(float64(c.config.LogSize))
+	logConfig.Size = units.HumanSize(float64(c.LogSizeMax()))
 	logConfig.Tag = c.config.LogTag
 
 	hostConfig.LogConfig = logConfig

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1342,10 +1342,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 	logrus.Debugf("%s messages will be logged to syslog", r.conmonPath)
 	args = append(args, "--syslog")
 
-	size := r.logSizeMax
-	if ctr.config.LogSize > 0 {
-		size = ctr.config.LogSize
-	}
+	size := ctr.LogSizeMax()
 	if size > 0 {
 		args = append(args, "--log-size-max", strconv.FormatInt(size, 10))
 	}


### PR DESCRIPTION
When generating Conmon's command line, we read containers.conf to get log_size_max and used it if the container didn't override it. However, `podman inspect` only reads from the container's own config, and ignores containers.conf. Unify the way we determine maximum log size with a single function and use it for both inspect and containers.conf, and add a test for this behavior.

Fixes https://issues.redhat.com/browse/RHEL-96776

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where `podman inspect` did not correctly display log size for containers when `log_size_max` was set in containers.conf.
```
