### PR TITLE
cirrus: fix golangci-lint cache leak + update freebsd version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -122,10 +122,10 @@ validate-source_task:
     setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'
     golangci-lint_cache:
         folder: /root/.cache/golangci-lint
-        reupload_on_changes: true
-        fingerprint_script:
+        fingerprint_script: &golangci_cache_fingerprint
             - go version
             - grep GOLANGCI_LINT_VERSION Makefile | head -1
+            - date +%U
     # Standard main execution stage call, used by nearly every task in CI.
     main_script: &main '/usr/bin/time --verbose --output="$STATS_LOGFILE" $GOSRC/$SCRIPT_BASE/runner.sh'
 
@@ -340,10 +340,7 @@ freebsd_alt_build_task:
         - go version # Downloads a new go version based on go.mod's go directive.
     golint_cache:
         folder: ~/.cache/golangci-lint
-        reupload_on_changes: true
-        fingerprint_script:
-            - go version
-            - grep GOLANGCI_LINT_VERSION Makefile | head -1
+        fingerprint_script: *golangci_cache_fingerprint
     lint_script:
         - gmake golangci-lint
     build_amd64_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -331,7 +331,7 @@ freebsd_alt_build_task:
         TEST_FLAVOR: "altbuild"
         ALT_NAME: 'FreeBSD Cross'
     freebsd_instance:
-        image_family: freebsd-13-4
+        image_family: freebsd-14-3
         # golangci-lint is a very, very hungry beast.
         cpu: 4
         memory: 8Gb


### PR DESCRIPTION
Do not use reupload_on_changes, this will make the cache grow unbound and I have seen the cache become so large then restoring it and uploading it took several minutes thus making the task time worse compared to no cache. I manually cleaned the cache a few times to fix this but it need to properly be fixed here.

To not have a stale cache for to long also use date +%U which will create a new cache once a week. This is in line with the offical golangci-lint github action which invalidates the cache every 7 days by default[1].

[1] https://github.com/golangci/golangci-lint-action/blob/main/README.md#cache-invalidation-interval

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
