### PR TITLE
fileperms: newer Go 1.13+ octal literal format

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -249,7 +249,7 @@ func ParseBuildOpts(cmd *cobra.Command, args []string, buildOpts *BuildFlagsWrap
 	var logFile *os.File
 	if cmd.Flag("logfile").Changed {
 		var err error
-		logFile, err = os.OpenFile(buildOpts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		logFile, err = os.OpenFile(buildOpts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -116,7 +116,7 @@ func commit(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if len(iidFile) > 0 {
-		if err = os.WriteFile(iidFile, []byte(response.Id), 0644); err != nil {
+		if err = os.WriteFile(iidFile, []byte(response.Id), 0o644); err != nil {
 			return fmt.Errorf("failed to write image ID: %w", err)
 		}
 	}

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -81,7 +81,7 @@ func export(_ *cobra.Command, args []string) error {
 		}
 		// open file here with O_WRONLY since on MacOS it can fail to open /dev/stderr in read mode for example
 		// https://github.com/containers/podman/issues/16870
-		file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/early_init_linux.go
+++ b/cmd/podman/early_init_linux.go
@@ -21,7 +21,7 @@ func setRLimits() error {
 
 func setUMask() {
 	// Be sure we can create directories with 0755 mode.
-	syscall.Umask(0022)
+	syscall.Umask(0o022)
 }
 
 func earlyInitHook() {

--- a/cmd/podman/generate/spec.go
+++ b/cmd/podman/generate/spec.go
@@ -59,7 +59,7 @@ func spec(_ *cobra.Command, args []string) error {
 	// if we are looking to print the output, do not mess it up by printing the path
 	// if we are using -v the user probably expects to pipe the output somewhere else
 	if len(opts.FileName) > 0 {
-		err = os.WriteFile(opts.FileName, report.Data, 0644)
+		err = os.WriteFile(opts.FileName, report.Data, 0o644)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/images/utils_linux.go
+++ b/cmd/podman/images/utils_linux.go
@@ -20,7 +20,7 @@ func setupPipe() (string, func() <-chan error, error) {
 		return "", nil, err
 	}
 	pipePath := filepath.Join(pipeDir, "saveio")
-	err = unix.Mkfifo(pipePath, 0600)
+	err = unix.Mkfifo(pipePath, 0o600)
 	if err != nil {
 		if e := os.RemoveAll(pipeDir); e != nil {
 			logrus.Errorf("Removing named pipe: %q", e)

--- a/cmd/podman/kube/generate.go
+++ b/cmd/podman/kube/generate.go
@@ -109,7 +109,7 @@ func generateKube(cmd *cobra.Command, args []string) error {
 		if err := fileutils.Exists(generateFile); err == nil {
 			return fmt.Errorf("cannot write to %q; file exists", generateFile)
 		}
-		if err := os.WriteFile(generateFile, content, 0644); err != nil {
+		if err := os.WriteFile(generateFile, content, 0o644); err != nil {
 			return fmt.Errorf("cannot write to %q: %w", generateFile, err)
 		}
 		return nil

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -170,7 +170,7 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if manifestPushOpts.DigestFile != "" {
-		if err := os.WriteFile(manifestPushOpts.DigestFile, []byte(digest), 0644); err != nil {
+		if err := os.WriteFile(manifestPushOpts.DigestFile, []byte(digest), 0o644); err != nil {
 			return err
 		}
 	}

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -111,7 +111,7 @@ func service(cmd *cobra.Command, args []string) error {
 			if err := syscall.Unlink(uri.Path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
-			mask := syscall.Umask(0177)
+			mask := syscall.Umask(0o177)
 			defer syscall.Umask(mask)
 		}
 	}
@@ -162,12 +162,12 @@ func resolveAPIURI(uri []string) (string, error) {
 
 		socketName := "podman.sock"
 		socketPath := filepath.Join(xdg, "podman", socketName)
-		if err := os.MkdirAll(filepath.Dir(socketPath), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
 			return "", err
 		}
 		return "unix://" + socketPath, nil
 	default:
-		if err := os.MkdirAll(filepath.Dir(registry.DefaultRootAPIPath), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(registry.DefaultRootAPIPath), 0o700); err != nil {
 			return "", err
 		}
 		return registry.DefaultRootAPIAddress, nil

--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -51,7 +51,7 @@ func logToKmsg(s string) bool {
 	}
 
 	if kmsgFile == nil {
-		f, err := os.OpenFile("/dev/kmsg", os.O_WRONLY, 0644)
+		f, err := os.OpenFile("/dev/kmsg", os.O_WRONLY, 0o644)
 		if err != nil {
 			noKmsg = true
 			return false

--- a/cmd/rootlessport/main.go
+++ b/cmd/rootlessport/main.go
@@ -84,7 +84,7 @@ func parent() error {
 	}
 
 	socketDir := filepath.Join(cfg.TmpDir, "rp")
-	err = os.MkdirAll(socketDir, 0700)
+	err = os.MkdirAll(socketDir, 0o700)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ outer:
 
 	// https://github.com/containers/podman/issues/11248
 	// Copy /dev/null to stdout and stderr to prevent SIGPIPE errors
-	if f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755); err == nil {
+	if f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0o755); err == nil {
 		unix.Dup2(int(f.Fd()), 1) //nolint:errcheck
 		unix.Dup2(int(f.Fd()), 2) //nolint:errcheck
 		f.Close()

--- a/internal/remote_build_helpers/utils_test.go
+++ b/internal/remote_build_helpers/utils_test.go
@@ -34,7 +34,7 @@ func TestTempFileManager(t *testing.T) {
 		secretPath := filepath.Join(tempdir, "secret.txt")
 
 		content := "test secret"
-		err := os.WriteFile(secretPath, []byte(content), 0600)
+		err := os.WriteFile(secretPath, []byte(content), 0o600)
 		assert.NoError(t, err)
 
 		filename, err := manager.CreateTempSecret(secretPath, tempdir)

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -99,7 +99,7 @@ func NewBoltState(path string, runtime *Runtime) (State, error) {
 		logrus.Infof("The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message.")
 	}
 
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		return nil, fmt.Errorf("opening database %s: %w", path, err)
 	}

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -279,7 +279,7 @@ func (s *BoltState) getDBCon() (*bolt.DB, error) {
 	// https://www.sqlite.org/src/artifact/c230a7a24?ln=994-1081
 	s.dbLock.Lock()
 
-	db, err := bolt.Open(s.dbPath, 0600, nil)
+	db, err := bolt.Open(s.dbPath, 0o600, nil)
 	if err != nil {
 		return nil, fmt.Errorf("opening database %s: %w", s.dbPath, err)
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -551,7 +551,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	}
 
 	artifacts := filepath.Join(c.config.StaticDir, artifactsDir)
-	if err := os.MkdirAll(artifacts, 0755); err != nil {
+	if err := os.MkdirAll(artifacts, 0o755); err != nil {
 		return fmt.Errorf("creating artifacts directory: %w", err)
 	}
 
@@ -685,7 +685,7 @@ func (c *Container) refresh() error {
 			return err
 		}
 		root := filepath.Join(c.runtime.config.Engine.TmpDir, "containers-root", c.ID())
-		if err := os.MkdirAll(root, 0755); err != nil {
+		if err := os.MkdirAll(root, 0o755); err != nil {
 			return fmt.Errorf("creating userNS tmpdir for container %s: %w", c.ID(), err)
 		}
 		if err := idtools.SafeChown(root, c.RootUID(), c.RootGID()); err != nil {
@@ -1827,7 +1827,7 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 	}
 	defer unix.Close(dirfd)
 
-	err = unix.Mkdirat(dirfd, "etc", 0755)
+	err = unix.Mkdirat(dirfd, "etc", 0o755)
 	if err != nil && !os.IsExist(err) {
 		return "", fmt.Errorf("create /etc: %w", err)
 	}
@@ -2437,7 +2437,7 @@ func (c *Container) saveSpec(spec *spec.Spec) error {
 	if err != nil {
 		return fmt.Errorf("exporting runtime spec for container %s to JSON: %w", c.ID(), err)
 	}
-	if err := os.WriteFile(jsonPath, fileJSON, 0644); err != nil {
+	if err := os.WriteFile(jsonPath, fileJSON, 0o644); err != nil {
 		return fmt.Errorf("writing runtime spec JSON for container %s to disk: %w", c.ID(), err)
 	}
 
@@ -2534,7 +2534,7 @@ func (c *Container) recreateIntermediateMountpointUser() (string, error) {
 			tmpDir = "/tmp"
 		}
 		dir := filepath.Join(tmpDir, fmt.Sprintf("intermediate-mountpoint-%d.%d", rootless.GetRootlessUID(), i))
-		err := os.Mkdir(dir, 0755)
+		err := os.Mkdir(dir, 0o755)
 		if err != nil {
 			if !errors.Is(err, os.ErrExist) {
 				return "", err
@@ -2765,7 +2765,7 @@ func (c *Container) extractSecretToCtrStorage(secr *ContainerSecret) error {
 	if err != nil {
 		return fmt.Errorf("unable to extract secret: %w", err)
 	}
-	err = os.WriteFile(secretFile, data, 0644)
+	err = os.WriteFile(secretFile, data, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to create %s: %w", secretFile, err)
 	}

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -186,7 +186,7 @@ func (c *Container) createInitRootfs() error {
 		return fmt.Errorf("getting runtime temporary directory: %w", err)
 	}
 	tmpDir = filepath.Join(tmpDir, "infra-container")
-	err = os.MkdirAll(tmpDir, 0755)
+	err = os.MkdirAll(tmpDir, 0o755)
 	if err != nil {
 		return fmt.Errorf("creating infra container temporary directory: %w", err)
 	}
@@ -932,7 +932,7 @@ func (c *Container) resolveWorkDir() error {
 		// we need to return the full error.
 		return fmt.Errorf("detecting workdir %q on container %s: %w", workdir, c.ID(), err)
 	}
-	if err := os.MkdirAll(resolvedWorkdir, 0755); err != nil {
+	if err := os.MkdirAll(resolvedWorkdir, 0o755); err != nil {
 		return fmt.Errorf("creating container %s workdir: %w", c.ID(), err)
 	}
 
@@ -1010,7 +1010,7 @@ func (c *Container) mountNotifySocket(g generate.Generator) error {
 
 	notifyDir := filepath.Join(c.bundlePath(), "notify")
 	logrus.Debugf("Checking notify %q dir", notifyDir)
-	if err := os.MkdirAll(notifyDir, 0755); err != nil {
+	if err := os.MkdirAll(notifyDir, 0o755); err != nil {
 		if !os.IsExist(err) {
 			return fmt.Errorf("unable to create notify %q dir: %w", notifyDir, err)
 		}
@@ -1218,7 +1218,7 @@ func (c *Container) exportCheckpoint(options ContainerCheckpointOptions) error {
 
 	// Create an archive for each volume associated with the container
 	if !options.IgnoreVolumes {
-		if err := os.MkdirAll(expVolDir, 0700); err != nil {
+		if err := os.MkdirAll(expVolDir, 0o700); err != nil {
 			return fmt.Errorf("creating volumes export directory %q: %w", expVolDir, err)
 		}
 
@@ -1278,7 +1278,7 @@ func (c *Container) exportCheckpoint(options ContainerCheckpointOptions) error {
 	}
 	defer outFile.Close()
 
-	if err := os.Chmod(options.TargetFile, 0600); err != nil {
+	if err := os.Chmod(options.TargetFile, 0o600); err != nil {
 		return err
 	}
 
@@ -2892,7 +2892,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 			if err != nil {
 				return "", "", fmt.Errorf("failed to create temporary passwd file: %w", err)
 			}
-			if err := os.Chmod(passwdFile, 0644); err != nil {
+			if err := os.Chmod(passwdFile, 0o644); err != nil {
 				return "", "", err
 			}
 			passwdPath = passwdFile
@@ -2903,7 +2903,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 				return "", "", fmt.Errorf("looking up location of container %s /etc/passwd: %w", c.ID(), err)
 			}
 
-			f, err := os.OpenFile(containerPasswd, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+			f, err := os.OpenFile(containerPasswd, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 			if err != nil {
 				return "", "", fmt.Errorf("container %s: %w", c.ID(), err)
 			}
@@ -2938,7 +2938,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 			if err != nil {
 				return "", "", fmt.Errorf("failed to create temporary group file: %w", err)
 			}
-			if err := os.Chmod(groupFile, 0644); err != nil {
+			if err := os.Chmod(groupFile, 0o644); err != nil {
 				return "", "", err
 			}
 			groupPath = groupFile
@@ -2949,7 +2949,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 				return "", "", fmt.Errorf("looking up location of container %s /etc/group: %w", c.ID(), err)
 			}
 
-			f, err := os.OpenFile(containerGroup, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+			f, err := os.OpenFile(containerGroup, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 			if err != nil {
 				return "", "", fmt.Errorf("container %s: %w", c.ID(), err)
 			}

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -29,12 +29,12 @@ type EventLogFile struct {
 // newLogFileEventer creates a new EventLogFile eventer
 func newLogFileEventer(options EventerOptions) (*EventLogFile, error) {
 	// Create events log dir
-	if err := os.MkdirAll(filepath.Dir(options.LogFilePath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(options.LogFilePath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating events dirs: %w", err)
 	}
 	// We have to make sure the file is created otherwise reading events will hang.
 	// https://github.com/containers/podman/issues/15688
-	fd, err := os.OpenFile(options.LogFilePath, os.O_RDONLY|os.O_CREATE, 0600)
+	fd, err := os.OpenFile(options.LogFilePath, os.O_RDONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create event log file: %w", err)
 	}
@@ -64,7 +64,7 @@ func (e EventLogFile) Write(ee Event) error {
 }
 
 func (e EventLogFile) writeString(s string) error {
-	f, err := os.OpenFile(e.options.LogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0700)
+	f, err := os.OpenFile(e.options.LogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o700)
 	if err != nil {
 		return err
 	}

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -407,7 +407,7 @@ func (c *Container) witeToFileHealthCheckResults(path string, result define.Heal
 	if err != nil {
 		return fmt.Errorf("unable to marshall healthchecks for writing: %w", err)
 	}
-	return os.WriteFile(path, newResults, 0700)
+	return os.WriteFile(path, newResults, 0o700)
 }
 
 func (c *Container) getHealthCheckLogDestination() string {

--- a/libpod/lock/file/file_lock.go
+++ b/libpod/lock/file/file_lock.go
@@ -27,7 +27,7 @@ func CreateFileLock(path string) (*FileLocks, error) {
 	if err == nil {
 		return nil, fmt.Errorf("directory %s exists: %w", path, syscall.EEXIST)
 	}
-	if err := os.MkdirAll(path, 0711); err != nil {
+	if err := os.MkdirAll(path, 0o711); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func (locks *FileLocks) AllocateLock() (uint32, error) {
 	id := uint32(0)
 	for ; ; id++ {
 		path := locks.getLockPath(id)
-		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 		if err != nil {
 			if os.IsExist(err) {
 				continue
@@ -103,7 +103,7 @@ func (locks *FileLocks) AllocateGivenLock(lck uint32) error {
 		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
-	f, err := os.OpenFile(locks.getLockPath(lck), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	f, err := os.OpenFile(locks.getLockPath(lck), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 	if err != nil {
 		return fmt.Errorf("creating lock %d: %w", lck, err)
 	}

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -149,10 +149,10 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	runtime.persistDir = filepath.Join(runtime.tmpDir, "persist")
 
 	// Create the exit files and attach sockets directories
-	if err := os.MkdirAll(runtime.exitsDir, 0750); err != nil {
+	if err := os.MkdirAll(runtime.exitsDir, 0o750); err != nil {
 		return nil, fmt.Errorf("creating OCI runtime exit files directory: %w", err)
 	}
-	if err := os.MkdirAll(runtime.persistDir, 0750); err != nil {
+	if err := os.MkdirAll(runtime.persistDir, 0o750); err != nil {
 		return nil, fmt.Errorf("creating OCI runtime persist directory: %w", err)
 	}
 	return runtime, nil
@@ -1285,7 +1285,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 	// This is needed as conmon writes the exit and oom file in the given persist directory path as just "exit" and "oom"
 	// So creating a directory with the container ID under the persist dir will help keep track of which container the
 	// exit and oom files belong to.
-	if err := os.MkdirAll(persistDir, 0750); err != nil {
+	if err := os.MkdirAll(persistDir, 0o750); err != nil {
 		return nil, fmt.Errorf("creating OCI runtime oom files directory for ctr %q: %w", ctr.ID(), err)
 	}
 

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -782,7 +782,7 @@ func (c *Container) prepareProcessExec(options *ExecOptions, env []string, sessi
 		return nil, err
 	}
 
-	if err := os.WriteFile(f.Name(), processJSON, 0644); err != nil {
+	if err := os.WriteFile(f.Name(), processJSON, 0o644); err != nil {
 		return nil, err
 	}
 	return f, nil

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1040,7 +1040,7 @@ func WithLogPath(path string) CtrCreateOption {
 		}
 		if isDirectory(path) {
 			containerDir := filepath.Join(path, ctr.ID())
-			if err := os.Mkdir(containerDir, 0755); err != nil {
+			if err := os.Mkdir(containerDir, 0o755); err != nil {
 				return fmt.Errorf("failed to create container log directory %s: %w", containerDir, err)
 			}
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -348,7 +348,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	}
 
 	// Make the static files directory if it does not exist
-	if err := os.MkdirAll(runtime.config.Engine.StaticDir, 0700); err != nil {
+	if err := os.MkdirAll(runtime.config.Engine.StaticDir, 0o700); err != nil {
 		// The directory is allowed to exist
 		if !errors.Is(err, os.ErrExist) {
 			return fmt.Errorf("creating runtime static files directory %q: %w", runtime.config.Engine.StaticDir, err)
@@ -356,7 +356,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	}
 
 	// Create the TmpDir if needed
-	if err := os.MkdirAll(runtime.config.Engine.TmpDir, 0751); err != nil {
+	if err := os.MkdirAll(runtime.config.Engine.TmpDir, 0o751); err != nil {
 		return fmt.Errorf("creating runtime temporary files directory: %w", err)
 	}
 
@@ -364,7 +364,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	// This is not strictly necessary at this point, but the path not
 	// existing can cause troubles with DB path validation on OSTree based
 	// systems. Ref: https://github.com/containers/podman/issues/23515
-	if err := os.MkdirAll(runtime.config.Engine.VolumePath, 0700); err != nil {
+	if err := os.MkdirAll(runtime.config.Engine.VolumePath, 0o700); err != nil {
 		return fmt.Errorf("creating runtime volume path directory: %w", err)
 	}
 
@@ -886,7 +886,7 @@ func (r *Runtime) refresh(ctx context.Context, alivePath string) error {
 	}
 
 	// Create a file indicating the runtime is alive and ready
-	file, err := os.OpenFile(alivePath, os.O_RDONLY|os.O_CREATE, 0644)
+	file, err := os.OpenFile(alivePath, os.O_RDONLY|os.O_CREATE, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating runtime status file: %w", err)
 	}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -472,7 +472,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	}()
 
 	ctr.config.SecretsPath = filepath.Join(ctr.config.StaticDir, "secrets")
-	err = os.MkdirAll(ctr.config.SecretsPath, 0755)
+	err = os.MkdirAll(ctr.config.SecretsPath, 0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -579,7 +579,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 
 	if useDevShm && !MountExists(ctr.config.Spec.Mounts, "/dev/shm") && ctr.config.ShmDir == "" && !ctr.config.NoShm {
 		ctr.config.ShmDir = filepath.Join(ctr.bundlePath(), "shm")
-		if err := os.MkdirAll(ctr.config.ShmDir, 0700); err != nil {
+		if err := os.MkdirAll(ctr.config.ShmDir, 0o700); err != nil {
 			if !os.IsExist(err) {
 				return nil, fmt.Errorf("unable to create shm dir: %w", err)
 			}

--- a/libpod/runtime_linux.go
+++ b/libpod/runtime_linux.go
@@ -34,7 +34,7 @@ func checkCgroups2UnifiedMode(runtime *Runtime) {
 			msg := fmt.Sprintf("RunRoot is pointing to a path (%s) which is not writable. Most likely podman will fail.", runtime.storageConfig.RunRoot)
 			if errors.Is(err, os.ErrNotExist) {
 				// if dir does not exist, try to create it
-				if err := os.MkdirAll(runtime.storageConfig.RunRoot, 0700); err != nil {
+				if err := os.MkdirAll(runtime.storageConfig.RunRoot, 0o700); err != nil {
 					logrus.Warn(msg)
 				}
 			} else {
@@ -58,7 +58,7 @@ func (r *Runtime) checkBootID(runtimeAliveFile string) error {
 			}
 		} else {
 			// Write the current boot ID to the alive file.
-			if err := os.WriteFile(runtimeAliveFile, systemBootID, 0644); err != nil {
+			if err := os.WriteFile(runtimeAliveFile, systemBootID, 0o644); err != nil {
 				return fmt.Errorf("writing boot ID to runtime alive file: %w", err)
 			}
 		}

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -162,7 +162,7 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 	} else {
 		// Create the mountpoint of this volume
 		volPathRoot := filepath.Join(r.config.Engine.VolumePath, volume.config.Name)
-		if err := os.MkdirAll(volPathRoot, 0700); err != nil {
+		if err := os.MkdirAll(volPathRoot, 0o700); err != nil {
 			return nil, fmt.Errorf("creating volume directory %q: %w", volPathRoot, err)
 		}
 		if err := idtools.SafeChown(volPathRoot, volume.config.UID, volume.config.GID); err != nil {
@@ -206,7 +206,7 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 		}
 
 		fullVolPath := filepath.Join(volPathRoot, "_data")
-		if err := os.MkdirAll(fullVolPath, 0755); err != nil {
+		if err := os.MkdirAll(fullVolPath, 0o755); err != nil {
 			return nil, fmt.Errorf("creating volume directory %q: %w", fullVolPath, err)
 		}
 		if err := idtools.SafeChown(fullVolPath, volume.config.UID, volume.config.GID); err != nil {

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -66,7 +66,7 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	// c/storage is set up *after* the DB - so even though we use the c/s
 	// root (or, for transient, runroot) dir, we need to make the dir
 	// ourselves.
-	if err := os.MkdirAll(basePath, 0700); err != nil {
+	if err := os.MkdirAll(basePath, 0o700); err != nil {
 		return nil, fmt.Errorf("creating root directory: %w", err)
 	}
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -41,7 +41,7 @@ func systemContextForAuthFile(t *testing.T, fileContents string) *types.SystemCo
 	f, err := os.CreateTemp(t.TempDir(), "auth.json")
 	require.NoError(t, err)
 	path := f.Name()
-	err = os.WriteFile(path, []byte(fileContents), 0700)
+	err = os.WriteFile(path, []byte(fileContents), 0o700)
 	require.NoError(t, err)
 	return &types.SystemContext{AuthFilePath: path}
 }

--- a/pkg/bindings/containers/checkpoint.go
+++ b/pkg/bindings/containers/checkpoint.go
@@ -43,7 +43,7 @@ func Checkpoint(ctx context.Context, nameOrID string, options *CheckpointOptions
 		return &report, response.Process(&report)
 	}
 
-	f, err := os.OpenFile(*options.Export, os.O_RDWR|os.O_CREATE, 0600)
+	f, err := os.OpenFile(*options.Export, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -249,7 +249,7 @@ func (b *bindingTest) PodcreateAndExpose(name *string, port *string) {
 
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// make cache dir
-	err := os.MkdirAll(ImageCacheDir, 0777)
+	err := os.MkdirAll(ImageCacheDir, 0o777)
 	Expect(err).ToNot(HaveOccurred())
 
 	// If running localized tests, the cache dir is created and populated. if the

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -999,7 +999,7 @@ func putSignature(manifestBlob []byte, mech signature.SigningMechanism, sigStore
 		return err
 	}
 	signatureDir := fmt.Sprintf("%s@%s=%s", sigStoreDir, instanceDigest.Algorithm(), instanceDigest.Hex())
-	if err := os.MkdirAll(signatureDir, 0751); err != nil {
+	if err := os.MkdirAll(signatureDir, 0o751); err != nil {
 		// The directory is allowed to exist
 		if !errors.Is(err, fs.ErrExist) {
 			return err
@@ -1009,5 +1009,5 @@ func putSignature(manifestBlob []byte, mech signature.SigningMechanism, sigStore
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(signatureDir, sigFilename), newSig, 0644)
+	return os.WriteFile(filepath.Join(signatureDir, sigFilename), newSig, 0o644)
 }

--- a/pkg/domain/infra/abi/quadlet.go
+++ b/pkg/domain/infra/abi/quadlet.go
@@ -126,7 +126,7 @@ func (ic *ContainerEngine) QuadletInstall(ctx context.Context, pathsOrURLs []str
 	installDir := systemdquadlet.GetInstallUnitDirPath(rootless.IsRootless())
 	logrus.Debugf("Going to install Quadlet to directory %s", installDir)
 
-	if err := os.MkdirAll(installDir, 0755); err != nil {
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		return nil, fmt.Errorf("unable to create Quadlet install path %s: %w", installDir, err)
 	}
 
@@ -274,7 +274,7 @@ func (ic *ContainerEngine) installQuadlet(_ context.Context, path, destName, ins
 		return "", fmt.Errorf("%q is not a supported Quadlet file type", filepath.Ext(finalPath))
 	}
 
-	file, err := os.OpenFile(finalPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(finalPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return "", fmt.Errorf("a Quadlet with name %s already exists, refusing to overwrite", filepath.Base(finalPath))
@@ -309,7 +309,7 @@ func (ic *ContainerEngine) installQuadlet(_ context.Context, path, destName, ins
 // appendStringToFile appends the given text to the specified file.
 // If the file does not exist, it will be created with 0644 permissions.
 func appendStringToFile(filePath, text string) error {
-	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -334,7 +334,7 @@ func (ir *ImageEngine) Save(_ context.Context, nameOrID string, tags []string, o
 			// This code was added to allow for opening stdout replacing
 			// os.Create(opts.Output) which was attempting to open the file
 			// for read/write which fails on Darwin platforms
-			f, err = os.OpenFile(opts.Output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			f, err = os.OpenFile(opts.Output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 		}
 	}
 	if err != nil {
@@ -364,7 +364,7 @@ func (ir *ImageEngine) Save(_ context.Context, nameOrID string, tags []string, o
 			return fmt.Errorf("%q already exists as a regular file", opts.Output)
 		}
 	case os.IsNotExist(err):
-		if err := os.Mkdir(opts.Output, 0755); err != nil {
+		if err := os.Mkdir(opts.Output, 0o755); err != nil {
 			return err
 		}
 	default:

--- a/pkg/farm/list_builder.go
+++ b/pkg/farm/list_builder.go
@@ -126,7 +126,7 @@ func (l *listLocal) build(ctx context.Context, images map[entities.BuildReport]e
 
 	// Write the manifest list's ID file if we're expected to
 	if l.options.iidFile != "" {
-		if err := os.WriteFile(l.options.iidFile, []byte("sha256:"+listID), 0644); err != nil {
+		if err := os.WriteFile(l.options.iidFile, []byte("sha256:"+listID), 0o644); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -288,7 +288,7 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 		if err != nil {
 			return nil, nil, err
 		}
-		err = os.Chmod(kdFile.Path, 0744)
+		err = os.Chmod(kdFile.Path, 0o744)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/machine/define/vmfile.go
+++ b/pkg/machine/define/vmfile.go
@@ -108,7 +108,7 @@ func (m *VMFile) makeSymlink(symlink *string) error {
 	}
 	sl := filepath.Join(homeDir, ".podman", *symlink)
 	// make the symlink dir and throw away if it already exists
-	if err := os.MkdirAll(filepath.Dir(sl), 0700); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := os.MkdirAll(filepath.Dir(sl), 0o700); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	m.Symlink = &sl

--- a/pkg/machine/define/vmfile_test.go
+++ b/pkg/machine/define/vmfile_test.go
@@ -59,7 +59,7 @@ func TestNewMachineFile(t *testing.T) {
 
 	p := "/var/tmp/podman/my.sock"
 	longp := filepath.Join(longTemp, utils.RandomString(100), "my.sock")
-	err := os.MkdirAll(filepath.Dir(longp), 0755)
+	err := os.MkdirAll(filepath.Dir(longp), 0o755)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -229,7 +229,7 @@ var _ = Describe("run basic podman commands", func() {
 
 		testString := "abcdefg1234567"
 		testFile := "testfile"
-		err = os.WriteFile(filepath.Join(dir, testFile), []byte(testString), 0644)
+		err = os.WriteFile(filepath.Join(dir, testFile), []byte(testString), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		name := randomString()

--- a/pkg/machine/e2e/cp_test.go
+++ b/pkg/machine/e2e/cp_test.go
@@ -39,7 +39,7 @@ var _ = Describe("run cp commands", func() {
 		sourceFileStat, err := os.Stat(filepath.Join(sourceDir, file))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.MkdirAll(filepath.Join(sourceDir, directory), 0755)
+		err = os.MkdirAll(filepath.Join(sourceDir, directory), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Get the directory stat to check permissions later
@@ -181,7 +181,7 @@ var _ = Describe("run cp commands", func() {
 		// Write a file header to the tar
 		err = tw.WriteHeader(&tar.Header{
 			Name:       path.Join(stdinDirectory, stdinFile),
-			Mode:       0755,
+			Mode:       0o755,
 			Uid:        1000,
 			ModTime:    now,
 			ChangeTime: now,
@@ -262,7 +262,7 @@ var _ = Describe("run cp commands", func() {
 		err = f.Close()
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.MkdirAll(directoryPath, 0755)
+		err = os.MkdirAll(directoryPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		f, err = os.Create(fileInDirectoryPath)
@@ -324,7 +324,7 @@ var _ = Describe("run cp commands", func() {
 		if runtime.GOOS != "windows" {
 			// try to copy the file to a location on the host where permission will get denied
 			hostDirPath := filepath.Join(GinkgoT().TempDir(), "test-guest-copy-dir")
-			err = os.MkdirAll(hostDirPath, 0444)
+			err = os.MkdirAll(hostDirPath, 0o444)
 			Expect(err).ToNot(HaveOccurred())
 			hostFileInDirPath := filepath.Join(hostDirPath, file)
 			session, err = mb.setCmd(cp.withQuiet().withSrc(name + ":~/" + file).withDest(hostFileInDirPath)).run()

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -496,7 +496,7 @@ var _ = Describe("podman machine init", func() {
 	It("verify a podman 4 config does not break podman 5", func() {
 		vmName := "foobar-machine"
 		configDir := filepath.Join(testDir, ".config", "containers", "podman", "machine", testProvider.VMType().String())
-		if err := os.MkdirAll(configDir, 0755); err != nil {
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
 			Expect(err).ToNot(HaveOccurred())
 		}
 		f, err := os.Create(filepath.Join(configDir, fmt.Sprintf("%s.json", vmName)))
@@ -596,10 +596,10 @@ var _ = Describe("podman machine init", func() {
 			Skip("Test is only for AppleHv with arm64 architecture")
 		}
 		configDir := filepath.Join(testDir, ".config", "containers")
-		err := os.MkdirAll(configDir, 0755)
+		err := os.MkdirAll(configDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.WriteFile(filepath.Join(configDir, "containers.conf"), rosettaConfig, 0644)
+		err = os.WriteFile(filepath.Join(configDir, "containers.conf"), rosettaConfig, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		i := initMachine{}

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -92,7 +92,7 @@ var _ = Describe("podman machine init - windows only", func() {
 		distName := fmt.Sprintf("podman-%s", name)
 		exportedPath := filepath.Join(testDir, "bogus.tar")
 		distrDir := filepath.Join(testDir, "testDistro")
-		err := os.Mkdir(distrDir, 0755)
+		err := os.Mkdir(distrDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// create a bogus machine

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -124,7 +124,7 @@ func setup() (string, *machineTestBuilder) {
 	if err != nil {
 		Fail(fmt.Sprintf("failed to create home directory: %q", err))
 	}
-	if err := os.MkdirAll(filepath.Join(homeDir, ".ssh"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(homeDir, ".ssh"), 0o700); err != nil {
 		Fail(fmt.Sprintf("failed to create ssh dir: %q", err))
 	}
 	sshConfig, err := os.Create(filepath.Join(homeDir, ".ssh", "config"))

--- a/pkg/machine/env/dir.go
+++ b/pkg/machine/env/dir.go
@@ -22,7 +22,7 @@ func GetDataDir(vmType define.VMType) (string, error) {
 	if err := fileutils.Exists(dataDir); !errors.Is(err, os.ErrNotExist) {
 		return dataDir, nil
 	}
-	mkdirErr := os.MkdirAll(dataDir, 0755)
+	mkdirErr := os.MkdirAll(dataDir, 0o755)
 	return dataDir, mkdirErr
 }
 
@@ -34,7 +34,7 @@ func GetGlobalDataDir() (string, error) {
 		return "", err
 	}
 
-	return dataDir, os.MkdirAll(dataDir, 0755)
+	return dataDir, os.MkdirAll(dataDir, 0o755)
 }
 
 func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
@@ -81,16 +81,16 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 	}
 
 	// make sure all machine dirs are present
-	if err := os.MkdirAll(rtDir, 0755); err != nil {
+	if err := os.MkdirAll(rtDir, 0o755); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		return nil, err
 	}
 
 	// Because this is a mkdirall, we make the image cache dir
 	// which is a subdir of datadir (so the datadir is made anyway)
-	err = os.MkdirAll(imageCacheDir.GetPath(), 0755)
+	err = os.MkdirAll(imageCacheDir.GetPath(), 0o755)
 
 	return &dirs, err
 }
@@ -116,7 +116,7 @@ func GetConfDir(vmType define.VMType) (string, error) {
 	if err := fileutils.Exists(confDir); !errors.Is(err, os.ErrNotExist) {
 		return confDir, nil
 	}
-	mkdirErr := os.MkdirAll(confDir, 0755)
+	mkdirErr := os.MkdirAll(confDir, 0o755)
 	return confDir, mkdirErr
 }
 

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -99,7 +99,7 @@ func (h HyperVStubber) CreateVM(_ define.CreateVMOpts, mc *vmconfigs.MachineConf
 			Contents: ignition.Resource{
 				Source: ignition.EncodeDataURLPtr(hyperVVsockNMConnection),
 			},
-			Mode: ignition.IntToPtr(0600),
+			Mode: ignition.IntToPtr(0o600),
 		},
 	})
 

--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -75,7 +75,7 @@ func (ign *DynamicIgnition) Write() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(ign.WritePath, b, 0644)
+	return os.WriteFile(ign.WritePath, b, 0o644)
 }
 
 func (ign *DynamicIgnition) getUsers() []PasswdUser {
@@ -242,7 +242,7 @@ func getDirs(usrName string) []Directory {
 				Path:  d,
 				User:  GetNodeUsr(usrName),
 			},
-			DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0755)},
+			DirectoryEmbedded1: DirectoryEmbedded1{Mode: IntToPtr(0o755)},
 		}
 		dirs[i] = newDir
 	}
@@ -266,7 +266,7 @@ func getFiles(usrName string, uid int, rootful bool, vmtype define.VMType, _ boo
 			Contents: Resource{
 				Source: EncodeDataURLPtr(""),
 			},
-			Mode: IntToPtr(0644),
+			Mode: IntToPtr(0o644),
 		},
 	})
 
@@ -301,7 +301,7 @@ pids_limit=0
 			Contents: Resource{
 				Source: EncodeDataURLPtr(containers),
 			},
-			Mode: IntToPtr(0744),
+			Mode: IntToPtr(0o744),
 		},
 	})
 
@@ -319,7 +319,7 @@ pids_limit=0
 				Contents: Resource{
 					Source: EncodeDataURLPtr(etcSubUID),
 				},
-				Mode: IntToPtr(0744),
+				Mode: IntToPtr(0o744),
 			},
 		})
 	}
@@ -337,7 +337,7 @@ pids_limit=0
 			Contents: Resource{
 				Source: EncodeDataURLPtr(fmt.Sprintf("%s\n", vmtype.String())),
 			},
-			Mode: IntToPtr(0644),
+			Mode: IntToPtr(0o644),
 		},
 	})
 
@@ -351,7 +351,7 @@ pids_limit=0
 			Contents: Resource{
 				Source: EncodeDataURLPtr(GetPodmanDockerTmpConfig(uid, rootful, true)),
 			},
-			Mode: IntToPtr(0644),
+			Mode: IntToPtr(0o644),
 		},
 	})
 
@@ -365,7 +365,7 @@ pids_limit=0
 				Contents: Resource{
 					Source: EncodeDataURLPtr(fmt.Sprintf("[zram0]\nzram-size=%d\n", swap)),
 				},
-				Mode: IntToPtr(0644),
+				Mode: IntToPtr(0o644),
 			},
 		})
 	}
@@ -472,7 +472,7 @@ func prepareCertFile(fpath string, name string) (File, error) {
 			Contents: Resource{
 				Source: EncodeDataURLPtr(string(b)),
 			},
-			Mode: IntToPtr(0644),
+			Mode: IntToPtr(0o644),
 		},
 	}
 	return file, nil
@@ -524,7 +524,7 @@ func getSSLFile(path, content string) File {
 			Contents: Resource{
 				Source: EncodeDataURLPtr(content),
 			},
-			Mode: IntToPtr(0644),
+			Mode: IntToPtr(0o644),
 		},
 	}
 }
@@ -610,7 +610,7 @@ func (i *IgnitionBuilder) BuildWithIgnitionFile(ignPath string) error {
 		return err
 	}
 
-	return os.WriteFile(i.dynamicIgnition.WritePath, inputIgnition, 0644)
+	return os.WriteFile(i.dynamicIgnition.WritePath, inputIgnition, 0o644)
 }
 
 // Build writes the internal `DynamicIgnition` config to its write path
@@ -632,7 +632,7 @@ func (i *IgnitionBuilder) AddPlaybook(contents string, destPath string, username
 			Contents: Resource{
 				Source: EncodeDataURLPtr(contents),
 			},
-			Mode: IntToPtr(0744),
+			Mode: IntToPtr(0o744),
 		},
 	}
 

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -22,7 +22,7 @@ func CreateSSHKeys(writeLocation string) (string, error) {
 	if err := fileutils.Exists(writeLocation); err == nil {
 		return "", fmt.Errorf("SSH key already exists: %s", writeLocation)
 	}
-	if err := os.MkdirAll(filepath.Dir(writeLocation), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(writeLocation), 0o700); err != nil {
 		return "", err
 	}
 	if err := generatekeys(writeLocation); err != nil {

--- a/pkg/machine/machine_common.go
+++ b/pkg/machine/machine_common.go
@@ -12,12 +12,12 @@ import (
 
 // GetDevNullFiles returns pointers to Read-only and Write-only DevNull files
 func GetDevNullFiles() (*os.File, *os.File, error) {
-	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
+	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0o755)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
+	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0o755)
 	if err != nil {
 		if e := dnr.Close(); e != nil {
 			err = e

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -283,7 +283,7 @@ func GetWinProxyStateDir(name string, vmtype define.VMType) (string, error) {
 		return "", err
 	}
 	stateDir := filepath.Join(dir, name)
-	if err = os.MkdirAll(stateDir, 0755); err != nil {
+	if err = os.MkdirAll(stateDir, 0o755); err != nil {
 		return "", err
 	}
 

--- a/pkg/machine/os/ostree.go
+++ b/pkg/machine/os/ostree.go
@@ -54,7 +54,7 @@ func (dist *OSTree) Apply(image string, _ ApplyOptions) error {
 			if err != nil {
 				return err
 			}
-			if err := os.Chmod(dir, 0755); err != nil {
+			if err := os.Chmod(dir, 0o755); err != nil {
 				return err
 			}
 
@@ -81,7 +81,7 @@ func (dist *OSTree) Apply(image string, _ ApplyOptions) error {
 			return err
 		}
 
-		if err := os.Chmod(dir, 0755); err != nil {
+		if err := os.Chmod(dir, 0o755); err != nil {
 			return err
 		}
 

--- a/pkg/machine/ports/ports.go
+++ b/pkg/machine/ports/ports.go
@@ -198,7 +198,7 @@ func storePortAllocations(ports map[int]struct{}) error {
 	}
 
 	opts := &ioutils.AtomicFileWriterOptions{ExplicitCommit: true}
-	w, err := ioutils.NewAtomicFileWriterWithOpts(filepath.Join(portDir, portAllocFileName), 0644, opts)
+	w, err := ioutils.NewAtomicFileWriterWithOpts(filepath.Join(portDir, portAllocFileName), 0o644, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -116,7 +116,7 @@ type Monitor struct {
 // NewQMPMonitor creates the monitor subsection of our vm
 func NewQMPMonitor(name string, machineRuntimeDir *define.VMFile) (Monitor, error) {
 	if err := fileutils.Exists(machineRuntimeDir.GetPath()); errors.Is(err, fs.ErrNotExist) {
-		if err := os.MkdirAll(machineRuntimeDir.GetPath(), 0755); err != nil {
+		if err := os.MkdirAll(machineRuntimeDir.GetPath(), 0o755); err != nil {
 			return Monitor{}, err
 		}
 	}

--- a/pkg/machine/wsl/filelock.go
+++ b/pkg/machine/wsl/filelock.go
@@ -21,7 +21,7 @@ func lockFile(path string) (*fileLock, error) {
 	// In the future we may want to switch this to an async open vs the win32 API
 	// to bring support for timeouts, so we don't export the current underlying
 	// File object.
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, &fs.PathError{
 			Op:   "lock",

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -86,7 +86,7 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 
 	distDir := filepath.Join(vmDataDir, "wsldist")
 	distTarget := filepath.Join(distDir, name)
-	if err := os.MkdirAll(distDir, 0755); err != nil {
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
 		return "", fmt.Errorf("could not create wsldist directory: %w", err)
 	}
 
@@ -430,11 +430,11 @@ func getElevatedOutputFile(mode int) (*os.File, error) {
 		return nil, err
 	}
 
-	if err = os.MkdirAll(dir, 0755); err != nil {
+	if err = os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
 
-	return os.OpenFile(name, mode, 0644)
+	return os.OpenFile(name, mode, 0o644)
 }
 
 func isMsiError(err error) bool {

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -247,7 +247,7 @@ func getUserModeNetDir() (string, error) {
 	}
 
 	dir := filepath.Join(vmDataDir, userModeDist)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("could not create %s directory: %w", userModeDist, err)
 	}
 
@@ -261,7 +261,7 @@ func getUserModeNetEntriesDir() (string, error) {
 	}
 
 	dir := filepath.Join(netDir, "entries")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("could not create %s/entries directory: %w", userModeDist, err)
 	}
 
@@ -275,7 +275,7 @@ func addUserModeNetEntry(mc *vmconfigs.MachineConfig) error {
 	}
 
 	path := filepath.Join(entriesDir, env.WithPodmanPrefix(mc.Name))
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("could not add user-mode networking registration: %w", err)
 	}

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -199,11 +199,11 @@ func reboot() error {
 	if err != nil {
 		return fmt.Errorf("could not determine data directory: %w", err)
 	}
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return fmt.Errorf("could not create data directory: %w", err)
 	}
 	commFile := filepath.Join(dataDir, "podman-relaunch.dat")
-	if err := os.WriteFile(commFile, []byte(encoded), 0600); err != nil {
+	if err := os.WriteFile(commFile, []byte(encoded), 0o600); err != nil {
 		return fmt.Errorf("could not serialize command state: %w", err)
 	}
 

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -209,7 +209,7 @@ func copyMappings(from, to string) error {
 	if bytes.Contains(content, []byte("4294967295")) {
 		content = []byte("0 0 1\n1 1 4294967294\n")
 	}
-	return os.WriteFile(to, content, 0600)
+	return os.WriteFile(to, content, 0o600)
 }
 
 func becomeRootInUserNS(pausePid string) (_ bool, _ int, retErr error) {
@@ -310,13 +310,13 @@ func becomeRootInUserNS(pausePid string) (_ bool, _ int, retErr error) {
 	if !uidsMapped {
 		logrus.Warnf("Using rootless single mapping into the namespace. This might break some images. Check /etc/subuid and /etc/subgid for adding sub*ids if not using a network user")
 		setgroups := fmt.Sprintf("/proc/%d/setgroups", pid)
-		err = os.WriteFile(setgroups, []byte("deny\n"), 0666)
+		err = os.WriteFile(setgroups, []byte("deny\n"), 0o666)
 		if err != nil {
 			return false, -1, fmt.Errorf("cannot write setgroups file: %w", err)
 		}
 		logrus.Debugf("write setgroups file exited with 0")
 
-		err = os.WriteFile(uidMap, []byte(fmt.Sprintf("%d %d 1\n", 0, os.Geteuid())), 0666)
+		err = os.WriteFile(uidMap, []byte(fmt.Sprintf("%d %d 1\n", 0, os.Geteuid())), 0o666)
 		if err != nil {
 			return false, -1, fmt.Errorf("cannot write uid_map: %w", err)
 		}
@@ -336,7 +336,7 @@ func becomeRootInUserNS(pausePid string) (_ bool, _ int, retErr error) {
 		gidsMapped = err == nil
 	}
 	if !gidsMapped {
-		err = os.WriteFile(gidMap, []byte(fmt.Sprintf("%d %d 1\n", 0, os.Getegid())), 0666)
+		err = os.WriteFile(gidMap, []byte(fmt.Sprintf("%d %d 1\n", 0, os.Getegid())), 0o666)
 		if err != nil {
 			return false, -1, fmt.Errorf("cannot write gid_map: %w", err)
 		}

--- a/pkg/systemd/quadlet/unitdirs_test.go
+++ b/pkg/systemd/quadlet/unitdirs_test.go
@@ -69,10 +69,10 @@ func TestUnitDirs(t *testing.T) {
 		symLinkTestBaseDir := t.TempDir()
 
 		actualDir := filepath.Join(symLinkTestBaseDir, "actual")
-		err = os.Mkdir(actualDir, 0755)
+		err = os.Mkdir(actualDir, 0o755)
 		assert.NoError(t, err)
 		innerDir := filepath.Join(actualDir, "inner")
-		err = os.Mkdir(innerDir, 0755)
+		err = os.Mkdir(innerDir, 0o755)
 		assert.NoError(t, err)
 		symlink := filepath.Join(symLinkTestBaseDir, "symlink")
 		err = os.Symlink(actualDir, symlink)
@@ -96,7 +96,7 @@ func TestUnitDirs(t *testing.T) {
 		createDir := func(path, name string, dirs []string) (string, []string) {
 			dirName := filepath.Join(path, name)
 			assert.NotContains(t, dirs, dirName)
-			err = os.Mkdir(dirName, 0755)
+			err = os.Mkdir(dirName, 0o755)
 			assert.NoError(t, err)
 			dirs = append(dirs, dirName)
 			return dirName, dirs
@@ -180,14 +180,14 @@ func TestUnitDirs(t *testing.T) {
 		err = syscall.Chroot(symLinkTestBaseDir)
 		assert.NoError(t, err)
 
-		err = os.MkdirAll(UnitDirAdmin, 0755)
+		err = os.MkdirAll(UnitDirAdmin, 0o755)
 		assert.NoError(t, err)
 		err = os.RemoveAll(UnitDirAdmin)
 		assert.NoError(t, err)
 
 		createDir := func(path, name string) string {
 			dirName := filepath.Join(path, name)
-			err = os.Mkdir(dirName, 0755)
+			err = os.Mkdir(dirName, 0o755)
 			assert.NoError(t, err)
 			return dirName
 		}

--- a/pkg/trust/policy.go
+++ b/pkg/trust/policy.go
@@ -258,5 +258,5 @@ func AddPolicyEntries(policyPath string, input AddPolicyEntriesInput) error {
 	if err != nil {
 		return fmt.Errorf("setting trust policy: %w", err)
 	}
-	return os.WriteFile(policyPath, data, 0644)
+	return os.WriteFile(policyPath, data, 0o644)
 }

--- a/pkg/trust/policy_test.go
+++ b/pkg/trust/policy_test.go
@@ -22,7 +22,7 @@ func TestAddPolicyEntries(t *testing.T) {
 	}
 	minimalPolicyJSON, err := json.Marshal(minimalPolicy)
 	require.NoError(t, err)
-	err = os.WriteFile(policyPath, minimalPolicyJSON, 0600)
+	err = os.WriteFile(policyPath, minimalPolicyJSON, 0o600)
 	require.NoError(t, err)
 
 	// Invalid input:
@@ -128,7 +128,7 @@ func TestAddPolicyEntries(t *testing.T) {
                 }
         }
 }`
-	err = os.WriteFile(policyPath, []byte(jsonWithUnknownData), 0600)
+	err = os.WriteFile(policyPath, []byte(jsonWithUnknownData), 0o600)
 	require.NoError(t, err)
 	err = AddPolicyEntries(policyPath, AddPolicyEntriesInput{
 		Scope:       "quay.io/innocuous",

--- a/pkg/trust/trust_test.go
+++ b/pkg/trust/trust_test.go
@@ -146,7 +146,7 @@ func TestPolicyDescription(t *testing.T) {
 	} {
 		policyJSON, err := json.Marshal(c.policy)
 		require.NoError(t, err)
-		err = os.WriteFile(policyPath, policyJSON, 0600)
+		err = os.WriteFile(policyPath, policyJSON, 0o600)
 		require.NoError(t, err)
 
 		res, err := policyDescriptionWithGPGIDReader(policyPath, "./testdata", idReader)

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -523,7 +523,7 @@ var _ = Describe("Podman artifact", func() {
 		artifact1Name := "localhost/test/artifact1"
 		podmanTest.PodmanExitCleanly("artifact", "add", artifact1Name, artifact1File)
 
-		f, err := os.OpenFile(artifact1File, os.O_APPEND|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(artifact1File, os.O_APPEND|os.O_WRONLY, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = f.WriteString("This is modification.")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Podman build", func() {
 
 	It("podman build with not found Containerfile or Dockerfile", func() {
 		targetPath := filepath.Join(podmanTest.TempDir, "notfound")
-		err = os.Mkdir(targetPath, 0755)
+		err = os.Mkdir(targetPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			Expect(os.RemoveAll(targetPath)).To(Succeed())
@@ -258,10 +258,10 @@ var _ = Describe("Podman build", func() {
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
 		fakeFile := filepath.Join(os.TempDir(), "Containerfile")
-		Expect(os.WriteFile(fakeFile, fmt.Appendf(nil, "FROM %s", CITEST_IMAGE), 0755)).To(Succeed())
+		Expect(os.WriteFile(fakeFile, fmt.Appendf(nil, "FROM %s", CITEST_IMAGE), 0o755)).To(Succeed())
 
 		targetFile := filepath.Join(podmanTest.TempDir, "Containerfile")
-		Expect(os.WriteFile(targetFile, []byte("FROM scratch"), 0755)).To(Succeed())
+		Expect(os.WriteFile(targetFile, []byte("FROM scratch"), 0o755)).To(Succeed())
 
 		defer func() {
 			Expect(os.RemoveAll(fakeFile)).To(Succeed())
@@ -354,7 +354,7 @@ var _ = Describe("Podman build", func() {
 RUN printenv http_proxy`, CITEST_IMAGE)
 
 		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
-		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		// --http-proxy should be true by default so we do not set it
 		session := podmanTest.Podman([]string{"build", "--pull-never", "--file", dockerfilePath, podmanTest.TempDir})
@@ -378,7 +378,7 @@ RUN printenv http_proxy`, CITEST_IMAGE)
 RUN exit 5`, CITEST_IMAGE)
 
 		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
-		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "-t", "error-test", "--file", dockerfilePath, podmanTest.TempDir})
 		session.Wait(120)
@@ -430,7 +430,7 @@ RUN exit 5`, CITEST_IMAGE)
 		targetSubPath := filepath.Join(podmanTest.TempDir, "emptydir")
 		if _, err = os.Stat(targetSubPath); err != nil {
 			if os.IsNotExist(err) {
-				err = os.Mkdir(targetSubPath, 0755)
+				err = os.Mkdir(targetSubPath, 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		}
@@ -439,7 +439,7 @@ RUN exit 5`, CITEST_IMAGE)
 COPY /emptydir/* /dir`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "ContainerfilePathToCopier")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 		defer os.Remove(containerfilePath)
 
@@ -460,10 +460,10 @@ COPY /emptydir/* /dir`, CITEST_IMAGE)
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
-		err = os.Mkdir(targetSubPath, 0755)
+		err = os.Mkdir(targetSubPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		dummyFile := filepath.Join(targetSubPath, "dummy")
-		err = os.WriteFile(dummyFile, []byte("dummy"), 0644)
+		err = os.WriteFile(dummyFile, []byte("dummy"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		containerfile := fmt.Sprintf(`FROM %s
@@ -471,7 +471,7 @@ ADD . /test
 RUN find /test`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		defer func() {
@@ -541,13 +541,13 @@ RUN find /test`, CITEST_IMAGE)
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
-		err = os.Mkdir(targetSubPath, 0755)
+		err = os.Mkdir(targetSubPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		containerfile := fmt.Sprintf("FROM %s", CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetSubPath, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		defer func() {
@@ -578,7 +578,7 @@ RUN find /test`, CITEST_IMAGE)
 
 		// Write target and fake files
 		targetPath := filepath.Join(podmanTest.TempDir, "build")
-		err = os.Mkdir(targetPath, 0755)
+		err = os.Mkdir(targetPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		containerfile := fmt.Sprintf(`FROM %s
@@ -586,23 +586,23 @@ ADD . /testfilter/
 RUN find /testfilter/`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		targetSubPath := filepath.Join(targetPath, "subdir")
-		err = os.Mkdir(targetSubPath, 0755)
+		err = os.Mkdir(targetSubPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		dummyFile1 := filepath.Join(targetPath, "dummy1")
-		err = os.WriteFile(dummyFile1, []byte("dummy1"), 0644)
+		err = os.WriteFile(dummyFile1, []byte("dummy1"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		dummyFile2 := filepath.Join(targetPath, "dummy2")
-		err = os.WriteFile(dummyFile2, []byte("dummy2"), 0644)
+		err = os.WriteFile(dummyFile2, []byte("dummy2"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		dummyFile3 := filepath.Join(targetSubPath, "dummy3")
-		err = os.WriteFile(dummyFile3, []byte("dummy3"), 0644)
+		err = os.WriteFile(dummyFile3, []byte("dummy3"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		defer func() {
@@ -619,7 +619,7 @@ subdir**`
 
 		// test .dockerignore
 		By("Test .dockererignore")
-		err = os.WriteFile(dockerignoreFile, []byte(dockerignoreContent), 0644)
+		err = os.WriteFile(dockerignoreFile, []byte(dockerignoreContent), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"build", "-t", "test", "."})
@@ -648,18 +648,18 @@ subdir**`
 		contents.WriteString("RUN find /testfilter/ -print\n")
 
 		containerfile := filepath.Join(tempdir, "Containerfile")
-		Expect(os.WriteFile(containerfile, contents.Bytes(), 0644)).ToNot(HaveOccurred())
+		Expect(os.WriteFile(containerfile, contents.Bytes(), 0o644)).ToNot(HaveOccurred())
 
 		contextDir := filepath.Join(podmanTest.TempDir, "context")
 		err = os.MkdirAll(contextDir, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(os.WriteFile(filepath.Join(contextDir, "expected"), contents.Bytes(), 0644)).
+		Expect(os.WriteFile(filepath.Join(contextDir, "expected"), contents.Bytes(), 0o644)).
 			ToNot(HaveOccurred())
 
 		subdirPath := filepath.Join(contextDir, "subdir")
-		Expect(os.MkdirAll(subdirPath, 0755)).ToNot(HaveOccurred())
-		Expect(os.WriteFile(filepath.Join(subdirPath, "extra"), contents.Bytes(), 0644)).
+		Expect(os.MkdirAll(subdirPath, 0o755)).ToNot(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(subdirPath, "extra"), contents.Bytes(), 0o644)).
 			ToNot(HaveOccurred())
 		randomFile := filepath.Join(subdirPath, "randomFile")
 		dd := exec.Command("dd", "if=/dev/urandom", "of="+randomFile, "bs=1G", "count=1")
@@ -675,7 +675,7 @@ subdir**`
 		}()
 
 		By("Test .containerignore filtering subdirectory")
-		err = os.WriteFile(filepath.Join(contextDir, ".containerignore"), []byte(`subdir/`), 0644)
+		err = os.WriteFile(filepath.Join(contextDir, ".containerignore"), []byte(`subdir/`), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"build", "-f", containerfile, contextDir})
@@ -700,14 +700,14 @@ subdir**`
 		// Write target and fake files
 		targetPath := podmanTest.TempDir
 		targetSubPath := filepath.Join(targetPath, "subdir")
-		err = os.Mkdir(targetSubPath, 0755)
+		err = os.Mkdir(targetSubPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		dummyFile := filepath.Join(targetSubPath, "dummy")
-		err = os.WriteFile(dummyFile, []byte("dummy"), 0644)
+		err = os.WriteFile(dummyFile, []byte("dummy"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		emptyDir := filepath.Join(targetSubPath, "emptyDir")
-		err = os.Mkdir(emptyDir, 0755)
+		err = os.Mkdir(emptyDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os.Chdir(targetSubPath)).To(Succeed())
 		Expect(os.Symlink("dummy", "dummy-symlink")).To(Succeed())
@@ -718,7 +718,7 @@ RUN find /test
 RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(targetSubPath, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		defer func() {
@@ -744,7 +744,7 @@ RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, CITEST_IMA
 		content := `FROM scratch
 RUN echo '56.78.12.34 image.example.com' > /etc/hosts`
 
-		Expect(os.WriteFile(containerFile, []byte(content), 0755)).To(Succeed())
+		Expect(os.WriteFile(containerFile, []byte(content), 0o755)).To(Succeed())
 
 		defer func() {
 			Expect(os.RemoveAll(containerFile)).To(Succeed())
@@ -770,7 +770,7 @@ RUN echo '56.78.12.34 image.example.com' > /etc/hosts`
 RUN cat /etc/hosts
 RUN grep CapEff /proc/self/status`
 
-		Expect(os.WriteFile(containerFile, []byte(content), 0755)).To(Succeed())
+		Expect(os.WriteFile(containerFile, []byte(content), 0o755)).To(Succeed())
 
 		defer func() {
 			Expect(os.RemoveAll(containerFile)).To(Succeed())
@@ -795,7 +795,7 @@ RUN grep CapEff /proc/self/status`
 	It("podman build --isolation && --arch", func() {
 		targetPath := podmanTest.TempDir
 		containerFile := filepath.Join(targetPath, "Containerfile")
-		Expect(os.WriteFile(containerFile, fmt.Appendf(nil, "FROM %s", CITEST_IMAGE), 0755)).To(Succeed())
+		Expect(os.WriteFile(containerFile, fmt.Appendf(nil, "FROM %s", CITEST_IMAGE), 0o755)).To(Succeed())
 
 		defer func() {
 			Expect(os.RemoveAll(containerFile)).To(Succeed())
@@ -839,7 +839,7 @@ RUN grep CapEff /proc/self/status`
 RUN echo hello`, CITEST_IMAGE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--timestamp", "0", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -856,7 +856,7 @@ RUN echo hello`, CITEST_IMAGE)
 		containerFile := filepath.Join(targetPath, "Containerfile")
 		content := `FROM scratch`
 
-		Expect(os.WriteFile(containerFile, []byte(content), 0755)).To(Succeed())
+		Expect(os.WriteFile(containerFile, []byte(content), 0o755)).To(Succeed())
 
 		session := podmanTest.Podman([]string{"build", "--log-rusage", "--pull-never", targetPath})
 		session.WaitWithDefaultTimeout()
@@ -869,7 +869,7 @@ RUN echo hello`, CITEST_IMAGE)
 	It("podman build --arch --os flag", func() {
 		containerfile := `FROM scratch`
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--arch", "foo", "--os", "bar", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -888,7 +888,7 @@ RUN echo hello`, CITEST_IMAGE)
 	It("podman build --os windows flag", func() {
 		containerfile := `FROM scratch`
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--os", "windows", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -911,7 +911,7 @@ RUN echo hello`, CITEST_IMAGE)
 		containerfile := fmt.Sprintf(`FROM %s
 RUN ls /dev/fuse`, CITEST_IMAGE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -927,7 +927,7 @@ RUN ls /dev/fuse`, CITEST_IMAGE)
 		containerfile := fmt.Sprintf(`FROM %s
 RUN ls /dev/test1`, CITEST_IMAGE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -944,11 +944,11 @@ RUN ls /dev/test1`, CITEST_IMAGE)
 		containerFilePath := filepath.Join(relativeDir, "Containerfile")
 		buildRoot := filepath.Join(relativeDir, "build-root")
 
-		err = os.Mkdir(relativeDir, 0755)
+		err = os.Mkdir(relativeDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
-		err = os.Mkdir(buildRoot, 0755)
+		err = os.Mkdir(buildRoot, 0o755)
 		Expect(err).ToNot(HaveOccurred())
-		err = os.WriteFile(containerFilePath, []byte(containerFile), 0755)
+		err = os.WriteFile(containerFilePath, []byte(containerFile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		build := podmanTest.Podman([]string{"build", "-f", containerFilePath, buildRoot})
 		build.WaitWithDefaultTimeout()
@@ -997,20 +997,20 @@ RUN ls /dev/test1`, CITEST_IMAGE)
 		localCtx1 := filepath.Join(podmanTest.TempDir, "context1")
 		localCtx2 := filepath.Join(podmanTest.TempDir, "context2")
 
-		Expect(os.MkdirAll(localCtx1, 0755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx1, "file1.txt"), []byte("Content from context1"), 0644)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx1, "config.json"), []byte(`{"source": "context1"}`), 0644)).To(Succeed())
+		Expect(os.MkdirAll(localCtx1, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx1, "file1.txt"), []byte("Content from context1"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx1, "config.json"), []byte(`{"source": "context1"}`), 0o644)).To(Succeed())
 
-		Expect(os.MkdirAll(filepath.Join(localCtx2, "subdir"), 0755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx2, "file2.txt"), []byte("Content from context2"), 0644)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx2, "subdir", "nested.txt"), []byte("Nested content"), 0644)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(localCtx2, "subdir"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx2, "file2.txt"), []byte("Content from context2"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx2, "subdir", "nested.txt"), []byte("Nested content"), 0o644)).To(Succeed())
 
 		containerfile := `FROM quay.io/libpod/alpine:latest
 COPY --from=localctx1 /file1.txt /from-context1.txt
 COPY --from=localctx1 /config.json /config1.json`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile1")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session := podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-local-single",
@@ -1031,7 +1031,7 @@ COPY --from=ctx2 /file2.txt /file2.txt
 COPY --from=ctx2 /subdir/nested.txt /nested.txt`
 
 		containerfilePath = filepath.Join(podmanTest.TempDir, "Containerfile2")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session = podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-local-multi",
@@ -1048,14 +1048,14 @@ COPY --from=ctx2 /subdir/nested.txt /nested.txt`
 		Expect(session.OutputToString()).To(Equal("Nested content"))
 
 		mainFile := filepath.Join(podmanTest.TempDir, "main.txt")
-		Expect(os.WriteFile(mainFile, []byte("From main context"), 0644)).To(Succeed())
+		Expect(os.WriteFile(mainFile, []byte("From main context"), 0o644)).To(Succeed())
 
 		containerfile = `FROM quay.io/libpod/alpine:latest
 COPY main.txt /main.txt
 COPY --from=additional /file1.txt /additional.txt`
 
 		containerfilePath = filepath.Join(podmanTest.TempDir, "Containerfile3")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session = podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-local-mixed",
@@ -1085,7 +1085,7 @@ COPY --from=additional /file1.txt /additional.txt`
 COPY --from=urlctx . /url-context/`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "ContainerfileURL1")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session := podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-url-single",
@@ -1106,7 +1106,7 @@ COPY --from=urlctx . /url-context/`
 COPY --from=archive . /from-archive/`
 
 		containerfilePath = filepath.Join(podmanTest.TempDir, "ContainerfileURL2")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session = podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-archive",
@@ -1130,8 +1130,8 @@ COPY --from=archive . /from-archive/`
 		Expect(output).To(ContainSubstring("README.md"))
 
 		localCtx := filepath.Join(podmanTest.TempDir, "localcontext")
-		Expect(os.MkdirAll(localCtx, 0755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx, "local.txt"), []byte("Local content"), 0644)).To(Succeed())
+		Expect(os.MkdirAll(localCtx, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx, "local.txt"), []byte("Local content"), 0o644)).To(Succeed())
 
 		containerfile = `FROM quay.io/libpod/alpine:latest
 COPY --from=urlrepo . /from-url/
@@ -1139,7 +1139,7 @@ COPY --from=localctx /local.txt /local.txt
 RUN echo "Combined URL and local contexts" > /combined.txt`
 
 		containerfilePath = filepath.Join(podmanTest.TempDir, "ContainerfileURL3")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session = podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-url-mixed",
@@ -1156,14 +1156,14 @@ RUN echo "Combined URL and local contexts" > /combined.txt`
 		Expect(session.OutputToString()).To(Equal("Local content"))
 
 		mainFile := filepath.Join(podmanTest.TempDir, "main-url-test.txt")
-		Expect(os.WriteFile(mainFile, []byte("Main context for URL test"), 0644)).To(Succeed())
+		Expect(os.WriteFile(mainFile, []byte("Main context for URL test"), 0o644)).To(Succeed())
 
 		containerfile = `FROM quay.io/libpod/alpine:latest
 COPY main-url-test.txt /main.txt
 COPY --from=gitrepo . /git-repo/`
 
 		containerfilePath = filepath.Join(podmanTest.TempDir, "ContainerfileURL5")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session = podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-url-main",
@@ -1194,7 +1194,7 @@ FROM quay.io/libpod/alpine:latest
 COPY --from=source /bin/busybox /busybox-from-stage`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "ContainerfileMultiStage")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session := podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-multi-stage",
@@ -1242,7 +1242,7 @@ COPY --from=dockershort /etc/os-release /os-release.txt`,
 
 		for _, tc := range testCases {
 			containerfilePath = filepath.Join(podmanTest.TempDir, fmt.Sprintf("Containerfile_%s", tc.name))
-			Expect(os.WriteFile(containerfilePath, []byte(tc.containerfile), 0644)).To(Succeed())
+			Expect(os.WriteFile(containerfilePath, []byte(tc.containerfile), 0o644)).To(Succeed())
 
 			session = podmanTest.Podman([]string{
 				"build", "--pull-never", "-t", fmt.Sprintf("test-%s", tc.name),
@@ -1272,16 +1272,16 @@ COPY --from=dockershort /etc/os-release /os-release.txt`,
 		podmanTest.RestartRemoteService()
 
 		localCtx := filepath.Join(podmanTest.TempDir, "local-mixed")
-		Expect(os.MkdirAll(localCtx, 0755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx, "local-config.json"), []byte(`{"context": "local", "version": "1.0"}`), 0644)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(localCtx, "app.conf"), []byte("# Local app configuration\nmode=production\nport=8080"), 0644)).To(Succeed())
+		Expect(os.MkdirAll(localCtx, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx, "local-config.json"), []byte(`{"context": "local", "version": "1.0"}`), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(localCtx, "app.conf"), []byte("# Local app configuration\nmode=production\nport=8080"), 0o644)).To(Succeed())
 
 		urlContext := "https://github.com/containers/PodmanHello.git"
 		alpineImage := "quay.io/libpod/alpine:latest"
 		busyboxImage := "quay.io/libpod/busybox:latest"
 
 		mainFile := filepath.Join(podmanTest.TempDir, "VERSION")
-		Expect(os.WriteFile(mainFile, []byte("v1.0.0-mixed"), 0644)).To(Succeed())
+		Expect(os.WriteFile(mainFile, []byte("v1.0.0-mixed"), 0o644)).To(Succeed())
 
 		containerfile := `FROM quay.io/libpod/alpine:latest
 
@@ -1307,7 +1307,7 @@ RUN echo "Build with all context types completed" > /app/build-summary.txt && \
 WORKDIR /app`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "ContainerfileMixed")
-		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath, []byte(containerfile), 0o644)).To(Succeed())
 
 		session := podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-all-contexts",
@@ -1356,7 +1356,7 @@ COPY --from=img1 /etc/os-release /prefix-test/docker-prefix.txt
 COPY --from=img2 /etc/alpine-release /prefix-test/container-prefix.txt`
 
 		containerfilePath2 := filepath.Join(podmanTest.TempDir, "ContainerfileMixed2")
-		Expect(os.WriteFile(containerfilePath2, []byte(containerfile2), 0644)).To(Succeed())
+		Expect(os.WriteFile(containerfilePath2, []byte(containerfile2), 0o644)).To(Succeed())
 
 		session = podmanTest.Podman([]string{
 			"build", "--pull-never", "-t", "test-prefix-mix",

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -328,7 +328,7 @@ var _ = Describe("Podman commit", func() {
 	It("podman commit should not commit secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -353,7 +353,7 @@ var _ = Describe("Podman commit", func() {
 	It("podman commit should not commit env secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -180,7 +180,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	// make cache dir
 	ImageCacheDir = filepath.Join(globalTmpDir, imageCacheDir)
-	err = os.MkdirAll(ImageCacheDir, 0700)
+	err = os.MkdirAll(ImageCacheDir, 0o700)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Cache images
@@ -195,7 +195,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		podman.createArtifact(image)
 	}
 
-	if err := os.MkdirAll(filepath.Join(ImageCacheDir, podman.ImageCacheFS+"-images"), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Join(ImageCacheDir, podman.ImageCacheFS+"-images"), 0o777); err != nil {
 		GinkgoWriter.Printf("%q\n", err)
 		os.Exit(1)
 	}
@@ -204,7 +204,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// tests are remote, this is a no-op
 	populateCache(podman)
 
-	if err := os.MkdirAll(filepath.Join(globalTmpDir, lockdir), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(globalTmpDir, lockdir), 0o700); err != nil {
 		GinkgoWriter.Printf("%q\n", err)
 		os.Exit(1)
 	}
@@ -350,11 +350,11 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		}
 	}
 
-	if err := os.MkdirAll(root, 0755); err != nil {
+	if err := os.MkdirAll(root, 0o755); err != nil {
 		panic(err)
 	}
 
-	if err := os.MkdirAll(networkConfigDir, 0755); err != nil {
+	if err := os.MkdirAll(networkConfigDir, 0o755); err != nil {
 		panic(err)
 	}
 
@@ -421,7 +421,7 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		for {
 			uuid := stringid.GenerateRandomID()
 			lockPath := fmt.Sprintf("%s-%s.sock-lock", pathPrefix, uuid)
-			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o700)
 			if err == nil {
 				lockFile.Close()
 				p.RemoteSocketLock = lockPath
@@ -440,7 +440,7 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		for {
 			uuid := stringid.GenerateRandomID()
 			lockPath := fmt.Sprintf("%s-%s.sock-lock", pathPrefix, uuid)
-			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o700)
 			if err == nil {
 				lockFile.Close()
 				p.RemoteSocketLock = lockPath
@@ -1531,7 +1531,7 @@ func (s *PodmanSessionIntegration) jq(jqCommand string) (string, error) {
 
 func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers string, label string, extraOptions []string) string {
 	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile-"+stringid.GenerateRandomID())
-	err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+	err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o755)
 	Expect(err).ToNot(HaveOccurred())
 	cmd := []string{"build", "--pull-never", "--layers=" + layers, "--file", dockerfilePath}
 	if label != "" {
@@ -1705,7 +1705,7 @@ func CopyDirectory(srcDir, dest string) error {
 
 		switch fileInfo.Mode() & os.ModeType {
 		case os.ModeDir:
-			if err := os.MkdirAll(destPath, 0755); err != nil {
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory: %q, error: %q", destPath, err.Error())
 			}
 			if err := CopyDirectory(sourcePath, destPath); err != nil {
@@ -1803,7 +1803,7 @@ func setupRegistry(portOverride *int) (*lockfile.LockFile, string, error) {
 func createArtifactFile(numBytes int64) (string, error) {
 	GinkgoHelper()
 	artifactDir := filepath.Join(podmanTest.TempDir, "artifacts")
-	if err := os.MkdirAll(artifactDir, 0755); err != nil {
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		return "", err
 	}
 	filename := RandomString(8)

--- a/test/e2e/container_create_volume_test.go
+++ b/test/e2e/container_create_volume_test.go
@@ -15,7 +15,7 @@ import (
 func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string) {
 	// Create a dummy file for data volume
 	dummyFile := filepath.Join(pTest.TempDir, data)
-	err := os.WriteFile(dummyFile, []byte(data), 0644)
+	err := os.WriteFile(dummyFile, []byte(data), 0o644)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create a data volume container image but no CMD binary in it

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Podman container inspect", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		volsctr := ctr1 + ":z,ro"
 
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, CITEST_IMAGE})
@@ -111,7 +111,7 @@ var _ = Describe("Podman container inspect", func() {
 		secretName := "mysecret"
 
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mySecretValue"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mySecretValue"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", secretName, secretFilePath})

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		SkipIfRootless("--cgroup-manager=cgoupfs and --cgroup-conf not supported in rootless mode with crun")
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
 
-		err := os.WriteFile(conffile, []byte("[containers]\ncgroup_conf = [\"pids.max=1234\",]\n"), 0755)
+		err := os.WriteFile(conffile, []byte("[containers]\ncgroup_conf = [\"pids.max=1234\",]\n"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)
@@ -297,7 +297,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		volume := filepath.Join(podmanTest.TempDir, "vol")
 		err = os.MkdirAll(volume, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
-		err := os.WriteFile(conffile, fmt.Appendf(nil, "[containers]\nvolumes=[\"%s:%s:Z\",]\n", volume, volume), 0755)
+		err := os.WriteFile(conffile, fmt.Appendf(nil, "[containers]\nvolumes=[\"%s:%s:Z\",]\n", volume, volume), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF", conffile)
@@ -495,7 +495,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		JustBeforeEach(func() {
 			conffile := filepath.Join(podmanTest.TempDir, "containers.conf")
-			err = os.WriteFile(conffile, fmt.Appendf(nil, "[containers]\nbase_hosts_file=\"%s\"\nno_hosts=false\n", baseHostsFile), 0755)
+			err = os.WriteFile(conffile, fmt.Appendf(nil, "[containers]\nbase_hosts_file=\"%s\"\nno_hosts=false\n", baseHostsFile), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 			os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)
 			if IsRemote() {
@@ -516,7 +516,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		Describe("base_hosts_file=path", func() {
 			BeforeEach(func() {
 				hostsPath := filepath.Join(podmanTest.TempDir, "hosts")
-				err := os.WriteFile(hostsPath, []byte("12.34.56.78 file.example.com"), 0755)
+				err := os.WriteFile(hostsPath, []byte("12.34.56.78 file.example.com"), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 				baseHostsFile = hostsPath
 			})
@@ -716,7 +716,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		}
 
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
-		err := os.WriteFile(conffile, []byte("[containers]\ncgroups=\"disabled\"\n"), 0755)
+		err := os.WriteFile(conffile, []byte("[containers]\ncgroups=\"disabled\"\n"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		result := podmanTest.Podman([]string{"create", ALPINE, "true"})
@@ -748,7 +748,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 	It("podman containers.conf runtime", func() {
 		SkipIfRemote("--runtime option is not available for remote commands")
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
-		err := os.WriteFile(conffile, []byte("[engine]\nruntime=\"testruntime\"\n"), 0755)
+		err := os.WriteFile(conffile, []byte("[engine]\nruntime=\"testruntime\"\n"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF", conffile)
@@ -764,7 +764,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		for _, mode := range []string{"pasta", "slirp4netns", "invalid"} {
 			conffile := filepath.Join(podmanTest.TempDir, "container.conf")
 			content := "[network]\ndefault_rootless_network_cmd=\"" + mode + "\"\n"
-			err := os.WriteFile(conffile, []byte(content), 0755)
+			err := os.WriteFile(conffile, []byte(content), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)
@@ -841,7 +841,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		// Create containers.conf override with container_name_as_hostname=true
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
-		err := os.WriteFile(conffile, []byte("[containers]\ncontainer_name_as_hostname=true\n"), 0755)
+		err := os.WriteFile(conffile, []byte("[containers]\ncontainer_name_as_hostname=true\n"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)
 		if IsRemote() {

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Podman cp", func() {
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp file test")
-		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create a container. NOTE that container mustn't be running for copying.
@@ -80,7 +80,7 @@ var _ = Describe("Podman cp", func() {
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp file test")
-		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create a container. NOTE that container mustn't be running for copying.
@@ -125,7 +125,7 @@ var _ = Describe("Podman cp", func() {
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp symlink test")
-		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "top"})
@@ -164,7 +164,7 @@ var _ = Describe("Podman cp", func() {
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp volume")
-		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"volume", "create", "data"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -152,10 +152,10 @@ var _ = Describe("Podman create", func() {
 
 	It("podman create --mount flag with multiple mounts", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
-		err = os.MkdirAll(vol2, 0755)
+		err = os.MkdirAll(vol2, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--mount", "type=bind,src=" + vol1 + ",target=/myvol1,z", "--mount", "type=bind,src=" + vol2 + ",target=/myvol2,z", ALPINE, "touch", "/myvol2/foo.txt"})
@@ -174,7 +174,7 @@ var _ = Describe("Podman create", func() {
 		}
 
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--mount", fmt.Sprintf("type=bind,src=%s,target=/create/test", mountPath), ALPINE, "grep", "/create/test", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
@@ -202,7 +202,7 @@ var _ = Describe("Podman create", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("shared"))
 
 		mountPath = filepath.Join(podmanTest.TempDir, "scratchpad")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session = podmanTest.Podman([]string{"create", "--name", "test_tmpfs", "--mount", "type=tmpfs,target=/create/test", ALPINE, "grep", "/create/test", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -571,7 +571,7 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 	It("podman exec with env var secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -813,7 +813,7 @@ var _ = Describe("Podman kube generate", func() {
 
 	It("with volume", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// we need a container name because IDs don't persist after rm/play
@@ -1171,7 +1171,7 @@ var _ = Describe("Podman kube generate", func() {
 ENTRYPOINT ["sleep"]`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		image := "generatekube:test"
@@ -1223,7 +1223,7 @@ ENTRYPOINT ["sleep"]`
 USER 1000`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		image := "generatekube:test"
@@ -1292,7 +1292,7 @@ RUN adduser -u 10001 -S test1
 USER test1`
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		image := "generatekube:test"
@@ -1668,7 +1668,7 @@ USER test1`
 		ctr2 := "ctr2"
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"create", "--name", ctr1, "-v", vol1, CITEST_IMAGE})
@@ -1699,10 +1699,10 @@ USER test1`
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
 
-		err1 := os.MkdirAll(vol1, 0755)
+		err1 := os.MkdirAll(vol1, 0o755)
 		Expect(err1).ToNot(HaveOccurred())
 
-		err2 := os.MkdirAll(vol2, 0755)
+		err2 := os.MkdirAll(vol2, 0o755)
 		Expect(err2).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"create", "--name", srcctr1, "-v", vol1, CITEST_IMAGE})

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -334,7 +334,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		containerfile := fmt.Sprintf(`FROM %s
 HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			Expect(os.Chdir(cwd)).To(Succeed())

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -48,7 +48,7 @@ func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
 	outfile := filepath.Join(p.TempDir, "registries.conf")
 	os.Setenv("CONTAINERS_REGISTRIES_CONF", outfile)
-	err := os.WriteFile(outfile, b, 0644)
+	err := os.WriteFile(outfile, b, 0o644)
 	Expect(err).ToNot(HaveOccurred())
 }
 
@@ -58,7 +58,7 @@ func resetRegistriesConfigEnv() {
 
 func (p *PodmanTestIntegration) StartRemoteService() {
 	if !isRootless() {
-		err := os.MkdirAll("/run/podman", 0755)
+		err := os.MkdirAll("/run/podman", 0o755)
 		Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -45,7 +45,7 @@ func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
 	outfile := filepath.Join(p.TempDir, "registries.conf")
 	os.Setenv("CONTAINERS_REGISTRIES_CONF", outfile)
-	err := os.WriteFile(outfile, b, 0644)
+	err := os.WriteFile(outfile, b, 0o644)
 	Expect(err).ToNot(HaveOccurred())
 }
 

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -514,7 +514,7 @@ var _ = Describe("Podman login and logout", func() {
 		err := os.WriteFile(authFile, fmt.Appendf(nil, `{"auths": {
 			"%s/podmantest": { "auth": "cG9kbWFudGVzdDp3cm9uZw==" },
 			"%s": { "auth": "cG9kbWFudGVzdDp0ZXN0" }
-		}}`, server, server), 0644)
+		}}`, server, server), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{
@@ -561,7 +561,7 @@ var _ = Describe("Podman login and logout", func() {
 			"%s/podmantest/test-alpine": { "auth": "cG9kbWFudGVzdDp3cm9uZw==" },
 			"%s/podmantest": { "auth": "cG9kbWFudGVzdDp0ZXN0" },
 			"%s": { "auth": "cG9kbWFudGVzdDp0ZXN0" }
-		}}`, server, server, server), 0644)
+		}}`, server, server, server), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		session = podmanTest.Podman([]string{

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -65,12 +65,12 @@ LABEL marge=mom
 	It("Check that image is built using Dockerfile", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
-		err := os.Mkdir(yamlDir, 0755)
+		err := os.Mkdir(yamlDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+yamlDir)
 		err = writeYaml(testYAML, filepath.Join(yamlDir, "top.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 		app1Dir := filepath.Join(yamlDir, "foobar")
-		err = os.Mkdir(app1Dir, 0755)
+		err = os.Mkdir(app1Dir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Dockerfile"))
 		Expect(err).ToNot(HaveOccurred())
@@ -105,12 +105,12 @@ LABEL marge=mom
 	It("Check that image is built using Containerfile", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
-		err := os.Mkdir(yamlDir, 0755)
+		err := os.Mkdir(yamlDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+yamlDir)
 		err = writeYaml(testYAML, filepath.Join(yamlDir, "top.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 		app1Dir := filepath.Join(yamlDir, "foobar")
-		err = os.Mkdir(app1Dir, 0755)
+		err = os.Mkdir(app1Dir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
 		Expect(err).ToNot(HaveOccurred())
@@ -145,7 +145,7 @@ LABEL marge=mom
 	It("Do not build image if already in the local store", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
-		err := os.Mkdir(yamlDir, 0755)
+		err := os.Mkdir(yamlDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+yamlDir)
 		err = writeYaml(testYAML, filepath.Join(yamlDir, "top.yaml"))
 		Expect(err).ToNot(HaveOccurred())
@@ -157,7 +157,7 @@ LABEL marge=mom
 		Expect(err).ToNot(HaveOccurred())
 
 		app1Dir := filepath.Join(yamlDir, "foobar")
-		err = os.Mkdir(app1Dir, 0755)
+		err = os.Mkdir(app1Dir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
 		Expect(err).ToNot(HaveOccurred())
@@ -192,7 +192,7 @@ LABEL marge=mom
 	It("Do not build image at all if --build=false", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
-		err := os.Mkdir(yamlDir, 0755)
+		err := os.Mkdir(yamlDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+yamlDir)
 		err = writeYaml(testYAML, filepath.Join(yamlDir, "top.yaml"))
 		Expect(err).ToNot(HaveOccurred())
@@ -204,7 +204,7 @@ LABEL marge=mom
 		Expect(err).ToNot(HaveOccurred())
 
 		app1Dir := filepath.Join(yamlDir, "foobar")
-		err = os.Mkdir(app1Dir, 0755)
+		err = os.Mkdir(app1Dir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
 		Expect(err).ToNot(HaveOccurred())
@@ -239,7 +239,7 @@ LABEL marge=mom
 	It("--build should override image in store", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
-		err := os.Mkdir(yamlDir, 0755)
+		err := os.Mkdir(yamlDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "os.Mkdir "+yamlDir)
 		err = writeYaml(testYAML, filepath.Join(yamlDir, "top.yaml"))
 		Expect(err).ToNot(HaveOccurred())
@@ -251,7 +251,7 @@ LABEL marge=mom
 		Expect(err).ToNot(HaveOccurred())
 
 		app1Dir := filepath.Join(yamlDir, "foobar")
-		err = os.Mkdir(app1Dir, 0755)
+		err = os.Mkdir(app1Dir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
 		Expect(err).ToNot(HaveOccurred())
@@ -326,12 +326,12 @@ status: {}
 	It("Check that command is expanded", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
-		err := os.Mkdir(yamlDir, 0755)
+		err := os.Mkdir(yamlDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+yamlDir)
 		err = writeYaml(testYAMLForEnvExpand, filepath.Join(yamlDir, "echo.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 		app1Dir := filepath.Join(yamlDir, "foobar")
-		err = os.Mkdir(app1Dir, 0755)
+		err = os.Mkdir(app1Dir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		err = writeYaml(playBuildFile+`ENV FOO foo-from-buildfile
 COPY FOO /bin/FOO
@@ -346,7 +346,7 @@ COPY FOO /bin/FOO
 echo GOT-HERE
 `, filepath.Join(app1Dir, "FOO"))
 		Expect(err).ToNot(HaveOccurred())
-		err = os.Chmod(filepath.Join(app1Dir, "FOO"), 0555)
+		err = os.Chmod(filepath.Join(app1Dir, "FOO"), 0o555)
 		Expect(err).ToNot(HaveOccurred(), "chmod FOO")
 
 		os.Setenv("FOO", "make sure we use FOO from kube file, not env")

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1555,7 +1555,7 @@ func generateMultiDocKubeYaml(kubeObjects []string, pathname string) error {
 
 func createSecret(podmanTest *PodmanTestIntegration, name string, value []byte) { //nolint:unparam
 	secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-	err := os.WriteFile(secretFilePath, value, 0755)
+	err := os.WriteFile(secretFilePath, value, 0o755)
 	Expect(err).ToNot(HaveOccurred())
 
 	secret := podmanTest.Podman([]string{"secret", "create", name, secretFilePath})
@@ -2481,7 +2481,7 @@ var _ = Describe("Podman kube play", func() {
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
 
 		infraImage := INFRA_IMAGE
-		err := os.WriteFile(conffile, fmt.Appendf(nil, "[engine]\ninfra_image=\"%s\"\n", infraImage), 0644)
+		err := os.WriteFile(conffile, fmt.Appendf(nil, "[engine]\ninfra_image=\"%s\"\n", infraImage), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF", conffile)
@@ -3512,7 +3512,7 @@ spec:
 
 		conffile := filepath.Join(podmanTest.TempDir, "kube.yaml")
 
-		err := os.WriteFile(conffile, []byte(testyaml), 0755)
+		err := os.WriteFile(conffile, []byte(testyaml), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		kube := podmanTest.Podman([]string{"kube", "play", conffile})
@@ -3868,7 +3868,7 @@ spec:
 		testfile := "testfile"
 
 		hostPathDir := filepath.Join(tempdir, testdir)
-		err := os.Mkdir(hostPathDir, 0755)
+		err := os.Mkdir(hostPathDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(hostPathDir)
 
@@ -4012,7 +4012,7 @@ VOLUME %s`, CITEST_IMAGE, hostPathDir+"/")
 		Expect(err).ToNot(HaveOccurred())
 
 		ctr := getCtr(withVolumeMount("/test", "", false), withImage(CITEST_IMAGE))
-		defaultMode := int32(0777)
+		defaultMode := int32(0o777)
 		pod := getPod(withVolume(getConfigMapVolume(volumeName, []map[string]string{}, false, &defaultMode)), withCtr(ctr))
 		podYaml, err := getKubeYaml("pod", pod)
 		Expect(err).ToNot(HaveOccurred())
@@ -5371,7 +5371,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 		Expect(err).ToNot(HaveOccurred())
 
 		ctr := getCtr(withVolumeMount("/test", "", false), withImage(CITEST_IMAGE))
-		defaultMode := int32(0777)
+		defaultMode := int32(0o777)
 		pod := getPod(withVolume(getSecretVolume(volumeName, []map[string]string{}, false, &defaultMode)), withCtr(ctr))
 		podYaml, err := getKubeYaml("pod", pod)
 		Expect(err).ToNot(HaveOccurred())
@@ -5445,7 +5445,7 @@ spec:
 		err := os.WriteFile(conffile, []byte(`
 [containers]
 ipcns="host"
-cgroups="disabled"`), 0644)
+cgroups="disabled"`), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 		os.Setenv("CONTAINERS_CONF", conffile)
 		err = writeYaml(simplePodYaml, kubeYaml)
@@ -5566,7 +5566,7 @@ spec:
 		}
 
 		hostPathLocation := podmanTest.TempDir
-		Expect(os.MkdirAll(filepath.Join(hostPathLocation, "testing", "onlythis"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(hostPathLocation, "testing", "onlythis"), 0o755)).To(Succeed())
 		file, err := os.Create(filepath.Join(hostPathLocation, "testing", "onlythis", "123.txt"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -5607,7 +5607,7 @@ spec:
 	It("with unsafe hostPath subpaths", func() {
 		hostPathLocation := filepath.Join(podmanTest.TempDir, "vol")
 
-		Expect(os.MkdirAll(filepath.Join(hostPathLocation, "testing"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(hostPathLocation, "testing"), 0o755)).To(Succeed())
 		Expect(os.Symlink("/", filepath.Join(hostPathLocation, "testing", "symlink"))).To(Succeed())
 
 		pod := getPod(withPodName("testpod"), withCtr(getCtr(withImage(CITEST_IMAGE), withName("testctr"), withCmd([]string{"top"}), withVolumeMount("/foo", "testing/symlink", false))), withVolume(getHostPathVolume("DirectoryOrCreate", hostPathLocation)))
@@ -5865,7 +5865,7 @@ spec:
 		outputFile := filepath.Join(podmanTest.TempDir, "pod.yaml")
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		podmanTest.PodmanExitCleanly("create", "--name", ctr1, "-v", vol1, CITEST_IMAGE)
@@ -5896,10 +5896,10 @@ spec:
 		volsFromAnnotaton := define.VolumesFromAnnotation + "/" + tgtctr
 		volsFromValue := frmopt1 + ";" + frmopt2
 
-		err1 := os.MkdirAll(vol1, 0755)
+		err1 := os.MkdirAll(vol1, 0o755)
 		Expect(err1).ToNot(HaveOccurred())
 
-		err2 := os.MkdirAll(vol2, 0755)
+		err2 := os.MkdirAll(vol2, 0o755)
 		Expect(err2).ToNot(HaveOccurred())
 
 		podmanTest.PodmanExitCleanly("create", "--name", srcctr1, "-v", vol1, CITEST_IMAGE)
@@ -6321,10 +6321,10 @@ log_driver = "k8s-file"
 log_path = "%s"
 `, customLogPath)
 
-		err := os.WriteFile(conffile, []byte(configContent), 0644)
+		err := os.WriteFile(conffile, []byte(configContent), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.MkdirAll(customLogPath, 0755)
+		err = os.MkdirAll(customLogPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)
@@ -6347,7 +6347,7 @@ spec:
     command: ["/bin/sh", "-c", "echo '%s'; sleep 2"]
 `, CITEST_IMAGE, expectedMessage)
 
-		err = os.WriteFile(kubeYaml, []byte(podYamlContent), 0644)
+		err = os.WriteFile(kubeYaml, []byte(podYamlContent), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		podmanTest.PodmanExitCleanly("kube", "play", kubeYaml)

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -176,15 +176,15 @@ var _ = Describe("Podman pod create", func() {
 	Describe("podman create pod with --hosts-file", func() {
 		BeforeEach(func() {
 			imageHosts := filepath.Join(podmanTest.TempDir, "pause_hosts")
-			err := os.WriteFile(imageHosts, []byte("56.78.12.34 image.example.com"), 0755)
+			err := os.WriteFile(imageHosts, []byte("56.78.12.34 image.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			configHosts := filepath.Join(podmanTest.TempDir, "hosts")
-			err = os.WriteFile(configHosts, []byte("12.34.56.78 config.example.com"), 0755)
+			err = os.WriteFile(configHosts, []byte("12.34.56.78 config.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			confFile := filepath.Join(podmanTest.TempDir, "containers.conf")
-			err = os.WriteFile(confFile, fmt.Appendf(nil, "[containers]\nbase_hosts_file=\"%s\"\n", configHosts), 0755)
+			err = os.WriteFile(confFile, fmt.Appendf(nil, "[containers]\nbase_hosts_file=\"%s\"\n", configHosts), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 			os.Setenv("CONTAINERS_CONF_OVERRIDE", confFile)
 			if IsRemote() {
@@ -200,7 +200,7 @@ var _ = Describe("Podman pod create", func() {
 
 		It("--hosts-file=path", func() {
 			hostsPath := filepath.Join(podmanTest.TempDir, "hosts")
-			err := os.WriteFile(hostsPath, []byte("23.45.67.89 file.example.com"), 0755)
+			err := os.WriteFile(hostsPath, []byte("23.45.67.89 file.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			podCreate := podmanTest.Podman([]string{"pod", "create", "--hostname", "hosts_test.dev", "--hosts-file=" + hostsPath, "--add-host=add.example.com:34.56.78.90", "--infra-image=foobar.com/hosts_test_pause:latest", "--infra-name=hosts_test_infra", "--name", "hosts_test_pod"})

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -598,7 +598,7 @@ var _ = Describe("Podman prune", func() {
 		Expect(create).Should(ExitCleanly())
 
 		containerFilePath := filepath.Join(podmanTest.TempDir, "ContainerFile-podman-leaker")
-		err := os.WriteFile(containerFilePath, []byte(longBuildImage), 0755)
+		err := os.WriteFile(containerFilePath, []byte(longBuildImage), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		build := podmanTest.Podman([]string{"build", "-f", containerFilePath, "-t", "podmanleaker"})

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -684,7 +684,7 @@ var _ = Describe("quadlet system generator", func() {
 			testcase := loadQuadletTestcaseWithServiceName(filepath.Join("quadlet", fileName), serviceName)
 
 			// Write the tested file to the quadlet dir
-			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0644)
+			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0o644)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Also copy any extra snippets
@@ -765,7 +765,7 @@ var _ = Describe("quadlet system generator", func() {
 			testcase := loadQuadletTestcase(filepath.Join("quadlet", fileName))
 
 			// Write the tested file to the quadlet dir
-			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0644)
+			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0o644)
 			Expect(err).ToNot(HaveOccurred())
 
 			session := podmanTest.Quadlet([]string{"-dryrun"}, "/something")
@@ -792,7 +792,7 @@ BOGUS=foo
 `, ALPINE)
 
 			quadletfilePath := filepath.Join(podmanTest.TempDir, "bogus.container")
-			err = os.WriteFile(quadletfilePath, []byte(quadletfile), 0644)
+			err = os.WriteFile(quadletfilePath, []byte(quadletfile), 0o644)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove(quadletfilePath)
 			session := podmanTest.Quadlet([]string{"-dryrun"}, podmanTest.TempDir)
@@ -833,7 +833,7 @@ BOGUS=foo
 			}
 
 			// Write the tested file to the quadlet dir
-			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0644)
+			err = os.WriteFile(filepath.Join(quadletDir, fileName), testcase.data, 0o644)
 			Expect(err).ToNot(HaveOccurred())
 
 			session := podmanTest.Quadlet([]string{"-dryrun"}, quadletDir)
@@ -1172,7 +1172,7 @@ BOGUS=foo
 			// Write additional files this test depends on to the quadlet dir
 			for _, dependencyFileName := range dependencyFiles {
 				dependencyTestCase := loadQuadletTestcase(filepath.Join("quadlet", dependencyFileName))
-				err = os.WriteFile(filepath.Join(quadletDir, dependencyFileName), dependencyTestCase.data, 0644)
+				err = os.WriteFile(filepath.Join(quadletDir, dependencyFileName), dependencyTestCase.data, 0o644)
 				Expect(err).ToNot(HaveOccurred())
 			}
 

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -80,7 +80,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 }
 `
 		aaFile := filepath.Join(os.TempDir(), "aaFile")
-		Expect(os.WriteFile(aaFile, []byte(aaProfile), 0755)).To(Succeed())
+		Expect(os.WriteFile(aaFile, []byte(aaProfile), 0o755)).To(Succeed())
 		parse := SystemExec("apparmor_parser", []string{"-Kr", aaFile})
 		Expect(parse).Should(ExitCleanly())
 

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -71,13 +71,13 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		content, err := os.ReadFile(filepath.Join(cgroupRoot, containerCgroup, "cgroup.procs"))
 		Expect(err).ToNot(HaveOccurred())
 		oldSubCgroupPath := filepath.Join(cgroupRoot, containerCgroup, "old-container")
-		err = os.MkdirAll(oldSubCgroupPath, 0755)
+		err = os.MkdirAll(oldSubCgroupPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
-		err = os.WriteFile(filepath.Join(oldSubCgroupPath, "cgroup.procs"), content, 0644)
+		err = os.WriteFile(filepath.Join(oldSubCgroupPath, "cgroup.procs"), content, 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		newCgroup := fmt.Sprintf("%s/new-container", containerCgroup)
-		err = os.MkdirAll(filepath.Join(cgroupRoot, newCgroup), 0755)
+		err = os.MkdirAll(filepath.Join(cgroupRoot, newCgroup), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		run = podmanTest.Podman([]string{"--cgroup-manager=cgroupfs", "run", "--rm", "--cgroupns=host", fmt.Sprintf("--cgroup-parent=%s", newCgroup), fedoraMinimal, "cat", "/proc/self/cgroup"})

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Podman run cpu", func() {
 		SkipIfRootlessCgroupsV1("Setting CPU not supported on cgroupv1 for rootless users")
 
 		if CGROUPSV2 {
-			if err := os.WriteFile("/sys/fs/cgroup/cgroup.subtree_control", []byte("+cpuset"), 0644); err != nil {
+			if err := os.WriteFile("/sys/fs/cgroup/cgroup.subtree_control", []byte("+cpuset"), 0o644); err != nil {
 				Skip("cpuset controller not available on the current kernel")
 			}
 		}

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -29,10 +29,10 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		signal := syscall.SIGFPE
 		// Set up a socket for communication
 		udsDir := filepath.Join(tempdir, "socket")
-		err := os.Mkdir(udsDir, 0700)
+		err := os.Mkdir(udsDir, 0o700)
 		Expect(err).ToNot(HaveOccurred())
 		udsPath := filepath.Join(udsDir, "fifo")
-		err = syscall.Mkfifo(udsPath, 0600)
+		err = syscall.Mkfifo(udsPath, 0o600)
 		Expect(err).ToNot(HaveOccurred())
 		if isRootless() {
 			err = podmanTest.RestoreArtifact(fedoraMinimal)
@@ -40,7 +40,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		}
 		_, pid := podmanTest.PodmanPID([]string{"run", "-v", fmt.Sprintf("%s:/h:Z", udsDir), fedoraMinimal, "bash", "-c", sigCatch})
 
-		uds, _ := os.OpenFile(udsPath, os.O_RDONLY|syscall.O_NONBLOCK, 0600)
+		uds, _ := os.OpenFile(udsPath, os.O_RDONLY|syscall.O_NONBLOCK, 0o600)
 		defer uds.Close()
 
 		// Wait for the script in the container to alert us that it is READY

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Podman run", func() {
 		testFilePath := filepath.Join(uls, uniqueString)
 		tarball := filepath.Join(tempdir, "rootfs.tar")
 
-		err := os.Mkdir(rootfs, 0770)
+		err := os.Mkdir(rootfs, 0o770)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Change image in predictable way to validate export
@@ -976,7 +976,7 @@ USER bin`, BB)
 	It("podman test hooks", func() {
 		SkipIfRemote("--hooks-dir does not work with remote")
 		hooksDir := filepath.Join(tempdir, "hooks,withcomma")
-		err := os.Mkdir(hooksDir, 0755)
+		err := os.Mkdir(hooksDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		hookJSONPath := filepath.Join(hooksDir, "checkhooks.json")
 		hookScriptPath := filepath.Join(hooksDir, "checkhooks.sh")
@@ -988,7 +988,7 @@ USER bin`, BB)
 	"stage" : [ "prestart" ]
 }
 `, hookScriptPath)
-		err = os.WriteFile(hookJSONPath, []byte(hookJSON), 0644)
+		err = os.WriteFile(hookJSONPath, []byte(hookJSON), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		random := stringid.GenerateRandomID()
@@ -1018,7 +1018,7 @@ rm -f $tmpfile.json
 # caller will confirm.
 echo -n madeit-$teststring >$tmpfile
 `, random, targetFile)
-		err = os.WriteFile(hookScriptPath, []byte(hookScript), 0755)
+		err = os.WriteFile(hookScriptPath, []byte(hookScript), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"--hooks-dir", hooksDir, "run", ALPINE, "ls"})
@@ -1033,28 +1033,28 @@ echo -n madeit-$teststring >$tmpfile
 	It("podman run with subscription secrets", func() {
 		SkipIfRemote("--default-mount-file option is not supported in podman-remote")
 		containersDir := filepath.Join(podmanTest.TempDir, "containers")
-		err := os.MkdirAll(containersDir, 0755)
+		err := os.MkdirAll(containersDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		secretsDir := filepath.Join(podmanTest.TempDir, "rhel", "secrets")
-		err = os.MkdirAll(secretsDir, 0755)
+		err = os.MkdirAll(secretsDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		mountsFile := filepath.Join(containersDir, "mounts.conf")
 		mountString := secretsDir + ":/run/secrets"
-		err = os.WriteFile(mountsFile, []byte(mountString), 0755)
+		err = os.WriteFile(mountsFile, []byte(mountString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		secretsFile := filepath.Join(secretsDir, "test.txt")
 		secretsString := "Testing secrets mount. I am mounted!"
-		err = os.WriteFile(secretsFile, []byte(secretsString), 0755)
+		err = os.WriteFile(secretsFile, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		targetDir := filepath.Join(tempdir, "symlink/target")
-		err = os.MkdirAll(targetDir, 0755)
+		err = os.MkdirAll(targetDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		keyFile := filepath.Join(targetDir, "key.pem")
-		err = os.WriteFile(keyFile, []byte(mountString), 0755)
+		err = os.WriteFile(keyFile, []byte(mountString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		execSession := SystemExec("ln", []string{"-s", targetDir, filepath.Join(secretsDir, "mysymlink")})
 		Expect(execSession).Should(ExitCleanly())
@@ -1208,13 +1208,13 @@ USER mail`, BB)
 
 	It("podman run --volumes-from flag", func() {
 		vol := filepath.Join(podmanTest.TempDir, "vol-test")
-		err := os.MkdirAll(vol, 0755)
+		err := os.MkdirAll(vol, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		filename := "test.txt"
 		volFile := filepath.Join(vol, filename)
 		data := "Testing --volumes-from!!!"
-		err = os.WriteFile(volFile, []byte(data), 0755)
+		err = os.WriteFile(volFile, []byte(data), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		mountpoint := "/myvol/"
 
@@ -1240,13 +1240,13 @@ USER mail`, BB)
 
 	It("podman run --volumes-from flag options", func() {
 		vol := filepath.Join(podmanTest.TempDir, "vol-test")
-		err := os.MkdirAll(vol, 0755)
+		err := os.MkdirAll(vol, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		filename := "test.txt"
 		volFile := filepath.Join(vol, filename)
 		data := "Testing --volumes-from!!!"
-		err = os.WriteFile(volFile, []byte(data), 0755)
+		err = os.WriteFile(volFile, []byte(data), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		mountpoint := "/myvol/"
 
@@ -1302,7 +1302,7 @@ USER mail`, BB)
 
 	It("podman run --volumes-from flag mount conflicts with image volume", func() {
 		volPathOnHost := filepath.Join(podmanTest.TempDir, "myvol")
-		err := os.MkdirAll(volPathOnHost, 0755)
+		err := os.MkdirAll(volPathOnHost, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		imgName := "testimg"
@@ -1330,10 +1330,10 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run --volumes flag with multiple volumes", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
-		err = os.MkdirAll(vol2, 0755)
+		err = os.MkdirAll(vol2, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:z", "--volume", vol2 + ":/myvol2:z", ALPINE, "touch", "/myvol2/foo.txt"})
@@ -1343,7 +1343,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run --volumes flag with empty host dir", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--volume", ":/myvol1:z", ALPINE, "touch", "/myvol2/foo.txt"})
@@ -1356,10 +1356,10 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run --mount flag with multiple mounts", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
-		err = os.MkdirAll(vol2, 0755)
+		err = os.MkdirAll(vol2, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--mount", "type=bind,src=" + vol1 + ",target=/myvol1,z", "--mount", "type=bind,src=" + vol2 + ",target=/myvol2,z", ALPINE, "touch", "/myvol2/foo.txt"})
@@ -1369,10 +1369,10 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run findmnt nothing shared", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(vol1, 0755)
+		err := os.MkdirAll(vol1, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
-		err = os.MkdirAll(vol2, 0755)
+		err = os.MkdirAll(vol2, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:z", "--volume", vol2 + ":/myvol2:z", fedoraMinimal, "findmnt", "-o", "TARGET,PROPAGATION"})
@@ -1383,7 +1383,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run findmnt shared", func() {
 		vol := filepath.Join(podmanTest.TempDir, "vol-test")
-		err := os.MkdirAll(vol, 0755)
+		err := os.MkdirAll(vol, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--volume", vol + ":/myvol:z", fedoraMinimal, "findmnt", "-no", "PROPAGATION", "/myvol"})
@@ -1565,11 +1565,11 @@ VOLUME %s`, ALPINE, volPath, volPath)
 	Describe("podman run with --hosts-file", func() {
 		BeforeEach(func() {
 			configHosts := filepath.Join(podmanTest.TempDir, "hosts")
-			err := os.WriteFile(configHosts, []byte("12.34.56.78 config.example.com"), 0755)
+			err := os.WriteFile(configHosts, []byte("12.34.56.78 config.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			confFile := filepath.Join(podmanTest.TempDir, "containers.conf")
-			err = os.WriteFile(confFile, fmt.Appendf(nil, "[containers]\nbase_hosts_file=\"%s\"\n", configHosts), 0755)
+			err = os.WriteFile(confFile, fmt.Appendf(nil, "[containers]\nbase_hosts_file=\"%s\"\n", configHosts), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 			os.Setenv("CONTAINERS_CONF_OVERRIDE", confFile)
 			if IsRemote() {
@@ -1585,7 +1585,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 		It("--hosts-file=path", func() {
 			hostsPath := filepath.Join(podmanTest.TempDir, "hosts")
-			err := os.WriteFile(hostsPath, []byte("23.45.67.89 file.example.com"), 0755)
+			err := os.WriteFile(hostsPath, []byte("23.45.67.89 file.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			session := podmanTest.Podman([]string{"run", "--hostname", "hosts_test.dev", "--hosts-file=" + hostsPath, "--add-host=add.example.com:34.56.78.90", "--name", "hosts_test", "--rm", "foobar.com/hosts_test:latest", "cat", "/etc/hosts"})
@@ -1658,7 +1658,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 		It("should fail with --no-hosts", func() {
 			hostsPath := filepath.Join(podmanTest.TempDir, "hosts")
-			err := os.WriteFile(hostsPath, []byte("23.45.67.89 file2.example.com"), 0755)
+			err := os.WriteFile(hostsPath, []byte("23.45.67.89 file2.example.com"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			session := podmanTest.Podman([]string{"run", "--no-hosts", "--hosts-file=" + hostsPath, "--name", "hosts_test", "--rm", "foobar.com/hosts_test:latest", "cat", "/etc/hosts"})
@@ -1670,7 +1670,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run with restart-policy always restarts containers", func() {
 		testDir := filepath.Join(podmanTest.RunRoot, "restart-test")
-		err := os.MkdirAll(testDir, 0755)
+		err := os.MkdirAll(testDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		aliveFile := filepath.Join(testDir, "running")
@@ -1929,7 +1929,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 
 	It("podman run --tz", func() {
 		testDir := filepath.Join(podmanTest.RunRoot, "tz-test")
-		err := os.MkdirAll(testDir, 0755)
+		err := os.MkdirAll(testDir, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		tzFile := filepath.Join(testDir, "tzfile.txt")
@@ -2075,7 +2075,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2097,7 +2097,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=mount", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2119,7 +2119,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=mount with target", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret_target", secretFilePath})
@@ -2141,7 +2141,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=mount with target at /tmp", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret_target2", secretFilePath})
@@ -2163,7 +2163,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=env", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2179,7 +2179,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret target option", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2195,7 +2195,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret mount with uid, gid, mode options", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2222,7 +2222,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret with --user", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2238,7 +2238,7 @@ WORKDIR /madethis`, BB)
 	It("podman run invalid secret option", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -2441,10 +2441,10 @@ log_driver = "k8s-file"
 log_path = "%s"
 `, confLogPath)
 
-		err := os.WriteFile(conffile, []byte(configContent), 0644)
+		err := os.WriteFile(conffile, []byte(configContent), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.MkdirAll(confLogPath, 0755)
+		err = os.MkdirAll(confLogPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)
@@ -2479,10 +2479,10 @@ log_driver = "k8s-file"
 log_path = "%s"
 `, confLogPath)
 
-		err := os.WriteFile(conffile, []byte(configContent), 0644)
+		err := os.WriteFile(conffile, []byte(configContent), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.MkdirAll(confLogPath, 0755)
+		err = os.MkdirAll(confLogPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF_OVERRIDE", conffile)

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 	It("podman run with volume flag", func() {
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		vol := mountPath + ":" + dest
 
@@ -73,7 +73,7 @@ var _ = Describe("Podman run with volumes", func() {
 			Skip("skip failing test on ppc64le")
 		}
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		mount := "type=bind,src=" + mountPath + ",target=" + dest
 
@@ -137,7 +137,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 	It("podman run with conflicting volumes errors", func() {
 		mountPath := filepath.Join(podmanTest.TmpDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"run", "-v", mountPath + ":" + dest, "-v", "/tmp" + ":" + dest, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
@@ -165,7 +165,7 @@ var _ = Describe("Podman run with volumes", func() {
 		err = podmanTest.RestoreArtifact(REDIS_IMAGE)
 		Expect(err).ToNot(HaveOccurred())
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		testFile := filepath.Join(mountPath, "test1")
 		f, err := os.Create(testFile)
@@ -179,7 +179,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 	It("podman run with mount flag and boolean options", func() {
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		mount := "type=bind,src=" + mountPath + ",target=" + dest
 
@@ -222,7 +222,7 @@ var _ = Describe("Podman run with volumes", func() {
 		}
 
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", mountPath + ":" + dest + ":suid,dev,exec", ALPINE, "grep", dest, "/proc/self/mountinfo"})
@@ -249,7 +249,7 @@ var _ = Describe("Podman run with volumes", func() {
 			Skip("Overlay mounts not supported when running in a container")
 		}
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Container should be able to start with custom overlay volume
@@ -294,12 +294,12 @@ var _ = Describe("Podman run with volumes", func() {
 
 		// create persistent upperdir on host
 		upperDir := filepath.Join(tempdir, "upper")
-		err := os.Mkdir(upperDir, 0755)
+		err := os.Mkdir(upperDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+upperDir)
 
 		// create persistent workdir on host
 		workDir := filepath.Join(tempdir, "work")
-		err = os.Mkdir(workDir, 0755)
+		err = os.Mkdir(workDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+workDir)
 
 		overlayOpts := fmt.Sprintf("upperdir=%s,workdir=%s", upperDir, workDir)
@@ -343,17 +343,17 @@ var _ = Describe("Podman run with volumes", func() {
 
 		// Use bindsource instead of named volume
 		bindSource := filepath.Join(tempdir, "bindsource")
-		err := os.Mkdir(bindSource, 0755)
+		err := os.Mkdir(bindSource, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+bindSource)
 
 		// create persistent upperdir on host
 		upperDir := filepath.Join(tempdir, "upper")
-		err = os.Mkdir(upperDir, 0755)
+		err = os.Mkdir(upperDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+upperDir)
 
 		// create persistent workdir on host
 		workDir := filepath.Join(tempdir, "work")
-		err = os.Mkdir(workDir, 0755)
+		err = os.Mkdir(workDir, 0o755)
 		Expect(err).ToNot(HaveOccurred(), "mkdir "+workDir)
 
 		overlayOpts := fmt.Sprintf("upperdir=%s,workdir=%s", upperDir, workDir)
@@ -672,7 +672,7 @@ VOLUME /test/`, ALPINE)
 			Skip("Overlay mounts not supported when running in a container")
 		}
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		testFile := filepath.Join(mountPath, "test1")
 		f, err := os.Create(testFile)
@@ -724,14 +724,14 @@ VOLUME /test/`, ALPINE)
 
 	It("overlay volume conflicts with named volume and mounts", func() {
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err := os.Mkdir(mountPath, 0755)
+		err := os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		testFile := filepath.Join(mountPath, "test1")
 		f, err := os.Create(testFile)
 		Expect(err).ToNot(HaveOccurred())
 		f.Close()
 		mountSrc := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err = os.MkdirAll(mountSrc, 0755)
+		err = os.MkdirAll(mountSrc, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		mountDest := "/run/test"
 		volName := "myvol"
@@ -783,7 +783,7 @@ VOLUME /test/`, ALPINE)
 		}
 
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		vol := mountPath + ":" + dest + ":U"
 
@@ -828,7 +828,7 @@ VOLUME /test/`, ALPINE)
 		}
 
 		mountPath := filepath.Join(podmanTest.TempDir, "foo")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// false bind mount
@@ -933,7 +933,7 @@ USER testuser`, CITEST_IMAGE)
 
 	It("podman run with -v $SRC:/run does not create /run/.containerenv", func() {
 		mountSrc := filepath.Join(podmanTest.TempDir, "vol-test1")
-		err := os.MkdirAll(mountSrc, 0755)
+		err := os.MkdirAll(mountSrc, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"run", "-v", mountSrc + ":/run", ALPINE, "true"})
@@ -979,7 +979,7 @@ USER testuser`, CITEST_IMAGE)
 
 	It("podman run -v with a relative dir", func() {
 		mountPath := filepath.Join(podmanTest.TempDir, "vol")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			err := os.RemoveAll(mountPath)
@@ -1135,7 +1135,7 @@ RUN chmod 755 /test1 /test2 /test3`, ALPINE)
 		err := podmanTest.RestoreArtifact(REDIS_IMAGE)
 		Expect(err).ToNot(HaveOccurred())
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
-		err = os.Mkdir(mountPath, 0755)
+		err = os.Mkdir(mountPath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		testFile := filepath.Join(mountPath, "test1")
 		f, err := os.Create(testFile)

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -172,7 +172,7 @@ default-docker:
   sigstore: file:///var/lib/containers/sigstore
   sigstore-staging: file:///var/lib/containers/sigstore
 `
-		Expect(os.WriteFile("/etc/containers/registries.d/default.yaml", []byte(sigstore), 0755)).To(Succeed())
+		Expect(os.WriteFile("/etc/containers/registries.d/default.yaml", []byte(sigstore), 0o755)).To(Succeed())
 
 		pushedImage := fmt.Sprintf("localhost:%d/alpine", port)
 		session = podmanTest.Podman([]string{"tag", ALPINE, pushedImage})

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -266,7 +266,7 @@ registries = []`
 		err = registryFileTmpl.Execute(&buffer, ep)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = os.WriteFile(fmt.Sprintf("%s/registry4.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry4.conf", tempdir), buffer.Bytes(), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
@@ -309,7 +309,7 @@ registries = []`
 		err = registryFileTmpl.Execute(&buffer, ep)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = os.WriteFile(fmt.Sprintf("%s/registry5.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry5.conf", tempdir), buffer.Bytes(), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		search := podmanTest.Podman([]string{"search", image, "--tls-verify=true"})
@@ -348,7 +348,7 @@ registries = []`
 		err = registryFileBadTmpl.Execute(&buffer, ep)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = os.WriteFile(fmt.Sprintf("%s/registry6.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry6.conf", tempdir), buffer.Bytes(), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		if IsRemote() {

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret create", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "-d", "file", "--driver-opts", "opt1=val", "a", secretFilePath})
@@ -66,7 +66,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret create with --ignore", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// First create a secret
@@ -94,7 +94,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret create bad name should fail", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		badName := "foo/bar"
@@ -111,7 +111,7 @@ var _ = Describe("Podman secret", func() {
 	It("podman secret inspect", func() {
 		random := stringid.GenerateRandomID()
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte(random), 0755)
+		err := os.WriteFile(secretFilePath, []byte(random), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -137,7 +137,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect with --format", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -153,7 +153,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect with --pretty", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -170,7 +170,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect multiple secrets", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -191,7 +191,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect bogus", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		inspect := podmanTest.Podman([]string{"secret", "inspect", "bogus"})
@@ -201,7 +201,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -217,7 +217,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls --quiet", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		secretName := "a"
@@ -247,7 +247,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls with filters", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		secret1 := "Secret1"
@@ -311,7 +311,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls with Go template", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -327,7 +327,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls with valid format fields Driver/CreatedAt", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		podmanTest.PodmanExitCleanly("secret", "create", "fmt", secretFilePath)
@@ -343,7 +343,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls with invalid Spec.* format should error", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		podmanTest.PodmanExitCleanly("secret", "create", "fmt2", secretFilePath)
@@ -356,7 +356,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret rm", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -384,7 +384,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret rm --all", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -440,7 +440,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret with labels", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"secret", "create", "--label", "foo=bar", "a", secretFilePath})
@@ -478,7 +478,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret exists should return true if secret exists", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		secretName := "does_exist"

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -622,7 +622,7 @@ qe ssh://root@podman.test:2222/run/podman/podman.sock ~/.ssh/id_rsa false true
 						khFile, err := os.Create(khPath)
 						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create %s", khPath))
 						defer khFile.Close()
-						err = os.WriteFile(khPath, []byte(strings.Join(initialKhLines, "\n")), 0600)
+						err = os.WriteFile(khPath, []byte(strings.Join(initialKhLines, "\n")), 0o600)
 						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to write to %s", khPath))
 					}
 					// Ensure that the remote end uses our built podman

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -76,7 +76,7 @@ RUN mkdir -p /usr/lib/systemd/; touch /usr/lib/systemd/systemd
 CMD /usr/lib/systemd/systemd`, ALPINE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0o755)
 		Expect(err).ToNot(HaveOccurred())
 		session := podmanTest.Podman([]string{"build", "-t", "systemd", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Podman volume plugins", func() {
 		os.Setenv("CONTAINERS_CONF", "config/containers.conf")
 		SkipIfRemote("Volume plugins only supported as local")
 		SkipIfRootless("Root is required for volume plugin testing")
-		err = os.MkdirAll("/run/docker/plugins", 0755)
+		err = os.MkdirAll("/run/docker/plugins", 0o755)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -42,7 +42,7 @@ var _ = Describe("Podman volume plugins", func() {
 		podmanTest.AddImageToRWStore(volumeTest)
 
 		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
-		err := os.Mkdir(pluginStatePath, 0755)
+		err := os.Mkdir(pluginStatePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Keep this distinct within tests to avoid multiple tests using the same plugin.
@@ -88,7 +88,7 @@ var _ = Describe("Podman volume plugins", func() {
 		podmanTest.AddImageToRWStore(volumeTest)
 
 		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
-		err := os.Mkdir(pluginStatePath, 0755)
+		err := os.Mkdir(pluginStatePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Keep this distinct within tests to avoid multiple tests using the same plugin.
@@ -116,7 +116,7 @@ var _ = Describe("Podman volume plugins", func() {
 		podmanTest.AddImageToRWStore(volumeTest)
 
 		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
-		err := os.Mkdir(pluginStatePath, 0755)
+		err := os.Mkdir(pluginStatePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Keep this distinct within tests to avoid multiple tests using the same plugin.
@@ -160,7 +160,7 @@ var _ = Describe("Podman volume plugins", func() {
 		podmanTest.AddImageToRWStore(volumeTest)
 
 		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
-		err := os.Mkdir(pluginStatePath, 0755)
+		err := os.Mkdir(pluginStatePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Keep this distinct within tests to avoid multiple tests using the same plugin.
@@ -201,7 +201,7 @@ testvol5 = "/run/docker/plugins/testvol5.sock"`), 0o644)
 		os.Setenv("CONTAINERS_CONF", confFile)
 
 		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
-		err = os.Mkdir(pluginStatePath, 0755)
+		err = os.Mkdir(pluginStatePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Keep this distinct within tests to avoid multiple tests using the same plugin.
@@ -265,7 +265,7 @@ Removed:
 		podmanTest.AddImageToRWStore(volumeTest)
 
 		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
-		err := os.Mkdir(pluginStatePath, 0755)
+		err := os.Mkdir(pluginStatePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Keep this distinct within tests to avoid multiple tests using the same plugin.

--- a/test/testvol/main.go
+++ b/test/testvol/main.go
@@ -158,7 +158,7 @@ func (d *DirDriver) Create(opts *volume.CreateRequest) error {
 	maps.Copy(newVol.options, opts.Options)
 
 	volPath := filepath.Join(d.volumesPath, opts.Name)
-	if err := os.Mkdir(volPath, 0755); err != nil {
+	if err := os.Mkdir(volPath, 0o755); err != nil {
 		return fmt.Errorf("making volume directory: %w", err)
 	}
 	newVol.path = volPath

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -506,7 +506,7 @@ func WriteJSONFile(data []byte, filePath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filePath, formatJSON, 0644)
+	return os.WriteFile(filePath, formatJSON, 0o644)
 }
 
 // Containerized check the podman command run inside container
@@ -553,7 +553,7 @@ func savePublicKey(fileName string, publicKey *rsa.PublicKey) (string, error) {
 
 	// Write public key to file
 	publicKeyFileName := fileName + ".rsa.pub"
-	if err := os.WriteFile(publicKeyFileName, pubPEM, 0600); err != nil {
+	if err := os.WriteFile(publicKeyFileName, pubPEM, 0o600); err != nil {
 		return "", err
 	}
 
@@ -575,7 +575,7 @@ func savePrivateKey(fileName string, privateKey *rsa.PrivateKey) (string, error)
 
 	// Write private key to file
 	privateKeyFileName := fileName + ".rsa"
-	if err := os.WriteFile(privateKeyFileName, keyPEM, 0600); err != nil {
+	if err := os.WriteFile(privateKeyFileName, keyPEM, 0o600); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Problem: While removing cgroupsv1 code, I noticed my neovim Go config automatically changed fileperms to the new octal format and I didn't want that polluting my diffs.

Decision: I thought it best to switch to the new octal format in a dedicated PR.

Action:
- Cursor switched to new octal format for all fileperm ocurrences in Go source and test files.
- vendor/, docs/ and non-Go files were ignored.
- Reviewed manually.

Ref: https://go.dev/ref/spec#Go_1.13

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

(We can block this until Podman 6 if we're not comfortable with this going in earlier, but it'd be really nice to have it go in sooner (maybe even v5.7, assuming nothing breaks)).