### PR TITLE
Allow failures on WSL machine tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -822,6 +822,7 @@ podman_machine_aarch64_task:
 podman_machine_windows_task:
     name: *std_name_fmt
     alias: podman_machine_windows
+    allow_failures: $TEST_FLAVOR == 'machine-wsl'
     # Docs: ./contrib/cirrus/CIModes.md
     # Duplicated from the main linux machine task as we also must match winmake.ps1 here since that is used on windows.
     only_if: >-


### PR DESCRIPTION
The WSL tests for `podman machine` are flaking with unreasonable frequency right now. Last Friday, I needed to re-run a job 8 times to get it to pass and complete the release of 5.7 RC1. This is simply not sustainable. Mark the tests allowed-failure until this can be resolved.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
