### PR TITLE
Feature/podman container runlabel docs 26379

### DIFF
--- a/docs/source/markdown/podman-container-runlabel.1.md.in
+++ b/docs/source/markdown/podman-container-runlabel.1.md.in
@@ -74,6 +74,22 @@ Display the contents of the `run` label of image foobar.
 $ podman container runlabel --display run foobar
 ```
 
+Re-run a container using a label that sets a fixed container name. The --replace flag ensures any existing container is removed first.
+```
+$ podman ps -a
+CONTAINER ID  IMAGE                             COMMAND               CREATED         STATUS                     PORTS       NAMES
+1254c038d892  docker.io/library/busybox:latest  echo Hello from r...  26 seconds ago  Exited (0) 26 seconds ago              test-runlabel
+
+$ podman container runlabel --replace RUN runlabel-test
+Hello from runlabel
+
+$ podman ps -a
+CONTAINER ID  IMAGE                             COMMAND               CREATED        STATUS                    PORTS       NAMES
+28efd9600d0c  docker.io/library/busybox:latest  echo Hello from r...  4 seconds ago  Exited (0) 4 seconds ago              test-runlabel
+
+```
+This command is useful when the label uses a fixed name (e.g., `--name mycontainer`) and you want to repeatedly run it without manually removing the previous container.
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[crun(1)](https://github.com/containers/crun/blob/main/crun.1.md)**, **[runc(8)](https://github.com/opencontainers/runc/blob/main/man/runc.8.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**, **[containers-auth.json(5)](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)**
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds an example to the `podman-container-runlabel` manpage demonstrating usage of the `--replace` flag. The example shows how the flag allows a runlabel command to be executed multiple times without failing, even if the label uses a fixed container name.

#### Which issue(s) this PR fixes:

Fixes: #26379 

#### Does this PR introduce a user-facing change?

Yes, it adds a new example to the manpage.

```release-note
docs: add example for --replace in podman container runlabel manpage
```

