### PR TITLE
docs: fix Go Report Card badge to reference current repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Podman: A tool for managing OCI containers and pods
 ![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/containers/podman)
-[![Go Report Card](https://goreportcard.com/badge/github.com/containers/podman)](https://goreportcard.com/report/github.com/containers/podman)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containers/podman/v5)](https://goreportcard.com/report/github.com/containers/podman/v5)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10499/badge)](https://www.bestpractices.dev/projects/10499)
 
 [![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=containers-podman)](https://insights.linuxfoundation.org/project/containers-podman)


### PR DESCRIPTION
Update the Go Report Card badge in README.md to reference the current containers/podman repository instead of the outdated containers/libpod repository. This ensures consistency with other badges and prevents potential confusion for contributors.


```release-note
None
```
