### PR TITLE
Makefile: Drop unused CONTAINER_RUNTIME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ endif
 SOURCES = $(shell find . -path './.*' -prune -o \( \( -name '*.go' -o -name '*.c' \) -a ! -name '*_test.go' \) -print) Makefile
 
 BUILDTAGS_CROSS ?= containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_overlay
-CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
 OCI_RUNTIME ?= ""
 
 # The 'sort' below is crucial: without it, 'make docs' behaves differently


### PR DESCRIPTION
This variable is dead code as far as I can tell. I think it got cargo culted from something similar in skopeo, where it *is* used:
https://github.com/containers/skopeo/blob/85598438ce295fc9acdc27a1d5f97b7501f411a5/Makefile#L75 etc.

(Instead it looks like there's a `PODMANCMD` here)

But I'm effectively using this PR as a way to suggest aligning with what we're doing in bootc, where we have a core principle that `Makefile` should *never* itself spawn containers (or VMs etc). All the rules in Makefile are things that should work when e.g. building RPMs or debs or the like.

Those tasks are things that are done via `Justfile`: https://github.com/bootc-dev/bootc/blob/main/Justfile

So for example to align, we'd add a `Justfile` here and then `make validatepr` would move to `just validatepr`.

```release-note
None
```
