### PR TITLE
Fix volume filters to use AND instead of OR logic

### DIFF
--- a/cmd/podman/parse/filters.go
+++ b/cmd/podman/parse/filters.go
@@ -9,7 +9,19 @@ import (
 func FilterArgumentsIntoFilters(filters []string) (url.Values, error) {
 	parsedFilters := make(url.Values)
 	for _, f := range filters {
-		fname, filter, hasFilter := strings.Cut(f, "=")
+		// Handle negative filters like label!=value by treating them as separate filter keys
+		var fname, filter string
+		var hasFilter bool
+
+		if strings.Contains(f, "!=") {
+			fname, filter, hasFilter = strings.Cut(f, "!=")
+			if hasFilter {
+				fname += "!"
+			}
+		} else {
+			fname, filter, hasFilter = strings.Cut(f, "=")
+		}
+
 		if !hasFilter {
 			return parsedFilters, fmt.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 		}

--- a/docs/source/markdown/podman-volume-ls.1.md.in
+++ b/docs/source/markdown/podman-volume-ls.1.md.in
@@ -18,8 +18,8 @@ flag. Use the **--quiet** flag to print only the volume names.
 
 Filter what volumes are shown in the output.
 Multiple filters can be given with multiple uses of the --filter flag.
-Filters with the same key work inclusive, with the only exception being `label`
-which is exclusive. Filters with different keys always work exclusive.
+Filters with the same key work inclusive (OR logic). Filters with different keys
+always work exclusive (AND logic).
 
 Volumes can be filtered by the following attributes:
 

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -21,6 +21,8 @@ Provide filter values.
 
 The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
 
+Filters with the same key work inclusive (OR logic). Filters with different keys always work exclusive (AND logic).
+
 Supported filters:
 
 | Filter      | Description                                                                                                |

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -70,8 +70,8 @@ func (r *Runtime) HasVolume(name string) (bool, error) {
 
 // Volumes retrieves all volumes
 // Filters can be provided which will determine which volumes are included in the
-// output. If multiple filters are used, a volume will be returned if
-// any of the filters are matched
+// output. If multiple filters are used, a volume will be returned only if
+// all of the filters are matched
 func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 	if !r.valid {
 		return nil, define.ErrRuntimeStopped
@@ -88,9 +88,12 @@ func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 
 	volsFiltered := make([]*Volume, 0, len(vols))
 	for _, vol := range vols {
-		include := false
+		include := true
 		for _, filter := range filters {
-			include = include || filter(vol)
+			if !filter(vol) {
+				include = false
+				break
+			}
 		}
 
 		if include {


### PR DESCRIPTION
    Volume ls and volume prune commands were incorrectly combining multiple
    filters with OR logic instead of AND logic. This meant that specifying
    multiple filters like --filter "label=a=b" --filter "label!=c=d" would
    return volumes that matched ANY filter rather than ALL filters, causing
    results to expand instead of narrow down as users expect.

    Changed the filtering logic in libpod/runtime_volume.go to require all
    filters to match (AND logic) instead of any filter matching (OR logic).
    Updated the function comment to reflect the correct AND behavior.

    Added integration tests covering:
    - Basic AND logic with label filters (label=a=b AND label=c=d)
    - Mixed positive/negative label filters (label=a=b AND label!=c=d)
    - Cross-filter-type combinations (label filters AND time filters)
    - Both volume ls and volume prune commands
    - Verification that within-key OR logic still works correctly

    Fixes: #26786

    Signed-off-by: Travis Lyons <travis.lyons@sourcegraph.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Volume filtering logic has been fixed in podman volume ls and podman volume prune commands - filters now use AND logic instead of OR:

   * 'AND': multiple filters must all match to include a volume in results
   * 'OR': previous incorrect behavior where any filter match would include the volume

```
