### PR TITLE
machine: change default macOS provider to libkrun

### DIFF
--- a/pkg/machine/e2e/README.md
+++ b/pkg/machine/e2e/README.md
@@ -67,7 +67,7 @@ above.
 ## MacOS
 
 Macs now support two different machine providers: `applehv` and `libkrun`. The
-`applehv` provider is the default.
+`libkrun` provider is the default.
 
 Note: On macOS, an error will occur if the path length of `$TMPDIR` is longer
 than 22 characters. Please set the appropriate path to `$TMPDIR`. Also, if
@@ -77,11 +77,11 @@ than 22 characters. Please set the appropriate path to `$TMPDIR`. Also, if
 
 1. `brew install vfkit`
 1. `make podman-remote`
+1. `export CONTAINERS_MACHINE_PROVIDER="applehv"`
 1. `make localmachine`
 
 ### [Libkrun](https://github.com/containers/libkrun)
 
 1. `brew install krunkit`
 1. `make podman-remote`
-1. `export CONTAINERS_MACHINE_PROVIDER="libkrun"`
 1. `make localmachine`

--- a/pkg/machine/provider/platform_test.go
+++ b/pkg/machine/provider/platform_test.go
@@ -11,11 +11,7 @@ import (
 func TestSupportedProviders(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
-		if runtime.GOARCH == "arm64" {
-			assert.Equal(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
-		} else {
-			assert.Equal(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
-		}
+		assert.Equal(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
 	case "windows":
 		assert.Equal(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
 	case "linux":
@@ -28,8 +24,7 @@ func TestInstalledProviders(t *testing.T) {
 	assert.NoError(t, err)
 	switch runtime.GOOS {
 	case "darwin":
-		// TODO: need to verify if an arm64 machine reports {applehv, libkrun}
-		assert.Equal(t, []define.VMType{define.AppleHvVirt}, installed)
+		assert.Equal(t, []define.VMType{define.LibKrun, define.AppleHvVirt}, installed)
 	case "windows":
 		provider, err := Get()
 		assert.NoError(t, err)
@@ -60,9 +55,8 @@ func TestBadSupportedProviders(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
-		if runtime.GOARCH != "arm64" {
-			assert.NotEqual(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
-		}
+		assert.NotEqual(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
+		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
 	case "windows":
 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
 	case "linux":
@@ -76,9 +70,8 @@ func TestBadInstalledProviders(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, installed)
-		if runtime.GOARCH != "arm64" {
-			assert.NotEqual(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, installed)
-		}
+		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, installed)
+		assert.NotEqual(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, installed)
 	case "windows":
 		assert.NotContains(t, installed, define.QemuVirt)
 	case "linux":


### PR DESCRIPTION
Now that Podman 6.0 no longer supports Intel Macs, use libkrun as the default machine provider.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Changes the default macOS machine provider to libkrun.
```
