### PR TITLE
Warn on BoltDB usage

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -81,6 +81,7 @@ function _run_sys() {
 }
 
 function _run_upgrade_test() {
+    export SUPPRESS_BOLTDB_WARNING=true
     showrun bats test/upgrade |& logformatter
 }
 

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -289,6 +289,7 @@ EOF
 
 }
 
+# TODO 6.0: Remove this
 @test "podman - BoltDB cannot create new databases" {
     skip_if_remote "DB checks only work for local Podman"
 
@@ -302,7 +303,7 @@ EOF
     assert "$output" =~ "Allowing deprecated database backend" \
            "with CI_DESIRED_DATABASE"
 
-    run_podman $safe_opts system reset --force
+    SUPPRESS_BOLTDB_WARNING=true run_podman $safe_opts system reset --force
 }
 
 @test "podman - empty string defaults for certain values" {

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -207,6 +207,8 @@ function wait_for_journal() {
     # Ref https://github.com/containers/podman/pull/21563#issuecomment-1965145324
     local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
     cat > $quadlet_file <<EOF
+[Service]
+Environment=SUPPRESS_BOLTDB_WARNING=true
 [Container]
 Image=$IMAGE
 # Note it is important that the trap is before the ready message,


### PR DESCRIPTION
We started logging this in 5.6. In 5.7, we up to a warning. The upcoming 5.8 will up the warnings further to errors.

Required as we're removing BoltDB support in 6.0 next Spring.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now warns when started with a BoltDB database. Support for BoltDB will be removed in Podman 6.0.
```
