### PR TITLE
Revert "Fix copyUIDGID parameter inversion in Docker compat API"

### DIFF
--- a/pkg/api/handlers/compat/containers_archive.go
+++ b/pkg/api/handlers/compat/containers_archive.go
@@ -123,17 +123,9 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 	containerName := utils.GetName(r)
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 
-	// Docker API semantics: copyUIDGID=true means "preserve UID/GID from archive"
-	// Podman internal semantics: Chown=true means "chown to container user" (override archive)
-	// For compat requests, we need to invert the value
-	chown := query.Chown
-	if !utils.IsLibpodRequest(r) {
-		chown = !query.Chown
-	}
-
 	copyFunc, err := containerEngine.ContainerCopyFromArchive(r.Context(), containerName, query.Path, r.Body,
 		entities.CopyOptions{
-			Chown:                chown,
+			Chown:                query.Chown,
 			NoOverwriteDirNonDir: query.NoOverwriteDirNonDir,
 			Rename:               rename,
 		})

--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -40,7 +40,7 @@ t HEAD "containers/${CTR}/archive?path=%2Fnon%2Fexistent%2Fpath" 404
 t HEAD "containers/${CTR}/archive?path=%2Fetc%2Fpasswd" 200
 
 # Send tarfile to container...
-t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F&copyUIDGID=true" ${HELLO_TAR} 200 ''
+t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F" ${HELLO_TAR} 200 ''
 
 # ...and 'exec cat file' to confirm that it got extracted into place.
 cat >$TMPD/exec.json <<EOF
@@ -80,44 +80,6 @@ EOF
 
 t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
 eid=$(jq -r '.Id' <<<"$output")
-t POST exec/$eid/start 200
-
-output_uidgid=$(grep -o '[0-9]*:[0-9]*' <<<"$output")
-is "$output_uidgid" "1042:1043" "UID:GID preserved with copyUIDGID=true"
-
-
-FILE_NAME=test1
-TAR_PATH="${TMPD}/${FILE_NAME}.tar"
-echo "Hello2_$(random_string 8)" > ${TMPD}/${FILE_NAME}.txt
-tar --owner=2001 --group=2002 --format=posix -C $TMPD -cvf ${TAR_PATH} ${FILE_NAME}.txt &> /dev/null
-
-t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F" ${TAR_PATH} 200 ''
-
-cat >$TMPD/exec.json <<EOF
-{ "AttachStdout":true,"Cmd":["stat","-c","%u:%g","/tmp/${FILE_NAME}.txt"]}
-EOF
-t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
-eid=$(jq -r '.Id' <<<"$output")
-t POST exec/$eid/start 200
-
-output_uidgid=$(grep -o '[0-9]*:[0-9]*' <<<"$output")
-is "$output_uidgid" "0:0" "UID:GID chowned to container user without copyUIDGID"
-
-# --- libpod
-FILE_NAME=test3
-TAR_PATH="${TMPD}/${FILE_NAME}.tar"
-echo "test3_$(random_string 8)" > ${TMPD}/${FILE_NAME}.txt
-tar --owner=4001 --group=4002 --format=posix -C $TMPD -cvf ${TAR_PATH} ${FILE_NAME}.txt &> /dev/null
-t PUT "libpod/containers/${CTR}/archive?path=%2Ftmp%2F" ${TAR_PATH} 200 ''
-
-cat >$TMPD/exec.json <<EOF
-{ "AttachStdout":true,"Cmd":["stat","-c","%u:%g","/tmp/${FILE_NAME}.txt"]}
-EOF
-t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
-eid=$(jq -r '.Id' <<<"$output")
-t POST exec/$eid/start 200
-
-output_uidgid=$(grep -o '[0-9]*:[0-9]*' <<<"$output")
-is "$output_uidgid" "0:0" "libpod API: UID:GID chowned to container user"
+t POST exec/$eid/start 200 $'\001\012'1042:1043
 
 cleanUpArchiveTest

--- a/test/python/docker/compat/test_containers.py
+++ b/test/python/docker/compat/test_containers.py
@@ -191,8 +191,7 @@ class TestContainers(common.DockerTestCase):
             ret, out = ctr.exec_run(["stat", "-c", "%u:%g", "/tmp/a.txt"])
 
             self.assertEqual(ret, 0)
-            # Docker-py implementation of put_archive dont do request with copyUIDGID=true
-            self.assertEqual(out.rstrip(), b"0:0", "UID/GID of copied file")
+            self.assertEqual(out.rstrip(), b"1042:1043", "UID/GID of copied file")
 
             ret, out = ctr.exec_run(["cat", "/tmp/a.txt"])
             self.assertEqual(ret, 0)


### PR DESCRIPTION
This reverts commit 2b848cca366fbd3cfd0cb7281078980b202f33d5.

The commit's assumption that `copyUIDGID=true` means that UID/GID from the tar should be preserved does not seem to be true. Opposite is true: if `copyUIDGUID=true` the main UID/GID of the container is used. I tested this on `moby`.

Also brief look at the source code seems to confirm this:
https://github.com/moby/moby/blob/16880e9e1ba21593215b40241d62c043410e0ae7/daemon/archive_unix.go#L136-L144
https://github.com/moby/moby/blob/16880e9e1ba21593215b40241d62c043410e0ae7/daemon/archive_tarcopyoptions_unix.go#L22-L30

Yes it's quite contra-intuitive but it does behave that way.

See this issue opened since 2017 https://github.com/moby/moby/issues/34096

>Now, docker cp hostfile container:containerpath will copy a file from the host to the container but preserving the original uid/gid (with the respective mapping to the container). docker cp -a hostfile container:containerpath (as defined in the documentation) is meant to "copy all uid/gid information" but it is in fact setting the uid and gid to the main user inside the container.

Also apparently there was a PR to fix this https://github.com/moby/moby/pull/34099 but is has newer been merged.

And another bug report  https://github.com/docker/docs/issues/17533 that suggest to change in documentation instead of the behaviour.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
