### PR TITLE
Add CREATED column to podman artifact ls output

### DIFF
--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -18,6 +18,7 @@ Print results with a Go template.
 
 | **Placeholder** | **Description**                                |
 |-----------------|------------------------------------------------|
+| .Created        | Artifact creation time in human readable units |
 | .Digest         | The computed digest of the artifact's manifest |
 | .Repository     | Repository name of the artifact                |
 | .Size           | Size artifact in human readable units          |
@@ -33,24 +34,24 @@ Print results with a Go template.
 List artifacts in the local store
 ```
 $ podman artifact ls
-REPOSITORY                TAG         DIGEST             SIZE
-quay.io/artifact/foobar1  latest      ab609fad386d       2.097GB
-quay.io/artifact/foobar2  special     cd734b558ceb       12.58MB
+REPOSITORY                TAG         DIGEST             CREATED          SIZE
+quay.io/artifact/foobar1  latest      ab609fad386d       3 weeks ago      2.097GB
+quay.io/artifact/foobar2  special     cd734b558ceb       2 days ago       12.58MB
 ```
 
 List artifacts in the local store without truncating the digest
 ```
 $ podman artifact ls --no-trunc
-REPOSITORY                TAG         DIGEST                                                              SIZE
-quay.io/artifact/foobar1  latest      ab609fad386df1433f461b0643d9cf575560baf633809dcc9c190da6cc3a3c29    2.097GB
-quay.io/artifact/foobar2  special     cd734b558ceb8ccc0281ca76530e1dea1eb479407d3163f75fb601bffb6f73d0    12.58MB
+REPOSITORY                TAG         DIGEST                                                              CREATED          SIZE
+quay.io/artifact/foobar1  latest      ab609fad386df1433f461b0643d9cf575560baf633809dcc9c190da6cc3a3c29    3 weeks ago      2.097GB
+quay.io/artifact/foobar2  special     cd734b558ceb8ccc0281ca76530e1dea1eb479407d3163f75fb601bffb6f73d0    2 days ago       12.58MB
 ```
 
 List artifacts in the local store without the title header
 ```
 $ podman artifact ls --noheading
-quay.io/artifact/foobar1  latest      ab609fad386d       2.097GB
-quay.io/artifact/foobar2  special     cd734b558ceb       12.58MB
+quay.io/artifact/foobar1  latest      ab609fad386d       3 weeks ago      2.097GB
+quay.io/artifact/foobar2  special     cd734b558ceb       2 days ago       12.58MB
 ```
 
 List artifact digests and size using a --format

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -78,6 +78,19 @@ var _ = Describe("Podman artifact", func() {
 		// Verify if the virtual size values are present in the output
 		Expect(virtualSizes).To(ContainElement("4192"))
 		Expect(virtualSizes).To(ContainElement("10240"))
+
+		// Check if .Created is reported and is not "<unknown>"
+		createdFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Created}}")
+		createdTimes := createdFormatSession.OutputToStringArray()
+
+		// Should list 2 lines (without the header)
+		Expect(createdTimes).To(HaveLen(2))
+
+		// Verify the created times are not "<unknown>" and end with " ago"
+		for _, created := range createdTimes {
+			Expect(created).ToNot(Equal("<unknown>"))
+			Expect(created).To(HaveSuffix(" ago"))
+		}
 	})
 
 	It("podman artifact simple add", func() {


### PR DESCRIPTION
This change adds a CREATED column to the podman artifact ls command output, displaying the artifact creation time in human-readable format (e.g., "3 weeks ago"), similar to podman image ls.

The creation time is extracted from the org.opencontainers.image.created annotation stored in the artifact manifest and formatted using units.HumanDuration.

Changes:
- Add Created field to artifactListOutput struct
- Parse and format creation time from manifest annotations
- Update default output format to include CREATED column
- Update documentation with Created placeholder
- Add test to verify Created column is displayed

Fixes #27314

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman artifact ls now lists the time the artifact was created.
```
