### PR TITLE
Fix Windows Installer GH release

### DIFF
--- a/contrib/win-installer/utils.ps1
+++ b/contrib/win-installer/utils.ps1
@@ -81,7 +81,11 @@ function SignItem() {
         }
     }
 
-    CheckCommand AzureSignTool.exe 'AzureSignTool'
+    # Check if AzureSignTool is installed
+    if (! (Get-Command 'AzureSignTool.exe' -errorAction SilentlyContinue)) {
+        Write-Error "Required dep `"AzureSignTool`" is not installed. "
+        Exit 1
+    }
 
     AzureSignTool.exe sign -du 'https://github.com/containers/podman' `
         -kvu "https://$ENV:VAULT_ID.vault.azure.net" `


### PR DESCRIPTION
Function `SignItem` used the helper `CheckCommand` that got removed as part of #27284. As a result the GH release job failed https://github.com/containers/podman/actions/runs/18792520254/job/53626352685

This commit address this problem.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
