### PR TITLE
docs: restore podman-systemd.unit.5

### DIFF
--- a/docs/source/markdown/links/podman-systemd.unit.5
+++ b/docs/source/markdown/links/podman-systemd.unit.5
@@ -1,1 +1,0 @@
-.so man7/podman-quadlet.7

--- a/docs/source/markdown/links/quadlet.5
+++ b/docs/source/markdown/links/quadlet.5
@@ -1,1 +1,1 @@
-.so man7/podman-quadlet.7
+.so man5/podman-systemd.unit.5

--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -119,4 +119,4 @@ sleep.service  f8e4759798d4 (systemd-sleep)  registry.fedoraproject.org/fedora:l
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-generate-systemd(1)](podman-generate-systemd.1.md)**, **[podman-run(1)](podman-run.1.md)**, **[podman-quadlet(7)](podman-quadlet.7.md)**, **sd_notify(3)**, **[systemd.unit(5)](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)**
+**[podman(1)](podman.1.md)**, **[podman-generate-systemd(1)](podman-generate-systemd.1.md)**, **[podman-run(1)](podman-run.1.md)**, **[podman-systemd.unit(5)](podman-systemd.unit.5.md)**, **sd_notify(3)**, **[systemd.unit(5)](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)**

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -311,7 +311,7 @@ CONTAINER ID  IMAGE                            COMMAND  CREATED        STATUS   
 bb310a0780ae  docker.io/library/alpine:latest  /bin/sh  3 minutes ago  Created                  busy_moser
 ```
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**, **systemctl(1)**, **systemd.unit(5)**, **systemd.service(5)**, **[conmon(8)](https://github.com/containers/conmon/blob/main/docs/conmon.8.md)**, **[podman-quadlet(7)](podman-quadlet.7.md)**
+**[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**, **systemctl(1)**, **systemd.unit(5)**, **systemd.service(5)**, **[conmon(8)](https://github.com/containers/conmon/blob/main/docs/conmon.8.md)**, **[podman-systemd.unit(5)](podman-systemd.unit.5.md)**
 
 ## HISTORY
 April 2020, Updated details and added use case to use generated .service files as root and non-root, by Sujil Shah (sushah at redhat dot com)

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1,12 +1,12 @@
-% podman-quadlet(7)
+% podman-systemd.unit(5)
 
 # NAME
 
-podman\-quadlet - High-level overview of Podman Quadlet integration with systemd
+podman-systemd.unit - High-level overview of Podman Quadlet integration with systemd
 
 # DESCRIPTION
 
-Podman Quadlet is a systemd unit generator that enables declarative container management by defining
+Quadlet is a systemd unit generator that enables declarative container management by defining
 Podman resources using specialized systemd unit files. It provides an interface between Podman and systemd,
 allowing users to manage containers, pods, volumes, images, and more through native systemd service units.
 
@@ -99,7 +99,6 @@ has an option with the same name but a different meaning.
 
 # SEE ALSO
 
-[podman-quadlet(7)](https://docs.podman.io/en/latest/markdown/podman-quadlet.7.html),
 [podman-container.unit(5)](podman-container.unit.5.md),
 [podman-pod.unit(5)](podman-pod.unit.5.md),
 [podman-volume.unit(5)](podman-volume.unit.5.md),

--- a/docs/source/markdown/podmansh.1.md
+++ b/docs/source/markdown/podmansh.1.md
@@ -127,7 +127,7 @@ _EOF
 ```
 
 ## SEE ALSO
-**[containers.conf(5)](containers.conf.5.md)**, **[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, **[podman-quadlet(7)](podman-quadlet.7.md)**
+**[containers.conf(5)](containers.conf.5.md)**, **[podman(1)](podman.1.md)**, **[podman-exec(1)](podman-exec.1.md)**, **[podman-systemd.unit(5)](podman-systemd.unit.5.md)**
 
 ## HISTORY
 May 2023, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/hack/xref-quadlet-docs
+++ b/hack/xref-quadlet-docs
@@ -27,7 +27,7 @@ our @Docs = (
     "docs/source/markdown/podman-pod.unit.5.md",
     "docs/source/markdown/podman-volume.unit.5.md",
     "docs/source/markdown/podman-image.unit.5.md",
-    "docs/source/markdown/podman-quadlet.7.md",
+    "docs/source/markdown/podman-systemd.unit.5.md",
 );
 
 # END   user-customizable section


### PR DESCRIPTION
There are endless of links pointing to this document we should not get rid of that.
Also I find having two podman-quadlet with different numbers rather confusing, while I understand the motivation I think for most users this is not intuitive. Most people will not type the man section numbers.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
