### PR TITLE
Fix regression in podman machine ssh

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -190,7 +190,7 @@ func toHumanFormat(vms []*machine.ListResponse, defaultCon *config.Connection) [
 		isDefault := false
 		// check port, in case we somehow have machines with the same name in different providers
 		if defaultCon != nil {
-			isDefault = vm.Name == defaultCon.Name && strings.Contains(defaultCon.URI, strconv.Itoa((vm.Port)))
+			isDefault = vm.Name == defaultCon.Name && strings.Contains(defaultCon.URI, strconv.Itoa(vm.Port))
 		}
 		if isDefault {
 			response.Name = vm.Name + "*"

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -60,14 +60,15 @@ func ssh(_ *cobra.Command, args []string) error {
 		// it implies podman cannot read its machine files, which is bad
 		mc, vmProvider, err = shim.VMExists(args[0])
 		if err != nil {
-			return err
-		}
-		if errors.Is(err, &define.ErrVMDoesNotExist{}) {
-			vmName = args[0]
-		} else {
+			var vmNotExistsErr *define.ErrVMDoesNotExist
+			if !errors.As(err, &vmNotExistsErr) {
+				return err
+			}
 			sshOpts.Args = append(sshOpts.Args, args[0])
+		} else {
+			vmName = args[0]
+			exists = true
 		}
-		exists = true
 	}
 
 	// If len is greater than 1, it means we might have been


### PR DESCRIPTION
While doing the provider obfuscation, I injected a regression where podman ssh machine failed.  The regression was added in 0f22c1c772cf2a685fe8fc28c3cac35e3c9ab67d.  I have fixed the regression and added a test to prevent future occurance.

Fixes: #27491

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
