### PR TITLE
podman auto-update: include container in invalid policy message

### DIFF
--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -393,7 +393,7 @@ func (u *updater) assembleTasks(ctx context.Context) []error {
 		}
 		policy, err := LookupPolicy(value)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("auto-updating container %q: %w", ctr.ID(), err))
 			continue
 		}
 		if policy == PolicyDefault {

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -267,7 +267,7 @@ function _confirm_update() {
 
     _wait_service_ready container-$cname.service
     run_podman 125 auto-update
-    is "$output" ".*invalid auto-update policy.*" "invalid policy setup"
+    assert "$output" =~ 'auto-updating container "[0-9a-f]{64}": invalid auto-update policy "'"$fakevalue"'": valid policies are \["disabled" "image" "local" "registry"\]' "invalid policy setup"
 
     run_podman inspect --format "{{.Image}}" $cname
     is "$output" "$ori_image" "Image ID should not change"
@@ -384,8 +384,7 @@ EOF
     # Exit code is expected, due to invalid 'fakevalue'
     run_podman 125 auto-update --rollback=false
     update_log=$output
-    is "$update_log" ".*invalid auto-update policy.*" "invalid policy setup"
-    is "$update_log" ".*Error: invalid auto-update policy.*" "invalid policy setup"
+    assert "$update_log" =~ '.*Error: auto-updating container "[0-9a-f]{64}": invalid auto-update policy.*' "invalid policy setup"
 
     local n_updated=$(grep -c 'Trying to pull' <<<"$update_log")
     is "$n_updated" "2" "Number of images updated from registry."


### PR DESCRIPTION
I noticed recently when I made a typo that then auto-update errored but it did not tell me which container was incorrect so I had to check all containers myself. Include the container ID in the error to make it clear which container has the issue.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
