### PR TITLE
pkg/bindings/containers: some attach/logs handling fixes

### DIFF
--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -259,12 +259,8 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 
 // DemuxHeader reads header for stream from server multiplexed stdin/stdout/stderr/2nd error channel
 func DemuxHeader(r io.Reader, buffer []byte) (fd, sz int, err error) {
-	n, err := io.ReadFull(r, buffer[0:8])
+	_, err = io.ReadFull(r, buffer[0:8])
 	if err != nil {
-		return
-	}
-	if n < 8 {
-		err = io.ErrUnexpectedEOF
 		return
 	}
 
@@ -284,13 +280,9 @@ func DemuxFrame(r io.Reader, buffer []byte, length int) (frame []byte, err error
 		buffer = append(buffer, make([]byte, length-len(buffer)+1)...)
 	}
 
-	n, err := io.ReadFull(r, buffer[0:length])
+	_, err = io.ReadFull(r, buffer[0:length])
 	if err != nil {
 		return nil, err
-	}
-	if n < length {
-		err = io.ErrUnexpectedEOF
-		return
 	}
 
 	return buffer[0:length], nil

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -219,7 +219,7 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 			// Read multiplexed channels and write to appropriate stream
 			fd, l, err := DemuxHeader(socket, buffer)
 			if err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				if errors.Is(err, io.EOF) {
 					return nil
 				}
 				return err
@@ -540,7 +540,7 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 			// Read multiplexed channels and write to appropriate stream
 			fd, l, err := DemuxHeader(socket, buffer)
 			if err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				if errors.Is(err, io.EOF) {
 					return nil
 				}
 				return err

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -232,19 +232,19 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 			switch fd {
 			case 0:
 				if isSet.stdout {
-					if _, err := stdout.Write(frame[0:l]); err != nil {
+					if _, err := stdout.Write(frame); err != nil {
 						return err
 					}
 				}
 			case 1:
 				if isSet.stdout {
-					if _, err := stdout.Write(frame[0:l]); err != nil {
+					if _, err := stdout.Write(frame); err != nil {
 						return err
 					}
 				}
 			case 2:
 				if isSet.stderr {
-					if _, err := stderr.Write(frame[0:l]); err != nil {
+					if _, err := stderr.Write(frame); err != nil {
 						return err
 					}
 				}
@@ -555,19 +555,19 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 				if options.GetAttachInput() {
 					// Write STDIN to STDOUT (echoing characters
 					// typed by another attach session)
-					if _, err := options.GetOutputStream().Write(frame[0:l]); err != nil {
+					if _, err := options.GetOutputStream().Write(frame); err != nil {
 						return err
 					}
 				}
 			case 1:
 				if options.GetAttachOutput() {
-					if _, err := options.GetOutputStream().Write(frame[0:l]); err != nil {
+					if _, err := options.GetOutputStream().Write(frame); err != nil {
 						return err
 					}
 				}
 			case 2:
 				if options.GetAttachError() {
-					if _, err := options.GetErrorStream().Write(frame[0:l]); err != nil {
+					if _, err := options.GetErrorStream().Write(frame); err != nil {
 						return err
 					}
 				}

--- a/pkg/bindings/containers/logs.go
+++ b/pkg/bindings/containers/logs.go
@@ -44,7 +44,7 @@ func Logs(ctx context.Context, nameOrID string, options *LogOptions, stdoutChan,
 	for {
 		fd, l, err := DemuxHeader(response.Body, buffer)
 		if err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -383,6 +383,11 @@ var _ = Describe("Podman containers ", func() {
 		o = strings.TrimSpace(o)
 		_, err = time.Parse(time.RFC1123Z, o)
 		Expect(err).ShouldNot(HaveOccurred())
+
+		// drain the line channel and make sure there are no more log lines
+		for l := range stdoutChan {
+			Fail("container logs returned more than one line: " + l)
+		}
 	})
 
 	It("podman top", func() {

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -250,7 +250,7 @@ var _ = Describe("Podman update", func() {
 		testCtr := "test-ctr-name"
 
 		// Test that the variable is not set.
-		ctr1 := podmanTest.Podman([]string{"run", "-t", "--name", testCtr, ALPINE, "printenv", "FOO"})
+		ctr1 := podmanTest.Podman([]string{"run", "--name", testCtr, ALPINE, "printenv", "FOO"})
 		ctr1.WaitWithDefaultTimeout()
 		Expect(ctr1).Should(Exit(1))
 
@@ -263,7 +263,7 @@ var _ = Describe("Podman update", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		env := session.OutputToString()
-		Expect(env).To(ContainSubstring("BAR"))
+		Expect(env).To(Equal("BAR"))
 
 		session = podmanTest.Podman([]string{"inspect", testCtr, "--format", "{{.Config.Env}}"})
 		session.WaitWithDefaultTimeout()
@@ -281,7 +281,7 @@ var _ = Describe("Podman update", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		env = session.OutputToString()
-		Expect(env).To(ContainSubstring("RAB"))
+		Expect(env).To(Equal("RAB"))
 
 		session = podmanTest.Podman([]string{"inspect", testCtr, "--format", "{{.Config.Env}}"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
They don't really explain flakes to me but when looking at where we can loose remote output this is what I found. I don't think it fixes whatever flake we are seeing but the changes itself should be correct and in my many debug runs in https://github.com/containers/podman/pull/26596 I have not observed flakes with this.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
