### PR TITLE
Packit: do not notify on podman-next failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -92,9 +92,6 @@ jobs:
   - job: copr_build
     trigger: commit
     packages: [podman-fedora]
-    notifications:
-      failure_comment:
-        message: "podman-next COPR build failed. @containers/packit-build please check."
     branch: main
     owner: rhcontainerbot
     project: podman-next


### PR DESCRIPTION
podman-next failure notifications are mostly if not totally ignored so there's no point keeping them.

While these notifications ideally shouldn't be ignored, some builds on podman-next frequently fail because of older toolchain and end up causing a lot of noise.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
