### PR TITLE
test: remove hack workaround in 'use plugin in containers'

### DIFF
--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -188,13 +188,6 @@ var _ = Describe("Podman volume plugins", func() {
 		ctr2.WaitWithDefaultTimeout()
 		Expect(ctr2).Should(ExitCleanly())
 		Expect(ctr2.OutputToString()).To(ContainSubstring("helloworld"))
-
-		// HACK: `volume rm -f` is timing out trying to remove containers using the volume.
-		// Solution: remove them manually...
-		// TODO: fix this when I get back
-		rmAll := podmanTest.Podman([]string{"rm", "-f", ctr2Name, ctr1Name})
-		rmAll.WaitWithDefaultTimeout()
-		Expect(rmAll).Should(ExitCleanly())
 	})
 
 	It("podman volume reload", func() {


### PR DESCRIPTION
Fixed #27116
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
