### PR TITLE
Fix seccomp profile path on Windows

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -737,8 +737,13 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		case "proc-opts":
 			s.ProcOpts = strings.Split(val, ",")
 		case "seccomp":
-			s.SeccompProfilePath = val
-			s.Annotations[define.InspectAnnotationSeccomp] = val
+			convertedPath, err := specgen.ConvertWinMountPath(val)
+			if err != nil {
+				// If the conversion fails, use the original path
+				convertedPath = val
+			}
+			s.SeccompProfilePath = convertedPath
+			s.Annotations[define.InspectAnnotationSeccomp] = convertedPath
 			// this option is for docker compatibility, it is the same as unmask=ALL
 		case "systempaths":
 			if val == "unconfined" {

--- a/pkg/specgenutil/specgenutil_windows_test.go
+++ b/pkg/specgenutil/specgenutil_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package specgenutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/containers/podman/v5/pkg/domain/entities"
+	"github.com/containers/podman/v5/pkg/specgen"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeccompProfilePath(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	cwd_wsl, err := specgen.ConvertWinMountPath(cwd)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		originalPath string
+		expectedPath string
+	}{
+		{`C:\Foo`, "/mnt/c/Foo"},
+		{`C:\Foo`, "/mnt/c/Foo"},
+		{`\\?\C:\Foo`, "/mnt/c/Foo"},
+		{`/c/bar`, "/mnt/c/bar"},
+		{`/c/bar`, "/mnt/c/bar"},
+		{`/mnt/c/bar`, "/mnt/c/bar"},
+		{`/test/this`, "/test/this"},
+		{`c:/bar/something`, "/mnt/c/bar/something"},
+		{`c`, cwd_wsl + "/c"},
+		{`\\computer\loc`, `\\computer\loc`},
+		{`\\.\drive\loc`, "/mnt/wsl/drive/loc"},
+	}
+
+	f := func(secopt string) (*specgen.SpecGenerator, error) {
+		sg := specgen.NewSpecGenerator("nothing", false)
+		err := FillOutSpecGen(sg, &entities.ContainerCreateOptions{
+			SecurityOpt: []string{secopt}}, []string{},
+		)
+		return sg, err
+	}
+
+	for _, test := range tests {
+		t.Run(test.originalPath, func(t *testing.T) {
+			msg := "Checking: " + test.originalPath
+			sg, err := f("seccomp=" + test.originalPath)
+			assert.NoError(t, err, msg)
+			assert.Equal(t, test.expectedPath, sg.SeccompProfilePath, msg)
+		})
+	}
+}


### PR DESCRIPTION
Call `specgen.ConvertWinMountPath()` on seccomp profile paths provided via security-opt parameter.

Fixes https://github.com/containers/podman/issues/26558

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
