### PR TITLE
Remove unnecessary crun check

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2325,9 +2325,6 @@ WORKDIR /madethis`, BB)
 
 	It("podman run check personality support", func() {
 		// TODO: Remove this as soon as this is merged and made available in our CI https://github.com/opencontainers/runc/pull/3126.
-		if !strings.Contains(podmanTest.OCIRuntime, "crun") {
-			Skip("Test only works on crun")
-		}
 		session := podmanTest.Podman([]string{"run", "--personality=LINUX32", "--name=testpersonality", ALPINE, "uname", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?

```release-note
None
```

Closes #27115 by removing the skip in `run_test.go`.