### PR TITLE
test: Wait for killed container to avoid leak

### DIFF
--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -114,6 +114,7 @@ load helpers
     run_podman run --rm -d --name $cname $IMAGE top
     run_podman kill $cname
     is "$output" $cname
+    run_podman ? wait $cname
 }
 
 # bats test_tags=ci:parallel


### PR DESCRIPTION
Wait for killed container ignoring exit status to avoid leak.

We see this sporadic failure a lot in the rootless/remote scenario:

https://openqa.opensuse.org/tests/5359148/file/podman-bats-user-remote.tap.txt

```
#not ok 302 [130] podman kill - print IDs or raw input # in 864 ms
# (from function `basic_teardown' in file test/system/helpers.bash, line 255,
#  from function `teardown' in test file test/system/helpers.bash, line 265)
#   `basic_teardown' failed
# 
# [23:46:42.104180370] $ /usr/bin/podman-remote run --rm -d quay.io/libpod/testimage:20241011 top
# [23:46:42.272297627] 547df43df0e9ce0132e19f3073a6268e4734132b3c742ef66cec9ce8519a4fb5
# 
# [23:46:42.278042528] $ /usr/bin/podman-remote kill -a
# [23:46:42.351655661] 547df43df0e9ce0132e19f3073a6268e4734132b3c742ef66cec9ce8519a4fb5
# 
# [23:46:42.371353512] $ /usr/bin/podman-remote run --rm -d --name c-t302-pmmcj57o quay.io/libpod/testimage:20241011 top
# [23:46:42.533612827] def040d84cb3a752616e01d72c7dbf358623f65241ce7221218f21685a584fdc
# 
# [23:46:42.538995022] $ /usr/bin/podman-remote kill c-t302-pmmcj57o
# [23:46:42.618828613] c-t302-pmmcj57o
# # [teardown]
# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# *** Leaked container: def040d84cb3 quay.io/libpod/testimage:20241011 c-t302-pmmcj57o  Removing
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
