### PR TITLE
Manpages: Add --filter flag usage examples to various commands #26351

### DIFF
--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -185,6 +185,82 @@ POD ID         NAME   STATUS    CREATED        INFRA ID       NAMES
 314f4da82d74   hi     Created   17 hours ago   a9f2d2165675   jovial_jackson,hopeful_archimedes,vibrant_ptolemy,heuristic_jennings,keen_raman,hopeful_newton,mystifying_bose,silly_lalande,serene_lichterman ...
 ```
 
+List all running pods with container IDs
+```
+$ podman pod ps --filter ctr-ids=aceb3b775797
+POD ID        NAME        STATUS      CREATED        INFRA ID      # OF CONTAINERS
+952330c7cff0  web-app     Running     3 minutes ago  b0f247c49669  3
+```
+
+List all pods with exactly 2 containers
+```
+$ podman pod ps --filter ctr-number=2
+POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
+b2ae050d17be  labeled-pod  Running     2 minutes ago  fda2a486b939  2
+```
+
+List pods with containers in `exited` status
+```
+$ podman pod ps --filter ctr-status=exited
+POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
+06c3a107763a  maintenance  Degraded    4 minutes ago  67e500cbb678  3
+1e3424d7e9c0  db-cluster   Degraded    4 minutes ago  d6650a490b69  3
+```
+
+List all current pods
+```
+$ podman pod ps
+POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
+95938982244d  nettest      Running     4 minutes ago  a28d133e8c63  3
+deee8956522e  utility      Running     4 minutes ago  6b730e3ac334  3
+06c3a107763a  maintenance  Degraded    4 minutes ago  67e500cbb678  3
+1e3424d7e9c0  db-cluster   Degraded    4 minutes ago  d6650a490b69  3
+952330c7cff0  web-app      Running     4 minutes ago  b0f247c49669  3
+```
+
+Filter pod by ID
+```
+$ podman pod ps --filter id=95938982244d
+POD ID        NAME        STATUS      CREATED        INFRA ID      # OF CONTAINERS
+95938982244d  nettest     Running     4 minutes ago  a28d133e8c63  3
+```
+
+Filter pod by label
+```
+$ podman pod ps --filter label=tier=frontend
+POD ID        NAME         STATUS      CREATED       INFRA ID      # OF CONTAINERS
+b2ae050d17be  labeled-pod  Running     1 second ago  fda2a486b939  2
+```
+
+Filter pod by name
+```
+$ podman pod ps --filter name=db-cluster
+POD ID        NAME        STATUS      CREATED        INFRA ID      # OF CONTAINERS
+1e3424d7e9c0  db-cluster  Degraded    4 minutes ago  d6650a490b69  3
+```
+
+Filter pod by pod status (e.g., Degraded)
+```
+$ podman pod ps --filter status=degraded
+POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
+95938982244d  nettest      Degraded    7 minutes ago  a28d133e8c63  3
+06c3a107763a  maintenance  Degraded    8 minutes ago  67e500cbb678  3
+1e3424d7e9c0  db-cluster   Degraded    8 minutes ago  d6650a490b69  3
+952330c7cff0  web-app      Degraded    8 minutes ago  b0f247c49669  3
+```
+
+Filter pods created before a time threshold (`--until`)
+```
+$ podman pod ps --filter until=2m
+POD ID        NAME         STATUS      CREATED        INFRA ID      # OF CONTAINERS
+b2ae050d17be  labeled-pod  Running     3 minutes ago  fda2a486b939  2
+95938982244d  nettest      Degraded    8 minutes ago  a28d133e8c63  3
+deee8956522e  utility      Running     8 minutes ago  6b730e3ac334  3
+06c3a107763a  maintenance  Degraded    8 minutes ago  67e500cbb678  3
+1e3424d7e9c0  db-cluster   Degraded    8 minutes ago  d6650a490b69  3
+952330c7cff0  web-app      Degraded    8 minutes ago  b0f247c49669  3
+```
+
 ## pod ps
 Print a list of pods
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -239,6 +239,54 @@ CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS 
 4089df24d4f3  docker.io/library/nginx:latest  nginx      2 minutes ago  Up 2 minutes  80/tcp    webserver
 92f58933c28c  docker.io/library/redis:latest  redis      3 minutes ago  Up 3 minutes  6379/tcp  cache
 ```
+Filter containers by Status.
+```
+$ podman ps --filter status=running
+CONTAINER ID  IMAGE                             COMMAND               CREATED         STATUS                  PORTS                           NAMES
+ff660efda598  docker.io/library/nginx:latest    nginx -g daemon o...  3 minutes ago   Up 3 minutes            0.0.0.0:8080->80/tcp            webserver
+5693e934f4c6  docker.io/library/redis:latest    redis-server          3 minutes ago   Up 3 minutes            6379/tcp                        cache
+2b271d67dbb6                                                          3 minutes ago   Up 3 minutes            0.0.0.0:9090->80/tcp            463241862e7e-infra
+23f99674da1c  docker.io/library/nginx:latest    nginx -g daemon o...  3 minutes ago   Up 3 minutes            0.0.0.0:9090->80/tcp            pod-nginx
+62180adfbd42  docker.io/library/redis:latest    redis-server          3 minutes ago   Up 3 minutes            0.0.0.0:9090->80/tcp, 6379/tcp  pod-redis
+5e3694604817  quay.io/centos/centos:latest      sleep 300             3 minutes ago   Up 3 minutes                                            centos-test
+af3d8b3f5471  docker.io/library/busybox:latest  sleep 1000            3 minutes ago   Up 3 minutes                                            test-dev
+b6ee47492b64  docker.io/library/nginx:latest    nginx -g daemon o...  3 minutes ago   Up 3 minutes (healthy)  80/tcp                          healthy-nginx
+db75e6c397db  docker.io/library/busybox:latest  sleep 300             23 seconds ago  Up 23 seconds                                         test-volume-container
+```
+```
+$ podman ps -a --filter status=exited
+CONTAINER ID  IMAGE                            COMMAND     CREATED        STATUS                    PORTS                NAMES
+94f211cc6e36  docker.io/library/alpine:latest  sleep 1     4 minutes ago  Exited (0) 4 minutes ago                       old-alpine
+75a800cb848a  docker.io/library/mysql:latest   mysqld      3 minutes ago  Exited (1) 3 minutes ago  3306/tcp, 33060/tcp  db-container
+2d9b3a94e31e  docker.io/library/nginx:latest   nginx       3 minutes ago  Exited (0) 3 minutes ago  80/tcp               nginx-cmd
+```
+
+Filter containers by name.
+```
+$ podman ps --filter name=webserver
+CONTAINER ID  IMAGE                           COMMAND               CREATED        STATUS        PORTS                 NAMES
+ff660efda598  docker.io/library/nginx:latest  nginx -g daemon o...  3 minutes ago  Up 3 minutes  0.0.0.0:8080->80/tcp  webserver
+```
+
+Filter containers by label.
+```
+$ podman ps --filter label=app=frontend
+CONTAINER ID  IMAGE                           COMMAND               CREATED        STATUS        PORTS                 NAMES
+ff660efda598  docker.io/library/nginx:latest  nginx -g daemon o...  3 minutes ago  Up 3 minutes  0.0.0.0:8080->80/tcp  webserver
+```
+Filter containers by volume.
+```
+$ podman ps --filter volume=mydata
+CONTAINER ID  IMAGE                             COMMAND     CREATED         STATUS         PORTS       NAMES
+db75e6c397db  docker.io/library/busybox:latest  sleep 300   42 seconds ago  Up 42 seconds              test-volume-container
+```
+
+Filter containers by network.
+```
+$ podman ps --filter network=web-net
+CONTAINER ID  IMAGE                         COMMAND     CREATED        STATUS        PORTS       NAMES
+5e3694604817  quay.io/centos/centos:latest  sleep 300   3 minutes ago  Up 3 minutes              centos-test
+```
 
 Use custom format to show container and pod information.
 ```

--- a/docs/source/markdown/podman-restart.1.md.in
+++ b/docs/source/markdown/podman-restart.1.md.in
@@ -93,6 +93,61 @@ $ podman restart --cidfile /home/user/cidfile-1
 $ podman restart --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
 ```
 
+Restart container by name.
+```
+$ podman restart --filter name=id-name-test
+```
+
+Restart container by label.
+```
+$ podman restart --filter label=app=label-test
+```
+
+Restart container by exit code.
+```
+$ podman restart --filter exited=0
+```
+
+Restart container by status.
+```
+$ podman restart --filter status=running
+```
+
+Restart container by ancestor image.
+```
+$ podman restart --filter ancestor=nginx
+```
+
+Restart containers created before another.
+```
+$ podman restart --filter before=second
+```
+
+Restart containers created since another.
+```
+$ podman restart --filter since=first
+```
+
+Restart container by volume.
+```
+$ podman restart --filter volume=vol-filter
+```
+
+Restart containers in a pod.
+```
+$ podman restart --filter pod=mypod
+```
+
+Restart container by network.
+```
+$ podman restart --filter network=net-filter
+```
+
+Restart containers created until time.
+```
+$ podman restart --filter until=10s
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -111,6 +111,46 @@ Forcibly remove the last created container. (This option is not available with t
 $ podman rm -f --latest
 ```
 
+Remove by name:
+```
+$ podman rm --filter name=test-alpine
+34f997d354017a0076402c3a79245a5b8bd11b597c84385bec25ae8941fd5238
+```
+
+Remove by label:
+```
+$ podman rm --filter label=app=frontend
+5a3694a13436168ea99490e74b489566c646d6a0db29868f57113298110d1b1c
+```
+
+Remove by status:
+```
+$ podman rm --filter status=exited
+4a3332649ed8bec1e0d82e113074b9a13d45582007aeac969c005992cc480a73
+f8e85f84a749b205fb602895afa6ec8a866045ff27b82f843033712c8b93a2c9
+7d17e850c9b172f11a3e20bab81da6fc694c35c2dc38d84083eb57869dcaca63
+47972eb04aa7c77705b597a929957d1e8a392e00b44c0a2a7f88a01f9f860d11
+```
+
+Remove by ancestor:
+```
+$ podman rm --filter ancestor=nginx
+8a7668cdec27664559a7da55ed5cda101f904441f7245e248218580656b2bae3
+0d297b336bf31d141c7720a791c45dafdb8b5033deaab12f29b88e5bff6b122d
+134475ac5140687d1eefff19f937dc24755f6c18e37e11d61b1084b59f1bdbe2
+```
+
+Remove by volume:
+```
+$ podman rm --filter volume=web-vol
+b3f4d4c6a67e2ef1e089efdc8ff3a47dba008eb0ff1e53ae60f59279cb43f9ba
+```
+
+Remove by network:
+```
+$ podman rm --filter network=web-net
+1c057cac90c0512df86197599eef5a9485afc900b1ade03c9739fa24c360bbda
+```
 ## Exit Status
   **0**   All specified containers removed
 

--- a/docs/source/markdown/podman-start.1.md.in
+++ b/docs/source/markdown/podman-start.1.md.in
@@ -83,6 +83,48 @@ Start last created container in interactive mode (This option is not available w
 podman start -i -l
 ```
 
+Start containers by label:
+```
+$ podman start --filter label=app=frontend
+9351ccb3ef4272532bc0c188bd4f0ddfc2b0de217732cd108259ea126b014647
+```
+Start container by name:
+```
+$ podman start --filter name=backend-app1
+93308911bd4769cda03b75eb7f56588e862e0ea3568f25e1e3defa4138b9b973
+```
+
+Start containers by status:
+```
+$ podman start --filter status=exited
+f8e85f84a749b205fb602895afa6ec8a866045ff27b82f843033712c8b93a2c9
+34f997d354017a0076402c3a79245a5b8bd11b597c84385bec25ae8941fd5238
+47972eb04aa7c77705b597a929957d1e8a392e00b44c0a2a7f88a01f9f860d11
+```
+Start container by name:
+```
+$ podman start --filter name=backend-app1
+93308911bd4769cda03b75eb7f56588e862e0ea3568f25e1e3defa4138b9b973
+```
+
+Start containers by volume:
+```
+$ podman start --filter volume=web-vol
+4a3332649ed8bec1e0d82e113074b9a13d45582007aeac969c005992cc480a73
+```
+Start container by network:
+```
+$ podman start --filter network=web-net
+4a3332649ed8bec1e0d82e113074b9a13d45582007aeac969c005992cc480a73
+f8e85f84a749b205fb602895afa6ec8a866045ff27b82f843033712c8b93a2c9
+```
+Start container by ancestor:
+```
+$ podman start --filter ancestor=nginx
+4a3332649ed8bec1e0d82e113074b9a13d45582007aeac969c005992cc480a73
+47972eb04aa7c77705b597a929957d1e8a392e00b44c0a2a7f88a01f9f860d11
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**
 

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -99,6 +99,24 @@ Stop the last created container (This option is not available with the remote Po
 $ podman stop --latest
 ```
 
+Stop by label.
+```
+$ podman stop --filter label=app=frontend
+9351ccb3ef4272532bc0c188bd4f0ddfc2b0de217732cd108259ea126b014647
+```
+
+Stop by name.
+```
+$ podman stop --filter name=db-replica
+6c2680da61d54690718ac3aecdb04a8aad95ae353e42cc942736823bd05c8a1d
+```
+
+Stop by role label.
+```
+$ podman stop --filter label=role=primary
+bb3ff91d969a8dc622d627e4a8d76c18bdbd417d317c5e7e66543c0b0c8ed1e8
+```
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-rm(1)](podman-rm.1.md)**
 

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -119,6 +119,36 @@ Deleted Images
 055733a33e7a78efa27d3c682df97a9e0489133bef071745144c8d0edda2d708
 Total reclaimed space: 1.4GB
 ```
+Prune containers by label.
+```
+$ podman system prune --filter label=role=cleanup
+WARNING! This command removes:
+        - all stopped containers
+        - all networks not used by at least one container
+        - all dangling images
+        - all dangling build cache
+
+Are you sure you want to continue? [y/N] y
+Deleted Containers
+5cd96fb787274db888f8b587c3690be1edea25b7f66b030037c528e2cea10b34
+Total reclaimed space: 24.55kB
+```
+
+Prune containers filter until.
+$ podman system prune --filter until=2m
+WARNING! This command removes:
+        - all stopped containers
+        - all networks not used by at least one container
+        - all dangling images
+        - all dangling build cache
+
+Are you sure you want to continue? [y/N] y
+Deleted Containers
+a12f9f6f2d901bc145c1e2c27dc8e5e2d04050854f4d9e01a6e10b1019e2d345
+0d08f2e467cbff04b63ccd83efeb6ccc6161f54c27d5100d1194defe7ea73cf7
+815dc403e1bc85bfa4a9d3184cbbe77fd019ea66780bf0b42e8726d5956d9bd3
+Total reclaimed space: 74.14kB
+```
 
 With `--force` flag
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR improves the documentation of the `--filter` flag by adding practical usage examples to the manpages of the following Podman commands:

- `podman ps`
- `podman start`
- `podman stop`
- `podman rm`
- `podman restart`
- `podman pod ps`
- `podman system prune`

These examples help clarify supported filter values, their expected behavior, and how they affect command output—making it easier for users to adopt advanced filtering in day-to-day operations.

#### Which issue(s) this PR fixes:

Fixes: #26351

#### Special notes for reviewer:

Each command was tested with a variety of containers and pods (different statuses, labels, volumes, networks, etc.) to ensure the examples reflect valid, working usage.

#### Does this PR introduce a user-facing change?

```release-note
Added usage examples for the `--filter` flag in manpages for `podman ps`, `start`, `stop`, `rm`, `restart`, `pod ps`, and `system prune`.
```
