### PR TITLE
windows: do not convert unconfined seccomp path

### DIFF
--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -44,7 +44,8 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(newImgs).To(Exit(0))
 		Expect(newImgs.outputToStringSlice()).To(HaveLen(1))
 
-		runAlp, err := mb.setCmd(bm.withPodmanCommand([]string{"run", TESTIMAGE, "cat", "/etc/os-release"})).run()
+		// seccomp option as regression test for https://github.com/containers/podman/issues/26855
+		runAlp, err := mb.setCmd(bm.withPodmanCommand([]string{"run", "--security-opt", "seccomp=unconfined", TESTIMAGE, "cat", "/etc/os-release"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runAlp).To(Exit(0))
 		Expect(runAlp.outputToString()).To(ContainSubstring("Alpine Linux"))

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -737,10 +737,15 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		case "proc-opts":
 			s.ProcOpts = strings.Split(val, ",")
 		case "seccomp":
-			convertedPath, err := specgen.ConvertWinMountPath(val)
-			if err != nil {
-				// If the conversion fails, use the original path
-				convertedPath = val
+			convertedPath := val
+			// Do not try to convert special value "unconfined",
+			// https://github.com/containers/podman/issues/26855
+			if val != "unconfined" {
+				convertedPath, err = specgen.ConvertWinMountPath(val)
+				if err != nil {
+					// If the conversion fails, use the original path
+					convertedPath = val
+				}
 			}
 			s.SeccompProfilePath = convertedPath
 			s.Annotations[define.InspectAnnotationSeccomp] = convertedPath

--- a/pkg/specgenutil/specgenutil_windows_test.go
+++ b/pkg/specgenutil/specgenutil_windows_test.go
@@ -32,6 +32,7 @@ func TestSeccompProfilePath(t *testing.T) {
 		{`c`, cwd_wsl + "/c"},
 		{`\\computer\loc`, `\\computer\loc`},
 		{`\\.\drive\loc`, "/mnt/wsl/drive/loc"},
+		{"unconfined", "unconfined"},
 	}
 
 	f := func(secopt string) (*specgen.SpecGenerator, error) {


### PR DESCRIPTION
unconfined is a special value and not a path as such it must not be converted otherwise --security-opt seccomp=unconfined fails as it tries to access a file called unconfined.

Fixes: 3e8b2d7d96 ("Fix seccomp profile path on Windows")
Fixes: #26855

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a regression in 5.6.0 which broke the `--security-opt seccomp=unconfined` option on windows. (#26855)
```
