### PR TITLE
Fixed Commands in `podman-for-windows` Guide

### DIFF
--- a/docs/tutorials/podman-for-windows.md
+++ b/docs/tutorials/podman-for-windows.md
@@ -165,7 +165,7 @@ Docker. Provided there is no other service listening on the Docker API pipe;
 no special settings will be required.
 
 ```
-PS C:\Users\User> .\docker.exe run -it fedora echo "Hello Podman!"
+PS C:\Users\User> docker run -it fedora echo "Hello Podman!"
 Hello Podman!
 ```
 


### PR DESCRIPTION
Does this PR introduce a user-facing change?

```release-note
Adjust commands in `podman-for-windows` guide
```

Original PR: https://github.com/containers/podman/pull/27066
Changes: Removed `[skip-ci]` prefix from commit messages. 