### PR TITLE
artifact add: default to latest tag when no tag specified

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -89,6 +89,9 @@ func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) erro
 		}
 		if tagged, ok := named.(reference.Tagged); ok {
 			tag = tagged.Tag()
+		} else {
+			// display consistency with images: show 'latest' when tag missing
+			tag = "latest"
 		}
 
 		// Note: Right now we only support things that are single manifests

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -132,6 +132,7 @@ func (as ArtifactStore) Inspect(ctx context.Context, nameOrDigest string) (*liba
 	if err != nil {
 		return nil, err
 	}
+
 	inspectData, _, err := artifacts.GetByNameOrDigest(nameOrDigest)
 	return inspectData, err
 }

--- a/pkg/libartifact/store/store.go
+++ b/pkg/libartifact/store/store.go
@@ -218,6 +218,11 @@ func (as ArtifactStore) Add(ctx context.Context, dest string, artifactBlobs []en
 		return nil, ErrEmptyArtifactName
 	}
 
+	// Add :latest tag if no tag/digest is present
+	if !strings.Contains(dest, ":") && !strings.Contains(dest, "@") {
+		dest += ":latest"
+	}
+
 	if options.Append && len(options.ArtifactMIMEType) > 0 {
 		return nil, errors.New("append option is not compatible with type option")
 	}

--- a/test/e2e/artifact_mount_test.go
+++ b/test/e2e/artifact_mount_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Podman artifact mount", func() {
 		// restart will fail if artifact does not exist
 		session = podmanTest.Podman([]string{"restart", "-t0", ctrName})
 		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(125, artifactName+": artifact does not exist"))
+		Expect(session).To(ExitWithError(125, artifactName+":latest: artifact does not exist"))
 
 		// create a artifact with the same name again and add another file to ensure it picks up the changes
 		artifactFile2Name := "otherfile"


### PR DESCRIPTION
Fixes issue where podman artifact add did not default to :latest tag like container images do, causing inconsistent behavior.

fixes #27083

```release-note
None
```
