### PR TITLE
fix: typo in uidmap option doc

### DIFF
--- a/docs/source/markdown/options/uidmap.container.md
+++ b/docs/source/markdown/options/uidmap.container.md
@@ -109,7 +109,7 @@ regardless of how the intermediate mapping is defined.
 
 Some mapping modifications may be cumbersome. For instance, a user
 starts with a mapping such as `--gidmap="0:0:65000"`, that needs to be
-changed such as the parent id `1000` is mapped to container id `100000`
+changed such as the parent id `1` is mapped to container id `100000`
 instead, leaving container id `1` unassigned. The corresponding `--gidmap`
 becomes `--gidmap="0:0:1" --gidmap="2:2:65534" --gidmap="100000:1:1"`.
 


### PR DESCRIPTION
The following section describes how to map to host ID `1`, not `1000`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
I'm assuming that despite the change in user-facing documentation, size this small doesn't need to be included in the release note.