### PR TITLE
Fix user namespace validation for containers in pods

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -308,10 +308,6 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 		if c.Flag("cgroups").Changed && vals.CgroupsMode == "split" && registry.IsRemote() {
 			return vals, fmt.Errorf("the option --cgroups=%q is not supported in remote mode", vals.CgroupsMode)
 		}
-
-		if c.Flag("pod").Changed && !strings.HasPrefix(c.Flag("pod").Value.String(), "new:") && c.Flag("userns").Changed {
-			return vals, errors.New("--userns and --pod cannot be set together")
-		}
 	}
 	if c.Flag("shm-size").Changed {
 		vals.ShmSize = c.Flag("shm-size").Value.String()

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -678,12 +678,14 @@ var _ = Describe("Podman create", func() {
 		create := podmanTest.Podman([]string{"create", "--uidmap", "0:1000:1000", "--pod", "new:testing123", ALPINE})
 		create.WaitWithDefaultTimeout()
 		Expect(create).ShouldNot(ExitCleanly())
-		Expect(create.ErrorToString()).To(ContainSubstring("cannot specify a new uid/gid map when entering a pod with an infra container"))
+		Expect(create.ErrorToString()).To(ContainSubstring("cannot set user namespace mode when joining pod with infra container"))
+
+		podmanTest.PodmanExitCleanly("pod", "rm", "-f", "testing123")
 
 		create = podmanTest.Podman([]string{"create", "--gidmap", "0:1000:1000", "--pod", "new:testing1234", ALPINE})
 		create.WaitWithDefaultTimeout()
 		Expect(create).ShouldNot(ExitCleanly())
-		Expect(create.ErrorToString()).To(ContainSubstring("cannot specify a new uid/gid map when entering a pod with an infra container"))
+		Expect(create.ErrorToString()).To(ContainSubstring("cannot set user namespace mode when joining pod with infra container"))
 	})
 
 	It("podman create --chrootdirs inspection test", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -803,7 +803,7 @@ ENTRYPOINT ["sleep","99999"]
 		// fail if --pod and --userns set together
 		session = podmanTest.Podman([]string{"run", "--pod", podName, "--userns", "keep-id", ALPINE, "id", "-u"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(125, "--userns and --pod cannot be set together"))
+		Expect(session).Should(ExitWithError(125, "cannot set user namespace mode when joining pod with infra container"))
 	})
 
 	It("podman pod create with --userns=keep-id can add users", func() {

--- a/test/system/620-option-conflicts.bats
+++ b/test/system/620-option-conflicts.bats
@@ -14,7 +14,6 @@ load helpers
 create,run        | --cpu-period=1 | --cpus=2               | $IMAGE
 create,run        | --cpu-quota=1  | --cpus=2               | $IMAGE
 create,run        | --no-hosts     | --add-host=foo:1.1.1.1 | $IMAGE
-create,run        | --userns=bar   | --pod=foo              | $IMAGE
 container cleanup | --all          | --exec=foo
 container cleanup | --exec=foo     | --rmi                  | foo
 "
@@ -48,6 +47,14 @@ container cleanup | --exec=foo     | --rmi                  | foo
                "podman $cmd --platform + --$opt"
         done
     done
+
+    # --userns and --pod have a different error message format
+    podname=p-$(safename)
+    run_podman pod create --name $podname
+    run_podman 125 run --uidmap=0:1000:1000 --pod=$podname $IMAGE true
+    is "$output" "Error: cannot set user namespace mode when joining pod with infra container: invalid argument" \
+       "podman run --uidmap + --pod"
+    run_podman pod rm -f $podname
 }
 
 


### PR DESCRIPTION
Remove incomplete CLI validation that only checked --pod flag and missed --pod-id-file (used by quadlet). Move validation to libpod/container_validate.go to catch all cases where --userns is set with --pod.

The new validation checks if container's ID mappings differ from the pod's
infra container and returns a clearer error message:
'cannot set user namespace mappings that differ from pod'

Fixes: #26848

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Improved validation and error message when setting user namespace for containers in pods. Now properly catches all cases including quadlet configurations.
```
