### PR TITLE
test: Fix test race in 030-run

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -78,7 +78,7 @@ echo $rand        |   0 | $rand
     echo "$content" > $PODMAN_TMPDIR/tempfile
 
     run_podman run --rm -i --preserve-fds=2 $IMAGE sh -c "cat <&4" 4<$PODMAN_TMPDIR/tempfile
-    is "$output" "$content" "container read input from fd 4"
+    assert "$output" =~ "$content" "container read input from fd 4"
 }
 
 # 'run --preserve-fd' passes a list of additional file descriptors into the container


### PR DESCRIPTION
This seems like a test race that appeared sometimes with crun on ppc64le:

https://openqa.opensuse.org/tests/5338518#external (click on `Show only failures`):

```
# Test messages # podman run --preserve-fds
# failure: 

tags: ci:parallel
(from function `bail-now' in file test/system/helpers.bash, line 187,
 from function `is' in file test/system/helpers.bash, line 1112,
 in test file test/system/030-run.bats, line 84)
  `is "$output" "$content" "container read input from fd 4"' failed

[08:22:48.845085215] # /usr/bin/podman run --rm -i --preserve-fds=2 quay.io/libpod/testimage:20241011 sh -c cat <&4
[08:22:49.560516399] 1u3PrTiBXHjtkNZdKzDN
process not running: No such process
#/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
#|     FAIL: container read input from fd 4
#| expected: '1u3PrTiBXHjtkNZdKzDN'
#|   actual: '1u3PrTiBXHjtkNZdKzDN'
#|         > 'process not running: No such process'
#\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# [teardown]
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
