### PR TITLE
quadlet: fix runtime error for invalid Mount value

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1858,6 +1858,9 @@ func handleLogOpt(unitFile *parser.UnitFile, groupName string, podman *PodmanCmd
 }
 
 func handleStorageSource(quadletUnitFile, serviceUnitFile *parser.UnitFile, source string, unitsInfoMap map[string]*UnitInfo, checkImage bool) (string, error) {
+	if source == "" {
+		return "", fmt.Errorf("source cannot be empty")
+	}
 	if source[0] == '.' {
 		var err error
 		source, err = getAbsolutePath(quadletUnitFile, source)

--- a/test/e2e/quadlet/mount-source-missing.container
+++ b/test/e2e/quadlet/mount-source-missing.container
@@ -1,0 +1,6 @@
+## assert-failed
+## assert-stderr-contains "source cannot be empty"
+
+[Container]
+Image=localhost/imagename
+Mount=/home:/home

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1142,6 +1142,8 @@ BOGUS=foo
 		Entry("Build - Neither WorkingDirectory nor File Key", "neither-workingdirectory-nor-file.build", "converting \"neither-workingdirectory-nor-file.build\": neither SetWorkingDirectory, nor File key specified"),
 		Entry("Build - No ImageTag Key", "no-imagetag.build", "converting \"no-imagetag.build\": no ImageTag key specified"),
 		Entry("emptyline.container", "emptyline.container", "converting \"emptyline.container\": no Image or Rootfs key specified"),
+
+		Entry("Mount - Missing source=...", "mount-source-missing.container", "converting \"mount-source-missing.container\": source cannot be empty"),
 	)
 
 	DescribeTable("Running success quadlet with ServiceName test case",


### PR DESCRIPTION
If the `Mount` option inside a quadlet is missing the source=... part, the code today panics with the following message.

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/containers/podman/v5/pkg/systemd/quadlet.handleStorageSource(0xc000140de0?, 0x1d?, {0x0?, 0x1?}, 0x5634e39e233e?, 0x10?)
...
```

This commit checks for the missing source and returns an error to avoid the panic.

I added the check in two places, in handleStorageSource and in resolveContainerMountParams. The actual panic happens due to a unchecked index access in the former function while the porblematic configuration should already be detected before calling that function.

#### Does this PR introduce a user-facing change?

```release-note
Fix panic when a quadlet `Mount` option is missing a `source=...` value. Podman now reports a clear error instead of crashing.
```
