### PR TITLE
Fix tmpfs U/chown option documentation

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -106,7 +106,7 @@ Options specific to type=**tmpfs** and **ramfs**:
 
 - *notmpcopyup*: Disable copying files from the image to the tmpfs/ramfs.
 
-- *U*, *chown*: *true* or *false* (default if unspecified: *false*). Recursively change the owner and group of the source volume based on the UID and GID of the container.
+- *U*, *chown*: *true* or *false* (default if unspecified: *false*). Set the uid and gid options for the tmpfs filesystem based on the UID and GID of the container. This is **not** recursive.
 
 Options specific to type=**devpts**:
 


### PR DESCRIPTION
See https://github.com/containers/podman/blob/5a0b74b13e6e8dfe9cc1d416eed743f219a83237/libpod/container_internal_common.go#L404-L411 for implementation that explicitly does not chown the tmpfs mount

#### Does this PR introduce a user-facing change?
Documentation change


```release-note
Fix tmpfs U/chown option documentation
```
