### PR TITLE
lint: reenable revive unused-parameter check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,7 +64,6 @@ linters:
     revive:
       rules:
         - name: unused-parameter
-          disabled: true
   exclusions:
     generated: strict
     presets:

--- a/cmd/podman-testing/create.go
+++ b/cmd/podman-testing/create.go
@@ -88,7 +88,7 @@ func init() {
 	flags.StringVarP(&createContainerOpts.Layer, "layer", "l", "", "ID of containers's read-write layer (default none)")
 }
 
-func createStorageLayer(cmd *cobra.Command, args []string) error {
+func createStorageLayer(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.CreateStorageLayer(mainContext, createStorageLayerOpts)
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func createStorageLayer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createLayer(cmd *cobra.Command, args []string) error {
+func createLayer(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.CreateLayer(mainContext, createLayerOpts)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func createLayer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createImage(cmd *cobra.Command, args []string) error {
+func createImage(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.CreateImage(mainContext, createImageOpts)
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func createImage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createContainer(cmd *cobra.Command, args []string) error {
+func createContainer(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.CreateContainer(mainContext, createContainerOpts)
 	if err != nil {
 		return err

--- a/cmd/podman-testing/data.go
+++ b/cmd/podman-testing/data.go
@@ -205,7 +205,7 @@ func init() {
 	flags.StringVarP(&removeContainerDataOpts.Key, "key", "k", "", "Name of the data item")
 }
 
-func createLayerData(cmd *cobra.Command, args []string) error {
+func createLayerData(_ *cobra.Command, _ []string) error {
 	if createLayerDataOpts.ID == "" {
 		return errors.New("layer ID not specified")
 	}
@@ -233,7 +233,7 @@ func createLayerData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createImageData(cmd *cobra.Command, args []string) error {
+func createImageData(_ *cobra.Command, _ []string) error {
 	if createImageDataOpts.ID == "" {
 		return errors.New("image ID not specified")
 	}
@@ -261,7 +261,7 @@ func createImageData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createContainerData(cmd *cobra.Command, args []string) error {
+func createContainerData(_ *cobra.Command, _ []string) error {
 	if createContainerDataOpts.ID == "" {
 		return errors.New("container ID not specified")
 	}
@@ -289,7 +289,7 @@ func createContainerData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func modifyLayerData(cmd *cobra.Command, args []string) error {
+func modifyLayerData(_ *cobra.Command, _ []string) error {
 	if modifyLayerDataOpts.ID == "" {
 		return errors.New("layer ID not specified")
 	}
@@ -314,7 +314,7 @@ func modifyLayerData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func modifyImageData(cmd *cobra.Command, args []string) error {
+func modifyImageData(_ *cobra.Command, _ []string) error {
 	if modifyImageDataOpts.ID == "" {
 		return errors.New("image ID not specified")
 	}
@@ -339,7 +339,7 @@ func modifyImageData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func modifyContainerData(cmd *cobra.Command, args []string) error {
+func modifyContainerData(_ *cobra.Command, _ []string) error {
 	if modifyContainerDataOpts.ID == "" {
 		return errors.New("container ID not specified")
 	}
@@ -364,7 +364,7 @@ func modifyContainerData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeLayerData(cmd *cobra.Command, args []string) error {
+func removeLayerData(_ *cobra.Command, _ []string) error {
 	if removeLayerDataOpts.ID == "" {
 		return errors.New("layer ID not specified")
 	}
@@ -378,7 +378,7 @@ func removeLayerData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeImageData(cmd *cobra.Command, args []string) error {
+func removeImageData(_ *cobra.Command, _ []string) error {
 	if removeImageDataOpts.ID == "" {
 		return errors.New("image ID not specified")
 	}
@@ -392,7 +392,7 @@ func removeImageData(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeContainerData(cmd *cobra.Command, args []string) error {
+func removeContainerData(_ *cobra.Command, _ []string) error {
 	if removeContainerDataOpts.ID == "" {
 		return errors.New("container ID not specified")
 	}

--- a/cmd/podman-testing/layer.go
+++ b/cmd/podman-testing/layer.go
@@ -54,7 +54,7 @@ func init() {
 	flags.StringVarP(&modifyLayerFile, "file", "f", "", "archive of contents to extract over layer")
 }
 
-func populateLayer(cmd *cobra.Command, args []string) error {
+func populateLayer(_ *cobra.Command, _ []string) error {
 	if populateLayerOpts.ID == "" {
 		return errors.New("layer ID not specified")
 	}
@@ -73,7 +73,7 @@ func populateLayer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func modifyLayer(cmd *cobra.Command, args []string) error {
+func modifyLayer(_ *cobra.Command, _ []string) error {
 	if modifyLayerOpts.ID == "" {
 		return errors.New("layer ID not specified")
 	}

--- a/cmd/podman-testing/main.go
+++ b/cmd/podman-testing/main.go
@@ -26,13 +26,13 @@ var (
 	mainCmd = &cobra.Command{
 		Use:  "podman-testing",
 		Long: "Assorted tools for use in testing podman",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			return before()
 		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
 			return after()
 		},
 		SilenceUsage:  true,

--- a/cmd/podman-testing/remove.go
+++ b/cmd/podman-testing/remove.go
@@ -83,7 +83,7 @@ func init() {
 	flags.StringVarP(&removeContainerOpts.ID, "container", "i", "", "ID of the container to remove")
 }
 
-func removeStorageLayer(cmd *cobra.Command, args []string) error {
+func removeStorageLayer(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.RemoveStorageLayer(mainContext, removeStorageLayerOpts)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func removeStorageLayer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeLayer(cmd *cobra.Command, args []string) error {
+func removeLayer(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.RemoveLayer(mainContext, removeLayerOpts)
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func removeLayer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeImage(cmd *cobra.Command, args []string) error {
+func removeImage(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.RemoveImage(mainContext, removeImageOpts)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func removeImage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeContainer(cmd *cobra.Command, args []string) error {
+func removeContainer(_ *cobra.Command, _ []string) error {
 	results, err := testingEngine.RemoveContainer(mainContext, removeContainerOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/artifact/add.go
+++ b/cmd/podman/artifact/add.go
@@ -58,7 +58,7 @@ func init() {
 	_ = addCmd.RegisterFlagCompletionFunc(fileMIMETypeFlagName, completion.AutocompleteNone)
 }
 
-func add(cmd *cobra.Command, args []string) error {
+func add(_ *cobra.Command, args []string) error {
 	artifactName := args[0]
 	blobs := args[1:]
 

--- a/cmd/podman/artifact/extract.go
+++ b/cmd/podman/artifact/extract.go
@@ -41,7 +41,7 @@ func init() {
 	_ = extractCmd.RegisterFlagCompletionFunc(titleFlagName, completion.AutocompleteNone)
 }
 
-func extract(cmd *cobra.Command, args []string) error {
+func extract(_ *cobra.Command, args []string) error {
 	err := registry.ImageEngine().ArtifactExtract(registry.Context(), args[0], args[1], extractOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/artifact/inspect.go
+++ b/cmd/podman/artifact/inspect.go
@@ -40,7 +40,7 @@ func init() {
 	// _ = inspectCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&machine.InspectInfo{}))
 }
 
-func inspect(cmd *cobra.Command, args []string) error {
+func inspect(_ *cobra.Command, args []string) error {
 	artifactOptions := entities.ArtifactInspectOptions{}
 	inspectData, err := registry.ImageEngine().ArtifactInspect(registry.Context(), args[0], artifactOptions)
 	if err != nil {

--- a/cmd/podman/artifact/rm.go
+++ b/cmd/podman/artifact/rm.go
@@ -41,7 +41,7 @@ func init() {
 	rmFlags(rmCmd)
 }
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	rmOptions.Artifacts = args
 
 	artifactRemoveReport, err := registry.ImageEngine().ArtifactRm(registry.Context(), rmOptions)

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -737,7 +737,7 @@ func AutocompleteSecrets(cmd *cobra.Command, args []string, toComplete string) (
 	return getSecrets(cmd, toComplete, completeDefault)
 }
 
-func AutocompleteSecretCreate(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteSecretCreate(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 1 {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -775,12 +775,12 @@ func AutocompleteManifestListAndMember(cmd *cobra.Command, args []string, toComp
 }
 
 // AutocompleteImageSearchFilters - Autocomplete `search --filter`.
-func AutocompleteImageSearchFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteImageSearchFilters(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return libimageDefine.SearchFilters, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompletePodExitPolicy - Autocomplete pod exit policy.
-func AutocompletePodExitPolicy(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePodExitPolicy(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return config.PodExitPolicies, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -844,13 +844,13 @@ func AutocompleteNetworks(cmd *cobra.Command, args []string, toComplete string) 
 
 // AutocompleteHostsFile - Autocomplete hosts file options.
 // -> "image", "none", paths
-func AutocompleteHostsFile(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteHostsFile(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	hostsFileModes := []string{"image", "none"}
 	return hostsFileModes, cobra.ShellCompDirectiveDefault
 }
 
 // AutocompleteDefaultOneArg - Autocomplete path only for the first argument.
-func AutocompleteDefaultOneArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteDefaultOneArg(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -1087,7 +1087,7 @@ func AutocompleteScp(cmd *cobra.Command, args []string, toComplete string) ([]st
 
 // AutocompleteDetachKeys - Autocomplete detach-keys options.
 // -> "ctrl-"
-func AutocompleteDetachKeys(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteDetachKeys(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if strings.HasSuffix(toComplete, ",") {
 		return []string{toComplete + "ctrl-"}, cobra.ShellCompDirectiveNoSpace
 	}
@@ -1096,36 +1096,36 @@ func AutocompleteDetachKeys(cmd *cobra.Command, args []string, toComplete string
 
 // AutocompleteChangeInstructions - Autocomplete change instructions options for commit and import.
 // -> "CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"
-func AutocompleteChangeInstructions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteChangeInstructions(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return ChangeCmds, cobra.ShellCompDirectiveNoSpace
 }
 
 // AutocompleteImageFormat - Autocomplete image format options.
 // -> "oci", "docker"
-func AutocompleteImageFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteImageFormat(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	ImageFormat := []string{"oci", "docker"}
 	return ImageFormat, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteInitCtr - Autocomplete init container type
 // -> "once", "always"
-func AutocompleteInitCtr(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteInitCtr(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	InitCtrType := []string{define.AlwaysInitContainer, define.OneShotInitContainer}
 	return InitCtrType, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteCreateAttach - Autocomplete create --attach options.
 // -> "stdin", "stdout", "stderr"
-func AutocompleteCreateAttach(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteCreateAttach(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return []string{"stdin", "stdout", "stderr"}, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteNamespace - Autocomplete namespace options.
 // -> host,container:[name],ns:[path],private
-func AutocompleteNamespace(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteNamespace(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"container:": func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
-		"ns:":        func(s string) ([]string, cobra.ShellCompDirective) { return nil, cobra.ShellCompDirectiveDefault },
+		"ns:":        func(_ string) ([]string, cobra.ShellCompDirective) { return nil, cobra.ShellCompDirectiveDefault },
 		"host":       nil,
 		"private":    nil,
 	}
@@ -1142,21 +1142,21 @@ func AutocompleteUserNamespace(cmd *cobra.Command, args []string, toComplete str
 
 // AutocompleteCgroupMode - Autocomplete cgroup mode options.
 // -> "enabled", "disabled", "no-conmon", "split"
-func AutocompleteCgroupMode(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteCgroupMode(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	cgroupModes := []string{"enabled", "disabled", "no-conmon", "split"}
 	return cgroupModes, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteImageVolume - Autocomplete image volume options.
 // -> "bind", "tmpfs", "ignore"
-func AutocompleteImageVolume(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteImageVolume(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	imageVolumes := []string{"bind", "tmpfs", "ignore"}
 	return imageVolumes, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteLogDriver - Autocomplete log-driver options.
 // -> "journald", "none", "k8s-file", "passthrough", "passthrough-tty"
-func AutocompleteLogDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteLogDriver(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	// don't show json-file
 	logDrivers := []string{define.JournaldLogging, define.NoLogging, define.KubernetesLogging}
 	if !registry.IsRemote() {
@@ -1167,7 +1167,7 @@ func AutocompleteLogDriver(cmd *cobra.Command, args []string, toComplete string)
 
 // AutocompleteLogOpt - Autocomplete log-opt options.
 // -> "path=", "tag="
-func AutocompleteLogOpt(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteLogOpt(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	logOptions := []string{"path=", "tag=", "max-size="}
 	if strings.HasPrefix(toComplete, "path=") {
 		return nil, cobra.ShellCompDirectiveDefault
@@ -1177,25 +1177,25 @@ func AutocompleteLogOpt(cmd *cobra.Command, args []string, toComplete string) ([
 
 // AutocompletePullOption - Autocomplete pull options for create and run command.
 // -> "always", "missing", "never"
-func AutocompletePullOption(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePullOption(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	pullOptions := []string{"always", "missing", "never", "newer"}
 	return pullOptions, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteRestartOption - Autocomplete restart options for create and run command.
 // -> "always", "no", "on-failure", "unless-stopped"
-func AutocompleteRestartOption(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteRestartOption(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	restartOptions := []string{define.RestartPolicyAlways, define.RestartPolicyNo,
 		define.RestartPolicyOnFailure, define.RestartPolicyUnlessStopped}
 	return restartOptions, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteSecurityOption - Autocomplete security options options.
-func AutocompleteSecurityOption(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteSecurityOption(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"apparmor=":         nil,
 		"no-new-privileges": nil,
-		"seccomp=":          func(s string) ([]string, cobra.ShellCompDirective) { return nil, cobra.ShellCompDirectiveDefault },
+		"seccomp=":          func(_ string) ([]string, cobra.ShellCompDirective) { return nil, cobra.ShellCompDirectiveDefault },
 		"label=": func(s string) ([]string, cobra.ShellCompDirective) {
 			if strings.HasPrefix(s, "d") {
 				return []string{"disable"}, cobra.ShellCompDirectiveNoFileComp
@@ -1208,7 +1208,7 @@ func AutocompleteSecurityOption(cmd *cobra.Command, args []string, toComplete st
 
 // AutocompleteStopSignal - Autocomplete stop signal options.
 // Autocompletes signals both lower or uppercase depending on the user input.
-func AutocompleteStopSignal(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteStopSignal(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// convertCase will convert a string to lowercase only if the user input is lowercase
 	convertCase := func(s string) string { return s }
 	if len(toComplete) > 0 && unicode.IsLower(rune(toComplete[0])) {
@@ -1232,14 +1232,14 @@ func AutocompleteStopSignal(cmd *cobra.Command, args []string, toComplete string
 
 // AutocompleteSystemdFlag - Autocomplete systemd flag options.
 // -> "true", "false", "always"
-func AutocompleteSystemdFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteSystemdFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	systemd := []string{"true", "false", "always"}
 	return systemd, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteUserFlag - Autocomplete user flag based on the names and groups (includes ids after first char) in /etc/passwd and /etc/group files.
 // -> user:group
-func AutocompleteUserFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteUserFlag(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if strings.Contains(toComplete, ":") {
 		// It would be nice to read the file in the image
 		// but at this point we don't know the image.
@@ -1295,7 +1295,7 @@ func AutocompleteUserFlag(cmd *cobra.Command, args []string, toComplete string) 
 
 // AutocompleteMountFlag - Autocomplete mount flag options.
 // -> "type=bind,", "type=volume,", "type=tmpfs,"
-func AutocompleteMountFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteMountFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{"type=bind,", "type=volume,", "type=tmpfs,"}
 	// TODO: Add support for all different options
 	return types, cobra.ShellCompDirectiveNoSpace
@@ -1303,7 +1303,7 @@ func AutocompleteMountFlag(cmd *cobra.Command, args []string, toComplete string)
 
 // AutocompleteVolumeFlag - Autocomplete volume flag options.
 // -> volumes and paths
-func AutocompleteVolumeFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteVolumeFlag(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	volumes, _ := getVolumes(cmd, toComplete)
 	directive := cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveDefault
 	if strings.Contains(toComplete, ":") {
@@ -1314,7 +1314,7 @@ func AutocompleteVolumeFlag(cmd *cobra.Command, args []string, toComplete string
 }
 
 // AutocompleteNetworkFlag - Autocomplete network flag options.
-func AutocompleteNetworkFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteNetworkFlag(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"container:": func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
 		"ns:": func(_ string) ([]string, cobra.ShellCompDirective) {
@@ -1588,7 +1588,7 @@ func getMethodNames(f reflect.Value, prefix string) []formatSuggestion {
 
 // AutocompleteEventFilter - Autocomplete event filter flag options.
 // -> "container=", "event=", "image=", "pod=", "volume=", "type="
-func AutocompleteEventFilter(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteEventFilter(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	event := func(_ string) ([]string, cobra.ShellCompDirective) {
 		return []string{events.Attach.String(), events.AutoUpdate.String(), events.Checkpoint.String(), events.Cleanup.String(),
 			events.Commit.String(), events.Create.String(), events.Exec.String(), events.ExecDied.String(),
@@ -1620,39 +1620,39 @@ func AutocompleteEventFilter(cmd *cobra.Command, args []string, toComplete strin
 
 // AutocompleteSystemdRestartOptions - Autocomplete systemd restart options.
 // -> "no", "on-success", "on-failure", "on-abnormal", "on-watchdog", "on-abort", "always"
-func AutocompleteSystemdRestartOptions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteSystemdRestartOptions(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return systemdDefine.RestartPolicies, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteTrustType - Autocomplete trust type options.
 // -> "signedBy", "accept", "reject"
-func AutocompleteTrustType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteTrustType(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{"signedBy", "accept", "reject"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteImageSort - Autocomplete images sort options.
 // -> "created", "id", "repository", "size", "tag"
-func AutocompleteImageSort(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteImageSort(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	sortBy := []string{"created", "id", "repository", "size", "tag"}
 	return sortBy, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteInspectType - Autocomplete inspect type options.
-func AutocompleteInspectType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteInspectType(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{AllType, ContainerType, ImageType, NetworkType, PodType, VolumeType}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteManifestFormat - Autocomplete manifest format options.
 // -> "oci", "v2s2"
-func AutocompleteManifestFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteManifestFormat(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{"oci", "v2s2"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteNetworkDriver - Autocomplete network driver option.
-func AutocompleteNetworkDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteNetworkDriver(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	engine, err := setupContainerEngine(cmd)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
@@ -1668,14 +1668,14 @@ func AutocompleteNetworkDriver(cmd *cobra.Command, args []string, toComplete str
 
 // AutocompleteNetworkIPAMDriver - Autocomplete network ipam driver option.
 // -> "bridge", "macvlan"
-func AutocompleteNetworkIPAMDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteNetworkIPAMDriver(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	drivers := []string{types.HostLocalIPAMDriver, types.DHCPIPAMDriver, types.NoneIPAMDriver}
 	return drivers, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompletePodShareNamespace - Autocomplete pod create --share flag option.
 // -> "ipc", "net", "pid", "user", "uts", "cgroup", "none"
-func AutocompletePodShareNamespace(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePodShareNamespace(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	namespaces := []string{"ipc", "net", "pid", "user", "uts", "cgroup", "none"}
 	split := strings.Split(toComplete, ",")
 	split[len(split)-1] = ""
@@ -1685,26 +1685,26 @@ func AutocompletePodShareNamespace(cmd *cobra.Command, args []string, toComplete
 
 // AutocompletePodPsSort - Autocomplete images sort options.
 // -> "created", "id", "name", "status", "number"
-func AutocompletePodPsSort(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePodPsSort(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	sortBy := []string{"created", "id", "name", "status", "number"}
 	return sortBy, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompletePsSort - Autocomplete images sort options.
 // -> "command", "created", "id", "image", "names", "runningfor", "size", "status"
-func AutocompletePsSort(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePsSort(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	sortBy := []string{"command", "created", "id", "image", "names", "runningfor", "size", "status"}
 	return sortBy, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteImageSaveFormat - Autocomplete image save format options.
-func AutocompleteImageSaveFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteImageSaveFormat(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return ValidSaveFormats, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteWaitCondition - Autocomplete wait condition options.
 // -> "unknown", "configured", "created", "running", "stopped", "paused", "exited", "removing"
-func AutocompleteWaitCondition(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteWaitCondition(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	states := []string{"unknown", "configured", "created", "exited",
 		"healthy", "initialized", "paused", "removing", "running",
 		"stopped", "stopping", "unhealthy"}
@@ -1713,13 +1713,13 @@ func AutocompleteWaitCondition(cmd *cobra.Command, args []string, toComplete str
 
 // AutocompleteCgroupManager - Autocomplete cgroup manager options.
 // -> "cgroupfs", "systemd"
-func AutocompleteCgroupManager(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteCgroupManager(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{config.CgroupfsCgroupsManager, config.SystemdCgroupsManager}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteContainersConfModules- Autocomplete containers.conf modules.
-func AutocompleteContainersConfModules(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteContainersConfModules(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	dirs, err := config.ModuleDirectories()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveDefault
@@ -1752,27 +1752,27 @@ func AutocompleteContainersConfModules(cmd *cobra.Command, args []string, toComp
 
 // AutocompleteEventBackend - Autocomplete event backend options.
 // -> "file", "journald", "none"
-func AutocompleteEventBackend(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteEventBackend(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{events.LogFile.String(), events.Journald.String(), events.Null.String()}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteNetworkBackend - Autocomplete network backend options.
 // -> "cni", "netavark"
-func AutocompleteNetworkBackend(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteNetworkBackend(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{string(types.CNI), string(types.Netavark)}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteLogLevel - Autocomplete log level options.
 // -> "trace", "debug", "info", "warn", "error", "fatal", "panic"
-func AutocompleteLogLevel(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteLogLevel(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return LogLevels, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteSDNotify - Autocomplete sdnotify options.
 // -> "container", "conmon", "ignore"
-func AutocompleteSDNotify(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteSDNotify(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{define.SdNotifyModeConmon, define.SdNotifyModeContainer, define.SdNotifyModeHealthy, define.SdNotifyModeIgnore}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
@@ -1780,7 +1780,7 @@ func AutocompleteSDNotify(cmd *cobra.Command, args []string, toComplete string) 
 var containerStatuses = []string{"created", "running", "paused", "stopped", "exited", "unknown"}
 
 // AutocompletePsFilters - Autocomplete ps filter options.
-func AutocompletePsFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePsFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"ancestor=": func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) },
 		"before=":   func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
@@ -1806,7 +1806,7 @@ func AutocompletePsFilters(cmd *cobra.Command, args []string, toComplete string)
 }
 
 // AutocompleteQuadletFilters - Autocomplete quadlet filter options.
-func AutocompleteQuadletFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteQuadletFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"name=": func(s string) ([]string, cobra.ShellCompDirective) { return getQuadlets(cmd, s) },
 	}
@@ -1814,7 +1814,7 @@ func AutocompleteQuadletFilters(cmd *cobra.Command, args []string, toComplete st
 }
 
 // AutocompletePodPsFilters - Autocomplete pod ps filter options.
-func AutocompletePodPsFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePodPsFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"ctr-ids=":    func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeIDs) },
 		"ctr-names=":  func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeNames) },
@@ -1836,7 +1836,7 @@ func AutocompletePodPsFilters(cmd *cobra.Command, args []string, toComplete stri
 }
 
 // AutocompleteImageFilters - Autocomplete image ls --filter options.
-func AutocompleteImageFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteImageFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	getImg := func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) }
 	kv := keyValueCompletion{
 		"after=":        getImg,
@@ -1857,7 +1857,7 @@ func AutocompleteImageFilters(cmd *cobra.Command, args []string, toComplete stri
 }
 
 // AutocompletePruneFilters - Autocomplete container/image prune --filter options.
-func AutocompletePruneFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompletePruneFilters(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"label=": nil,
 		"until=": nil,
@@ -1866,7 +1866,7 @@ func AutocompletePruneFilters(cmd *cobra.Command, args []string, toComplete stri
 }
 
 // AutocompleteNetworkFilters - Autocomplete network ls --filter options.
-func AutocompleteNetworkFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteNetworkFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"dangling=": getBoolCompletion,
 		"driver=": func(_ string) ([]string, cobra.ShellCompDirective) {
@@ -1881,7 +1881,7 @@ func AutocompleteNetworkFilters(cmd *cobra.Command, args []string, toComplete st
 }
 
 // AutocompleteVolumeFilters - Autocomplete volume ls --filter options.
-func AutocompleteVolumeFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteVolumeFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	local := func(_ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"local"}, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -1901,7 +1901,7 @@ func AutocompleteVolumeFilters(cmd *cobra.Command, args []string, toComplete str
 }
 
 // AutocompleteSecretFilters - Autocomplete secret ls --filter options.
-func AutocompleteSecretFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteSecretFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kv := keyValueCompletion{
 		"id=":   func(s string) ([]string, cobra.ShellCompDirective) { return getSecrets(cmd, s, completeIDs) },
 		"name=": func(s string) ([]string, cobra.ShellCompDirective) { return getSecrets(cmd, s, completeNames) },
@@ -1911,13 +1911,13 @@ func AutocompleteSecretFilters(cmd *cobra.Command, args []string, toComplete str
 
 // AutocompleteCheckpointCompressType - Autocomplete checkpoint compress type options.
 // -> "gzip", "none", "zstd"
-func AutocompleteCheckpointCompressType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteCheckpointCompressType(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{"gzip", "none", "zstd"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteCompressionFormat - Autocomplete compression-format type options.
-func AutocompleteCompressionFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteCompressionFormat(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	types := []string{"gzip", "zstd", "zstd:chunked"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
@@ -1951,6 +1951,6 @@ func AutocompleteSSH(cmd *cobra.Command, args []string, toComplete string) ([]st
 }
 
 // AutocompleteHealthOnFailure - action to take once the container turns unhealthy.
-func AutocompleteHealthOnFailure(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AutocompleteHealthOnFailure(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return define.SupportedHealthCheckOnFailureActions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/podman/compose.go
+++ b/cmd/podman/compose.go
@@ -44,7 +44,7 @@ func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{Command: composeCommand})
 }
 
-func composeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func composeCompletion(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var stdout strings.Builder
 
 	args = append(args, toComplete)

--- a/cmd/podman/compose_machine_unix.go
+++ b/cmd/podman/compose_machine_unix.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 )
 
-func extractConnectionString(podmanSocket *define.VMFile, podmanPipe *define.VMFile) (string, error) {
+func extractConnectionString(podmanSocket *define.VMFile, _ *define.VMFile) (string, error) {
 	if podmanSocket == nil {
 		return "", errors.New("socket of machine is not set")
 	}

--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -69,7 +69,7 @@ func init() {
 	validate.AddLatestFlag(containerAttachCommand, &attachOpts.Latest)
 }
 
-func attach(cmd *cobra.Command, args []string) error {
+func attach(_ *cobra.Command, args []string) error {
 	if len(args) > 1 || (len(args) == 0 && !attachOpts.Latest) {
 		return errors.New("attach requires the name or id of one running container or the latest flag")
 	}

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -61,7 +61,7 @@ func init() {
 	validate.AddLatestFlag(cleanupCommand, &cleanupOptions.Latest)
 }
 
-func cleanup(cmd *cobra.Command, args []string) error {
+func cleanup(_ *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -96,7 +96,7 @@ func init() {
 	commitFlags(containerCommitCommand)
 }
 
-func commit(cmd *cobra.Command, args []string) error {
+func commit(_ *cobra.Command, args []string) error {
 	container := strings.TrimPrefix(args[0], "/")
 	if len(args) == 2 {
 		commitOptions.ImageName = args[1]

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -80,7 +80,7 @@ func init() {
 	cpFlags(containerCpCommand)
 }
 
-func cp(cmd *cobra.Command, args []string) error {
+func cp(_ *cobra.Command, args []string) error {
 	// Parse user input.
 	sourceContainerStr, sourcePath, destContainerStr, destPath, err := copy.ParseSourceAndDestination(args[0], args[1])
 	if err != nil {

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -68,7 +68,7 @@ func init() {
 	exportFlags(containerExportCommand)
 }
 
-func export(cmd *cobra.Command, args []string) error {
+func export(_ *cobra.Command, args []string) error {
 	if len(outputFile) == 0 {
 		file := os.Stdout
 		if term.IsTerminal(int(file.Fd())) {

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -65,7 +65,7 @@ func init() {
 	validate.AddLatestFlag(containerInitCommand, &initOptions.Latest)
 }
 
-func initContainer(cmd *cobra.Command, args []string) error {
+func initContainer(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	args = utils.RemoveSlash(args)
 	report, err := registry.ContainerEngine().ContainerInit(registry.Context(), args, initOptions)

--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -40,7 +40,7 @@ func init() {
 	validate.AddLatestFlag(inspectCmd, &inspectOpts.Latest)
 }
 
-func inspectExec(cmd *cobra.Command, args []string) error {
+func inspectExec(_ *cobra.Command, args []string) error {
 	// Force container type
 	inspectOpts.Type = common.ContainerType
 	return inspect.Inspect(args, *inspectOpts)

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -86,7 +86,7 @@ func init() {
 	validate.AddLatestFlag(containerPauseCommand, &pauseOpts.Latest)
 }
 
-func pause(cmd *cobra.Command, args []string) error {
+func pause(_ *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)

--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -46,7 +46,7 @@ func init() {
 	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePruneFilters)
 }
 
-func prune(cmd *cobra.Command, _ []string) error {
+func prune(_ *cobra.Command, _ []string) error {
 	var (
 		pruneOptions = entities.ContainerPruneOptions{}
 		err          error

--- a/cmd/podman/containers/rename.go
+++ b/cmd/podman/containers/rename.go
@@ -44,7 +44,7 @@ func init() {
 	})
 }
 
-func rename(cmd *cobra.Command, args []string) error {
+func rename(_ *cobra.Command, args []string) error {
 	if len(args) > 2 {
 		return errors.New("must provide at least two arguments to rename")
 	}

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -83,7 +83,7 @@ func init() {
 	validate.AddLatestFlag(containerStartCommand, &startOptions.Latest)
 }
 
-func validateStart(cmd *cobra.Command, args []string) error {
+func validateStart(_ *cobra.Command, args []string) error {
 	if len(args) == 0 && !startOptions.Latest && !startOptions.All && len(filters) < 1 {
 		return errors.New("start requires at least one argument")
 	}

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -95,7 +95,7 @@ func init() {
 
 // stats is different in that it will assume running containers if
 // no input is given, so we need to validate differently
-func checkStatOptions(cmd *cobra.Command, args []string) error {
+func checkStatOptions(_ *cobra.Command, args []string) error {
 	opts := 0
 	if statsOptions.All {
 		opts++

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -76,7 +76,7 @@ func init() {
 	validate.AddLatestFlag(containerUnmountCommand, &unmountOpts.Latest)
 }
 
-func unmount(cmd *cobra.Command, args []string) error {
+func unmount(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	args = utils.RemoveSlash(args)
 	reports, err := registry.ContainerEngine().ContainerUnmount(registry.Context(), args, unmountOpts)

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -87,7 +87,7 @@ func init() {
 	validate.AddLatestFlag(containerUnpauseCommand, &unpauseOpts.Latest)
 }
 
-func unpause(cmd *cobra.Command, args []string) error {
+func unpause(_ *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)

--- a/cmd/podman/farm/create.go
+++ b/cmd/podman/farm/create.go
@@ -37,7 +37,7 @@ func init() {
 	})
 }
 
-func create(cmd *cobra.Command, args []string) error {
+func create(_ *cobra.Command, args []string) error {
 	farmName := args[0]
 	connections := args[1:]
 

--- a/cmd/podman/farm/remove.go
+++ b/cmd/podman/farm/remove.go
@@ -42,7 +42,7 @@ func init() {
 	flags.BoolVarP(&rmOpts.All, "all", "a", false, "Remove all farms")
 }
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	deletedFarms := []string{}
 	err := config.EditConnectionConfig(func(cfg *config.ConnectionsFile) error {
 		if rmOpts.All {

--- a/cmd/podman/generate/spec.go
+++ b/cmd/podman/generate/spec.go
@@ -49,7 +49,7 @@ func init() {
 	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 
-func spec(cmd *cobra.Command, args []string) error {
+func spec(_ *cobra.Command, args []string) error {
 	opts.ID = args[0]
 	report, err := registry.ContainerEngine().GenerateSpec(registry.Context(), opts)
 	if err != nil {

--- a/cmd/podman/healthcheck/run.go
+++ b/cmd/podman/healthcheck/run.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-func run(cmd *cobra.Command, args []string) error {
+func run(_ *cobra.Command, args []string) error {
 	response, err := registry.ContainerEngine().HealthCheckRun(context.Background(), args[0], entities.HealthCheckOptions{})
 	if err != nil {
 		return err

--- a/cmd/podman/images/buildx_inspect.go
+++ b/cmd/podman/images/buildx_inspect.go
@@ -39,7 +39,7 @@ func init() {
 	})
 }
 
-func runBuildxInspect(cmd *cobra.Command, args []string) error {
+func runBuildxInspect(_ *cobra.Command, _ []string) error {
 	info, err := registry.ContainerEngine().Info(registry.Context())
 
 	if err != nil {

--- a/cmd/podman/images/exists.go
+++ b/cmd/podman/images/exists.go
@@ -26,7 +26,7 @@ func init() {
 	})
 }
 
-func exists(cmd *cobra.Command, args []string) error {
+func exists(_ *cobra.Command, args []string) error {
 	found, err := registry.ImageEngine().Exists(registry.Context(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -94,7 +94,7 @@ func importFlags(cmd *cobra.Command) {
 	}
 }
 
-func importCon(cmd *cobra.Command, args []string) error {
+func importCon(_ *cobra.Command, args []string) error {
 	var (
 		source    string
 		reference string

--- a/cmd/podman/images/inspect.go
+++ b/cmd/podman/images/inspect.go
@@ -37,7 +37,7 @@ func init() {
 	_ = inspectCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&inspectTypes.ImageData{}))
 }
 
-func inspectExec(cmd *cobra.Command, args []string) error {
+func inspectExec(_ *cobra.Command, args []string) error {
 	inspectOpts.Type = common.ImageType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -70,7 +70,7 @@ func loadFlags(cmd *cobra.Command) {
 	}
 }
 
-func load(cmd *cobra.Command, args []string) error {
+func load(_ *cobra.Command, _ []string) error {
 	if len(loadOpts.Input) > 0 {
 		// Download the input file if needed.
 		if strings.HasPrefix(loadOpts.Input, "https://") || strings.HasPrefix(loadOpts.Input, "http://") {

--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -55,7 +55,7 @@ func init() {
 	_ = pruneCmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePruneFilters)
 }
 
-func prune(cmd *cobra.Command, args []string) error {
+func prune(_ *cobra.Command, _ []string) error {
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Printf("%s", createPruneWarningMessage(pruneOpts))

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -61,7 +61,7 @@ func imageRemoveFlagSet(flags *pflag.FlagSet) {
 	flags.BoolVar(&imageOpts.NoPrune, "no-prune", false, "Do not remove dangling images")
 }
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	if len(args) < 1 && !imageOpts.All {
 		return errors.New("image name or ID must be specified")
 	}

--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -45,7 +45,7 @@ func scpFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&quiet, "quiet", "q", false, "Suppress the output")
 }
 
-func scp(cmd *cobra.Command, args []string) (finalErr error) {
+func scp(_ *cobra.Command, args []string) (finalErr error) {
 	var (
 		err error
 	)

--- a/cmd/podman/images/tag.go
+++ b/cmd/podman/images/tag.go
@@ -44,6 +44,6 @@ func init() {
 	})
 }
 
-func tag(cmd *cobra.Command, args []string) error {
+func tag(_ *cobra.Command, args []string) error {
 	return registry.ImageEngine().Tag(registry.Context(), args[0], args[1:], entities.ImageTagOptions{})
 }

--- a/cmd/podman/images/trust_set.go
+++ b/cmd/podman/images/trust_set.go
@@ -52,7 +52,7 @@ File(s) must exist before using this command`)
 	_ = setTrustCommand.RegisterFlagCompletionFunc(typeFlagName, common.AutocompleteTrustType)
 }
 
-func setTrust(cmd *cobra.Command, args []string) error {
+func setTrust(_ *cobra.Command, args []string) error {
 	validTrustTypes := []string{"accept", "insecureAcceptAnything", "reject", "signedBy", "sigstoreSigned"}
 
 	valid, err := isValidImageURI(args[0])

--- a/cmd/podman/images/unmount.go
+++ b/cmd/podman/images/unmount.go
@@ -50,7 +50,7 @@ func init() {
 	unmountFlags(unmountCommand.Flags())
 }
 
-func unmount(cmd *cobra.Command, args []string) error {
+func unmount(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	if len(args) < 1 && !unmountOpts.All {
 		return errors.New("image name or ID must be specified")

--- a/cmd/podman/images/untag.go
+++ b/cmd/podman/images/untag.go
@@ -43,6 +43,6 @@ func init() {
 	})
 }
 
-func untag(cmd *cobra.Command, args []string) error {
+func untag(_ *cobra.Command, args []string) error {
 	return registry.ImageEngine().Untag(registry.Context(), args[0], args[1:], entities.ImageUntagOptions{})
 }

--- a/cmd/podman/images/version.go
+++ b/cmd/podman/images/version.go
@@ -29,7 +29,7 @@ func init() {
 	})
 }
 
-func version(cmd *cobra.Command, args []string) error {
+func version(_ *cobra.Command, _ []string) error {
 	fmt.Printf("%s %s\n", define.Package, define.Version)
 	return nil
 }

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -41,6 +41,6 @@ func init() {
 	inspectOpts = inspect.AddInspectFlagSet(inspectCmd)
 }
 
-func inspectExec(cmd *cobra.Command, args []string) error {
+func inspectExec(_ *cobra.Command, args []string) error {
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -47,7 +47,7 @@ func downFlags(cmd *cobra.Command) {
 	flags.BoolVar(&downOptions.Force, "force", false, "remove volumes")
 }
 
-func down(cmd *cobra.Command, args []string) error {
+func down(_ *cobra.Command, args []string) error {
 	reader, err := readerFromArg(args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 // Implementation of podman-logout.
-func logout(cmd *cobra.Command, args []string) error {
+func logout(_ *cobra.Command, args []string) error {
 	sysCtx := &types.SystemContext{}
 	common.SetRegistriesConfPath(sysCtx)
 	return auth.Logout(sysCtx, &logoutOptions, args)

--- a/cmd/podman/machine/client9p.go
+++ b/cmd/podman/machine/client9p.go
@@ -37,7 +37,7 @@ func init() {
 	})
 }
 
-func remoteDirClient(cmd *cobra.Command, args []string) error {
+func remoteDirClient(_ *cobra.Command, args []string) error {
 	port, err := strconv.Atoi(args[0])
 	if err != nil {
 		return fmt.Errorf("error parsing port number: %w", err)

--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -52,7 +52,7 @@ func init() {
 	_ = infoCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.MachineInfo{}))
 }
 
-func info(cmd *cobra.Command, args []string) error {
+func info(cmd *cobra.Command, _ []string) error {
 	info := entities.MachineInfo{}
 	version, err := define.GetVersion()
 	if err != nil {

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -65,7 +65,7 @@ func init() {
 	flags.BoolVar(&listFlag.allProviders, "all-providers", false, "Show machines from all providers")
 }
 
-func list(cmd *cobra.Command, args []string) error {
+func list(cmd *cobra.Command, _ []string) error {
 	var (
 		opts machine.ListOptions
 		err  error
@@ -91,7 +91,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return listResponse[i].LastUp.After(listResponse[j].LastUp)
 	})
 	// Bring currently running machines to top
-	sort.Slice(listResponse, func(i, j int) bool {
+	sort.Slice(listResponse, func(i, _ int) bool {
 		return listResponse[i].Running
 	})
 

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -61,7 +61,7 @@ func machinePreRunE(c *cobra.Command, args []string) error {
 }
 
 // autocompleteMachineSSH - Autocomplete machine ssh command.
-func autocompleteMachineSSH(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func autocompleteMachineSSH(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		return getMachines(toComplete)
 	}
@@ -69,7 +69,7 @@ func autocompleteMachineSSH(cmd *cobra.Command, args []string, toComplete string
 }
 
 // autocompleteMachineCp - Autocomplete machine cp command.
-func autocompleteMachineCp(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func autocompleteMachineCp(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) < 2 {
 		if i := strings.IndexByte(toComplete, ':'); i > -1 {
 			// TODO: offer virtual machine path completion
@@ -96,7 +96,7 @@ func autocompleteMachineCp(cmd *cobra.Command, args []string, toComplete string)
 }
 
 // autocompleteMachine - Autocomplete machines.
-func autocompleteMachine(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func autocompleteMachine(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		return getMachines(toComplete)
 	}

--- a/cmd/podman/machine/machine_unix.go
+++ b/cmd/podman/machine/machine_unix.go
@@ -14,7 +14,7 @@ func isUnixSocket(file os.DirEntry) bool {
 	return file.Type()&os.ModeSocket != 0
 }
 
-func rootlessOnly(cmd *cobra.Command, args []string) error {
+func rootlessOnly(cmd *cobra.Command, _ []string) error {
 	if !rootless.IsRootless() {
 		return fmt.Errorf("cannot run command %q as root", cmd.CommandPath())
 	}

--- a/cmd/podman/machine/os/apply.go
+++ b/cmd/podman/machine/os/apply.go
@@ -38,7 +38,7 @@ func init() {
 	flags.BoolVar(&restart, restartFlagName, false, "Restart VM to apply changes")
 }
 
-func apply(cmd *cobra.Command, args []string) error {
+func apply(_ *cobra.Command, args []string) error {
 	vmName := ""
 	if len(args) == 2 {
 		vmName = args[1]

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -47,7 +47,7 @@ func init() {
 
 // TODO Remember that this changed upstream and needs to updated as such!
 
-func ssh(cmd *cobra.Command, args []string) error {
+func ssh(_ *cobra.Command, args []string) error {
 	var (
 		err     error
 		mc      *vmconfigs.MachineConfig

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 // TODO  Name shouldn't be required, need to create a default vm
-func stop(cmd *cobra.Command, args []string) error {
+func stop(_ *cobra.Command, args []string) error {
 	var (
 		err error
 	)

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -89,7 +89,7 @@ func parseCommands() *cobra.Command {
 				}
 
 				// add error message to the command so the user knows that this command is not supported with local/remote
-				c.Command.RunE = func(cmd *cobra.Command, args []string) error {
+				c.Command.RunE = func(cmd *cobra.Command, _ []string) error {
 					return fmt.Errorf("cannot use command %q with the %s podman client", cmd.CommandPath(), client)
 				}
 				// turn off flag parsing to make we do not get flag errors
@@ -110,7 +110,7 @@ func parseCommands() *cobra.Command {
 		_, found := c.Command.Annotations[registry.UnshareNSRequired]
 		if found {
 			if rootless.IsRootless() && os.Getuid() != 0 {
-				c.Command.RunE = func(cmd *cobra.Command, args []string) error {
+				c.Command.RunE = func(cmd *cobra.Command, _ []string) error {
 					return fmt.Errorf("cannot run command %q in rootless mode, must execute `podman unshare` first", cmd.CommandPath())
 				}
 			}

--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -76,7 +76,7 @@ func init() {
 	_ = annotateCmd.RegisterFlagCompletionFunc(subjectFlagName, completion.AutocompleteNone)
 }
 
-func annotate(cmd *cobra.Command, args []string) error {
+func annotate(_ *cobra.Command, args []string) error {
 	var listImageSpec, instanceSpec string
 	switch len(args) {
 	case 1:

--- a/cmd/podman/manifest/exists.go
+++ b/cmd/podman/manifest/exists.go
@@ -25,7 +25,7 @@ func init() {
 	})
 }
 
-func exists(cmd *cobra.Command, args []string) error {
+func exists(_ *cobra.Command, args []string) error {
 	found, err := registry.ImageEngine().ManifestExists(registry.Context(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/manifest/remove.go
+++ b/cmd/podman/manifest/remove.go
@@ -27,7 +27,7 @@ func init() {
 	})
 }
 
-func remove(cmd *cobra.Command, args []string) error {
+func remove(_ *cobra.Command, args []string) error {
 	updatedListID, err := registry.ImageEngine().ManifestRemoveDigest(registry.Context(), args[0], args[1])
 	if err != nil {
 		return fmt.Errorf("removing from manifest list %s: %w", args[0], err)

--- a/cmd/podman/manifest/rm.go
+++ b/cmd/podman/manifest/rm.go
@@ -34,7 +34,7 @@ func init() {
 	flags.BoolVarP(&rmOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified manifest is missing")
 }
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	report, rmErrors := registry.ImageEngine().ManifestRm(context.Background(), args, rmOptions)
 	if report != nil {
 		for _, u := range report.Untagged {

--- a/cmd/podman/networks/connect.go
+++ b/cmd/podman/networks/connect.go
@@ -58,7 +58,7 @@ func init() {
 	networkConnectFlags(networkConnectCommand)
 }
 
-func networkConnect(cmd *cobra.Command, args []string) error {
+func networkConnect(_ *cobra.Command, args []string) error {
 	networkConnectOptions.Container = args[1]
 	if macAddress != "" {
 		mac, err := net.ParseMAC(macAddress)

--- a/cmd/podman/networks/disconnect.go
+++ b/cmd/podman/networks/disconnect.go
@@ -38,7 +38,7 @@ func init() {
 	networkDisconnectFlags(flags)
 }
 
-func networkDisconnect(cmd *cobra.Command, args []string) error {
+func networkDisconnect(_ *cobra.Command, args []string) error {
 	networkDisconnectOptions.Container = args[1]
 	return registry.ContainerEngine().NetworkDisconnect(registry.Context(), args[0], networkDisconnectOptions)
 }

--- a/cmd/podman/networks/exists.go
+++ b/cmd/podman/networks/exists.go
@@ -26,7 +26,7 @@ func init() {
 	})
 }
 
-func networkExists(cmd *cobra.Command, args []string) error {
+func networkExists(_ *cobra.Command, args []string) error {
 	response, err := registry.ContainerEngine().NetworkExists(registry.Context(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -61,7 +61,7 @@ func init() {
 	networkListFlags(flags)
 }
 
-func networkList(cmd *cobra.Command, args []string) error {
+func networkList(cmd *cobra.Command, _ []string) error {
 	var err error
 	networkListOptions.Filters, err = parse.FilterArgumentsIntoFilters(filters)
 	if err != nil {

--- a/cmd/podman/networks/prune.go
+++ b/cmd/podman/networks/prune.go
@@ -51,7 +51,7 @@ func init() {
 	networkPruneFlags(networkPruneCommand, flags)
 }
 
-func networkPrune(cmd *cobra.Command, _ []string) error {
+func networkPrune(_ *cobra.Command, _ []string) error {
 	var err error
 	if !force {
 		reader := bufio.NewReader(os.Stdin)

--- a/cmd/podman/networks/reload.go
+++ b/cmd/podman/networks/reload.go
@@ -46,7 +46,7 @@ func init() {
 	validate.AddLatestFlag(networkReloadCommand, &reloadOptions.Latest)
 }
 
-func networkReload(cmd *cobra.Command, args []string) error {
+func networkReload(_ *cobra.Command, args []string) error {
 	responses, err := registry.ContainerEngine().NetworkReload(registry.Context(), args, reloadOptions)
 	if err != nil {
 		return err

--- a/cmd/podman/networks/update.go
+++ b/cmd/podman/networks/update.go
@@ -45,7 +45,7 @@ func init() {
 	networkUpdateFlags(networkUpdateCommand)
 }
 
-func networkUpdate(cmd *cobra.Command, args []string) error {
+func networkUpdate(_ *cobra.Command, args []string) error {
 	name := args[0]
 
 	err := registry.ContainerEngine().NetworkUpdate(registry.Context(), name, networkUpdateOptions)

--- a/cmd/podman/pods/exists.go
+++ b/cmd/podman/pods/exists.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-func exists(cmd *cobra.Command, args []string) error {
+func exists(_ *cobra.Command, args []string) error {
 	response, err := registry.ContainerEngine().PodExists(context.Background(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -40,7 +40,7 @@ func init() {
 	validate.AddLatestFlag(inspectCmd, &inspectOpts.Latest)
 }
 
-func inspectExec(cmd *cobra.Command, args []string) error {
+func inspectExec(_ *cobra.Command, args []string) error {
 	inspectOpts.Type = common.PodType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/pods/prune.go
+++ b/cmd/podman/pods/prune.go
@@ -42,7 +42,7 @@ func init() {
 	flags.BoolVarP(&pruneOptions.Force, "force", "f", false, "Do not prompt for confirmation.  The default is false")
 }
 
-func prune(cmd *cobra.Command, args []string) error {
+func prune(_ *cobra.Command, _ []string) error {
 	if !pruneOptions.Force {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println("WARNING! This will remove all stopped/exited pods..")

--- a/cmd/podman/pods/restart.go
+++ b/cmd/podman/pods/restart.go
@@ -45,7 +45,7 @@ func init() {
 	validate.AddLatestFlag(restartCommand, &restartOptions.Latest)
 }
 
-func restart(cmd *cobra.Command, args []string) error {
+func restart(_ *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)

--- a/cmd/podman/pods/start.go
+++ b/cmd/podman/pods/start.go
@@ -57,7 +57,7 @@ func init() {
 	validate.AddLatestFlag(startCommand, &startOptions.Latest)
 }
 
-func start(cmd *cobra.Command, args []string) error {
+func start(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 
 	ids, err := specgenutil.ReadPodIDFiles(startOptions.PodIDFiles)

--- a/cmd/podman/quadlet/install.go
+++ b/cmd/podman/quadlet/install.go
@@ -46,7 +46,7 @@ func init() {
 	installFlags(quadletInstallCmd)
 }
 
-func install(cmd *cobra.Command, args []string) error {
+func install(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	installReport, err := registry.ContainerEngine().QuadletInstall(registry.Context(), args, installOptions)
 	if err != nil {

--- a/cmd/podman/quadlet/list.go
+++ b/cmd/podman/quadlet/list.go
@@ -51,7 +51,7 @@ func init() {
 	listFlags(quadletListCmd)
 }
 
-func list(cmd *cobra.Command, args []string) error {
+func list(cmd *cobra.Command, _ []string) error {
 	quadlets, err := registry.ContainerEngine().QuadletList(registry.Context(), listOptions)
 	if err != nil {
 		return err

--- a/cmd/podman/quadlet/print.go
+++ b/cmd/podman/quadlet/print.go
@@ -31,7 +31,7 @@ func init() {
 	})
 }
 
-func print(cmd *cobra.Command, args []string) error {
+func print(_ *cobra.Command, args []string) error {
 	quadletContents, err := registry.ContainerEngine().QuadletPrint(registry.Context(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/quadlet/remove.go
+++ b/cmd/podman/quadlet/remove.go
@@ -45,7 +45,7 @@ func init() {
 	rmFlags(quadletRmCmd)
 }
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	if len(args) < 1 && !removeOptions.All {
 		return errors.New("at least one quadlet file must be selected")
 	}

--- a/cmd/podman/registry/registry.go
+++ b/cmd/podman/registry/registry.go
@@ -44,7 +44,7 @@ func ImageEngine() entities.ImageEngine {
 }
 
 // NewImageEngine is a wrapper for building an ImageEngine to be used for PreRunE functions
-func NewImageEngine(cmd *cobra.Command, args []string) (entities.ImageEngine, error) {
+func NewImageEngine(cmd *cobra.Command, _ []string) (entities.ImageEngine, error) {
 	if imageEngine == nil {
 		podmanOptions.FlagSet = cmd.Flags()
 		engine, err := infra.NewImageEngine(&podmanOptions)
@@ -61,7 +61,7 @@ func ContainerEngine() entities.ContainerEngine {
 }
 
 // NewContainerEngine is a wrapper for building a ContainerEngine to be used for PreRunE functions
-func NewContainerEngine(cmd *cobra.Command, args []string) (entities.ContainerEngine, error) {
+func NewContainerEngine(cmd *cobra.Command, _ []string) (entities.ContainerEngine, error) {
 	if containerEngine == nil {
 		podmanOptions.FlagSet = cmd.Flags()
 		if cmd.Name() == "reset" && cmd.Parent().Name() == "system" {

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -108,7 +108,7 @@ func init() {
 	rootFlags(rootCmd, registry.PodmanConfig())
 
 	// backwards compat still allow --cni-config-dir
-	rootCmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	rootCmd.Flags().SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		if name == "cni-config-dir" {
 			name = "network-config-dir"
 		}
@@ -394,7 +394,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func persistentPostRunE(cmd *cobra.Command, args []string) error {
+func persistentPostRunE(cmd *cobra.Command, _ []string) error {
 	logrus.Debugf("Called %s.PersistentPostRunE(%s)", cmd.Name(), strings.Join(os.Args, " "))
 
 	if registry.IsRemote() {

--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -64,7 +64,7 @@ func init() {
 	_ = createCmd.RegisterFlagCompletionFunc(labelFlagName, completion.AutocompleteNone)
 }
 
-func create(cmd *cobra.Command, args []string) error {
+func create(_ *cobra.Command, args []string) error {
 	name := args[0]
 
 	// Validate that --ignore and --replace are not used together

--- a/cmd/podman/secrets/exists.go
+++ b/cmd/podman/secrets/exists.go
@@ -26,7 +26,7 @@ func init() {
 	})
 }
 
-func exists(cmd *cobra.Command, args []string) error {
+func exists(_ *cobra.Command, args []string) error {
 	found, err := registry.ContainerEngine().SecretExists(registry.Context(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -60,7 +60,7 @@ func init() {
 	flags.BoolVarP(&listFlag.quiet, quietFlagName, "q", false, "Print secret IDs only")
 }
 
-func ls(cmd *cobra.Command, args []string) error {
+func ls(cmd *cobra.Command, _ []string) error {
 	var err error
 	lsOpts := entities.SecretListRequest{}
 

--- a/cmd/podman/secrets/rm.go
+++ b/cmd/podman/secrets/rm.go
@@ -36,7 +36,7 @@ var (
 	rmOptions = entities.SecretRmOptions{}
 )
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)

--- a/cmd/podman/shell_completion_test.go
+++ b/cmd/podman/shell_completion_test.go
@@ -46,7 +46,7 @@ func checkCommand(t *testing.T, cmd *cobra.Command) {
 	// loop over all local flags
 	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 		// an error means that there is a completion function for this flag
-		err := cmd.RegisterFlagCompletionFunc(flag.Name, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		err := cmd.RegisterFlagCompletionFunc(flag.Name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return nil, cobra.ShellCompDirectiveDefault
 		})
 

--- a/cmd/podman/system/check.go
+++ b/cmd/podman/system/check.go
@@ -46,7 +46,7 @@ func init() {
 	_ = checkCommand.RegisterFlagCompletionFunc("max", completion.AutocompleteNone)
 }
 
-func check(cmd *cobra.Command, args []string) error {
+func check(cmd *cobra.Command, _ []string) error {
 	flags := cmd.Flags()
 	if flags.Changed("max") {
 		maxAge, err := flags.GetDuration("max")

--- a/cmd/podman/system/connection/add.go
+++ b/cmd/podman/system/connection/add.go
@@ -211,7 +211,7 @@ func add(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func create(cmd *cobra.Command, args []string) error {
+func create(_ *cobra.Command, args []string) error {
 	dest, err := translateDest(dockerPath)
 	if err != nil {
 		return err

--- a/cmd/podman/system/connection/default.go
+++ b/cmd/podman/system/connection/default.go
@@ -44,7 +44,7 @@ func init() {
 	})
 }
 
-func defaultRunE(cmd *cobra.Command, args []string) error {
+func defaultRunE(_ *cobra.Command, args []string) error {
 	connection := args[0]
 	return config.EditConnectionConfig(func(cfg *config.ConnectionsFile) error {
 		if _, found := cfg.Connection.Connections[connection]; !found {

--- a/cmd/podman/system/connection/remove.go
+++ b/cmd/podman/system/connection/remove.go
@@ -52,7 +52,7 @@ func init() {
 	_ = flags.MarkHidden("force")
 }
 
-func rm(cmd *cobra.Command, args []string) error {
+func rm(_ *cobra.Command, args []string) error {
 	return config.EditConnectionConfig(func(cfg *config.ConnectionsFile) error {
 		if rmOpts.All {
 			cfg.Connection.Connections = nil

--- a/cmd/podman/system/connection/rename.go
+++ b/cmd/podman/system/connection/rename.go
@@ -32,7 +32,7 @@ func init() {
 	})
 }
 
-func rename(cmd *cobra.Command, args []string) error {
+func rename(_ *cobra.Command, args []string) error {
 	return config.EditConnectionConfig(func(cfg *config.ConnectionsFile) error {
 		if _, found := cfg.Connection.Connections[args[0]]; !found {
 			return fmt.Errorf("%q destination is not defined. See \"podman system connection add ...\" to create a connection", args[0])

--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -51,7 +51,7 @@ func init() {
 	_ = dfSystemCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&dfSummary{}))
 }
 
-func df(cmd *cobra.Command, args []string) error {
+func df(cmd *cobra.Command, _ []string) error {
 	reports, err := registry.ContainerEngine().SystemDf(registry.Context(), dfOptions)
 	if err != nil {
 		return err

--- a/cmd/podman/system/dial_stdio.go
+++ b/cmd/podman/system/dial_stdio.go
@@ -21,7 +21,7 @@ var (
 		Short:  "Proxy the stdio stream to the daemon connection. Should not be invoked manually.",
 		Args:   validate.NoArgs,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDialStdio()
 		},
 		Example: "podman system dial-stdio",

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -74,7 +74,7 @@ func infoFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&define.Info{}))
 }
 
-func info(cmd *cobra.Command, args []string) error {
+func info(cmd *cobra.Command, _ []string) error {
 	info, err := registry.ContainerEngine().Info(registry.Context())
 	if err != nil {
 		return err

--- a/cmd/podman/system/locks.go
+++ b/cmd/podman/system/locks.go
@@ -14,7 +14,7 @@ var (
 		Short:  "Debug Libpod's use of locks, identifying any potential conflicts",
 		Args:   validate.NoArgs,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runLocks()
 		},
 		Example: "podman system locks",

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -52,7 +52,7 @@ func init() {
 	_ = migrateCommand.RegisterFlagCompletionFunc(newRuntimeFlagName, completion.AutocompleteNone)
 }
 
-func migrate(cmd *cobra.Command, args []string) {
+func migrate(_ *cobra.Command, _ []string) {
 	if err := registry.ContainerEngine().Migrate(registry.Context(), migrateOptions); err != nil {
 		fmt.Println(err)
 

--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -55,7 +55,7 @@ func init() {
 	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePruneFilters)
 }
 
-func prune(cmd *cobra.Command, args []string) error {
+func prune(_ *cobra.Command, _ []string) error {
 	var err error
 	// Prompt for confirmation if --force is not set, unless --external
 	if !force && !pruneOptions.External {

--- a/cmd/podman/system/renumber.go
+++ b/cmd/podman/system/renumber.go
@@ -39,7 +39,7 @@ func init() {
 	})
 }
 
-func renumber(cmd *cobra.Command, args []string) {
+func renumber(_ *cobra.Command, _ []string) {
 	if err := registry.ContainerEngine().Renumber(registry.Context()); err != nil {
 		fmt.Println(err)
 		// FIXME change this to return the error like other commands

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -44,7 +44,7 @@ func init() {
 	flags.BoolVarP(&forceFlag, "force", "f", false, "Do not prompt for confirmation")
 }
 
-func reset(cmd *cobra.Command, args []string) {
+func reset(_ *cobra.Command, _ []string) {
 	// Get all the external containers in use
 	listCtn, err := registry.ContainerEngine().ContainerListExternal(registry.Context())
 	if err != nil {

--- a/cmd/podman/system/unshare.go
+++ b/cmd/podman/system/unshare.go
@@ -37,7 +37,7 @@ func init() {
 	flags.SetInterspersed(false)
 	flags.BoolVar(&unshareOptions.RootlessNetNS, "rootless-netns", false, "Join the rootless network namespace used for CNI and netavark networking")
 	// backwards compat still allow --rootless-cni
-	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	flags.SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		if name == "rootless-cni" {
 			name = "rootless-netns"
 		}
@@ -45,7 +45,7 @@ func init() {
 	})
 }
 
-func unshare(cmd *cobra.Command, args []string) error {
+func unshare(_ *cobra.Command, args []string) error {
 	if isRootless := rootless.IsRootless(); !isRootless {
 		return errors.New("please use unshare with rootless")
 	}

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -40,7 +40,7 @@ func init() {
 	_ = versionCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.SystemVersionReport{}))
 }
 
-func version(cmd *cobra.Command, args []string) error {
+func version(cmd *cobra.Command, _ []string) error {
 	versions, err := registry.ContainerEngine().Version(registry.Context())
 	if err != nil {
 		return err

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -3,7 +3,7 @@ package utils
 import "github.com/spf13/pflag"
 
 // AliasFlags is a function to handle backwards compatibility with old flags
-func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+func AliasFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case "dns-opt":
 		name = "dns-option"
@@ -36,7 +36,7 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 }
 
 // TimeoutAliasFlags is a function to handle backwards compatibility with old timeout flags
-func TimeoutAliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+func TimeoutAliasFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 	if name == "timeout" {
 		name = "time"
 	}

--- a/cmd/podman/volumes/exists.go
+++ b/cmd/podman/volumes/exists.go
@@ -26,7 +26,7 @@ func init() {
 	})
 }
 
-func volumeExists(cmd *cobra.Command, args []string) error {
+func volumeExists(_ *cobra.Command, args []string) error {
 	response, err := registry.ContainerEngine().VolumeExists(registry.Context(), args[0])
 	if err != nil {
 		return err

--- a/cmd/podman/volumes/import.go
+++ b/cmd/podman/volumes/import.go
@@ -33,7 +33,7 @@ func init() {
 	})
 }
 
-func importVol(cmd *cobra.Command, args []string) error {
+func importVol(_ *cobra.Command, args []string) error {
 	opts := entities.VolumeImportOptions{}
 
 	filepath := args[1]

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -45,7 +45,7 @@ func init() {
 	_ = inspectCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&define.InspectVolumeData{}))
 }
 
-func volumeInspect(cmd *cobra.Command, args []string) error {
+func volumeInspect(_ *cobra.Command, args []string) error {
 	if (inspectOpts.All && len(args) > 0) || (!inspectOpts.All && len(args) < 1) {
 		return errors.New("provide one or more volume names or use --all")
 	}

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -62,7 +62,7 @@ func init() {
 	flags.BoolVarP(&cliOpts.Quiet, "quiet", "q", false, "Print volume output in quiet mode")
 }
 
-func list(cmd *cobra.Command, args []string) error {
+func list(cmd *cobra.Command, _ []string) error {
 	var err error
 	if cliOpts.Quiet && cmd.Flag("format").Changed {
 		return errors.New("quiet and format flags cannot be used together")

--- a/cmd/podman/volumes/mount.go
+++ b/cmd/podman/volumes/mount.go
@@ -34,7 +34,7 @@ func init() {
 	})
 }
 
-func volumeMount(cmd *cobra.Command, args []string) error {
+func volumeMount(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	reports, err := registry.ContainerEngine().VolumeMount(registry.Context(), args)
 	if err != nil {

--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -46,7 +46,7 @@ func init() {
 	flags.BoolP("force", "f", false, "Do not prompt for confirmation")
 }
 
-func prune(cmd *cobra.Command, args []string) error {
+func prune(cmd *cobra.Command, _ []string) error {
 	var (
 		pruneOptions  = entities.VolumePruneOptions{}
 		listOptions   = entities.VolumeListOptions{}

--- a/cmd/podman/volumes/reload.go
+++ b/cmd/podman/volumes/reload.go
@@ -31,7 +31,7 @@ func init() {
 	})
 }
 
-func reload(cmd *cobra.Command, args []string) error {
+func reload(_ *cobra.Command, _ []string) error {
 	report, err := registry.ContainerEngine().VolumeReload(registry.Context())
 	if err != nil {
 		return err

--- a/cmd/podman/volumes/unmount.go
+++ b/cmd/podman/volumes/unmount.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-func volumeUnmount(cmd *cobra.Command, args []string) error {
+func volumeUnmount(_ *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
 	reports, err := registry.ContainerEngine().VolumeUnmount(registry.Context(), args)
 	if err != nil {

--- a/internal/domain/infra/abi/testing.go
+++ b/internal/domain/infra/abi/testing.go
@@ -23,7 +23,7 @@ type TestingEngine struct {
 	Store  storage.Store
 }
 
-func (te *TestingEngine) CreateStorageLayer(ctx context.Context, opts entities.CreateStorageLayerOptions) (*entities.CreateStorageLayerReport, error) {
+func (te *TestingEngine) CreateStorageLayer(_ context.Context, opts entities.CreateStorageLayerOptions) (*entities.CreateStorageLayerReport, error) {
 	driver, err := te.Store.GraphDriver()
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (te *TestingEngine) CreateStorageLayer(ctx context.Context, opts entities.C
 	return &entities.CreateStorageLayerReport{ID: id}, nil
 }
 
-func (te *TestingEngine) CreateLayer(ctx context.Context, opts entities.CreateLayerOptions) (*entities.CreateLayerReport, error) {
+func (te *TestingEngine) CreateLayer(_ context.Context, opts entities.CreateLayerOptions) (*entities.CreateLayerReport, error) {
 	layer, err := te.Store.CreateLayer(opts.ID, opts.Parent, nil, "", true, nil)
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (te *TestingEngine) CreateLayer(ctx context.Context, opts entities.CreateLa
 	return &entities.CreateLayerReport{ID: layer.ID}, nil
 }
 
-func (te *TestingEngine) CreateLayerData(ctx context.Context, opts entities.CreateLayerDataOptions) (*entities.CreateLayerDataReport, error) {
+func (te *TestingEngine) CreateLayerData(_ context.Context, opts entities.CreateLayerDataOptions) (*entities.CreateLayerDataReport, error) {
 	for key, data := range opts.Data {
 		if err := te.Store.SetLayerBigData(opts.ID, key, bytes.NewReader(data)); err != nil {
 			return nil, err
@@ -55,7 +55,7 @@ func (te *TestingEngine) CreateLayerData(ctx context.Context, opts entities.Crea
 	return &entities.CreateLayerDataReport{}, nil
 }
 
-func (te *TestingEngine) ModifyLayer(ctx context.Context, opts entities.ModifyLayerOptions) (*entities.ModifyLayerReport, error) {
+func (te *TestingEngine) ModifyLayer(_ context.Context, opts entities.ModifyLayerOptions) (*entities.ModifyLayerReport, error) {
 	mnt, err := te.Store.Mount(opts.ID, "")
 	if err != nil {
 		return nil, err
@@ -70,14 +70,14 @@ func (te *TestingEngine) ModifyLayer(ctx context.Context, opts entities.ModifyLa
 	return &entities.ModifyLayerReport{}, nil
 }
 
-func (te *TestingEngine) PopulateLayer(ctx context.Context, opts entities.PopulateLayerOptions) (*entities.PopulateLayerReport, error) {
+func (te *TestingEngine) PopulateLayer(_ context.Context, opts entities.PopulateLayerOptions) (*entities.PopulateLayerReport, error) {
 	if _, err := te.Store.ApplyDiff(opts.ID, bytes.NewReader(opts.ContentsArchive)); err != nil {
 		return nil, err
 	}
 	return &entities.PopulateLayerReport{}, nil
 }
 
-func (te *TestingEngine) CreateImage(ctx context.Context, opts entities.CreateImageOptions) (*entities.CreateImageReport, error) {
+func (te *TestingEngine) CreateImage(_ context.Context, opts entities.CreateImageOptions) (*entities.CreateImageReport, error) {
 	image, err := te.Store.CreateImage(opts.ID, opts.Names, opts.Layer, "", nil)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (te *TestingEngine) CreateImage(ctx context.Context, opts entities.CreateIm
 	return &entities.CreateImageReport{ID: image.ID}, nil
 }
 
-func (te *TestingEngine) CreateImageData(ctx context.Context, opts entities.CreateImageDataOptions) (*entities.CreateImageDataReport, error) {
+func (te *TestingEngine) CreateImageData(_ context.Context, opts entities.CreateImageDataOptions) (*entities.CreateImageDataReport, error) {
 	for key, data := range opts.Data {
 		if err := te.Store.SetImageBigData(opts.ID, key, data, manifest.Digest); err != nil {
 			return nil, err
@@ -94,7 +94,7 @@ func (te *TestingEngine) CreateImageData(ctx context.Context, opts entities.Crea
 	return &entities.CreateImageDataReport{}, nil
 }
 
-func (te *TestingEngine) CreateContainer(ctx context.Context, opts entities.CreateContainerOptions) (*entities.CreateContainerReport, error) {
+func (te *TestingEngine) CreateContainer(_ context.Context, opts entities.CreateContainerOptions) (*entities.CreateContainerReport, error) {
 	image, err := te.Store.CreateContainer(opts.ID, opts.Names, opts.Image, opts.Layer, "", nil)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (te *TestingEngine) CreateContainer(ctx context.Context, opts entities.Crea
 	return &entities.CreateContainerReport{ID: image.ID}, nil
 }
 
-func (te *TestingEngine) CreateContainerData(ctx context.Context, opts entities.CreateContainerDataOptions) (*entities.CreateContainerDataReport, error) {
+func (te *TestingEngine) CreateContainerData(_ context.Context, opts entities.CreateContainerDataOptions) (*entities.CreateContainerDataReport, error) {
 	for key, data := range opts.Data {
 		if err := te.Store.SetContainerBigData(opts.ID, key, data); err != nil {
 			return nil, err
@@ -111,7 +111,7 @@ func (te *TestingEngine) CreateContainerData(ctx context.Context, opts entities.
 	return &entities.CreateContainerDataReport{}, nil
 }
 
-func (te *TestingEngine) RemoveStorageLayer(ctx context.Context, opts entities.RemoveStorageLayerOptions) (*entities.RemoveStorageLayerReport, error) {
+func (te *TestingEngine) RemoveStorageLayer(_ context.Context, opts entities.RemoveStorageLayerOptions) (*entities.RemoveStorageLayerReport, error) {
 	driver, err := te.Store.GraphDriver()
 	if err != nil {
 		return nil, err
@@ -122,21 +122,21 @@ func (te *TestingEngine) RemoveStorageLayer(ctx context.Context, opts entities.R
 	return &entities.RemoveStorageLayerReport{ID: opts.ID}, nil
 }
 
-func (te *TestingEngine) RemoveLayer(ctx context.Context, opts entities.RemoveLayerOptions) (*entities.RemoveLayerReport, error) {
+func (te *TestingEngine) RemoveLayer(_ context.Context, opts entities.RemoveLayerOptions) (*entities.RemoveLayerReport, error) {
 	if err := te.Store.Delete(opts.ID); err != nil {
 		return nil, err
 	}
 	return &entities.RemoveLayerReport{ID: opts.ID}, nil
 }
 
-func (te *TestingEngine) RemoveImage(ctx context.Context, opts entities.RemoveImageOptions) (*entities.RemoveImageReport, error) {
+func (te *TestingEngine) RemoveImage(_ context.Context, opts entities.RemoveImageOptions) (*entities.RemoveImageReport, error) {
 	if err := te.Store.Delete(opts.ID); err != nil {
 		return nil, err
 	}
 	return &entities.RemoveImageReport{ID: opts.ID}, nil
 }
 
-func (te *TestingEngine) RemoveContainer(ctx context.Context, opts entities.RemoveContainerOptions) (*entities.RemoveContainerReport, error) {
+func (te *TestingEngine) RemoveContainer(_ context.Context, opts entities.RemoveContainerOptions) (*entities.RemoveContainerReport, error) {
 	if err := te.Store.Delete(opts.ID); err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (te *TestingEngine) datapath(itemType, id, key string) (string, error) {
 	return datapath, nil
 }
 
-func (te *TestingEngine) RemoveLayerData(ctx context.Context, opts entities.RemoveLayerDataOptions) (*entities.RemoveLayerDataReport, error) {
+func (te *TestingEngine) RemoveLayerData(_ context.Context, opts entities.RemoveLayerDataOptions) (*entities.RemoveLayerDataReport, error) {
 	datapath, err := te.datapath("layer", opts.ID, opts.Key)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (te *TestingEngine) RemoveLayerData(ctx context.Context, opts entities.Remo
 	return &entities.RemoveLayerDataReport{}, nil
 }
 
-func (te *TestingEngine) RemoveImageData(ctx context.Context, opts entities.RemoveImageDataOptions) (*entities.RemoveImageDataReport, error) {
+func (te *TestingEngine) RemoveImageData(_ context.Context, opts entities.RemoveImageDataOptions) (*entities.RemoveImageDataReport, error) {
 	datapath, err := te.datapath("image", opts.ID, opts.Key)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func (te *TestingEngine) RemoveImageData(ctx context.Context, opts entities.Remo
 	return &entities.RemoveImageDataReport{}, nil
 }
 
-func (te *TestingEngine) RemoveContainerData(ctx context.Context, opts entities.RemoveContainerDataOptions) (*entities.RemoveContainerDataReport, error) {
+func (te *TestingEngine) RemoveContainerData(_ context.Context, opts entities.RemoveContainerDataOptions) (*entities.RemoveContainerDataReport, error) {
 	datapath, err := te.datapath("container", opts.ID, opts.Key)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (te *TestingEngine) RemoveContainerData(ctx context.Context, opts entities.
 	return &entities.RemoveContainerDataReport{}, nil
 }
 
-func (te *TestingEngine) ModifyLayerData(ctx context.Context, opts entities.ModifyLayerDataOptions) (*entities.ModifyLayerDataReport, error) {
+func (te *TestingEngine) ModifyLayerData(_ context.Context, opts entities.ModifyLayerDataOptions) (*entities.ModifyLayerDataReport, error) {
 	datapath, err := te.datapath("layer", opts.ID, opts.Key)
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ func (te *TestingEngine) ModifyLayerData(ctx context.Context, opts entities.Modi
 	return &entities.ModifyLayerDataReport{}, nil
 }
 
-func (te *TestingEngine) ModifyImageData(ctx context.Context, opts entities.ModifyImageDataOptions) (*entities.ModifyImageDataReport, error) {
+func (te *TestingEngine) ModifyImageData(_ context.Context, opts entities.ModifyImageDataOptions) (*entities.ModifyImageDataReport, error) {
 	datapath, err := te.datapath("image", opts.ID, opts.Key)
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (te *TestingEngine) ModifyImageData(ctx context.Context, opts entities.Modi
 	return &entities.ModifyImageDataReport{}, nil
 }
 
-func (te *TestingEngine) ModifyContainerData(ctx context.Context, opts entities.ModifyContainerDataOptions) (*entities.ModifyContainerDataReport, error) {
+func (te *TestingEngine) ModifyContainerData(_ context.Context, opts entities.ModifyContainerDataOptions) (*entities.ModifyContainerDataReport, error) {
 	datapath, err := te.datapath("container", opts.ID, opts.Key)
 	if err != nil {
 		return nil, err

--- a/internal/domain/infra/tunnel/testing.go
+++ b/internal/domain/infra/tunnel/testing.go
@@ -13,78 +13,78 @@ type TestingEngine struct {
 	ClientCtx context.Context
 }
 
-func (te *TestingEngine) CreateStorageLayer(ctx context.Context, opts entities.CreateStorageLayerOptions) (*entities.CreateStorageLayerReport, error) {
+func (te *TestingEngine) CreateStorageLayer(_ context.Context, _ entities.CreateStorageLayerOptions) (*entities.CreateStorageLayerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) CreateLayer(ctx context.Context, opts entities.CreateLayerOptions) (*entities.CreateLayerReport, error) {
+func (te *TestingEngine) CreateLayer(_ context.Context, _ entities.CreateLayerOptions) (*entities.CreateLayerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) CreateLayerData(ctx context.Context, opts entities.CreateLayerDataOptions) (*entities.CreateLayerDataReport, error) {
+func (te *TestingEngine) CreateLayerData(_ context.Context, _ entities.CreateLayerDataOptions) (*entities.CreateLayerDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) ModifyLayer(ctx context.Context, opts entities.ModifyLayerOptions) (*entities.ModifyLayerReport, error) {
+func (te *TestingEngine) ModifyLayer(_ context.Context, _ entities.ModifyLayerOptions) (*entities.ModifyLayerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) PopulateLayer(ctx context.Context, opts entities.PopulateLayerOptions) (*entities.PopulateLayerReport, error) {
+func (te *TestingEngine) PopulateLayer(_ context.Context, _ entities.PopulateLayerOptions) (*entities.PopulateLayerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveStorageLayer(ctx context.Context, opts entities.RemoveStorageLayerOptions) (*entities.RemoveStorageLayerReport, error) {
+func (te *TestingEngine) RemoveStorageLayer(_ context.Context, _ entities.RemoveStorageLayerOptions) (*entities.RemoveStorageLayerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) CreateImage(ctx context.Context, opts entities.CreateImageOptions) (*entities.CreateImageReport, error) {
+func (te *TestingEngine) CreateImage(_ context.Context, _ entities.CreateImageOptions) (*entities.CreateImageReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) CreateImageData(ctx context.Context, opts entities.CreateImageDataOptions) (*entities.CreateImageDataReport, error) {
+func (te *TestingEngine) CreateImageData(_ context.Context, _ entities.CreateImageDataOptions) (*entities.CreateImageDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveLayer(ctx context.Context, opts entities.RemoveLayerOptions) (*entities.RemoveLayerReport, error) {
+func (te *TestingEngine) RemoveLayer(_ context.Context, _ entities.RemoveLayerOptions) (*entities.RemoveLayerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveImage(ctx context.Context, opts entities.RemoveImageOptions) (*entities.RemoveImageReport, error) {
+func (te *TestingEngine) RemoveImage(_ context.Context, _ entities.RemoveImageOptions) (*entities.RemoveImageReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveContainer(ctx context.Context, opts entities.RemoveContainerOptions) (*entities.RemoveContainerReport, error) {
+func (te *TestingEngine) RemoveContainer(_ context.Context, _ entities.RemoveContainerOptions) (*entities.RemoveContainerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) CreateContainer(ctx context.Context, opts entities.CreateContainerOptions) (*entities.CreateContainerReport, error) {
+func (te *TestingEngine) CreateContainer(_ context.Context, _ entities.CreateContainerOptions) (*entities.CreateContainerReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) CreateContainerData(ctx context.Context, opts entities.CreateContainerDataOptions) (*entities.CreateContainerDataReport, error) {
+func (te *TestingEngine) CreateContainerData(_ context.Context, _ entities.CreateContainerDataOptions) (*entities.CreateContainerDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveLayerData(ctx context.Context, opts entities.RemoveLayerDataOptions) (*entities.RemoveLayerDataReport, error) {
+func (te *TestingEngine) RemoveLayerData(_ context.Context, _ entities.RemoveLayerDataOptions) (*entities.RemoveLayerDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveImageData(ctx context.Context, opts entities.RemoveImageDataOptions) (*entities.RemoveImageDataReport, error) {
+func (te *TestingEngine) RemoveImageData(_ context.Context, _ entities.RemoveImageDataOptions) (*entities.RemoveImageDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) RemoveContainerData(ctx context.Context, opts entities.RemoveContainerDataOptions) (*entities.RemoveContainerDataReport, error) {
+func (te *TestingEngine) RemoveContainerData(_ context.Context, _ entities.RemoveContainerDataOptions) (*entities.RemoveContainerDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) ModifyLayerData(ctx context.Context, opts entities.ModifyLayerDataOptions) (*entities.ModifyLayerDataReport, error) {
+func (te *TestingEngine) ModifyLayerData(_ context.Context, _ entities.ModifyLayerDataOptions) (*entities.ModifyLayerDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) ModifyImageData(ctx context.Context, opts entities.ModifyImageDataOptions) (*entities.ModifyImageDataReport, error) {
+func (te *TestingEngine) ModifyImageData(_ context.Context, _ entities.ModifyImageDataOptions) (*entities.ModifyImageDataReport, error) {
 	return nil, syscall.ENOSYS
 }
 
-func (te *TestingEngine) ModifyContainerData(ctx context.Context, opts entities.ModifyContainerDataOptions) (*entities.ModifyContainerDataReport, error) {
+func (te *TestingEngine) ModifyContainerData(_ context.Context, _ entities.ModifyContainerDataOptions) (*entities.ModifyContainerDataReport, error) {
 	return nil, syscall.ENOSYS
 }

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -900,7 +900,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 	ctrExecSessionsBkt := ctrExists.Bucket(execBkt)
 	if ctrExecSessionsBkt != nil {
 		sessions := []string{}
-		err = ctrExecSessionsBkt.ForEach(func(id, value []byte) error {
+		err = ctrExecSessionsBkt.ForEach(func(id, _ []byte) error {
 			sessions = append(sessions, string(id))
 
 			return nil
@@ -919,7 +919,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		return fmt.Errorf("container %s does not have a dependencies bucket: %w", ctr.ID(), define.ErrInternal)
 	}
 	deps := []string{}
-	err = ctrDepsBkt.ForEach(func(id, value []byte) error {
+	err = ctrDepsBkt.ForEach(func(id, _ []byte) error {
 		deps = append(deps, string(id))
 
 		return nil
@@ -1034,7 +1034,7 @@ func (s *BoltState) lookupContainerID(idOrName string, ctrBucket, namesBucket *b
 	// We were not given a full container ID or name.
 	// Search for partial ID matches.
 	exists := false
-	err := ctrBucket.ForEach(func(checkID, checkName []byte) error {
+	err := ctrBucket.ForEach(func(checkID, _ []byte) error {
 		if strings.HasPrefix(string(checkID), idOrName) {
 			if exists {
 				return fmt.Errorf("more than one result for container ID %s: %w", idOrName, define.ErrCtrExists)

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -948,7 +948,7 @@ func (c *Container) ReloadNetwork() error {
 }
 
 // Refresh is DEPRECATED and REMOVED.
-func (c *Container) Refresh(ctx context.Context) error {
+func (c *Container) Refresh(_ context.Context) error {
 	// This has been deprecated for a long while, and is in the process of
 	// being removed.
 	return define.ErrNotImplemented
@@ -1080,7 +1080,7 @@ func (c *Container) Restore(ctx context.Context, options ContainerCheckpointOpti
 }
 
 // Indicate whether or not the container should restart
-func (c *Container) ShouldRestart(ctx context.Context) bool {
+func (c *Container) ShouldRestart(_ context.Context) bool {
 	logrus.Debugf("Checking if container %s should restart", c.ID())
 	if !c.batched {
 		c.lock.Lock()
@@ -1110,7 +1110,7 @@ func (c *Container) CopyFromArchive(_ context.Context, containerPath string, cho
 
 // CopyToArchive copies the contents from the specified path *inside* the
 // container to the tarStream.
-func (c *Container) CopyToArchive(ctx context.Context, containerPath string, tarStream io.Writer) (func() error, error) {
+func (c *Container) CopyToArchive(_ context.Context, containerPath string, tarStream io.Writer) (func() error, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -1124,7 +1124,7 @@ func (c *Container) CopyToArchive(ctx context.Context, containerPath string, tar
 }
 
 // Stat the specified path *inside* the container and return a file info.
-func (c *Container) Stat(ctx context.Context, containerPath string) (*define.FileInfo, error) {
+func (c *Container) Stat(_ context.Context, containerPath string) (*define.FileInfo, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -478,7 +478,7 @@ func (c *Container) execStartAndAttach(sessionID string, streams *define.AttachS
 // ExecHTTPStartAndAttach starts and performs an HTTP attach to an exec session.
 // newSize resizes the tty to this size before the process is started, must be nil if the exec session has no tty
 func (c *Container) ExecHTTPStartAndAttach(sessionID string, r *http.Request, w http.ResponseWriter,
-	streams *HTTPAttachStreams, detachKeys *string, cancel <-chan bool, hijackDone chan<- bool, newSize *resize.TerminalSize) error {
+	streams *HTTPAttachStreams, _ *string, cancel <-chan bool, hijackDone chan<- bool, newSize *resize.TerminalSize) error {
 	// TODO: How do we combine streams with the default streams set in the exec session?
 
 	// Ensure that we don't leak a goroutine here

--- a/libpod/container_graph.go
+++ b/libpod/container_graph.go
@@ -394,7 +394,7 @@ func stopContainerGraph(ctx context.Context, graph *ContainerGraph, pod *Pod, ti
 	nodeDetails.ctrErrors = syncmap.New[string, error]()
 	nodeDetails.ctrsVisited = syncmap.New[string, bool]()
 
-	traversalFunc := func(ctr *Container, pod *Pod) error {
+	traversalFunc := func(ctr *Container, _ *Pod) error {
 		ctr.lock.Lock()
 		defer ctr.lock.Unlock()
 

--- a/libpod/events/journal_unsupported.go
+++ b/libpod/events/journal_unsupported.go
@@ -3,6 +3,6 @@
 package events
 
 // newJournalDEventer always returns an error if libsystemd not found
-func newJournalDEventer(options EventerOptions) (Eventer, error) {
+func newJournalDEventer(_ EventerOptions) (Eventer, error) {
 	return nil, ErrNoJournaldLogging
 }

--- a/libpod/events/nullout.go
+++ b/libpod/events/nullout.go
@@ -10,12 +10,12 @@ import (
 type EventToNull struct{}
 
 // Write eats the event and always returns nil
-func (e EventToNull) Write(ee Event) error {
+func (e EventToNull) Write(_ Event) error {
 	return nil
 }
 
 // Read does nothing and returns an error.
-func (e EventToNull) Read(ctx context.Context, options ReadOptions) error {
+func (e EventToNull) Read(_ context.Context, _ ReadOptions) error {
 	return errors.New("cannot read events with the \"none\" backend")
 }
 

--- a/libpod/healthcheck_nosystemd_linux.go
+++ b/libpod/healthcheck_nosystemd_linux.go
@@ -7,17 +7,17 @@ import (
 )
 
 // createTimer systemd timers for healthchecks of a container
-func (c *Container) createTimer(interval string, isStartup bool) error {
+func (c *Container) createTimer(_ string, _ bool) error {
 	return nil
 }
 
 // startTimer starts a systemd timer for the healthchecks
-func (c *Container) startTimer(isStartup bool) error {
+func (c *Container) startTimer(_ bool) error {
 	return nil
 }
 
 // removeTransientFiles removes the systemd timer and unit files
 // for the container
-func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool, unitName string) error {
+func (c *Container) removeTransientFiles(_ context.Context, _ bool, _ string) error {
 	return nil
 }

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -120,7 +120,7 @@ func (p *Pod) getInfraContainer() (*Container, error) {
 	return p.runtime.GetContainer(infraID)
 }
 
-func GenerateForKubeDaemonSet(ctx context.Context, pod *YAMLPod, options entities.GenerateKubeOptions) (*YAMLDaemonSet, error) {
+func GenerateForKubeDaemonSet(_ context.Context, pod *YAMLPod, options entities.GenerateKubeOptions) (*YAMLDaemonSet, error) {
 	// Restart policy for DaemonSets can only be set to Always
 	if pod.Spec.RestartPolicy != "" && pod.Spec.RestartPolicy != v1.RestartPolicyAlways {
 		return nil, fmt.Errorf("k8s DaemonSets can only have restartPolicy set to Always")
@@ -177,7 +177,7 @@ func GenerateForKubeDaemonSet(ctx context.Context, pod *YAMLPod, options entitie
 
 // GenerateForKubeDeployment returns a YAMLDeployment from a YAMLPod that is then used to create a kubernetes Deployment
 // kind YAML.
-func GenerateForKubeDeployment(ctx context.Context, pod *YAMLPod, options entities.GenerateKubeOptions) (*YAMLDeployment, error) {
+func GenerateForKubeDeployment(_ context.Context, pod *YAMLPod, options entities.GenerateKubeOptions) (*YAMLDeployment, error) {
 	// Restart policy for Deployments can only be set to Always
 	if options.Type == define.K8sKindDeployment && (pod.Spec.RestartPolicy != "" && pod.Spec.RestartPolicy != v1.RestartPolicyAlways) {
 		return nil, fmt.Errorf("k8s Deployments can only have restartPolicy set to Always")
@@ -236,7 +236,7 @@ func GenerateForKubeDeployment(ctx context.Context, pod *YAMLPod, options entiti
 
 // GenerateForKubeJob returns a YAMLDeployment from a YAMLPod that is then used to create a kubernetes Job
 // kind YAML.
-func GenerateForKubeJob(ctx context.Context, pod *YAMLPod, options entities.GenerateKubeOptions) (*YAMLJob, error) {
+func GenerateForKubeJob(_ context.Context, pod *YAMLPod, options entities.GenerateKubeOptions) (*YAMLJob, error) {
 	// Restart policy for Job cannot be set to Always
 	if options.Type == define.K8sKindJob && pod.Spec.RestartPolicy == v1.RestartPolicyAlways {
 		return nil, fmt.Errorf("k8s Jobs can not have restartPolicy set to Always; only Never and OnFailure policies allowed")

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -357,7 +357,7 @@ func resultToBasicNetworkConfig(result types.StatusBlock) define.InspectBasicNet
 }
 
 // NetworkDisconnect removes a container from the network
-func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) error {
+func (c *Container) NetworkDisconnect(nameOrID, netName string, _ bool) error {
 	// only the bridge mode supports cni networks
 	if err := isBridgeNetMode(c.config.NetMode); err != nil {
 		return err

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -72,17 +72,17 @@ func (r *MissingRuntime) Path() string {
 }
 
 // CreateContainer is not available as the runtime is missing
-func (r *MissingRuntime) CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) (int64, error) {
+func (r *MissingRuntime) CreateContainer(_ *Container, _ *ContainerCheckpointOptions) (int64, error) {
 	return 0, r.printError()
 }
 
 // StartContainer is not available as the runtime is missing
-func (r *MissingRuntime) StartContainer(ctr *Container) error {
+func (r *MissingRuntime) StartContainer(_ *Container) error {
 	return r.printError()
 }
 
 // UpdateContainer is not available as the runtime is missing
-func (r *MissingRuntime) UpdateContainer(ctr *Container, resources *spec.LinuxResources) error {
+func (r *MissingRuntime) UpdateContainer(_ *Container, _ *spec.LinuxResources) error {
 	return r.printError()
 }
 
@@ -90,63 +90,63 @@ func (r *MissingRuntime) UpdateContainer(ctr *Container, resources *spec.LinuxRe
 // TODO: We could attempt to unix.Kill() the PID as recorded in the state if we
 // really want to smooth things out? Won't be perfect, but if the container has
 // a PID namespace it could be enough?
-func (r *MissingRuntime) KillContainer(ctr *Container, signal uint, all bool) error {
+func (r *MissingRuntime) KillContainer(_ *Container, _ uint, _ bool) error {
 	return r.printError()
 }
 
 // StopContainer is not available as the runtime is missing
-func (r *MissingRuntime) StopContainer(ctr *Container, timeout uint, all bool) error {
+func (r *MissingRuntime) StopContainer(_ *Container, _ uint, _ bool) error {
 	return r.printError()
 }
 
 // DeleteContainer is not available as the runtime is missing
-func (r *MissingRuntime) DeleteContainer(ctr *Container) error {
+func (r *MissingRuntime) DeleteContainer(_ *Container) error {
 	return r.printError()
 }
 
 // PauseContainer is not available as the runtime is missing
-func (r *MissingRuntime) PauseContainer(ctr *Container) error {
+func (r *MissingRuntime) PauseContainer(_ *Container) error {
 	return r.printError()
 }
 
 // UnpauseContainer is not available as the runtime is missing
-func (r *MissingRuntime) UnpauseContainer(ctr *Container) error {
+func (r *MissingRuntime) UnpauseContainer(_ *Container) error {
 	return r.printError()
 }
 
 // Attach is not available as the runtime is missing
-func (r *MissingRuntime) Attach(ctr *Container, params *AttachOptions) error {
+func (r *MissingRuntime) Attach(_ *Container, _ *AttachOptions) error {
 	return r.printError()
 }
 
 // HTTPAttach is not available as the runtime is missing
-func (r *MissingRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.ResponseWriter, streams *HTTPAttachStreams, detachKeys *string, cancel <-chan bool, hijackDone chan<- bool, streamAttach, streamLogs bool) error {
+func (r *MissingRuntime) HTTPAttach(_ *Container, _ *http.Request, _ http.ResponseWriter, _ *HTTPAttachStreams, _ *string, _ <-chan bool, _ chan<- bool, _, _ bool) error {
 	return r.printError()
 }
 
 // AttachResize is not available as the runtime is missing
-func (r *MissingRuntime) AttachResize(ctr *Container, newSize resize.TerminalSize) error {
+func (r *MissingRuntime) AttachResize(_ *Container, _ resize.TerminalSize) error {
 	return r.printError()
 }
 
 // ExecContainer is not available as the runtime is missing
-func (r *MissingRuntime) ExecContainer(ctr *Container, sessionID string, options *ExecOptions, streams *define.AttachStreams, newSize *resize.TerminalSize) (int, chan error, error) {
+func (r *MissingRuntime) ExecContainer(_ *Container, _ string, _ *ExecOptions, _ *define.AttachStreams, _ *resize.TerminalSize) (int, chan error, error) {
 	return -1, nil, r.printError()
 }
 
 // ExecContainerHTTP is not available as the runtime is missing
-func (r *MissingRuntime) ExecContainerHTTP(ctr *Container, sessionID string, options *ExecOptions, req *http.Request, w http.ResponseWriter,
-	streams *HTTPAttachStreams, cancel <-chan bool, hijackDone chan<- bool, holdConnOpen <-chan bool, newSize *resize.TerminalSize) (int, chan error, error) {
+func (r *MissingRuntime) ExecContainerHTTP(_ *Container, _ string, _ *ExecOptions, _ *http.Request, _ http.ResponseWriter,
+	_ *HTTPAttachStreams, _ <-chan bool, _ chan<- bool, _ <-chan bool, _ *resize.TerminalSize) (int, chan error, error) {
 	return -1, nil, r.printError()
 }
 
 // ExecContainerDetached is not available as the runtime is missing
-func (r *MissingRuntime) ExecContainerDetached(ctr *Container, sessionID string, options *ExecOptions, stdin bool) (int, error) {
+func (r *MissingRuntime) ExecContainerDetached(_ *Container, _ string, _ *ExecOptions, _ bool) (int, error) {
 	return -1, r.printError()
 }
 
 // ExecAttachResize is not available as the runtime is missing.
-func (r *MissingRuntime) ExecAttachResize(ctr *Container, sessionID string, newSize resize.TerminalSize) error {
+func (r *MissingRuntime) ExecAttachResize(_ *Container, _ string, _ resize.TerminalSize) error {
 	return r.printError()
 }
 
@@ -154,22 +154,22 @@ func (r *MissingRuntime) ExecAttachResize(ctr *Container, sessionID string, newS
 // TODO: We can also investigate using unix.Kill() on the PID of the exec
 // session here if we want to make stopping containers possible. Won't be
 // perfect, though.
-func (r *MissingRuntime) ExecStopContainer(ctr *Container, sessionID string, timeout uint) error {
+func (r *MissingRuntime) ExecStopContainer(_ *Container, _ string, _ uint) error {
 	return r.printError()
 }
 
 // ExecUpdateStatus is not available as the runtime is missing.
-func (r *MissingRuntime) ExecUpdateStatus(ctr *Container, sessionID string) (bool, error) {
+func (r *MissingRuntime) ExecUpdateStatus(_ *Container, _ string) (bool, error) {
 	return false, r.printError()
 }
 
 // CheckpointContainer is not available as the runtime is missing
-func (r *MissingRuntime) CheckpointContainer(ctr *Container, options ContainerCheckpointOptions) (int64, error) {
+func (r *MissingRuntime) CheckpointContainer(_ *Container, _ ContainerCheckpointOptions) (int64, error) {
 	return 0, r.printError()
 }
 
 // CheckConmonRunning is not available as the runtime is missing
-func (r *MissingRuntime) CheckConmonRunning(ctr *Container) (bool, error) {
+func (r *MissingRuntime) CheckConmonRunning(_ *Container) (bool, error) {
 	return false, r.printError()
 }
 
@@ -197,14 +197,14 @@ func (r *MissingRuntime) SupportsKVM() bool {
 // AttachSocketPath does not work as there is no runtime to attach to.
 // (Theoretically we could follow ExitFilePath but there is no guarantee the
 // container is running and thus has an attach socket...)
-func (r *MissingRuntime) AttachSocketPath(ctr *Container) (string, error) {
+func (r *MissingRuntime) AttachSocketPath(_ *Container) (string, error) {
 	return "", r.printError()
 }
 
 // ExecAttachSocketPath does not work as there is no runtime to attach to.
 // (Again, we could follow ExitFilePath, but no guarantee there is an existing
 // and running exec session)
-func (r *MissingRuntime) ExecAttachSocketPath(ctr *Container, sessionID string) (string, error) {
+func (r *MissingRuntime) ExecAttachSocketPath(_ *Container, _ string) (string, error) {
 	return "", r.printError()
 }
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -210,7 +210,7 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 		return nil, err
 	}
 
-	if err := shutdown.Register("libpod", func(sig os.Signal) error {
+	if err := shutdown.Register("libpod", func(_ os.Signal) error {
 		if runtime.store != nil {
 			_, _ = runtime.store.Shutdown(false)
 		}
@@ -1304,7 +1304,7 @@ func (r *Runtime) PruneBuildContainers() ([]*reports.PruneReport, error) {
 
 // SystemCheck checks our storage for consistency, and depending on the options
 // specified, will attempt to remove anything which fails consistency checks.
-func (r *Runtime) SystemCheck(ctx context.Context, options entities.SystemCheckOptions) (entities.SystemCheckReport, error) {
+func (r *Runtime) SystemCheck(_ context.Context, options entities.SystemCheckOptions) (entities.SystemCheckReport, error) {
 	what := storage.CheckEverything()
 	if options.Quick {
 		// Turn off checking layer digests and layer contents to do quick check.

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -59,7 +59,7 @@ func (r *Runtime) NewContainer(ctx context.Context, rSpec *spec.Spec, spec *spec
 	return r.newContainer(ctx, rSpec, options...)
 }
 
-func (r *Runtime) PrepareVolumeOnCreateContainer(ctx context.Context, ctr *Container) error {
+func (r *Runtime) PrepareVolumeOnCreateContainer(_ context.Context, ctr *Container) error {
 	// Copy the content from the underlying image into the newly created
 	// volume if configured to do so.
 	if !r.config.Containers.PrepareVolumeOnCreate {
@@ -117,7 +117,7 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 
 // RenameContainer renames the given container.
 // Returns a copy of the container that has been renamed if successful.
-func (r *Runtime) RenameContainer(ctx context.Context, ctr *Container, newName string) (*Container, error) {
+func (r *Runtime) RenameContainer(_ context.Context, ctr *Container, newName string) (*Container, error) {
 	ctr.lock.Lock()
 	defer ctr.lock.Unlock()
 

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -161,7 +161,7 @@ func (r *Runtime) GetRunningPods() ([]*Pod, error) {
 }
 
 // PrunePods removes unused pods and their containers from local storage.
-func (r *Runtime) PrunePods(ctx context.Context) (map[string]error, error) {
+func (r *Runtime) PrunePods(_ context.Context) (map[string]error, error) {
 	response := make(map[string]error)
 	states := []string{define.PodStateStopped, define.PodStateExited}
 	filterFunc := func(p *Pod) bool {

--- a/libpod/runtime_pod_common.go
+++ b/libpod/runtime_pod_common.go
@@ -15,7 +15,7 @@ import (
 )
 
 // NewPod makes a new, empty pod
-func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, options ...PodCreateOption) (_ *Pod, deferredErr error) {
+func (r *Runtime) NewPod(_ context.Context, p specgen.PodSpecGenerator, options ...PodCreateOption) (_ *Pod, deferredErr error) {
 	if !r.valid {
 		return nil, define.ErrRuntimeStopped
 	}
@@ -94,7 +94,7 @@ func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, option
 }
 
 // AddInfra adds the created infra container to the pod state
-func (r *Runtime) AddInfra(ctx context.Context, pod *Pod, infraCtr *Container) (*Pod, error) {
+func (r *Runtime) AddInfra(_ context.Context, pod *Pod, infraCtr *Container) (*Pod, error) {
 	if !r.valid {
 		return nil, define.ErrRuntimeStopped
 	}

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -306,7 +306,7 @@ func (s *SQLiteState) GetDBConfig() (*DBConfig, error) {
 }
 
 // ValidateDBConfig validates paths in the given runtime against the database
-func (s *SQLiteState) ValidateDBConfig(runtime *Runtime) (defErr error) {
+func (s *SQLiteState) ValidateDBConfig(_ *Runtime) (defErr error) {
 	if !s.valid {
 		return define.ErrDBClosed
 	}

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -137,7 +137,7 @@ func TestGetContainerPodSameIDFails(t *testing.T) {
 }
 
 func TestAddInvalidContainerFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.AddContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 	})
@@ -274,21 +274,21 @@ func TestAddCtrDepInPodFails(t *testing.T) {
 }
 
 func TestGetNonexistentContainerFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.Container("does not exist")
 		assert.Error(t, err)
 	})
 }
 
 func TestGetContainerWithEmptyIDFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.Container("")
 		assert.Error(t, err)
 	})
 }
 
 func TestLookupContainerWithEmptyIDFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.LookupContainer("")
 		assert.Error(t, err)
 
@@ -298,7 +298,7 @@ func TestLookupContainerWithEmptyIDFails(t *testing.T) {
 }
 
 func TestLookupNonexistentContainerFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.LookupContainer("does not exist")
 		assert.Error(t, err)
 
@@ -415,14 +415,14 @@ func TestLookupCtrByPodIDFails(t *testing.T) {
 }
 
 func TestHasContainerEmptyIDFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.HasContainer("")
 		assert.Error(t, err)
 	})
 }
 
 func TestHasContainerNoSuchContainerReturnsFalse(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		exists, err := state.HasContainer("does not exist")
 		assert.NoError(t, err)
 		assert.False(t, exists)
@@ -494,14 +494,14 @@ func TestUpdateContainerNotInDatabaseReturnsError(t *testing.T) {
 }
 
 func TestUpdateInvalidContainerReturnsError(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.UpdateContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 	})
 }
 
 func TestSaveInvalidContainerReturnsError(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.SaveContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 	})
@@ -551,7 +551,7 @@ func TestRemoveNonexistentContainerFails(t *testing.T) {
 }
 
 func TestGetAllContainersOnNewStateIsEmpty(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		ctrs, err := state.AllContainers(false)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(ctrs))
@@ -594,7 +594,7 @@ func TestGetAllContainersTwoContainers(t *testing.T) {
 }
 
 func TestContainerInUseInvalidContainer(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.ContainerInUse(&Container{})
 		assert.Error(t, err)
 	})
@@ -930,7 +930,7 @@ func TestCannotUseBadIDAsGenericDependency(t *testing.T) {
 }
 
 func TestRewriteContainerConfigDoesNotExist(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.RewriteContainerConfig(&Container{}, &ContainerConfig{})
 		assert.Error(t, err)
 	})
@@ -966,7 +966,7 @@ func TestRewriteContainerConfigRewritesConfig(t *testing.T) {
 }
 
 func TestRewritePodConfigDoesNotExist(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.RewritePodConfig(&Pod{}, &PodConfig{})
 		assert.Error(t, err)
 	})
@@ -1002,14 +1002,14 @@ func TestRewritePodConfigRewritesConfig(t *testing.T) {
 }
 
 func TestGetPodDoesNotExist(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.Pod("doesnotexist")
 		assert.Error(t, err)
 	})
 }
 
 func TestGetPodEmptyID(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.Pod("")
 		assert.Error(t, err)
 	})
@@ -1084,14 +1084,14 @@ func TestGetPodByCtrID(t *testing.T) {
 }
 
 func TestLookupPodEmptyID(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.LookupPod("")
 		assert.Error(t, err)
 	})
 }
 
 func TestLookupNotExistPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.LookupPod("doesnotexist")
 		assert.Error(t, err)
 	})
@@ -1188,14 +1188,14 @@ func TestLookupPodByCtrName(t *testing.T) {
 }
 
 func TestHasPodEmptyIDErrors(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.HasPod("")
 		assert.Error(t, err)
 	})
 }
 
 func TestHasPodNoSuchPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		exist, err := state.HasPod("nonexistent")
 		assert.NoError(t, err)
 		assert.False(t, exist)
@@ -1245,7 +1245,7 @@ func TestHasPodCtrIDFalse(t *testing.T) {
 }
 
 func TestAddPodInvalidPodErrors(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.AddPod(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -1368,7 +1368,7 @@ func TestAddPodCtrNameConflictFails(t *testing.T) {
 }
 
 func TestRemovePodInvalidPodErrors(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.RemovePod(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -1479,7 +1479,7 @@ func TestRemovePodAfterEmptySucceeds(t *testing.T) {
 }
 
 func TestAllPodsEmptyOnEmptyState(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		allPods, err := state.AllPods()
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(allPods))
@@ -1541,7 +1541,7 @@ func TestAllPodsMultiplePods(t *testing.T) {
 }
 
 func TestPodHasContainerNoSuchPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.PodHasContainer(&Pod{config: &PodConfig{}}, strings.Repeat("0", 32))
 		assert.Error(t, err)
 	})
@@ -1617,7 +1617,7 @@ func TestPodHasContainerSucceeds(t *testing.T) {
 }
 
 func TestPodContainersByIDInvalidPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.PodContainersByID(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -1719,7 +1719,7 @@ func TestPodContainersByIDMultipleContainers(t *testing.T) {
 }
 
 func TestPodContainersInvalidPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.PodContainers(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -1822,7 +1822,7 @@ func TestPodContainersMultipleContainers(t *testing.T) {
 }
 
 func TestRemovePodContainersInvalidPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.RemovePodContainers(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -2508,7 +2508,7 @@ func TestRemoveContainerFromPodWithDependencySucceedsAfterDepRemoved(t *testing.
 }
 
 func TestUpdatePodInvalidPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.UpdatePod(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -2525,7 +2525,7 @@ func TestUpdatePodPodNotInStateFails(t *testing.T) {
 }
 
 func TestSavePodInvalidPod(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		err := state.SavePod(&Pod{config: &PodConfig{}})
 		assert.Error(t, err)
 	})
@@ -2581,13 +2581,13 @@ func TestGetContainerConfigSucceeds(t *testing.T) {
 }
 
 func TestGetContainerConfigEmptyIDFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.GetContainerConfig("")
 		assert.Error(t, err)
 	})
 }
 func TestGetContainerConfigNonExistentIDFails(t *testing.T) {
-	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
 		_, err := state.GetContainerConfig("does not exist")
 		assert.Error(t, err)
 	})

--- a/libpod/util_linux_test.go
+++ b/libpod/util_linux_test.go
@@ -21,17 +21,17 @@ func TestLabelVolumePath(t *testing.T) {
 	}()
 
 	// Relabel returns ENOTSUP unconditionally.
-	lvpRelabel = func(path string, fileLabel string, shared bool) error {
+	lvpRelabel = func(_ string, _ string, _ bool) error {
 		return syscall.ENOTSUP
 	}
 
 	// InitLabels and ReleaseLabel both return dummy values and nil errors.
-	lvpInitLabels = func(options []string) (string, string, error) {
+	lvpInitLabels = func(_ []string) (string, string, error) {
 		pLabel := "system_u:system_r:container_t:s0:c1,c2"
 		mLabel := "system_u:object_r:container_file_t:s0:c1,c2"
 		return pLabel, mLabel, nil
 	}
-	lvpReleaseLabel = func(label string) {}
+	lvpReleaseLabel = func(_ string) {}
 
 	// LabelVolumePath should not return an error if the operation is unsupported.
 	err := LabelVolumePath("/foo/bar", "")

--- a/pkg/api/handlers/compat/secrets.go
+++ b/pkg/api/handlers/compat/secrets.go
@@ -146,6 +146,6 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, report)
 }
 
-func UpdateSecret(w http.ResponseWriter, r *http.Request) {
+func UpdateSecret(w http.ResponseWriter, _ *http.Request) {
 	utils.Error(w, http.StatusNotImplemented, errors.New("update is not supported"))
 }

--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -35,7 +35,7 @@ func Error(w http.ResponseWriter, code int, err error) {
 	WriteJSON(w, code, em)
 }
 
-func VolumeNotFound(w http.ResponseWriter, name string, err error) {
+func VolumeNotFound(w http.ResponseWriter, _ string, err error) {
 	if errors.Is(err, define.ErrNoSuchVolume) || errors.Is(err, define.ErrVolumeExists) {
 		Error(w, http.StatusNotFound, err)
 		return
@@ -43,7 +43,7 @@ func VolumeNotFound(w http.ResponseWriter, name string, err error) {
 	InternalServerError(w, err)
 }
 
-func ContainerNotFound(w http.ResponseWriter, name string, err error) {
+func ContainerNotFound(w http.ResponseWriter, _ string, err error) {
 	if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrExists) {
 		Error(w, http.StatusNotFound, err)
 		return
@@ -51,7 +51,7 @@ func ContainerNotFound(w http.ResponseWriter, name string, err error) {
 	InternalServerError(w, err)
 }
 
-func ImageNotFound(w http.ResponseWriter, name string, err error) {
+func ImageNotFound(w http.ResponseWriter, _ string, err error) {
 	if !errors.Is(err, storage.ErrImageUnknown) {
 		InternalServerError(w, err)
 		return
@@ -59,11 +59,11 @@ func ImageNotFound(w http.ResponseWriter, name string, err error) {
 	Error(w, http.StatusNotFound, err)
 }
 
-func ArtifactNotFound(w http.ResponseWriter, name string, err error) {
+func ArtifactNotFound(w http.ResponseWriter, _ string, err error) {
 	Error(w, http.StatusNotFound, err)
 }
 
-func NetworkNotFound(w http.ResponseWriter, name string, err error) {
+func NetworkNotFound(w http.ResponseWriter, _ string, err error) {
 	if !errors.Is(err, define.ErrNoSuchNetwork) {
 		InternalServerError(w, err)
 		return
@@ -71,7 +71,7 @@ func NetworkNotFound(w http.ResponseWriter, name string, err error) {
 	Error(w, http.StatusNotFound, err)
 }
 
-func PodNotFound(w http.ResponseWriter, name string, err error) {
+func PodNotFound(w http.ResponseWriter, _ string, err error) {
 	if !errors.Is(err, define.ErrNoSuchPod) {
 		InternalServerError(w, err)
 		return
@@ -79,7 +79,7 @@ func PodNotFound(w http.ResponseWriter, name string, err error) {
 	Error(w, http.StatusNotFound, err)
 }
 
-func SessionNotFound(w http.ResponseWriter, name string, err error) {
+func SessionNotFound(w http.ResponseWriter, _ string, err error) {
 	if !errors.Is(err, define.ErrNoSuchExecSession) {
 		InternalServerError(w, err)
 		return
@@ -87,7 +87,7 @@ func SessionNotFound(w http.ResponseWriter, name string, err error) {
 	Error(w, http.StatusNotFound, err)
 }
 
-func SecretNotFound(w http.ResponseWriter, nameOrID string, err error) {
+func SecretNotFound(w http.ResponseWriter, _ string, err error) {
 	if errorhandling.Cause(err).Error() != "no such secret" {
 		InternalServerError(w, err)
 		return

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -82,7 +82,7 @@ func newServer(runtime *libpod.Runtime, listener net.Listener, opts entities.Ser
 		idleTracker: tracker,
 	}
 
-	server.BaseContext = func(l net.Listener) context.Context {
+	server.BaseContext = func(_ net.Listener) context.Context {
 		ctx := context.WithValue(context.Background(), types.DecoderKey, handlers.NewAPIDecoder())
 		ctx = context.WithValue(ctx, types.CompatDecoderKey, handlers.NewCompatAPIDecoder())
 		ctx = context.WithValue(ctx, types.RuntimeKey, runtime)
@@ -143,7 +143,7 @@ func newServer(runtime *libpod.Runtime, listener net.Listener, opts entities.Ser
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		// If in trace mode log request and response bodies
 		router.Use(loggingHandler())
-		_ = router.Walk(func(route *mux.Route, r *mux.Router, ancestors []*mux.Route) error {
+		_ = router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
 			path, err := route.GetPathTemplate()
 			if err != nil {
 				path = "<N/A>"
@@ -189,7 +189,7 @@ func (s *APIServer) setupSystemd() {
 func (s *APIServer) Serve() error {
 	s.setupPprof()
 
-	if err := shutdown.Register("service", func(sig os.Signal) error {
+	if err := shutdown.Register("service", func(_ os.Signal) error {
 		err := s.Shutdown(true)
 		if err == nil {
 			// For `systemctl stop podman.service` support, exit code should be 0

--- a/pkg/bindings/artifacts/inspect.go
+++ b/pkg/bindings/artifacts/inspect.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities/types"
 )
 
-func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*types.ArtifactInspectReport, error) {
+func Inspect(ctx context.Context, nameOrID string, _ *InspectOptions) (*types.ArtifactInspectReport, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/bindings/artifacts/list.go
+++ b/pkg/bindings/artifacts/list.go
@@ -9,7 +9,7 @@ import (
 )
 
 // List returns a list of artifacts in local storage.
-func List(ctx context.Context, options *ListOptions) ([]*entities.ArtifactListReport, error) {
+func List(ctx context.Context, _ *ListOptions) ([]*entities.ArtifactListReport, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -277,7 +277,7 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 		val := strings.TrimSuffix(b.String(), "\n")
 		_url.Path = val
 	}
-	dialContext := func(ctx context.Context, _, _ string) (net.Conn, error) {
+	dialContext := func(_ context.Context, _, _ string) (net.Conn, error) {
 		return ssh.DialNet(conn, "unix", _url)
 	}
 	connection.Client = &http.Client{
@@ -292,7 +292,7 @@ func tcpClient(_url *url.URL) (Connection, error) {
 	connection := Connection{
 		URI: _url,
 	}
-	dialContext := func(ctx context.Context, _, _ string) (net.Conn, error) {
+	dialContext := func(_ context.Context, _, _ string) (net.Conn, error) {
 		return net.Dial("tcp", _url.Host)
 	}
 	// use proxy if env `CONTAINER_PROXY` set
@@ -305,7 +305,7 @@ func tcpClient(_url *url.URL) (Connection, error) {
 		if err != nil {
 			return connection, fmt.Errorf("unable to dial to proxy %s, %w", proxyURI, err)
 		}
-		dialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		dialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 			logrus.Debugf("use proxy %s, but proxy dialer does not support dial timeout", proxyURI)
 			return proxyDialer.Dial("tcp", _url.Host)
 		}

--- a/pkg/bindings/containers/term_unix.go
+++ b/pkg/bindings/containers/term_unix.go
@@ -15,10 +15,10 @@ func makeRawTerm(stdin *os.File) (*term.State, error) {
 	return term.MakeRaw(int(stdin.Fd()))
 }
 
-func notifyWinChange(ctx context.Context, winChange chan os.Signal, stdin *os.File, stdout *os.File) {
+func notifyWinChange(_ context.Context, winChange chan os.Signal, _ *os.File, _ *os.File) {
 	signal.Notify(winChange, sig.SIGWINCH)
 }
 
-func getTermSize(stdin *os.File, stdout *os.File) (width, height int, err error) {
+func getTermSize(stdin *os.File, _ *os.File) (width, height int, err error) {
 	return term.GetSize(int(stdin.Fd()))
 }

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -19,7 +19,7 @@ import (
 
 // Exists a lightweight way to determine if an image exists in local storage.  It returns a
 // boolean response.
-func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool, error) {
+func Exists(ctx context.Context, nameOrID string, _ *ExistsOptions) (bool, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return false, err
@@ -326,7 +326,7 @@ func Search(ctx context.Context, term string, options *SearchOptions) ([]types.I
 	return results, nil
 }
 
-func Scp(ctx context.Context, source, destination *string, options ScpOptions) (reports.ScpReport, error) {
+func Scp(ctx context.Context, source, _ *string, options ScpOptions) (reports.ScpReport, error) {
 	rep := reports.ScpReport{}
 
 	conn, err := bindings.GetClient(ctx)

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -62,7 +62,7 @@ func Create(ctx context.Context, name string, images []string, options *CreateOp
 }
 
 // Exists returns true if a given manifest list exists
-func Exists(ctx context.Context, name string, options *ExistsOptions) (bool, error) {
+func Exists(ctx context.Context, name string, _ *ExistsOptions) (bool, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -197,7 +197,7 @@ func Connect(ctx context.Context, networkName string, containerNameOrID string, 
 }
 
 // Exists returns true if a given network exists
-func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool, error) {
+func Exists(ctx context.Context, nameOrID string, _ *ExistsOptions) (bool, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/bindings/pods/pods.go
+++ b/pkg/bindings/pods/pods.go
@@ -37,7 +37,7 @@ func CreatePodFromSpec(ctx context.Context, spec *entitiesTypes.PodSpec) (*entit
 }
 
 // Exists is a lightweight method to determine if a pod exists in local storage
-func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool, error) {
+func Exists(ctx context.Context, nameOrID string, _ *ExistsOptions) (bool, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/bindings/volumes/volumes.go
+++ b/pkg/bindings/volumes/volumes.go
@@ -128,7 +128,7 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error 
 }
 
 // Exists returns true if a given volume exists
-func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool, error) {
+func Exists(ctx context.Context, nameOrID string, _ *ExistsOptions) (bool, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -292,7 +292,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 }
 
 // GeneratePruneContainerFilterFuncs return ContainerFilter functions based of filter for prune operation
-func GeneratePruneContainerFilterFuncs(filter string, filterValues []string, r *libpod.Runtime) (func(container *libpod.Container) bool, error) {
+func GeneratePruneContainerFilterFuncs(filter string, filterValues []string, _ *libpod.Runtime) (func(container *libpod.Container) bool, error) {
 	switch filter {
 	case "label":
 		return func(c *libpod.Container) bool {

--- a/pkg/domain/infra/abi/apply.go
+++ b/pkg/domain/infra/abi/apply.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func (ic *ContainerEngine) KubeApply(ctx context.Context, body io.Reader, options entities.ApplyOptions) error {
+func (ic *ContainerEngine) KubeApply(_ context.Context, body io.Reader, options entities.ApplyOptions) error {
 	// Read the yaml file
 	content, err := io.ReadAll(body)
 	if err != nil {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -163,7 +163,7 @@ func getContainers(runtime *libpod.Runtime, options getContainersOptions) ([]con
 }
 
 // ContainerExists returns whether the container exists in container storage
-func (ic *ContainerEngine) ContainerExists(ctx context.Context, nameOrID string, options entities.ContainerExistsOptions) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) ContainerExists(_ context.Context, nameOrID string, options entities.ContainerExistsOptions) (*entities.BoolReport, error) {
 	_, err := ic.Libpod.LookupContainer(nameOrID)
 	if err != nil {
 		if !errors.Is(err, define.ErrNoSuchCtr) {
@@ -253,7 +253,7 @@ func waitExitOnFirst(ctx context.Context, containers []containerWrapper, options
 	return response
 }
 
-func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
+func (ic *ContainerEngine) ContainerPause(_ context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
 	containers, err := getContainers(ic.Libpod, getContainersOptions{all: options.All, latest: options.Latest, names: namesOrIds, filters: options.Filters})
 	if err != nil {
 		return nil, err
@@ -274,7 +274,7 @@ func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []stri
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
+func (ic *ContainerEngine) ContainerUnpause(_ context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
 	containers, err := getContainers(ic.Libpod, getContainersOptions{all: options.All, latest: options.Latest, names: namesOrIds, filters: options.Filters})
 	if err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerPrune(ctx context.Context, options entities.ContainerPruneOptions) ([]*reports.PruneReport, error) {
+func (ic *ContainerEngine) ContainerPrune(_ context.Context, options entities.ContainerPruneOptions) ([]*reports.PruneReport, error) {
 	filterFuncs := make([]libpod.ContainerFilter, 0, len(options.Filters))
 	for k, v := range options.Filters {
 		generatedFunc, err := dfilters.GeneratePruneContainerFilterFuncs(k, v, ic.Libpod)
@@ -397,7 +397,7 @@ func (ic *ContainerEngine) ContainerPrune(ctx context.Context, options entities.
 	return ic.Libpod.PruneContainers(filterFuncs)
 }
 
-func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []string, options entities.KillOptions) ([]*entities.KillReport, error) {
+func (ic *ContainerEngine) ContainerKill(_ context.Context, namesOrIds []string, options entities.KillOptions) ([]*entities.KillReport, error) {
 	sig, err := signal.ParseSignalNameOrNumber(options.Signal)
 	if err != nil {
 		return nil, err
@@ -551,7 +551,7 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 	return rmReports, nil
 }
 
-func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []string, options entities.InspectOptions) ([]*entities.ContainerInspectReport, []error, error) {
+func (ic *ContainerEngine) ContainerInspect(_ context.Context, namesOrIds []string, options entities.InspectOptions) ([]*entities.ContainerInspectReport, []error, error) {
 	if options.Latest {
 		ctr, err := ic.Libpod.GetLatestContainer()
 		if err != nil {
@@ -604,7 +604,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) ContainerTop(ctx context.Context, options entities.TopOptions) (*entities.StringSliceReport, error) {
+func (ic *ContainerEngine) ContainerTop(_ context.Context, options entities.TopOptions) (*entities.StringSliceReport, error) {
 	var (
 		container *libpod.Container
 		err       error
@@ -684,7 +684,7 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 	return &entities.CommitReport{Id: newImage.ID()}, nil
 }
 
-func (ic *ContainerEngine) ContainerExport(ctx context.Context, nameOrID string, options entities.ContainerExportOptions) error {
+func (ic *ContainerEngine) ContainerExport(_ context.Context, nameOrID string, options entities.ContainerExportOptions) error {
 	ctr, err := ic.Libpod.LookupContainer(nameOrID)
 	if err != nil {
 		return err
@@ -957,7 +957,7 @@ func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, o
 	return define.TranslateExecErrorToExitCode(ec, err), err
 }
 
-func (ic *ContainerEngine) ContainerExecDetached(ctx context.Context, nameOrID string, options entities.ExecOptions) (string, error) {
+func (ic *ContainerEngine) ContainerExecDetached(_ context.Context, nameOrID string, options entities.ExecOptions) (string, error) {
 	err := checkExecPreserveFDs(options)
 	if err != nil {
 		return "", err
@@ -1101,19 +1101,19 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerList(ctx context.Context, options entities.ContainerListOptions) ([]entities.ListContainer, error) {
+func (ic *ContainerEngine) ContainerList(_ context.Context, options entities.ContainerListOptions) ([]entities.ListContainer, error) {
 	if options.Latest {
 		options.Last = 1
 	}
 	return ps.GetContainerLists(ic.Libpod, options)
 }
 
-func (ic *ContainerEngine) ContainerListExternal(ctx context.Context) ([]entities.ListContainer, error) {
+func (ic *ContainerEngine) ContainerListExternal(_ context.Context) ([]entities.ListContainer, error) {
 	return ps.GetExternalContainerLists(ic.Libpod)
 }
 
 // Diff provides changes to given container
-func (ic *ContainerEngine) Diff(ctx context.Context, namesOrIDs []string, opts entities.DiffOptions) (*entities.DiffReport, error) {
+func (ic *ContainerEngine) Diff(_ context.Context, namesOrIDs []string, opts entities.DiffOptions) (*entities.DiffReport, error) {
 	var (
 		base   string
 		parent string
@@ -1410,7 +1410,7 @@ func (ic *ContainerEngine) ContainerInit(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerMount(ctx context.Context, nameOrIDs []string, options entities.ContainerMountOptions) ([]*entities.ContainerMountReport, error) {
+func (ic *ContainerEngine) ContainerMount(_ context.Context, nameOrIDs []string, options entities.ContainerMountOptions) ([]*entities.ContainerMountReport, error) {
 	hasCapSysAdmin, err := unshare.HasCapSysAdmin()
 	if err != nil {
 		return nil, err
@@ -1519,7 +1519,7 @@ func (ic *ContainerEngine) ContainerMount(ctx context.Context, nameOrIDs []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerUnmount(ctx context.Context, nameOrIDs []string, options entities.ContainerUnmountOptions) ([]*entities.ContainerUnmountReport, error) {
+func (ic *ContainerEngine) ContainerUnmount(_ context.Context, nameOrIDs []string, options entities.ContainerUnmountOptions) ([]*entities.ContainerUnmountReport, error) {
 	reports := []*entities.ContainerUnmountReport{}
 	names := []string{}
 	if options.All {
@@ -1582,7 +1582,7 @@ func (ic *ContainerEngine) Config(_ context.Context) (*config.Config, error) {
 	return ic.Libpod.GetConfig()
 }
 
-func (ic *ContainerEngine) ContainerPort(ctx context.Context, nameOrID string, options entities.ContainerPortOptions) ([]*entities.ContainerPortReport, error) {
+func (ic *ContainerEngine) ContainerPort(_ context.Context, nameOrID string, options entities.ContainerPortOptions) ([]*entities.ContainerPortReport, error) {
 	containers, err := getContainers(ic.Libpod, getContainersOptions{all: options.All, latest: options.Latest, names: []string{nameOrID}})
 	if err != nil {
 		return nil, err
@@ -1836,7 +1836,7 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 }
 
 // ContainerUpdate finds and updates the given container's cgroup config with the specified options
-func (ic *ContainerEngine) ContainerUpdate(ctx context.Context, updateOptions *entities.ContainerUpdateOptions) (string, error) {
+func (ic *ContainerEngine) ContainerUpdate(_ context.Context, updateOptions *entities.ContainerUpdateOptions) (string, error) {
 	updateOptions.ProcessSpecgen()
 	containers, err := getContainers(ic.Libpod, getContainersOptions{latest: updateOptions.Latest, names: []string{updateOptions.NameOrID}})
 	if err != nil {

--- a/pkg/domain/infra/abi/farm.go
+++ b/pkg/domain/infra/abi/farm.go
@@ -14,12 +14,12 @@ import (
 )
 
 // FarmNodeName returns the local engine's name.
-func (ir *ImageEngine) FarmNodeName(ctx context.Context) string {
+func (ir *ImageEngine) FarmNodeName(_ context.Context) string {
 	return entities.LocalFarmImageBuilderName
 }
 
 // FarmNodeDriver returns a description of the local image builder driver
-func (ir *ImageEngine) FarmNodeDriver(ctx context.Context) string {
+func (ir *ImageEngine) FarmNodeDriver(_ context.Context) string {
 	return entities.LocalFarmImageBuilderDriver
 }
 

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string, options entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
+func (ic *ContainerEngine) GenerateSystemd(_ context.Context, nameOrID string, options entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
 	// First assume it's a container.
 	ctr, ctrErr := ic.Libpod.LookupContainer(nameOrID)
 	if ctrErr == nil {
@@ -46,7 +46,7 @@ func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string,
 	return &entities.GenerateSystemdReport{Units: units}, nil
 }
 
-func (ic *ContainerEngine) GenerateSpec(ctx context.Context, opts *entities.GenerateSpecOptions) (*entities.GenerateSpecReport, error) {
+func (ic *ContainerEngine) GenerateSpec(_ context.Context, opts *entities.GenerateSpecOptions) (*entities.GenerateSpecReport, error) {
 	var spec *specgen.SpecGenerator
 	var pspec *specgen.PodSpecGenerator
 	var err error

--- a/pkg/domain/infra/abi/healthcheck.go
+++ b/pkg/domain/infra/abi/healthcheck.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) HealthCheckRun(ctx context.Context, nameOrID string, options entities.HealthCheckOptions) (*define.HealthCheckResults, error) {
+func (ic *ContainerEngine) HealthCheckRun(ctx context.Context, nameOrID string, _ entities.HealthCheckOptions) (*define.HealthCheckResults, error) {
 	status, err := ic.Libpod.HealthCheck(ctx, nameOrID)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -134,7 +134,7 @@ func toDomainHistoryLayer(layer *libimage.ImageHistory) entities.ImageHistoryLay
 	return l
 }
 
-func (ir *ImageEngine) History(ctx context.Context, nameOrID string, opts entities.ImageHistoryOptions) (*entities.ImageHistoryReport, error) {
+func (ir *ImageEngine) History(ctx context.Context, nameOrID string, _ entities.ImageHistoryOptions) (*entities.ImageHistoryReport, error) {
 	image, _, err := ir.Libpod.LibimageRuntime().LookupImage(nameOrID, nil)
 	if err != nil {
 		return nil, err
@@ -321,7 +321,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	return &entities.ImagePullReport{Images: pulledIDs}, nil
 }
 
-func (ir *ImageEngine) Inspect(ctx context.Context, namesOrIDs []string, opts entities.InspectOptions) ([]*entities.ImageInspectReport, []error, error) {
+func (ir *ImageEngine) Inspect(ctx context.Context, namesOrIDs []string, _ entities.InspectOptions) ([]*entities.ImageInspectReport, []error, error) {
 	reports := []*entities.ImageInspectReport{}
 	errs := []error{}
 
@@ -442,7 +442,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	return nil, pushError
 }
 
-func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, options entities.ImageTagOptions) error {
+func (ir *ImageEngine) Tag(_ context.Context, nameOrID string, tags []string, _ entities.ImageTagOptions) error {
 	// Allow tagging manifest list instead of resolving instances from manifest
 	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}
 	image, _, err := ir.Libpod.LibimageRuntime().LookupImage(nameOrID, lookupOptions)
@@ -457,7 +457,7 @@ func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, 
 	return nil
 }
 
-func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string, options entities.ImageUntagOptions) error {
+func (ir *ImageEngine) Untag(_ context.Context, nameOrID string, tags []string, _ entities.ImageUntagOptions) error {
 	image, _, err := ir.Libpod.LibimageRuntime().LookupImage(nameOrID, nil)
 	if err != nil {
 		return err
@@ -796,7 +796,7 @@ func (ir *ImageEngine) Scp(ctx context.Context, src, dst string, opts entities.I
 	return &entities.ImageScpReport{}, nil
 }
 
-func Transfer(ctx context.Context, source entities.ScpTransferImageOptions, dest entities.ScpTransferImageOptions, opts entities.ScpTransferOptions) (*entities.ScpTransferReport, error) {
+func Transfer(_ context.Context, source entities.ScpTransferImageOptions, dest entities.ScpTransferImageOptions, opts entities.ScpTransferOptions) (*entities.ScpTransferReport, error) {
 	if source.User == "" {
 		return nil, fmt.Errorf("you must define a user when transferring from root to rootless storage: %w", define.ErrInvalidArg)
 	}

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -70,7 +70,7 @@ func (ir *ImageEngine) ManifestCreate(ctx context.Context, name string, images [
 }
 
 // ManifestExists checks if a manifest list with the given name exists in local storage
-func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entities.BoolReport, error) {
+func (ir *ImageEngine) ManifestExists(_ context.Context, name string) (*entities.BoolReport, error) {
 	_, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
 	if err != nil {
 		if errors.Is(err, storage.ErrImageUnknown) {
@@ -442,7 +442,7 @@ func (ir *ImageEngine) digestFromDigestOrManifestListMember(ctx context.Context,
 }
 
 // ManifestRemoveDigest removes specified digest from the specified manifest list
-func (ir *ImageEngine) ManifestRemoveDigest(ctx context.Context, name, image string) (string, error) {
+func (ir *ImageEngine) ManifestRemoveDigest(_ context.Context, name, image string) (string, error) {
 	instanceDigest, err := digest.Parse(image)
 	if err != nil {
 		return "", fmt.Errorf(`invalid image digest "%s": %v`, image, err)
@@ -549,7 +549,7 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 }
 
 // ManifestListClear clears out all instances from the manifest list
-func (ir *ImageEngine) ManifestListClear(ctx context.Context, name string) (string, error) {
+func (ir *ImageEngine) ManifestListClear(_ context.Context, name string) (string, error) {
 	manifestList, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
 	if err != nil {
 		return "", err

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -18,7 +18,7 @@ import (
 	netutil "go.podman.io/common/libnetwork/util"
 )
 
-func (ic *ContainerEngine) NetworkUpdate(ctx context.Context, netName string, options entities.NetworkUpdateOptions) error {
+func (ic *ContainerEngine) NetworkUpdate(_ context.Context, netName string, options entities.NetworkUpdateOptions) error {
 	var networkUpdateOptions types.NetworkUpdateOptions
 	networkUpdateOptions.AddDNSServers = options.AddDNSServers
 	networkUpdateOptions.RemoveDNSServers = options.RemoveDNSServers
@@ -29,7 +29,7 @@ func (ic *ContainerEngine) NetworkUpdate(ctx context.Context, netName string, op
 	return nil
 }
 
-func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.NetworkListOptions) ([]types.Network, error) {
+func (ic *ContainerEngine) NetworkList(_ context.Context, options entities.NetworkListOptions) ([]types.Network, error) {
 	// dangling filter is not provided by netutil
 	var wantDangling bool
 
@@ -67,7 +67,7 @@ func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.Net
 	return nets, err
 }
 
-func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, options entities.InspectOptions) ([]entities.NetworkInspectReport, []error, error) {
+func (ic *ContainerEngine) NetworkInspect(_ context.Context, namesOrIds []string, _ entities.InspectOptions) ([]entities.NetworkInspectReport, []error, error) {
 	var errs []error
 	statuses, err := ic.GetContainerNetStatuses()
 	if err != nil {
@@ -104,7 +104,7 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 	return networks, errs, nil
 }
 
-func (ic *ContainerEngine) NetworkReload(ctx context.Context, names []string, options entities.NetworkReloadOptions) ([]*entities.NetworkReloadReport, error) {
+func (ic *ContainerEngine) NetworkReload(_ context.Context, names []string, options entities.NetworkReloadOptions) ([]*entities.NetworkReloadReport, error) {
 	containers, err := getContainers(ic.Libpod, getContainersOptions{all: options.All, latest: options.Latest, names: names})
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 	return reports, nil
 }
 
-func (ic *ContainerEngine) NetworkCreate(ctx context.Context, network types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error) {
+func (ic *ContainerEngine) NetworkCreate(_ context.Context, network types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error) {
 	if slices.Contains([]string{"none", "host", "bridge", "private", slirp4netns.BinaryName, pasta.BinaryName, "container", "ns", "default"}, network.Name) {
 		return nil, fmt.Errorf("cannot create network with name %q because it conflicts with a valid network mode", network.Name)
 	}
@@ -192,16 +192,16 @@ func (ic *ContainerEngine) NetworkCreate(ctx context.Context, network types.Netw
 }
 
 // NetworkDisconnect removes a container from a given network
-func (ic *ContainerEngine) NetworkDisconnect(ctx context.Context, networkname string, options entities.NetworkDisconnectOptions) error {
+func (ic *ContainerEngine) NetworkDisconnect(_ context.Context, networkname string, options entities.NetworkDisconnectOptions) error {
 	return ic.Libpod.DisconnectContainerFromNetwork(options.Container, networkname, options.Force)
 }
 
-func (ic *ContainerEngine) NetworkConnect(ctx context.Context, networkname string, options entities.NetworkConnectOptions) error {
+func (ic *ContainerEngine) NetworkConnect(_ context.Context, networkname string, options entities.NetworkConnectOptions) error {
 	return ic.Libpod.ConnectContainerToNetwork(options.Container, networkname, options.PerNetworkOptions)
 }
 
 // NetworkExists checks if the given network exists
-func (ic *ContainerEngine) NetworkExists(ctx context.Context, networkname string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) NetworkExists(_ context.Context, networkname string) (*entities.BoolReport, error) {
 	_, err := ic.Libpod.Network().NetworkInspect(networkname)
 	exists := true
 	// if err is ErrNoSuchNetwork do not return it
@@ -216,7 +216,7 @@ func (ic *ContainerEngine) NetworkExists(ctx context.Context, networkname string
 }
 
 // Network prune removes unused networks
-func (ic *ContainerEngine) NetworkPrune(ctx context.Context, options entities.NetworkPruneOptions) ([]*entities.NetworkPruneReport, error) {
+func (ic *ContainerEngine) NetworkPrune(_ context.Context, options entities.NetworkPruneOptions) ([]*entities.NetworkPruneReport, error) {
 	// get all filters
 	filters, err := netutil.GenerateNetworkPruneFilters(options.Filters)
 	if err != nil {

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -50,7 +50,7 @@ func getPodsByContext(all, latest bool, pods []string, runtime *libpod.Runtime) 
 	return outpods, err
 }
 
-func (ic *ContainerEngine) PodExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) PodExists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	_, err := ic.Libpod.LookupPod(nameOrID)
 	if err != nil && !errors.Is(err, define.ErrNoSuchPod) {
 		return nil, err
@@ -292,7 +292,7 @@ func (ic *ContainerEngine) PodRm(ctx context.Context, namesOrIds []string, optio
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodPrune(ctx context.Context, options entities.PodPruneOptions) ([]*entities.PodPruneReport, error) {
+func (ic *ContainerEngine) PodPrune(ctx context.Context, _ entities.PodPruneOptions) ([]*entities.PodPruneReport, error) {
 	return ic.prunePodHelper(ctx)
 }
 
@@ -311,7 +311,7 @@ func (ic *ContainerEngine) prunePodHelper(ctx context.Context) ([]*entities.PodP
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodCreate(ctx context.Context, specg entities.PodSpec) (*entities.PodCreateReport, error) {
+func (ic *ContainerEngine) PodCreate(_ context.Context, specg entities.PodSpec) (*entities.PodCreateReport, error) {
 	pod, err := generate.MakePod(&specg, ic.Libpod)
 	if err != nil {
 		return nil, err
@@ -404,7 +404,7 @@ func (ic *ContainerEngine) PodClone(ctx context.Context, podClone entities.PodCl
 	return &entities.PodCloneReport{Id: pod.ID()}, nil
 }
 
-func (ic *ContainerEngine) PodTop(ctx context.Context, options entities.PodTopOptions) (*entities.StringSliceReport, error) {
+func (ic *ContainerEngine) PodTop(_ context.Context, options entities.PodTopOptions) (*entities.StringSliceReport, error) {
 	var (
 		pod *libpod.Pod
 		err error
@@ -481,7 +481,7 @@ func (ic *ContainerEngine) listPodReportFromPod(p *libpod.Pod) (*entities.ListPo
 	}, nil
 }
 
-func (ic *ContainerEngine) PodPs(ctx context.Context, options entities.PodPSOptions) ([]*entities.ListPodsReport, error) {
+func (ic *ContainerEngine) PodPs(_ context.Context, options entities.PodPSOptions) ([]*entities.ListPodsReport, error) {
 	var (
 		err error
 		pds = []*libpod.Pod{}
@@ -522,7 +522,7 @@ func (ic *ContainerEngine) PodPs(ctx context.Context, options entities.PodPSOpti
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodInspect(ctx context.Context, nameOrIDs []string, options entities.InspectOptions) ([]*entities.PodInspectReport, []error, error) {
+func (ic *ContainerEngine) PodInspect(_ context.Context, nameOrIDs []string, options entities.InspectOptions) ([]*entities.PodInspectReport, []error, error) {
 	if options.Latest {
 		pod, err := ic.Libpod.GetLatestPod()
 		if err != nil {

--- a/pkg/domain/infra/abi/pods_stats.go
+++ b/pkg/domain/infra/abi/pods_stats.go
@@ -17,7 +17,7 @@ import (
 )
 
 // PodStats implements printing stats about pods.
-func (ic *ContainerEngine) PodStats(ctx context.Context, namesOrIds []string, options entities.PodStatsOptions) ([]*entities.PodStatsReport, error) {
+func (ic *ContainerEngine) PodStats(_ context.Context, namesOrIds []string, options entities.PodStatsOptions) ([]*entities.PodStatsReport, error) {
 	// Cgroups v2 check for rootless.
 	if rootless.IsRootless() {
 		unified, err := cgroups.IsCgroup2UnifiedMode()

--- a/pkg/domain/infra/abi/quadlet.go
+++ b/pkg/domain/infra/abi/quadlet.go
@@ -546,7 +546,7 @@ func getQuadletPathByName(name string) (string, error) {
 	return "", fmt.Errorf("could not locate quadlet %q in any supported quadlet directory", name)
 }
 
-func (ic *ContainerEngine) QuadletPrint(ctx context.Context, quadlet string) (string, error) {
+func (ic *ContainerEngine) QuadletPrint(_ context.Context, quadlet string) (string, error) {
 	quadletPath, err := getQuadletPathByName(quadlet)
 	if err != nil {
 		return "", err

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -16,7 +16,7 @@ import (
 	"go.podman.io/common/pkg/secrets"
 )
 
-func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader io.Reader, options entities.SecretCreateOptions) (*entities.SecretCreateReport, error) {
+func (ic *ContainerEngine) SecretCreate(_ context.Context, name string, reader io.Reader, options entities.SecretCreateOptions) (*entities.SecretCreateReport, error) {
 	data, _ := io.ReadAll(reader)
 	secretsPath := ic.Libpod.GetSecretsStorageDir()
 	manager, err := ic.Libpod.SecretsManager()
@@ -65,7 +65,7 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 	}, nil
 }
 
-func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string, options entities.SecretInspectOptions) ([]*entities.SecretInfoReport, []error, error) {
+func (ic *ContainerEngine) SecretInspect(_ context.Context, nameOrIDs []string, options entities.SecretInspectOptions) ([]*entities.SecretInfoReport, []error, error) {
 	var (
 		secret *secrets.Secret
 		data   []byte
@@ -102,7 +102,7 @@ func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) SecretList(ctx context.Context, opts entities.SecretListRequest) ([]*entities.SecretInfoReport, error) {
+func (ic *ContainerEngine) SecretList(_ context.Context, opts entities.SecretListRequest) ([]*entities.SecretInfoReport, error) {
 	manager, err := ic.Libpod.SecretsManager()
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func (ic *ContainerEngine) SecretList(ctx context.Context, opts entities.SecretL
 	return report, nil
 }
 
-func (ic *ContainerEngine) SecretRm(ctx context.Context, nameOrIDs []string, options entities.SecretRmOptions) ([]*entities.SecretRmReport, error) {
+func (ic *ContainerEngine) SecretRm(_ context.Context, nameOrIDs []string, options entities.SecretRmOptions) ([]*entities.SecretRmReport, error) {
 	var (
 		err      error
 		toRemove []string
@@ -158,7 +158,7 @@ func (ic *ContainerEngine) SecretRm(ctx context.Context, nameOrIDs []string, opt
 	return reports, nil
 }
 
-func (ic *ContainerEngine) SecretExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) SecretExists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	manager, err := ic.Libpod.SecretsManager()
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -22,7 +22,7 @@ import (
 	"go.podman.io/storage/pkg/fileutils"
 )
 
-func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
+func (ic *ContainerEngine) Info(_ context.Context) (*define.Info, error) {
 	info, err := ic.Libpod.Info()
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 	return systemPruneReport, nil
 }
 
-func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.SystemDfOptions) (*entities.SystemDfReport, error) {
+func (ic *ContainerEngine) SystemDf(ctx context.Context, _ entities.SystemDfOptions) (*entities.SystemDfReport, error) {
 	var (
 		dfImages = []*entities.SystemDfImageReport{}
 	)
@@ -302,11 +302,11 @@ func (ic *ContainerEngine) Reset(ctx context.Context) error {
 	return ic.Libpod.Reset(ctx)
 }
 
-func (ic *ContainerEngine) Renumber(ctx context.Context) error {
+func (ic *ContainerEngine) Renumber(_ context.Context) error {
 	return ic.Libpod.RenumberLocks()
 }
 
-func (ic *ContainerEngine) Migrate(ctx context.Context, options entities.SystemMigrateOptions) error {
+func (ic *ContainerEngine) Migrate(_ context.Context, options entities.SystemMigrateOptions) error {
 	return ic.Libpod.Migrate(options.NewRuntime)
 }
 
@@ -316,7 +316,7 @@ func unshareEnv(graphroot, runroot string) []string {
 		fmt.Sprintf("CONTAINERS_RUNROOT=%s", runroot))
 }
 
-func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options entities.SystemUnshareOptions) error {
+func (ic *ContainerEngine) Unshare(_ context.Context, args []string, options entities.SystemUnshareOptions) error {
 	unshare := func() error {
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Env = unshareEnv(ic.Libpod.StorageConfig().GraphRoot, ic.Libpod.StorageConfig().RunRoot)
@@ -332,7 +332,7 @@ func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options e
 	return unshare()
 }
 
-func (ic *ContainerEngine) Version(ctx context.Context) (*entities.SystemVersionReport, error) {
+func (ic *ContainerEngine) Version(_ context.Context) (*entities.SystemVersionReport, error) {
 	var report entities.SystemVersionReport
 	v, err := define.GetVersion()
 	if err != nil {
@@ -342,7 +342,7 @@ func (ic *ContainerEngine) Version(ctx context.Context) (*entities.SystemVersion
 	return &report, err
 }
 
-func (ic *ContainerEngine) Locks(ctx context.Context) (*entities.LocksReport, error) {
+func (ic *ContainerEngine) Locks(_ context.Context) (*entities.LocksReport, error) {
 	var report entities.LocksReport
 	conflicts, held, err := ic.Libpod.LockConflicts()
 	if err != nil {

--- a/pkg/domain/infra/abi/trust.go
+++ b/pkg/domain/infra/abi/trust.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/podman/v5/pkg/trust"
 )
 
-func (ir *ImageEngine) ShowTrust(ctx context.Context, args []string, options entities.ShowTrustOptions) (*entities.ShowTrustReport, error) {
+func (ir *ImageEngine) ShowTrust(_ context.Context, _ []string, options entities.ShowTrustOptions) (*entities.ShowTrustReport, error) {
 	var (
 		err    error
 		report entities.ShowTrustReport
@@ -38,7 +38,7 @@ func (ir *ImageEngine) ShowTrust(ctx context.Context, args []string, options ent
 	return &report, nil
 }
 
-func (ir *ImageEngine) SetTrust(ctx context.Context, args []string, options entities.SetTrustOptions) error {
+func (ir *ImageEngine) SetTrust(_ context.Context, args []string, options entities.SetTrustOptions) error {
 	if len(args) != 1 {
 		return fmt.Errorf("SetTrust called with unexpected %d args", len(args))
 	}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -92,7 +92,7 @@ func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, op
 	return reports, nil
 }
 
-func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.VolumeInspectReport, []error, error) {
+func (ic *ContainerEngine) VolumeInspect(_ context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.VolumeInspectReport, []error, error) {
 	var (
 		err  error
 		errs []error
@@ -154,7 +154,7 @@ func (ic *ContainerEngine) pruneVolumesHelper(ctx context.Context, filterFuncs [
 	return pruned, nil
 }
 
-func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeListOptions) ([]*entities.VolumeListReport, error) {
+func (ic *ContainerEngine) VolumeList(_ context.Context, opts entities.VolumeListOptions) ([]*entities.VolumeListReport, error) {
 	volumeFilters := []libpod.VolumeFilter{}
 	for filter, value := range opts.Filter {
 		filterFunc, err := filters.GenerateVolumeFilters(filter, value, ic.Libpod)
@@ -186,7 +186,7 @@ func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeL
 }
 
 // VolumeExists check if a given volume name exists
-func (ic *ContainerEngine) VolumeExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) VolumeExists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	exists, err := ic.Libpod.HasVolume(nameOrID)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (ic *ContainerEngine) VolumeExists(ctx context.Context, nameOrID string) (*
 }
 
 // Volumemounted check if a given volume using plugin or filesystem is mounted or not.
-func (ic *ContainerEngine) VolumeMounted(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) VolumeMounted(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	vol, err := ic.Libpod.LookupVolume(nameOrID)
 	if err != nil {
 		return nil, err
@@ -211,7 +211,7 @@ func (ic *ContainerEngine) VolumeMounted(ctx context.Context, nameOrID string) (
 	return &entities.BoolReport{Value: false}, nil
 }
 
-func (ic *ContainerEngine) VolumeMount(ctx context.Context, nameOrIDs []string) ([]*entities.VolumeMountReport, error) {
+func (ic *ContainerEngine) VolumeMount(_ context.Context, nameOrIDs []string) ([]*entities.VolumeMountReport, error) {
 	reports := []*entities.VolumeMountReport{}
 	for _, name := range nameOrIDs {
 		report := entities.VolumeMountReport{Id: name}
@@ -227,7 +227,7 @@ func (ic *ContainerEngine) VolumeMount(ctx context.Context, nameOrIDs []string) 
 	return reports, nil
 }
 
-func (ic *ContainerEngine) VolumeUnmount(ctx context.Context, nameOrIDs []string) ([]*entities.VolumeUnmountReport, error) {
+func (ic *ContainerEngine) VolumeUnmount(_ context.Context, nameOrIDs []string) ([]*entities.VolumeUnmountReport, error) {
 	reports := []*entities.VolumeUnmountReport{}
 	for _, name := range nameOrIDs {
 		report := entities.VolumeUnmountReport{Id: name}
@@ -248,7 +248,7 @@ func (ic *ContainerEngine) VolumeReload(ctx context.Context) (*entities.VolumeRe
 	return &entities.VolumeReloadReport{VolumeReload: *report}, nil
 }
 
-func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, options entities.VolumeExportOptions) error {
+func (ic *ContainerEngine) VolumeExport(_ context.Context, nameOrID string, options entities.VolumeExportOptions) error {
 	vol, err := ic.Libpod.LookupVolume(nameOrID)
 	if err != nil {
 		return err
@@ -267,7 +267,7 @@ func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, op
 	return nil
 }
 
-func (ic *ContainerEngine) VolumeImport(ctx context.Context, nameOrID string, options entities.VolumeImportOptions) error {
+func (ic *ContainerEngine) VolumeImport(_ context.Context, nameOrID string, options entities.VolumeImportOptions) error {
 	vol, err := ic.Libpod.LookupVolume(nameOrID)
 	if err != nil {
 		return err

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -22,15 +22,15 @@ func (ir *ImageEngine) ArtifactExtract(_ context.Context, name string, target st
 	return artifacts.Extract(ir.ClientCtx, name, target, &options)
 }
 
-func (ir *ImageEngine) ArtifactExtractTarStream(_ context.Context, w io.Writer, name string, opts entities.ArtifactExtractOptions) error {
+func (ir *ImageEngine) ArtifactExtractTarStream(_ context.Context, _ io.Writer, _ string, _ entities.ArtifactExtractOptions) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (ir *ImageEngine) ArtifactInspect(_ context.Context, name string, opts entities.ArtifactInspectOptions) (*entities.ArtifactInspectReport, error) {
+func (ir *ImageEngine) ArtifactInspect(_ context.Context, name string, _ entities.ArtifactInspectOptions) (*entities.ArtifactInspectReport, error) {
 	return artifacts.Inspect(ir.ClientCtx, name, &artifacts.InspectOptions{})
 }
 
-func (ir *ImageEngine) ArtifactList(_ context.Context, opts entities.ArtifactListOptions) ([]*entities.ArtifactListReport, error) {
+func (ir *ImageEngine) ArtifactList(_ context.Context, _ entities.ArtifactListOptions) ([]*entities.ArtifactListReport, error) {
 	return artifacts.List(ir.ClientCtx, &artifacts.ListOptions{})
 }
 

--- a/pkg/domain/infra/tunnel/auto-update.go
+++ b/pkg/domain/infra/tunnel/auto-update.go
@@ -7,6 +7,6 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) ([]*entities.AutoUpdateReport, []error) {
+func (ic *ContainerEngine) AutoUpdate(_ context.Context, _ entities.AutoUpdateOptions) ([]*entities.AutoUpdateReport, []error) {
 	return nil, []error{errors.New("not implemented")}
 }

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -28,11 +28,11 @@ import (
 	"go.podman.io/storage/types"
 )
 
-func (ic *ContainerEngine) ContainerRunlabel(ctx context.Context, label string, image string, args []string, options entities.ContainerRunlabelOptions) error {
+func (ic *ContainerEngine) ContainerRunlabel(_ context.Context, _ string, _ string, _ []string, _ entities.ContainerRunlabelOptions) error {
 	return errors.New("not implemented")
 }
 
-func (ic *ContainerEngine) ContainerExists(ctx context.Context, nameOrID string, options entities.ContainerExistsOptions) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) ContainerExists(_ context.Context, nameOrID string, options entities.ContainerExistsOptions) (*entities.BoolReport, error) {
 	exists, err := containers.Exists(ic.ClientCtx, nameOrID, new(containers.ExistsOptions).WithExternal(options.External))
 	return &entities.BoolReport{Value: exists}, err
 }
@@ -90,7 +90,7 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 	return responses, nil
 }
 
-func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
+func (ic *ContainerEngine) ContainerPause(_ context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
 	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, options.All, false, namesOrIds, options.Filters)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []stri
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
+func (ic *ContainerEngine) ContainerUnpause(_ context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
 	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, options.All, false, namesOrIds, options.Filters)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []st
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []string, opts entities.StopOptions) ([]*entities.StopReport, error) {
+func (ic *ContainerEngine) ContainerStop(_ context.Context, namesOrIds []string, opts entities.StopOptions) ([]*entities.StopReport, error) {
 	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds, opts.Filters)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []string, opts entities.KillOptions) ([]*entities.KillReport, error) {
+func (ic *ContainerEngine) ContainerKill(_ context.Context, namesOrIds []string, opts entities.KillOptions) ([]*entities.KillReport, error) {
 	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, opts.All, false, namesOrIds, nil)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []string, opts entities.RestartOptions) ([]*entities.RestartReport, error) {
+func (ic *ContainerEngine) ContainerRestart(_ context.Context, namesOrIds []string, opts entities.RestartOptions) ([]*entities.RestartReport, error) {
 	var (
 		reports = []*entities.RestartReport{}
 	)
@@ -239,7 +239,7 @@ func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []st
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string, opts entities.RmOptions) ([]*reports.RmReport, error) {
+func (ic *ContainerEngine) ContainerRm(_ context.Context, namesOrIds []string, opts entities.RmOptions) ([]*reports.RmReport, error) {
 	// TODO there is no endpoint for container eviction.  Need to discuss
 	options := new(containers.RemoveOptions).WithForce(opts.Force).WithVolumes(opts.Volumes).WithIgnore(opts.Ignore).WithDepend(opts.Depend)
 	if opts.Timeout != nil {
@@ -315,12 +315,12 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 	return rmReports, nil
 }
 
-func (ic *ContainerEngine) ContainerPrune(ctx context.Context, opts entities.ContainerPruneOptions) ([]*reports.PruneReport, error) {
+func (ic *ContainerEngine) ContainerPrune(_ context.Context, opts entities.ContainerPruneOptions) ([]*reports.PruneReport, error) {
 	options := new(containers.PruneOptions).WithFilters(opts.Filters)
 	return containers.Prune(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.ContainerInspectReport, []error, error) {
+func (ic *ContainerEngine) ContainerInspect(_ context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.ContainerInspectReport, []error, error) {
 	var (
 		reports = make([]*entities.ContainerInspectReport, 0, len(namesOrIds))
 		errs    = []error{}
@@ -344,7 +344,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) ContainerTop(ctx context.Context, opts entities.TopOptions) (*entities.StringSliceReport, error) {
+func (ic *ContainerEngine) ContainerTop(_ context.Context, opts entities.TopOptions) (*entities.StringSliceReport, error) {
 	switch {
 	case opts.Latest:
 		return nil, errors.New("latest is not supported")
@@ -359,7 +359,7 @@ func (ic *ContainerEngine) ContainerTop(ctx context.Context, opts entities.TopOp
 	return &entities.StringSliceReport{Value: topOutput}, nil
 }
 
-func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string, opts entities.CommitOptions) (*entities.CommitReport, error) {
+func (ic *ContainerEngine) ContainerCommit(_ context.Context, nameOrID string, opts entities.CommitOptions) (*entities.CommitReport, error) {
 	var (
 		repo string
 		tag  = "latest"
@@ -396,11 +396,11 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 	return &entities.CommitReport{Id: response.ID}, nil
 }
 
-func (ic *ContainerEngine) ContainerExport(ctx context.Context, nameOrID string, options entities.ContainerExportOptions) error {
+func (ic *ContainerEngine) ContainerExport(_ context.Context, nameOrID string, options entities.ContainerExportOptions) error {
 	return containers.Export(ic.ClientCtx, nameOrID, options.Output, nil)
 }
 
-func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds []string, opts entities.CheckpointOptions) ([]*entities.CheckpointReport, error) {
+func (ic *ContainerEngine) ContainerCheckpoint(_ context.Context, namesOrIds []string, opts entities.CheckpointOptions) ([]*entities.CheckpointReport, error) {
 	var (
 		err          error
 		ctrs         []entities.ListContainer
@@ -454,7 +454,7 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []string, opts entities.RestoreOptions) ([]*entities.RestoreReport, error) {
+func (ic *ContainerEngine) ContainerRestore(_ context.Context, namesOrIds []string, opts entities.RestoreOptions) ([]*entities.RestoreReport, error) {
 	if opts.ImportPrevious != "" {
 		return nil, fmt.Errorf("--import-previous is not supported on the remote client")
 	}
@@ -534,7 +534,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerCreate(ctx context.Context, s *specgen.SpecGenerator) (*entities.ContainerCreateReport, error) {
+func (ic *ContainerEngine) ContainerCreate(_ context.Context, s *specgen.SpecGenerator) (*entities.ContainerCreateReport, error) {
 	response, err := containers.CreateWithSpec(ic.ClientCtx, s, nil)
 	if err != nil {
 		return nil, err
@@ -620,7 +620,7 @@ func makeExecConfig(options entities.ExecOptions) *handlers.ExecCreateConfig {
 	return createConfig
 }
 
-func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, options entities.ExecOptions, streams define.AttachStreams) (exitCode int, retErr error) {
+func (ic *ContainerEngine) ContainerExec(_ context.Context, nameOrID string, options entities.ExecOptions, streams define.AttachStreams) (exitCode int, retErr error) {
 	createConfig := makeExecConfig(options)
 
 	sessionID, err := containers.ExecCreate(ic.ClientCtx, nameOrID, createConfig)
@@ -658,7 +658,7 @@ func (ic *ContainerEngine) ContainerExec(ctx context.Context, nameOrID string, o
 	return inspectOut.ExitCode, nil
 }
 
-func (ic *ContainerEngine) ContainerExecDetached(ctx context.Context, nameOrID string, options entities.ExecOptions) (retSessionID string, retErr error) {
+func (ic *ContainerEngine) ContainerExecDetached(_ context.Context, nameOrID string, options entities.ExecOptions) (retSessionID string, retErr error) {
 	createConfig := makeExecConfig(options)
 
 	sessionID, err := containers.ExecCreate(ic.ClientCtx, nameOrID, createConfig)
@@ -775,7 +775,7 @@ func logIfRmError(id string, err error, reports []*reports.RmReport) {
 	}
 }
 
-func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []string, options entities.ContainerStartOptions) ([]*entities.ContainerStartReport, error) {
+func (ic *ContainerEngine) ContainerStart(_ context.Context, namesOrIds []string, options entities.ContainerStartOptions) ([]*entities.ContainerStartReport, error) {
 	reports := []*entities.ContainerStartReport{}
 	var exitCode = define.ExecErrorCodeGeneric
 	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, options.All, len(options.Filters) > 0, namesOrIds, options.Filters)
@@ -861,13 +861,13 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerList(ctx context.Context, opts entities.ContainerListOptions) ([]entities.ListContainer, error) {
+func (ic *ContainerEngine) ContainerList(_ context.Context, opts entities.ContainerListOptions) ([]entities.ListContainer, error) {
 	options := new(containers.ListOptions).WithFilters(opts.Filters).WithAll(opts.All).WithLast(opts.Last)
 	options.WithNamespace(opts.Namespace).WithSize(opts.Size).WithSync(opts.Sync).WithExternal(opts.External)
 	return containers.List(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) ContainerListExternal(ctx context.Context) ([]entities.ListContainer, error) {
+func (ic *ContainerEngine) ContainerListExternal(_ context.Context) ([]entities.ListContainer, error) {
 	options := new(containers.ListOptions).WithAll(true)
 	options.WithNamespace(true).WithSize(true).WithSync(true).WithExternal(true)
 	return containers.List(ic.ClientCtx, options)
@@ -969,7 +969,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	return &report, nil
 }
 
-func (ic *ContainerEngine) Diff(ctx context.Context, namesOrIDs []string, opts entities.DiffOptions) (*entities.DiffReport, error) {
+func (ic *ContainerEngine) Diff(_ context.Context, namesOrIDs []string, opts entities.DiffOptions) (*entities.DiffReport, error) {
 	var base string
 	options := new(containers.DiffOptions).WithDiffType(opts.Type.String())
 	if len(namesOrIDs) > 0 {
@@ -984,11 +984,11 @@ func (ic *ContainerEngine) Diff(ctx context.Context, namesOrIDs []string, opts e
 	return &entities.DiffReport{Changes: changes}, err
 }
 
-func (ic *ContainerEngine) ContainerCleanup(ctx context.Context, namesOrIds []string, options entities.ContainerCleanupOptions) ([]*entities.ContainerCleanupReport, error) {
+func (ic *ContainerEngine) ContainerCleanup(_ context.Context, _ []string, _ entities.ContainerCleanupOptions) ([]*entities.ContainerCleanupReport, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ic *ContainerEngine) ContainerInit(ctx context.Context, namesOrIds []string, options entities.ContainerInitOptions) ([]*entities.ContainerInitReport, error) {
+func (ic *ContainerEngine) ContainerInit(_ context.Context, namesOrIds []string, options entities.ContainerInitOptions) ([]*entities.ContainerInitReport, error) {
 	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, options.All, false, namesOrIds, nil)
 	if err != nil {
 		return nil, err
@@ -1016,11 +1016,11 @@ func (ic *ContainerEngine) ContainerInit(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerMount(ctx context.Context, nameOrIDs []string, options entities.ContainerMountOptions) ([]*entities.ContainerMountReport, error) {
+func (ic *ContainerEngine) ContainerMount(_ context.Context, _ []string, _ entities.ContainerMountOptions) ([]*entities.ContainerMountReport, error) {
 	return nil, errors.New("mounting containers is not supported for remote clients")
 }
 
-func (ic *ContainerEngine) ContainerUnmount(ctx context.Context, nameOrIDs []string, options entities.ContainerUnmountOptions) ([]*entities.ContainerUnmountReport, error) {
+func (ic *ContainerEngine) ContainerUnmount(_ context.Context, _ []string, _ entities.ContainerUnmountOptions) ([]*entities.ContainerUnmountReport, error) {
 	return nil, errors.New("unmounting containers is not supported for remote clients")
 }
 
@@ -1028,7 +1028,7 @@ func (ic *ContainerEngine) Config(_ context.Context) (*config.Config, error) {
 	return config.Default()
 }
 
-func (ic *ContainerEngine) ContainerPort(ctx context.Context, nameOrID string, options entities.ContainerPortOptions) ([]*entities.ContainerPortReport, error) {
+func (ic *ContainerEngine) ContainerPort(_ context.Context, nameOrID string, options entities.ContainerPortOptions) ([]*entities.ContainerPortReport, error) {
 	var (
 		reports    = []*entities.ContainerPortReport{}
 		namesOrIds = []string{}
@@ -1054,16 +1054,16 @@ func (ic *ContainerEngine) ContainerPort(ctx context.Context, nameOrID string, o
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID, path string, reader io.Reader, options entities.CopyOptions) (entities.ContainerCopyFunc, error) {
+func (ic *ContainerEngine) ContainerCopyFromArchive(_ context.Context, nameOrID, path string, reader io.Reader, options entities.CopyOptions) (entities.ContainerCopyFunc, error) {
 	copyOptions := new(containers.CopyOptions).WithChown(options.Chown).WithRename(options.Rename).WithNoOverwriteDirNonDir(options.NoOverwriteDirNonDir)
 	return containers.CopyFromArchiveWithOptions(ic.ClientCtx, nameOrID, path, reader, copyOptions)
 }
 
-func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID string, path string, writer io.Writer) (entities.ContainerCopyFunc, error) {
+func (ic *ContainerEngine) ContainerCopyToArchive(_ context.Context, nameOrID string, path string, writer io.Writer) (entities.ContainerCopyFunc, error) {
 	return containers.CopyToArchive(ic.ClientCtx, nameOrID, path, writer)
 }
 
-func (ic *ContainerEngine) ContainerStat(ctx context.Context, nameOrID string, path string) (*entities.ContainerStatReport, error) {
+func (ic *ContainerEngine) ContainerStat(_ context.Context, nameOrID string, path string) (*entities.ContainerStatReport, error) {
 	return containers.Stat(ic.ClientCtx, nameOrID, path)
 }
 
@@ -1071,7 +1071,7 @@ func (ic *ContainerEngine) ContainerStat(ctx context.Context, nameOrID string, p
 func (ic *ContainerEngine) Shutdown(_ context.Context) {
 }
 
-func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []string, options entities.ContainerStatsOptions) (statsChan chan entities.ContainerStatsReport, err error) {
+func (ic *ContainerEngine) ContainerStats(_ context.Context, namesOrIds []string, options entities.ContainerStatsOptions) (statsChan chan entities.ContainerStatsReport, err error) {
 	if options.Latest {
 		return nil, errors.New("latest is not supported for the remote client")
 	}
@@ -1079,16 +1079,16 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 }
 
 // ContainerRename renames the given container.
-func (ic *ContainerEngine) ContainerRename(ctx context.Context, nameOrID string, opts entities.ContainerRenameOptions) error {
+func (ic *ContainerEngine) ContainerRename(_ context.Context, nameOrID string, opts entities.ContainerRenameOptions) error {
 	return containers.Rename(ic.ClientCtx, nameOrID, new(containers.RenameOptions).WithName(opts.NewName))
 }
 
-func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts entities.ContainerCloneOptions) (*entities.ContainerCreateReport, error) {
+func (ic *ContainerEngine) ContainerClone(_ context.Context, _ entities.ContainerCloneOptions) (*entities.ContainerCreateReport, error) {
 	return nil, errors.New("cloning a container is not supported on the remote client")
 }
 
 // ContainerUpdate finds and updates the given container's cgroup config with the specified options
-func (ic *ContainerEngine) ContainerUpdate(ctx context.Context, updateOptions *entities.ContainerUpdateOptions) (string, error) {
+func (ic *ContainerEngine) ContainerUpdate(_ context.Context, updateOptions *entities.ContainerUpdateOptions) (string, error) {
 	updateOptions.ProcessSpecgen()
 	return containers.Update(ic.ClientCtx, updateOptions)
 }

--- a/pkg/domain/infra/tunnel/events.go
+++ b/pkg/domain/infra/tunnel/events.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) Events(ctx context.Context, opts entities.EventsOptions) error {
+func (ic *ContainerEngine) Events(_ context.Context, opts entities.EventsOptions) error {
 	filters := make(map[string][]string)
 	if len(opts.Filter) > 0 {
 		for _, filter := range opts.Filter {

--- a/pkg/domain/infra/tunnel/farm.go
+++ b/pkg/domain/infra/tunnel/farm.go
@@ -13,12 +13,12 @@ const (
 )
 
 // FarmNodeName returns the remote engine's name.
-func (ir *ImageEngine) FarmNodeName(ctx context.Context) string {
+func (ir *ImageEngine) FarmNodeName(_ context.Context) string {
 	return ir.NodeName
 }
 
 // FarmNodeDriver returns a description of the image builder driver
-func (ir *ImageEngine) FarmNodeDriver(ctx context.Context) string {
+func (ir *ImageEngine) FarmNodeDriver(_ context.Context) string {
 	return remoteFarmImageBuilderDriver
 }
 

--- a/pkg/domain/infra/tunnel/healthcheck.go
+++ b/pkg/domain/infra/tunnel/healthcheck.go
@@ -8,6 +8,6 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) HealthCheckRun(ctx context.Context, nameOrID string, options entities.HealthCheckOptions) (*define.HealthCheckResults, error) {
+func (ic *ContainerEngine) HealthCheckRun(_ context.Context, nameOrID string, _ entities.HealthCheckOptions) (*define.HealthCheckResults, error) {
 	return containers.RunHealthCheck(ic.ClientCtx, nameOrID, nil)
 }

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -30,12 +30,12 @@ func (ir *ImageEngine) Exists(_ context.Context, nameOrID string) (*entities.Boo
 	return &entities.BoolReport{Value: found}, err
 }
 
-func (ir *ImageEngine) Remove(ctx context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
+func (ir *ImageEngine) Remove(_ context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
 	options := new(images.RemoveOptions).WithForce(opts.Force).WithIgnore(opts.Ignore).WithAll(opts.All).WithLookupManifest(opts.LookupManifest).WithNoPrune(opts.NoPrune)
 	return images.Remove(ir.ClientCtx, imagesArg, options)
 }
 
-func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions) ([]*entities.ImageSummary, error) {
+func (ir *ImageEngine) List(_ context.Context, opts entities.ImageListOptions) ([]*entities.ImageSummary, error) {
 	filters := make(map[string][]string, len(opts.Filter))
 	for _, filter := range opts.Filter {
 		f := strings.SplitN(filter, "=", 2)
@@ -62,15 +62,15 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 	return is, nil
 }
 
-func (ir *ImageEngine) Mount(ctx context.Context, images []string, options entities.ImageMountOptions) ([]*entities.ImageMountReport, error) {
+func (ir *ImageEngine) Mount(_ context.Context, _ []string, _ entities.ImageMountOptions) ([]*entities.ImageMountReport, error) {
 	return nil, errors.New("mounting images is not supported for remote clients")
 }
 
-func (ir *ImageEngine) Unmount(ctx context.Context, images []string, options entities.ImageUnmountOptions) ([]*entities.ImageUnmountReport, error) {
+func (ir *ImageEngine) Unmount(_ context.Context, _ []string, _ entities.ImageUnmountOptions) ([]*entities.ImageUnmountReport, error) {
 	return nil, errors.New("unmounting images is not supported for remote clients")
 }
 
-func (ir *ImageEngine) History(ctx context.Context, nameOrID string, opts entities.ImageHistoryOptions) (*entities.ImageHistoryReport, error) {
+func (ir *ImageEngine) History(_ context.Context, nameOrID string, _ entities.ImageHistoryOptions) (*entities.ImageHistoryReport, error) {
 	options := new(images.HistoryOptions)
 	results, err := images.History(ir.ClientCtx, nameOrID, options)
 	if err != nil {
@@ -97,7 +97,7 @@ func (ir *ImageEngine) History(ctx context.Context, nameOrID string, opts entiti
 	return &history, nil
 }
 
-func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOptions) ([]*reports.PruneReport, error) {
+func (ir *ImageEngine) Prune(_ context.Context, opts entities.ImagePruneOptions) ([]*reports.PruneReport, error) {
 	filters := make(map[string][]string, len(opts.Filter))
 	for _, filter := range opts.Filter {
 		f := strings.Split(filter, "=")
@@ -111,7 +111,7 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 	return reports, nil
 }
 
-func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.ImagePullOptions) (*entities.ImagePullReport, error) {
+func (ir *ImageEngine) Pull(_ context.Context, rawImage string, opts entities.ImagePullOptions) (*entities.ImagePullReport, error) {
 	if opts.OciDecryptConfig != nil {
 		return nil, fmt.Errorf("decryption is not supported for remote clients")
 	}
@@ -141,7 +141,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.
 	return &entities.ImagePullReport{Images: pulledImages}, nil
 }
 
-func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, opt entities.ImageTagOptions) error {
+func (ir *ImageEngine) Tag(_ context.Context, nameOrID string, tags []string, _ entities.ImageTagOptions) error {
 	options := new(images.TagOptions)
 	for _, newTag := range tags {
 		var (
@@ -167,7 +167,7 @@ func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, 
 	return nil
 }
 
-func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string, opt entities.ImageUntagOptions) error {
+func (ir *ImageEngine) Untag(_ context.Context, nameOrID string, tags []string, _ entities.ImageUntagOptions) error {
 	options := new(images.UntagOptions)
 	if len(tags) == 0 {
 		return images.Untag(ir.ClientCtx, nameOrID, "", "", options)
@@ -200,7 +200,7 @@ func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string
 	return nil
 }
 
-func (ir *ImageEngine) Inspect(ctx context.Context, namesOrIDs []string, opts entities.InspectOptions) ([]*entities.ImageInspectReport, []error, error) {
+func (ir *ImageEngine) Inspect(_ context.Context, namesOrIDs []string, opts entities.InspectOptions) ([]*entities.ImageInspectReport, []error, error) {
 	options := new(images.GetOptions).WithSize(opts.Size)
 	reports := []*entities.ImageInspectReport{}
 	errs := []error{}
@@ -222,7 +222,7 @@ func (ir *ImageEngine) Inspect(ctx context.Context, namesOrIDs []string, opts en
 	return reports, errs, nil
 }
 
-func (ir *ImageEngine) Load(ctx context.Context, opts entities.ImageLoadOptions) (*entities.ImageLoadReport, error) {
+func (ir *ImageEngine) Load(_ context.Context, opts entities.ImageLoadOptions) (*entities.ImageLoadReport, error) {
 	if localMap, ok := localapi.CheckPathOnRunningMachine(ir.ClientCtx, opts.Input); ok {
 		report, err := images.LoadLocal(ir.ClientCtx, localMap.RemotePath)
 		if err == nil {
@@ -255,7 +255,7 @@ func (ir *ImageEngine) Load(ctx context.Context, opts entities.ImageLoadOptions)
 	return images.Load(ir.ClientCtx, f)
 }
 
-func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOptions) (*entities.ImageImportReport, error) {
+func (ir *ImageEngine) Import(_ context.Context, opts entities.ImageImportOptions) (*entities.ImageImportReport, error) {
 	var (
 		err error
 		f   *os.File
@@ -273,7 +273,7 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 	return images.Import(ir.ClientCtx, f, options)
 }
 
-func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) (*entities.ImagePushReport, error) {
+func (ir *ImageEngine) Push(_ context.Context, source string, destination string, opts entities.ImagePushOptions) (*entities.ImagePushReport, error) {
 	if opts.Signers != nil {
 		return nil, fmt.Errorf("forwarding Signers is not supported for remote clients")
 	}
@@ -307,7 +307,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	return &entities.ImagePushReport{ManifestDigest: options.GetManifestDigest()}, nil
 }
 
-func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string, opts entities.ImageSaveOptions) error {
+func (ir *ImageEngine) Save(_ context.Context, nameOrID string, tags []string, opts entities.ImageSaveOptions) error {
 	var (
 		f   *os.File
 		err error
@@ -373,7 +373,7 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 	return archive.Untar(f, opts.Output, &archive.TarOptions{NoLchown: true})
 }
 
-func (ir *ImageEngine) Search(ctx context.Context, term string, opts entities.ImageSearchOptions) ([]entities.ImageSearchReport, error) {
+func (ir *ImageEngine) Search(_ context.Context, term string, opts entities.ImageSearchOptions) ([]entities.ImageSearchReport, error) {
 	mappedFilters := make(map[string][]string)
 	filters, err := filter.ParseSearchFilter(opts.Filters)
 	if err != nil {
@@ -420,7 +420,7 @@ func (ir *ImageEngine) Build(_ context.Context, containerFiles []string, opts en
 	return report, nil
 }
 
-func (ir *ImageEngine) Tree(ctx context.Context, nameOrID string, opts entities.ImageTreeOptions) (*entities.ImageTreeReport, error) {
+func (ir *ImageEngine) Tree(_ context.Context, nameOrID string, opts entities.ImageTreeOptions) (*entities.ImageTreeReport, error) {
 	options := new(images.TreeOptions).WithWhatRequires(opts.WhatRequires)
 	return images.Tree(ir.ClientCtx, nameOrID, options)
 }
@@ -429,11 +429,11 @@ func (ir *ImageEngine) Tree(ctx context.Context, nameOrID string, opts entities.
 func (ir *ImageEngine) Shutdown(_ context.Context) {
 }
 
-func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entities.SignOptions) (*entities.SignReport, error) {
+func (ir *ImageEngine) Sign(_ context.Context, _ []string, _ entities.SignOptions) (*entities.SignReport, error) {
 	return nil, errors.New("not implemented yet")
 }
 
-func (ir *ImageEngine) Scp(ctx context.Context, src, dst string, opts entities.ImageScpOptions) (*entities.ImageScpReport, error) {
+func (ir *ImageEngine) Scp(_ context.Context, src, dst string, opts entities.ImageScpOptions) (*entities.ImageScpReport, error) {
 	options := new(images.ScpOptions)
 
 	var destination *string

--- a/pkg/domain/infra/tunnel/kube.go
+++ b/pkg/domain/infra/tunnel/kube.go
@@ -12,7 +12,7 @@ import (
 	"go.podman.io/image/v5/types"
 )
 
-func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string, opts entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
+func (ic *ContainerEngine) GenerateSystemd(_ context.Context, nameOrID string, opts entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
 	options := new(
 		generate.SystemdOptions).
 		WithUseName(opts.Name).
@@ -45,16 +45,16 @@ func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string,
 // GenerateKube Kubernetes YAML (v1 specification) for nameOrIDs
 //
 // Note: Caller is responsible for closing returned Reader
-func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string, opts entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
+func (ic *ContainerEngine) GenerateKube(_ context.Context, nameOrIDs []string, opts entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
 	options := new(generate.KubeOptions).WithService(opts.Service).WithType(opts.Type).WithReplicas(opts.Replicas).WithNoTrunc(opts.UseLongAnnotations).WithPodmanOnly(opts.PodmanOnly)
 	return generate.Kube(ic.ClientCtx, nameOrIDs, options)
 }
 
-func (ic *ContainerEngine) GenerateSpec(ctx context.Context, opts *entities.GenerateSpecOptions) (*entities.GenerateSpecReport, error) {
+func (ic *ContainerEngine) GenerateSpec(_ context.Context, _ *entities.GenerateSpecOptions) (*entities.GenerateSpecReport, error) {
 	return nil, fmt.Errorf("GenerateSpec is not supported on the remote API")
 }
 
-func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts entities.PlayKubeOptions) (*entities.PlayKubeReport, error) {
+func (ic *ContainerEngine) PlayKube(_ context.Context, body io.Reader, opts entities.PlayKubeOptions) (*entities.PlayKubeReport, error) {
 	options := new(kube.PlayOptions).WithAuthfile(opts.Authfile).WithUsername(opts.Username).WithPassword(opts.Password)
 	options.WithCertDir(opts.CertDir).WithQuiet(opts.Quiet).WithSignaturePolicy(opts.SignaturePolicy).WithConfigMaps(opts.ConfigMaps)
 	options.WithLogDriver(opts.LogDriver).WithNetwork(opts.Networks).WithSeccompProfileRoot(opts.SeccompProfileRoot)
@@ -78,11 +78,11 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, opts en
 	return play.KubeWithBody(ic.ClientCtx, body, options)
 }
 
-func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, options entities.PlayKubeDownOptions) (*entities.PlayKubeReport, error) {
+func (ic *ContainerEngine) PlayKubeDown(_ context.Context, body io.Reader, options entities.PlayKubeDownOptions) (*entities.PlayKubeReport, error) {
 	return play.DownWithBody(ic.ClientCtx, body, kube.DownOptions{Force: &options.Force})
 }
 
-func (ic *ContainerEngine) KubeApply(ctx context.Context, body io.Reader, opts entities.ApplyOptions) error {
+func (ic *ContainerEngine) KubeApply(_ context.Context, body io.Reader, opts entities.ApplyOptions) error {
 	options := new(kube.ApplyOptions).WithKubeconfig(opts.Kubeconfig).WithCACertFile(opts.CACertFile).WithNamespace(opts.Namespace)
 	return kube.ApplyWithBody(ic.ClientCtx, body, options)
 }

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ManifestCreate implements manifest create via ImageEngine
-func (ir *ImageEngine) ManifestCreate(ctx context.Context, name string, images []string, opts entities.ManifestCreateOptions) (string, error) {
+func (ir *ImageEngine) ManifestCreate(_ context.Context, name string, images []string, opts entities.ManifestCreateOptions) (string, error) {
 	options := new(manifests.CreateOptions).WithAll(opts.All).WithAmend(opts.Amend).WithAnnotation(opts.Annotations)
 	imageID, err := manifests.Create(ir.ClientCtx, name, images, options)
 	if err != nil {
@@ -25,7 +25,7 @@ func (ir *ImageEngine) ManifestCreate(ctx context.Context, name string, images [
 }
 
 // ManifestExists checks if a manifest list with the given name exists
-func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entities.BoolReport, error) {
+func (ir *ImageEngine) ManifestExists(_ context.Context, name string) (*entities.BoolReport, error) {
 	exists, err := manifests.Exists(ir.ClientCtx, name, nil)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entiti
 }
 
 // ManifestInspect returns contents of manifest list with given name
-func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts entities.ManifestInspectOptions) (*define.ManifestListData, error) {
+func (ir *ImageEngine) ManifestInspect(_ context.Context, name string, opts entities.ManifestInspectOptions) (*define.ManifestListData, error) {
 	options := new(manifests.InspectOptions).WithAuthfile(opts.Authfile)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
@@ -127,7 +127,7 @@ func (ir *ImageEngine) ManifestAddArtifact(_ context.Context, name string, files
 }
 
 // ManifestAnnotate updates an entry of the manifest list
-func (ir *ImageEngine) ManifestAnnotate(ctx context.Context, name, images string, opts entities.ManifestAnnotateOptions) (string, error) {
+func (ir *ImageEngine) ManifestAnnotate(_ context.Context, name, images string, opts entities.ManifestAnnotateOptions) (string, error) {
 	options := new(manifests.ModifyOptions).WithArch(opts.Arch).WithVariant(opts.Variant)
 	options.WithFeatures(opts.Features).WithOS(opts.OS).WithOSVersion(opts.OSVersion)
 
@@ -169,7 +169,7 @@ func mergeAnnotations(preferred map[string]string, aux []string) (map[string]str
 }
 
 // ManifestRemoveDigest removes the digest from manifest list
-func (ir *ImageEngine) ManifestRemoveDigest(ctx context.Context, name string, image string) (string, error) {
+func (ir *ImageEngine) ManifestRemoveDigest(_ context.Context, name string, image string) (string, error) {
 	updatedListID, err := manifests.Remove(ir.ClientCtx, name, image, nil)
 	if err != nil {
 		return updatedListID, fmt.Errorf("removing from manifest %s: %w", name, err)
@@ -213,7 +213,7 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 }
 
 // ManifestListClear clears out all instances from a manifest list
-func (ir *ImageEngine) ManifestListClear(ctx context.Context, name string) (string, error) {
+func (ir *ImageEngine) ManifestListClear(_ context.Context, name string) (string, error) {
 	listContents, err := manifests.InspectListData(ir.ClientCtx, name, &manifests.InspectOptions{})
 	if err != nil {
 		return "", err

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -12,17 +12,17 @@ import (
 	"go.podman.io/common/libnetwork/types"
 )
 
-func (ic *ContainerEngine) NetworkUpdate(ctx context.Context, netName string, opts entities.NetworkUpdateOptions) error {
+func (ic *ContainerEngine) NetworkUpdate(_ context.Context, netName string, opts entities.NetworkUpdateOptions) error {
 	options := new(network.UpdateOptions).WithAddDNSServers(opts.AddDNSServers).WithRemoveDNSServers(opts.RemoveDNSServers)
 	return network.Update(ic.ClientCtx, netName, options)
 }
 
-func (ic *ContainerEngine) NetworkList(ctx context.Context, opts entities.NetworkListOptions) ([]types.Network, error) {
+func (ic *ContainerEngine) NetworkList(_ context.Context, opts entities.NetworkListOptions) ([]types.Network, error) {
 	options := new(network.ListOptions).WithFilters(opts.Filters)
 	return network.List(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]entities.NetworkInspectReport, []error, error) {
+func (ic *ContainerEngine) NetworkInspect(_ context.Context, namesOrIds []string, _ entities.InspectOptions) ([]entities.NetworkInspectReport, []error, error) {
 	var (
 		reports = make([]entities.NetworkInspectReport, 0, len(namesOrIds))
 		errs    = []error{}
@@ -46,11 +46,11 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) NetworkReload(ctx context.Context, names []string, opts entities.NetworkReloadOptions) ([]*entities.NetworkReloadReport, error) {
+func (ic *ContainerEngine) NetworkReload(_ context.Context, _ []string, _ entities.NetworkReloadOptions) ([]*entities.NetworkReloadReport, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, opts entities.NetworkRmOptions) ([]*entities.NetworkRmReport, error) {
+func (ic *ContainerEngine) NetworkRm(_ context.Context, namesOrIds []string, opts entities.NetworkRmOptions) ([]*entities.NetworkRmReport, error) {
 	reports := make([]*entities.NetworkRmReport, 0, len(namesOrIds))
 	options := new(network.RemoveOptions).WithForce(opts.Force)
 	if opts.Timeout != nil {
@@ -71,7 +71,7 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 	return reports, nil
 }
 
-func (ic *ContainerEngine) NetworkCreate(ctx context.Context, net types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error) {
+func (ic *ContainerEngine) NetworkCreate(_ context.Context, net types.Network, createOptions *types.NetworkCreateOptions) (*types.Network, error) {
 	options := new(network.ExtraCreateOptions)
 	if createOptions != nil {
 		options = options.WithIgnoreIfExists(createOptions.IgnoreIfExists)
@@ -84,18 +84,18 @@ func (ic *ContainerEngine) NetworkCreate(ctx context.Context, net types.Network,
 }
 
 // NetworkDisconnect removes a container from a given network
-func (ic *ContainerEngine) NetworkDisconnect(ctx context.Context, networkname string, opts entities.NetworkDisconnectOptions) error {
+func (ic *ContainerEngine) NetworkDisconnect(_ context.Context, networkname string, opts entities.NetworkDisconnectOptions) error {
 	options := new(network.DisconnectOptions).WithForce(opts.Force)
 	return network.Disconnect(ic.ClientCtx, networkname, opts.Container, options)
 }
 
 // NetworkConnect removes a container from a given network
-func (ic *ContainerEngine) NetworkConnect(ctx context.Context, networkname string, opts entities.NetworkConnectOptions) error {
+func (ic *ContainerEngine) NetworkConnect(_ context.Context, networkname string, opts entities.NetworkConnectOptions) error {
 	return network.Connect(ic.ClientCtx, networkname, opts.Container, &opts.PerNetworkOptions)
 }
 
 // NetworkExists checks if the given network exists
-func (ic *ContainerEngine) NetworkExists(ctx context.Context, networkname string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) NetworkExists(_ context.Context, networkname string) (*entities.BoolReport, error) {
 	exists, err := network.Exists(ic.ClientCtx, networkname, nil)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (ic *ContainerEngine) NetworkExists(ctx context.Context, networkname string
 }
 
 // Network prune removes unused networks
-func (ic *ContainerEngine) NetworkPrune(ctx context.Context, options entities.NetworkPruneOptions) ([]*entities.NetworkPruneReport, error) {
+func (ic *ContainerEngine) NetworkPrune(_ context.Context, options entities.NetworkPruneOptions) ([]*entities.NetworkPruneReport, error) {
 	opts := new(network.PruneOptions).WithFilters(options.Filters)
 	return network.Prune(ic.ClientCtx, opts)
 }

--- a/pkg/domain/infra/tunnel/pods.go
+++ b/pkg/domain/infra/tunnel/pods.go
@@ -12,12 +12,12 @@ import (
 	"github.com/containers/podman/v5/pkg/util"
 )
 
-func (ic *ContainerEngine) PodExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) PodExists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	exists, err := pods.Exists(ic.ClientCtx, nameOrID, nil)
 	return &entities.BoolReport{Value: exists}, err
 }
 
-func (ic *ContainerEngine) PodKill(ctx context.Context, namesOrIds []string, opts entities.PodKillOptions) ([]*entities.PodKillReport, error) {
+func (ic *ContainerEngine) PodKill(_ context.Context, namesOrIds []string, opts entities.PodKillOptions) ([]*entities.PodKillReport, error) {
 	_, err := util.ParseSignal(opts.Signal)
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (ic *ContainerEngine) PodKill(ctx context.Context, namesOrIds []string, opt
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodLogs(ctx context.Context, nameOrIDs string, options entities.PodLogsOptions) error {
+func (ic *ContainerEngine) PodLogs(ctx context.Context, _ string, options entities.PodLogsOptions) error {
 	// PodLogsOptions are similar but contains few extra fields like ctrName
 	// So cast other values as is so we can reuse the code
 	containerLogsOpts := entities.PodLogsOptionsToContainerLogsOptions(options)
@@ -54,7 +54,7 @@ func (ic *ContainerEngine) PodLogs(ctx context.Context, nameOrIDs string, option
 	return ic.ContainerLogs(ctx, name, containerLogsOpts)
 }
 
-func (ic *ContainerEngine) PodPause(ctx context.Context, namesOrIds []string, options entities.PodPauseOptions) ([]*entities.PodPauseReport, error) {
+func (ic *ContainerEngine) PodPause(_ context.Context, namesOrIds []string, options entities.PodPauseOptions) ([]*entities.PodPauseReport, error) {
 	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (ic *ContainerEngine) PodPause(ctx context.Context, namesOrIds []string, op
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, options entities.PodunpauseOptions) ([]*entities.PodUnpauseReport, error) {
+func (ic *ContainerEngine) PodUnpause(_ context.Context, namesOrIds []string, options entities.PodunpauseOptions) ([]*entities.PodUnpauseReport, error) {
 	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opts entities.PodStopOptions) ([]*entities.PodStopReport, error) {
+func (ic *ContainerEngine) PodStop(_ context.Context, namesOrIds []string, opts entities.PodStopOptions) ([]*entities.PodStopReport, error) {
 	timeout := -1
 	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
 	if err != nil {
@@ -127,7 +127,7 @@ func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opt
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodRestart(ctx context.Context, namesOrIds []string, options entities.PodRestartOptions) ([]*entities.PodRestartReport, error) {
+func (ic *ContainerEngine) PodRestart(_ context.Context, namesOrIds []string, options entities.PodRestartOptions) ([]*entities.PodRestartReport, error) {
 	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func (ic *ContainerEngine) PodRestart(ctx context.Context, namesOrIds []string, 
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, options entities.PodStartOptions) ([]*entities.PodStartReport, error) {
+func (ic *ContainerEngine) PodStart(_ context.Context, namesOrIds []string, options entities.PodStartOptions) ([]*entities.PodStartReport, error) {
 	foundPods, err := getPodsByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
@@ -170,7 +170,7 @@ func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, op
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodRm(ctx context.Context, namesOrIds []string, opts entities.PodRmOptions) ([]*entities.PodRmReport, error) {
+func (ic *ContainerEngine) PodRm(_ context.Context, namesOrIds []string, opts entities.PodRmOptions) ([]*entities.PodRmReport, error) {
 	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
 	if err != nil {
 		return nil, err
@@ -195,19 +195,19 @@ func (ic *ContainerEngine) PodRm(ctx context.Context, namesOrIds []string, opts 
 	return reports, nil
 }
 
-func (ic *ContainerEngine) PodPrune(ctx context.Context, opts entities.PodPruneOptions) ([]*entities.PodPruneReport, error) {
+func (ic *ContainerEngine) PodPrune(_ context.Context, _ entities.PodPruneOptions) ([]*entities.PodPruneReport, error) {
 	return pods.Prune(ic.ClientCtx, nil)
 }
 
-func (ic *ContainerEngine) PodCreate(ctx context.Context, specg entities.PodSpec) (*entities.PodCreateReport, error) {
+func (ic *ContainerEngine) PodCreate(_ context.Context, specg entities.PodSpec) (*entities.PodCreateReport, error) {
 	return pods.CreatePodFromSpec(ic.ClientCtx, &specg)
 }
 
-func (ic *ContainerEngine) PodClone(ctx context.Context, podClone entities.PodCloneOptions) (*entities.PodCloneReport, error) {
+func (ic *ContainerEngine) PodClone(_ context.Context, _ entities.PodCloneOptions) (*entities.PodCloneReport, error) {
 	return nil, nil
 }
 
-func (ic *ContainerEngine) PodTop(ctx context.Context, opts entities.PodTopOptions) (*entities.StringSliceReport, error) {
+func (ic *ContainerEngine) PodTop(_ context.Context, opts entities.PodTopOptions) (*entities.StringSliceReport, error) {
 	switch {
 	case opts.Latest:
 		return nil, errors.New("latest is not supported")
@@ -222,12 +222,12 @@ func (ic *ContainerEngine) PodTop(ctx context.Context, opts entities.PodTopOptio
 	return &entities.StringSliceReport{Value: topOutput}, nil
 }
 
-func (ic *ContainerEngine) PodPs(ctx context.Context, opts entities.PodPSOptions) ([]*entities.ListPodsReport, error) {
+func (ic *ContainerEngine) PodPs(_ context.Context, opts entities.PodPSOptions) ([]*entities.ListPodsReport, error) {
 	options := new(pods.ListOptions).WithFilters(opts.Filters)
 	return pods.List(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) PodInspect(ctx context.Context, namesOrIDs []string, options entities.InspectOptions) ([]*entities.PodInspectReport, []error, error) {
+func (ic *ContainerEngine) PodInspect(_ context.Context, namesOrIDs []string, _ entities.InspectOptions) ([]*entities.PodInspectReport, []error, error) {
 	var errs []error
 	podReport := make([]*entities.PodInspectReport, 0, len(namesOrIDs))
 	for _, name := range namesOrIDs {
@@ -248,7 +248,7 @@ func (ic *ContainerEngine) PodInspect(ctx context.Context, namesOrIDs []string, 
 	return podReport, errs, nil
 }
 
-func (ic *ContainerEngine) PodStats(ctx context.Context, namesOrIds []string, opts entities.PodStatsOptions) ([]*entities.PodStatsReport, error) {
+func (ic *ContainerEngine) PodStats(_ context.Context, namesOrIds []string, opts entities.PodStatsOptions) ([]*entities.PodStatsReport, error) {
 	options := new(pods.StatsOptions).WithAll(opts.All)
 	return pods.Stats(ic.ClientCtx, namesOrIds, options)
 }

--- a/pkg/domain/infra/tunnel/quadlet.go
+++ b/pkg/domain/infra/tunnel/quadlet.go
@@ -9,18 +9,18 @@ import (
 
 var errNotImplemented = errors.New("not implemented for the remote Podman client")
 
-func (ic *ContainerEngine) QuadletInstall(ctx context.Context, pathsOrURLs []string, options entities.QuadletInstallOptions) (*entities.QuadletInstallReport, error) {
+func (ic *ContainerEngine) QuadletInstall(_ context.Context, _ []string, _ entities.QuadletInstallOptions) (*entities.QuadletInstallReport, error) {
 	return nil, errNotImplemented
 }
 
-func (ic *ContainerEngine) QuadletList(ctx context.Context, options entities.QuadletListOptions) ([]*entities.ListQuadlet, error) {
+func (ic *ContainerEngine) QuadletList(_ context.Context, _ entities.QuadletListOptions) ([]*entities.ListQuadlet, error) {
 	return nil, errNotImplemented
 }
 
-func (ic *ContainerEngine) QuadletPrint(ctx context.Context, quadlet string) (string, error) {
+func (ic *ContainerEngine) QuadletPrint(_ context.Context, _ string) (string, error) {
 	return "", errNotImplemented
 }
 
-func (ic *ContainerEngine) QuadletRemove(ctx context.Context, quadlets []string, options entities.QuadletRemoveOptions) (*entities.QuadletRemoveReport, error) {
+func (ic *ContainerEngine) QuadletRemove(_ context.Context, _ []string, _ entities.QuadletRemoveOptions) (*entities.QuadletRemoveReport, error) {
 	return nil, errNotImplemented
 }

--- a/pkg/domain/infra/tunnel/secrets.go
+++ b/pkg/domain/infra/tunnel/secrets.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/podman/v5/pkg/errorhandling"
 )
 
-func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader io.Reader, options entities.SecretCreateOptions) (*entities.SecretCreateReport, error) {
+func (ic *ContainerEngine) SecretCreate(_ context.Context, name string, reader io.Reader, options entities.SecretCreateOptions) (*entities.SecretCreateReport, error) {
 	opts := new(secrets.CreateOptions).
 		WithDriver(options.Driver).
 		WithDriverOpts(options.DriverOpts).
@@ -25,7 +25,7 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 	return created, nil
 }
 
-func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string, options entities.SecretInspectOptions) ([]*entities.SecretInfoReport, []error, error) {
+func (ic *ContainerEngine) SecretInspect(_ context.Context, nameOrIDs []string, options entities.SecretInspectOptions) ([]*entities.SecretInfoReport, []error, error) {
 	allInspect := make([]*entities.SecretInfoReport, 0, len(nameOrIDs))
 	errs := make([]error, 0, len(nameOrIDs))
 	opts := new(secrets.InspectOptions).
@@ -49,13 +49,13 @@ func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string
 	return allInspect, errs, nil
 }
 
-func (ic *ContainerEngine) SecretList(ctx context.Context, opts entities.SecretListRequest) ([]*entities.SecretInfoReport, error) {
+func (ic *ContainerEngine) SecretList(_ context.Context, opts entities.SecretListRequest) ([]*entities.SecretInfoReport, error) {
 	options := new(secrets.ListOptions).WithFilters(opts.Filters)
 	secrs, _ := secrets.List(ic.ClientCtx, options)
 	return secrs, nil
 }
 
-func (ic *ContainerEngine) SecretRm(ctx context.Context, nameOrIDs []string, options entities.SecretRmOptions) ([]*entities.SecretRmReport, error) {
+func (ic *ContainerEngine) SecretRm(_ context.Context, nameOrIDs []string, options entities.SecretRmOptions) ([]*entities.SecretRmReport, error) {
 	allRm := make([]*entities.SecretRmReport, 0, len(nameOrIDs))
 	if options.All {
 		allSecrets, err := secrets.List(ic.ClientCtx, nil)
@@ -95,7 +95,7 @@ func (ic *ContainerEngine) SecretRm(ctx context.Context, nameOrIDs []string, opt
 	return allRm, nil
 }
 
-func (ic *ContainerEngine) SecretExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) SecretExists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	exists, err := secrets.Exists(ic.ClientCtx, nameOrID)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -9,21 +9,21 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
+func (ic *ContainerEngine) Info(_ context.Context) (*define.Info, error) {
 	return system.Info(ic.ClientCtx, nil)
 }
 
-func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool, cgroupMode string) error {
+func (ic *ContainerEngine) SetupRootless(_ context.Context, _ bool, _ string) error {
 	panic(errors.New("rootless engine mode is not supported when tunneling"))
 }
 
 // SystemPrune prunes unused data from the system.
-func (ic *ContainerEngine) SystemPrune(ctx context.Context, opts entities.SystemPruneOptions) (*entities.SystemPruneReport, error) {
+func (ic *ContainerEngine) SystemPrune(_ context.Context, opts entities.SystemPruneOptions) (*entities.SystemPruneReport, error) {
 	options := new(system.PruneOptions).WithAll(opts.All).WithVolumes(opts.Volume).WithFilters(opts.Filters).WithExternal(opts.External).WithBuild(opts.Build)
 	return system.Prune(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) SystemCheck(ctx context.Context, opts entities.SystemCheckOptions) (*entities.SystemCheckReport, error) {
+func (ic *ContainerEngine) SystemCheck(_ context.Context, opts entities.SystemCheckOptions) (*entities.SystemCheckReport, error) {
 	options := new(system.CheckOptions).WithQuick(opts.Quick).WithRepair(opts.Repair).WithRepairLossy(opts.RepairLossy)
 	if opts.UnreferencedLayerMaximumAge != nil {
 		duration := *opts.UnreferencedLayerMaximumAge
@@ -32,30 +32,30 @@ func (ic *ContainerEngine) SystemCheck(ctx context.Context, opts entities.System
 	return system.Check(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) Migrate(ctx context.Context, options entities.SystemMigrateOptions) error {
+func (ic *ContainerEngine) Migrate(_ context.Context, _ entities.SystemMigrateOptions) error {
 	return errors.New("runtime migration is not supported on remote clients")
 }
 
-func (ic *ContainerEngine) Renumber(ctx context.Context) error {
+func (ic *ContainerEngine) Renumber(_ context.Context) error {
 	return errors.New("lock renumbering is not supported on remote clients")
 }
 
-func (ic *ContainerEngine) Reset(ctx context.Context) error {
+func (ic *ContainerEngine) Reset(_ context.Context) error {
 	return errors.New("system reset is not supported on remote clients")
 }
 
-func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.SystemDfOptions) (*entities.SystemDfReport, error) {
+func (ic *ContainerEngine) SystemDf(_ context.Context, _ entities.SystemDfOptions) (*entities.SystemDfReport, error) {
 	return system.DiskUsage(ic.ClientCtx, nil)
 }
 
-func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options entities.SystemUnshareOptions) error {
+func (ic *ContainerEngine) Unshare(_ context.Context, _ []string, _ entities.SystemUnshareOptions) error {
 	return errors.New("unshare is not supported on remote clients")
 }
 
-func (ic *ContainerEngine) Version(ctx context.Context) (*entities.SystemVersionReport, error) {
+func (ic *ContainerEngine) Version(_ context.Context) (*entities.SystemVersionReport, error) {
 	return system.Version(ic.ClientCtx, nil)
 }
 
-func (ic *ContainerEngine) Locks(ctx context.Context) (*entities.LocksReport, error) {
+func (ic *ContainerEngine) Locks(_ context.Context) (*entities.LocksReport, error) {
 	return nil, errors.New("locks is not supported on remote clients")
 }

--- a/pkg/domain/infra/tunnel/trust.go
+++ b/pkg/domain/infra/tunnel/trust.go
@@ -7,10 +7,10 @@ import (
 	"github.com/containers/podman/v5/pkg/domain/entities"
 )
 
-func (ir *ImageEngine) ShowTrust(ctx context.Context, args []string, options entities.ShowTrustOptions) (*entities.ShowTrustReport, error) {
+func (ir *ImageEngine) ShowTrust(_ context.Context, _ []string, _ entities.ShowTrustOptions) (*entities.ShowTrustReport, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ir *ImageEngine) SetTrust(ctx context.Context, args []string, options entities.SetTrustOptions) error {
+func (ir *ImageEngine) SetTrust(_ context.Context, _ []string, _ entities.SetTrustOptions) error {
 	return errors.New("not implemented")
 }

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/podman/v5/pkg/errorhandling"
 )
 
-func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
+func (ic *ContainerEngine) VolumeCreate(_ context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
 	response, err := volumes.Create(ic.ClientCtx, opts, nil)
 	if err != nil {
 		return nil, err
@@ -19,7 +19,7 @@ func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.Volum
 	return &entities.IDOrNameResponse{IDOrName: response.Name}, nil
 }
 
-func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, opts entities.VolumeRmOptions) ([]*entities.VolumeRmReport, error) {
+func (ic *ContainerEngine) VolumeRm(_ context.Context, namesOrIds []string, opts entities.VolumeRmOptions) ([]*entities.VolumeRmReport, error) {
 	if opts.All {
 		vols, err := volumes.List(ic.ClientCtx, nil)
 		if err != nil {
@@ -43,7 +43,7 @@ func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, op
 	return reports, nil
 }
 
-func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.VolumeInspectReport, []error, error) {
+func (ic *ContainerEngine) VolumeInspect(_ context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.VolumeInspectReport, []error, error) {
 	var (
 		reports = make([]*entities.VolumeInspectReport, 0, len(namesOrIds))
 		errs    = []error{}
@@ -75,18 +75,18 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) VolumePrune(ctx context.Context, opts entities.VolumePruneOptions) ([]*reports.PruneReport, error) {
+func (ic *ContainerEngine) VolumePrune(_ context.Context, opts entities.VolumePruneOptions) ([]*reports.PruneReport, error) {
 	options := new(volumes.PruneOptions).WithFilters(opts.Filters)
 	return volumes.Prune(ic.ClientCtx, options)
 }
 
-func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeListOptions) ([]*entities.VolumeListReport, error) {
+func (ic *ContainerEngine) VolumeList(_ context.Context, opts entities.VolumeListOptions) ([]*entities.VolumeListReport, error) {
 	options := new(volumes.ListOptions).WithFilters(opts.Filter)
 	return volumes.List(ic.ClientCtx, options)
 }
 
 // VolumeExists checks if the given volume exists
-func (ic *ContainerEngine) VolumeExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) VolumeExists(_ context.Context, nameOrID string) (*entities.BoolReport, error) {
 	exists, err := volumes.Exists(ic.ClientCtx, nameOrID, nil)
 	if err != nil {
 		return nil, err
@@ -98,26 +98,26 @@ func (ic *ContainerEngine) VolumeExists(ctx context.Context, nameOrID string) (*
 
 // Volumemounted check if a given volume using plugin or filesystem is mounted or not.
 // TODO: Not used and exposed to tunnel. Will be used by `export` command which is unavailable to `podman-remote`
-func (ic *ContainerEngine) VolumeMounted(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
+func (ic *ContainerEngine) VolumeMounted(_ context.Context, _ string) (*entities.BoolReport, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ic *ContainerEngine) VolumeMount(ctx context.Context, nameOrIDs []string) ([]*entities.VolumeMountReport, error) {
+func (ic *ContainerEngine) VolumeMount(_ context.Context, _ []string) ([]*entities.VolumeMountReport, error) {
 	return nil, errors.New("mounting volumes is not supported for remote clients")
 }
 
-func (ic *ContainerEngine) VolumeUnmount(ctx context.Context, nameOrIDs []string) ([]*entities.VolumeUnmountReport, error) {
+func (ic *ContainerEngine) VolumeUnmount(_ context.Context, _ []string) ([]*entities.VolumeUnmountReport, error) {
 	return nil, errors.New("unmounting volumes is not supported for remote clients")
 }
 
-func (ic *ContainerEngine) VolumeReload(ctx context.Context) (*entities.VolumeReloadReport, error) {
+func (ic *ContainerEngine) VolumeReload(_ context.Context) (*entities.VolumeReloadReport, error) {
 	return nil, errors.New("volume reload is not supported for remote clients")
 }
 
-func (ic *ContainerEngine) VolumeExport(ctx context.Context, nameOrID string, options entities.VolumeExportOptions) error {
+func (ic *ContainerEngine) VolumeExport(_ context.Context, nameOrID string, options entities.VolumeExportOptions) error {
 	return volumes.Export(ic.ClientCtx, nameOrID, options.Output)
 }
 
-func (ic *ContainerEngine) VolumeImport(ctx context.Context, nameOrID string, options entities.VolumeImportOptions) error {
+func (ic *ContainerEngine) VolumeImport(_ context.Context, nameOrID string, options entities.VolumeImportOptions) error {
 	return volumes.Import(ic.ClientCtx, nameOrID, options.Input)
 }

--- a/pkg/farm/farm.go
+++ b/pkg/farm/farm.go
@@ -221,7 +221,7 @@ func (f *Farm) Schedule(ctx context.Context, platforms []string) (Schedule, erro
 // Build runs a build using the specified targetplatform:service map.  If all
 // builds succeed, it copies the resulting images from the remote hosts to the
 // local service and builds a manifest list with the specified reference name.
-func (f *Farm) Build(ctx context.Context, schedule Schedule, options entities.BuildOptions, reference string, localEngine entities.ImageEngine) error {
+func (f *Farm) Build(ctx context.Context, schedule Schedule, options entities.BuildOptions, reference string, _ entities.ImageEngine) error {
 	switch options.OutputFormat {
 	default:
 		return fmt.Errorf("unknown output format %q requested", options.OutputFormat)
@@ -348,7 +348,7 @@ func (f *Farm) Build(ctx context.Context, schedule Schedule, options entities.Bu
 
 	// Assemble the final result.
 	perArchBuilds := make(map[entities.BuildReport]entities.ImageEngine)
-	buildResults.Range(func(k, v any) bool {
+	buildResults.Range(func(_, v any) bool {
 		result, ok := v.(buildResult)
 		if !ok {
 			fmt.Fprintf(os.Stderr, "report %v not a build result?", v)

--- a/pkg/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/pkg/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1081,12 +1081,12 @@ type RootPaths struct {
 }
 
 // TODO: remove me when watch is refactored
-func LabelSelectorQueryParam(version string) string {
+func LabelSelectorQueryParam(_ string) string {
 	return "labelSelector"
 }
 
 // TODO: remove me when watch is refactored
-func FieldSelectorQueryParam(version string) string {
+func FieldSelectorQueryParam(_ string) string {
 	return "fieldSelector"
 }
 

--- a/pkg/libartifact/store/config.go
+++ b/pkg/libartifact/store/config.go
@@ -21,7 +21,7 @@ func (u unparsedArtifactImage) Reference() types.ImageReference {
 	return u.ir
 }
 
-func (u unparsedArtifactImage) Manifest(ctx context.Context) ([]byte, string, error) {
+func (u unparsedArtifactImage) Manifest(_ context.Context) ([]byte, string, error) {
 	b, err := json.Marshal(u.mannyfest)
 	if err != nil {
 		return nil, "", err
@@ -29,7 +29,7 @@ func (u unparsedArtifactImage) Manifest(ctx context.Context) ([]byte, string, er
 	return b, specV1.MediaTypeImageIndex, nil
 }
 
-func (u unparsedArtifactImage) Signatures(ctx context.Context) ([][]byte, error) {
+func (u unparsedArtifactImage) Signatures(_ context.Context) ([][]byte, error) {
 	return [][]byte{}, nil
 }
 

--- a/pkg/machine/e2e/config_basic_test.go
+++ b/pkg/machine/e2e/config_basic_test.go
@@ -4,7 +4,7 @@ type basicMachine struct {
 	args []string
 }
 
-func (s *basicMachine) buildCmd(m *machineTestBuilder) []string {
+func (s *basicMachine) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"-r"}
 	if len(s.args) > 0 {
 		cmd = append(cmd, s.args...)

--- a/pkg/machine/e2e/config_compose_test.go
+++ b/pkg/machine/e2e/config_compose_test.go
@@ -4,7 +4,7 @@ type fakeCompose struct {
 	cmd []string
 }
 
-func (f *fakeCompose) buildCmd(m *machineTestBuilder) []string {
+func (f *fakeCompose) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"compose"}
 	cmd = append(cmd, "env")
 	f.cmd = cmd

--- a/pkg/machine/e2e/config_cp_test.go
+++ b/pkg/machine/e2e/config_cp_test.go
@@ -8,7 +8,7 @@ type cpMachine struct {
 	cmd []string
 }
 
-func (c *cpMachine) buildCmd(m *machineTestBuilder) []string {
+func (c *cpMachine) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"machine", "cp"}
 
 	if c.quiet {

--- a/pkg/machine/e2e/config_help_test.go
+++ b/pkg/machine/e2e/config_help_test.go
@@ -4,7 +4,7 @@ type helpMachine struct {
 	cmd []string
 }
 
-func (i *helpMachine) buildCmd(m *machineTestBuilder) []string {
+func (i *helpMachine) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"help"}
 	i.cmd = cmd
 	return cmd

--- a/pkg/machine/e2e/config_info_test.go
+++ b/pkg/machine/e2e/config_info_test.go
@@ -5,7 +5,7 @@ type infoMachine struct {
 	cmd    []string
 }
 
-func (i *infoMachine) buildCmd(m *machineTestBuilder) []string {
+func (i *infoMachine) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"machine", "info"}
 	if len(i.format) > 0 {
 		cmd = append(cmd, "--format", i.format)

--- a/pkg/machine/e2e/config_list_test.go
+++ b/pkg/machine/e2e/config_list_test.go
@@ -15,7 +15,7 @@ type listMachine struct {
 	cmd []string
 }
 
-func (i *listMachine) buildCmd(m *machineTestBuilder) []string {
+func (i *listMachine) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"machine", "list"}
 	if len(i.format) > 0 {
 		cmd = append(cmd, "--format", i.format)

--- a/pkg/machine/e2e/config_reset_test.go
+++ b/pkg/machine/e2e/config_reset_test.go
@@ -10,7 +10,7 @@ type resetMachine struct {
 	cmd []string
 }
 
-func (i *resetMachine) buildCmd(m *machineTestBuilder) []string {
+func (i *resetMachine) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"machine", "reset"}
 	if i.force {
 		cmd = append(cmd, "--force")

--- a/pkg/machine/e2e/config_system_connection_list_test.go
+++ b/pkg/machine/e2e/config_system_connection_list_test.go
@@ -8,7 +8,7 @@ type listSystemConnection struct {
 	format string
 }
 
-func (l *listSystemConnection) buildCmd(m *machineTestBuilder) []string {
+func (l *listSystemConnection) buildCmd(_ *machineTestBuilder) []string {
 	cmd := []string{"system", "connection", "list"}
 	if len(l.format) > 0 {
 		cmd = append(cmd, "--format", l.format)

--- a/pkg/machine/e2e/config_unix_test.go
+++ b/pkg/machine/e2e/config_unix_test.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-func pgrep(n string) (string, error) {
+func pgrep(_ string) (string, error) {
 	out, err := exec.Command("pgrep", "gvproxy").Output()
 	return string(out), err
 }

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -30,7 +30,7 @@ func GetDevNullFiles() (*os.File, *os.File, error) {
 
 // WaitAPIAndPrintInfo prints info about the machine and does a ping test on the
 // API socket
-func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardSock string, noInfo, rootful bool) {
+func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardSock string, noInfo, _ bool) {
 	suffix := ""
 	var fmtString string
 

--- a/pkg/machine/machine_unix.go
+++ b/pkg/machine/machine_unix.go
@@ -9,7 +9,7 @@ import (
 	"net"
 )
 
-func DialNamedPipe(ctx context.Context, path string) (net.Conn, error) {
+func DialNamedPipe(_ context.Context, _ string) (net.Conn, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/machine/os/machine_os.go
+++ b/pkg/machine/os/machine_os.go
@@ -21,7 +21,7 @@ type MachineOS struct {
 }
 
 // Apply applies the image by sshing into the machine and running apply from inside the VM.
-func (m *MachineOS) Apply(image string, opts ApplyOptions) error {
+func (m *MachineOS) Apply(image string, _ ApplyOptions) error {
 	args := []string{"podman", "machine", "os", "apply", image}
 
 	if err := machine.LocalhostSSH(m.VM.SSH.RemoteUsername, m.VM.SSH.IdentityPath, m.VMName, m.VM.SSH.Port, args); err != nil {

--- a/pkg/machine/os/ostree.go
+++ b/pkg/machine/os/ostree.go
@@ -35,7 +35,7 @@ type OSTree struct {
 // rpm-ostree needs to be run as root. If a user wants to use an image in containers-storage,
 // rpm-ostree will look at the root storage, and not the user storage, which is unexpected behavior.
 // Exporting to an oci-dir works around this, without nagging the user to configure the machine in rootful mode.
-func (dist *OSTree) Apply(image string, opts ApplyOptions) error {
+func (dist *OSTree) Apply(image string, _ ApplyOptions) error {
 	imageWithTransport := image
 
 	transport := alltransports.TransportFromImageName(image)

--- a/pkg/machine/ports/ports_unix.go
+++ b/pkg/machine/ports/ports_unix.go
@@ -9,7 +9,7 @@ import (
 
 func getPortCheckListenConfig() *net.ListenConfig {
 	return &net.ListenConfig{
-		Control: func(network, address string, c syscall.RawConn) (cerr error) {
+		Control: func(_, _ string, c syscall.RawConn) (cerr error) {
 			if err := c.Control(func(fd uintptr) {
 				// Prevent listening socket from holding over in TIME_WAIT in the rare case a connection
 				// attempt occurs in the short window the socket is listening. This ensures the registration

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -243,7 +243,7 @@ func (q *QEMUStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() erro
 	}, nil
 }
 
-func (q *QEMUStubber) State(mc *vmconfigs.MachineConfig, bypass bool) (define.Status, error) {
+func (q *QEMUStubber) State(mc *vmconfigs.MachineConfig, _ bool) (define.Status, error) {
 	// Check if qmp socket path exists
 	if err := fileutils.Exists(mc.QEMUHypervisor.QMPMonitor.Address.GetPath()); errors.Is(err, fs.ErrNotExist) {
 		return define.Stopped, nil

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -89,7 +89,7 @@ func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {
 	return nil
 }
 
-func (q *QEMUStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConfig, builder *ignition.IgnitionBuilder) error {
+func (q *QEMUStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConfig, _ *ignition.IgnitionBuilder) error {
 	monitor, err := command.NewQMPMonitor(opts.Name, opts.Dirs.RuntimeDir)
 	if err != nil {
 		return err
@@ -243,7 +243,7 @@ func waitForReady(readySocket *define.VMFile, pid int, stdErrBuffer *bytes.Buffe
 	return err
 }
 
-func (q *QEMUStubber) Exists(name string) (bool, error) {
+func (q *QEMUStubber) Exists(_ string) (bool, error) {
 	return false, nil
 }
 
@@ -380,15 +380,15 @@ func (q *QEMUStubber) MountType() vmconfigs.VolumeMountType {
 	return vmconfigs.VirtIOFS
 }
 
-func (q *QEMUStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool) error {
+func (q *QEMUStubber) PostStartNetworking(_ *vmconfigs.MachineConfig, _ bool) error {
 	return nil
 }
 
-func (q *QEMUStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) error {
+func (q *QEMUStubber) UpdateSSHPort(_ *vmconfigs.MachineConfig, _ int) error {
 	// managed by gvproxy on this backend, so nothing to do
 	return nil
 }
 
-func (q *QEMUStubber) GetRosetta(mc *vmconfigs.MachineConfig) (bool, error) {
+func (q *QEMUStubber) GetRosetta(_ *vmconfigs.MachineConfig) (bool, error) {
 	return false, nil
 }

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -753,7 +753,7 @@ func confirmationMessage(files []string) {
 	}
 }
 
-func Reset(mps []vmconfigs.VMProvider, opts machine.ResetOptions) error {
+func Reset(mps []vmconfigs.VMProvider, _ machine.ResetOptions) error {
 	var resetErrors *multierror.Error
 	removeDirs := []*machineDefine.MachineDirs{}
 

--- a/pkg/machine/ssh_unix.go
+++ b/pkg/machine/ssh_unix.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-func setupIOPassthrough(cmd *exec.Cmd, interactive bool, stdin io.Reader) error {
+func setupIOPassthrough(cmd *exec.Cmd, _ bool, stdin io.Reader) error {
 	cmd.Stdin = stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -299,7 +299,7 @@ func (mc *MachineConfig) IsFirstBoot() bool {
 	return mc.LastUp.IsZero()
 }
 
-func (mc *MachineConfig) ConnectionInfo(vmtype define.VMType) (*define.VMFile, *define.VMFile, error) {
+func (mc *MachineConfig) ConnectionInfo(_ define.VMType) (*define.VMFile, *define.VMFile, error) {
 	socket, err := mc.APISocket()
 	return socket, getPipe(mc.Name), err
 }
@@ -352,7 +352,7 @@ func loadMachineFromFQPath(path *define.VMFile) (*MachineConfig, error) {
 // LoadMachinesInDir returns all the machineconfigs located in given dir
 func LoadMachinesInDir(dirs *define.MachineDirs) (map[string]*MachineConfig, error) {
 	mcs := make(map[string]*MachineConfig)
-	if err := filepath.WalkDir(dirs.ConfigDir.GetPath(), func(path string, d fs.DirEntry, err error) error {
+	if err := filepath.WalkDir(dirs.ConfigDir.GetPath(), func(_ string, d fs.DirEntry, _ error) error {
 		if strings.HasSuffix(d.Name(), ".json") {
 			fullPath, err := dirs.ConfigDir.AppendToNewVMFile(d.Name(), nil)
 			if err != nil {

--- a/pkg/machine/vmconfigs/machine_unix.go
+++ b/pkg/machine/vmconfigs/machine_unix.go
@@ -6,6 +6,6 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 )
 
-func getPipe(name string) *define.VMFile {
+func getPipe(_ string) *define.VMFile {
 	return nil
 }

--- a/pkg/pidhandle/pidhandle_linux_test.go
+++ b/pkg/pidhandle/pidhandle_linux_test.go
@@ -14,14 +14,14 @@ func TestNewPIDHandle(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return 255, nil
 	}
 
 	// Mock the nameToHandleAt
 	original_nameToHandleAt := nameToHandleAt
 	defer func() { nameToHandleAt = original_nameToHandleAt }()
-	nameToHandleAt = func(dirfd int, path string, flags int) (handle unix.FileHandle, mountID int, err error) {
+	nameToHandleAt = func(_ int, _ string, _ int) (handle unix.FileHandle, mountID int, err error) {
 		return newFileHandle(254, []byte("test")), 1, nil
 	}
 
@@ -39,7 +39,7 @@ func TestNewPIDHandlepidfdOpenNotSupported(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return -1, unix.ENOSYS
 	}
 
@@ -57,14 +57,14 @@ func TestPIDHandleStringnameToHandleAtNotSupported(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return 254, nil
 	}
 
 	// Mock the nameToHandleAt
 	original_nameToHandleAt := nameToHandleAt
 	defer func() { nameToHandleAt = original_nameToHandleAt }()
-	nameToHandleAt = func(dirfd int, path string, flags int) (handle unix.FileHandle, mountID int, err error) {
+	nameToHandleAt = func(_ int, _ string, _ int) (handle unix.FileHandle, mountID int, err error) {
 		return newFileHandle(-1, []byte("")), 1, unix.ENOTSUP
 	}
 
@@ -81,28 +81,28 @@ func TestNewPIDHandleFromString(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return 254, nil
 	}
 
 	// Mock the newFileHandle
 	original_newFileHandle := newFileHandle
 	defer func() { newFileHandle = original_newFileHandle }()
-	newFileHandle = func(fhType int32, bytes []byte) unix.FileHandle {
+	newFileHandle = func(_ int32, _ []byte) unix.FileHandle {
 		return unix.NewFileHandle(254, []byte("test"))
 	}
 
 	// Mock the openByHandleAt
 	original_openByHandleAt := openByHandleAt
 	defer func() { openByHandleAt = original_openByHandleAt }()
-	openByHandleAt = func(mountFD int, handle unix.FileHandle, flags int) (fd int, err error) {
+	openByHandleAt = func(_ int, _ unix.FileHandle, _ int) (fd int, err error) {
 		return 255, nil
 	}
 
 	// Mock the nameToHandleAt
 	original_nameToHandleAt := nameToHandleAt
 	defer func() { nameToHandleAt = original_nameToHandleAt }()
-	nameToHandleAt = func(dirfd int, path string, flags int) (handle unix.FileHandle, mountID int, err error) {
+	nameToHandleAt = func(_ int, _ string, _ int) (handle unix.FileHandle, mountID int, err error) {
 		return newFileHandle(255, []byte("test")), 1, nil
 	}
 
@@ -120,21 +120,21 @@ func TestNewPIDHandleFromStringWrongPidData(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return 254, nil
 	}
 
 	// Mock the newFileHandle
 	original_newFileHandle := newFileHandle
 	defer func() { newFileHandle = original_newFileHandle }()
-	newFileHandle = func(fhType int32, bytes []byte) unix.FileHandle {
+	newFileHandle = func(_ int32, _ []byte) unix.FileHandle {
 		return unix.NewFileHandle(254, []byte("test"))
 	}
 
 	// Mock the openByHandleAt
 	original_openByHandleAt := openByHandleAt
 	defer func() { openByHandleAt = original_openByHandleAt }()
-	openByHandleAt = func(mountFD int, handle unix.FileHandle, flags int) (fd int, err error) {
+	openByHandleAt = func(_ int, _ unix.FileHandle, _ int) (fd int, err error) {
 		return 255, nil
 	}
 
@@ -161,21 +161,21 @@ func TestPIDHandleKill(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return 254, nil
 	}
 
 	// Mock the pidfdSendSignal
 	original_pidfdSendSignal := pidfdSendSignal
 	defer func() { pidfdSendSignal = original_pidfdSendSignal }()
-	pidfdSendSignal = func(pidfd int, sig unix.Signal, info *unix.Siginfo, flags int) (err error) {
+	pidfdSendSignal = func(_ int, _ unix.Signal, _ *unix.Siginfo, _ int) (err error) {
 		return unix.ESRCH
 	}
 
 	// Mock the nameToHandleAt
 	original_nameToHandleAt := nameToHandleAt
 	defer func() { nameToHandleAt = original_nameToHandleAt }()
-	nameToHandleAt = func(dirfd int, path string, flags int) (handle unix.FileHandle, mountID int, err error) {
+	nameToHandleAt = func(_ int, _ string, _ int) (handle unix.FileHandle, mountID int, err error) {
 		return newFileHandle(254, []byte("test")), 1, nil
 	}
 
@@ -191,7 +191,7 @@ func TestPIDHandleKillPidfdNotSupported(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return -1, unix.ENOSYS
 	}
 
@@ -215,7 +215,7 @@ func TestPIDHandleKillPidfdNotSupportedStartTimeNotMatch(t *testing.T) {
 	// Mock the pidfdOpen
 	original := pidfdOpen
 	defer func() { pidfdOpen = original }()
-	pidfdOpen = func(pid int, flags int) (int, error) {
+	pidfdOpen = func(_ int, _ int) (int, error) {
 		return -1, unix.ENOSYS
 	}
 

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -73,7 +73,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string, config *config.Co
 		}
 
 		// mount the internal devices recursively
-		if err := filepath.WalkDir(resolvedDevicePath, func(dpath string, d fs.DirEntry, e error) error {
+		if err := filepath.WalkDir(resolvedDevicePath, func(dpath string, d fs.DirEntry, _ error) error {
 			if d.Type()&os.ModeDevice == os.ModeDevice {
 				found = true
 				device := fmt.Sprintf("%s:%s", dpath, filepath.Join(dest, strings.TrimPrefix(dpath, src)))

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -43,7 +43,7 @@ import (
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 )
 
-func ToPodOpt(ctx context.Context, podName string, p entities.PodCreateOptions, publishAllPorts bool, podYAML *v1.PodTemplateSpec) (entities.PodCreateOptions, error) {
+func ToPodOpt(_ context.Context, podName string, p entities.PodCreateOptions, publishAllPorts bool, podYAML *v1.PodTemplateSpec) (entities.PodCreateOptions, error) {
 	p.Net = &entities.NetOptions{NoHosts: p.Net.NoHosts, NoHostname: p.Net.NoHostname}
 
 	p.Name = podName

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -276,7 +276,7 @@ func VolumeFromEmptyDir(emptyDirVolumeSource *v1.EmptyDirVolumeSource, name stri
 	}
 }
 
-func VolumeFromImage(imageVolumeSource *v1.ImageVolumeSource, name string) (*KubeVolume, error) {
+func VolumeFromImage(imageVolumeSource *v1.ImageVolumeSource, _ string) (*KubeVolume, error) {
 	return &KubeVolume{
 		Type:            KubeVolumeTypeImage,
 		Source:          imageVolumeSource.Reference,

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -394,7 +394,7 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 // GetNamespaceOptions transforms a slice of kernel namespaces
 // into a slice of pod create options. Currently, not all
 // kernel namespaces are supported, and they will be returned in an error
-func GetNamespaceOptions(ns []string, netnsIsHost bool) ([]libpod.PodCreateOption, error) {
+func GetNamespaceOptions(ns []string, _ bool) ([]libpod.PodCreateOption, error) {
 	var options []libpod.PodCreateOption
 	var erroredOptions []libpod.PodCreateOption
 	if ns == nil {

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -83,7 +83,7 @@ func getCgroupPermissions(unmask []string) string {
 }
 
 // SpecGenToOCI returns the base configuration for the container.
-func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, newImage *libimage.Image, mounts []spec.Mount, pod *libpod.Pod, finalCmd []string, compatibleOptions *libpod.InfraInherit) (*spec.Spec, error) {
+func SpecGenToOCI(_ context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, newImage *libimage.Image, mounts []spec.Mount, pod *libpod.Pod, finalCmd []string, compatibleOptions *libpod.InfraInherit) (*spec.Spec, error) {
 	cgroupPerm := getCgroupPermissions(s.Unmask)
 
 	g, err := generate.New("linux")

--- a/pkg/specgen/generate/storage_linux.go
+++ b/pkg/specgen/generate/storage_linux.go
@@ -8,6 +8,6 @@ import (
 	"go.podman.io/common/libimage"
 )
 
-func imageRunPath(ctx context.Context, img *libimage.Image) (string, error) {
+func imageRunPath(_ context.Context, _ *libimage.Image) (string, error) {
 	return "/run", nil
 }

--- a/pkg/specgen/winpath_linux.go
+++ b/pkg/specgen/winpath_linux.go
@@ -17,6 +17,6 @@ func resolveRelativeOnWindows(path string) string {
 	return path
 }
 
-func winPathExists(path string) bool {
+func winPathExists(_ string) bool {
 	return false
 }

--- a/pkg/systemd/dbus.go
+++ b/pkg/systemd/dbus.go
@@ -128,7 +128,7 @@ func dbusAuthRootlessConnection(createBus func(opts ...godbus.ConnOption) (*godb
 
 func newRootlessConnection() (*dbus.Conn, error) {
 	return dbus.NewConnection(func() (*godbus.Conn, error) {
-		return dbusAuthRootlessConnection(func(opts ...godbus.ConnOption) (*godbus.Conn, error) {
+		return dbusAuthRootlessConnection(func(_ ...godbus.ConnOption) (*godbus.Conn, error) {
 			path := filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "systemd", "private")
 			path, err := filepath.EvalSymlinks(path)
 			if err != nil {

--- a/pkg/systemd/parser/unitfile_test.go
+++ b/pkg/systemd/parser/unitfile_test.go
@@ -346,7 +346,7 @@ func FuzzParser(f *testing.F) {
 		f.Add([]byte(sample))
 	}
 
-	f.Fuzz(func(t *testing.T, orig []byte) {
+	f.Fuzz(func(_ *testing.T, orig []byte) {
 		unitFile := NewUnitFile()
 		unitFile.Path = "foo/bar"
 		unitFile.Filename = "bar"

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1515,7 +1515,7 @@ func GetPodResourceName(podUnit *parser.UnitFile) string {
 	return podName
 }
 
-func ConvertPod(podUnit *parser.UnitFile, name string, unitsInfoMap map[string]*UnitInfo, isUser bool) (*parser.UnitFile, error, error) {
+func ConvertPod(podUnit *parser.UnitFile, _ string, unitsInfoMap map[string]*UnitInfo, isUser bool) (*parser.UnitFile, error, error) {
 	var warn, warnings error
 
 	service, unitInfo, err := initServiceUnitFile(podUnit, isUser, unitsInfoMap, PodGroup)

--- a/pkg/systemd/quadlet/unitdirs.go
+++ b/pkg/systemd/quadlet/unitdirs.go
@@ -195,7 +195,7 @@ func GetUserLevelFilter(resolvedUnitDirAdminUser string) func(string, bool) bool
 }
 
 func GetNonNumericFilter(resolvedUnitDirAdminUser string, systemUserDirLevel int) func(string, bool) bool {
-	return func(path string, isUserFlag bool) bool {
+	return func(path string, _ bool) bool {
 		// when running in rootless, recursive walk directories that are non numeric
 		// ignore sub dirs under the `users` directory which correspond to a user id
 		if strings.HasPrefix(path, resolvedUnitDirAdminUser) {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -700,7 +700,7 @@ func TestGetRootlessKeepIDMapping(t *testing.T) {
 	}
 }
 
-func getDefaultMountOptionsNoStat(path string) (defaultMountOptions, error) {
+func getDefaultMountOptionsNoStat(_ string) (defaultMountOptions, error) {
 	return defaultMountOptions{false, true, true}, nil
 }
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -69,6 +69,6 @@ func (p *PodmanTestIntegration) StartRemoteService() {
 }
 
 // Just a stub for compiling with `!remote`.
-func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
+func getRemoteOptions(_ *PodmanTestIntegration, _ []string) []string {
 	return nil
 }

--- a/test/e2e/pull_chunked_test.go
+++ b/test/e2e/pull_chunked_test.go
@@ -32,7 +32,7 @@ func pullChunkedTests() { // included in pull_test.go, must use a Ginkgo DSL at 
 		// This is, nominally, a built-in feature of Ginkgo, but we run the tests with -vv, making the
 		// full output always captured in a log. So, here, we need to conditionalize explicitly.
 		var lastPullOutput bytes.Buffer
-		ReportAfterEach(func(ctx SpecContext, report SpecReport) {
+		ReportAfterEach(func(_ SpecContext, report SpecReport) {
 			if report.Failed() {
 				AddReportEntry("last pull operation", lastPullOutput.String())
 			}
@@ -156,7 +156,7 @@ func pullChunkedTests() { // included in pull_test.go, must use a Ginkgo DSL at 
 					modified[0] = digest.NewDigestFromEncoded(diffIDs[0].Algorithm(), hex.EncodeToString(digestBytes))
 					return modified
 				})
-				chunkedMissing = createChunkedImage("missing", func(diffIDs []digest.Digest) []digest.Digest {
+				chunkedMissing = createChunkedImage("missing", func(_ []digest.Digest) []digest.Digest {
 					return nil
 				})
 				chunkedEmpty = createChunkedImage("empty", func(diffIDs []digest.Digest) []digest.Digest {

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -358,7 +358,7 @@ qe ssh://root@podman.test:2222/run/podman/podman.sock ~/.ssh/id_rsa false true
 					pr.SetURL(baseURL)
 				},
 				Transport: &http.Transport{
-					DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 						By("Proxying to " + podmanTest.RemoteSocket)
 						url, err := url.Parse(podmanTest.RemoteSocket)
 						if err != nil {

--- a/test/testvol/create.go
+++ b/test/testvol/create.go
@@ -10,7 +10,7 @@ var createCmd = &cobra.Command{
 	Short: "create a volume",
 	Long:  `Create a volume in the volume plugin listening on --sock-name`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		return createVol(config.sockName, args[0])
 	},
 }

--- a/test/testvol/list.go
+++ b/test/testvol/list.go
@@ -11,7 +11,7 @@ var listCmd = &cobra.Command{
 	Short: "list all volumes",
 	Long:  `List all volumes from the volume plugin listening on --sock-name`,
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return listVol(config.sockName)
 	},
 }

--- a/test/testvol/main.go
+++ b/test/testvol/main.go
@@ -25,7 +25,7 @@ var serveCmd = &cobra.Command{
 	Short: "serve the volume plugin on the unix socket",
 	Long:  `Creates simple directory volumes using the Volume Plugin API for testing volume plugin functionality`,
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return startServer(config.sockName)
 	},
 }
@@ -52,7 +52,7 @@ func init() {
 	rootCmd.AddCommand(serveCmd, createCmd, removeCmd, listCmd)
 }
 
-func before(cmd *cobra.Command, args []string) error {
+func before(_ *cobra.Command, _ []string) error {
 	if config.logLevel == "" {
 		config.logLevel = "error"
 	}

--- a/test/testvol/remove.go
+++ b/test/testvol/remove.go
@@ -10,7 +10,7 @@ var removeCmd = &cobra.Command{
 	Short: "remove a volume",
 	Long:  `Remove a volume in the volume plugin listening on --sock-name`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		return removeVol(config.sockName, args[0])
 	},
 }

--- a/test/utils/utils_suite_test.go
+++ b/test/utils/utils_suite_test.go
@@ -31,7 +31,7 @@ func FakePodmanTestCreate() *FakePodmanTest {
 	return p
 }
 
-func (p *FakePodmanTest) makeOptions(args []string, options PodmanExecOptions) []string {
+func (p *FakePodmanTest) makeOptions(args []string, _ PodmanExecOptions) []string {
 	return FakeOutputs[strings.Join(args, " ")]
 }
 


### PR DESCRIPTION
To help maintain the sanity of whoever has to review this PR I've limited my changes to only change argument names violating this linter to `_`. There seems to be a few spots that could be cleaned up further but that feels out of scope for a change this large.

Resolves #27111

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
