### PR TITLE
docs: clarify that `--userns=keep-id` runs container as host UID

### DIFF
--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -56,6 +56,8 @@ For details see **--uidmap**.
 
 **keep-id**: creates a user namespace where the current user's UID:GID are mapped to the same values in the container. For containers created by root, the current mapping is created into a new user namespace.
 
+  In addition, the init process within the container will run under the current user's UID. This behavior overrides the image's `USER` instruction unless you explicitly set `--user`.
+
   Valid `keep-id` options:
 
   - *uid*=UID: override the UID inside the container that is used to map the current user to.


### PR DESCRIPTION
## Description

Currently, the docs state that the `--userns=keep-id` option maps the rootless user's UID/GID to the same values inside the container, but they don’t make explicit that the **container's init process itself runs as that mapped UID/GID**.

This behaviour has caused some confusion (see #24934). In practice:

- Without `--userns=keep-id`, rootless containers default to running as `root` inside the container (mapped to the host UID externally).
- With `--userns=keep-id`, the init process runs as the host UID/GID inside the container, overriding the image’s `USER` instruction unless `--user` is explicitly set.

This PR updates the documentation to make that behaviour clear.

#### Does this PR introduce a user-facing change?

```release-note
None
```