### PR TITLE
docs: remove remote limitation note for --build-context option

### DIFF
--- a/docs/source/markdown/options/build-context.md
+++ b/docs/source/markdown/options/build-context.md
@@ -10,7 +10,7 @@ different stages in COPY instruction.
 
 Valid values are:
 
-* Local directory – e.g. --build-context project2=../path/to/project2/src (This option is not available with the remote Podman client. On Podman machine setup (i.e macOS and Windows) path must exists on the machine VM)
+* Local directory – e.g. --build-context project2=../path/to/project2/src
 * HTTP URL to a tarball – e.g. --build-context src=https://example.org/releases/src.tar
 * Container image – specified with a container-image:// prefix, e.g. --build-context alpine=container-image://alpine:3.15, (also accepts docker://, docker-image://)
 

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -214,10 +214,6 @@ skip_if_remote "secret files not implemented under podman-remote" \
 skip_if_remote "--signature-policy does not work with podman-remote" \
                "buildah-bud-policy"
 
-skip_if_remote "--build-context option not implemented in podman-remote" \
-               "build-with-additional-build-context and COPY, additional context from host" \
-               "build-with-additional-build-context and RUN --mount=from=, additional-context not image and also test conflict with stagename" \
-
 skip_if_remote "env-variable for Containerfile.in pre-processing is not propagated on remote" \
                "bud with Containerfile.in, via envariable" \
 


### PR DESCRIPTION
- Removal of a note in the build-context documentation about remote Podman client limitations
- Removal of skip statements for build-context tests in the test suite

Pull request #26628 adds support for --build-context for the remote client.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
