### PR TITLE
Revert "test/e2e: try debug potential pasta issue"

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -2354,31 +2353,9 @@ WORKDIR /madethis`, BB)
 
 		podmanTest.AddImageToRWStore(ALPINE)
 
-		success := false
-		registryArgs := []string{"run", "-d", "--name", "registry", "-p", "5006:5000"}
-		if isRootless() {
-			// Debug code for https://github.com/containers/podman/issues/24219
-			logFile := filepath.Join(podmanTest.TempDir, "pasta.log")
-			registryArgs = append(registryArgs, "--network", "pasta:--trace,--log-file,"+logFile)
-			defer func() {
-				if success {
-					// only print the log on errors otherwise it will clutter CI logs way to much
-					return
-				}
-
-				f, err := os.Open(logFile)
-				Expect(err).ToNot(HaveOccurred())
-				defer f.Close()
-				GinkgoWriter.Println("pasta trace log:")
-				_, err = io.Copy(GinkgoWriter, f)
-				Expect(err).ToNot(HaveOccurred())
-			}()
-		}
-		registryArgs = append(registryArgs, REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml")
-
 		lock := GetPortLock("5006")
 		defer lock.Unlock()
-		session := podmanTest.Podman(registryArgs)
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5006:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -2412,8 +2389,6 @@ WORKDIR /madethis`, BB)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull " + imgPath))
-
-		success = true
 	})
 
 	It("podman run --shm-size-systemd", func() {


### PR DESCRIPTION
This reverts commit f517e5216763f9e51729fa277e8e0045a484d950.

The issue #24219 has been fixed a long time ago and this no longer flakes so we do not need to run with debug logs all the time.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
