### PR TITLE
Reading healthchecks result from conmon's pipe

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -46,6 +46,9 @@ const (
 	// Important: The conmon attach socket uses an extra byte at the beginning of each
 	// message to specify the STREAM so we have to increase the buffer size by one
 	bufferSize = conmonConfig.BufSize + 1
+
+	// Healthcheck message type from conmon (using negative to avoid PID conflicts)
+	HealthCheckMsgStatusUpdate = -100
 )
 
 // ConmonOCIRuntime is an OCI runtime managed by Conmon.
@@ -982,7 +985,8 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 	if err != nil {
 		return 0, fmt.Errorf("creating socket pair: %w", err)
 	}
-	defer errorhandling.CloseQuiet(parentSyncPipe)
+	// Note: parentSyncPipe is NOT closed here because it's used for continuous healthcheck monitoring
+	// defer errorhandling.CloseQuiet(parentSyncPipe)
 
 	childStartPipe, parentStartPipe, err := newPipe()
 	if err != nil {
@@ -1038,6 +1042,13 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 	if ctr.config.ConmonPidFile != "" {
 		args = append(args, "--conmon-pidfile", ctr.config.ConmonPidFile)
 	}
+
+	// Add healthcheck-related arguments (build-conditional)
+	logrus.Debugf("HEALTHCHECK: Adding healthcheck args for container %s (has healthcheck: %v)", ctr.ID(), ctr.HasHealthCheck())
+	args = r.addHealthCheckArgs(ctr, args)
+
+	// Log the final conmon command for debugging
+	logrus.Debugf("HEALTHCHECK: Final conmon command for container %s: %v", ctr.ID(), args)
 
 	if r.noPivot {
 		args = append(args, "--no-pivot")
@@ -1200,6 +1211,8 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 	// regardless of whether we errored or not, we no longer need the children pipes
 	childSyncPipe.Close()
 	childStartPipe.Close()
+
+	// Note: parentSyncPipe is NOT closed here because it's used for continuous healthcheck monitoring
 	if err != nil {
 		return 0, err
 	}
@@ -1220,7 +1233,8 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		return 0, fmt.Errorf("conmon failed: %w", err)
 	}
 
-	pid, err := readConmonPipeData(r.name, parentSyncPipe, ociLog)
+	logrus.Debugf("HEALTHCHECK: About to read sync pipe data for container %s", ctr.ID())
+	pid, err := readConmonPipeData(r.name, parentSyncPipe, ociLog, ctr)
 	if err != nil {
 		if err2 := r.DeleteContainer(ctr); err2 != nil {
 			logrus.Errorf("Removing container %s from runtime after creation failed", ctr.ID())
@@ -1323,7 +1337,6 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 		logDriverArg = define.NoLogging
 	case define.PassthroughLogging, define.PassthroughTTYLogging:
 		logDriverArg = define.PassthroughLogging
-	//lint:ignore ST1015 the default case has to be here
 	default: //nolint:gocritic
 		// No case here should happen except JSONLogging, but keep this here in case the options are extended
 		logrus.Errorf("%s logging specified but not supported. Choosing k8s-file logging instead", ctr.LogDriver())
@@ -1391,13 +1404,15 @@ func readConmonPidFile(pidFile string) (int, error) {
 	return 0, nil
 }
 
+// syncInfo is used to return data from monitor process to daemon
+type syncInfo struct {
+	Data    int    `json:"data"`
+	Message string `json:"message,omitempty"`
+}
+
 // readConmonPipeData attempts to read a syncInfo struct from the pipe
-func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, error) {
-	// syncInfo is used to return data from monitor process to daemon
-	type syncInfo struct {
-		Data    int    `json:"data"`
-		Message string `json:"message,omitempty"`
-	}
+// If ctr is provided, it will also start continuous healthcheck monitoring
+func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string, ctr ...*Container) (int, error) {
 
 	// Wait to get container pid from conmon
 	type syncStruct struct {
@@ -1409,15 +1424,24 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 		var si *syncInfo
 		rdr := bufio.NewReader(pipe)
 		b, err := rdr.ReadBytes('\n')
+
+		// Log the raw JSON string received from conmon
+		logrus.Debugf("HEALTHCHECK: Raw JSON received from conmon: %q", string(b))
+		logrus.Debugf("HEALTHCHECK: JSON length: %d bytes", len(b))
+
 		// ignore EOF here, error is returned even when data was read
 		// if it is no valid json unmarshal will fail below
 		if err != nil && !errors.Is(err, io.EOF) {
+			logrus.Debugf("HEALTHCHECK: Error reading from conmon pipe: %v", err)
 			ch <- syncStruct{err: err}
+			return
 		}
 		if err := json.Unmarshal(b, &si); err != nil {
+			logrus.Debugf("HEALTHCHECK: Failed to unmarshal JSON from conmon: %v", err)
 			ch <- syncStruct{err: fmt.Errorf("conmon bytes %q: %w", string(b), err)}
 			return
 		}
+		logrus.Debugf("HEALTHCHECK: Successfully parsed JSON from conmon: Data=%d, Message=%q", si.Data, si.Message)
 		ch <- syncStruct{si: si}
 	}()
 
@@ -1437,6 +1461,13 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 			return -1, fmt.Errorf("container create failed (no logs from conmon): %w", ss.err)
 		}
 		logrus.Debugf("Received: %d", ss.si.Data)
+
+		// Start continuous healthcheck monitoring if container is provided and PID is valid
+		if len(ctr) > 0 && ctr[0] != nil && ss.si.Data > 0 {
+			logrus.Debugf("HEALTHCHECK: Starting continuous healthcheck monitoring for container %s (PID: %d)", ctr[0].ID(), ss.si.Data)
+			go readConmonHealthCheckPipeData(ctr[0], pipe)
+		}
+
 		if ss.si.Data < 0 {
 			if ociLog != "" {
 				ociLogData, err := os.ReadFile(ociLog)
@@ -1458,6 +1489,94 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 		return -1, fmt.Errorf("container creation timeout: %w", define.ErrInternal)
 	}
 	return data, nil
+}
+
+// readConmonHealthCheckPipeData continuously reads healthcheck status updates from conmon
+func readConmonHealthCheckPipeData(ctr *Container, pipe *os.File) {
+	logrus.Debugf("HEALTHCHECK: Starting continuous healthcheck monitoring for container %s", ctr.ID())
+
+	rdr := bufio.NewReader(pipe)
+	for {
+		// Read one line from the pipe
+		b, err := rdr.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				logrus.Debugf("HEALTHCHECK: Pipe closed for container %s, stopping monitoring", ctr.ID())
+				return
+			}
+			logrus.Errorf("HEALTHCHECK: Error reading from pipe for container %s: %v", ctr.ID(), err)
+			return
+		}
+
+		// Log the raw JSON string received from conmon
+		logrus.Debugf("HEALTHCHECK: Raw JSON received from conmon for container %s: %q", ctr.ID(), string(b))
+		logrus.Debugf("HEALTHCHECK: JSON length: %d bytes", len(b))
+
+		// Parse the JSON
+		var si syncInfo
+		if err := json.Unmarshal(b, &si); err != nil {
+			logrus.Errorf("HEALTHCHECK: Failed to parse JSON from conmon for container %s: %v", ctr.ID(), err)
+			continue
+		}
+
+		logrus.Debugf("HEALTHCHECK: Parsed sync info for container %s: Data=%d, Message=%q", ctr.ID(), si.Data, si.Message)
+
+		// Handle healthcheck status updates (negative message types)
+		if si.Data == HealthCheckMsgStatusUpdate && si.Message != "" {
+			logrus.Infof("HEALTHCHECK: Received healthcheck status update for container %s: %s", ctr.ID(), si.Message)
+			// Process the healthcheck status update
+			if err := handleHealthCheckStatusUpdate(ctr, si.Message); err != nil {
+				logrus.Errorf("HEALTHCHECK: Failed to process healthcheck status update for container %s: %v", ctr.ID(), err)
+			}
+		} else if si.Data == HealthCheckMsgStatusUpdate {
+			logrus.Debugf("HEALTHCHECK: Received healthcheck message type %d for container %s but no message content", si.Data, ctr.ID())
+		} else if si.Data < 0 {
+			// This might be a healthcheck message with a different negative type number
+			logrus.Debugf("HEALTHCHECK: Received negative message type %d for container %s - might be healthcheck related", si.Data, ctr.ID())
+		} else if si.Data > 0 {
+			// This might be a PID or other positive message - log but don't process as healthcheck
+			logrus.Debugf("HEALTHCHECK: Received positive message type %d for container %s - not healthcheck related", si.Data, ctr.ID())
+		}
+	}
+}
+
+// handleHealthCheckStatusUpdate processes healthcheck status updates from conmon
+func handleHealthCheckStatusUpdate(ctr *Container, message string) error {
+	logrus.Debugf("HEALTHCHECK: Processing healthcheck status update for container %s: %s", ctr.ID(), message)
+
+	// Parse the healthcheck status JSON from conmon
+	type healthCheckStatus struct {
+		Type        string `json:"type"`
+		ContainerID string `json:"container_id"`
+		Status      string `json:"status"`
+		ExitCode    int    `json:"exit_code"`
+		Timestamp   int64  `json:"timestamp"`
+	}
+
+	var hcStatus healthCheckStatus
+	if err := json.Unmarshal([]byte(message), &hcStatus); err != nil {
+		logrus.Errorf("HEALTHCHECK: Failed to parse healthcheck status JSON for container %s: %v", ctr.ID(), err)
+		return fmt.Errorf("failed to parse healthcheck status from conmon: %w", err)
+	}
+
+	logrus.Debugf("HEALTHCHECK: Parsed healthcheck status for container %s: Type=%s, ContainerID=%s, Status=%s, ExitCode=%d, Timestamp=%d",
+		ctr.ID(), hcStatus.Type, hcStatus.ContainerID, hcStatus.Status, hcStatus.ExitCode, hcStatus.Timestamp)
+
+	// Verify this is for the correct container
+	if hcStatus.ContainerID != ctr.ID() {
+		logrus.Errorf("HEALTHCHECK: Healthcheck status for wrong container: expected %s, got %s", ctr.ID(), hcStatus.ContainerID)
+		return fmt.Errorf("healthcheck status for wrong container: expected %s, got %s", ctr.ID(), hcStatus.ContainerID)
+	}
+
+	// Update the container's healthcheck status
+	logrus.Debugf("HEALTHCHECK: Updating healthcheck status for container %s to %s", ctr.ID(), hcStatus.Status)
+	if err := ctr.updateHealthStatus(hcStatus.Status); err != nil {
+		logrus.Errorf("HEALTHCHECK: Failed to update healthcheck status for container %s: %v", ctr.ID(), err)
+		return fmt.Errorf("failed to update healthcheck status for container %s: %w", ctr.ID(), err)
+	}
+
+	logrus.Infof("HEALTHCHECK: Successfully updated healthcheck status for container %s to %s (exit code: %d)", ctr.ID(), hcStatus.Status, hcStatus.ExitCode)
+	return nil
 }
 
 // writeConmonPipeData writes nonce data to a pipe

--- a/libpod/oci_conmon_nosystemd.go
+++ b/libpod/oci_conmon_nosystemd.go
@@ -1,0 +1,18 @@
+//go:build !remote && (linux || freebsd) && !systemd
+
+package libpod
+
+import "github.com/sirupsen/logrus"
+
+// addHealthCheckArgs adds healthcheck-related arguments to conmon for non-systemd builds
+func (r *ConmonOCIRuntime) addHealthCheckArgs(ctr *Container, args []string) []string {
+	// Add healthcheck flag if container has healthcheck config (non-systemd builds only)
+	// For systemd builds, healthchecks are managed by systemd, not conmon
+	if ctr.HasHealthCheck() {
+		logrus.Debugf("HEALTHCHECK: Adding --enable-healthcheck flag for container %s", ctr.ID())
+		args = append(args, "--enable-healthcheck")
+	} else {
+		logrus.Debugf("HEALTHCHECK: Container %s does not have healthcheck config, skipping --enable-healthcheck flag", ctr.ID())
+	}
+	return args
+}

--- a/libpod/oci_conmon_systemd.go
+++ b/libpod/oci_conmon_systemd.go
@@ -1,0 +1,10 @@
+//go:build !remote && (linux || freebsd) && systemd
+
+package libpod
+
+// addHealthCheckArgs adds healthcheck-related arguments to conmon for systemd builds
+func (r *ConmonOCIRuntime) addHealthCheckArgs(ctr *Container, args []string) []string {
+	// For systemd builds, healthchecks are managed by systemd, not conmon
+	// No healthcheck flags needed for conmon
+	return args
+}

--- a/pkg/specgen/generate/oci_freebsd.go
+++ b/pkg/specgen/generate/oci_freebsd.go
@@ -4,6 +4,7 @@ package generate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -160,6 +161,49 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	if s.Init != nil && *s.Init {
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
+	}
+
+	// Add healthcheck configuration as JSON annotation (for conmon)
+	if s.ContainerHealthCheckConfig.HealthConfig != nil {
+		// Convert durations to seconds for easier parsing in conmon
+		healthCheckForConmon := struct {
+			Test        []string `json:"test"`
+			Interval    int      `json:"interval"` // seconds
+			Timeout     int      `json:"timeout"`  // seconds
+			Retries     int      `json:"retries"`
+			StartPeriod int      `json:"start_period"` // seconds
+		}{
+			Test:        s.ContainerHealthCheckConfig.HealthConfig.Test,
+			Interval:    int(s.ContainerHealthCheckConfig.HealthConfig.Interval.Seconds()),
+			Timeout:     int(s.ContainerHealthCheckConfig.HealthConfig.Timeout.Seconds()),
+			Retries:     s.ContainerHealthCheckConfig.HealthConfig.Retries,
+			StartPeriod: int(s.ContainerHealthCheckConfig.HealthConfig.StartPeriod.Seconds()),
+		}
+		healthCheckJSON, err := json.Marshal(healthCheckForConmon)
+		if err == nil {
+			configSpec.Annotations["io.podman.healthcheck"] = string(healthCheckJSON)
+		}
+	}
+
+	if s.ContainerHealthCheckConfig.StartupHealthConfig != nil {
+		// Convert durations to seconds for easier parsing in conmon
+		startupHealthCheckForConmon := struct {
+			Test        []string `json:"test"`
+			Interval    int      `json:"interval"` // seconds
+			Timeout     int      `json:"timeout"`  // seconds
+			Retries     int      `json:"retries"`
+			StartPeriod int      `json:"start_period"` // seconds
+		}{
+			Test:        s.ContainerHealthCheckConfig.StartupHealthConfig.Test,
+			Interval:    int(s.ContainerHealthCheckConfig.StartupHealthConfig.Interval.Seconds()),
+			Timeout:     int(s.ContainerHealthCheckConfig.StartupHealthConfig.Timeout.Seconds()),
+			Retries:     s.ContainerHealthCheckConfig.StartupHealthConfig.Retries,
+			StartPeriod: int(s.ContainerHealthCheckConfig.StartupHealthConfig.StartPeriod.Seconds()),
+		}
+		startupHealthCheckJSON, err := json.Marshal(startupHealthCheckForConmon)
+		if err == nil {
+			configSpec.Annotations["io.podman.startup-healthcheck"] = string(startupHealthCheckJSON)
+		}
 	}
 
 	if s.OOMScoreAdj != nil {

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -334,6 +334,57 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
 	}
 
+	// Add healthcheck configuration as JSON annotation (for conmon)
+	if s.ContainerHealthCheckConfig.HealthConfig != nil {
+		logrus.Debugf("HEALTHCHECK: Adding regular healthcheck annotation to OCI spec")
+		// Convert durations to seconds for easier parsing in conmon
+		healthCheckForConmon := struct {
+			Test        []string `json:"test"`
+			Interval    int      `json:"interval"` // seconds
+			Timeout     int      `json:"timeout"`  // seconds
+			Retries     int      `json:"retries"`
+			StartPeriod int      `json:"start_period"` // seconds
+		}{
+			Test:        s.ContainerHealthCheckConfig.HealthConfig.Test,
+			Interval:    int(s.ContainerHealthCheckConfig.HealthConfig.Interval.Seconds()),
+			Timeout:     int(s.ContainerHealthCheckConfig.HealthConfig.Timeout.Seconds()),
+			Retries:     s.ContainerHealthCheckConfig.HealthConfig.Retries,
+			StartPeriod: int(s.ContainerHealthCheckConfig.HealthConfig.StartPeriod.Seconds()),
+		}
+		healthCheckJSON, err := json.Marshal(healthCheckForConmon)
+		if err == nil {
+			configSpec.Annotations["io.podman.healthcheck"] = string(healthCheckJSON)
+			logrus.Debugf("HEALTHCHECK: Added healthcheck annotation: %s", string(healthCheckJSON))
+		} else {
+			logrus.Errorf("HEALTHCHECK: Failed to marshal healthcheck config: %v", err)
+		}
+	}
+
+	if s.ContainerHealthCheckConfig.StartupHealthConfig != nil {
+		logrus.Debugf("HEALTHCHECK: Adding startup healthcheck annotation to OCI spec")
+		// Convert durations to seconds for easier parsing in conmon
+		startupHealthCheckForConmon := struct {
+			Test        []string `json:"test"`
+			Interval    int      `json:"interval"` // seconds
+			Timeout     int      `json:"timeout"`  // seconds
+			Retries     int      `json:"retries"`
+			StartPeriod int      `json:"start_period"` // seconds
+		}{
+			Test:        s.ContainerHealthCheckConfig.StartupHealthConfig.Test,
+			Interval:    int(s.ContainerHealthCheckConfig.StartupHealthConfig.Interval.Seconds()),
+			Timeout:     int(s.ContainerHealthCheckConfig.StartupHealthConfig.Timeout.Seconds()),
+			Retries:     s.ContainerHealthCheckConfig.StartupHealthConfig.Retries,
+			StartPeriod: int(s.ContainerHealthCheckConfig.StartupHealthConfig.StartPeriod.Seconds()),
+		}
+		startupHealthCheckJSON, err := json.Marshal(startupHealthCheckForConmon)
+		if err == nil {
+			configSpec.Annotations["io.podman.startup-healthcheck"] = string(startupHealthCheckJSON)
+			logrus.Debugf("HEALTHCHECK: Added startup healthcheck annotation: %s", string(startupHealthCheckJSON))
+		} else {
+			logrus.Errorf("HEALTHCHECK: Failed to marshal startup healthcheck config: %v", err)
+		}
+	}
+
 	if s.OOMScoreAdj != nil {
 		g.SetProcessOOMScoreAdj(*s.OOMScoreAdj)
 	}


### PR DESCRIPTION

#### Does this PR introduce a user-facing change?

```release-note
Added `-100` message parsing (healthchecks) from `conmon`'s unix pipe. 

```
Depends on conmon's PR suggested: https://github.com/containers/conmon/pull/599