### PR TITLE
secrets: align 'secret ls' format docs and completion

### DIFF
--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -46,8 +46,8 @@ func init() {
 	flags := lsCmd.Flags()
 
 	formatFlagName := "format"
-	flags.StringVar(&listFlag.format, formatFlagName, "{{range .}}{{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.CreatedAt}}\t{{.UpdatedAt}}\n{{end -}}", "Format volume output using Go template")
-	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.SecretInfoReport{}))
+	flags.StringVar(&listFlag.format, formatFlagName, "{{range .}}{{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.CreatedAt}}\t{{.UpdatedAt}}\n{{end -}}", "Format secret output using Go template")
+	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.SecretListReport{}))
 
 	filterFlagName := "filter"
 	flags.StringArrayVarP(&listFlag.filter, filterFlagName, "f", []string{}, "Filter secret output")

--- a/docs/source/markdown/podman-secret-ls.1.md.in
+++ b/docs/source/markdown/podman-secret-ls.1.md.in
@@ -32,16 +32,11 @@ Valid placeholders for the Go template are listed below:
 
 | **Placeholder**          | **Description**                                                   |
 | ------------------------ | ----------------------------------------------------------------- |
-| .CreatedAt ...           | When secret was created (relative timestamp, human-readable)      |
+| .CreatedAt               | When secret was created (relative timestamp, human-readable)      |
+| .Driver                  | Driver name (string)                                              |
 | .ID                      | ID of secret                                                      |
-| .SecretData              | Secret Data (Displayed only with --showsecret option)		       |
-| .Spec ...                | Details of secret                                                 |
-| .Spec.Driver ...         | Driver info                                                       |
-| .Spec.Driver.Name        | Driver name (string)                                              |
-| .Spec.Driver.Options ... | Driver options (map of driver-specific options)                   |
-| .Spec.Labels ...         | Labels for this secret                                            |
-| .Spec.Name               | Name of secret                                                    |
-| .UpdatedAt ...           | When secret was last updated (relative timestamp, human-readable) |
+| .Name                    | Name of secret                                                    |
+| .UpdatedAt               | When secret was last updated (relative timestamp, human-readable) |
 
 @@option noheading
 


### PR DESCRIPTION
Change format completion to use SecretListReport (matches runtime output)
Fix help text to say 'Format secret output using Go template'
Update podman-secret-ls manpage placeholders to valid fields: .ID, .Name, .Driver, .CreatedAt, .UpdatedAt

This resolves template errors when users format with .Spec.* fields that are not available from 'secret ls'.


fixes : #27151
```release-note
 None
```
