### PR TITLE
Add BoltDB deprecation notice

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -94,6 +94,11 @@ func NewBoltState(path string, runtime *Runtime) (State, error) {
 		logrus.Debugf("Allowing deprecated database backend due to CI_DESIRED_DATABASE.")
 	}
 
+	// TODO: Up this to WARN level in 5.7, ERROR level in 5.8
+	if os.Getenv("SUPPRESS_BOLTDB_WARNING") == "" {
+		logrus.Infof("The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message.")
+	}
+
 	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		return nil, fmt.Errorf("opening database %s: %w", path, err)


### PR DESCRIPTION
Right now, only log-level=info, so not shown by default. We can continue to up this in subsequent releases to convince folks of the urgency of switching.

Resolves https://issues.redhat.com/browse/RUN-3343

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The BoltDB database, deprecated since Podman 5.0's release last year, will be removed in next year's Podman 6.0 release. A warning has been added for users of this database to indicate the need to migrate.
```
