### PR TITLE
test/e2e: simplify directory change handling

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -251,11 +251,7 @@ var _ = Describe("Podman build", func() {
 
 	It("podman build Containerfile locations", func() {
 		// Given
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(os.TempDir())).To(Succeed())
-		defer Expect(os.Chdir(cwd)).To(BeNil())
+		GinkgoT().Chdir(os.TempDir())
 
 		fakeFile := filepath.Join(os.TempDir(), "Containerfile")
 		Expect(os.WriteFile(fakeFile, []byte(fmt.Sprintf("FROM %s", CITEST_IMAGE)), 0755)).To(Succeed())
@@ -281,11 +277,7 @@ var _ = Describe("Podman build", func() {
 	})
 
 	It("podman build basic alpine and print id to external file", func() {
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(os.TempDir())).To(Succeed())
-		defer Expect(os.Chdir(cwd)).To(BeNil())
+		GinkgoT().Chdir(os.TempDir())
 
 		targetFile := filepath.Join(podmanTest.TempDir, "idFile")
 
@@ -453,10 +445,6 @@ COPY /emptydir/* /dir`, CITEST_IMAGE)
 
 	It("podman remote test container/docker file is not inside context dir", func() {
 		// Given
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
@@ -474,12 +462,8 @@ RUN find /test`, CITEST_IMAGE)
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
-		defer func() {
-			Expect(os.Chdir(cwd)).To(Succeed())
-		}()
-
 		// make cwd as context root path
-		Expect(os.Chdir(targetPath)).To(Succeed())
+		GinkgoT().Chdir(targetPath)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "-f", "Containerfile", targetSubPath})
 		session.WaitWithDefaultTimeout()
@@ -532,10 +516,6 @@ RUN find /test`, CITEST_IMAGE)
 			Skip("Only valid at remote test")
 		}
 		// Given
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-
 		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		// Write target and fake files
@@ -550,12 +530,8 @@ RUN find /test`, CITEST_IMAGE)
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
-		defer func() {
-			Expect(os.Chdir(cwd)).To(Succeed())
-		}()
-
 		// make cwd as context root path
-		Expect(os.Chdir(targetPath)).To(Succeed())
+		GinkgoT().Chdir(targetPath)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "-f", "subdir/Containerfile", "."})
 		session.WaitWithDefaultTimeout()
@@ -570,10 +546,6 @@ RUN find /test`, CITEST_IMAGE)
 			Skip("Only valid at remote test")
 		}
 		// Given
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-
 		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		// Write target and fake files
@@ -606,12 +578,11 @@ RUN find /testfilter/`, CITEST_IMAGE)
 		Expect(err).ToNot(HaveOccurred())
 
 		defer func() {
-			Expect(os.Chdir(cwd)).To(Succeed())
 			Expect(os.RemoveAll(targetPath)).To(Succeed())
 		}()
 
 		// make cwd as context root path
-		Expect(os.Chdir(targetPath)).To(Succeed())
+		GinkgoT().Chdir(targetPath)
 
 		dockerignoreContent := `dummy1
 subdir**`
@@ -635,10 +606,6 @@ subdir**`
 	It("Remote build .containerignore filtering embedded directory (#13535)", func() {
 		SkipIfNotRemote("Testing remote .containerignore file filtering")
 		podmanTest.RestartRemoteService()
-
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
 
 		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
@@ -668,11 +635,7 @@ subdir**`
 		Eventually(ddSession, "30s", "1s").Should(Exit(0))
 
 		// make cwd as context root path
-		Expect(os.Chdir(contextDir)).ToNot(HaveOccurred())
-		defer func() {
-			err := os.Chdir(cwd)
-			Expect(err).ToNot(HaveOccurred())
-		}()
+		GinkgoT().Chdir(contextDir)
 
 		By("Test .containerignore filtering subdirectory")
 		err = os.WriteFile(filepath.Join(contextDir, ".containerignore"), []byte(`subdir/`), 0644)
@@ -691,10 +654,6 @@ subdir**`
 		SkipIfNotRemote("Testing remote contextDir empty")
 		podmanTest.RestartRemoteService()
 
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-
 		podmanTest.AddImageToRWStore(CITEST_IMAGE)
 
 		// Write target and fake files
@@ -709,7 +668,7 @@ subdir**`
 		emptyDir := filepath.Join(targetSubPath, "emptyDir")
 		err = os.Mkdir(emptyDir, 0755)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(targetSubPath)).To(Succeed())
+		GinkgoT().Chdir(targetSubPath)
 		Expect(os.Symlink("dummy", "dummy-symlink")).To(Succeed())
 
 		containerfile := fmt.Sprintf(`FROM %s
@@ -721,12 +680,8 @@ RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, CITEST_IMA
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
-		defer func() {
-			Expect(os.Chdir(cwd)).To(Succeed())
-		}()
-
 		// make cwd as context root path
-		Expect(os.Chdir(targetPath)).To(Succeed())
+		GinkgoT().Chdir(targetPath)
 
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", targetSubPath})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -302,13 +302,9 @@ var _ = Describe("Podman commit", func() {
 	})
 
 	It("podman commit container and print id to external file", func() {
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(os.TempDir())).To(Succeed())
+		GinkgoT().Chdir(os.TempDir())
 		targetPath := podmanTest.TempDir
 		targetFile := filepath.Join(targetPath, "idFile")
-		defer Expect(os.Chdir(cwd)).To(BeNil())
 
 		_, ec, _ := podmanTest.RunLsContainer("test1")
 		Expect(ec).To(Equal(0))

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -336,12 +336,9 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
 		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).ToNot(HaveOccurred())
-		defer func() {
-			Expect(os.Chdir(cwd)).To(Succeed())
-		}()
 
 		// make cwd as context root path
-		Expect(os.Chdir(podmanTest.TempDir)).To(Succeed())
+		GinkgoT().Chdir(podmanTest.TempDir)
 
 		session := podmanTest.Podman([]string{"build", "--format", "docker", "-t", "test", "."})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -77,11 +77,8 @@ LABEL marge=mom
 		// Write a file to be copied
 		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).ToNot(HaveOccurred())
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(yamlDir)).To(Succeed())
-		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		GinkgoT().Chdir(yamlDir)
 
 		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
 		session.WaitWithDefaultTimeout()
@@ -117,11 +114,8 @@ LABEL marge=mom
 		// Write a file to be copied
 		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).ToNot(HaveOccurred())
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(yamlDir)).To(Succeed())
-		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		GinkgoT().Chdir(yamlDir)
 
 		session := podmanTest.Podman([]string{"kube", "play", "top.yaml"})
 		session.WaitWithDefaultTimeout()
@@ -165,11 +159,7 @@ LABEL marge=mom
 		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).ToNot(HaveOccurred())
 
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(yamlDir)).To(Succeed())
-		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+		GinkgoT().Chdir(yamlDir)
 
 		// Build the image into the local store
 		build := podmanTest.Podman([]string{"build", "-t", "foobar", "-f", "Containerfile"})
@@ -212,11 +202,7 @@ LABEL marge=mom
 		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).ToNot(HaveOccurred())
 
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(yamlDir)).To(Succeed())
-		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+		GinkgoT().Chdir(yamlDir)
 
 		// Build the image into the local store
 		build := podmanTest.Podman([]string{"build", "-t", "foobar", "-f", "Containerfile"})
@@ -259,11 +245,7 @@ LABEL marge=mom
 		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).ToNot(HaveOccurred())
 
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(yamlDir)).To(Succeed())
-		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+		GinkgoT().Chdir(yamlDir)
 
 		// Build the image into the local store
 		build := podmanTest.Podman([]string{"build", "-t", "foobar", "-f", "Containerfile"})
@@ -352,11 +334,7 @@ echo GOT-HERE
 		os.Setenv("FOO", "make sure we use FOO from kube file, not env")
 		defer os.Unsetenv("FOO")
 
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(yamlDir)).To(Succeed())
-		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+		GinkgoT().Chdir(yamlDir)
 
 		session := podmanTest.Podman([]string{"kube", "play", "echo.yaml"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -422,14 +422,10 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman create pod and print id to external file", func() {
-		// Switch to temp dir and restore it afterwards
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(os.Chdir(os.TempDir())).To(Succeed())
+		GinkgoT().Chdir(os.TempDir())
 
 		targetFile := filepath.Join(podmanTest.TempDir, "idFile")
 		defer Expect(os.RemoveAll(targetFile)).To(BeNil())
-		defer Expect(os.Chdir(cwd)).To(BeNil())
 
 		session := podmanTest.Podman([]string{"pod", "create", "--name=abc", "--pod-id-file", targetFile})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -965,15 +965,7 @@ USER testuser`, CITEST_IMAGE)
 		f, err := os.CreateTemp(mountPath, "podman")
 		Expect(err).ToNot(HaveOccurred())
 
-		cwd, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = os.Chdir(mountPath)
-		Expect(err).ToNot(HaveOccurred())
-		defer func() {
-			err := os.Chdir(cwd)
-			Expect(err).ToNot(HaveOccurred())
-		}()
+		GinkgoT().Chdir(mountPath)
 
 		run := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "./:" + dest, ALPINE, "ls", dest})
 		run.WaitWithDefaultTimeout()


### PR DESCRIPTION
This PR simplifies e2e tests by refactoring to [`T.Chdir`](https://pkg.go.dev/testing#T.Chdir) instead of `os.Chdir`.

#### Does this PR introduce a user-facing change?

```release-note
None
```
