### PR TITLE
Makefile: Clarify different `binaries` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,11 +232,11 @@ all: binaries docs
 
 .PHONY: binaries
 ifeq ($(GOOS),freebsd)
-binaries: podman podman-remote ## Build podman and podman-remote binaries
+binaries: podman podman-remote ## (FreeBSD) Build podman and podman-remote binaries
 else ifneq (, $(findstring $(GOOS),darwin windows))
-binaries: podman-remote ## Build podman-remote (client) only binaries
+binaries: podman-remote ## (macOS/Windows) Build podman-remote (client) only binaries
 else
-binaries: podman podman-remote podman-testing podmansh rootlessport quadlet ## Build podman, podman-remote and rootlessport binaries quadlet
+binaries: podman podman-remote podman-testing podmansh rootlessport quadlet ## (Linux) Build podman, podman-remote and rootlessport binaries quadlet
 endif
 
 # Extract text following double-# for targets, as their description for


### PR DESCRIPTION
I ran `make help` and found it confusing that `binaries` is listed three times:

```console
Target:                     Description:
--------------              --------------------
binaries                    Build podman and podman-remote binaries
binaries                    Build podman, podman-remote and rootlessport binaries quadlet
binaries                    Build podman-remote (client) only binaries
clean-binaries              Remove platform/architecture specific binary files
clean                       Clean all make artifacts
docs                        Generate documentation
help                        (Default) Print listing of key targets with their descriptions
install.tools               Install needed tools
install                     Install binaries to system locations
local-cross                 Cross compile podman binary for multiple architectures
podman-mac-helper           Build podman-mac-helper for macOS
podman-remote-release-%.zip Build podman-remote for %=$GOOS_$GOARCH, and docs. into an installation zip.
rpm-install                 Install rpm packages
rpm                         Build rpm packages
test                        Run unit, integration, and system tests.
validatepr                  Go Format and lint, which all code changes must pass
```

So I'm proposing a way to differentiate btween them.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
