### PR TITLE
test/buildah-bud/run-buildah-bud-tests: loosen the branch regexp

### DIFF
--- a/test/buildah-bud/run-buildah-bud-tests
+++ b/test/buildah-bud/run-buildah-bud-tests
@@ -152,7 +152,7 @@ if [[ -n $do_checkout ]]; then
     # will need a special unreleased version (go calls then "pseudoversions").
     # In the usual case, we can do a shallow git clone:
     shallow_checkout="--branch $buildah_version"
-    if [[ $buildah_version =~ .*-.*\.[0-9]{14}-.* ]]; then
+    if [[ $buildah_version =~ .*[0-9]{14}-.* ]] ; then
         # ...but with a pseudoversion, we must git-clone the entire repo,
         # then do a git checkout within it
         shallow_checkout=


### PR DESCRIPTION
Recognize that pseudoversions that look like v0.0.0-20250814150820-1f7f1d285d22 are also not real branch names.  Brief discussion in https://github.com/containers/podman/pull/26819#discussion_r2276212916.

```release-note
None
```