### PR TITLE
ocs(run,create): document remote transport limitations for oci-archive/docker-archive/docker-daemon

### DIFF
--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -49,12 +49,14 @@ file, and it must not contain a digest.
 
     $ podman save --format docker-archive fedora -o /tmp/fedora
     $ podman create docker-archive:/tmp/fedora echo hello
+  Note: On remote clients, including Mac and Windows (excluding WSL2) machines, this transport is not supported.
 
   **docker-daemon:**_docker-reference_
   An image in _docker-reference_ format stored in the docker daemon internal storage. The _docker-reference_ can also be an image ID (docker-daemon:algo:digest).
 
     $ sudo docker pull fedora
     $ sudo podman create docker-daemon:docker.io/library/fedora echo hello
+  Note: On remote clients, including Mac and Windows (excluding WSL2) machines, this transport is not supported.
 
   **oci-archive:**_path_**:**_tag_
   An image in a directory compliant with the "Open Container Image Layout Specification" at the specified _path_
@@ -62,6 +64,7 @@ and specified with a _tag_.
 
     $ podman save --format oci-archive fedora -o /tmp/fedora
     $ podman create oci-archive:/tmp/fedora echo hello
+  Note: On remote clients, including Mac and Windows (excluding WSL2) machines, this transport is not supported.
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -69,12 +69,14 @@ file, and it must not contain a digest.
 
     $ podman save --format docker-archive fedora -o /tmp/fedora
     $ podman run docker-archive:/tmp/fedora echo hello
+  Note: On remote clients, including Mac and Windows (excluding WSL2) machines, this transport is not supported.
 
   **docker-daemon:**_docker-reference_
   An image in _docker-reference_ format stored in the docker daemon internal storage. The _docker-reference_ can also be an image ID (docker-daemon:algo:digest).
 
     $ sudo docker pull fedora
     $ sudo podman run docker-daemon:docker.io/library/fedora echo hello
+  Note: On remote clients, including Mac and Windows (excluding WSL2) machines, this transport is not supported.
 
   **oci-archive:**_path_**:**_tag_
   An image in a directory compliant with the "Open Container Image Layout Specification" at the specified _path_
@@ -82,6 +84,7 @@ and specified with a _tag_.
 
     $ podman save --format oci-archive fedora -o /tmp/fedora
     $ podman run oci-archive:/tmp/fedora echo hello
+  Note: On remote clients, including Mac and Windows (excluding WSL2) machines, this transport is not supported.
 
 ## OPTIONS
 @@option add-host


### PR DESCRIPTION
Document that on remote clients (incl. Mac/Windows, excluding WSL2) file-based transports oci-archive:, docker-archive:, and docker-daemon


Fixes : #24634
```release-note
None
```
