### PR TITLE
Fix: Improve error message for empty device modes

### DIFF
--- a/pkg/specgen/generate/config_common.go
+++ b/pkg/specgen/generate/config_common.go
@@ -15,8 +15,11 @@ func ParseDevice(device string) (string, string, string, error) {
 	arr := strings.Split(device, ":")
 	switch len(arr) {
 	case 3:
+		if arr[2] == "" {
+			return "", "", "", fmt.Errorf("empty device mode in device specification: %s", device)
+		}
 		if !IsValidDeviceMode(arr[2]) {
-			return "", "", "", fmt.Errorf("invalid device mode: %s", arr[2])
+			return "", "", "", fmt.Errorf("invalid device mode %q in device %q", arr[2], device)
 		}
 		permissions = arr[2]
 		fallthrough
@@ -25,7 +28,7 @@ func ParseDevice(device string) (string, string, string, error) {
 			permissions = arr[1]
 		} else {
 			if len(arr[1]) > 0 && arr[1][0] != '/' {
-				return "", "", "", fmt.Errorf("invalid device mode: %s", arr[1])
+				return "", "", "", fmt.Errorf("invalid device mode %q in device %q", arr[1], device)
 			}
 			dst = arr[1]
 		}

--- a/pkg/specgen/generate/config_common_test.go
+++ b/pkg/specgen/generate/config_common_test.go
@@ -20,6 +20,7 @@ func TestParseDevice(t *testing.T) {
 		{"/dev/foo:/dev/bar:rw", "/dev/foo", "/dev/bar", "rw"},
 		{"/dev/foo:rw", "/dev/foo", "/dev/foo", "rw"},
 		{"/dev/foo::rw", "/dev/foo", "/dev/foo", "rw"},
+		{"/dev/foo:", "/dev/foo", "/dev/foo", "rwm"},
 	}
 	for _, test := range tests {
 		src, dst, perm, err := ParseDevice(test.device)
@@ -27,5 +28,28 @@ func TestParseDevice(t *testing.T) {
 		assert.Equal(t, src, test.src)
 		assert.Equal(t, dst, test.dst)
 		assert.Equal(t, perm, test.perm)
+	}
+}
+
+func TestParseDeviceErrors(t *testing.T) {
+	errorTests := []struct {
+		device        string
+		expectedError string
+	}{
+		{"/dev/fuse::", "empty device mode in device specification: /dev/fuse::"},
+		{"/dev/fuse:invalid", `invalid device mode "invalid" in device "/dev/fuse:invalid"`},
+		{"/dev/fuse:/path:xyz", `invalid device mode "xyz" in device "/dev/fuse:/path:xyz"`},
+		{"/dev/fuse:/path:rw:extra", `invalid device specification: /dev/fuse:/path:rw:extra`},
+		{"/dev/fuse:/path:rw:extra:more", `invalid device specification: /dev/fuse:/path:rw:extra:more`},
+		{"/dev/fuse:notapath", `invalid device mode "notapath" in device "/dev/fuse:notapath"`},
+		{"/dev/fuse:x", `invalid device mode "x" in device "/dev/fuse:x"`},
+		{"/dev/fuse:rwx", `invalid device mode "rwx" in device "/dev/fuse:rwx"`},
+		{"/dev/fuse:rrw", `invalid device mode "rrw" in device "/dev/fuse:rrw"`},
+	}
+
+	for _, test := range errorTests {
+		_, _, _, err := ParseDevice(test.device)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), test.expectedError)
 	}
 }

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -82,7 +82,13 @@ var _ = Describe("Podman run device", func() {
 	It("podman run device rename and bad permission test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(125, "invalid device mode: rd"))
+		Expect(session).Should(ExitWithError(125, "invalid device mode \"rd\" in device \"/dev/kmsg:/dev/kmsg1:rd\""))
+	})
+
+	It("podman run device with empty mode test", func() {
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/fuse::", ALPINE, "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "empty device mode in device specification: /dev/fuse::"))
 	})
 
 	It("podman run device host device and container device parameter are directories", func() {


### PR DESCRIPTION
- Add specific check for empty device modes in ParseDevice function
- Change error message from 'invalid device mode: ' to 'empty device mode in device specification: <device>'
- Include full device specification in error message for better context
- Add test cases for empty device mode scenarios
- Resolves issue where '/dev/fuse::' provided unhelpful error message

Fixes #26629

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

## Problem Description

When using device mappings with empty device modes (e.g., `/dev/fuse::`), users encounter an unhelpful error message that lacks context about which device specification caused the issue. This was reported in issue #26629 where cluster-api Docker infrastructure provider generated device mappings like `/dev/fuse::` resulting in the error: Error: invalid device mode:
The error message provides no context about which device specification is problematic, making debugging difficult in complex container configurations.

## User-Visible Impact

This affects users who:
- Use the Podman API with malformed device specifications  
- Use CLI commands with empty device modes like `podman run --device /dev/fuse::`
- Work with automated tools (like cluster-api) that may generate invalid device specifications

Without this fix, users cannot easily identify which device mapping is problematic, requiring manual inspection of all device specifications to find the issue.

## Technical Details

The fix adds specific empty mode detection in the `ParseDevice` function before calling `IsValidDeviceMode`. When an empty device mode is detected (e.g., in `/dev/fuse::`), it now returns a descriptive error message that includes the full device specification.

## Changes Made

- **pkg/specgen/generate/config_common.go**: Added empty device mode check in ParseDevice function
- **pkg/specgen/generate/config_common_test.go**: Added test case for empty device mode error  
- **test/e2e/run_device_test.go**: Added e2e test verifying the improved error message

## Testing

- ✅ Unit tests pass: `go test ./pkg/specgen/generate/ -v -run TestParseDevice`
- ✅ E2E tests pass with expected error message
- ✅ Valid device specifications continue to work correctly
- ✅ Other invalid modes still generate appropriate error messages

**Test command:**
```bash
./bin/podman run -it --rm --device /dev/fuse:: alpine:latest true
# Now outputs: Error: empty device mode in device specification: /dev/fuse::
```

Fixes: #26629

#### Does this PR introduce a user-facing change?

```release-note
Improved error message for empty device modes in device specifications. 
When using device mappings like `/dev/fuse::`, the error now clearly 
states "empty device mode in device specification" instead of the 
generic "invalid device mode" message, making it easier to identify 
and fix configuration issues.
```
