### PR TITLE
Quadlet build - consider File path that starts with a systemd specifier as absolute

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1428,7 +1428,7 @@ func ConvertBuild(build *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, isU
 	// Context or WorkingDirectory has to be last argument
 	if len(context) > 0 {
 		podman.add(context)
-	} else if !filepath.IsAbs(filePath) && !isURL(filePath) {
+	} else if !startsWithSystemdSpecifier(filePath) && !filepath.IsAbs(filePath) && !isURL(filePath) {
 		// Special handling for relative filePaths
 		if len(workingDirectory) == 0 {
 			return nil, warnings, fmt.Errorf("relative path in File key requires SetWorkingDirectory key to be set")

--- a/test/e2e/quadlet/no-workingdirectory-systemd-specifier.build
+++ b/test/e2e/quadlet/no-workingdirectory-systemd-specifier.build
@@ -1,0 +1,3 @@
+[Build]
+ImageTag=localhost/example
+File=%h/images/example.Containerfile

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1074,6 +1074,7 @@ BOGUS=foo
 		Entry("Build - Variant Key", "variant.build"),
 		Entry("Build - No Default Dependencies", "no_deps.build"),
 		Entry("Build - Retry", "retry.build"),
+		Entry("Build - No WorkingDirectory with systemd specifier", "no-workingdirectory-systemd-specifier.build"),
 
 		Entry("Pod - Basic", "basic.pod"),
 		Entry("Pod - DNS", "dns.pod"),


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
No

```release-note
None
```

Fixes: https://github.com/containers/podman/issues/26746