### PR TITLE
docs: fix redoc swagger URL

### DIFF
--- a/docs/source/_static/api.html
+++ b/docs/source/_static/api.html
@@ -37,7 +37,7 @@
     </style>
   </head>
   <body>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@v2/bundles/redoc.standalone.js"> </script>
     <select id="versionSelect" aria-label="Version">
       <option>latest</option>
     </select>


### PR DESCRIPTION
Currently our API docs are not working as it fails to fetch the js file with the redoc code which renders the swagger.

The reason this fails is because we have been tracking the "next" version and that was recently bumped to v3.0.0-rc.0 which also seem to have moved the location to use "bundle" (no s). As such we now get a 404 as the CDN doesn't find the file. [1]

I don't get why we have been tracking next to begin with, using latest would still work as it points but that could be moved anytime as well so switch the URL to pull in the lastest v2 version which should be safer against unexpected changes like that.

While it could of course also break in a minor v2 release hard coding an exact version would mean a fair amount of churn updating this (which I guess would not happen) so this looks like the best compromise to me.

[1] https://www.npmjs.com/package/redoc/v/3.0.0-rc.0

Fixes: #27505

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
