### PR TITLE
Update github action to use pull_request_target

### DIFF
--- a/.github/workflows/first_contrib_cert_generator.yml
+++ b/.github/workflows/first_contrib_cert_generator.yml
@@ -3,7 +3,7 @@ name: Generate Contributor Certificate Preview
 # This action triggers automatically when a pull request is closed,
 # or can be run manually from the Actions tab.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main


### PR DESCRIPTION
pull_request doesn't have access to the secret, pull_request_target does have access to the secrets

#### Does this PR introduce a user-facing change?

```release-note
None
```
