### PR TITLE
docs: add examples with resource limits and mounts 

### DIFF
--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -227,6 +227,38 @@ Create a pod on two networks.
 $ podman pod create --network net1:ip=10.89.1.5 --network net2:ip=10.89.10.10
 ```
 
+Create a pod with shared CPU and memory limits for all containers.
+```
+$ podman pod create --cpus=2 --memory=512m mypod
+```
+
+Create a pod with shared volume mounts accessible to all containers.
+```
+$ podman pod create --volume /host/path:/container/path:Z mypod
+```
+
+Create a pod with shared resource limits and volume mounts for all containers.
+```
+$ podman pod create --volume /data:/data:Z --volume /config:/etc/config:ro --cpus=1.5 --memory=1g --cpu-shares=512 mypod
+```
+
+Create a pod with shared device access and resource limits.
+```
+$ podman pod create --device /dev/sda:/dev/sda:rw --cpus=4 --memory=2g --blkio-weight=500 mypod
+```
+
+Create a pod with shared CPU set limits and volumes from another container that will be shared to all containers in the pod.
+```
+$ podman pod create --cpuset-cpus=0,2 --volumes-from=source-container --memory=1g mypod
+```
+
+Create a pod with shared resources and add containers to it.
+```
+$ podman pod create --cpus=2 --memory=1g --volume /data:/data:Z mypod
+$ podman create --pod mypod nginx
+$ podman create --pod mypod redis
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **containers.conf(1)**, **[cgroups(7)](https://man7.org/linux/man-pages/man7/cgroups.7.html)**
 


### PR DESCRIPTION
This PR adds comprehensive examples to the `podman pod create` manpage to demonstrate the newer features where resource limits and volume mounts are shared with all containers in a pod.


```release-note
docs: add examples with resource limits and mounts 
```
fixes : #26371
