### PR TITLE
docs: add resource limit examples to podman pod clone manpage

### DIFF
--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -126,6 +126,18 @@ Clone the specified pod to a new named pod.
 # podman pod clone 2d4d4fca7219b4437e0d74fcdc272c4f031426a6eacd207372691207079551de new_name
 5a9b7851013d326aa4ac4565726765901b3ecc01fcbc0f237bc7fd95588a24f9
 ```
+
+Clone a pod with memory limits.
+```
+# podman pod clone --memory=1g --memory-swap=2g pod-name
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
+
+Clone a pod with CPU limits.
+```
+# podman pod clone --cpus=2.5 --cpu-shares=1024 pod-name
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
 ## SEE ALSO
 **[podman-pod-create(1)](podman-pod-create.1.md)**
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

issue fixes : #26372

## What does this PR do?

Adds missing examples for setting resource limits when cloning pods in the `podman pod clone` manpage.

## Changes

- Added example for memory limits: `--memory=1g --memory-swap=2g`
- Added example for CPU limits: `--cpus=2.5 --cpu-shares=1024`

## Why is this needed?

The original manpage only had one resource limit example (`--cpus=5` with `--destroy`). 
This PR adds focused examples for the most commonly used resource limits (memory and CPU)
to help users understand how to set resource limits when cloning pods.


