### PR TITLE
libpod: fix healthchecks not executing every interval on linux

### DIFF
--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -40,7 +40,8 @@ func (c *Container) createTimer(interval string, isStartup bool) error {
 		cmd = append(cmd, "--setenv=PATH="+path)
 	}
 
-	cmd = append(cmd, "--unit", hcUnitName, fmt.Sprintf("--on-unit-inactive=%s", interval), "--timer-property=AccuracySec=1s", podman)
+	// StartLimitIntervalSec=0 so we don't hit the restart limit
+	cmd = append(cmd, "--unit", hcUnitName, fmt.Sprintf("--on-unit-inactive=%s", interval), "--timer-property=AccuracySec=1s", "--property=StartLimitIntervalSec=0", podman)
 
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmd = append(cmd, "--log-level=debug", "--syslog")

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -104,6 +104,11 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
     assert "$cidmatch" =~ " $cid-[0-9a-f]+\.timer  *.*/podman healthcheck run $cid" \
            "Healthcheck systemd unit exists"
 
+    # Check that the right service option is applied so we don't hit the systemd restart limit.
+    # Even though the code sets StartLimitIntervalSec the systemd command prints StartLimitInterval*U*Sec
+    run -0 systemctl show "$cid-*.service"
+    assert "$output" =~ "StartLimitIntervalUSec=0" "The hc service has the right interval set"
+
     current_time=$(date --iso-8601=ns)
     # After three successive failures, container should no longer be healthy
     _check_health $ctrname "Four or more failures" "


### PR DESCRIPTION
By default, systemd sets a limit of how many times a service can start, which means that if you have a healthcheck that runs more often than the limits, systemd will refuse to start it with a message like "Start request repeated too quickly." emitted to the journal.

I'm not familiar enough with the e2e test suite to confidently write a test for this -- hints appreciated! :)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that prevented healthchecks from running consistently on time on Linux.
```
