### PR TITLE
 docs: add Containerfile doc link

### DIFF
--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -34,7 +34,7 @@ There’s an old saying that “nobody runs an operating system just to run an o
 
 Sometimes we can find a publicly available container image for the exact workload we’re looking for and it will already be packaged exactly how we want. But, more often than not, there’s something that we want to add, remove, or customize. It can be as simple as a configuration setting for security or performance, or as complex as adding a complex workload. Either way, containers make it fairly easy to make the changes we need.
 
-Container Images aren’t actually images. They are repositories often made up of multiple layers. These layers can easily be added, saved, and shared with others by using a Containerfile (Dockerfile). This single file often contains all the instructions needed to build a new container image and can easily be shared with others publicly using tools like GitHub.
+Container Images aren’t actually images. They are repositories often made up of multiple layers. These layers can easily be added, saved, and shared with others by using a Containerfile_ (Dockerfile). This single file often contains all the instructions needed to build a new container image and can easily be shared with others publicly using tools like GitHub.
 
 Here's an example of how to build a container image from content that resides in a git repository::
 

--- a/docs/source/includes.rst
+++ b/docs/source/includes.rst
@@ -16,4 +16,5 @@
 .. _podman run: http://docs.podman.io/en/latest/markdown/podman-run.1.html
 .. _podman build: http://docs.podman.io/en/latest/markdown/podman-build.1.html
 .. _podman push: http://docs.podman.io/en/latest/markdown/podman-push.1.html
+.. _Containerfile: https://github.com/containers/container-libs/blob/main/common/docs/Containerfile.5.md
 .. image:: https://raw.githubusercontent.com/containers/podman/main/logo/podman-logo.png


### PR DESCRIPTION
Adds a link to the [Containerfile](https://github.com/containers/container-libs/blob/main/common/docs/Containerfile.5.md) documentation from the podman docs "Introduction" section

Fixes: #27086

#### Does this PR introduce a user-facing change?

```release-note
None
```

