### PR TITLE
Configurable GINKGOTIMEOUT in `winmake.ps1`

### DIFF
--- a/winmake.ps1
+++ b/winmake.ps1
@@ -69,7 +69,8 @@ function Local-Unit {
     $skippackages+="pkg\domain\infra\abi,pkg\emulation,pkg\machine\apple,pkg\machine\applehv,pkg\machine\e2e,pkg\machine\libkrun,"
     $skippackages+="pkg\machine\provider,pkg\machine\proxyenv,pkg\machine\qemu,pkg\specgen\generate,pkg\systemd,test\e2e,test\utils,cmd\rootlessport,"
     $skippackages+="pkg\pidhandle"
-    Run-Command "./bin/ginkgo.exe -vv -r --tags `"$remotetags`" --timeout=15m --trace --no-color --skip-package `"$skippackages`""
+    if ($null -eq $ENV:GINKGOTIMEOUT) { $ENV:GINKGOTIMEOUT = '--timeout=15m' }
+    Run-Command "./bin/ginkgo.exe -vv -r --tags `"$remotetags`" ${ENV:GINKGOTIMEOUT} --trace --no-color --skip-package `"$skippackages`""
 }
 
 function Local-Machine {
@@ -86,7 +87,8 @@ function Local-Machine {
         $focus = "--focus ""$FOCUS"" --silence-skips"
     }
 
-    Run-Command "./bin/ginkgo.exe -vv --tags `"$remotetags`" --timeout=50m --trace --no-color $focus $files pkg/machine/e2e/."
+    if ($null -eq $ENV:GINKGOTIMEOUT) { $ENV:GINKGOTIMEOUT = '--timeout=50m' }
+    Run-Command "./bin/ginkgo.exe -vv --tags `"$remotetags`" ${ENV:GINKGOTIMEOUT} --trace --no-color $focus $files pkg/machine/e2e/."
 }
 
 # Expect starting directory to be /podman


### PR DESCRIPTION
Fixes #26795 

Allows to override default timeout values for test runs.

I used the same logic as in https://github.com/containers/podman/blob/86747750394c6c1e57c440f76abcfb5c793ac78b/Makefile#L143 where the env variable is updated prior to use if it is not set by user.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
