### PR TITLE
Fix use of duplicate machine names

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -208,7 +208,10 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	// Check if machine already exists
 	var errNotExists *define.ErrVMDoesNotExist
 	_, _, err := shim.VMExists(initOpts.Name)
-	// errors.As checks for nil so safe to use.
+	// if nil, means we found a vm and need to reject it by name
+	if err == nil {
+		return &define.ErrVMAlreadyExists{Name: initOpts.Name}
+	}
 	if !errors.As(err, &errNotExists) {
 		return err
 	}

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -117,6 +117,11 @@ var _ = Describe("podman machine init", func() {
 			Expect(testMachine.Resources.CPUs).To(Equal(uint64(cpus)))
 			Expect(testMachine.Resources.Memory).To(BeEquivalentTo(uint64(2048)))
 		}
+		// creating a new VM with the same name must fail
+		repeatSession, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(repeatSession).To(Exit(125))
+		Expect(repeatSession.errorToString()).To(ContainSubstring(fmt.Sprintf("Error: machine %q already exists", mb.names[0])))
 	})
 
 	It("run playbook", func() {
@@ -655,7 +660,6 @@ var _ = Describe("podman machine init", func() {
 		session, err := mb.setName(machineName).setCmd(i.withImage(mb.imagePath).withProvider(providerOverride)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session.errorToString()).To(ContainSubstring(fmt.Sprintf("unsupported provider %q", providerOverride)))
-
 	})
 
 	It("machine init --provider", func() {
@@ -699,7 +703,6 @@ var _ = Describe("podman machine init", func() {
 			Expect(p).To(Equal(l.VMType))
 		}
 	})
-
 })
 
 var p4Config = []byte(`{


### PR DESCRIPTION
A condition was changed in the refgactor of init where duplicate names would be allowed but no machine was created.  Duplicate names are not permitted and should return an error.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
