### PR TITLE
quadlet: add HttpProxy option for Container sections

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -338,6 +338,7 @@ Valid options for `[Container]` are listed below:
 | HealthStartupTimeout=1m33s           | --health-startup-timeout=1m33s                       |
 | HealthTimeout=20s                    | --health-timeout=20s                                 |
 | HostName=example.com                 | --hostname example.com                               |
+| HttpProxy=true                       | --http-proxy=true                                    |
 | Image=ubi8                           | Image specification - ubi8                           |
 | IP=192.5.0.1                         | --ip 192.5.0.1                                       |
 | IP6=2001:db8::1                      | --ip6 2001:db8::1                                    |
@@ -646,6 +647,15 @@ Equivalent to the Podman `--health-timeout` option.
 
 Sets the host name that is available inside the container.
 Equivalent to the Podman `--hostname` option.
+
+### `HttpProxy=`
+
+Controls whether proxy environment variables (http_proxy, https_proxy, ftp_proxy, no_proxy) are passed from the Podman process into the container during image pulls and builds.
+
+Set to `true` to enable proxy inheritance (default Podman behavior) or `false` to disable it.
+This option is particularly useful on systems that require proxy configuration for internet access but don't want proxy settings passed to the container runtime.
+
+Equivalent to the Podman `--http-proxy` option.
 
 ### `Image=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -109,6 +109,7 @@ const (
 	KeyHealthStartupTimeout  = "HealthStartupTimeout"
 	KeyHealthTimeout         = "HealthTimeout"
 	KeyHostName              = "HostName"
+	KeyHttpProxy             = "HttpProxy"
 	KeyImage                 = "Image"
 	KeyImageTag              = "ImageTag"
 	KeyInterfaceName         = "InterfaceName"
@@ -274,6 +275,7 @@ var (
 				KeyHealthStartupTimeout:  true,
 				KeyHealthTimeout:         true,
 				KeyHostName:              true,
+				KeyHttpProxy:             true,
 				KeyIP6:                   true,
 				KeyIP:                    true,
 				KeyImage:                 true,
@@ -676,6 +678,7 @@ func ConvertContainer(container *parser.UnitFile, isUser bool, unitsInfoMap map[
 	boolKeys := map[string]string{
 		KeyRunInit:         "--init",
 		KeyEnvironmentHost: "--env-host",
+		KeyHttpProxy:       "--http-proxy",
 		KeyReadOnlyTmpfs:   "--read-only-tmpfs",
 	}
 	lookupAndAddBoolean(container, ContainerGroup, boolKeys, podman)

--- a/test/e2e/quadlet/httpproxy-false.container
+++ b/test/e2e/quadlet/httpproxy-false.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --http-proxy=false
+
+[Container]
+Image=localhost/imagename
+HttpProxy=false

--- a/test/e2e/quadlet/httpproxy-true.container
+++ b/test/e2e/quadlet/httpproxy-true.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args --http-proxy
+
+[Container]
+Image=localhost/imagename
+HttpProxy=true

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -901,6 +901,8 @@ BOGUS=foo
 		Entry("group-add.container", "group-add.container"),
 		Entry("health.container", "health.container"),
 		Entry("host.container", "host.container"),
+		Entry("httpproxy-false.container", "httpproxy-false.container"),
+		Entry("httpproxy-true.container", "httpproxy-true.container"),
 		Entry("hostname.container", "hostname.container"),
 		Entry("idmapping.container", "idmapping.container"),
 		Entry("image.container", "image.container"),


### PR DESCRIPTION
Add support for HttpProxy key in quadlet Container sections to control proxy environment variable inheritance during image pulls and builds.

## Changes
- Add `HttpProxy` key support to quadlet Container sections
- `HttpProxy=true` enables proxy inheritance (default podman behavior)  
- `HttpProxy=false` disables proxy inheritance
- When omitted, uses podman's default behavior
- Add test cases for both scenarios
- Update documentation with usage examples

## Problem solved
This addresses the need for declarative control over proxy settings for container image pulls without requiring manual workarounds with `PodmanArgs=--http-proxy=false`.

## Example usage
```ini
[Container]
Image=registry.example.com/myapp:latest
HttpProxy=false

[Service]
Environment=HTTP_PROXY=http://proxy.example.com:8080
```

## Implementation details
- Follows existing quadlet boolean key patterns (like `EnvironmentHost`, `ReadOnlyTmpfs`)
- HttpProxy=true → adds `--http-proxy` to podman command
- HttpProxy=false → adds `--http-proxy=false` to podman command  
- No HttpProxy key → no flag added (podman default behavior)

#### Does this PR introduce a user-facing change?

```release-note
Add HttpProxy option to quadlet Container sections for controlling proxy environment variable inheritance during image pulls and builds.
```

This fixes #26925