### PR TITLE
quadlet: add `cat` alias for `print`

### DIFF
--- a/cmd/podman/quadlet/print.go
+++ b/cmd/podman/quadlet/print.go
@@ -17,6 +17,7 @@ var (
 		Long:              quadletPrintDescription,
 		RunE:              print,
 		ValidArgsFunction: common.AutocompleteQuadlets,
+		Aliases:           []string{"cat"},
 		Args:              cobra.ExactArgs(1),
 		Example: `podman quadlet print myquadlet.container
 podman quadlet print mypod.pod

--- a/docs/source/markdown/podman-quadlet-print.1.md
+++ b/docs/source/markdown/podman-quadlet-print.1.md
@@ -6,12 +6,15 @@ podman\-quadlet\-print - Display the contents of a quadlet
 ## SYNOPSIS
 **podman quadlet print** *quadlet*
 
+**podman quadlet cat** *quadlet*
+
 ## DESCRIPTION
 
 Print the contents of a Quadlet, displaying the file including all comments.
 
 ## EXAMPLES
 
+Using `podman quadlet print` to display the contents of a quadlet named `myquadlet.container`:
 ```
 $ podman quadlet print myquadlet.container
 [Container]

--- a/test/system/253-podman-quadlet.bats
+++ b/test/system/253-podman-quadlet.bats
@@ -75,6 +75,10 @@ EOF
     run_podman quadlet print alpine-quadlet.container
     assert "$output" == "$(<$quadlet_file)" "print output matches quadlet file"
 
+    # Test quadlet cat
+    run_podman quadlet cat alpine-quadlet.container
+    assert "$output" == "$(<$quadlet_file)" "cat output matches quadlet file"
+
     # Test quadlet rm
     run_podman quadlet rm alpine-quadlet.container
     # Verify remove output contains the quadlet name on a single line


### PR DESCRIPTION
Add new alias `podman quadlet cat` to `podman quadlet print` to align Podman's quadlet CLI with systemd conventions.

Fixes: https://github.com/containers/podman/issues/27296

#### Tests

I tried my best to find proper test for `quadlet print` 😅 . I am not sure if changed bats file in the commit is correct, can you please double check?

#### Does this PR introduce a user-facing change?

```release-note
Added `podman quadlet cat` alias for `podman quadlet print`
```
