### PR TITLE
test: ensure complex --output values have correct behaviour

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -1427,4 +1427,20 @@ COPY --from=img2 /etc/alpine-release /prefix-test/container-prefix.txt`
 		Expect(metadata).To(ContainSubstring("containerimage.digest"))
 		Expect(metadata).To(ContainSubstring("containerimage.descriptor"))
 	})
+
+	It("podman build --output type=local,dest=./folder outputs to ./folder", func() {
+		SkipIfRemote("--output is not supported in remote mode")
+		podmanTest.PodmanExitCleanly("build", "-f", "build/basicalpine/Containerfile", "--output", fmt.Sprintf("type=local,dest=%v", podmanTest.TempDir))
+		files, err := os.ReadDir(podmanTest.TempDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(files)).To(BeNumerically(">", 1))
+	})
+
+	// Should error because no type
+	It("podman build --output dest=./folder must fail", func() {
+		SkipIfRemote("--output is not supported in remote mode")
+		session := podmanTest.Podman([]string{"build", "-f", "build/basicalpine/Containerfile", "--output", fmt.Sprintf("dest=%v", podmanTest.TempDir)})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, `missing required key "type"`))
+	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

No

```release-note
```

#### Note
I don't believe documentation changes are needed. I may be wrong ?

This PR lays the groundwork for introducing `type=registry`, which I will work on when this PR is merged