### PR TITLE
libimage: preserve ref.name when loading from oci-dir

### DIFF
--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -247,7 +247,8 @@ var _ = Describe("Podman load", func() {
 		load := podmanTest.Podman([]string{"load", "-q", "-i", outfile})
 		load.WaitWithDefaultTimeout()
 		Expect(load).Should(ExitCleanly())
-		Expect(load.OutputToString()).To(ContainSubstring("Loaded image: sha256:"))
+		// With preserved ref.name in oci-dir, the loaded image should report the original name
+		Expect(load.OutputToString()).To(ContainSubstring("Loaded image: localhost/hello:world"))
 	})
 
 	It("podman load xz compressed image", func() {


### PR DESCRIPTION
Fix oci-dir loads to read org.opencontainers.image.ref.name from index.json, aligning behavior with oci-archive. Previously, oci-dir loads defaulted to ID-only names.Remote behavior unchanged (remote does not support directory loads).

Update test/e2e/load_test.go to assert the loaded image name is preserved for oci-dir (“Loaded image: localhost/hello:world”).

fixes : #26850

```release-note
None
```
