### PR TITLE
Add --ignore option to podman artifact rm command

### DIFF
--- a/cmd/podman/artifact/rm.go
+++ b/cmd/podman/artifact/rm.go
@@ -32,6 +32,7 @@ var (
 func rmFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.BoolVarP(&rmOptions.All, "all", "a", false, "Remove all artifacts")
+	flags.BoolVarP(&rmOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified artifact does not exist")
 }
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{

--- a/docs/source/markdown/podman-artifact-rm.1.md
+++ b/docs/source/markdown/podman-artifact-rm.1.md
@@ -22,6 +22,10 @@ providing a name or digest of the artifact.
 
 Print usage statement.
 
+#### **--ignore**, **-i**
+
+Ignore errors when a specified artifact does not exist. A user might have decided
+to manually remove an artifact which would lead to a failure during script execution.
 
 ## EXAMPLES
 
@@ -47,6 +51,12 @@ Remove all artifacts in local storage.
 $ podman artifact rm -a
 Deleted: cee15f7c5ce3e86ae6ce60d84bebdc37ad34acfa9a2611cf47501469ac83a1ab
 Deleted: 72875f8f6f78d5b8ba98b2dd2c0a6f395fde8f05ff63a1df580d7a88f5afa97b
+```
+
+Ignore errors when removing non-existent artifacts.
+```
+$ podman artifact rm --ignore nonexistent-artifact existing-artifact
+Deleted: e7b417f49fc24fc7ead6485da0ebd5bc4419d8a3f394c169fee5a6f38faa4056
 ```
 
 ## SEE ALSO

--- a/pkg/api/handlers/libpod/artifacts.go
+++ b/pkg/api/handlers/libpod/artifacts.go
@@ -169,6 +169,7 @@ func BatchRemoveArtifact(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		All       bool     `schema:"all"`
 		Artifacts []string `schema:"artifacts"`
+		Ignore    bool     `schema:"ignore"`
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -191,6 +192,7 @@ func BatchRemoveArtifact(w http.ResponseWriter, r *http.Request) {
 	removeOptions := entities.ArtifactRemoveOptions{
 		Artifacts: query.Artifacts,
 		All:       query.All,
+		Ignore:    query.Ignore,
 	}
 
 	artifacts, err := imageEngine.ArtifactRm(r.Context(), removeOptions)

--- a/pkg/bindings/artifacts/types.go
+++ b/pkg/bindings/artifacts/types.go
@@ -52,6 +52,8 @@ type RemoveOptions struct {
 	All *bool
 	// Artifacts is a list of Artifact IDs or names to remove
 	Artifacts []string
+	// Ignore errors when a specified artifact does not exist
+	Ignore *bool
 }
 
 // AddOptions are optional options for removing images

--- a/pkg/bindings/artifacts/types_remove_options.go
+++ b/pkg/bindings/artifacts/types_remove_options.go
@@ -46,3 +46,18 @@ func (o *RemoveOptions) GetArtifacts() []string {
 	}
 	return o.Artifacts
 }
+
+// WithIgnore set field Ignore to given value
+func (o *RemoveOptions) WithIgnore(value bool) *RemoveOptions {
+	o.Ignore = &value
+	return o
+}
+
+// GetIgnore returns value of field Ignore
+func (o *RemoveOptions) GetIgnore() bool {
+	if o.Ignore == nil {
+		var z bool
+		return z
+	}
+	return *o.Ignore
+}

--- a/pkg/domain/entities/artifact.go
+++ b/pkg/domain/entities/artifact.go
@@ -96,6 +96,8 @@ type ArtifactRemoveOptions struct {
 	All bool
 	// Artifacts is a list of Artifact IDs or names to remove
 	Artifacts []string
+	// Ignore errors when a specified artifact does not exist
+	Ignore bool
 }
 
 type ArtifactRemoveReport = entitiesTypes.ArtifactRemoveReport

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -57,6 +57,7 @@ func (ir *ImageEngine) ArtifactRm(_ context.Context, opts entities.ArtifactRemov
 	removeOptions := artifacts.RemoveOptions{
 		All:       &opts.All,
 		Artifacts: opts.Artifacts,
+		Ignore:    &opts.Ignore,
 	}
 
 	return artifacts.Remove(ir.ClientCtx, "", &removeOptions)

--- a/test/system/701-artifact-ignore.bats
+++ b/test/system/701-artifact-ignore.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Tests for podman artifact rm --ignore functionality
+#
+
+load helpers
+
+function setup() {
+    basic_setup
+}
+
+function teardown() {
+    basic_teardown
+}
+
+# Helper function to create a test artifact file
+create_test_file() {
+    local size=${1:-1024}
+    local filename=$(mktemp --tmpdir="${PODMAN_TMPDIR}" artifactfile.XXXXXX)
+    dd if=/dev/urandom of="$filename" bs=1 count="$size" 2>/dev/null
+    echo "$filename"
+}
+
+# bats test_tags=ci:parallel
+@test "podman artifact rm --ignore nonexistent artifact" {
+    local artifact_name="localhost/test/nonexistent-artifact"
+
+    # Removing nonexistent artifact without --ignore should fail
+    run_podman 125 artifact rm "$artifact_name"
+    assert "$output" =~ "artifact does not exist"
+
+    # Removing nonexistent artifact with --ignore should succeed
+    run_podman artifact rm --ignore "$artifact_name"
+    is "$output" "" "No output expected when ignoring nonexistent artifact"
+}
+
+# bats test_tags=ci:parallel
+@test "podman artifact rm --ignore with existing artifact" {
+    local artifact_name="localhost/test/existing-artifact"
+    local file1
+
+    file1=$(create_test_file 1024)
+
+    # Add artifact
+    run_podman artifact add "$artifact_name" "$file1"
+    local digest="$output"
+
+    # Remove with --ignore should work normally
+    run_podman artifact rm --ignore "$artifact_name"
+    assert "$output" =~ "$digest" "Should output digest of removed artifact"
+
+    # Verify artifact was removed
+    run_podman 125 artifact inspect "$artifact_name"
+    assert "$output" =~ "artifact does not exist"
+
+    rm -f "$file1"
+}
+
+# bats test_tags=ci:parallel
+@test "podman artifact rm --ignore mixed artifacts" {
+    local existing1="localhost/test/existing1"
+    local existing2="localhost/test/existing2"
+    local nonexistent="localhost/test/nonexistent"
+    local file1 file2
+
+    file1=$(create_test_file 512)
+    file2=$(create_test_file 1024)
+
+    # Add two artifacts
+    run_podman artifact add "$existing1" "$file1"
+    local digest1="$output"
+
+    run_podman artifact add "$existing2" "$file2"
+    local digest2="$output"
+
+    # Try removing mix without --ignore should fail
+    run_podman 125 artifact rm "$nonexistent" "$existing1" "$existing2"
+    assert "$output" =~ "artifact does not exist"
+
+    # Verify existing artifacts are still there after failure
+    run_podman artifact inspect "$existing1"
+    run_podman artifact inspect "$existing2"
+
+    # Try removing mix with --ignore should succeed
+    run_podman artifact rm --ignore "$existing1" "$nonexistent" "$existing2"
+
+    # Output should contain digests of removed artifacts
+    assert "$output" =~ "$digest1" "Should contain digest of first artifact"
+    assert "$output" =~ "$digest2" "Should contain digest of second artifact"
+
+    # Verify artifacts were removed
+    run_podman 125 artifact inspect "$existing1"
+    run_podman 125 artifact inspect "$existing2"
+
+    rm -f "$file1" "$file2"
+}
+
+# bats test_tags=ci:parallel
+@test "podman artifact rm --ignore with --all" {
+    local artifact1="localhost/test/artifact1"
+    local artifact2="localhost/test/artifact2"
+    local file1 file2
+
+    file1=$(create_test_file 512)
+    file2=$(create_test_file 1024)
+
+    # Add artifacts
+    run_podman artifact add "$artifact1" "$file1"
+    run_podman artifact add "$artifact2" "$file2"
+
+    # Remove all with --ignore should work
+    run_podman artifact rm --ignore --all
+
+    # Verify artifacts were removed
+    run_podman 125 artifact inspect "$artifact1"
+    run_podman 125 artifact inspect "$artifact2"
+
+    rm -f "$file1" "$file2"
+}


### PR DESCRIPTION
This commit implements the --ignore functionality for the artifact rm command, allowing users to ignore errors when specified artifacts do not exist.

Changes made:
- Add Ignore field to ArtifactRemoveOptions entity types
- Add --ignore CLI flag (-i short form) to artifact rm command
- Implement ignore logic in ABI backend to continue processing on errors
- Update API handlers and tunnel implementation for podman-remote support
- Add comprehensive documentation and examples to man page
- Add e2e and system BATS tests for --ignore functionality
- Clean up whitespace in BATS test files

The --ignore option follows the same pattern as other podman ignore options like 'podman image rm --ignore' and 'podman pod rm --ignore'. It allows scripts to continue execution when trying to remove artifacts that may not exist, preventing race conditions in cleanup scenarios.

Usage examples:
  podman artifact rm --ignore nonexistent-artifact
  podman artifact rm --ignore existing-artifact nonexistent-artifact

Fixes: https://github.com/containers/podman/issues/27084

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman artifact rm --ignore option added.
```
