### PR TITLE
Fix cache misses when pulling WSL machine image

### DIFF
--- a/pkg/machine/define/image_format.go
+++ b/pkg/machine/define/image_format.go
@@ -24,9 +24,6 @@ func (imf ImageFormat) Kind() string {
 }
 
 func (imf ImageFormat) KindWithCompression() string {
-	// Tar uses xz; all others use zstd
-	if imf == Tar {
-		return "tar.xz"
-	}
+	// All image formats are compressed with zstd
 	return fmt.Sprintf("%s.zst", imf.Kind())
 }

--- a/pkg/machine/define/image_format_test.go
+++ b/pkg/machine/define/image_format_test.go
@@ -59,9 +59,9 @@ func TestImageFormat_KindWithCompression(t *testing.T) {
 			imf:  Raw,
 			want: "raw.zst",
 		}, {
-			name: "tar.xz",
+			name: "tar.zst",
 			imf:  Tar,
-			want: "tar.xz",
+			want: "tar.zst",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes a regression introduced by b2e6d53 that made always failing the match of the WSL image from the registry with the image in the local cache. 

The result was that the WSL machine image was always pulled from quay.io even if an identical image was in the local cache.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass ~~`make validatepr`~~ `.\winmake.ps1 lint` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fix failure to use locally cached WSL machine images, resulting in always pulling the file from the registry.
```
