### PR TITLE
Revert "Remove bin/podman.cross Make target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,9 @@ podman-testing: bin/podman-testing
 generate-bindings: .install.golangci-lint
 	$(GOCMD) generate ./pkg/bindings/... ;
 
-# DO NOT USE: use local-cross instead
+# Do the cross build with the OS/ARCH extrcted from the target name, i.e.
+# pass a path like "podman.cross.linux.amd64". This target is used by
+# local-cross to build all CROSS_BUILD_TARGETS.
 bin/podman.cross.%:
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}"; \

--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ generate-bindings: .install.golangci-lint
 # Do the cross build with the OS/ARCH extrcted from the target name, i.e.
 # pass a path like "podman.cross.linux.amd64". This target is used by
 # local-cross to build all CROSS_BUILD_TARGETS.
-bin/podman.cross.%:
+bin/podman.cross.%: $(SOURCES)
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}"; \
 	GOARCH="$${TARGET##*.}"; \

--- a/Makefile
+++ b/Makefile
@@ -481,6 +481,18 @@ podman-testing: bin/podman-testing
 generate-bindings: .install.golangci-lint
 	$(GOCMD) generate ./pkg/bindings/... ;
 
+# DO NOT USE: use local-cross instead
+bin/podman.cross.%:
+	TARGET="$*"; \
+	GOOS="$${TARGET%%.*}"; \
+	GOARCH="$${TARGET##*.}"; \
+	CGO_ENABLED=0 \
+		$(GO) build \
+		$(BUILDFLAGS) \
+		$(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' \
+		-tags '$(BUILDTAGS_CROSS)' \
+		-o "$@" ./cmd/podman
+
 .PHONY: local-cross
 local-cross: $(CROSS_BUILD_TARGETS) ## Cross compile podman binary for multiple architectures
 


### PR DESCRIPTION
This reverts commit c45b27ffb094cc09e88bf9dd9dcebfacc80e574f.

This commit was just wrong, local-cross depends on this target as it calls a target like "bin/podman.cross.linux.amd64". Without this it is just broken as there is no matching target.

$ make bin/podman.cross.linux.amd64
make: *** No rule to make target 'bin/podman.cross.linux.amd64'.  Stop.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
