### PR TITLE
docs(kube play): clarify --annotation flag only affects containers, not pods

### DIFF
--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -104,7 +104,7 @@ func playFlags(cmd *cobra.Command) {
 	flags.StringArrayVar(
 		&playOptions.annotations,
 		annotationFlagName, []string{},
-		"Add annotations to pods (key=value)",
+		"Add Podman-specific annotations to containers and pods created by Podman (key=value)",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(annotationFlagName, completion.AutocompleteNone)
 	credsFlagName := "creds"

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -201,6 +201,8 @@ An image can be automatically mounted into a container if the annotation `io.pod
 
 @@option annotation.container
 
+Note: For `podman kube play`, the `--annotation` flag adds Podman-specific annotations to the containers and pods created by Podman, not to the Kubernetes YAML itself. These annotations can be used to configure Podman-specific features like user namespaces (`io.podman.annotations.userns`), volumes-from (`io.podman.annotations.volumes-from`), and other container behaviors.
+
 @@option authfile
 
 #### **--build**


### PR DESCRIPTION
This PR updates the documentation and help text for the `--annotation` flag in `podman kube play`:

Makes it clear that the flag only adds Podman-specific annotations to containers in the created pods, not to the Kubernetes Pod object. Notes that the infra container does not receive the annotation. Addresses confusion reported in #26450 and related discussions.

No code behavior is changed; this is a documentation and UX clarification only.

```release-note
docs:(kube play):clarify -- annotation flag only affects containers, not pods 
```
fixes : #26448
