### PR TITLE
docs: Add missing flag examples to podman system connection add man page

### DIFF
--- a/docs/source/markdown/podman-system-connection-add.1.md
+++ b/docs/source/markdown/podman-system-connection-add.1.md
@@ -56,6 +56,20 @@ Add a named system connection to local tcp socket:
 ```
 $ podman system connection add debug tcp://localhost:8080
 ```
+Add a connection with a custom port:
+```
+$ podman system connection add --port 2222 staging user@staging.example.com
+```
+
+Add a connection with a custom socket path:
+```
+$ podman system connection add --socket-path /run/user/1000/podman/podman.sock remote-user user@remote.example.com
+```
+
+Add a connection and make it the default:
+```
+$ podman system connection add --default production root@prod.example.com
+```
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-system(1)](podman-system.1.md)**, **[podman-system-connection(1)](podman-system-connection.1.md)**
 


### PR DESCRIPTION
```release-note
NONE
```

Add missing flag examples to podman-system-connection-add man page

This PR addresses issue #26360 by adding practical examples for flags that
were previously documented but lacked usage examples in the man page.

Added examples for:
- `--port`: Shows how to specify a custom SSH port
- `--socket-path`: Shows how to specify a custom socket path on remote host  
- `--default`: Shows how to make a connection the default

The new examples demonstrate common use cases for managing remote Podman
connections  commands for different
scenarios like staging and production environments.


Fixes: #26360

Signed-off-by: Raghul-M <raghul.m1430@gmail.com>
