### PR TITLE
Add default_log_path config option for all container operations

### DIFF
--- a/vendor/go.podman.io/common/pkg/config/config.go
+++ b/vendor/go.podman.io/common/pkg/config/config.go
@@ -175,6 +175,11 @@ type ContainersConfig struct {
 	// LogPath is the path to the container log file.
 	LogPath string `toml:"log_path,omitempty"`
 
+	// DefaultLogPath is the default log path for containers when no explicit path is specified.
+	// When set, podman kube play will automatically use this path for logging unless
+	// overridden by --log-opt path=
+	DefaultLogPath string `toml:"default_log_path,omitempty"`
+
 	// LogSizeMax is the maximum number of bytes after which the log file
 	// will be truncated. It can be expressed as a human-friendly string
 	// that is parsed to bytes.

--- a/vendor/go.podman.io/common/pkg/config/containers.conf
+++ b/vendor/go.podman.io/common/pkg/config/containers.conf
@@ -224,6 +224,18 @@ default_sysctls = [
 # 
 #log_path = ""
 
+# Default log path for containers when no explicit path is specified.
+# When set, both 'podman run' and 'podman kube play' will automatically use this path
+# for logging unless overridden by --log-opt path=. This applies to log drivers that
+# support file-based logging (k8s-file, json-file, etc.). Unlike log_path which
+# affects all containers globally, this setting provides a user-configurable default.
+# IMPORTANT: Must be a relative path (absolute paths are rejected for security).
+# Must not contain directory traversal sequences (..) and cannot be empty/whitespace.
+# A subdirectory named with the container ID will be created under this path.
+# For example: default_log_path = "my/custom/path"
+#
+#default_log_path = ""
+
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or
 # exceed conmon's read buffer. The file is truncated and re-opened so the


### PR DESCRIPTION
Introduces a new default_log_path configuration option that provides automatic log path assignment for both podman run and podman kube play operations. This setting works with all file-based log drivers and is only applied when no explicit --log-opt path= is provided, giving users better control over container log organization without requiring manual path specification for each command.

#### Does this PR introduce a user-facing change?
Yes

```release-note
Added `default_log_path` configuration option for automatic log path assignment. When configured, this option automatically sets log paths for containers using file-based log drivers (journald, k8s-file, json-file) when no explicit `--log-opt path=` is specified, providing better control over container log organization without requiring manual path specification for each command.
action required
```
