### PR TITLE
pkg/machine/e2e: remove build context skip

### DIFF
--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -249,7 +249,6 @@ var _ = Describe("run basic podman commands", func() {
 	})
 
 	It("podman build contexts", func() {
-		skipIfVmtype(define.HyperVVirt, "FIXME: #23429 - Error running podman build with option --build-context on Hyper-V")
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow()).run()
@@ -272,15 +271,6 @@ var _ = Describe("run basic podman commands", func() {
 
 		bm := basicMachine{}
 		build, err := mb.setCmd(bm.withPodmanCommand([]string{"build", "-t", name, "--build-context", "test-context=" + additionalContextDir, mainContextDir})).run()
-
-		if build != nil && build.ExitCode() != 0 {
-			output := build.outputToString() + build.errorToString()
-			if strings.Contains(output, "multipart/form-data") &&
-				strings.Contains(output, "not supported") {
-				Skip("Build contexts with multipart/form-data are not supported on this version")
-			}
-		}
-
 		Expect(err).ToNot(HaveOccurred())
 		Expect(build).To(Exit(0))
 		Expect(build.outputToString()).To(ContainSubstring("COMMIT"))


### PR DESCRIPTION
The machine images should contain a new enough podman on the server side to support this so the skips can be removed.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
