### PR TITLE
docs: add LFX Insights badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/containers/libpod)](https://goreportcard.com/report/github.com/containers/libpod)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10499/badge)](https://www.bestpractices.dev/projects/10499)
 
+[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
+[![LFX Contributors](https://insights.linuxfoundation.org/api/badge/contributors?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
+[![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
+
 <br/>
 
 Podman (the POD MANager) is a tool for managing containers and images, volumes mounted into those containers, and pods made from groups of containers.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
 [![LFX Contributors](https://insights.linuxfoundation.org/api/badge/contributors?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
-[![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
+
 
 <br/>
 


### PR DESCRIPTION
This adds the LFX Health score and 2 contributor badges to the README. Nice work on scoring an excellent!

[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
[![LFX Contributors](https://insights.linuxfoundation.org/api/badge/contributors?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)
[![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)

#### Does this PR introduce a user-facing change?
```release-note
None
```