### PR TITLE
Add CreatedAt format option to podman artifact ls

### DIFF
--- a/docs/source/markdown/podman-artifact-ls.1.md.in
+++ b/docs/source/markdown/podman-artifact-ls.1.md.in
@@ -19,6 +19,7 @@ Print results with a Go template.
 | **Placeholder** | **Description**                                |
 |-----------------|------------------------------------------------|
 | .Created        | Elapsed time since the artifact was created    |
+| .CreatedAt      | Full timestamp of when the artifact was created|
 | .Digest         | The computed digest of the artifact's manifest |
 | .Repository     | Repository name of the artifact                |
 | .Size           | Size artifact in human readable units          |

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -88,6 +88,16 @@ var _ = Describe("Podman artifact", func() {
 		// Assuming the test runs less than a minute
 		humanReadableDurationRegexp := `^(Less than a second|1 second|\d+ seconds) ago$`
 		Expect(created).To(ContainElements(MatchRegexp(humanReadableDurationRegexp), MatchRegexp(humanReadableDurationRegexp)))
+
+		// Check if .CreatedAt is reported correctly
+		createdAtFormatSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.CreatedAt}}")
+		createdAt := createdAtFormatSession.OutputToStringArray()
+
+		Expect(createdAt).To(HaveLen(2))
+
+		// Verify the timestamp format looks like "2025-10-23 12:34:56.789 +0000 UTC"
+		timestampRegexp := `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)? \+\d{4} UTC$`
+		Expect(createdAt).To(ContainElements(MatchRegexp(timestampRegexp), MatchRegexp(timestampRegexp)))
 	})
 
 	It("podman artifact simple add", func() {


### PR DESCRIPTION
This change adds a .CreatedAt format option to the podman artifact ls command to match the behavior of podman images --format CreatedAt.

The .Created field continues to display human-readable elapsed time (e.g., '6 hours ago'), while the new .CreatedAt field displays the full timestamp (e.g., '2025-10-23 12:34:56 +0000 UTC').

Changes:
- Refactored artifactListOutput struct to store time.Time value
- Added CreatedAt() method returning full timestamp string
- Added Created() method for human-readable duration
- Updated documentation to include .CreatedAt field
- Added e2e test for .CreatedAt format option

Generated-with: Cursor AI

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman artifact list --format '{{ .CreatedAt }}' is now supported.
```
