### PR TITLE
cmd/podman/system: fix error handling in renumber and migrate commands

### DIFF
--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -3,12 +3,8 @@
 package system
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
-	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/pkg/completion"
@@ -30,7 +26,7 @@ var (
 		Args:              validate.NoArgs,
 		Short:             "Migrate containers",
 		Long:              migrateDescription,
-		Run:               migrate,
+		RunE:              migrate,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 )
@@ -52,13 +48,6 @@ func init() {
 	_ = migrateCommand.RegisterFlagCompletionFunc(newRuntimeFlagName, completion.AutocompleteNone)
 }
 
-func migrate(cmd *cobra.Command, args []string) {
-	if err := registry.ContainerEngine().Migrate(registry.Context(), migrateOptions); err != nil {
-		fmt.Println(err)
-
-		// FIXME change this to return the error like other commands
-		// defer will never run on os.Exit()
-		os.Exit(define.ExecErrorCodeGeneric)
-	}
-	os.Exit(0)
+func migrate(cmd *cobra.Command, args []string) error {
+	return registry.ContainerEngine().Migrate(registry.Context(), migrateOptions)
 }

--- a/cmd/podman/system/renumber.go
+++ b/cmd/podman/system/renumber.go
@@ -3,12 +3,8 @@
 package system
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
-	"github.com/containers/podman/v5/libpod/define"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/pkg/completion"
 )
@@ -27,7 +23,7 @@ var (
 		Args:              validate.NoArgs,
 		Short:             "Migrate lock numbers",
 		Long:              renumberDescription,
-		Run:               renumber,
+		RunE:              renumber,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 )
@@ -39,12 +35,6 @@ func init() {
 	})
 }
 
-func renumber(cmd *cobra.Command, args []string) {
-	if err := registry.ContainerEngine().Renumber(registry.Context()); err != nil {
-		fmt.Println(err)
-		// FIXME change this to return the error like other commands
-		// defer will never run on os.Exit()
-		os.Exit(define.ExecErrorCodeGeneric)
-	}
-	os.Exit(0)
+func renumber(cmd *cobra.Command, args []string) error {
+	return registry.ContainerEngine().Renumber(registry.Context())
 }


### PR DESCRIPTION
- Change function signatures to return error instead of calling os.Exit()
- Update cobra commands to use RunE instead of Run for proper error handling
- Remove unused imports (fmt, os, define)
- Remove FIXME comments about error handling inconsistency

This allows defer statements to run properly and improves testability.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
