### PR TITLE
Fixes dependencies on static user systemd units.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /build/
 /conmon/
 contrib/spec/podman.spec
-contrib/systemd/system/*.service
 *.coverprofile
 coverprofile
 /.coverage

--- a/contrib/systemd/system/podman-auto-update.service.in
+++ b/contrib/systemd/system/podman-auto-update.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Podman auto-update service
 Documentation=man:podman-auto-update(1)
-Wants=network-online.target
-After=network-online.target
+Wants=@@NETWORK_ONLINE_UNIT@@
+After=@@NETWORK_ONLINE_UNIT@@
 
 [Service]
 Type=oneshot

--- a/contrib/systemd/system/podman-clean-transient.service.in
+++ b/contrib/systemd/system/podman-clean-transient.service.in
@@ -10,8 +10,8 @@
 Description=Clean up podman transient data
 RequiresMountsFor=%t/containers
 Documentation=man:podman-system-prune(1)
-Requires=boot-complete.target
-After=local-fs.target boot-complete.target
+Requires=@@BOOT_COMPLETE_UNIT@@
+After=@@LOCAL_FS_UNIT@@ @@BOOT_COMPLETE_UNIT@@
 
 [Service]
 Type=oneshot

--- a/contrib/systemd/system/podman-kube@.service.in
+++ b/contrib/systemd/system/podman-kube@.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=A template for running K8s workloads via podman-kube-play
 Documentation=man:podman-kube-play(1)
-Wants=network-online.target
-After=network-online.target
+Wants=@@NETWORK_ONLINE_UNIT@@
+After=@@NETWORK_ONLINE_UNIT@@
 RequiresMountsFor=%t/containers
 
 [Service]

--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -2,8 +2,8 @@
 Description=Podman Start All Containers With Restart Policy Set To Always
 Documentation=man:podman-start(1)
 StartLimitIntervalSec=0
-Wants=network-online.target
-After=network-online.target
+Wants=@@NETWORK_ONLINE_UNIT@@
+After=@@NETWORK_ONLINE_UNIT@@
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
https://github.com/containers/podman/issues/24637

#### Change

- Fixes static user units to use `podman-user-wait-network-online.service` rather than `network-online.target` as dependencies, by extending the template parameters and supply different values from system and user units.
- Discovers units from `contrib/systemd/user/*` rather than hard-coded list in `Makefile`.
- Honors `contrib/systemd/user/*` which seems to be unused at the moment.

#### Test

1. `make && make install` was run before and after this change in separate containers.
    ```console
    $ podman run -it --rm -v ./podman:/src -v /tmp/after:/usr/local/lib/systemd/ buildpack-deps`
    root@container:/ $ apt update && apt install ...
    root@container:/ $ cd /src
    root@container:/src $ make && make install
    ```
3. Both succeeded and the resulted `/usr/local/lib/systemd/` were mapped to the host and diffed, showing expected results.
    ```diff
    $ git --no-pager diff before after
    diff --git a/before/user/podman-auto-update.service b/after/user/podman-auto-update.service
    index 3f84e06..b952912 100644
    --- a/before/user/podman-auto-update.service
    +++ b/after/user/podman-auto-update.service
    @@ -1,8 +1,8 @@
     [Unit]
     Description=Podman auto-update service
     Documentation=man:podman-auto-update(1)
    -Wants=network-online.target
    -After=network-online.target
    +Wants=podman-user-wait-network-online.service
    +After=podman-user-wait-network-online.service
     
     [Service]
     Type=oneshot
    diff --git a/before/user/podman-clean-transient.service b/after/user/podman-clean-transient.service
    index 886668e..532b446 100644
    --- a/before/user/podman-clean-transient.service
    +++ b/after/user/podman-clean-transient.service
    @@ -10,6 +10,8 @@
     Description=Clean up podman transient data
     RequiresMountsFor=%t/containers
     Documentation=man:podman-system-prune(1)
    +Requires=
    +After= 
     
     [Service]
     Type=oneshot
    diff --git a/before/user/podman-kube@.service b/after/user/podman-kube@.service
    index 363fec2..33d2769 100644
    --- a/before/user/podman-kube@.service
    +++ b/after/user/podman-kube@.service
    @@ -1,8 +1,8 @@
     [Unit]
     Description=A template for running K8s workloads via podman-kube-play
     Documentation=man:podman-kube-play(1)
    -Wants=network-online.target
    -After=network-online.target
    +Wants=podman-user-wait-network-online.service
    +After=podman-user-wait-network-online.service
     RequiresMountsFor=%t/containers
     
     [Service]
    diff --git a/before/user/podman-restart.service b/after/user/podman-restart.service
    index 78c2019..ca9fe2f 100644
    --- a/before/user/podman-restart.service
    +++ b/after/user/podman-restart.service
    @@ -2,8 +2,8 @@
     Description=Podman Start All Containers With Restart Policy Set To Always
     Documentation=man:podman-start(1)
     StartLimitIntervalSec=0
    -Wants=network-online.target
    -After=network-online.target
    +Wants=podman-user-wait-network-online.service
    +After=podman-user-wait-network-online.service
     
     [Service]
     Type=oneshot
    ```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
