### PR TITLE
test/buildah-bud: enable one skipped test

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -330,9 +330,6 @@ skip "FIXME: 2024-05-28 new VMs from #338" \
 skip_if_remote "FIXME: 2025-04-01 git related errors returning wrong exit code" \
                "bud with ADD with git repository source"
 
-skip "FIXME: #26906 - new test failing in podman for some reason" \
-     "bud with no instructions but with CLI flags that require a new image be written"
-
 # END   temporary workarounds that must be reevaluated periodically
 ###############################################################################
 

--- a/test/buildah-bud/buildah-tests.diff
+++ b/test/buildah-bud/buildah-tests.diff
@@ -1,4 +1,4 @@
-From 3170dbcf74c62990a288402fb15c7f4f99703144 Mon Sep 17 00:00:00 2001
+From 4c30f5e698bc1d4ca498347435174a6be7232876 Mon Sep 17 00:00:00 2001
 From: Ed Santiago <santiago@redhat.com>
 Date: Thu, 6 Oct 2022 17:32:59 -0600
 Subject: [PATCH] tweaks for running buildah tests under podman
@@ -6,14 +6,14 @@ Subject: [PATCH] tweaks for running buildah tests under podman
 Signed-off-by: Ed Santiago <santiago@redhat.com>
 Signed-off-by: Paul Holzinger <pholzing@redhat.com>
 ---
- tests/helpers.bash | 158 +++++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 154 insertions(+), 4 deletions(-)
+ tests/helpers.bash | 166 +++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 162 insertions(+), 4 deletions(-)
 
 diff --git a/tests/helpers.bash b/tests/helpers.bash
-index 9cb1bbc0c..b661fd4ad 100644
+index 5acd0a3c3..7a0721305 100644
 --- a/tests/helpers.bash
 +++ b/tests/helpers.bash
-@@ -84,6 +84,42 @@ EOF
+@@ -85,6 +85,42 @@ EOF
      BUILDAH_REGISTRY_OPTS="${regconfopt} ${regconfdir} --short-name-alias-conf ${TEST_SCRATCH_DIR}/cache/shortnames.conf"
      COPY_REGISTRY_OPTS="${BUILDAH_REGISTRY_OPTS}"
      PODMAN_REGISTRY_OPTS="${regconfopt}"
@@ -56,7 +56,7 @@ index 9cb1bbc0c..b661fd4ad 100644
  }
  
  function starthttpd() { # directory [working-directory-or-"" [certfile, keyfile]]
-@@ -148,6 +184,22 @@ function teardown_tests() {
+@@ -149,6 +185,22 @@ function teardown_tests() {
      stop_git_daemon
      stop_registry
  
@@ -79,7 +79,7 @@ index 9cb1bbc0c..b661fd4ad 100644
      # Workaround for #1991 - buildah + overlayfs leaks mount points.
      # Many tests leave behind /var/tmp/.../root/overlay and sub-mounts;
      # let's find those and clean them up, otherwise 'rm -rf' fails.
-@@ -269,7 +321,12 @@ function copy() {
+@@ -270,7 +322,12 @@ function copy() {
  }
  
  function podman() {
@@ -93,7 +93,7 @@ index 9cb1bbc0c..b661fd4ad 100644
  }
  
  # There are various scenarios where we would like to execute `tests` as rootless user, however certain commands like `buildah mount`
-@@ -376,8 +433,78 @@ function run_buildah() {
+@@ -377,8 +434,86 @@ function run_buildah() {
          --retry)         retry=3;        shift;;  # retry network flakes
      esac
  
@@ -110,6 +110,14 @@ index 9cb1bbc0c..b661fd4ad 100644
 +        else
 +            set "build" "--force-rm=false" "--layers=false" "$@"
 +        fi
++        # buildah --squash equals podman --squash-all so we need to replace that as well
++        new_args=()
++        for arg in "$@"; do
++            new_arg="${arg/#--squash/--squash-all}"
++            new_args+=("$new_arg")
++        done
++        set "${new_args[@]}"
++
 +        # Figure out an archive format that will match the --format flag, if one was used.
 +        local nativearchive=oci-archive
 +        local formatpattern="((--format( |=))(oci|docker))"
@@ -173,7 +181,7 @@ index 9cb1bbc0c..b661fd4ad 100644
  
      # If session is rootless and `buildah mount` is invoked, perform unshare,
      # since normal user cannot mount a filesystem unless they're in a user namespace along with its own mount namespace.
-@@ -391,8 +518,8 @@ function run_buildah() {
+@@ -392,8 +527,8 @@ function run_buildah() {
          retry=$(( retry - 1 ))
  
          # stdout is only emitted upon error; this echo is to help a debugger
@@ -184,7 +192,7 @@ index 9cb1bbc0c..b661fd4ad 100644
          # without "quotes", multiple lines are glommed together into one
          if [ -n "$output" ]; then
              echo "$output"
-@@ -419,6 +546,9 @@ function run_buildah() {
+@@ -420,6 +555,9 @@ function run_buildah() {
              false
          fi
  
@@ -194,7 +202,7 @@ index 9cb1bbc0c..b661fd4ad 100644
          if [ -n "$expected_rc" ]; then
              if [ "$status" -eq "$expected_rc" ]; then
                  return
-@@ -756,6 +886,26 @@ function skip_if_no_unshare() {
+@@ -757,6 +895,26 @@ function skip_if_no_unshare() {
    fi
  }
  
@@ -222,5 +230,5 @@ index 9cb1bbc0c..b661fd4ad 100644
  #  start_git_daemon  #
  ######################
 -- 
-2.50.1
+2.51.0
 


### PR DESCRIPTION
For podman build --squash is different from the buildah bud --squash option, in podman it must use --squash-all.

Fixes: #26906

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
