### PR TITLE
Machine init --provider

### DIFF
--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -100,7 +100,7 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 	host.Arch = runtime.GOARCH
 	host.OS = runtime.GOOS
 
-	dirs, err := env.GetMachineDirs(provider.VMType())
+	dirs, err := env.GetMachineDirs(machineProvider.VMType())
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 			host.DefaultMachine = vm.Name
 		}
 		// If machine is running or starting, it is automatically the current machine
-		state, err := provider.State(vm, false)
+		state, err := machineProvider.State(vm, false)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func hostInfo() (*entities.MachineHostInfo, error) {
 		}
 	}
 
-	host.VMType = provider.VMType().String()
+	host.VMType = machineProvider.VMType().String()
 
 	host.MachineImageDir = dirs.DataDir.GetPath()
 	host.MachineConfigDir = dirs.ConfigDir.GetPath()

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -60,7 +60,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		dirs, err := env.GetMachineDirs(provider.VMType())
+		dirs, err := env.GetMachineDirs(machineProvider.VMType())
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -41,10 +41,7 @@ var (
 	}
 )
 
-var (
-	// TODO This needs to be deleted!
-	provider vmconfigs.VMProvider
-)
+var machineProvider vmconfigs.VMProvider
 
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
@@ -54,7 +51,7 @@ func init() {
 
 func machinePreRunE(c *cobra.Command, args []string) error {
 	var err error
-	provider, err = provider2.Get()
+	machineProvider, err = provider2.Get()
 	if err != nil {
 		return err
 	}
@@ -102,6 +99,14 @@ func autocompleteMachine(_ *cobra.Command, args []string, toComplete string) ([]
 		return getMachines(toComplete)
 	}
 	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+func autocompleteMachineProvider(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	suggestions := make([]string, 0)
+	for _, p := range provider2.GetAll() {
+		suggestions = append(suggestions, p.VMType().String())
+	}
+	return suggestions, cobra.ShellCompDirectiveNoFileComp
 }
 
 func getMachines(toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/docs/source/markdown/podman-machine-init.1.md.in
+++ b/docs/source/markdown/podman-machine-init.1.md.in
@@ -96,6 +96,12 @@ Add the provided Ansible playbook to the machine and execute it after the first 
 Note: The playbook will be executed with the same privileges given to the user in the virtual machine. The playbook provided cannot include other files from the host system, as they will not be copied.
 Use of the `--playbook` flag will require the image to include Ansible. The default image provided will have Ansible included.
 
+
+#### **--provider**
+
+Specify the provider for the machine to be created.  This allows users to override the default provider on platforms
+that have multiple providers.
+
 #### **--rootful**
 
 Whether this machine prefers rootful (`true`) or rootless (`false`)
@@ -235,6 +241,11 @@ $ podman machine init --usb vendor=13d3,product=5406
 Initialize the default Podman machine with a usb device passthrough with specified with options. Only supported for QEMU Machines.
 ```
 $ podman machine init --usb bus=1,devnum=3
+```
+
+Initialize a machine on different provider than the default
+```
+$ podman machine init --provider applehv
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -22,6 +22,17 @@ environment variable while the machines are running can lead to unexpected behav
 
 Podman machine behaviour can be modified via the [machine] section in the containers.conf(5) file.
 
+Podman is based on virtual machine providers. The following table describes which providers are
+supported by platform.  The asterisk denotes the default provider for the platform.
+
+| Platform | Provider |
+| --------  |----------|
+| Linux | qemu*    |
+| MacOS | libkrun* |
+| MacOS | applehv  |
+| Windows | wsl*     |
+| Windows | hyperv   |
+
 ## SUBCOMMANDS
 
 | Command | Man Page                                                 | Description                                                     |

--- a/pkg/machine/e2e/config_darwin_test.go
+++ b/pkg/machine/e2e/config_darwin_test.go
@@ -1,14 +1,3 @@
 package e2e_test
 
-import "github.com/containers/podman/v6/pkg/machine/define"
-
 const podmanBinary = "../../../bin/darwin/podman"
-
-func getOtherProvider() string {
-	if isVmtype(define.AppleHvVirt) {
-		return "libkrun"
-	} else if isVmtype(define.LibKrun) {
-		return "applehv"
-	}
-	return ""
-}

--- a/pkg/machine/e2e/config_freebsd_test.go
+++ b/pkg/machine/e2e/config_freebsd_test.go
@@ -1,7 +1,3 @@
 package e2e_test
 
 const podmanBinary = "../../../bin/podman-remote"
-
-func getOtherProvider() string {
-	return ""
-}

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -10,22 +10,8 @@ import (
 )
 
 type initMachine struct {
-	/*
-	      --cpus uint              Number of CPUs (default 1)
-	      --disk-size uint         Disk size in GiB (default 100)
-	      --ignition-path string   Path to ignition file
-	      --username string        Username of the remote user (default "core" for FCOS, "user" for Fedora)
-	      --image-path string      Path to bootable image (default "testing")
-	  -m, --memory uint            Memory in MiB (default 2048)
-	      --now                    Start machine now
-	      --rootful                Whether this machine should prefer rootful container execution
-	      --playbook string        Run an ansible playbook after first boot
-	      --tls-verify             Require HTTPS and verify certificates when contacting registries
-	      --timezone string        Set timezone (default "local")
-	  -v, --volume stringArray     Volumes to mount, source:target
-	      --volume-driver string   Optional volume driver
-	*/
 	playbook           string
+	provider           string
 	cpus               *uint
 	diskSize           *uint
 	swap               *uint
@@ -79,6 +65,9 @@ func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
 	}
 	if l := len(i.playbook); l > 0 {
 		cmd = append(cmd, "--playbook", i.playbook)
+	}
+	if l := len(i.provider); l > 0 {
+		cmd = append(cmd, "--provider", i.provider)
 	}
 	if i.userModeNetworking {
 		cmd = append(cmd, "--user-mode-networking")
@@ -173,6 +162,11 @@ func (i *initMachine) withRootful(r bool) *initMachine {
 
 func (i *initMachine) withRunPlaybook(p string) *initMachine {
 	i.playbook = p
+	return i
+}
+
+func (i *initMachine) withProvider(p string) *initMachine {
+	i.provider = p
 	return i
 }
 

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -1,7 +1,3 @@
 package e2e_test
 
 const podmanBinary = "../../../bin/podman-remote"
-
-func getOtherProvider() string {
-	return ""
-}

--- a/pkg/machine/e2e/config_list_test.go
+++ b/pkg/machine/e2e/config_list_test.go
@@ -48,8 +48,3 @@ func (i *listMachine) withFormat(format string) *listMachine {
 	i.format = format
 	return i
 }
-
-func (i *listMachine) withAllProviders() *listMachine {
-	i.allProviders = true
-	return i
-}

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -7,8 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega/gexec"
-
-	"github.com/containers/podman/v6/pkg/machine/define"
 )
 
 const podmanBinary = "../../../bin/windows/podman.exe"
@@ -27,15 +25,6 @@ func pgrep(n string) (string, error) {
 		return "", fmt.Errorf("no task found")
 	}
 	return strOut, nil
-}
-
-func getOtherProvider() string {
-	if isVmtype(define.WSLVirt) {
-		return "hyperv"
-	} else if isVmtype(define.HyperVVirt) {
-		return "wsl"
-	}
-	return ""
 }
 
 func runWslCommand(cmdArgs []string) (*machineSession, error) {

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -33,6 +33,12 @@ func Get() (vmconfigs.VMProvider, error) {
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
+	return GetByVMType(resolvedVMType)
+}
+
+// GetByVMType takes a VMType (presumably from ParseVMType) and returns the correlating
+// VMProvider
+func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
 	switch resolvedVMType {
 	case define.AppleHvVirt:
 		return new(applehv.AppleHVStubber), nil
@@ -42,8 +48,8 @@ func Get() (vmconfigs.VMProvider, error) {
 		}
 		return new(libkrun.LibKrunStubber), nil
 	default:
-		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}
+	return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 }
 
 func GetAll() []vmconfigs.VMProvider {

--- a/pkg/machine/provider/platform_unix.go
+++ b/pkg/machine/provider/platform_unix.go
@@ -30,16 +30,22 @@ func Get() (vmconfigs.VMProvider, error) {
 	}
 
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
-	switch resolvedVMType {
-	case define.QemuVirt:
-		return qemu.NewStubber()
-	default:
-		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
-	}
+	return GetByVMType(resolvedVMType)
 }
 
 func GetAll() []vmconfigs.VMProvider {
 	return []vmconfigs.VMProvider{new(qemu.QEMUStubber)}
+}
+
+// GetByVMType takes a VMType (presumably from ParseVMType) and returns the correlating
+// VMProvider
+func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
+	switch resolvedVMType {
+	case define.QemuVirt:
+		return qemu.NewStubber()
+	default:
+	}
+	return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 }
 
 // SupportedProviders returns the providers that are supported on the host operating system

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -5,12 +5,11 @@ import (
 	"os"
 
 	"github.com/containers/libhvee/pkg/hypervctl"
+	"github.com/containers/podman/v6/pkg/machine/define"
+	"github.com/containers/podman/v6/pkg/machine/hyperv"
 	"github.com/containers/podman/v6/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v6/pkg/machine/wsl"
 	"github.com/containers/podman/v6/pkg/machine/wsl/wutil"
-
-	"github.com/containers/podman/v6/pkg/machine/define"
-	"github.com/containers/podman/v6/pkg/machine/hyperv"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
 )
@@ -28,8 +27,13 @@ func Get() (vmconfigs.VMProvider, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	logrus.Debugf("Using Podman machine with `%s` virtualization provider", resolvedVMType.String())
+	return GetByVMType(resolvedVMType)
+}
+
+// GetByVMType takes a VMType (presumably from ParseVMType) and returns the correlating
+// VMProvider
+func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
 	switch resolvedVMType {
 	case define.WSLVirt:
 		return new(wsl.WSLStubber), nil
@@ -39,8 +43,8 @@ func Get() (vmconfigs.VMProvider, error) {
 		}
 		return new(hyperv.HyperVStubber), nil
 	default:
-		return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 	}
+	return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 }
 
 func GetAll() []vmconfigs.VMProvider {


### PR DESCRIPTION
Add the ability for users to override the default provider when creating mahcines.  The new flag is `--provider` and allows you to specifiy a valid vmtype for the platform.  This PR also removes the previous list test where we tested listing all providers.  I added a PR for testing --provider which includes a standard `machine ls` which defaults now to showing all providers.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Users can set the machine provider option when creating a machine.
```
