### PR TITLE
Fix: Rootless Podman-in-Podman on WSL

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -34,6 +34,8 @@ ln -fs /dev/null /etc/systemd/system/systemd-oomd.socket
 mkdir -p /etc/systemd/system/systemd-sysusers.service.d/
 echo CREATE_MAIL_SPOOL=no >> /etc/default/useradd
 adduser -m [USER] -G wheel
+sed -ir 's/65536/1000000/' /etc/subuid
+sed -ir 's/65536/1000000/' /etc/subgid
 mkdir -p /home/[USER]/.config/systemd/[USER]/
 chown [USER]:[USER] /home/[USER]/.config
 `


### PR DESCRIPTION
Fixes: #27411

## pkg/machine/wsl/declares.go
Adjust SUB_UID and SUB_GID ranges to support running rootless Podman inside a rootless run Podman container.

By default, a new user is assigned the following sub-ID ranges:
  SUB_UID_MIN=100000, SUB_GID_MIN=100000, SUB_UID_COUNT=65536, SUB_GID_COUNT=65536
This means the user’s sub-UID and sub-GID ranges are 100000–165535.

When the container is run rootless by the user in WSL, ID mappings occur as follows:
- Container ID 0 (root) maps to user ID 1000 on the host (user in WSL).
- Container IDs 1–65536 map to IDs 100000–165535 on host (the subid range previously mentioned).

If a new user is created inside this container (to build containers for example), it will attempt to use the default sub-ID range (100000–165535). However, this exceeds the container’s available ID mapping, since only IDs up to 65536 are mapped, causing rootless PinP to fail.

To enable container-in-container builds, the sub-ID ranges for the user in WSL must be large enough to provide at least 65536 usable IDs. A minimum SUB_UID_COUNT and SUB_GID_COUNT of 165536 is thus required, but 200000 is used here to provide additional margin.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed Rootless Podman-in-Podman on WSL, by sufficiently increasing the SUB_GID and SUB_UID range of the user on WSL (#27411).
```
