### PR TITLE
Skip rather than comment bad diff tests

### DIFF
--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Podman diff", func() {
 	})
 
 	It("podman image diff", func() {
+		Skip("FIXME: #26680 Broken with Buildah v1.41 diff test showing different behavior base on storage driver")
 		file1 := "/" + stringid.GenerateRandomID()
 		file2 := "/" + stringid.GenerateRandomID()
 		file3 := "/" + stringid.GenerateRandomID()
@@ -104,11 +105,10 @@ RUN echo test
 		session = podmanTest.Podman([]string{"image", "diff", image, baseImage})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		// Comment out https://github.com/containers/podman/issues/26680.
-		//		Expect(session.OutputToStringArray()).To(HaveLen(4))
-		//		Expect(session.OutputToString()).To(ContainSubstring("A " + file1))
-		//		Expect(session.OutputToString()).To(ContainSubstring("A " + file2))
-		//		Expect(session.OutputToString()).To(ContainSubstring("A " + file3))
+		Expect(session.OutputToStringArray()).To(HaveLen(4))
+		Expect(session.OutputToString()).To(ContainSubstring("A " + file1))
+		Expect(session.OutputToString()).To(ContainSubstring("A " + file2))
+		Expect(session.OutputToString()).To(ContainSubstring("A " + file3))
 	})
 
 	It("podman image diff of single image", func() {
@@ -131,46 +131,43 @@ RUN echo test
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
-	// Commented out on July 23, 2025 to avoid issue noted in
-	// https://github.com/containers/podman/issues/26680.  Uncomment
-	// once that is addressed.
-	//
-	//	It("podman diff container and image with same name", func() {
-	//		imagefile := "/" + stringid.GenerateRandomID()
-	//		confile := "/" + stringid.GenerateRandomID()
-	//
-	//		// Create container image with the files
-	//		containerfile := fmt.Sprintf(`
-	// FROM  %s
-	// RUN touch %s`, ALPINE, imagefile)
-	//
-	//		name := "podman-diff-test"
-	//		podmanTest.BuildImage(containerfile, name, "false")
-	//
-	//		session := podmanTest.Podman([]string{"run", "--name", name, ALPINE, "touch", confile})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//
-	//		// podman diff prefers image over container when they have the same name
-	//		session = podmanTest.Podman([]string{"diff", name})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//		Expect(session.OutputToStringArray()).To(HaveLen(1))
-	//		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
-	//
-	//		session = podmanTest.Podman([]string{"image", "diff", name})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//		Expect(session.OutputToStringArray()).To(HaveLen(1))
-	//		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
-	//
-	//		// container diff has to show the container
-	//		session = podmanTest.Podman([]string{"container", "diff", name})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//		Expect(session.OutputToStringArray()).To(HaveLen(2))
-	//		Expect(session.OutputToString()).To(ContainSubstring(confile))
-	//	})
+	It("podman diff container and image with same name", func() {
+		Skip("FIXME: #26680 Broken with Buildah v1.41 diff test showing different behavior base on storage driver")
+		imagefile := "/" + stringid.GenerateRandomID()
+		confile := "/" + stringid.GenerateRandomID()
+
+		// Create container image with the files
+		containerfile := fmt.Sprintf(`
+FROM  %s
+RUN touch %s`, ALPINE, imagefile)
+
+		name := "podman-diff-test"
+		podmanTest.BuildImage(containerfile, name, "false")
+
+		session := podmanTest.Podman([]string{"run", "--name", name, ALPINE, "touch", confile})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		// podman diff prefers image over container when they have the same name
+		session = podmanTest.Podman([]string{"diff", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
+
+		session = podmanTest.Podman([]string{"image", "diff", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
+
+		// container diff has to show the container
+		session = podmanTest.Podman([]string{"container", "diff", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+		Expect(session.OutputToString()).To(ContainSubstring(confile))
+	})
 
 	It("podman diff without args", func() {
 		session := podmanTest.Podman([]string{"diff"})


### PR DESCRIPTION
I hastily commented out some tests that were problematic for the vendor of Buildah v1.41 into Podman main (5.6 to be) in #26666.

@luap99 noted that I should have skipped them, this PR removes the comments and puts the Skip into play.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
