### PR TITLE
Feat: send additional build contexts as tar files for remote builds

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1491,7 +1491,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: Content-Type
 	//    type: string
 	//    default: application/x-tar
-	//    enum: ["application/x-tar"]
+	//    enum: ["application/x-tar", "multipart/form-data"]
 	//  - in: header
 	//    name: X-Registry-Config
 	//    type: string
@@ -1515,6 +1515,28 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      Instead of building for a set of platforms specified using the platform option, inspect the build's base images,
 	//      and build for all of the platforms that are available.  Stages that use *scratch* as a starting point can not be inspected,
 	//      so at least one non-*scratch* stage must be present for detection to work usefully.
+	//  - in: query
+	//    name: additionalbuildcontexts
+	//    type: array
+	//    items:
+	//      type: string
+	//    default: []
+	//    description: |
+	//      Additional build contexts for builds that require more than one context.
+	//      Each additional context must be specified as a key-value pair in the format "name=value".
+	//
+	//      The value can be specified in two formats:
+	//      - URL context: Use the prefix "url:" followed by a URL to a tar archive
+	//        Example: "mycontext=url:https://example.com/context.tar"
+	//      - Image context: Use the prefix "image:" followed by an image reference
+	//        Example: "mycontext=image:alpine:latest" or "mycontext=image:docker.io/library/ubuntu:22.04"
+	//
+	//      Local contexts are provided via multipart/form-data upload. When using multipart/form-data,
+	//      include additional build contexts as separate form fields with names prefixed by "build-context-".
+	//      For example, a local context named "mycontext" should be uploaded as a tar file in a field
+	//      named "build-context-mycontext".
+	//
+	//      (As of version 5.6.0)
 	//  - in: query
 	//    name: extrahosts
 	//    type: string


### PR DESCRIPTION
Fixed the --build-context flag to properly send files for remote builds. Previously only the main context was sent over as a tar while additional contexts were passed as local paths and this would cause builds to fail since the files wouldn't exist.

New changes modifies the Build API to use multipart HTTP requests allowing multiple build contexts to be sent as tar files. Each additional context is packaged and transferred based on its type:
- Local Directories: Sent as tar archives
- Git Repositories: URL sent to the server, which then clones it
- Container Images: Image reference sent to the server, which pulls the image
- URLs/archives: URL sent to the server, which handles the download

Skip("Waiting for VM images with Podman > 5.5.2 for multipart build context support") is in place until VM images are updated to podman 5.6.0

Version check is in place to make sure that the server is updated to at least the upcoming 5.6.0 update or else the fix wont be usable.

Fixes: #23433

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for --build-context for podman-remote
```
