### PR TITLE
Add default runtime flags in config

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -448,6 +448,12 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 	for _, arg := range podmanConfig.RuntimeFlags {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
 	}
+	configIndex := filepath.Base(podmanConfig.RuntimePath)
+	if len(runtimeFlags) == 0 {
+		for _, arg := range podmanConfig.ContainersConfDefaultsRO.Engine.OCIRuntimesFlags[configIndex] {
+			runtimeFlags = append(runtimeFlags, "--"+arg)
+		}
+	}
 	if podmanConfig.ContainersConf.Engine.CgroupManager == config.SystemdCgroupsManager {
 		runtimeFlags = append(runtimeFlags, "--systemd-cgroup")
 	}

--- a/docs/source/markdown/options/runtime-flag.md
+++ b/docs/source/markdown/options/runtime-flag.md
@@ -6,4 +6,6 @@
 
 Adds global flags for the container runtime. To list the supported flags, please consult the manpages of the selected container runtime.
 
+Default runtime flags can be added in containers.conf.
+
 Note: Do not pass the leading -- to the flag. To pass the runc flag --log-format json to buildah build, the option given is --runtime-flag log-format=json.

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -147,6 +147,8 @@ consult the manpages of the selected container runtime (`runc` is the default
 runtime, the manpage to consult is `runc(8)`.  When the machine is configured
 for cgroup V2, the default runtime is `crun`, the manpage to consult is `crun(8)`.).
 
+Default runtime flags can be added in containers.conf.
+
 Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to podman build, the option given can be `--runtime-flag log-format=json`.
 

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -93,6 +93,14 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 		supportsKVM[r] = true
 	}
 
+	configIndex := filepath.Base(name)
+
+	if len(runtimeFlags) == 0 {
+		for _, arg := range runtimeCfg.Engine.OCIRuntimesFlags[configIndex] {
+			runtimeFlags = append(runtimeFlags, "--"+arg)
+		}
+	}
+
 	runtime := new(ConmonOCIRuntime)
 	runtime.name = name
 	runtime.conmonPath = conmonPath
@@ -108,10 +116,9 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	// TODO: probe OCI runtime for feature and enable automatically if
 	// available.
 
-	base := filepath.Base(name)
-	runtime.supportsJSON = supportsJSON[base]
-	runtime.supportsNoCgroups = supportsNoCgroups[base]
-	runtime.supportsKVM = supportsKVM[base]
+	runtime.supportsJSON = supportsJSON[configIndex]
+	runtime.supportsNoCgroups = supportsNoCgroups[configIndex]
+	runtime.supportsKVM = supportsKVM[configIndex]
 
 	foundPath := false
 	for _, path := range paths {


### PR DESCRIPTION
Added a way to define default runtime flags in config.


Default runtime flags should be defined as shown below:
```
[engine.runtimes_flags]
runsc = [
  "net-raw",
]

crun = [
  "debug",
]
```
#### Fixes: https://github.com/containers/container-libs/issues/91


#### This PR depends on https://github.com/containers/container-libs/pull/281

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add Engine.runtimes_flags configuration option to containers.conf allowing users to specify default runtime flags for each runtime. Flags should be specified without '--' leading up to it.
```
