### PR TITLE
Add support for criu's tcp-close functionality.

### DIFF
--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -52,6 +52,7 @@ func init() {
 	flags.BoolVarP(&restoreOptions.All, "all", "a", false, "Restore all checkpointed containers")
 	flags.BoolVarP(&restoreOptions.Keep, "keep", "k", false, "Keep all temporary checkpoint files")
 	flags.BoolVar(&restoreOptions.TCPEstablished, "tcp-established", false, "Restore a container with established TCP connections")
+	flags.BoolVar(&restoreOptions.TCPClose, "tcp-close", false, "Restore a container and close all TCP connections")
 	flags.BoolVar(&restoreOptions.FileLocks, "file-locks", false, "Restore a container with file locks")
 
 	importFlagName := "import"

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -150,6 +150,14 @@ initial *container* start, with a new set of port forwarding rules.
 
 For more details, see **[podman run --publish](podman-run.1.md#--publish)**.
 
+#### **--tcp-close**
+
+Restore a *container* and close all TCP connections. This option is useful
+when TCP connections are not needed after restore or when connections
+will be reestablished by the application. If the checkpoint image was created with
+**--tcp-close**, this option should be used during restore.\
+The default is **false**.
+
 #### **--tcp-established**
 
 Restore a *container* with established TCP connections. If the checkpoint image

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -965,6 +965,8 @@ type ContainerCheckpointOptions struct {
 	// TCPEstablished tells the API to checkpoint a container
 	// even if it contains established TCP connections
 	TCPEstablished bool
+	// TCPClose tells the API to close all TCP connections during restore
+	TCPClose bool
 	// TargetFile tells the API to read (or write) the checkpoint image
 	// from (or to) the filename set in TargetFile
 	TargetFile string

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1082,6 +1082,9 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		if restoreOptions.TCPEstablished {
 			args = append(args, "--runtime-opt", "--tcp-established")
 		}
+		if restoreOptions.TCPClose {
+			args = append(args, "--runtime-opt", "--tcp-close")
+		}
 		if restoreOptions.FileLocks {
 			args = append(args, "--runtime-opt", "--file-locks")
 		}

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -307,6 +307,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		Keep            bool   `schema:"keep"`
 		TCPEstablished  bool   `schema:"tcpEstablished"`
+		TCPClose        bool   `schema:"tcpClose"`
 		Import          bool   `schema:"import"`
 		Name            string `schema:"name"`
 		IgnoreRootFS    bool   `schema:"ignoreRootFS"`
@@ -329,6 +330,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		Name:            query.Name,
 		Keep:            query.Keep,
 		TCPEstablished:  query.TCPEstablished,
+		TCPClose:        query.TCPClose,
 		IgnoreRootFS:    query.IgnoreRootFS,
 		IgnoreVolumes:   query.IgnoreVolumes,
 		IgnoreStaticIP:  query.IgnoreStaticIP,

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1636,7 +1636,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: tcpEstablished
 	//    type: boolean
-	//    description: checkpoint a container with established TCP connections
+	//    description: restore a container with established TCP connections
+	//  - in: query
+	//    name: tcpClose
+	//    type: boolean
+	//    description: restore a container but close the TCP connections
 	//  - in: query
 	//    name: import
 	//    type: boolean

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -83,6 +83,7 @@ type RestoreOptions struct {
 	Keep           *bool
 	Name           *string
 	TCPEstablished *bool
+	TCPClose       *bool
 	Pod            *string
 	PrintStats     *bool
 	PublishPorts   []string

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -152,6 +152,21 @@ func (o *RestoreOptions) GetTCPEstablished() bool {
 	return *o.TCPEstablished
 }
 
+// WithTCPClose set field TCPClose to given value
+func (o *RestoreOptions) WithTCPClose(value bool) *RestoreOptions {
+	o.TCPClose = &value
+	return o
+}
+
+// GetTCPClose returns value of field TCPClose
+func (o *RestoreOptions) GetTCPClose() bool {
+	if o.TCPClose == nil {
+		var z bool
+		return z
+	}
+	return *o.TCPClose
+}
+
 // WithPod set field Pod to given value
 func (o *RestoreOptions) WithPod(value string) *RestoreOptions {
 	o.Pod = &value

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -225,6 +225,7 @@ type RestoreOptions struct {
 	Latest          bool
 	Name            string
 	TCPEstablished  bool
+	TCPClose        bool
 	ImportPrevious  string
 	PublishPorts    []string
 	Pod             string

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -694,6 +694,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 	restoreOptions := libpod.ContainerCheckpointOptions{
 		Keep:            options.Keep,
 		TCPEstablished:  options.TCPEstablished,
+		TCPClose:        options.TCPClose,
 		TargetFile:      options.Import,
 		Name:            options.Name,
 		IgnoreRootfs:    options.IgnoreRootFS,

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -439,6 +439,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 	options.WithKeep(opts.Keep)
 	options.WithName(opts.Name)
 	options.WithTCPEstablished(opts.TCPEstablished)
+	options.WithTCPClose(opts.TCPClose)
 	options.WithPod(opts.Pod)
 	options.WithPrintStats(opts.PrintStats)
 	options.WithPublishPorts(opts.PublishPorts)


### PR DESCRIPTION
Fixes: #26676

#### Does this PR introduce a user-facing change?

```release-note
Add `--tcp-close` option to container restore to allow restoring multiple copies of a container with tcp connections
```

#### Related PR

[PR to enable --tcp-close in crun](https://github.com/containers/crun/pull/1835)
