### PR TITLE
docs: add missing manifest parameter to build API endpoints

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -492,7 +492,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// ---
 	// tags:
 	//  - images (compat)
-	// summary: Create image
+	// summary: Build image
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
 	//  - in: header
@@ -1494,7 +1494,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// ---
 	// tags:
 	//  - images
-	// summary: Create image
+	// summary: Build image
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
 	//  - in: header
@@ -1818,6 +1818,12 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    type: array
 	//    items:
 	//      type: string
+	//  - in: query
+	//    name: manifest
+	//    type: string
+	//    default:
+	//    description: |
+	//      Add the image to the specified manifest list. Creates a manifest list if it does not exist.
 	// produces:
 	// - application/json
 	// responses:
@@ -2166,6 +2172,12 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    type: array
 	//    items:
 	//      type: string
+	//  - in: query
+	//    name: manifest
+	//    type: string
+	//    default:
+	//    description: |
+	//      Add the image to the specified manifest list. Creates a manifest list if it does not exist.
 	// produces:
 	// - application/json
 	// responses:


### PR DESCRIPTION
Add manifest parameter documentation to `/libpod/build`, and `/libpod/local/build` endpoints in OpenAPI spec.

Fixes: https://github.com/containers/podman/issues/27261

**For reviewer:  I am not sure if I should add this to the compat API. The Docker documentation didn't mention `Manifest`, but our implementation will work with that query argument for the compat API.**

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
