### PR TITLE
pkg/bindings: use HTTP 101 upgrade request for attach

### DIFF
--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -180,7 +180,7 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 					return err
 				}
 
-				return nil
+				return <-stdoutChan
 			}
 		}
 	} else {


### PR DESCRIPTION
For exec and attach use an upgrade request which the server responds with HTTP 101 status. Since go 1.12 the Body can be casted to an io.Writer and then use that to write to the server.

This does however not allow us to skip the ugly hack of overwriting the default dialContext() because the ReadWriterCloser on the body does not allow us to call CloseWrite() which is critical to correctly close the stdin side. So we still have to extract the underlying net.Conn for that.

Using the cast response.Body is important because the underlying http lib reads from the socket to parse the header and response code of course and it is possible that it read more content than needed that is kept in its buffer but because we then only directly read from the connection it was possible we miss the first few bytes of the message.

This should fix the issue and hopefully also some long standing podman-remote missing output flakes in CI.

Fixes: #26951

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a race condition with podman-remote where podman run/exec could loose some initial bytes of the output.
```
