### PR TITLE
feat(completions): sysctl completion

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1954,3 +1954,35 @@ func AutocompleteSSH(cmd *cobra.Command, args []string, toComplete string) ([]st
 func AutocompleteHealthOnFailure(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return define.SupportedHealthCheckOnFailureActions, cobra.ShellCompDirectiveNoFileComp
 }
+
+// AutocompleteSysctl - autocomplete list all sysctl names
+func AutocompleteSysctl(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var completions []string
+	sysPath := "/proc/sys"
+
+	err := filepath.Walk(sysPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			rel, err := filepath.Rel(sysPath, path)
+			if err != nil {
+				return err
+			}
+			sysctlName := strings.ReplaceAll(rel, string(os.PathSeparator), ".")
+
+			if strings.HasPrefix(sysctlName, toComplete) {
+				completions = append(completions, sysctlName)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -733,8 +733,8 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			sysctlFlagName, []string{},
 			"Sysctl options",
 		)
-		//TODO: Add function for sysctl completion.
-		_ = cmd.RegisterFlagCompletionFunc(sysctlFlagName, completion.AutocompleteNone)
+
+		_ = cmd.RegisterFlagCompletionFunc(sysctlFlagName, AutocompleteSysctl)
 
 		securityOptFlagName := "security-opt"
 		createFlags.StringArrayVar(

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -410,3 +410,15 @@ function _check_no_suggestions() {
     # cleanup container
     run_podman rm $ctrname
 }
+
+# bats test_tags=ci:parallel
+@test "podman run --sysctl completion for sysctl" {
+    skip_if_remote "sysctl option not working via remote"
+
+    run_completion run --sysctl net.
+
+    assert "$output" =~ "^net\." \
+      "Only suggestions with 'net.' should be present for podman run --sysctl net."
+
+    _check_completion_end NoFileComp
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

Yes, added shell autocompletion feature for the `--sysctl` flag in `podman create/run` commands.
Closes #27114

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added shell autocompletion feature for the `--sysctl` flag in `podman create/run` commands.
```