### PR TITLE
tests: Get rid of netcat on the host and use Bash's /dev/tcp

### DIFF
--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -338,7 +338,7 @@ EOF
     # send a random string to the container. This will cause the container
     # to output the string to its logs, then exit.
     teststring=$(random_string 30)
-    echo "$teststring" | nc 127.0.0.1 $port_out
+    echo "$teststring" > /dev/tcp/127.0.0.1/$port_out
 
     # Confirm that the container log output is the string we sent it.
     run_podman wait $cid

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -153,7 +153,7 @@ load helpers.network
 
         # emit random string, and check it
         teststring=$(random_string 30)
-        echo "$teststring" | nc 127.0.0.1 $myport
+        echo "$teststring" > /dev/tcp/127.0.0.1/$myport
 
         run_podman logs $cid
         # Sigh. We can't check line-by-line, because 'nc' output order is
@@ -296,7 +296,7 @@ load helpers.network
 
     # emit random string, and check it
     teststring=$(random_string 30)
-    echo "$teststring" | nc 127.0.0.1 $myport
+    echo "$teststring" > /dev/tcp/127.0.0.1/$myport
 
     run_podman logs $cid
     # Sigh. We can't check line-by-line, because 'nc' output order is

--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -423,7 +423,7 @@ function wait_for_port() {
 function tcp_port_probe() {
     local address="${2:-0.0.0.0}"
 
-    : | nc "${address}" "${1}"
+    (exec echo -n >/dev/tcp/"$address/$1") >/dev/null 2>&1
 }
 
 ### Pasta Helpers ##############################################################


### PR DESCRIPTION
Get rid of netcat on the host and use Bash's /dev/tcp

The only remaining uses of nc now are in containers.

#### Does this PR introduce a user-facing change?

```release-note
None
```
