### PR TITLE
Add a documentation entry about hooks for podman-run

### DIFF
--- a/docs/source/markdown/options/hooks-dir.run.md
+++ b/docs/source/markdown/options/hooks-dir.run.md
@@ -1,0 +1,9 @@
+####> This option file is used in:
+####>   podman run
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--hooks-dir**
+
+Specify directories containing OCI (Open Container Initiative) hook configuration files.
+
+Each `*json*` file in the path configures a OCI hook for Podman containers. Read the documentation for more information about the [the different hook properties and configuration](https://specs.opencontainers.org/runtime-spec/config/#posix-platform-hooks).

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -238,6 +238,8 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 Print usage statement
 
+@@option hooks-dir.run
+
 @@option hostname.container
 
 @@option hosts-file


### PR DESCRIPTION
Add a documentation entry about hooks for podman-run, by documenting the hooks-dir argument.

Fixes: #27281 
