### PR TITLE
docs: Add missing --ignore flag example to podman rm man page

### DIFF
--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -151,6 +151,15 @@ Remove by network:
 $ podman rm --filter network=web-net
 1c057cac90c0512df86197599eef5a9485afc900b1ade03c9739fa24c360bbda
 ```
+
+Remove containers ignoring errors if they don't exist :
+```
+$ podman rm --ignore mycontainer1 mycontainer2 nonexistent-container
+mycontainer1
+mycontainer2
+```
+
+
 ## Exit Status
   **0**   All specified containers removed
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

## Add missing --ignore flag example to podman-rm man page

This PR addresses the missing example for the --ignore flag in the podman rm
command documentation. The --ignore flag is particularly useful for scripting
scenarios where containers may or may not exist.

Added example shows:
- How to use --ignore when removing multiple containers
- Demonstrates that the command succeeds even when some containers don't exist
- Shows expected output when containers are successfully removed

The --ignore flag prevents errors when trying to remove non-existent containers,
making it valuable for automation scripts and cleanup operations where container
existence is uncertain.

Before this change, users could see the --ignore flag was available in the
OPTIONS section but had no practical example of how to use it effectively.

This improvement helps users understand when and how to use the --ignore flag
for more robust container management scripts.

Fixes: #26369

Signed-off-by: Raghul-M <raghul.m1430@gmail.com>
