### PR TITLE
Added virtual size option in artifact ls format

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -36,10 +36,11 @@ type listFlagType struct {
 }
 
 type artifactListOutput struct {
-	Digest     string
-	Repository string
-	Size       string
-	Tag        string
+	Digest      string
+	Repository  string
+	Size        string
+	Tag         string
+	VirtualSize string
 }
 
 var (
@@ -106,10 +107,11 @@ func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) erro
 		}
 
 		artifacts = append(artifacts, artifactListOutput{
-			Digest:     artifactHash,
-			Repository: named.Name(),
-			Size:       units.HumanSize(float64(lr.Artifact.TotalSizeBytes())),
-			Tag:        tag,
+			Digest:      artifactHash,
+			Repository:  named.Name(),
+			Size:        units.HumanSize(float64(lr.Artifact.TotalSizeBytes())),
+			Tag:         tag,
+			VirtualSize: fmt.Sprintf("%d", lr.Artifact.TotalSizeBytes()),
 		})
 	}
 

--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -22,6 +22,7 @@ Print results with a Go template.
 | .Repository     | Repository name of the artifact                |
 | .Size           | Size artifact in human readable units          |
 | .Tag            | Tag of the artifact name                       |
+| .VirtualSize    | Size of artifact in bytes                      |
 
 @@option no-trunc
 

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -65,6 +65,17 @@ var _ = Describe("Podman artifact", func() {
 		noHeaderOutput := noHeaderSession.OutputToStringArray()
 		Expect(noHeaderOutput).To(HaveLen(2))
 		Expect(noHeaderOutput).ToNot(ContainElement("REPOSITORY"))
+
+		// Check if .VirtualSize is reported correctly
+		virtualSizeFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.VirtualSize}}")
+		virtualSizes := virtualSizeFormatSession.OutputToStringArray()
+
+		// Should list 2 lines (without the header)
+		Expect(virtualSizes).To(HaveLen(2))
+
+		// Verify if the virtual size values are present in the output
+		Expect(virtualSizes).To(ContainElement("4192"))
+		Expect(virtualSizes).To(ContainElement("10240"))
 	})
 
 	It("podman artifact simple add", func() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

Yes, added the option to format the list showing the virtual size `podman artifact ls --format '{{ .VirtualSize }}'`
Closes #27085

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added virtual size option for artifact list --format
```
