### PR TITLE
[v4.9-rhel] Add conditional release-checking system test

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -283,4 +283,13 @@ run_podman --noout system connection ls
     is "${lines[-1]}" ".*Shutting down engines"
 }
 
+@test "release" {
+  [[ "${RELEASE_TESTING:-false}" == "true" ]] || \
+    skip "Release testing may be enabled by setting \$RELEASE_TESTING = 'true'."
+
+  run_podman --version
+
+  assert "$output" "!~" "dev" "The Podman version string does not mention 'dev'."
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Unfortunately on a number of occasions, Podman has been released officially with a `-dev` suffix in the version number.  Assist in catching this mistake at release time by the addition of a simple conditional test.  Note that it must be positively enabled by a magic env. var. before executing the system tests.

Ref. original PR: https://github.com/containers/podman/pull/26540

***Note:*** Backport created with AI assistance.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
