### PR TITLE
Add tmt integration plan

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -132,6 +132,20 @@ jobs:
             context:
               revdeps: "yes"
 
+  - job: tests
+    identifier: tmt-revdeps
+    trigger: pull_request
+    packages: [podman-fedora]
+    notifications:
+      failure_comment:
+        message: "tmt tests failed for commit {commit_sha}. @lsm5, @psss, @thrix please check."
+    targets:
+      - fedora-latest
+    fmf_url: https://github.com/teemtee/tmt
+    fmf_path: /plans/friends
+    fmf_ref: main
+    tmt_plan: "/podman"
+
   - job: propose_downstream
     trigger: release
     update_release: false


### PR DESCRIPTION
See:
- https://github.com/teemtee/tmt/issues/4047
- https://github.com/teemtee/tmt/pull/4026
- https://github.com/containers/crun/pull/1881
- https://github.com/containers/container-selinux/pull/410

An alternative design is to add the tests in `.packit.yaml`. Let me know which approach would be preferred. I don't quite follow the steps you do with `podman-next*.repo`, maybe we could look into that as well?

(should use only one PR where we discuss and test these)
