### PR TITLE
docs: Add custom socket path example to podman system service man page

### DIFF
--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -133,6 +133,13 @@ podman system service --time 5
 
 The default socket was used as no URI argument was provided.
 
+Run an API service with a custom socket path and no timeout:
+```
+podman system service --time 0 unix:///var/run/mypodman.sock
+```
+
+This starts the API service listening on the custom socket `/var/run/mypodman.sock` with no inactivity timeout (runs indefinitely).
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-system-connection(1)](podman-system-connection.1.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**
 


### PR DESCRIPTION
## Add missing custom socket path example to podman-system-service man page

This PR addresses issue #26356 by adding a practical example showing how to 
specify a custom socket path when running the podman system service command.


Added example:
```
podman system service --time 0 unix:///var/run/mypodman.sock
```

This example shows users how to:
- Specify a custom socket path using the unix:// URI format
- Run the service with no timeout (--time 0) for persistent operation
- Use a practical socket location that demonstrates the concept

The addition improves documentation completeness and helps users understand
how to configure custom API service endpoints.

Fixes: #26356

Signed-off-by: Raghul-M <raghul.m1430@gmail.com>
