### PR TITLE
Fix copyUIDGID parameter inversion in Docker compat API

### DIFF
--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -40,7 +40,7 @@ t HEAD "containers/${CTR}/archive?path=%2Fnon%2Fexistent%2Fpath" 404
 t HEAD "containers/${CTR}/archive?path=%2Fetc%2Fpasswd" 200
 
 # Send tarfile to container...
-t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F" ${HELLO_TAR} 200 ''
+t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F&copyUIDGID=true" ${HELLO_TAR} 200 ''
 
 # ...and 'exec cat file' to confirm that it got extracted into place.
 cat >$TMPD/exec.json <<EOF
@@ -80,6 +80,44 @@ EOF
 
 t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
 eid=$(jq -r '.Id' <<<"$output")
-t POST exec/$eid/start 200 $'\001\012'1042:1043
+t POST exec/$eid/start 200
+
+output_uidgid=$(grep -o '[0-9]*:[0-9]*' <<<"$output")
+is "$output_uidgid" "1042:1043" "UID:GID preserved with copyUIDGID=true"
+
+
+FILE_NAME=test1
+TAR_PATH="${TMPD}/${FILE_NAME}.tar"
+echo "Hello2_$(random_string 8)" > ${TMPD}/${FILE_NAME}.txt
+tar --owner=2001 --group=2002 --format=posix -C $TMPD -cvf ${TAR_PATH} ${FILE_NAME}.txt &> /dev/null
+
+t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F" ${TAR_PATH} 200 ''
+
+cat >$TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["stat","-c","%u:%g","/tmp/${FILE_NAME}.txt"]}
+EOF
+t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200
+
+output_uidgid=$(grep -o '[0-9]*:[0-9]*' <<<"$output")
+is "$output_uidgid" "0:0" "UID:GID chowned to container user without copyUIDGID"
+
+# --- libpod
+FILE_NAME=test3
+TAR_PATH="${TMPD}/${FILE_NAME}.tar"
+echo "test3_$(random_string 8)" > ${TMPD}/${FILE_NAME}.txt
+tar --owner=4001 --group=4002 --format=posix -C $TMPD -cvf ${TAR_PATH} ${FILE_NAME}.txt &> /dev/null
+t PUT "libpod/containers/${CTR}/archive?path=%2Ftmp%2F" ${TAR_PATH} 200 ''
+
+cat >$TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["stat","-c","%u:%g","/tmp/${FILE_NAME}.txt"]}
+EOF
+t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200
+
+output_uidgid=$(grep -o '[0-9]*:[0-9]*' <<<"$output")
+is "$output_uidgid" "0:0" "libpod API: UID:GID chowned to container user"
 
 cleanUpArchiveTest

--- a/test/python/docker/compat/test_containers.py
+++ b/test/python/docker/compat/test_containers.py
@@ -191,7 +191,8 @@ class TestContainers(common.DockerTestCase):
             ret, out = ctr.exec_run(["stat", "-c", "%u:%g", "/tmp/a.txt"])
 
             self.assertEqual(ret, 0)
-            self.assertEqual(out.rstrip(), b"1042:1043", "UID/GID of copied file")
+            # Docker-py implementation of put_archive dont do request with copyUIDGID=true
+            self.assertEqual(out.rstrip(), b"0:0", "UID/GID of copied file")
 
             ret, out = ctr.exec_run(["cat", "/tmp/a.txt"])
             self.assertEqual(ret, 0)


### PR DESCRIPTION
Docker API's `copyUIDGID=true` means "preserve UID/GID from archive" but Podman's internal `Chown=true` means "chown to container user". This caused Docker SDK clients to have files incorrectly chowned to `root:root` instead of preserving the archive's UID/GID.

Fixes: https://github.com/containers/podman/issues/27332
Fixes: https://issues.redhat.com/browse/RUN-3643

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed Docker API compatibility issue where `copyUIDGID=true` parameter was not preserving UID/GID from tar archives when copying files to containers. Files are now correctly preserved with their original ownership instead of being changed to root:root (#27332)
```
