### PR TITLE
WIP: volume protection by pinning

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1927,16 +1927,17 @@ func AutocompleteVolumeFilters(cmd *cobra.Command, _ []string, toComplete string
 	}
 	getImg := func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) }
 	kv := keyValueCompletion{
-		"after=":     getImg,
+		"after=":    getImg,
 		"anonymous=": getBoolCompletion,
-		"dangling=":  getBoolCompletion,
-		"driver=":    local,
-		"label=":     nil,
-		"name=":      func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
-		"opt=":       nil,
-		"scope=":     local,
-		"since=":     getImg,
-		"until=":     nil,
+		"dangling=": getBoolCompletion,
+		"driver=":   local,
+		"label=":    nil,
+		"name=":     func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
+		"opt=":      nil,
+		"pinned=":   getBoolCompletion,
+		"scope=":    local,
+		"since=":    getImg,
+		"until=":    nil,
 	}
 	return completeKeyValues(toComplete, kv)
 }
@@ -1949,6 +1950,7 @@ func AutocompleteVolumePruneFilters(cmd *cobra.Command, _ []string, toComplete s
 		"all=":       getBoolCompletion,
 		"anonymous=": getBoolCompletion,
 		"label=":     nil,
+		"pinned=":    getBoolCompletion,
 		"since=":     getImg,
 		"until=":     nil,
 	}

--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -36,7 +36,8 @@ var (
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example:           `podman system prune`,
 	}
-	force bool
+	force         bool
+	includePinned bool
 )
 
 func init() {
@@ -50,6 +51,7 @@ func init() {
 	flags.BoolVar(&pruneOptions.External, "external", false, "Remove container data in storage not controlled by podman")
 	flags.BoolVar(&pruneOptions.Build, "build", false, "Remove build containers")
 	flags.BoolVar(&pruneOptions.Volume, "volumes", false, "Prune volumes")
+	flags.BoolVar(&includePinned, "include-pinned", false, "Include pinned volumes in prune operation")
 	filterFlagName := "filter"
 	flags.StringArrayVar(&filters, filterFlagName, []string{}, "Provide filter values (e.g. 'label=<key>=<value>')")
 	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePruneFilters)
@@ -57,13 +59,21 @@ func init() {
 
 func prune(_ *cobra.Command, _ []string) error {
 	var err error
+	if includePinned && !pruneOptions.Volume {
+		return fmt.Errorf("--include-pinned requires --volumes")
+	}
+
 	// Prompt for confirmation if --force is not set, unless --external
 	if !force && !pruneOptions.External {
 		reader := bufio.NewReader(os.Stdin)
 		volumeString := ""
 		if pruneOptions.Volume {
 			volumeString = `
+	- all non-pinned volumes not used by at least one container`
+			if includePinned {
+				volumeString = `
 	- all volumes not used by at least one container`
+			}
 		}
 		buildString := ""
 		if pruneOptions.Build {
@@ -79,6 +89,11 @@ func prune(_ *cobra.Command, _ []string) error {
 		if strings.ToLower(answer)[0] != 'y' {
 			return nil
 		}
+	}
+
+	// Set the include pinned flag for volume pruning
+	if pruneOptions.Volume {
+		pruneOptions.VolumePruneOptions.IncludePinned = includePinned
 	}
 
 	// Remove all unused pods, containers, images, networks, and volume data.

--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -22,9 +22,9 @@ var (
 		RunE:              create,
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example: `podman volume create myvol
-podman volume create
-podman volume create --label foo=bar myvol
-podman volume create --uid 4321 --gid 1234 myvol`,
+  podman volume create
+  podman volume create --label foo=bar myvol
+  podman volume create --uid 4321 --gid 1234 myvol`,
 	}
 )
 
@@ -36,6 +36,7 @@ var (
 		Ignore bool
 		UID    int
 		GID    int
+		Pinned bool
 	}{}
 )
 
@@ -68,6 +69,10 @@ func init() {
 	gidFlagName := "gid"
 	flags.IntVar(&opts.GID, gidFlagName, 0, "Set the GID of the volume owner")
 	_ = createCommand.RegisterFlagCompletionFunc(gidFlagName, completion.AutocompleteNone)
+
+	pinnedFlagName := "pinned"
+	flags.BoolVar(&opts.Pinned, pinnedFlagName, false, "Mark volume as pinned (excluded from prune and rm by default)")
+	_ = createCommand.RegisterFlagCompletionFunc(pinnedFlagName, completion.AutocompleteNone)
 }
 
 func create(cmd *cobra.Command, args []string) error {
@@ -92,6 +97,7 @@ func create(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("gid") {
 		createOpts.GID = &opts.GID
 	}
+	createOpts.Pinned = opts.Pinned
 	response, err := registry.ContainerEngine().VolumeCreate(context.Background(), createOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/volumes/pin.go
+++ b/cmd/podman/volumes/pin.go
@@ -1,0 +1,67 @@
+package volumes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/podman/v6/cmd/podman/common"
+	"github.com/containers/podman/v6/cmd/podman/registry"
+	"github.com/containers/podman/v6/cmd/podman/utils"
+	"github.com/containers/podman/v6/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+pinDescription = `Mark or unmark a volume as pinned.
+
+Pinned volumes are excluded from volume prune, volume rm, system prune, and system reset operations by default.`
+
+	pinCommand = &cobra.Command{
+		Use:               "pin [options] VOLUME [VOLUME...]",
+		Short:             "Mark or unmark volume as pinned",
+		Long:              pinDescription,
+		RunE:              pin,
+		ValidArgsFunction: common.AutocompleteVolumes,
+		Example: `podman volume pin myvol
+  podman volume pin --unpin myvol
+  podman volume pin vol1 vol2 vol3`,
+	}
+	pinOptions = entities.VolumePinOptions{}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: pinCommand,
+		Parent:  volumeCmd,
+	})
+	flags := pinCommand.Flags()
+	flags.BoolVar(&pinOptions.Unpin, "unpin", false, "Remove pinning from volume")
+}
+
+// pin executes the volume pin command for one or more volumes.
+func pin(_ *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("must specify at least one volume name")
+	}
+
+	responses, err := registry.ContainerEngine().VolumePin(context.Background(), args, pinOptions)
+	if err != nil {
+		return err
+	}
+
+	errs := make(utils.OutputErrors, 0)
+	for _, r := range responses {
+		if r.Err != nil {
+			errs = append(errs, fmt.Errorf("volume %s: %w", r.Id, r.Err))
+			continue
+		}
+
+		if pinOptions.Unpin {
+			fmt.Printf("Volume %s is now unpinned\n", r.Id)
+		} else {
+			fmt.Printf("Volume %s is now pinned\n", r.Id)
+		}
+	}
+
+	return errs.PrintErrors()
+}

--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -44,6 +44,7 @@ func init() {
 	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteVolumePruneFilters)
 	flags.BoolP("force", "f", false, "Do not prompt for confirmation")
 	flags.BoolP("all", "a", false, "Remove all unused volumes, both anonymous and named")
+	flags.Bool("include-pinned", false, "Include pinned volumes in prune operation")
 }
 
 func prune(cmd *cobra.Command, _ []string) error {
@@ -68,6 +69,8 @@ func prune(cmd *cobra.Command, _ []string) error {
 		pruneOptions.Filters.Set("all", "true")
 	}
 
+	includePinned, _ := cmd.Flags().GetBool("include-pinned")
+	pruneOptions.IncludePinned = includePinned
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
 		if allFlag {
@@ -79,6 +82,17 @@ func prune(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
+
+		// Exclude pinned volumes from the confirmation preview unless
+		// --include-pinned was requested. The actual prune call also
+		// receives IncludePinned as the authoritative behavior flag.
+		if !includePinned {
+			if listOptions.Filter == nil {
+				listOptions.Filter = make(map[string][]string, 1)
+			}
+			listOptions.Filter["pinned"] = []string{"false"}
+		}
+
 		filteredVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), listOptions)
 		if err != nil {
 			return err

--- a/cmd/podman/volumes/rm.go
+++ b/cmd/podman/volumes/rm.go
@@ -27,14 +27,15 @@ var (
 		RunE:              rm,
 		ValidArgsFunction: common.AutocompleteVolumes,
 		Example: `podman volume rm myvol1 myvol2
-podman volume rm --all
-podman volume rm --force myvol`,
+  podman volume rm --all
+  podman volume rm --force myvol`,
 	}
 )
 
 var (
-	rmOptions   = entities.VolumeRmOptions{}
-	stopTimeout int
+	rmOptions     = entities.VolumeRmOptions{}
+	stopTimeout   int
+	includePinned bool
 )
 
 func init() {
@@ -45,6 +46,7 @@ func init() {
 	flags := rmCommand.Flags()
 	flags.BoolVarP(&rmOptions.All, "all", "a", false, "Remove all volumes")
 	flags.BoolVarP(&rmOptions.Force, "force", "f", false, "Remove a volume by force, even if it is being used by a container")
+	flags.BoolVar(&includePinned, "include-pinned", false, "Include pinned volumes in removal operation")
 	timeFlagName := "time"
 	flags.IntVarP(&stopTimeout, timeFlagName, "t", int(containerConfig.Engine.StopTimeout), "Seconds to wait for running containers to stop before killing the container")
 	_ = rmCommand.RegisterFlagCompletionFunc(timeFlagName, completion.AutocompleteNone)
@@ -62,6 +64,7 @@ func rm(cmd *cobra.Command, args []string) error {
 		timeout := uint(stopTimeout)
 		rmOptions.Timeout = &timeout
 	}
+	rmOptions.IncludePinned = includePinned
 	responses, err := registry.ContainerEngine().VolumeRm(context.Background(), args, rmOptions)
 	if err != nil {
 		if rmOptions.Force && strings.Contains(err.Error(), define.ErrNoSuchVolume.Error()) {
@@ -89,5 +92,6 @@ func setExitCode(err error) {
 		registry.SetExitCode(1)
 	} else if errors.Is(err, define.ErrVolumeBeingUsed) || strings.Contains(err.Error(), define.ErrVolumeBeingUsed.Error()) {
 		registry.SetExitCode(2)
+		// ErrVolumePinned intentionally falls back to the generic exit code (125).
 	}
 }

--- a/commands-demo.md
+++ b/commands-demo.md
@@ -105,6 +105,7 @@
 | [podman-volume-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-volume-create.1.html)               | Create a new volume                                                        |
 | [podman-volume-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-volume-inspect.1.html)             | Get detailed information on one or more volumes                            |
 | [podman-volume-ls(1)](https://podman.readthedocs.io/en/latest/markdown/podman-volume-ls.1.html)                       | List all the available volumes                                             |
+| [podman-volume-pin(1)](https://podman.readthedocs.io/en/latest/markdown/podman-volume-pin.1.html)                     | Mark or unmark one or more volumes as pinned                               |
 | [podman-volume-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-volume-prune.1.html)                 | Remove all unused volumes                                                  |
 | [podman-volume-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-volume-rm.1.html)                       | Remove one or more volumes                                                 |
 | [podman-wait(1)](https://podman.readthedocs.io/en/latest/markdown/podman-wait.1.html)                                 | Wait on one or more containers to stop and print their exit codes          |

--- a/docs/source/markdown/options/filter.volume-ls.md
+++ b/docs/source/markdown/options/filter.volume-ls.md
@@ -13,13 +13,12 @@ Volumes can be filtered by the following attributes:
 
 | **Filter**  | **Description**                                                                       |
 | ----------  | ------------------------------------------------------------------------------------- |
-| anonymous   | [Bool] Matches anonymous volumes (true) or named volumes (false)                      |
 | dangling    | [Dangling] Matches all volumes not referenced by any containers                       |
 | driver      | [Driver] Matches volumes based on their driver                                        |
 | label       | [Key] or [Key=Value] Label assigned to a volume                                       |
-| label!      | [Key] or [Key=Value] Volumes without the specified label                              |
 | name        | [Name] Volume name (accepts regex)                                                    |
 | opt         | Matches a storage driver options                                                      |
+| pinned      | [Bool] Matches volumes based on their pinned status (true/false)                      |
 | scope       | Filters volume by scope                                                               |
 | after/since | Filter by volumes created after the given VOLUME (name or tag)                        |
 | until       | Filter by volumes created before given timestamp                                      |

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -11,7 +11,7 @@ podman\-system\-prune - Remove all unused pods, containers, images, networks, an
 
 Use the **--all** option to delete all unused images.  Unused images are dangling images as well as any image that does not have any containers based on it.
 
-By default, volumes are not removed to prevent important data from being deleted if there is currently no container using the volume. Use the **--volumes** flag when running the command to prune volumes as well.
+By default, volumes are not removed to prevent important data from being deleted if there is currently no container using the volume. Use the **--volumes** flag when running the command to prune volumes as well. By default, pinned volumes are excluded from pruning even when **--volumes** is specified. Use the **--include-pinned** flag to include pinned volumes in the prune operation.
 
 By default, build containers are not removed to prevent interference with builds in progress. Use the **--build** flag when running the command to remove build containers as well.
 
@@ -58,6 +58,10 @@ Do not prompt for confirmation
 #### **--help**, **-h**
 
 Print usage statement
+
+#### **--include-pinned**
+
+Include pinned volumes in the prune operation when **--volumes** is specified. By default, pinned volumes are excluded from pruning to protect important data. This flag only has an effect when **--volumes** is also used.
 
 #### **--volumes**
 

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -11,6 +11,8 @@ podman\-system\-reset - Reset storage back to initial state
 It also removes the configured graphRoot and runRoot directories. Make sure these are not set to
 some important directory.
 
+By default, pinned volumes are excluded from the reset operation to protect important data. Use the **--include-pinned** flag to include pinned volumes in the reset.
+
 This command must be run **before** changing any of the following fields in the
 `containers.conf` or `storage.conf` files: `driver`, `static_dir`, `tmp_dir`
 or `volume_path`.
@@ -30,6 +32,10 @@ Do not prompt for confirmation
 
 Print usage statement
 
+#### **--include-pinned**
+
+Include pinned volumes in the reset operation. By default, pinned volumes are excluded from the reset to protect important data.
+
 ## EXAMPLES
 
 Reset all storage back to a clean initialized state.
@@ -42,7 +48,7 @@ WARNING! This will remove:
         - all networks
         - all build cache
         - all machines
-        - all volumes
+        - all volumes (excluding pinned volumes)
         - the graphRoot directory: /var/lib/containers/storage
         - the runRoot directory: /run/containers/storage
 Are you sure you want to continue? [y/N] y

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -74,6 +74,10 @@ This option is mandatory when using the **image** driver.
 
 When not using the **local** and **image** drivers, the given options are passed directly to the volume plugin. In this case, supported options are dictated by the plugin in question, not Podman.
 
+#### **--pinned**
+
+Mark the volume as pinned. Pinned volumes are excluded from **podman volume prune**, **podman volume rm**, **podman system prune**, and **podman system reset** operations by default, protecting them from accidental deletion during cleanup operations. The pinned status can be changed later using **podman volume pin**.
+
 #### **--uid**=*uid*
 
 Set the UID that the volume will be created as. Differently than `--opt o=uid=*uid*`, the specified value is not passed to the mount operation. The specified UID will own the volume's mount point directory and affects the volume chown operation.
@@ -136,6 +140,11 @@ Create tmpfs named volume testvol with specified options.
 Create volume overriding the owner UID and GID.
 ```
 # podman volume create --uid 1000 --gid 1000 myvol
+```
+
+Create a pinned volume that is protected from prune and remove operations.
+```
+$ podman volume create --pinned datavol
 ```
 
 Create image named volume using the specified local image in containers/storage.
@@ -215,7 +224,7 @@ If performance is the priority, please check out the more performant [goofys](ht
 
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[containers.conf(5)](https://github.com/containers/container-libs/blob/main/common/docs/containers.conf.5.md)**, **[podman-volume(1)](podman-volume.1.md)**, **mount(8)**, **xfs_quota(8)**, **xfs_quota(8)**, **projects(5)**, **projid(5)**
+**[podman(1)](podman.1.md)**, **[containers.conf(5)](https://github.com/containers/container-libs/blob/main/common/docs/containers.conf.5.md)**, **[podman-volume(1)](podman-volume.1.md)**, **[podman-volume-pin(1)](podman-volume-pin.1.md)**, **mount(8)**, **xfs_quota(8)**, **xfs_quota(8)**, **projects(5)**, **projid(5)**
 
 ## HISTORY
 January 2020, updated with information on volume plugins by Matthew Heon <mheon@redhat.com>

--- a/docs/source/markdown/podman-volume-inspect.1.md
+++ b/docs/source/markdown/podman-volume-inspect.1.md
@@ -40,6 +40,7 @@ Valid placeholders for the Go template are listed below:
 | .NeedsChown         | Indicates volume will be chowned on next use                                |
 | .NeedsCopyUp        | Indicates data at the destination will be copied into the volume on next use|
 | .Options ...        | Volume options                                                              |
+| .Pinned             | Whether the volume is pinned                                                |
 | .Scope              | Volume scope                                                                |
 | .Status ...         | Status of the volume                                                        |
 | .StorageID          | StorageID of the volume                                                     |

--- a/docs/source/markdown/podman-volume-ls.1.md.in
+++ b/docs/source/markdown/podman-volume-ls.1.md.in
@@ -37,6 +37,7 @@ Valid placeholders for the Go template are listed below:
 | .NeedsChown               | Indicates whether volume needs to be chowned |
 | .NeedsCopyUp              | Indicates if volume needs to be copied up to |
 | .Options ...              | Volume options                               |
+| .Pinned                   | Whether the volume is pinned                 |
 | .Scope                    | Volume scope                                 |
 | .Status ...               | Status of the volume                         |
 | .StorageID                | StorageID of the volume                      |
@@ -79,6 +80,16 @@ $ podman volume ls --filter name=foo,label=blue
 List volumes with the label key=value.
 ```
 $ podman volume ls --filter label=key=value
+```
+
+List all pinned volumes.
+```
+$ podman volume ls --filter pinned=true
+```
+
+List all non-pinned volumes.
+```
+$ podman volume ls --filter pinned=false
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-volume-pin.1.md
+++ b/docs/source/markdown/podman-volume-pin.1.md
@@ -1,0 +1,53 @@
+% podman-volume-pin 1
+
+## NAME
+podman\-volume\-pin - Mark or unmark volumes as pinned
+
+## SYNOPSIS
+**podman volume pin** [*options*] *volume* [*volume* ...]
+
+## DESCRIPTION
+
+Mark or unmark one or more volumes as pinned. Pinned volumes are excluded from **podman volume prune**, **podman volume rm**, **podman system prune**, and **podman system reset** operations by default, protecting them from accidental deletion.
+
+This is useful for volumes containing important persistent data that should be preserved during cleanup operations.
+
+By default, **podman volume pin** marks volumes as pinned. Use the **--unpin** option to remove the pinned status from volumes.
+
+## OPTIONS
+
+#### **--help**
+
+Print usage statement.
+
+#### **--unpin**
+
+Remove the pinned status from the specified volumes instead of pinning them.
+
+## EXAMPLES
+
+Mark a volume as pinned.
+```
+$ podman volume pin myvol
+Volume myvol is now pinned
+```
+
+Mark multiple volumes as pinned.
+```
+$ podman volume pin vol1 vol2 vol3
+Volume vol1 is now pinned
+Volume vol2 is now pinned
+Volume vol3 is now pinned
+```
+
+Remove the pinned status from a volume.
+```
+$ podman volume pin --unpin myvol
+Volume myvol is now unpinned
+```
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-volume(1)](podman-volume.1.md)**, **[podman-volume-create(1)](podman-volume-create.1.md)**, **[podman-volume-prune(1)](podman-volume-prune.1.md)**, **[podman-volume-rm(1)](podman-volume-rm.1.md)**, **[podman-system-prune(1)](podman-system-prune.1.md)**, **[podman-system-reset(1)](podman-system-reset.1.md)**
+
+## HISTORY
+March 2026, Originally compiled by Brent Baude <bbaude@redhat.com>

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -1,7 +1,7 @@
 % podman-volume-prune 1
 
 ## NAME
-podman\-volume\-prune - Remove unused volumes
+podman-volume-prune - Remove unused volumes
 
 ## SYNOPSIS
 **podman volume prune** [*options*]
@@ -14,6 +14,9 @@ Use **--all** (or **-a**) to remove all unused volumes, including named ones.
 
 The **--filter** flag can be used to restrict which volumes are considered. Users are prompted to confirm
 removal unless **--force** is used.
+
+By default, pinned volumes are excluded from pruning to protect important data. Use **--include-pinned**
+to include pinned volumes in the prune operation.
 
 ## OPTIONS
 
@@ -33,8 +36,14 @@ Supported filters:
 |:-----------:|------------------------------------------------------------------------------------------------------------|
 | all         | [Bool] When true, remove all unused volumes (same as **--all**). When false or unset, only anonymous volumes are considered. |
 | anonymous   | [Bool] Only remove volumes that are anonymous (true) or named (false).                                     |
+| dangling    | [Bool] Only remove volumes not referenced by any containers                                                |
+| driver      | [String] Only remove volumes with the given driver                                                         |
 | label       | [String] Only remove volumes, with (or without, in the case of label!=[...] is used) the specified labels. |
 | label!      | [String] Only remove volumes without the specified labels.                                                 |
+| name        | [String] Only remove volume with the given name                                                            |
+| opt         | [String] Only remove volumes created with the given options                                                |
+| pinned      | [Bool] Only remove volumes based on their pinned status (true/false)                                       |
+| scope       | [String] Only remove volumes with the given scope                                                          |
 | until       | [DateTime] Only remove volumes created before given timestamp.                                             |
 | after/since | [Volume] Filter by volumes created after the given VOLUME (name or tag)                                    |
 
@@ -50,6 +59,9 @@ Do not prompt for confirmation.
 
 Print usage statement
 
+#### **--include-pinned**
+
+Include pinned volumes in the prune operation. By default, pinned volumes are excluded from pruning to protect important data.
 
 ## EXAMPLES
 
@@ -94,7 +106,7 @@ $ podman volume prune --filter label!=environment
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-volume(1)](podman-volume.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-volume(1)](podman-volume.1.md)**, **[podman-volume-pin(1)](podman-volume-pin.1.md)**
 
 ## HISTORY
 November 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/source/markdown/podman-volume-rm.1.md
+++ b/docs/source/markdown/podman-volume-rm.1.md
@@ -13,6 +13,8 @@ If a volume is being used by a container, an error is returned unless the **--fo
 flag is being used. To remove all volumes, use the **--all** flag.
 Volumes can be removed individually by providing their full name or a unique partial name.
 
+By default, pinned volumes are excluded from removal operations to protect important data. Use the **--include-pinned** flag to allow removal of pinned volumes.
+
 ## OPTIONS
 
 #### **--all**, **-a**
@@ -27,6 +29,10 @@ If it is being used by containers, the containers are removed first.
 #### **--help**
 
 Print usage statement
+
+#### **--include-pinned**
+
+Include pinned volumes in the removal operation. By default, pinned volumes are excluded from removal to protect important data. This flag must be used if you want to remove volumes that have been marked as pinned.
 
 #### **--time**, **-t**=*seconds*
 
@@ -59,7 +65,7 @@ $ podman volume rm --force myvol
   **125** The command fails for any other reason
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-volume(1)](podman-volume.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-volume(1)](podman-volume.1.md)**, **[podman-volume-pin(1)](podman-volume-pin.1.md)**
 
 ## HISTORY
 November 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/source/markdown/podman-volume.1.md
+++ b/docs/source/markdown/podman-volume.1.md
@@ -20,7 +20,8 @@ podman volume is a set of subcommands that manage volumes.
 | inspect | [podman-volume-inspect(1)](podman-volume-inspect.1.md) | Get detailed information on one or more volumes.                               |
 | ls      | [podman-volume-ls(1)](podman-volume-ls.1.md)           | List all the available volumes.                                                |
 | mount   | [podman-volume-mount(1)](podman-volume-mount.1.md)     | Mount a volume filesystem.                                                     |
-| prune   | [podman-volume-prune(1)](podman-volume-prune.1.md)     | Remove unused volumes.                                                         |
+| pin     | [podman-volume-pin(1)](podman-volume-pin.1.md)         | Mark or unmark volumes as pinned.                                              |
+| prune   | [podman-volume-prune(1)](podman-volume-prune.1.md)     | Remove all unused volumes.                                                     |
 | reload  | [podman-volume-reload(1)](podman-volume-reload.1.md)   | Reload all volumes from volumes plugins.                                       |
 | rm      | [podman-volume-rm(1)](podman-volume-rm.1.md)           | Remove one or more volumes.                                                    |
 | unmount | [podman-volume-unmount(1)](podman-volume-unmount.1.md) | Unmount a volume.                                                     |

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -73,6 +73,8 @@ var (
 	ErrExecSessionStateInvalid = errors.New("exec session state improper")
 	// ErrVolumeBeingUsed indicates that a volume is being used by at least one container
 	ErrVolumeBeingUsed = errors.New("volume is being used")
+	// ErrVolumePinned indicates that a volume is pinned and protected from removal
+	ErrVolumePinned = errors.New("volume is pinned")
 
 	// ErrRuntimeFinalized indicates that the runtime has already been
 	// created and cannot be modified

--- a/libpod/define/volume_inspect.go
+++ b/libpod/define/volume_inspect.go
@@ -63,6 +63,9 @@ type InspectVolumeData struct {
 	StorageID string `json:"StorageID,omitempty"`
 	// LockNumber is the number of the volume's Libpod lock.
 	LockNumber uint32
+	// Pinned indicates that this volume should be excluded from
+	// system prune operations by default.
+	Pinned bool `json:"Pinned,omitempty"`
 }
 
 type VolumeReload struct {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1716,14 +1716,14 @@ func WithVolumeNoChown() VolumeCreateOption {
 	}
 }
 
-// WithVolumeDisableQuota prevents the volume from being assigned a quota.
-func WithVolumeDisableQuota() VolumeCreateOption {
+// WithVolumePinned marks a volume as pinned at creation time.
+func WithVolumePinned() VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
 			return define.ErrVolumeFinalized
 		}
 
-		volume.config.DisableQuota = true
+		volume.state.Pinned = true
 
 		return nil
 	}
@@ -1739,6 +1739,19 @@ func WithVolumeAnonymous() VolumeCreateOption {
 		}
 
 		volume.config.IsAnon = true
+
+		return nil
+	}
+}
+
+// WithVolumeDisableQuota prevents the volume from being assigned a quota.
+func WithVolumeDisableQuota() VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return define.ErrVolumeFinalized
+		}
+
+		volume.config.DisableQuota = true
 
 		return nil
 	}

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -92,7 +92,7 @@ func (r *Runtime) removeAllDirs() error {
 // Reset removes all Libpod files.
 // All containers, images, volumes, pods, and networks will be removed.
 // Calls Shutdown(), rendering the runtime unusable after this is run.
-func (r *Runtime) Reset(ctx context.Context) error {
+func (r *Runtime) Reset(ctx context.Context, includePinned bool) error {
 	// Acquire the alive lock and hold it.
 	// Ensures that we don't let other Podman commands run while we are
 	// removing everything.
@@ -162,7 +162,17 @@ func (r *Runtime) Reset(ctx context.Context) error {
 		return err
 	}
 	for _, v := range volumes {
-		if err := r.RemoveVolume(ctx, v, true, &timeout); err != nil {
+		// Skip pinned volumes - they should not be removed during reset
+		if !includePinned {
+			isPinned, err := v.IsPinnedWithError()
+			if err != nil {
+				return fmt.Errorf("checking pinned status for volume %s: %w", v.Name(), err)
+			}
+			if isPinned {
+				continue
+			}
+		}
+		if err := r.RemoveVolumeWithOptions(ctx, v, true, &timeout, includePinned); err != nil {
 			if errors.Is(err, define.ErrNoSuchVolume) {
 				continue
 			}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -1039,7 +1039,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, opts ctrRmO
 			if !volume.Anonymous() {
 				continue
 			}
-			if err := runtime.removeVolume(ctx, volume, false, opts.Timeout, false); err != nil && !errors.Is(err, define.ErrNoSuchVolume) {
+			if err := runtime.removeVolume(ctx, volume, false, opts.Timeout, false, false); err != nil && !errors.Is(err, define.ErrNoSuchVolume) {
 				if errors.Is(err, define.ErrVolumeBeingUsed) {
 					// Ignore error, since podman will report original error
 					volumesFrom, _ := c.volumesFrom()
@@ -1195,7 +1195,7 @@ func (r *Runtime) evictContainer(ctx context.Context, idOrName string, removeVol
 			if !volume.Anonymous() {
 				continue
 			}
-			if err := r.removeVolume(ctx, volume, false, timeout, false); err != nil && err != define.ErrNoSuchVolume && err != define.ErrVolumeBeingUsed {
+			if err := r.removeVolume(ctx, volume, false, timeout, false, false); err != nil && err != define.ErrNoSuchVolume && err != define.ErrVolumeBeingUsed {
 				logrus.Errorf("Cleaning up volume (%s): %v", v.Name, err)
 			}
 		}

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -67,7 +67,10 @@ func (r *Runtime) RemoveContainersForImageCallback(ctx context.Context, force bo
 			}
 			// Do a force removal of the volume, and all containers
 			// using it.
-			if err := r.RemoveVolume(ctx, vol, true, nil); err != nil {
+			if err := r.RemoveVolumeWithOptions(ctx, vol, true, nil, false); err != nil {
+				if errors.Is(err, define.ErrVolumePinned) {
+					return fmt.Errorf("removing image %s: volume %s is pinned; unpin it first with 'podman volume unpin %s': %w", imageID, vol.Name(), vol.Name(), err)
+				}
 				return fmt.Errorf("removing image %s: volume %s backed by image could not be removed: %w", imageID, vol.Name(), err)
 			}
 		}

--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -262,7 +262,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool,
 		if !volume.Anonymous() {
 			continue
 		}
-		if err := r.removeVolume(ctx, volume, false, timeout, false); err != nil {
+		if err := r.removeVolume(ctx, volume, false, timeout, false, false); err != nil {
 			// If the anonymous volume is still being used that means it was likely transferred
 			// to another container via --volumes-from so no need to log this as real error.
 			if errors.Is(err, define.ErrNoSuchVolume) || errors.Is(err, define.ErrVolumeRemoved) || errors.Is(err, define.ErrVolumeBeingUsed) {

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -5,6 +5,7 @@ package libpod
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/containers/podman/v6/libpod/define"
 	"github.com/containers/podman/v6/libpod/events"
@@ -28,7 +29,17 @@ func (r *Runtime) RemoveVolume(ctx context.Context, v *Volume, force bool, timeo
 		return define.ErrRuntimeStopped
 	}
 
-	return r.removeVolume(ctx, v, force, timeout, false)
+	return r.RemoveVolumeWithOptions(ctx, v, force, timeout, false)
+}
+
+// RemoveVolumeWithOptions removes a volume and allows explicit control over
+// pinned-volume protection.
+func (r *Runtime) RemoveVolumeWithOptions(ctx context.Context, v *Volume, force bool, timeout *uint, includePinned bool) error {
+	if !r.valid {
+		return define.ErrRuntimeStopped
+	}
+
+	return r.removeVolume(ctx, v, force, timeout, false, includePinned)
 }
 
 // GetVolume retrieves a volume given its full name.
@@ -128,7 +139,53 @@ func (r *Runtime) PruneVolumes(ctx context.Context, filterFuncs []VolumeFilter) 
 		report.Id = vol.Name()
 		var timeout *uint
 		if err := r.RemoveVolume(ctx, vol, false, timeout); err != nil {
-			if !errors.Is(err, define.ErrVolumeBeingUsed) && !errors.Is(err, define.ErrVolumeRemoved) {
+			if !errors.Is(err, define.ErrVolumeBeingUsed) && !errors.Is(err, define.ErrVolumeRemoved) && !errors.Is(err, define.ErrVolumePinned) {
+				report.Err = err
+			} else {
+				// We didn't remove the volume for some reason
+				continue
+			}
+		} else {
+			vol.newVolumeEvent(events.Prune)
+		}
+		preports = append(preports, report)
+	}
+	return preports, nil
+}
+
+// PruneVolumesWithOptions removes unused volumes from the system with options
+func (r *Runtime) PruneVolumesWithOptions(ctx context.Context, filterFuncs []VolumeFilter, includePinned bool) ([]*reports.PruneReport, error) {
+	preports := make([]*reports.PruneReport, 0)
+	vols, err := r.Volumes(filterFuncs...)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vol := range vols {
+		report := new(reports.PruneReport)
+		report.Id = vol.Name()
+
+		// Skip pinned volumes unless explicitly requested
+		if !includePinned {
+			isPinned, err := vol.IsPinnedWithError()
+			if err != nil {
+				report.Err = fmt.Errorf("checking pinned status for volume %s: %w", vol.Name(), err)
+				preports = append(preports, report)
+				continue
+			}
+			if isPinned {
+				continue
+			}
+		}
+
+		volSize, err := vol.Size()
+		if err != nil {
+			volSize = 0
+		}
+		report.Size = volSize
+		var timeout *uint
+		if err := r.RemoveVolumeWithOptions(ctx, vol, false, timeout, includePinned); err != nil {
+			if !errors.Is(err, define.ErrVolumeBeingUsed) && !errors.Is(err, define.ErrVolumeRemoved) && !errors.Is(err, define.ErrVolumePinned) {
 				report.Err = err
 			} else {
 				// We didn't remove the volume for some reason

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -293,7 +293,7 @@ func (r *Runtime) UpdateVolumePlugins(ctx context.Context) *define.VolumeReload 
 		if vol.UsesVolumeDriver() {
 			if _, ok := allPluginVolumes[vol.Name()]; !ok {
 				// The volume is no longer in the plugin. Let's remove it from the libpod db.
-				if err := r.removeVolume(ctx, vol, false, nil, true); err != nil {
+				if err := r.removeVolume(ctx, vol, false, nil, true, false); err != nil {
 					if errors.Is(err, define.ErrVolumeBeingUsed) {
 						// Volume is still used by at least one container. This is very bad,
 						// the plugin no longer has this but we still need it.
@@ -358,12 +358,26 @@ func makeVolumeInPluginIfNotExist(name string, options map[string]string, plugin
 // removeVolume removes the specified volume from state as well tears down its mountpoint and storage.
 // ignoreVolumePlugin is used to only remove the volume from the db and not the plugin,
 // this is required when the volume was already removed from the plugin, i.e. in UpdateVolumePlugins().
-func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool, timeout *uint, ignoreVolumePlugin bool) error {
+func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool, timeout *uint, ignoreVolumePlugin bool, includePinned bool) error {
 	if !v.valid {
 		if ok, _ := r.state.HasVolume(v.Name()); !ok {
 			return nil
 		}
 		return define.ErrVolumeRemoved
+	}
+
+	if !includePinned {
+		// This check intentionally runs before taking the volume lock below.
+		// Lock ordering requires container locks before volume locks, and
+		// pre-locking here can create ABBA deadlocks during dependency cleanup.
+		// A narrow pin/unpin race window exists for the same reason.
+		isPinned, err := v.IsPinnedWithError()
+		if err != nil {
+			return fmt.Errorf("checking pinned status for volume %s: %w", v.Name(), err)
+		}
+		if isPinned {
+			return fmt.Errorf("volume %s is pinned and cannot be removed without --include-pinned flag: %w", v.Name(), define.ErrVolumePinned)
+		}
 	}
 
 	// DANGEROUS: Do not lock here yet because we might needed to remove containers first.

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -112,6 +112,10 @@ type VolumeState struct {
 	UIDChowned int `json:"uidChowned,omitempty"`
 	// GIDChowned is the GID the volume was chowned to.
 	GIDChowned int `json:"gidChowned,omitempty"`
+	// Pinned indicates that this volume should be excluded from
+	// system prune and reset operations by default.
+	// It is persistent state and must survive reboot/refresh.
+	Pinned bool `json:"pinned,omitempty"`
 }
 
 // Name retrieves the volume's name
@@ -278,6 +282,58 @@ func (v *Volume) UsesVolumeDriver() bool {
 		return false
 	}
 	return v.config.Driver != define.VolumeDriverLocal && v.config.Driver != ""
+}
+
+// IsPinned returns whether this volume is marked as pinned.
+// Pinned volumes are excluded from volume prune, volume rm, system prune, and
+// reset operations by default.
+// On refresh errors, this method logs and returns false.
+// Prefer IsPinnedWithError when callers need to handle failures explicitly.
+func (v *Volume) IsPinned() bool {
+	pinned, err := v.IsPinnedWithError()
+	if err != nil {
+		logrus.Errorf("Refreshing volume %s state for pin check: %v", v.Name(), err)
+		return false
+	}
+
+	return pinned
+}
+
+// IsPinnedWithError returns whether this volume is marked as pinned.
+func (v *Volume) IsPinnedWithError() (bool, error) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	if err := v.update(); err != nil {
+		return false, err
+	}
+
+	return v.state.Pinned, nil
+}
+
+// SetPinned sets the pinned status of the volume.
+// Pinned volumes are excluded from volume prune, volume rm, system prune, and
+// reset operations by default.
+func (v *Volume) SetPinned(pinned bool) error {
+	if !v.valid {
+		return define.ErrVolumeRemoved
+	}
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	if err := v.update(); err != nil {
+		return err
+	}
+
+	// If the volume is already in the desired state, this is a no-op
+	if v.state.Pinned == pinned {
+		return nil
+	}
+
+	v.state.Pinned = pinned
+
+	return v.save()
 }
 
 func (v *Volume) Mount() (string, error) {

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -72,5 +72,7 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 		data.Timeout = v.runtime.config.Engine.VolumePluginTimeout
 	}
 
+	data.Pinned = v.state.Pinned
+
 	return data, nil
 }

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -108,6 +108,8 @@ func (v *Volume) refresh() error {
 // It is performed before a refresh and clears the state after a reboot.
 // It does not save the results - assumes the database will do that for us.
 func resetVolumeState(state *VolumeState) {
+	// Pinned is intentionally not reset here. It represents persisted user
+	// intent and must survive refresh after reboot.
 	state.MountCount = 0
 	state.MountPoint = ""
 	state.CopiedUp = false

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -48,6 +48,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 		filterFunc, err := filters.GenerateVolumeFilters(filter, filterValues, runtime)
 		if err != nil {
 			utils.InternalServerError(w, err)
+			return
 		}
 		volumeFilters = append(volumeFilters, filterFunc)
 	}
@@ -85,7 +86,6 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 			volVals = append(volVals, *v)
 		}
 	}
-
 	response := volume.ListResponse{
 		Volumes:  volVals,
 		Warnings: []string{},
@@ -230,8 +230,9 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 		decoder = utils.GetDecoder(r)
 	)
 	query := struct {
-		Force   bool  `schema:"force"`
-		Timeout *uint `schema:"timeout"`
+		Force         bool  `schema:"force"`
+		Timeout       *uint `schema:"timeout"`
+		IncludePinned bool  `schema:"includePinned"`
 	}{
 		// override any golang type defaults
 	}
@@ -257,8 +258,8 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 	vol, err := runtime.LookupVolume(name)
 	if err == nil {
 		// As above, we do not pass `force` from the query parameters here
-		if err := runtime.RemoveVolume(r.Context(), vol, false, query.Timeout); err != nil {
-			if errors.Is(err, define.ErrVolumeBeingUsed) {
+		if err := runtime.RemoveVolumeWithOptions(r.Context(), vol, false, query.Timeout, query.IncludePinned); err != nil {
+			if errors.Is(err, define.ErrVolumeBeingUsed) || errors.Is(err, define.ErrVolumePinned) {
 				utils.Error(w, http.StatusConflict, err)
 			} else {
 				utils.InternalServerError(w, err)
@@ -281,6 +282,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 
 func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	decoder := utils.GetDecoder(r)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
@@ -298,7 +300,15 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 		filterFuncs = append(filterFuncs, filterFunc)
 	}
 
-	pruned, err := runtime.PruneVolumes(r.Context(), filterFuncs)
+	query := struct {
+		IncludePinned bool `schema:"includePinned"`
+	}{}
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
+		return
+	}
+
+	pruned, err := runtime.PruneVolumesWithOptions(r.Context(), filterFuncs, query.IncludePinned)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -22,10 +22,11 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
 	query := struct {
-		All      bool `schema:"all"`
-		Volumes  bool `schema:"volumes"`
-		External bool `schema:"external"`
-		Build    bool `schema:"build"`
+		All           bool `schema:"all"`
+		Volumes       bool `schema:"volumes"`
+		External      bool `schema:"external"`
+		Build         bool `schema:"build"`
+		IncludePinned bool `schema:"includePinned"`
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -49,6 +50,7 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 		External: query.External,
 		Build:    query.Build,
 	}
+	pruneOptions.VolumePruneOptions.IncludePinned = query.IncludePinned
 	report, err := containerEngine.SystemPrune(r.Context(), pruneOptions)
 	if err != nil {
 		utils.InternalServerError(w, err)

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -81,12 +81,16 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	if input.GID != nil {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeGID(*input.GID), libpod.WithVolumeNoChown())
 	}
+	if input.Pinned {
+		volumeOptions = append(volumeOptions, libpod.WithVolumePinned())
+	}
 
 	vol, err := runtime.NewVolume(r.Context(), volumeOptions...)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}
+
 	inspectOut, err := vol.Inspect()
 	if err != nil {
 		utils.InternalServerError(w, err)
@@ -147,6 +151,7 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 
 func pruneVolumesHelper(r *http.Request) ([]*reports.PruneReport, error) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
 		return nil, err
@@ -162,7 +167,14 @@ func pruneVolumesHelper(r *http.Request) ([]*reports.PruneReport, error) {
 		filterFuncs = append(filterFuncs, filterFunc)
 	}
 
-	reports, err := runtime.PruneVolumes(r.Context(), filterFuncs)
+	query := struct {
+		IncludePinned bool `schema:"includePinned"`
+	}{}
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		return nil, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err)
+	}
+
+	reports, err := runtime.PruneVolumesWithOptions(r.Context(), filterFuncs, query.IncludePinned)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +187,9 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 		decoder = r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	)
 	query := struct {
-		Force   bool  `schema:"force"`
-		Timeout *uint `schema:"timeout"`
+		Force         bool  `schema:"force"`
+		Timeout       *uint `schema:"timeout"`
+		IncludePinned bool  `schema:"includePinned"`
 	}{
 		// override any golang type defaults
 	}
@@ -192,8 +205,8 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 		utils.VolumeNotFound(w, name, err)
 		return
 	}
-	if err := runtime.RemoveVolume(r.Context(), vol, query.Force, query.Timeout); err != nil {
-		if errors.Is(err, define.ErrVolumeBeingUsed) {
+	if err := runtime.RemoveVolumeWithOptions(r.Context(), vol, query.Force, query.Timeout, query.IncludePinned); err != nil {
+		if errors.Is(err, define.ErrVolumeBeingUsed) || errors.Is(err, define.ErrVolumePinned) {
 			utils.Error(w, http.StatusConflict, err)
 			return
 		}

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -83,6 +83,10 @@ func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
 	//     type: boolean
 	//     description: Remove build cache
 	//   - in: query
+	//     name: includePinned
+	//     type: boolean
+	//     description: include pinned volumes in prune
+	//   - in: query
 	//     name: filters
 	//     type: string
 	//     description: |

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -70,7 +70,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//        - label=<key> or label=<key>:<value> Matches volumes based on the presence of a label alone or a label and a value.
 	//        - name=<volume-name> Matches all of volume name.
 	//        - opt=<driver-option> Matches a storage driver options
-	//        - `until=<timestamp>` List volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `pinned=true|false` Matches volumes based on their pinned status.
+	//        - `until=<timestamp>` List volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine's time.
 	// responses:
 	//   '200':
 	//     "$ref": "#/responses/volumeListLibpod"
@@ -93,8 +94,13 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//      Available filters:
 	//        - `all` When true, prune all unused volumes; when false or unset, only anonymous unused volumes.
 	//        - `anonymous` When true/false, restrict to anonymous or named volumes only.
-	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine's time.
 	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
+	//        - `pinned=true|false` Restrict to pinned or unpinned volumes.
+	//  - in: query
+	//    name: includePinned
+	//    type: boolean
+	//    description: include pinned volumes in the prune operation
 	// responses:
 	//   '200':
 	//      "$ref": "#/responses/volumePruneLibpod"
@@ -141,6 +147,10 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    name: timeout
 	//    type: integer
 	//    description: timeout before forcibly killing any containers using the volume
+	//  - in: query
+	//    name: includePinned
+	//    type: boolean
+	//    description: allow removal of pinned volumes
 	// produces:
 	// - application/json
 	// responses:
@@ -149,7 +159,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   404:
 	//     $ref: "#/responses/volumeNotFound"
 	//   409:
-	//     description: Volume is in use and cannot be removed
+	//     description: Volume is in use or pinned and cannot be removed
 	//   500:
 	//     $ref: "#/responses/internalError"
 	r.Handle(VersionedPath("/libpod/volumes/{name}"), s.APIHandler(libpod.RemoveVolume)).Methods(http.MethodDelete)
@@ -229,6 +239,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//        - driver=<volume-driver-name> Matches volumes based on their driver.
 	//        - label=<key> or label=<key>:<value> Matches volumes based on the presence of a label alone or a label and a value.
 	//        - name=<volume-name> Matches all of volume name.
+	//        - `pinned=true|false` Matches volumes based on their pinned status.
 	//        - `until=<timestamp>` List volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
 	//
 	//      Note:
@@ -309,6 +320,10 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    name: timeout
 	//    type: integer
 	//    description: timeout before forcibly killing any containers using the volume
+	//  - in: query
+	//    name: includePinned
+	//    type: boolean
+	//    description: allow removal of pinned volumes
 	// produces:
 	// - application/json
 	// responses:
@@ -317,7 +332,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   404:
 	//     $ref: "#/responses/volumeNotFound"
 	//   409:
-	//     description: Volume is in use and cannot be removed
+	//     description: Volume is in use or pinned and cannot be removed
 	//   500:
 	//     "$ref": "#/responses/internalError"
 	r.Handle(VersionedPath("/volumes/{name}"), s.APIHandler(compat.RemoveVolume)).Methods(http.MethodDelete)
@@ -338,8 +353,13 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//      JSON encoded value of filters (a map[string][]string). Docker API 1.42+ - by default only anonymous (unnamed) unused volumes are pruned; use filter all=true to prune all unused volumes.
 	//      Available filters:
 	//        - `all` When true, prune all unused volumes (anonymous and named). When false or unset, only anonymous unused volumes are pruned.
-	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `pinned=true|false` Restrict to pinned or unpinned volumes.
+	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine's time.
 	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
+	//  - in: query
+	//    name: includePinned
+	//    type: boolean
+	//    description: include pinned volumes in the prune operation
 	// responses:
 	//   '200':
 	//      "$ref": "#/responses/volumePruneResponse"

--- a/pkg/bindings/system/types.go
+++ b/pkg/bindings/system/types.go
@@ -14,11 +14,12 @@ type EventsOptions struct {
 //
 //go:generate go run ../generator/generator.go PruneOptions
 type PruneOptions struct {
-	All      *bool
-	Filters  map[string][]string
-	Volumes  *bool
-	External *bool
-	Build    *bool
+	All           *bool
+	Filters       map[string][]string
+	Volumes       *bool
+	External      *bool
+	Build         *bool
+	IncludePinned *bool `schema:"includePinned"`
 }
 
 // VersionOptions are optional options for getting version info

--- a/pkg/bindings/system/types_params_test.go
+++ b/pkg/bindings/system/types_params_test.go
@@ -1,0 +1,14 @@
+package system
+
+import "testing"
+
+func TestPruneOptionsSerializeIncludePinned(t *testing.T) {
+	params, err := new(PruneOptions).WithIncludePinned(true).ToParams()
+	if err != nil {
+		t.Fatalf("serializing prune options: %v", err)
+	}
+
+	if got := params.Get("includePinned"); got != "true" {
+		t.Fatalf("expected includePinned=true, got %q", got)
+	}
+}

--- a/pkg/bindings/system/types_prune_options.go
+++ b/pkg/bindings/system/types_prune_options.go
@@ -91,3 +91,18 @@ func (o *PruneOptions) GetBuild() bool {
 	}
 	return *o.Build
 }
+
+// WithIncludePinned set field IncludePinned to given value
+func (o *PruneOptions) WithIncludePinned(value bool) *PruneOptions {
+	o.IncludePinned = &value
+	return o
+}
+
+// GetIncludePinned returns value of field IncludePinned
+func (o *PruneOptions) GetIncludePinned() bool {
+	if o.IncludePinned == nil {
+		var z bool
+		return z
+	}
+	return *o.IncludePinned
+}

--- a/pkg/bindings/volumes/types.go
+++ b/pkg/bindings/volumes/types.go
@@ -24,6 +24,8 @@ type ListOptions struct {
 type PruneOptions struct {
 	// Filters applied to the pruning of volumes
 	Filters map[string][]string
+	// IncludePinned includes pinned volumes in pruning
+	IncludePinned *bool `schema:"includePinned"`
 }
 
 // RemoveOptions are optional options for removing volumes
@@ -33,6 +35,8 @@ type RemoveOptions struct {
 	// Force removes the volume even if it is being used
 	Force   *bool
 	Timeout *uint
+	// IncludePinned includes pinned volumes for removal
+	IncludePinned *bool `schema:"includePinned"`
 }
 
 // ExistsOptions are optional options for checking

--- a/pkg/bindings/volumes/types_params_test.go
+++ b/pkg/bindings/volumes/types_params_test.go
@@ -1,0 +1,25 @@
+package volumes
+
+import "testing"
+
+func TestPruneOptionsSerializeIncludePinned(t *testing.T) {
+	params, err := new(PruneOptions).WithIncludePinned(true).ToParams()
+	if err != nil {
+		t.Fatalf("serializing prune options: %v", err)
+	}
+
+	if got := params.Get("includePinned"); got != "true" {
+		t.Fatalf("expected includePinned=true, got %q", got)
+	}
+}
+
+func TestRemoveOptionsSerializeIncludePinned(t *testing.T) {
+	params, err := new(RemoveOptions).WithIncludePinned(true).ToParams()
+	if err != nil {
+		t.Fatalf("serializing remove options: %v", err)
+	}
+
+	if got := params.Get("includePinned"); got != "true" {
+		t.Fatalf("expected includePinned=true, got %q", got)
+	}
+}

--- a/pkg/bindings/volumes/types_prune_options.go
+++ b/pkg/bindings/volumes/types_prune_options.go
@@ -31,3 +31,18 @@ func (o *PruneOptions) GetFilters() map[string][]string {
 	}
 	return o.Filters
 }
+
+// WithIncludePinned set field IncludePinned to given value
+func (o *PruneOptions) WithIncludePinned(value bool) *PruneOptions {
+	o.IncludePinned = &value
+	return o
+}
+
+// GetIncludePinned returns value of field IncludePinned
+func (o *PruneOptions) GetIncludePinned() bool {
+	if o.IncludePinned == nil {
+		var z bool
+		return z
+	}
+	return *o.IncludePinned
+}

--- a/pkg/bindings/volumes/types_remove_options.go
+++ b/pkg/bindings/volumes/types_remove_options.go
@@ -46,3 +46,18 @@ func (o *RemoveOptions) GetTimeout() uint {
 	}
 	return *o.Timeout
 }
+
+// WithIncludePinned set field IncludePinned to given value
+func (o *RemoveOptions) WithIncludePinned(value bool) *RemoveOptions {
+	o.IncludePinned = &value
+	return o
+}
+
+// GetIncludePinned returns value of field IncludePinned
+func (o *RemoveOptions) GetIncludePinned() bool {
+	if o.IncludePinned == nil {
+		var z bool
+		return z
+	}
+	return *o.IncludePinned
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -50,7 +50,6 @@ type ContainerEngine interface { //nolint:interfacebloat
 	ContainerStat(ctx context.Context, nameOrDir string, path string) (*ContainerStatReport, error)
 	ContainerStats(ctx context.Context, namesOrIds []string, options ContainerStatsOptions) (chan ContainerStatsReport, error)
 	ContainerStop(ctx context.Context, namesOrIds []string, options StopOptions) ([]*StopReport, error)
-	ContainerStopService(ctx context.Context, namesOrIds []string, options StopOptions) ([]*StopReport, error)
 	ContainerTop(ctx context.Context, options TopOptions) (*StringSliceReport, error)
 	ContainerUnmount(ctx context.Context, nameOrIDs []string, options ContainerUnmountOptions) ([]*ContainerUnmountReport, error)
 	ContainerUnpause(ctx context.Context, namesOrIds []string, options PauseUnPauseOptions) ([]*PauseUnpauseReport, error)
@@ -101,7 +100,7 @@ type ContainerEngine interface { //nolint:interfacebloat
 	QuadletPrint(ctx context.Context, quadlet string) (string, error)
 	QuadletRemove(ctx context.Context, quadlets []string, options QuadletRemoveOptions) (*QuadletRemoveReport, error)
 	Renumber(ctx context.Context) error
-	Reset(ctx context.Context) error
+	Reset(ctx context.Context, options SystemResetOptions) error
 	SetupRootless(ctx context.Context, noMoveProcess bool, cgroupMode string) error
 	SecretCreate(ctx context.Context, name string, reader io.Reader, options SecretCreateOptions) (*SecretCreateReport, error)
 	SecretInspect(ctx context.Context, nameOrIDs []string, options SecretInspectOptions) ([]*SecretInfoReport, []error, error)
@@ -125,4 +124,5 @@ type ContainerEngine interface { //nolint:interfacebloat
 	VolumeReload(ctx context.Context) (*VolumeReloadReport, error)
 	VolumeExport(ctx context.Context, nameOrID string, options VolumeExportOptions) error
 	VolumeImport(ctx context.Context, nameOrID string, options VolumeImportOptions) error
+	VolumePin(ctx context.Context, namesOrIds []string, opts VolumePinOptions) ([]*VolumePinReport, error)
 }

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -10,6 +10,7 @@ type (
 	SystemPruneOptions      = types.SystemPruneOptions
 	SystemPruneReport       = types.SystemPruneReport
 	SystemMigrateOptions    = types.SystemMigrateOptions
+	SystemResetOptions      = types.SystemResetOptions
 	SystemCheckOptions      = types.SystemCheckOptions
 	SystemCheckReport       = types.SystemCheckReport
 	SystemDfOptions         = types.SystemDfOptions

--- a/pkg/domain/entities/types/system.go
+++ b/pkg/domain/entities/types/system.go
@@ -42,11 +42,18 @@ type SystemCheckReport struct {
 
 // SystemPruneOptions provides options to prune system.
 type SystemPruneOptions struct {
-	All      bool
-	Volume   bool
-	Filters  map[string][]string `json:"filters" schema:"filters"`
-	External bool
-	Build    bool
+	All                bool
+	Volume             bool
+	Filters            map[string][]string `json:"filters" schema:"filters"`
+	External           bool
+	Build              bool
+	VolumePruneOptions VolumePruneOptions `json:"volumePruneOptions" schema:"volumePruneOptions"`
+}
+
+// VolumePruneOptions describes the options needed
+// to prune a volume from the CLI
+type VolumePruneOptions struct {
+	IncludePinned bool `json:"includePinned" schema:"includePinned"`
 }
 
 // SystemPruneReport provides report after system prune is executed.
@@ -63,6 +70,11 @@ type SystemPruneReport struct {
 // cli to migrate runtimes of containers
 type SystemMigrateOptions struct {
 	NewRuntime string
+}
+
+// SystemResetOptions describes the options for resetting system storage
+type SystemResetOptions struct {
+	IncludePinned bool
 }
 
 // SystemDfOptions describes the options for getting df information

--- a/pkg/domain/entities/types/volumes.go
+++ b/pkg/domain/entities/types/volumes.go
@@ -22,6 +22,11 @@ type VolumeCreateOptions struct {
 	UID *int `schema:"uid"`
 	// GID that the volume will be created as
 	GID *int `schema:"gid"`
+// Pinned indicates that this volume should be excluded from
+// volume prune, volume rm, system prune, and reset operations.
+// This allows atomically creating and pinning a volume to avoid
+// race conditions.
+Pinned bool `schema:"pinned"`
 }
 
 type VolumeRmReport struct {

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -13,22 +13,22 @@ type VolumeCreateOptions = types.VolumeCreateOptions
 type VolumeConfigResponse = types.VolumeConfigResponse
 
 type VolumeRmOptions struct {
-	All     bool
-	Force   bool
-	Ignore  bool
-	Timeout *uint
+	All           bool
+	Force         bool
+	Ignore        bool
+	Timeout       *uint
+	IncludePinned bool
 }
 
 type VolumeRmReport = types.VolumeRmReport
 
 type VolumeInspectReport = types.VolumeInspectReport
 
-// VolumePruneOptions describes the options needed to prune volumes.
-// Behavior is determined only by filters (Docker API 1.42+):
-// - when filter "all" is not set or not truthy, only anonymous unused volumes are pruned (default);
-// - when filter "all" is true, all unused volumes are pruned.
+// VolumePruneOptions describes the options needed
+// to prune a volume from the CLI
 type VolumePruneOptions struct {
-	Filters url.Values `json:"filters" schema:"filters"`
+	Filters       url.Values `json:"filters" schema:"filters"`
+	IncludePinned bool       `json:"includePinned" schema:"includePinned"`
 }
 
 type VolumeListOptions struct {
@@ -55,4 +55,15 @@ type VolumeExportOptions struct {
 type VolumeImportOptions struct {
 	// Input will be closed upon being fully consumed
 	Input io.Reader
+}
+
+// VolumePinOptions describes the options for pinning/unpinning volumes
+type VolumePinOptions struct {
+	Unpin bool
+}
+
+// VolumePinReport describes the response from pinning/unpinning a volume
+type VolumePinReport struct {
+	Id  string
+	Err error
 }

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -52,6 +52,31 @@ func GenerateVolumeFilters(filter string, filterValues []string, runtime *libpod
 		}, nil
 	case "until":
 		return createUntilFilterVolumeFunction(filterValues)
+	case "pinned":
+		for _, val := range filterValues {
+			switch strings.ToLower(val) {
+			case "true", "1", "false", "0":
+			default:
+				return nil, fmt.Errorf("%q is not a valid value for the \"pinned\" filter - must be true or false", val)
+			}
+		}
+		return func(v *libpod.Volume) bool {
+			for _, val := range filterValues {
+				pinned := v.IsPinned()
+
+				switch strings.ToLower(val) {
+				case "true", "1":
+					if pinned {
+						return true
+					}
+				case "false", "0":
+					if !pinned {
+						return true
+					}
+				}
+			}
+			return false
+		}, nil
 	case "dangling":
 		for _, val := range filterValues {
 			switch strings.ToLower(val) {
@@ -93,8 +118,6 @@ func GeneratePruneVolumeFilters(filter string, filterValues []string, runtime *l
 	switch filter {
 	case "after", "since":
 		return createAfterFilterVolumeFunction(filterValues, runtime)
-	case "anonymous":
-		return createAnonymousFilterVolumeFunction(filterValues)
 	case "label":
 		return func(v *libpod.Volume) bool {
 			return filters.MatchLabelFilters(filterValues, v.Labels())
@@ -105,6 +128,33 @@ func GeneratePruneVolumeFilters(filter string, filterValues []string, runtime *l
 		}, nil
 	case "until":
 		return createUntilFilterVolumeFunction(filterValues)
+	case "anonymous":
+		return createAnonymousFilterVolumeFunction(filterValues)
+	case "pinned":
+		for _, val := range filterValues {
+			switch strings.ToLower(val) {
+			case "true", "1", "false", "0":
+			default:
+				return nil, fmt.Errorf("%q is not a valid value for the \"pinned\" filter - must be true or false", val)
+			}
+		}
+		return func(v *libpod.Volume) bool {
+			for _, val := range filterValues {
+				pinned := v.IsPinned()
+
+				switch strings.ToLower(val) {
+				case "true", "1":
+					if pinned {
+						return true
+					}
+				case "false", "0":
+					if !pinned {
+						return true
+					}
+				}
+			}
+			return false
+		}, nil
 	}
 	return nil, fmt.Errorf("%q is an invalid volume filter", filter)
 }

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1424,8 +1424,12 @@ func (ic *ContainerEngine) playKubePVC(ctx context.Context, mountLabel string, p
 		err = ic.importVolume(ctx, vol, tarFile)
 		if err != nil {
 			// Remove the volume to avoid partial success
-			if rmErr := ic.Libpod.RemoveVolume(ctx, vol, true, nil); rmErr != nil {
-				logrus.Debug(rmErr)
+			if rmErr := ic.Libpod.RemoveVolumeWithOptions(ctx, vol, true, nil, true); rmErr != nil {
+				if errors.Is(rmErr, define.ErrVolumePinned) {
+					logrus.Warnf("Could not clean up partially imported volume %s: volume is pinned", vol.Name())
+				} else {
+					logrus.Debug(rmErr)
+				}
 			}
 			return nil, err
 		}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -158,12 +158,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 
 		// Remove unused volume data.
 		if options.Volume {
-			volumePruneOptions := entities.VolumePruneOptions{}
-			volumePruneOptions.Filters = (url.Values)(options.Filters)
-
-			if len(volumePruneOptions.Filters) == 0 {
-				volumePruneOptions.Filters.Set("all", "true")
-			}
+			volumePruneOptions := volumePruneOptionsFromSystemPruneOptions(options)
 
 			volumePruneReports, err := ic.VolumePrune(ctx, volumePruneOptions)
 			if err != nil {
@@ -180,6 +175,13 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 
 	systemPruneReport.ReclaimedSpace = reclaimedSpace
 	return systemPruneReport, nil
+}
+
+func volumePruneOptionsFromSystemPruneOptions(options entities.SystemPruneOptions) entities.VolumePruneOptions {
+	return entities.VolumePruneOptions{
+		Filters:       (url.Values)(options.Filters),
+		IncludePinned: options.VolumePruneOptions.IncludePinned,
+	}
 }
 
 func (ic *ContainerEngine) SystemDf(ctx context.Context, _ entities.SystemDfOptions) (*entities.SystemDfReport, error) {
@@ -300,8 +302,8 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, _ entities.SystemDfOpti
 	}, nil
 }
 
-func (ic *ContainerEngine) Reset(ctx context.Context) error {
-	return ic.Libpod.Reset(ctx)
+func (ic *ContainerEngine) Reset(ctx context.Context, options entities.SystemResetOptions) error {
+	return ic.Libpod.Reset(ctx, options.IncludePinned)
 }
 
 func (ic *ContainerEngine) Renumber(_ context.Context) error {

--- a/pkg/domain/infra/abi/system_test.go
+++ b/pkg/domain/infra/abi/system_test.go
@@ -1,0 +1,29 @@
+//go:build !remote && (linux || freebsd)
+
+package abi
+
+import (
+	"testing"
+
+	"github.com/containers/podman/v6/pkg/domain/entities"
+)
+
+func TestVolumePruneOptionsFromSystemPruneOptionsIncludesPinned(t *testing.T) {
+	filters := map[string][]string{
+		"label": {"keep=true"},
+	}
+	systemPruneOptions := entities.SystemPruneOptions{
+		Filters: filters,
+	}
+	systemPruneOptions.VolumePruneOptions.IncludePinned = true
+
+	volumePruneOptions := volumePruneOptionsFromSystemPruneOptions(systemPruneOptions)
+
+	if !volumePruneOptions.IncludePinned {
+		t.Fatalf("expected IncludePinned to be propagated")
+	}
+
+	if got := volumePruneOptions.Filters.Get("label"); got != "keep=true" {
+		t.Fatalf("expected label filter to be propagated, got %q", got)
+	}
+}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -14,15 +14,12 @@ import (
 	"github.com/containers/podman/v6/pkg/domain/entities/reports"
 	"github.com/containers/podman/v6/pkg/domain/filters"
 	"github.com/containers/podman/v6/pkg/domain/infra/abi/parse"
-	"github.com/containers/podman/v6/pkg/util"
 )
 
 func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
 	var volumeOptions []libpod.VolumeCreateOption
 	if len(opts.Name) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeName(opts.Name))
-	} else {
-		volumeOptions = append(volumeOptions, libpod.WithVolumeAnonymous())
 	}
 	if len(opts.Driver) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeDriver(opts.Driver))
@@ -48,11 +45,15 @@ func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.Volum
 	if opts.GID != nil {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeGID(*opts.GID), libpod.WithVolumeNoChown())
 	}
+	if opts.Pinned {
+		volumeOptions = append(volumeOptions, libpod.WithVolumePinned())
+	}
 
 	vol, err := ic.Libpod.NewVolume(ctx, volumeOptions...)
 	if err != nil {
 		return nil, err
 	}
+
 	return &entities.IDOrNameResponse{IDOrName: vol.Name()}, nil
 }
 
@@ -86,7 +87,7 @@ func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, op
 	}
 	for _, vol := range vols {
 		reports = append(reports, &entities.VolumeRmReport{
-			Err: ic.Libpod.RemoveVolume(ctx, vol, opts.Force, opts.Timeout),
+			Err: ic.Libpod.RemoveVolumeWithOptions(ctx, vol, opts.Force, opts.Timeout, opts.IncludePinned),
 			Id:  vol.Name(),
 		})
 	}
@@ -137,18 +138,19 @@ func (ic *ContainerEngine) VolumeInspect(_ context.Context, namesOrIds []string,
 
 func (ic *ContainerEngine) VolumePrune(ctx context.Context, options entities.VolumePruneOptions) ([]*reports.PruneReport, error) {
 	funcs := []libpod.VolumeFilter{}
-	for filter, filterValues := range util.NormalizeVolumePruneFilters(options.Filters) {
+	for filter, filterValues := range options.Filters {
 		filterFunc, err := filters.GenerateVolumeFilters(filter, filterValues, ic.Libpod)
 		if err != nil {
 			return nil, err
 		}
 		funcs = append(funcs, filterFunc)
 	}
-	return ic.pruneVolumesHelper(ctx, funcs)
+	return ic.pruneVolumesHelper(ctx, funcs, options.IncludePinned)
 }
 
-func (ic *ContainerEngine) pruneVolumesHelper(ctx context.Context, filterFuncs []libpod.VolumeFilter) ([]*reports.PruneReport, error) {
-	pruned, err := ic.Libpod.PruneVolumes(ctx, filterFuncs)
+// pruneVolumesHelper applies volume prune filters and includePinned behavior.
+func (ic *ContainerEngine) pruneVolumesHelper(ctx context.Context, filterFuncs []libpod.VolumeFilter, includePinned bool) ([]*reports.PruneReport, error) {
+	pruned, err := ic.Libpod.PruneVolumesWithOptions(ctx, filterFuncs, includePinned)
 	if err != nil {
 		return nil, err
 	}
@@ -266,6 +268,26 @@ func (ic *ContainerEngine) VolumeExport(_ context.Context, nameOrID string, opti
 	}
 
 	return nil
+}
+
+// VolumePin pins or unpins the given volumes based on opts.Unpin.
+func (ic *ContainerEngine) VolumePin(_ context.Context, namesOrIds []string, opts entities.VolumePinOptions) ([]*entities.VolumePinReport, error) {
+	reports := make([]*entities.VolumePinReport, 0, len(namesOrIds))
+
+	for _, nameOrId := range namesOrIds {
+		report := &entities.VolumePinReport{Id: nameOrId}
+
+		vol, err := ic.Libpod.LookupVolume(nameOrId)
+		if err != nil {
+			report.Err = err
+		} else {
+			report.Err = vol.SetPinned(!opts.Unpin)
+		}
+
+		reports = append(reports, report)
+	}
+
+	return reports, nil
 }
 
 func (ic *ContainerEngine) VolumeImport(_ context.Context, nameOrID string, options entities.VolumeImportOptions) error {

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -19,7 +19,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, _ bool, _ string) er
 
 // SystemPrune prunes unused data from the system.
 func (ic *ContainerEngine) SystemPrune(_ context.Context, opts entities.SystemPruneOptions) (*entities.SystemPruneReport, error) {
-	options := new(system.PruneOptions).WithAll(opts.All).WithVolumes(opts.Volume).WithFilters(opts.Filters).WithExternal(opts.External).WithBuild(opts.Build)
+	options := new(system.PruneOptions).WithAll(opts.All).WithVolumes(opts.Volume).WithFilters(opts.Filters).WithExternal(opts.External).WithBuild(opts.Build).WithIncludePinned(opts.VolumePruneOptions.IncludePinned)
 	return system.Prune(ic.ClientCtx, options)
 }
 
@@ -40,7 +40,7 @@ func (ic *ContainerEngine) Renumber(_ context.Context) error {
 	return errors.New("lock renumbering is not supported on remote clients")
 }
 
-func (ic *ContainerEngine) Reset(_ context.Context) error {
+func (ic *ContainerEngine) Reset(_ context.Context, _ entities.SystemResetOptions) error {
 	return errors.New("system reset is not supported on remote clients")
 }
 

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -31,7 +31,7 @@ func (ic *ContainerEngine) VolumeRm(_ context.Context, namesOrIds []string, opts
 	}
 	reports := make([]*entities.VolumeRmReport, 0, len(namesOrIds))
 	for _, id := range namesOrIds {
-		options := new(volumes.RemoveOptions).WithForce(opts.Force)
+		options := new(volumes.RemoveOptions).WithForce(opts.Force).WithIncludePinned(opts.IncludePinned)
 		if opts.Timeout != nil {
 			options = options.WithTimeout(*opts.Timeout)
 		}
@@ -76,7 +76,7 @@ func (ic *ContainerEngine) VolumeInspect(_ context.Context, namesOrIds []string,
 }
 
 func (ic *ContainerEngine) VolumePrune(_ context.Context, opts entities.VolumePruneOptions) ([]*reports.PruneReport, error) {
-	options := new(volumes.PruneOptions).WithFilters(opts.Filters)
+	options := new(volumes.PruneOptions).WithFilters(opts.Filters).WithIncludePinned(opts.IncludePinned)
 	return volumes.Prune(ic.ClientCtx, options)
 }
 
@@ -120,4 +120,16 @@ func (ic *ContainerEngine) VolumeExport(_ context.Context, nameOrID string, opti
 
 func (ic *ContainerEngine) VolumeImport(_ context.Context, nameOrID string, options entities.VolumeImportOptions) error {
 	return volumes.Import(ic.ClientCtx, nameOrID, options.Input)
+}
+
+func (ic *ContainerEngine) VolumePin(_ context.Context, namesOrIds []string, _ entities.VolumePinOptions) ([]*entities.VolumePinReport, error) {
+	reports := make([]*entities.VolumePinReport, 0, len(namesOrIds))
+	for _, nameOrId := range namesOrIds {
+		report := &entities.VolumePinReport{
+			Id:  nameOrId,
+			Err: errors.New("volume pinning is not supported for remote clients"),
+		}
+		reports = append(reports, report)
+	}
+	return reports, nil
 }

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -41,6 +41,19 @@ var _ = Describe("Podman volume create", func() {
 		Expect(check.OutputToStringArray()).To(HaveLen(1))
 	})
 
+	It("podman create pinned volume", func() {
+		volName := "pinned-vol"
+		session := podmanTest.Podman([]string{"volume", "create", "--pinned", volName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal(volName))
+
+		inspect := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .Pinned }}", volName})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		Expect(inspect.OutputToString()).To(Equal("true"))
+	})
+
 	It("podman create volume with existing name fails", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
@@ -247,9 +260,9 @@ var _ = Describe("Podman volume create", func() {
 	})
 
 	It("image-backed volume basic functionality", func() {
-		podmanTest.AddImageToRWStore(FEDORA_MINIMAL)
+		podmanTest.AddImageToRWStore(fedoraMinimal)
 		volName := "testvol"
-		volCreate := podmanTest.Podman([]string{"volume", "create", "--driver", "image", "--opt", fmt.Sprintf("image=%s", FEDORA_MINIMAL), volName})
+		volCreate := podmanTest.Podman([]string{"volume", "create", "--driver", "image", "--opt", fmt.Sprintf("image=%s", fedoraMinimal), volName})
 		volCreate.WaitWithDefaultTimeout()
 		Expect(volCreate).Should(ExitCleanly())
 
@@ -258,7 +271,7 @@ var _ = Describe("Podman volume create", func() {
 		Expect(runCmd).Should(ExitCleanly())
 		Expect(runCmd.OutputToString()).To(ContainSubstring("Fedora"))
 
-		rmCmd := podmanTest.Podman([]string{"rmi", "--force", FEDORA_MINIMAL})
+		rmCmd := podmanTest.Podman([]string{"rmi", "--force", fedoraMinimal})
 		rmCmd.WaitWithDefaultTimeout()
 		Expect(rmCmd).Should(ExitCleanly())
 
@@ -274,9 +287,9 @@ var _ = Describe("Podman volume create", func() {
 	})
 
 	It("image-backed volume force removal", func() {
-		podmanTest.AddImageToRWStore(FEDORA_MINIMAL)
+		podmanTest.AddImageToRWStore(fedoraMinimal)
 		volName := "testvol"
-		volCreate := podmanTest.Podman([]string{"volume", "create", "--driver", "image", "--opt", fmt.Sprintf("image=%s", FEDORA_MINIMAL), volName})
+		volCreate := podmanTest.Podman([]string{"volume", "create", "--driver", "image", "--opt", fmt.Sprintf("image=%s", fedoraMinimal), volName})
 		volCreate.WaitWithDefaultTimeout()
 		Expect(volCreate).Should(ExitCleanly())
 

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	. "github.com/containers/podman/v6/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,103 +13,187 @@ var _ = Describe("Podman volume prune", func() {
 		podmanTest.CleanupVolume()
 	})
 
-	It("podman prune volume -a removes all unused volumes", func() {
-		podmanTest.PodmanExitCleanly("volume", "create")
-		podmanTest.PodmanExitCleanly("volume", "create")
-		podmanTest.PodmanExitCleanly("create", "-v", "myvol:/myvol", ALPINE, "ls")
+	It("podman prune volume", func() {
+		session := podmanTest.Podman([]string{"volume", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session := podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "-a", "--force")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
-	It("podman volume prune", func() {
-		session := podmanTest.PodmanExitCleanly("create", "-v", "/anon", ALPINE, "top")
-		podmanTest.PodmanExitCleanly("rm", session.OutputToString())
+	It("podman volume prune excludes pinned volumes by default", func() {
+		pinnedVolName := "pinned-prune-vol"
+		unpinnedVolName := "unpinned-prune-vol"
 
-		podmanTest.PodmanExitCleanly("volume", "create", "named_vol")
+		session := podmanTest.Podman([]string{"volume", "create", "--pinned", pinnedVolName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
-		Expect(session.OutputToStringArray()).To(HaveLen(3))
+		session = podmanTest.Podman([]string{"volume", "create", unpinnedVolName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
-		Expect(session.OutputToStringArray()).To(HaveLen(2))
-		Expect(session.OutputToString()).To(ContainSubstring("named_vol"))
-	})
+		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(ContainElement(pinnedVolName))
+		Expect(session.OutputToStringArray()).To(Not(ContainElement(unpinnedVolName)))
 
-	It("podman volume prune --filter all=true removes all unused volumes", func() {
-		podmanTest.PodmanExitCleanly("volume", "create", "prune_filter_all_test")
-		podmanTest.PodmanExitCleanly("volume", "prune", "--filter", "all=true", "--force")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--include-pinned"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session := podmanTest.PodmanExitCleanly("volume", "ls")
-		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(Not(ContainElement(pinnedVolName)))
 	})
 
 	It("podman prune volume --filter until", func() {
-		podmanTest.PodmanExitCleanly("volume", "create", "--label", "label1=value1", "myvol1")
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session := podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "until=50")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=50"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "until=5000000000")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=5000000000"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 	})
 
 	It("podman prune volume --filter", func() {
-		podmanTest.PodmanExitCleanly("volume", "create", "--label", "label1=value1", "myvol1")
-		podmanTest.PodmanExitCleanly("volume", "create", "--label", "sharedlabel1=slv1", "myvol2")
-		podmanTest.PodmanExitCleanly("volume", "create", "--label", "sharedlabel1=slv2", "myvol3")
-		podmanTest.PodmanExitCleanly("volume", "create", "--label", "sharedlabel1", "myvol4")
-		podmanTest.PodmanExitCleanly("create", "-v", "myvol5:/myvol5", ALPINE, "ls")
-		podmanTest.PodmanExitCleanly("create", "-v", "myvol6:/myvol6", ALPINE, "ls")
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session := podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv1", "myvol2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv2", "myvol3"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1", "myvol4"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"create", "-v", "myvol5:/myvol5", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"create", "-v", "myvol6:/myvol6", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(7))
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label=label1=value1")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=label1=value1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(6))
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label=sharedlabel1=slv1")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1=slv1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(5))
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label=sharedlabel1")
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(3))
 
-		podmanTest.PodmanExitCleanly("volume", "create", "--label", "testlabel", "myvol7")
-		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label!=testlabel")
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "testlabel", "myvol7"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label!=testlabel"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 	})
 
 	It("podman system prune --volume", func() {
 		useCustomNetworkDir(podmanTest, tempdir)
-		podmanTest.PodmanExitCleanly("volume", "create")
-		podmanTest.PodmanExitCleanly("volume", "create")
-		podmanTest.PodmanExitCleanly("create", "-v", "myvol:/myvol", ALPINE, "ls")
+		session := podmanTest.Podman([]string{"volume", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session := podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
-		podmanTest.PodmanExitCleanly("system", "prune", "--force", "--volumes")
+		session = podmanTest.Podman([]string{"system", "prune", "--force", "--volumes"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 	})
 
@@ -117,13 +202,24 @@ var _ = Describe("Podman volume prune", func() {
 		vol2 := "vol2"
 		vol3 := "vol3"
 
-		podmanTest.PodmanExitCleanly("volume", "create", vol1)
-		podmanTest.PodmanExitCleanly("volume", "create", vol2)
-		podmanTest.PodmanExitCleanly("volume", "create", vol3)
+		session := podmanTest.Podman([]string{"volume", "create", vol1})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitCleanly())
 
-		podmanTest.PodmanExitCleanly("volume", "prune", "-f", "--filter", "since="+vol1)
+		session = podmanTest.Podman([]string{"volume", "create", vol2})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitCleanly())
 
-		session := podmanTest.PodmanExitCleanly("volume", "ls", "-q")
+		session = podmanTest.Podman([]string{"volume", "create", vol3})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "prune", "-f", "--filter", "since=" + vol1})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
+		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol1))
 	})

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -119,4 +119,19 @@ var _ = Describe("Podman volume rm", func() {
 		podmanTest.PodmanExitCleanly("volume", "rm", volNames[0])
 		podmanTest.PodmanExitCleanly("volume", "rm", volNames[2])
 	})
+
+	It("podman volume rm requires --include-pinned for pinned volumes", func() {
+		volName := "pinned-rm-vol"
+		session := podmanTest.Podman([]string{"volume", "create", "--pinned", volName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"volume", "rm", volName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError(125, fmt.Sprintf("volume %s is pinned and cannot be removed without --include-pinned flag", volName)))
+
+		session = podmanTest.Podman([]string{"volume", "rm", "--include-pinned", volName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+	})
 })


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes.

```release-note
* Added `--pinned` flag to `volume create` to create pinned volumes
* Added new `volume pin` commands to pin/unpin existing volumes
* Added `--include-pinned` flag to `volume rm` to allow removing pinned volumes
* Added pinned volume filtering support
* Added support for pinned volumes in `system prune` command
* Added HTTP API and ABI support for volume pinning
* Added runtime methods for handling pinned volumes and pruning
```

#### References
Reference https://github.com/containers/podman/issues/26807
Reference https://github.com/containers/podman/issues/23217

#### Actions required
- This is just the first step to demonstrate the function. Things like tunnel/remote implementation are still missing (it's just a stub).
- It needs to be discussed if we want to overload the CLI with `volume unpin` or rather use `volume pin --unpin` as supplied.

#### Note
Those are my first steps with the Podman code - please bear with me.