### PR TITLE
tests: Fix "quadlet kube - start error" test race condition

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1196,6 +1196,8 @@ EOF
     cat > $quadlet_file <<EOF
 [Kube]
 Yaml=${yaml_source}
+[Service]
+Type=simple
 EOF
 
     run_quadlet "$quadlet_file"


### PR DESCRIPTION
This test fails on Tumbleweed (podman 5.5.2) in what appears to be a race condition in the ncat version used (7.95).  We don't have this problem in SLES 16.0 (podman 5.4.2) with ncat 7.92.

```
not ok 438 [252] quadlet kube - start error in 92169ms
# tags: ci:parallel
# (from function bail-now' in file test/system/helpers.bash, line 187,
#  from function assert' in file test/system/helpers.bash, line 1062,
#  in test file test/system/252-quadlet.bats, line 1208)
#   assert $status -eq 1 "systemctl start should report failure"' failed
# $ /usr/libexec/podman/quadlet --user /run/user/1000/systemd/user
#
# # Automatically generated by /usr/libexec/podman/quadlet
# #
# [X-Kube]
# Yaml=/tmp/podman_bats.gbDWIG/start_errt438-ddovx7cl.yaml
#
# [Unit]
# Wants=podman-user-wait-network-online.service
# After=podman-user-wait-network-online.service
# SourcePath=/tmp/podman_bats.gbDWIG/quadlet.PEX4hn/start_err_t438-ddovx7cl.kube
# RequiresMountsFor=%t/containers
#
# [Service]
# KillMode=mixed
# Environment=PODMAN_SYSTEMD_UNIT=%n
# Type=notify
# NotifyAccess=all
# SyslogIdentifier=%N
# ExecStart=/usr/bin/podman kube play --replace --service-container=true /tmp/podman_bats.gbDWIG/start_errt438-ddovx7cl.yaml
# ExecStopPost=/usr/bin/podman kube down /tmp/podman_bats.gbDWIG/start_errt438-ddovx7cl.yaml
# $ systemctl start start_err_t438-ddovx7cl.service
# timeout: sending signal TERM to command ‘ncat’
#
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: systemctl start should report failure
# #| expected: -eq 1
# #|   actual:     0
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

#### Does this PR introduce a user-facing change?
```release-note
None
```
