### PR TITLE
fix gofumpt issues on main

### DIFF
--- a/pkg/machine/e2e/config_darwin_test.go
+++ b/pkg/machine/e2e/config_darwin_test.go
@@ -4,9 +4,7 @@ import "os"
 
 const podmanBinary = "../../../bin/darwin/podman"
 
-var (
-	fakeImagePath string = os.DevNull
-)
+var fakeImagePath string = os.DevNull
 
 func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
 	i.image = fakeImagePath

--- a/pkg/machine/e2e/config_freebsd_test.go
+++ b/pkg/machine/e2e/config_freebsd_test.go
@@ -4,9 +4,7 @@ import "os"
 
 const podmanBinary = "../../../bin/podman-remote"
 
-var (
-	fakeImagePath string = os.DevNull
-)
+var fakeImagePath string = os.DevNull
 
 func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
 	i.image = fakeImagePath

--- a/pkg/machine/e2e/config_linux_test.go
+++ b/pkg/machine/e2e/config_linux_test.go
@@ -4,9 +4,7 @@ import "os"
 
 const podmanBinary = "../../../bin/podman-remote"
 
-var (
-	fakeImagePath string = os.DevNull
-)
+var fakeImagePath string = os.DevNull
 
 func (i *initMachine) withFakeImage(_ *machineTestBuilder) *initMachine {
 	i.image = fakeImagePath


### PR DESCRIPTION
Two PRs[1,2] were merged without rebasing resulting in a conflict since the one enabled gofumpt while the other PR contained formatting not according to that so now the lint fails.

[1] https://github.com/containers/podman/pull/27498
[2] https://github.com/containers/podman/pull/27493

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
