### PR TITLE
fix(emulation): avoid nil pointer dereference in registeredBinfmtMisc

### DIFF
--- a/pkg/emulation/binfmtmisc_linux.go
+++ b/pkg/emulation/binfmtmisc_linux.go
@@ -27,7 +27,10 @@ func registeredBinfmtMisc() ([]string, error) {
 		if filepath.Base(path) == "register" { // skip this one
 			return nil
 		}
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 		info, err := d.Info()


### PR DESCRIPTION
When `/proc/sys/fs/binfmt_misc` is not mounted, filepath.WalkDir may pass a nil DirEntry. This caused podman info to panic. Add a nil check to avoid dereferencing it.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
