### PR TITLE
fix: Correct typo in chrootdirs option

### DIFF
--- a/docs/source/markdown/options/chrootdirs.md
+++ b/docs/source/markdown/options/chrootdirs.md
@@ -5,5 +5,5 @@
 #### **--chrootdirs**=*path*
 
 Path to a directory inside the container that is treated as a `chroot` directory.
-Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory is mounted into that location as well.
+Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, /etc/hostname) that is mounted into the root directory is mounted into that location as well.
 Multiple directories are separated with a comma.


### PR DESCRIPTION
In explanation of chrootdirs option, leading / is dropped from podman managed file path (/etc/hostname). So this PR adds leading /.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
