### PR TITLE
cmd/podman: add replace flag to quadlet install

### DIFF
--- a/cmd/podman/quadlet/install.go
+++ b/cmd/podman/quadlet/install.go
@@ -36,6 +36,7 @@ podman quadlet install https://github.com/containers/podman/blob/main/test/e2e/q
 func installFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.BoolVar(&installOptions.ReloadSystemd, "reload-systemd", true, "Reload systemd after installing Quadlets")
+	flags.BoolVarP(&installOptions.Replace, "replace", "r", false, "Replace the installation even if the quadlet already exists")
 }
 
 func init() {

--- a/docs/source/markdown/podman-quadlet-install.1.md
+++ b/docs/source/markdown/podman-quadlet-install.1.md
@@ -28,6 +28,12 @@ Reload systemd after installing Quadlets (default true).
 In order to disable it users need to manually set the value
 of this flag to `false`.
 
+#### **--replace**, **-r**
+
+Replace the Quadlet installation even if the generated unit file already exists (default false).
+In order to enable it, users need to manually set the value
+of this flag to `true`. This flag is used primarily to update an existing unit.
+
 ## EXAMPLES
 
 Install quadlet from a file.

--- a/pkg/domain/entities/quadlet.go
+++ b/pkg/domain/entities/quadlet.go
@@ -4,6 +4,8 @@ package entities
 type QuadletInstallOptions struct {
 	// Whether to reload systemd after installation is completed
 	ReloadSystemd bool
+	// Replace the installation even if the quadlet already exists
+	Replace bool
 }
 
 // QuadletInstallReport contains the output of the `quadlet install` command


### PR DESCRIPTION
Fixes: #26930

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes, this PR adds a new --replace flag to the quadlet install command.
When specified, the flag replace the installation of a Quadlet even if it already exists.

This allows users to reinstall a Quadlet without needing to manually run podman quadlet rm and podman quadlet install.
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add --replace flag to quadlet install
```
