### PR TITLE
Add AppArmor key to quadlet containers

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -305,6 +305,7 @@ Valid options for `[Container]` are listed below:
 | AddDevice=/dev/foo                   | --device /dev/foo                                    |
 | AddHost=example\.com:192.168.10.11   | --add-host example.com:192.168.10.11                 |
 | Annotation="XYZ"                     | --annotation "XYZ"                                   |
+| AppArmor="alternate-profile"         | --security-opt apparmor=alternate-profile            |
 | AutoUpdate=registry                  | --label "io.containers.autoupdate=registry"          |
 | CgroupsMode=no-conmon                | --cgroups=no-conmon                                  |
 | ContainerName=name                   | --name name                                          |
@@ -427,6 +428,10 @@ Set one or more OCI annotations on the container. The format is a list of `key=v
 similar to `Environment`.
 
 This key can be listed multiple times.
+
+### `AppArmor=`
+
+Sets the apparmor confinement profile for the container. A value of `unconfined` turns off apparmor confinement.
 
 ### `AutoUpdate=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -62,6 +62,7 @@ const (
 	KeyAddHost               = "AddHost"
 	KeyAllTags               = "AllTags"
 	KeyAnnotation            = "Annotation"
+	KeyAppArmor              = "AppArmor"
 	KeyArch                  = "Arch"
 	KeyArtifact              = "Artifact"
 	KeyAuthFile              = "AuthFile"
@@ -248,6 +249,7 @@ var (
 				KeyAddDevice:             true,
 				KeyAddHost:               true,
 				KeyAnnotation:            true,
+				KeyAppArmor:              true,
 				KeyAutoUpdate:            true,
 				KeyCgroupsMode:           true,
 				KeyContainerName:         true,
@@ -773,6 +775,11 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 	securityLabelLevel, ok := container.Lookup(ContainerGroup, KeySecurityLabelLevel)
 	if ok && len(securityLabelLevel) > 0 {
 		podman.add("--security-opt", fmt.Sprintf("label=level:%s", securityLabelLevel))
+	}
+
+	apparmor, hasApparmor := container.Lookup(ContainerGroup, KeyAppArmor)
+	if hasApparmor && len(apparmor) > 0 {
+		podman.add("--security-opt", fmt.Sprintf("apparmor=%s", apparmor))
 	}
 
 	devices := container.LookupAllStrv(ContainerGroup, KeyAddDevice)

--- a/test/e2e/quadlet/apparmor.container
+++ b/test/e2e/quadlet/apparmor.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--security-opt" "apparmor=someprofilename"
+
+[Container]
+Image=localhost/imagename
+AppArmor=someprofilename

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -896,6 +896,7 @@ BOGUS=foo
 		runSuccessQuadletTestCase,
 		Entry("Basic container", "basic.container"),
 		Entry("annotation.container", "annotation.container"),
+		Entry("apparmor.container", "apparmor.container"),
 		Entry("autoupdate.container", "autoupdate.container"),
 		Entry("basepodman.container", "basepodman.container"),
 		Entry("capabilities.container", "capabilities.container"),


### PR DESCRIPTION
This addresses #27095 by adding an AppArmor key to `.container` quadlet files.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ x ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ x ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ x ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ x ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ x ] All commits pass `make validatepr` (format/lint checks)
- [ x ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Add AppArmor key to quadlet `.container` files which equates to `--security-opt apparmor=` flag.
```
