### PR TITLE
Use fake images for machine tests

### DIFF
--- a/pkg/machine/e2e/config_darwin_test.go
+++ b/pkg/machine/e2e/config_darwin_test.go
@@ -1,3 +1,14 @@
 package e2e_test
 
+import "os"
+
 const podmanBinary = "../../../bin/darwin/podman"
+
+var (
+	fakeImagePath string = os.DevNull
+)
+
+func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
+	i.image = fakeImagePath
+	return i
+}

--- a/pkg/machine/e2e/config_freebsd_test.go
+++ b/pkg/machine/e2e/config_freebsd_test.go
@@ -1,3 +1,14 @@
 package e2e_test
 
+import "os"
+
 const podmanBinary = "../../../bin/podman-remote"
+
+var (
+	fakeImagePath string = os.DevNull
+)
+
+func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
+	i.image = fakeImagePath
+	return i
+}

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -1,3 +1,14 @@
 package e2e_test
 
+import "os"
+
 const podmanBinary = "../../../bin/podman-remote"
+
+var (
+	fakeImagePath string = os.DevNull
+)
+
+func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
+	i.image = fakeImagePath
+	return i
+}

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -40,3 +40,8 @@ func runWslCommand(cmdArgs []string) (*machineSession, error) {
 	ms.waitWithTimeout(defaultTimeout)
 	return &ms, nil
 }
+
+func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
+	i.image = mb.imagePath
+	return i
+}

--- a/pkg/machine/e2e/info_test.go
+++ b/pkg/machine/e2e/info_test.go
@@ -28,7 +28,7 @@ var _ = Describe("podman machine info", func() {
 
 		// Create a machine and check if info has been updated
 		i := new(initMachine)
-		initSession, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		initSession, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(initSession).To(Exit(0))
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -54,7 +54,7 @@ var _ = Describe("podman machine init", func() {
 
 		bi := new(initMachine)
 		want := fmt.Sprintf("system connection \"%s\" already exists", badName)
-		badInit, berr := mb.setName(badName).setCmd(bi.withImage(mb.imagePath)).run()
+		badInit, berr := mb.setName(badName).setCmd(bi.withFakeImage(mb)).run()
 		Expect(berr).ToNot(HaveOccurred())
 		Expect(badInit).To(Exit(125))
 		Expect(badInit.errorToString()).To(ContainSubstring(want))
@@ -88,7 +88,7 @@ var _ = Describe("podman machine init", func() {
 		// Check that mounting to certain target directories like /tmp at the / level is NOT ok
 		tmpVol := initMachine{}
 		targetMount := "/tmp"
-		tmpVolSession, err := mb.setCmd(tmpVol.withImage(mb.imagePath).withVolume(fmt.Sprintf("/whatever:%s", targetMount))).run()
+		tmpVolSession, err := mb.setCmd(tmpVol.withFakeImage(mb).withVolume(fmt.Sprintf("/whatever:%s", targetMount))).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(tmpVolSession).To(Exit(125))
 		Expect(tmpVolSession.errorToString()).To(ContainSubstring(fmt.Sprintf("Error: machine mount destination cannot be %q: consider another location or a subdirectory of an existing location", targetMount)))
@@ -102,7 +102,7 @@ var _ = Describe("podman machine init", func() {
 
 	It("simple init", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -118,7 +118,7 @@ var _ = Describe("podman machine init", func() {
 			Expect(testMachine.Resources.Memory).To(BeEquivalentTo(uint64(2048)))
 		}
 		// creating a new VM with the same name must fail
-		repeatSession, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		repeatSession, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(repeatSession).To(Exit(125))
 		Expect(repeatSession.errorToString()).To(ContainSubstring(fmt.Sprintf("Error: machine %q already exists", mb.names[0])))
@@ -379,7 +379,7 @@ var _ = Describe("podman machine init", func() {
 
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withIgnitionPath(tmpFile.Name())).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb).withIgnitionPath(tmpFile.Name())).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -455,7 +455,7 @@ var _ = Describe("podman machine init", func() {
 	It("init should cleanup on failure", func() {
 		i := new(initMachine)
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
@@ -482,7 +482,7 @@ var _ = Describe("podman machine init", func() {
 			// Bad ignition path - init fails
 			i = new(initMachine)
 			i.ignitionPath = "/bad/path"
-			session, err = mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+			session, err = mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(session).To(Exit(125))
 
@@ -534,7 +534,7 @@ var _ = Describe("podman machine init", func() {
 		// We should be able to init with a bad config present
 		i := new(initMachine)
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -657,7 +657,7 @@ var _ = Describe("podman machine init", func() {
 
 		i := initMachine{}
 		machineName := randomString()
-		session, err := mb.setName(machineName).setCmd(i.withImage(mb.imagePath).withProvider(providerOverride)).run()
+		session, err := mb.setName(machineName).setCmd(i.withFakeImage(mb).withProvider(providerOverride)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session.errorToString()).To(ContainSubstring(fmt.Sprintf("unsupported provider %q", providerOverride)))
 	})
@@ -678,7 +678,7 @@ var _ = Describe("podman machine init", func() {
 		// --provider
 		for name, p := range verify {
 			i := initMachine{}
-			session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withProvider(p)).run()
+			session, err := mb.setName(name).setCmd(i.withFakeImage(mb).withProvider(p)).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(session.ExitCode()).To(Equal(0))
 		}

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -22,7 +22,7 @@ var _ = Describe("podman machine init - windows only", func() {
 		}
 		i := new(initMachine)
 		name := randomString()
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withUserModeNetworking(true)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb).withUserModeNetworking(true)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -79,7 +79,7 @@ var _ = Describe("podman machine init - windows only", func() {
 			}
 		}()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(125))
 		Expect(session.errorToString()).To(ContainSubstring("already exists on hypervisor"))
@@ -97,7 +97,7 @@ var _ = Describe("podman machine init - windows only", func() {
 
 		// create a bogus machine
 		i := new(initMachine)
-		session, err := mb.setName("foobarexport").setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName("foobarexport").setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -122,7 +122,7 @@ var _ = Describe("podman machine init - windows only", func() {
 		}()
 
 		// Trying to make a vm with the same name as an existing name should result in a 125
-		checkSession, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		checkSession, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkSession).To(Exit(125))
 	})

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -23,12 +23,12 @@ var _ = Describe("podman inspect stop", func() {
 
 	It("inspect two machines", func() {
 		i := new(initMachine)
-		foo1, err := mb.setName("foo1").setCmd(i.withImage(mb.imagePath)).run()
+		foo1, err := mb.setName("foo1").setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(foo1).To(Exit(0))
 
 		ii := new(initMachine)
-		foo2, err := mb.setName("foo2").setCmd(ii.withImage(mb.imagePath)).run()
+		foo2, err := mb.setName("foo2").setCmd(ii.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(foo2).To(Exit(0))
 
@@ -43,7 +43,7 @@ var _ = Describe("podman inspect stop", func() {
 	It("inspect with go format", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -83,7 +83,7 @@ var _ = Describe("podman inspect stop", func() {
 		for range 2 {
 			name := randomString()
 			i := new(initMachine)
-			session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+			session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -23,7 +23,7 @@ var _ = Describe("podman machine list", func() {
 		Expect(firstList.outputToStringSlice()).To(HaveLen(1)) // just the header
 
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -50,11 +50,11 @@ var _ = Describe("podman machine list", func() {
 		Expect(noheaderSession.outputToStringSlice()).To(BeEmpty())
 
 		i := new(initMachine)
-		session, err := mb.setName(name1).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name1).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
-		session2, err := mb.setName(name2).setCmd(i.withImage(mb.imagePath)).run()
+		session2, err := mb.setName(name2).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session2).To(Exit(0))
 
@@ -113,7 +113,7 @@ var _ = Describe("podman machine list", func() {
 		name1 := randomString()
 
 		i := new(initMachine)
-		session, err := mb.setName(name1).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name1).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -150,7 +150,7 @@ var _ = Describe("podman machine list", func() {
 	})
 	It("list machine in machine-readable byte format", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -172,7 +172,7 @@ var _ = Describe("podman machine list", func() {
 	})
 	It("list machine in human-readable format", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/reset_test.go
+++ b/pkg/machine/e2e/reset_test.go
@@ -18,7 +18,7 @@ var _ = Describe("podman machine reset", func() {
 	It("reset machine with one defined machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -54,7 +54,7 @@ var _ = Describe("podman machine reset", func() {
 
 		name2 := randomString()
 		i2 := new(initMachine)
-		session2, err := mb.setName(name2).setCmd(i2.withImage(mb.imagePath)).run()
+		session2, err := mb.setName(name2).setCmd(i2.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session2).To(Exit(0))
 

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -24,7 +24,7 @@ var _ = Describe("podman machine rm", func() {
 	It("Remove machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		rm := rmMachine{}
@@ -47,13 +47,13 @@ var _ = Describe("podman machine rm", func() {
 		// Ensure that the system connections have the right rootfulness
 		name = randomString()
 		i = new(initMachine)
-		session, err = mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err = mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
 		name2 := randomString()
 		i = new(initMachine)
-		session, err = mb.setName(name2).setCmd(i.withImage(mb.imagePath).withRootful(true)).run()
+		session, err = mb.setName(name2).setCmd(i.withFakeImage(mb).withRootful(true)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -99,7 +99,7 @@ var _ = Describe("podman machine rm", func() {
 
 	It("machine rm --save-ignition --save-image", func() {
 		i := new(initMachine)
-		session, err := mb.setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -141,7 +141,7 @@ var _ = Describe("podman machine rm", func() {
 
 		fooName := "foo"
 		foo := new(initMachine)
-		session, err := mb.setName(fooName).setCmd(foo.withImage(mb.imagePath)).run()
+		session, err := mb.setName(fooName).setCmd(foo.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -181,7 +181,7 @@ var _ = Describe("podman machine rm", func() {
 	It("Removing all machines doesn't delete ssh keys", func() {
 		fooName := "foo"
 		foo := new(initMachine)
-		session, err := mb.setName(fooName).setCmd(foo.withImage(mb.imagePath)).run()
+		session, err := mb.setName(fooName).setCmd(foo.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -73,7 +73,7 @@ var _ = Describe("podman machine set", func() {
 		skipIfNotVmtype(define.WSLVirt, "tests are only for WSL provider")
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -170,7 +170,7 @@ var _ = Describe("podman machine set", func() {
 
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -21,7 +21,7 @@ var _ = Describe("podman machine ssh", func() {
 	It("ssh to non-running machine", func() {
 		name := randomString()
 		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		session, err := mb.setName(name).setCmd(i.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -143,7 +143,7 @@ var _ = Describe("podman machine start", func() {
 
 		j := initMachine{}
 		dontstartme := randomString()
-		session2, err := mb.setName(dontstartme).setCmd(j.withImage(mb.imagePath)).run()
+		session2, err := mb.setName(dontstartme).setCmd(j.withFakeImage(mb)).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session2).To(Exit(0))
 


### PR DESCRIPTION
In tests that do not start a machine, we can use "fake" images to speed up tests.  In the case of darwin and Linux, that can be /dev/null.  The hypervisors don't care.

In the case of Windows, some research will need to be done to determine the same approach but this is a start.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
