### PR TITLE
Ignore prompt if stdin not a tty on machine start

### DIFF
--- a/docs/source/markdown/options/update-connection.md
+++ b/docs/source/markdown/options/update-connection.md
@@ -7,7 +7,8 @@
 When used in conjunction with `podman machine init --now` or `podman machine start`, this option sets the
 associated machine system connection as the default. When using this option, a `-u` or `-update-connection` will
 set the value to true.  To set this value to false, meaning no change and no prompting,
-use `--update-connection=false`.
+use `--update-connection=false`. If the value is unset and stdin is not a tty, no prompt or update
+shall occur.
 
 If the value is set to true, the machine connection will be set as the system default.
 If the value is set to false, the system default will be unchanged.

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
+	"golang.org/x/term"
 )
 
 // List is done at the host level to allow for a *possible* future where
@@ -501,8 +502,11 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 	// Do not do anything with the system connection if its already
 	// the default system connection.
 	if !conn.Default {
-		// Prompt for system connection update
-		if updateSystemConn == nil {
+		if updateSystemConn != nil {
+			updateDefaultConnection = *updateSystemConn
+		} else if term.IsTerminal(int(os.Stdin.Fd())) {
+			// Prompt for system connection update if there is a terminal
+			// on stdin
 			response, err := promptUpdateSystemConn()
 			if err != nil {
 				return err
@@ -517,8 +521,6 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 				fmt.Println("Default system connection will remain unchanged")
 			}
 			updateDefaultConnection = response
-		} else {
-			updateDefaultConnection = *updateSystemConn
 		}
 	}
 


### PR DESCRIPTION
When starting a machine and the user has not explicitly passed -u=true|false AND stdin is a not a tty, we should not prompt to update connections.

Fixes: #27556

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
