### PR TITLE
added updated state in podman-auto-update.1.md.in

### DIFF
--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -58,15 +58,15 @@ The `UPDATED` field indicates the availability of a new image with "pending".
 Change the default output format.  This can be of a supported type like 'json' or a Go template.
 Valid placeholders for the Go template are listed below:
 
-| **Placeholder** | **Description**                        |
-| --------------- | -------------------------------------- |
-| .Container      | ID and name of the container           |
-| .ContainerID    | ID of the container                    |
-| .ContainerName  | Name of the container                  |
-| .Image          | Name of the image                      |
-| .Policy         | Auto-update policy of the container    |
-| .Unit           | Name of the systemd unit               |
-| .Updated        | Update status: true,false,failed       |
+| **Placeholder** | **Description**                          |
+| --------------- | ---------------------------------------- |
+| .Container      | ID and name of the container             |
+| .ContainerID    | ID of the container                      |
+| .ContainerName  | Name of the container                    |
+| .Image          | Name of the image                        |
+| .Policy         | Auto-update policy of the container      |
+| .Unit           | Name of the systemd unit                 |
+| .Updated        | Update status: true,false,failed,pending |
 
 #### **--rollback**
 


### PR DESCRIPTION
added missing state "pending" for updated is avialable. im not sure if others missing, i just found this missing while creating a script

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
```release-note
None
```
