### PR TITLE
Fixed help text for podman run/create --image-volume option

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -174,7 +174,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		imageVolumeFlagName := "image-volume"
 		createFlags.String(
 			imageVolumeFlagName, cf.ImageVolume,
-			`Tells podman how to handle the builtin image volumes ("bind"|"tmpfs"|"ignore")`,
+			`Tells podman how to handle the builtin image volumes ("anonymous"|"tmpfs"|"ignore")`,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(imageVolumeFlagName, AutocompleteImageVolume)
 

--- a/docs/source/locale/ja/LC_MESSAGES/markdown.po
+++ b/docs/source/locale/ja/LC_MESSAGES/markdown.po
@@ -9067,18 +9067,18 @@ msgstr ""
 
 #: ../../source/markdown/podman-create.1.md:810
 #: ../../source/markdown/podman-run.1.md:852
-msgid "**--image-volume**=**bind** | *tmpfs* | *ignore*"
+msgid "**--image-volume**=**anonymous** | *tmpfs* | *ignore*"
 msgstr ""
 
 #: ../../source/markdown/podman-create.1.md:812
 #: ../../source/markdown/podman-run.1.md:854
-msgid "Tells Podman how to handle the builtin image volumes. Default is **bind**."
+msgid "Tells Podman how to handle the builtin image volumes. Default is **anonymous**."
 msgstr ""
 
 #: ../../source/markdown/podman-create.1.md:814
 #: ../../source/markdown/podman-run.1.md:856
 msgid ""
-"**bind**: An anonymous named volume is created and mounted into the "
+"**anonymous**: An anonymous named volume is created and mounted into the "
 "container."
 msgstr ""
 

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -2,11 +2,11 @@
 ####>   podman create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+#### **--image-volume**=**anonymous** | *tmpfs* | *ignore*
 
 Tells Podman how to handle the builtin image volumes. Default is **bind**.
 
-- **bind**: An anonymous named volume is created and mounted into the container.
+- **anonymous**: An anonymous named volume is created and mounted into the container.
 - **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
 content that disappears when the container is stopped.
 - **ignore**: All volumes are just ignored and no action is taken.


### PR DESCRIPTION
'bind' was listed as one of valid values for --image-volume option instead of 'anonymous' in the help text of podman run and podman create commands

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed invalid "bind" value in the help text for --image-volume option of podman create and podman run commands
```
