### PR TITLE
Fixed #27421 aritfact push and pull with authfile

### DIFF
--- a/pkg/api/handlers/libpod/artifacts.go
+++ b/pkg/api/handlers/libpod/artifacts.go
@@ -320,6 +320,7 @@ func PushArtifact(w http.ResponseWriter, r *http.Request) {
 	}
 	defer auth.RemoveAuthfile(authfile)
 
+	artifactsPushOptions.Authfile = authfile
 	if authConf != nil {
 		artifactsPushOptions.Username = authConf.Username
 		artifactsPushOptions.Password = authConf.Password

--- a/pkg/domain/infra/tunnel/artifact.go
+++ b/pkg/domain/infra/tunnel/artifact.go
@@ -38,6 +38,7 @@ func (ir *ImageEngine) ArtifactPull(_ context.Context, name string, opts entitie
 	options := artifacts.PullOptions{
 		Username:   &opts.Username,
 		Password:   &opts.Password,
+		Authfile:   &opts.AuthFilePath,
 		Quiet:      &opts.Quiet,
 		RetryDelay: &opts.RetryDelay,
 		Retry:      opts.MaxRetries,
@@ -67,6 +68,7 @@ func (ir *ImageEngine) ArtifactPush(_ context.Context, name string, opts entitie
 	options := artifacts.PushOptions{
 		Username:   &opts.Username,
 		Password:   &opts.Password,
+		Authfile:   &opts.Authfile,
 		Quiet:      &opts.Quiet,
 		RetryDelay: &opts.RetryDelay,
 		Retry:      opts.Retry,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixes the #27431, `artifact` to use `authfile` when push and pull 
```
