### PR TITLE
Quadlet build - add support for IgnoreFile key

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1724,6 +1724,7 @@ Valid options for `[Build]` are listed below:
 | ForceRM=false                       | --force-rm=false                            |
 | GlobalArgs=--log-level=debug        | --log-level=debug                           |
 | GroupAdd=keep-groups                | --group-add=keep-groups                     |
+| IgnoreFile=/path/to/.customignore   | --ignorefile=/path/to/.customignore         |
 | ImageTag=localhost/imagename        | --tag=localhost/imagename                   |
 | Label=label                         | --label=label                               |
 | Network=host                        | --network=host                              |
@@ -1830,6 +1831,13 @@ Assign additional groups to the primary user running within the container proces
 `keep-groups` special flag.
 
 This is equivalent to the `--group-add` option of `podman build`.
+
+### `IgnoreFile=`
+
+Path to an alternate .containerignore file to use when building the image.
+Note that when using a relative path you should also set `SetWorkingDirectory=`
+
+This is equivalent to the `--ignorefile` option of `podman build`.
 
 ### `ImageTag=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -113,6 +113,7 @@ const (
 	KeyHealthTimeout         = "HealthTimeout"
 	KeyHostName              = "HostName"
 	KeyHttpProxy             = "HttpProxy"
+	KeyIgnoreFile            = "IgnoreFile"
 	KeyImage                 = "Image"
 	KeyImageTag              = "ImageTag"
 	KeyInterfaceName         = "InterfaceName"
@@ -446,6 +447,7 @@ var (
 				KeyForceRM:              true,
 				KeyGlobalArgs:           true,
 				KeyGroupAdd:             true,
+				KeyIgnoreFile:           true,
 				KeyImageTag:             true,
 				KeyLabel:                true,
 				KeyNetwork:              true,
@@ -1392,6 +1394,7 @@ func ConvertBuild(build *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, isU
 	stringKeys := map[string]string{
 		KeyArch:       "--arch",
 		KeyAuthFile:   "--authfile",
+		KeyIgnoreFile: "--ignorefile",
 		KeyTarget:     "--target",
 		KeyVariant:    "--variant",
 		KeyRetry:      "--retry",

--- a/test/e2e/quadlet/ignorefile.build
+++ b/test/e2e/quadlet/ignorefile.build
@@ -1,0 +1,6 @@
+## assert-podman-args "--ignorefile" "/path/to/.customignore"
+
+[Build]
+ImageTag=localhost/imagename
+SetWorkingDirectory=unit
+IgnoreFile=/path/to/.customignore

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1056,6 +1056,7 @@ BOGUS=foo
 		Entry("Build - ForceRM Key", "force-rm.build"),
 		Entry("Build - GlobalArgs", "globalargs.build"),
 		Entry("Build - GroupAdd Key", "group-add.build"),
+		Entry("Build - IgnoreFile Key", "ignorefile.build"),
 		Entry("Build - Containers Conf Modules", "containersconfmodule.build"),
 		Entry("Build - Label Key", "label.build"),
 		Entry("Build - Multiple Tags", "multiple-tags.build"),


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes

```release-note
Qualdet - add support for IgnoreFile in .build files
```

Resolves: https://github.com/containers/podman/issues/27268
