### PR TITLE
fix: Correct order of setting up header fields for endpoint responses 

### DIFF
--- a/pkg/api/handlers/compat/containers_stats_linux.go
+++ b/pkg/api/handlers/compat/containers_stats_linux.go
@@ -55,8 +55,8 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 
 	coder := json.NewEncoder(w)
 	// Write header and content type.
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	if flusher, ok := w.(http.Flusher); ok {
 		flusher.Flush()
 	}

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -120,8 +120,8 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	statusWritten := false
 	writeStatusCode := func(code int) {
 		if !statusWritten {
-			w.WriteHeader(code)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
 			flush()
 			statusWritten = true
 		}

--- a/pkg/api/handlers/libpod/containers_stats.go
+++ b/pkg/api/handlers/libpod/containers_stats.go
@@ -76,8 +76,8 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			// Write header and content type.
-			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			wroteContent = true
 		}
 

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -597,8 +597,8 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	statusWritten := false
 	writeStatusCode := func(code int) {
 		if !statusWritten {
-			w.WriteHeader(code)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
 			flush()
 			statusWritten = true
 		}

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -152,8 +152,8 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	flush()
 
 	enc := json.NewEncoder(w)

--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -138,8 +138,8 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	flush()
 
 	enc := json.NewEncoder(w)

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -451,8 +451,8 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	flush()
 
 	enc := json.NewEncoder(w)

--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -146,8 +146,8 @@ func CompatPull(ctx context.Context, w http.ResponseWriter, runtime *libpod.Runt
 	statusWritten := false
 	writeStatusCode := func(code int) {
 		if !statusWritten {
-			w.WriteHeader(code)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
 			flush()
 			statusWritten = true
 		}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Some Endpoints do not contain the `Content-Type` header field in their responses, this is due to inconsistent order of setting headers and http status codes in some places.
This PR aligns the order of `w.Header().Set` and  `w.WriteHeader` calls to the suggested order of first the header fields and then the status code as suggested in the go documentation(https://pkg.go.dev/net/http#ResponseWriter).

The following endpoints were affected:
```
StatsContainer 
VersionedPath("/containers/{name}/stats")
/containers/{name}/stats
VersionedPath("/libpod/containers/{name}/stats")
VersionedPath("/libpod/containers/stats")

PushImage 
VersionedPath("/images/{name:.*}/push")
/images/{name:.*}/push

CommitContainer
/libpod/commit

ImagesPull
/libpod/images/pull

PushImage
/libpod/images/{name:.*}/push

ManifestPush
/{name:.*}/registry/{destination:.*}

CompatPull
VersionedPath("/images/create")
/images/create
VersionedPath("/libpod/images/pull")
```

#### Does this PR introduce a user-facing change?
Yes, clients that act upon the `Content-Type` will be affected, for example the `/libpod/images/pull` sets its `Content-Type` header field to `application/json`, which is not correct as the response body contains a stream of jsons. The issue of non-compliant returned content types is already known and similar to #23741.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed missing Content-Type header field for StatsContainer, PushImage, CommitContainer, ImagesPull, PushImage, ManifestPush and CompatPull endpoints
```
