### PR TITLE
test/system: two small fixes

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1638,7 +1638,7 @@ search               | $IMAGE           |
            "$command --authfile=nonexistent-path"
 
         if [[ "$command" != "logout" ]]; then
-           REGISTRY_AUTH_FILE=$bogus run_podman ? $command $args
+           REGISTRY_AUTH_FILE=$bogus run_podman '?' $command $args
            assert "$output" !~ "credential file is not accessible" \
               "$command REGISTRY_AUTH_FILE=nonexistent-path"
 

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -114,7 +114,7 @@ load helpers
     run_podman run --rm -d --name $cname $IMAGE top
     run_podman kill $cname
     is "$output" $cname
-    run_podman ? wait $cname
+    run_podman '?' wait $cname
 }
 
 # bats test_tags=ci:parallel

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -114,7 +114,9 @@ load helpers
     run_podman run --rm -d --name $cname $IMAGE top
     run_podman kill $cname
     is "$output" $cname
-    run_podman '?' wait $cname
+    # Wait for the container to get removed to avoid the leak check from triggering,
+    # since it might have already been removed here ignore the exit code check.
+    run_podman '?' wait --condition=removing $cname
 }
 
 # bats test_tags=ci:parallel


### PR DESCRIPTION
Follow up to https://github.com/containers/podman/pull/27230

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
