### PR TITLE
[v5.6-rhel] Bump to Buildah v1.41.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.3.0
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.7.1
-	github.com/containers/buildah v1.41.4
+	github.com/containers/buildah v1.41.5
 	github.com/containers/common v0.64.2
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.6

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEm
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.7.1 h1:CNAR0jviDj6FS5Vg85NTgKWLDzZPfi/lj+VJfhMDTIs=
 github.com/containernetworking/plugins v1.7.1/go.mod h1:xuMdjuio+a1oVQsHKjr/mgzuZ24leAsqUYRnzGoXHy0=
-github.com/containers/buildah v1.41.4 h1:IHYWex7rwhsOwtRXQ+VMEQr96gUbSbSvxJcX6AoiDeA=
-github.com/containers/buildah v1.41.4/go.mod h1:IFW8MbAgXYiUBCcAFExlHkPfE41DJWVBCbDZWZ9WEng=
+github.com/containers/buildah v1.41.5 h1:tdxtsb+SctAQ0/vdAJg5AMArVypeN2DmIjHV1bkoMO4=
+github.com/containers/buildah v1.41.5/go.mod h1:IFW8MbAgXYiUBCcAFExlHkPfE41DJWVBCbDZWZ9WEng=
 github.com/containers/common v0.64.2 h1:1xepE7QwQggUXxmyQ1Dbh6Cn0yd7ktk14sN3McSWf5I=
 github.com/containers/common v0.64.2/go.mod h1:o29GfYy4tefUuShm8mOn2AiL5Mpzdio+viHI7n24KJ4=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 
+## v1.41.5 (2025-09-29)
+
+    [release-1.41] Run: create parent directories of mount targets with mode 0755
+    [release-1.41] tests/run.bats: "run masks" test: accept "unreadable" masked directories
+
 ## v1.41.4 (2025-09-03)
 
     [release-1.41] c/common to v0.64.2, ulikunitz/xv v0.5.12, docker/docker v28.3.3

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.41.5 (2025-09-29)
+
+    [release-1.41] Run: create parent directories of mount targets with mode 0755
+    [release-1.41] tests/run.bats: "run masks" test: accept "unreadable" masked directories
+
 - Changelog for v1.41.4 (2025-09-03)
   * [release-1.41] c/common to v0.64.2, ulikunitz/xv v0.5.12, docker/docker v28.3.3
 

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.41.4"
+	Version = "1.41.5"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/run_common.go
+++ b/vendor/github.com/containers/buildah/run_common.go
@@ -2102,6 +2102,12 @@ func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemo
 				// forced permissions
 				mode = &perms
 			}
+			if mode == nil && destination != cleanedDestination {
+				// parent directories default to 0o755, for
+				// the sake of commands running as UID != 0
+				perms := os.FileMode(0o755)
+				mode = &perms
+			}
 			targets.Paths = append(targets.Paths, copier.EnsurePath{
 				Path:     destination,
 				Typeflag: typeFlag,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.7.1
 ## explicit; go 1.23.0
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.41.4
+# github.com/containers/buildah v1.41.5
 ## explicit; go 1.23.3
 github.com/containers/buildah
 github.com/containers/buildah/bind


### PR DESCRIPTION
Vendor Buildah v1.41.5 into Podman v5.6.  This addresses a build secret mount issue first noted in https://github.com/containers/buildah/issues/6361

Fixes: https://issues.redhat.com/browse/RHEL-116091, https://issues.redhat.com/browse/RHEL-116090

ZeroDay cards for RHEL 9.7/10.1

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
