### PR TITLE
make machine --user-mode-networking docs more clear

### DIFF
--- a/docs/source/markdown/options/user-mode-networking.md
+++ b/docs/source/markdown/options/user-mode-networking.md
@@ -4,18 +4,21 @@
 ####> are applicable to all of those.
 #### **--user-mode-networking**
 
-Indicates that this machine relays traffic from the guest through a user-space
-process running on the host. In some VPN configurations the VPN may drop
-traffic from alternate network interfaces, including VM network devices. By
-enabling user-mode networking (a setting of `true`), VPNs observe all
-podman machine traffic as coming from the host, bypassing the problem.
+This option can only be used for the WSL provider on Windows. On all other
+platforms this option is ignored and user mode networking will always be
+`true` there because these providers always depend on gvproxy (our user
+mode networking tool for the VMs)
 
-When the qemu backend is used (Linux, Mac), user-mode networking is
-mandatory and the only allowed value is `true`. In contrast, The Windows/WSL
-backend defaults to `false`, and follows the standard WSL network setup.
+In contrast, The Windows/WSL backend defaults to `false`, and follows the
+standard WSL network setup.
 Changing this setting to `true` on Windows/WSL informs Podman to replace
 the WSL networking setup on start of this machine instance with a user-mode
 networking distribution. Since WSL shares the same kernel across
 distributions, all other running distributions reuses this network.
 Likewise, when the last machine instance with a `true` setting stops, the
 original networking setup is restored.
+
+In some VPN configurations the VPN may drop traffic from alternate network
+interfaces, including VM network devices. By enabling user-mode networking
+VPNs observe all podman machine traffic as coming from the host, bypassing
+the problem.


### PR DESCRIPTION
The docs were outdated mentioning the qemu backed for Mac and I find the way they are written to be a bit confusing.

I think it is best to start with that this option is not supported on all the providers except WSL.

Fixes: #26780

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
