### PR TITLE
update tests duo to CRUN#1767 to support both values

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20250627t155202z-f42f41d13"
+    IMAGE_SUFFIX: "c20250812t173301z-f42f41d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -762,14 +762,13 @@ if root && test -e /dev/nullb0; then
   t POST libpod/containers/updateCtr/update ${TMPD}/update.json 201
 
   cgroupPath=/sys/fs/cgroup/cpu.weight
-  # 002 is the byte length
-  cpu_weight_expect=$'\001\0025'
 
   # Verify CPU weight
   echo '{ "AttachStdout":true,"Cmd":["cat", "'$cgroupPath'"]}' >${TMPD}/exec.json
   t POST containers/updateCtr/exec ${TMPD}/exec.json 201 .Id~[0-9a-f]\\{64\\}
   eid=$(jq -r '.Id' <<<"$output")
-  t POST exec/$eid/start 200 $cpu_weight_expect
+  t POST exec/$eid/start 200
+  like "$(<$WORKDIR/curl.result.out)" $'^\x01.\(20\|5\)$' "cpu.weight is 5 or 20"
 
   BlkioDeviceReadBps_expected='[
   {

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -141,7 +141,8 @@ var _ = Describe("Podman update", func() {
 		podmanTest.CheckFileInContainerSubstring(ctrID, "/sys/fs/cgroup/memory.swap.max", "1073741824")
 
 		// checking cpu-shares
-		podmanTest.CheckFileInContainerSubstring(ctrID, "/sys/fs/cgroup/cpu.weight", "5")
+		exec := podmanTest.PodmanExitCleanly("exec", ctrID, "cat", "/sys/fs/cgroup/cpu.weight")
+		Expect(exec.OutputToString()).To(Or(ContainSubstring("5"), ContainSubstring("20")))
 
 		// checking pids-limit
 		podmanTest.CheckFileInContainerSubstring(ctrID, "/sys/fs/cgroup/pids.max", "123")


### PR DESCRIPTION
Update the `podman update container all options v2 tests`. this is a change duo to CRUN changes : https://github.com/containers/crun/pull/1767
we will need support both new and old values using for cpu weight calculation.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
