### PR TITLE
tests: Skip link-local IPv4/IPv6 addresses in ipv{4,6}_get_addr_global()

### DIFF
--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -11,7 +11,9 @@ function has_ipv4() {
 
 # has_ipv6() - Check if one default route is available for IPv6
 function has_ipv6() {
-    [ -n "$(ip -j -6 route show | jq -rM '.[] | select(.dst == "default")')" ]
+    # Require both global IPv6 addresses AND a default route for true IPv6 connectivity
+    ip -j -6 addr show | jq -e '[.[].addr_info[] | select(.scope == "global")] | length > 0' >/dev/null &&
+    ip -j -6 route show | jq -e 'any(.dst == "default")' >/dev/null
 }
 
 # skip_if_no_ipv4() - Skip current test if IPv4 traffic can't be routed


### PR DESCRIPTION
This PR:
- Fixes `ipv4_get_addr_global` & `ipv6_get_addr_global` by skipping link-local IPv4/IPv6 addresses as they are not globally routable.
- Fixes `has_ipv6` to also require a global IPv6 address.

TODO
- Solve issue with openQA s390x worker which has IPv6.

Otherwise we see this issue in openQA with IPv4 which uses TAP networking.  The openQA worker lacks IPv6 ATM.  This PR solves the issue for us.

```
not ok 569 [505] No IPv4 in 470ms
# tags: ci:parallel
# (from function `bail-now' in file test/system/helpers.bash, line 187,
#  from function `assert' in file test/system/helpers.bash, line 1062,
#  in test file test/system/505-networking-pasta.bats, line 300)
#   `assert "${container_address}" = "null" \' failed
#
# [17:42:37.016489330] $ /usr/bin/podman run --rm --net=pasta:-6 quay.io/libpod/testimage:20241011 ip -j -4 address show
# [17:42:37.184016463] [{"ifindex":1,"ifname":"lo","flags":["LOOPBACK","UP","LOWER_UP"],"mtu":65536,"qdisc":"noqueue","operstate":"UNKNOWN","group":"default","txqlen":1000,"addr_info":[{"family":"inet","local":"127.0.0.1","prefixlen":8,"scope":"host","label":"lo","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":2,"ifname":"tap0","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":65520,"qdisc":"pfifo_fast","operstate":"UNKNOWN","group":"default","txqlen":1000,"addr_info":[{"family":"inet","local":"169.254.2.1","prefixlen":16,"scope":"global","label":"tap0","valid_life_time":4294967295,"preferred_life_time":4294967295}]}]
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: Container has IPv4 global address with IPv4 disabled
# #| expected: = null
# #|   actual:   169.254.2.1
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # [teardown]
```

```
not ok 576 [505] IPv6 default route in 543ms
# tags: ci:parallel
# (from function `bail-now' in file test/system/helpers.bash, line 187,
#  from function `assert' in file test/system/helpers.bash, line 1062,
#  in test file test/system/505-networking-pasta.bats, line 387)
#   `assert "${container_route}" = "${host_route}" \' failed
#
# [17:42:41.168101271] $ /usr/bin/podman run --rm --net=pasta quay.io/libpod/testimage:20241011 ip -j -6 route show
# [17:42:41.343733630] [{"dst":"fe80::/64","dev":"ens4","protocol":"kernel","metric":256,"flags":[],"pref":"medium"}]
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: Container route not matching host
# #| expected: = fe80::2
# #|   actual:   null
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # [teardown]
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
