### PR TITLE
[v5.6] Bump to Buildah v1.41.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.3.0
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.7.1
-	github.com/containers/buildah v1.41.1
+	github.com/containers/buildah v1.41.3
 	github.com/containers/common v0.64.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.6

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEm
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.7.1 h1:CNAR0jviDj6FS5Vg85NTgKWLDzZPfi/lj+VJfhMDTIs=
 github.com/containernetworking/plugins v1.7.1/go.mod h1:xuMdjuio+a1oVQsHKjr/mgzuZ24leAsqUYRnzGoXHy0=
-github.com/containers/buildah v1.41.1 h1:WiFZsxLbnPgo00gAX4pVwFa+e3Kypx0IoC9ubFMlQDs=
-github.com/containers/buildah v1.41.1/go.mod h1:vVIYC6f5gbPNfhprdMZh9lkOJzzM7lta0romUtBFSw0=
+github.com/containers/buildah v1.41.3 h1:L6wyRXGR+Cejx+/LMsEryi1JmuwbAICZEje+tQ7ihMs=
+github.com/containers/buildah v1.41.3/go.mod h1:vVIYC6f5gbPNfhprdMZh9lkOJzzM7lta0romUtBFSw0=
 github.com/containers/common v0.64.1 h1:E8vSiL+B84/UCsyVSb70GoxY9cu+0bseLujm4EKF6GE=
 github.com/containers/common v0.64.1/go.mod h1:CtfQNHoCAZqWeXMwdShcsxmMJSeGRgKKMqAwRKmWrHE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -330,11 +330,6 @@ skip "FIXME: 2024-05-28 new VMs from #338" \
 skip_if_remote "FIXME: 2025-04-01 git related errors returning wrong exit code" \
                "bud with ADD with git repository source"
 
-# 2025-08-07 test needs to be fixed in buildah repo, unknown issue, fixing to get v5.6 RC2 out
-# https://github.com/containers/podman/issues/26773
-skip "FIXME: 2025-08-07 Buildah v1.41.1 vendor into Podman for v5.6 RC2" \
-     "bud should include excluded pulled up parent directories in squashed images"
-
 # END   temporary workarounds that must be reevaluated periodically
 ###############################################################################
 

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -104,11 +104,10 @@ RUN echo test
 		session = podmanTest.Podman([]string{"image", "diff", image, baseImage})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		// Comment out https://github.com/containers/podman/issues/26680.
-		//		Expect(session.OutputToStringArray()).To(HaveLen(4))
-		//		Expect(session.OutputToString()).To(ContainSubstring("A " + file1))
-		//		Expect(session.OutputToString()).To(ContainSubstring("A " + file2))
-		//		Expect(session.OutputToString()).To(ContainSubstring("A " + file3))
+		Expect(session.OutputToStringArray()).To(HaveLen(3))
+		Expect(session.OutputToString()).To(ContainSubstring("A " + file1))
+		Expect(session.OutputToString()).To(ContainSubstring("A " + file2))
+		Expect(session.OutputToString()).To(ContainSubstring("A " + file3))
 	})
 
 	It("podman image diff of single image", func() {
@@ -131,46 +130,42 @@ RUN echo test
 		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 
-	// Commented out on July 23, 2025 to avoid issue noted in
-	// https://github.com/containers/podman/issues/26680.  Uncomment
-	// once that is addressed.
-	//
-	//	It("podman diff container and image with same name", func() {
-	//		imagefile := "/" + stringid.GenerateRandomID()
-	//		confile := "/" + stringid.GenerateRandomID()
-	//
-	//		// Create container image with the files
-	//		containerfile := fmt.Sprintf(`
-	// FROM  %s
-	// RUN touch %s`, ALPINE, imagefile)
-	//
-	//		name := "podman-diff-test"
-	//		podmanTest.BuildImage(containerfile, name, "false")
-	//
-	//		session := podmanTest.Podman([]string{"run", "--name", name, ALPINE, "touch", confile})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//
-	//		// podman diff prefers image over container when they have the same name
-	//		session = podmanTest.Podman([]string{"diff", name})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//		Expect(session.OutputToStringArray()).To(HaveLen(1))
-	//		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
-	//
-	//		session = podmanTest.Podman([]string{"image", "diff", name})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//		Expect(session.OutputToStringArray()).To(HaveLen(1))
-	//		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
-	//
-	//		// container diff has to show the container
-	//		session = podmanTest.Podman([]string{"container", "diff", name})
-	//		session.WaitWithDefaultTimeout()
-	//		Expect(session).Should(ExitCleanly())
-	//		Expect(session.OutputToStringArray()).To(HaveLen(2))
-	//		Expect(session.OutputToString()).To(ContainSubstring(confile))
-	//	})
+	It("podman diff container and image with same name", func() {
+		imagefile := "/" + stringid.GenerateRandomID()
+		confile := "/" + stringid.GenerateRandomID()
+
+		// Create container image with the files
+		containerfile := fmt.Sprintf(`
+	 FROM  %s
+	 RUN touch %s`, ALPINE, imagefile)
+
+		name := "podman-diff-test"
+		podmanTest.BuildImage(containerfile, name, "false")
+
+		session := podmanTest.Podman([]string{"run", "--name", name, ALPINE, "touch", confile})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		// podman diff prefers image over container when they have the same name
+		session = podmanTest.Podman([]string{"diff", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
+
+		session = podmanTest.Podman([]string{"image", "diff", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToString()).To(ContainSubstring(imagefile))
+
+		// container diff has to show the container
+		session = podmanTest.Podman([]string{"container", "diff", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+		Expect(session.OutputToString()).To(ContainSubstring(confile))
+	})
 
 	It("podman diff without args", func() {
 		session := podmanTest.Podman([]string{"diff"})

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 # Changelog
 
+## v1.41.3 (2025-08-14)
+
+    Commit: don't depend on MountImage(), because .imagestore
+
+## v1.41.2 (2025-08-13)
+
+    Rework how we decide what to filter out of layer diffs
+    Note that we have to build `true` first for the sake of its tests
+    copier.Stat(): return owner UID and GID if available
+    copier.Get(): ensure that directory entries end in "/"
+    copier.Get(): strip user and group names from entries
+    imagebuildah.Executor/StageExecutor: check numeric --from= values
+
 ## v1.41.1 (2025-08-06)
 
     [release-1.41] Bump Buildah to v1.41.1

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,14 @@
+- Changelog for v1.41.3 (2025-08-14)
+  * Commit: don't depend on MountImage(), because .imagestore
+
+- Changelog for v1.41.2 (2025-08-13)
+  * Rework how we decide what to filter out of layer diffs
+  * Note that we have to build `true` first for the sake of its tests
+  * copier.Stat(): return owner UID and GID if available
+  * copier.Get(): ensure that directory entries end in "/"
+  * copier.Get(): strip user and group names from entries
+  * imagebuildah.Executor/StageExecutor: check numeric --from= values
+
 - Changelog for v1.41.1 (2025-08-06)
   * [release-1.41] Bump Buildah to v1.41.1
   * [release-1.41] Bump c/* projects and Buildah to v1.41.1

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.41.1"
+	Version = "1.41.3"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/image.go
+++ b/vendor/github.com/containers/buildah/image.go
@@ -107,6 +107,8 @@ type containerImageRef struct {
 	extraImageContent     map[string]string
 	compatSetParent       types.OptionalBool
 	layerExclusions       []copier.ConditionalRemovePath
+	layerMountTargets     []copier.ConditionalRemovePath
+	layerPullUps          []copier.EnsureParentPath
 	unsetAnnotations      []string
 	setAnnotations        []string
 	createdAnnotation     types.OptionalBool
@@ -784,7 +786,73 @@ func (mb *ociManifestBuilder) manifestAndConfig() ([]byte, []byte, error) {
 	return omanifestbytes, oconfig, nil
 }
 
-func (i *containerImageRef) NewImageSource(_ context.Context, _ *types.SystemContext) (src types.ImageSource, err error) {
+// filterExclusionsByImage returns a slice of the members of "exclusions" which are present in the image with the specified ID
+func (i containerImageRef) filterExclusionsByImage(ctx context.Context, exclusions []copier.EnsureParentPath, imageID string) ([]copier.EnsureParentPath, error) {
+	if len(exclusions) == 0 || imageID == "" {
+		return nil, nil
+	}
+	var paths []copier.EnsureParentPath
+	mountPoint, err := i.store.MountImage(imageID, nil, i.mountLabel)
+	cleanup := func() {
+		if _, err := i.store.UnmountImage(imageID, false); err != nil {
+			logrus.Debugf("unmounting image %q: %v", imageID, err)
+		}
+	}
+	if err != nil && errors.Is(err, storage.ErrLayerUnknown) {
+		// if an imagestore is being used, this could be expected
+		if b, err2 := NewBuilder(ctx, i.store, BuilderOptions{
+			FromImage:       imageID,
+			PullPolicy:      define.PullNever,
+			ContainerSuffix: "tmp",
+		}); err2 == nil {
+			mountPoint, err = b.Mount(i.mountLabel)
+			cleanup = func() {
+				cid := b.ContainerID
+				if err := b.Delete(); err != nil {
+					logrus.Debugf("unmounting image %q as container %q: %v", imageID, cid, err)
+				}
+			}
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("mounting image %q to examine its contents: %w", imageID, err)
+	}
+	defer cleanup()
+	globs := make([]string, 0, len(exclusions))
+	for _, exclusion := range exclusions {
+		globs = append(globs, exclusion.Path)
+	}
+	options := copier.StatOptions{}
+	stats, err := copier.Stat(mountPoint, mountPoint, options, globs)
+	if err != nil {
+		return nil, fmt.Errorf("checking for potential exclusion items in image %q: %w", imageID, err)
+	}
+	for _, stat := range stats {
+		for _, exclusion := range exclusions {
+			if stat.Glob != exclusion.Path {
+				continue
+			}
+			for result, stat := range stat.Results {
+				if result != exclusion.Path {
+					continue
+				}
+				if exclusion.ModTime != nil && !exclusion.ModTime.Equal(stat.ModTime) {
+					continue
+				}
+				if exclusion.Mode != nil && *exclusion.Mode != stat.Mode {
+					continue
+				}
+				if exclusion.Owner != nil && (int64(exclusion.Owner.UID) != stat.UID && int64(exclusion.Owner.GID) != stat.GID) {
+					continue
+				}
+				paths = append(paths, exclusion)
+			}
+		}
+	}
+	return paths, nil
+}
+
+func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemContext) (src types.ImageSource, err error) {
 	// These maps will let us check if a layer ID is part of one group or another.
 	parentLayerIDs := make(map[string]bool)
 	apiLayerIDs := make(map[string]bool)
@@ -948,6 +1016,7 @@ func (i *containerImageRef) NewImageSource(_ context.Context, _ *types.SystemCon
 		}
 		var rc io.ReadCloser
 		var errChan chan error
+		var layerExclusions []copier.ConditionalRemovePath
 		if i.confidentialWorkload.Convert {
 			// Convert the root filesystem into an encrypted disk image.
 			rc, err = i.extractConfidentialWorkloadFS(i.confidentialWorkload)
@@ -980,6 +1049,18 @@ func (i *containerImageRef) NewImageSource(_ context.Context, _ *types.SystemCon
 				if i.emptyLayer && layerID == i.layerID {
 					continue
 				}
+				if layerID == i.layerID {
+					// We need to filter out any mount targets that we created.
+					layerExclusions = append(slices.Clone(i.layerExclusions), i.layerMountTargets...)
+					// And we _might_ need to filter out directories that modified
+					// by creating and removing mount targets, _if_ they were the
+					// same in the base image for this stage.
+					layerPullUps, err := i.filterExclusionsByImage(ctx, i.layerPullUps, i.fromImageID)
+					if err != nil {
+						return nil, fmt.Errorf("checking which exclusions are in base image %q: %w", i.fromImageID, err)
+					}
+					layerExclusions = append(layerExclusions, layerPullUps...)
+				}
 				// Extract this layer, one of possibly many.
 				rc, err = i.store.Diff("", layerID, diffOptions)
 				if err != nil {
@@ -1002,7 +1083,7 @@ func (i *containerImageRef) NewImageSource(_ context.Context, _ *types.SystemCon
 		// At this point, there are multiple ways that can happen.
 		diffBeingAltered := i.compression != archive.Uncompressed
 		diffBeingAltered = diffBeingAltered || i.layerModTime != nil || i.layerLatestModTime != nil
-		diffBeingAltered = diffBeingAltered || len(i.layerExclusions) != 0
+		diffBeingAltered = diffBeingAltered || len(layerExclusions) != 0
 		if diffBeingAltered {
 			destHasher = digest.Canonical.Digester()
 			multiWriter = io.MultiWriter(counter, destHasher.Hash())
@@ -1022,7 +1103,7 @@ func (i *containerImageRef) NewImageSource(_ context.Context, _ *types.SystemCon
 		// Use specified timestamps in the layer, if we're doing that for history
 		// entries.
 		nestedWriteCloser := ioutils.NewWriteCloserWrapper(writer, writeCloser.Close)
-		writeCloser = makeFilteredLayerWriteCloser(nestedWriteCloser, i.layerModTime, i.layerLatestModTime, i.layerExclusions)
+		writeCloser = makeFilteredLayerWriteCloser(nestedWriteCloser, i.layerModTime, i.layerLatestModTime, layerExclusions)
 		writer = writeCloser
 		// Okay, copy from the raw diff through the filter, compressor, and counter and
 		// digesters.
@@ -1443,6 +1524,24 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		return nil, fmt.Errorf("getting the per-container data directory for %q: %w", b.ContainerID, err)
 	}
 
+	gatherExclusions := func(excludesFiles []string) ([]copier.ConditionalRemovePath, error) {
+		var excludes []copier.ConditionalRemovePath
+		for _, excludesFile := range excludesFiles {
+			if strings.Contains(excludesFile, containerExcludesSubstring) {
+				continue
+			}
+			excludesData, err := os.ReadFile(excludesFile)
+			if err != nil {
+				return nil, fmt.Errorf("reading commit exclusions for %q: %w", b.ContainerID, err)
+			}
+			var theseExcludes []copier.ConditionalRemovePath
+			if err := json.Unmarshal(excludesData, &theseExcludes); err != nil {
+				return nil, fmt.Errorf("parsing commit exclusions for %q: %w", b.ContainerID, err)
+			}
+			excludes = append(excludes, theseExcludes...)
+		}
+		return excludes, nil
+	}
 	mountTargetFiles, err := filepath.Glob(filepath.Join(cdir, containerExcludesDir, "*"))
 	if err != nil {
 		return nil, fmt.Errorf("checking for commit exclusions for %q: %w", b.ContainerID, err)
@@ -1451,29 +1550,27 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 	if err != nil {
 		return nil, fmt.Errorf("checking for commit pulled-up items for %q: %w", b.ContainerID, err)
 	}
-	excludesFiles := slices.Clone(mountTargetFiles)
-	if !options.ConfidentialWorkloadOptions.Convert && !options.Squash {
-		excludesFiles = append(excludesFiles, pulledUpFiles...)
+	layerMountTargets, err := gatherExclusions(mountTargetFiles)
+	if err != nil {
+		return nil, err
+	}
+	if len(layerMountTargets) > 0 {
+		logrus.Debugf("these items were created for use as mount targets: %#v", layerMountTargets)
+	}
+	layerPullUps, err := gatherExclusions(pulledUpFiles)
+	if err != nil {
+		return nil, err
+	}
+	if len(layerPullUps) > 0 {
+		logrus.Debugf("these items appear to have been pulled up: %#v", layerPullUps)
 	}
 	var layerExclusions []copier.ConditionalRemovePath
-	for _, excludesFile := range excludesFiles {
-		if strings.Contains(excludesFile, containerExcludesSubstring) {
-			continue
-		}
-		excludesData, err := os.ReadFile(excludesFile)
-		if err != nil {
-			return nil, fmt.Errorf("reading commit exclusions for %q: %w", b.ContainerID, err)
-		}
-		var excludes []copier.ConditionalRemovePath
-		if err := json.Unmarshal(excludesData, &excludes); err != nil {
-			return nil, fmt.Errorf("parsing commit exclusions for %q: %w", b.ContainerID, err)
-		}
-		layerExclusions = append(layerExclusions, excludes...)
-	}
 	if options.CompatLayerOmissions == types.OptionalBoolTrue {
-		layerExclusions = append(layerExclusions, compatLayerExclusions...)
+		layerExclusions = slices.Clone(compatLayerExclusions)
 	}
-	logrus.Debugf("excluding these items from committed layer: %#v", layerExclusions)
+	if len(layerExclusions) > 0 {
+		logrus.Debugf("excluding these items from committed layer: %#v", layerExclusions)
+	}
 
 	manifestType := options.PreferredManifestType
 	if manifestType == "" {
@@ -1577,6 +1674,8 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		extraImageContent:     maps.Clone(options.ExtraImageContent),
 		compatSetParent:       options.CompatSetParent,
 		layerExclusions:       layerExclusions,
+		layerMountTargets:     layerMountTargets,
+		layerPullUps:          layerPullUps,
 		createdAnnotation:     options.CreatedAnnotation,
 	}
 	if ref.created != nil {

--- a/vendor/github.com/containers/buildah/imagebuildah/executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/executor.go
@@ -862,7 +862,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							logrus.Debugf("stage %d name: %q resolves to %q", stageIndex, stageName, baseWithArg)
 							stageName = baseWithArg
 							// If --from=<index> convert index to name
-							if index, err := strconv.Atoi(stageName); err == nil {
+							if index, err := strconv.Atoi(stageName); err == nil && index >= 0 && index < stageIndex {
 								stageName = stages[index].Name
 							}
 							// Check if selected base is not an additional

--- a/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
@@ -467,7 +467,7 @@ func (s *StageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 				// exists and if stage short_name matches any
 				// additionalContext replace stage with additional
 				// build context.
-				if index, err := strconv.Atoi(from); err == nil {
+				if index, err := strconv.Atoi(from); err == nil && index >= 0 && index < s.index {
 					from = s.stages[index].Name
 				}
 				if foundContext, ok := s.executor.additionalBuildContexts[from]; ok {
@@ -1395,7 +1395,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				// also account if the index is given instead
 				// of name so convert index in --from=<index>
 				// to name.
-				if index, err := strconv.Atoi(from); err == nil {
+				if index, err := strconv.Atoi(from); err == nil && index >= 0 && index < s.index {
 					from = s.stages[index].Name
 				}
 				// If additional buildContext contains this

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.7.1
 ## explicit; go 1.23.0
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.41.1
+# github.com/containers/buildah v1.41.3
 ## explicit; go 1.23.3
 github.com/containers/buildah
 github.com/containers/buildah/bind


### PR DESCRIPTION
Bump Buildah to v1.41.3 in preparation for Podman v5.6.0. This also cures a last minute issue in the build code.
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
