### PR TITLE
cirrus: fix podman machine windows only_if condition

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -817,7 +817,13 @@ podman_machine_windows_task:
     name: *std_name_fmt
     alias: podman_machine_windows
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *only_if_machine_test
+    # Duplicated from the main linux machine task as we also must match winmake.ps1 here since that is used on windows.
+    only_if: >-
+        $CIRRUS_PR == '' ||
+        $CIRRUS_CHANGE_TITLE =~ '.*CI:ALL.*' ||
+        changesInclude('.cirrus.yml', 'Makefile', 'contrib/cirrus/**', 'vendor/**', 'test/tools/**', 'test/registries*.conf', 'hack/**', 'version/rawversion/*') ||
+        changesInclude('winmake.ps1') ||
+        changesInclude('cmd/podman/machine/**', 'pkg/machine/**', '**/*machine*.go')
     # Special case, we do not run macos/windows builds on rhel branches.
     # Thus the machine task should not be run too, while we use only_if
     # everywhere to do so here it would mean we would need duplicate the


### PR DESCRIPTION
The winmake target is critical for the machine task as this is used to actually run the ginkgo command line. PR #26847 modified that line will not actually running the tests which means it is easy to break CI with this. Now the chnage of the PR was correct so it worked fine this time but for the future make sure we actually run the tests in such cases.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
