### PR TITLE
Final backports for v5.6.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20250627t155202z-f42f41d13"
+    IMAGE_SUFFIX: "c20250812t173301z-f42f41d13"
 
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,20 @@
 # Release Notes
 
 ## 5.6.1
+### Security
+- This release addresses CVE-2025-9566, where Kubernetes YAML run by `podman play kube` containing `ConfigMap` and `Secret` volumes can use crafted symlinks to overwrite content on the host.
+
 ### Bugfixes
 - Fixed a bug where network creation and removal events were displayed incorrectly when the `journald` events driver was in use.
 - Fixed a bug where the `--security-opt seccomp=unconfined` option was broken on Windows ([#26855](https://github.com/containers/podman/issues/26855)).
 - Fixed a bug where containers created with a name longer than 64 characters, no explicit hostname, the the `container_name_as_hostname` option in `containers.conf` set to `true` would fail to start.
 - Fixed a bug where Podman would fail to start containers when runc 1.3.0 or later was used as the OCI runtime ([#26938](https://github.com/containers/podman/issues/26938)).
+
+### Misc
+- Adjusted the systemd-tmpfiles script to recursively remove temporary files directories placed in `/tmp`, ensuring proper operation of Podman after a reboot if `/tmp` is not a tmpfs.
+- Updated Buildah to v1.41.4
+- Updated the containers/storage to v1.59.1
+- Updated the containers/common library to v0.64.2
 
 ## 5.6.0
 ### Features

--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -1,9 +1,16 @@
 # /tmp/podman-run-* directory can contain content for Podman containers that have run
-# for many days. This following line prevents systemd from removing this content.
+# for many days. The following lines prevents systemd from removing this content.
+# At the same time, these directories must also be cleaned on reboot.
+# Thus, each path has two lines: x to not periodically clean, R! to recursively
+# remove on reboot.
 x /tmp/podman-run-*
+R! /tmp/podman-run-*
 x /tmp/storage-run-*
+R! /tmp/storage-run-*
 x /tmp/containers-user-*
+R! /tmp/containers-user-*
 x /tmp/run-*/libpod
+R! /tmp/run-*/libpod
 D! /var/lib/containers/storage/tmp 0700 root root
 D! /run/podman 0700 root root
 D! /var/lib/cni/networks

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -762,14 +762,13 @@ if root && test -e /dev/nullb0; then
   t POST libpod/containers/updateCtr/update ${TMPD}/update.json 201
 
   cgroupPath=/sys/fs/cgroup/cpu.weight
-  # 002 is the byte length
-  cpu_weight_expect=$'\001\0025'
 
   # Verify CPU weight
   echo '{ "AttachStdout":true,"Cmd":["cat", "'$cgroupPath'"]}' >${TMPD}/exec.json
   t POST containers/updateCtr/exec ${TMPD}/exec.json 201 .Id~[0-9a-f]\\{64\\}
   eid=$(jq -r '.Id' <<<"$output")
-  t POST exec/$eid/start 200 $cpu_weight_expect
+  t POST exec/$eid/start 200
+  like "$(<$WORKDIR/curl.result.out)" $'^\x01.\(20\|5\)$' "cpu.weight is 5 or 20"
 
   BlkioDeviceReadBps_expected='[
   {

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -141,7 +141,8 @@ var _ = Describe("Podman update", func() {
 		podmanTest.CheckFileInContainerSubstring(ctrID, "/sys/fs/cgroup/memory.swap.max", "1073741824")
 
 		// checking cpu-shares
-		podmanTest.CheckFileInContainerSubstring(ctrID, "/sys/fs/cgroup/cpu.weight", "5")
+		exec := podmanTest.PodmanExitCleanly("exec", ctrID, "cat", "/sys/fs/cgroup/cpu.weight")
+		Expect(exec.OutputToString()).To(Or(ContainSubstring("5"), ContainSubstring("20")))
 
 		// checking pids-limit
 		podmanTest.CheckFileInContainerSubstring(ctrID, "/sys/fs/cgroup/pids.max", "123")


### PR DESCRIPTION
Plus release notes

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
