### PR TITLE
fake images: windows hyperv

### DIFF
--- a/pkg/machine/e2e/config_darwin_test.go
+++ b/pkg/machine/e2e/config_darwin_test.go
@@ -1,12 +1,3 @@
 package e2e_test
 
-import "os"
-
 const podmanBinary = "../../../bin/darwin/podman"
-
-var fakeImagePath string = os.DevNull
-
-func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
-	i.image = fakeImagePath
-	return i
-}

--- a/pkg/machine/e2e/config_freebsd_test.go
+++ b/pkg/machine/e2e/config_freebsd_test.go
@@ -1,12 +1,3 @@
 package e2e_test
 
-import "os"
-
 const podmanBinary = "../../../bin/podman-remote"
-
-var fakeImagePath string = os.DevNull
-
-func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
-	i.image = fakeImagePath
-	return i
-}

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -1,12 +1,3 @@
 package e2e_test
 
-import "os"
-
 const podmanBinary = "../../../bin/podman-remote"
-
-var fakeImagePath string = os.DevNull
-
-func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
-	i.image = fakeImagePath
-	return i
-}

--- a/pkg/machine/e2e/config_unix_test.go
+++ b/pkg/machine/e2e/config_unix_test.go
@@ -3,10 +3,24 @@
 package e2e_test
 
 import (
+	"os"
 	"os/exec"
 )
+
+var fakeImagePath string = os.DevNull
 
 func pgrep(_ string) (string, error) {
 	out, err := exec.Command("pgrep", "gvproxy").Output()
 	return string(out), err
+}
+
+func initPlatform()    {}
+func cleanupPlatform() {}
+
+// withFakeImage should be used in tests where the machine is
+// initialized (or not) but never started.  It is intended
+// to speed up CI by not processing our large machine files.
+func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
+	i.image = fakeImagePath
+	return i
 }

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -2,14 +2,43 @@ package e2e_test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
+	"github.com/containers/libhvee/pkg/hypervctl"
+	"github.com/containers/podman/v6/pkg/machine/define"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega/gexec"
 )
 
 const podmanBinary = "../../../bin/windows/podman.exe"
+
+var fakeImagePath string = ""
+
+func initPlatform() {
+	switch testProvider.VMType().String() {
+	case define.HyperVVirt.String():
+		vmm := hypervctl.NewVirtualMachineManager()
+		name := fmt.Sprintf("podman-hyperv-%s.vhdx", randomString())
+		fullFileName := filepath.Join(tmpDir, name)
+		if err := vmm.CreateVhdxFile(fullFileName, 15*1024*1024); err != nil {
+			Fail(fmt.Sprintf("Failed to create file %s %q", fullFileName, err))
+		}
+		fakeImagePath = fullFileName
+		fmt.Println("Created fake disk image: " + fakeImagePath)
+	case define.WSLVirt.String():
+	default:
+		Fail(fmt.Sprintf("unknown Windows provider: %q", testProvider.VMType().String()))
+	}
+}
+
+func cleanupPlatform() {
+	if err := os.Remove(fakeImagePath); err != nil {
+		fmt.Printf("Failed to remove %s image: %q\n", fakeImagePath, err)
+	}
+}
 
 // pgrep emulates the pgrep linux command
 func pgrep(n string) (string, error) {
@@ -41,7 +70,17 @@ func runWslCommand(cmdArgs []string) (*machineSession, error) {
 	return &ms, nil
 }
 
-func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
-	i.image = mb.imagePath
+// withFakeImage should be used in tests where the machine is
+// initialized (or not) but never started.  It is intended
+// to speed up CI by not processing our large machine files.
+func (i *initMachine) withFakeImage(mb *machineTestBuilder) *initMachine {
+	switch testProvider.VMType() {
+	case define.HyperVVirt:
+		i.image = fakeImagePath
+	case define.WSLVirt:
+		i.image = mb.imagePath
+	default:
+		Fail(fmt.Sprintf("unknown Windows provider: %q", testProvider.VMType().String()))
+	}
 	return i
 }

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -72,6 +72,9 @@ var _ = BeforeSuite(func() {
 	if pullError != nil {
 		Fail(fmt.Sprintf("failed to pull disk: %q", pullError))
 	}
+
+	fmt.Println("Running platform specific set-up")
+	initPlatform()
 })
 
 type timing struct {
@@ -96,6 +99,8 @@ var _ = SynchronizedAfterSuite(func() {}, func() {
 	for _, t := range timings {
 		GinkgoWriter.Printf("%s\t\t%f seconds\n", t.name, t.length.Seconds())
 	}
+	fmt.Println("Running platform specific cleanup")
+	cleanupPlatform()
 })
 
 // The config does not matter to much for our testing, however we


### PR DESCRIPTION
this pr is a follow on to #27493.  it adds support for hyperv "fake" images and suggests a benefit in terms of test speed.  for hyperv, we create a generic 4MB vhdx and stick it into the temp dir.  this saves us from any image copy or compression.

i also followed up on a few comments Paul made about using windows|unix instead of each platform.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
