### PR TITLE
Fix remote client rejecting empty --detach-keys string

### DIFF
--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -80,9 +80,14 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 	if options.Changed("DetachKeys") {
 		params.Add("detachKeys", options.GetDetachKeys())
 
-		detachKeysInBytes, err = term.ToBytes(options.GetDetachKeys())
-		if err != nil {
-			return fmt.Errorf("invalid detach keys: %w", err)
+		// Empty string disables detaching; do not attempt to parse
+		if options.GetDetachKeys() == "" {
+			detachKeysInBytes = []byte{}
+		} else {
+			detachKeysInBytes, err = term.ToBytes(options.GetDetachKeys())
+			if err != nil {
+				return fmt.Errorf("invalid detach keys: %w", err)
+			}
 		}
 	}
 	if isSet.stdin {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1226,6 +1226,14 @@ EOF
     run_podman rm $ctr_name
 }
 
+# Regression test for https://github.com/containers/podman/issues/27414
+# bats test_tags=ci:parallel
+@test "podman run with empty --detach-keys" {
+    # Empty string should disable detaching, not error with "invalid detach keys"
+    run_podman run --rm --detach-keys="" $IMAGE echo "success"
+    is "$output" "success" "empty detach-keys should work"
+}
+
 # 15895: --privileged + --systemd = hide /dev/ttyNN
 # bats test_tags=ci:parallel
 @test "podman run --privileged as root with systemd will not mount /dev/tty" {


### PR DESCRIPTION
### Problem
The remote client (`podman --remote`) incorrectly throws an error when `--detach-keys=""` is specified:
```
Error: invalid detach keys: Unknown character: ''
```

According to the documentation (`docs/source/markdown/options/detach-keys.md`):
> Specifying "" disables this feature
The local client handles this correctly and was fixed in v1.7.0 (issue #5166), but the remote client was missed.

The remote client bindings call `term.ToBytes()` directly on the user-provided string, which fails for empty strings. The local implementation checks for empty string first before calling `term.ToBytes()`.

### Solution
Added the same empty string check in `pkg/bindings/containers/attach.go` that exists in the local code path (`libpod/oci_conmon_attach_common.go:199`):

```go
if options.GetDetachKeys() == "" {
    detachKeysInBytes = []byte{}
} else {
    detachKeysInBytes, err = term.ToBytes(options.GetDetachKeys())
    // ...
}
```

Fixes: #27414

```release-note
'None'
```
