### PR TITLE
Bump bundled krunkit from 0.2.2 to 1.1.0

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -9,7 +9,7 @@ else
 endif
 GVPROXY_VERSION=$(shell $(GO) list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
 VFKIT_VERSION ?= 0.6.1
-KRUNKIT_VERSION ?= 0.2.2
+KRUNKIT_VERSION ?= 1.1.0
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
 KRUNKIT_RELEASE_URL ?= https://github.com/containers/krunkit/releases/download/v$(KRUNKIT_VERSION)/krunkit-podman-unsigned-$(KRUNKIT_VERSION).tgz


### PR DESCRIPTION
Bump bundled krunkit to 1.1.0. For podman, this release means better I/O performance due to this libkrun version defaulting to a more relaxed disk image sync on macOS, and raising the vCPU limit to the maximum allowed by Hypervisor.framework.

Fixes: #27216

```release-note
Upgrade bundled krunkit to 1.1.0
```