### PR TITLE
Add --network=host to validatepr container for GitHub access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,7 @@ validatepr: ## Go Format and lint, which all code changes must pass
 	$(PODMANCMD) run --rm \
 		-v $(CURDIR):/go/src/github.com/containers/podman \
 		--security-opt label=disable \
+		--network=host \
 		-it \
 		-w /go/src/github.com/containers/podman \
 		quay.io/libpod/validatepr:latest  \


### PR DESCRIPTION
Allows the validatepr container to fetch dependencies from GitHub during validation by enabling host networking.


This PR fixes the error of `make validatepr` on macOS:
```
...
+ echo 'Running validation tooling'
Running validation tooling
++ awk '/MemTotal/ {print $2}' /proc/meminfo
+ mem=5009584
+ ((  5009584 < 3900000  ))
+ make validate
make[1]: Entering directory '/go/src/github.com/containers/podman'
VERSION=2.6.0 ./hack/install_golangci.sh
Installing golangci-lint v2.6.0 into ./bin/golangci-lint
golangci/golangci-lint info checking GitHub for tag 'v2.6.0'
golangci/golangci-lint info found version: 2.6.0 for v2.6.0/linux/arm64
golangci/golangci-lint info installed ./bin/golangci-lint
hack/golangci-lint.sh
Linting for GOOS=linux
+ ./bin/golangci-lint run --build-tags=apparmor,seccomp,selinux
pkg/selinux/selinux.go:4:2: could not import github.com/opencontainers/selinux/go-selinux (/root/go/pkg/mod/go.podman.io/storage@v1.61.1-0.20251112195944-4afce3558e66/layers.go:22:2: reading github.com/opencontainers/selinux/go.mod at revision v1.13.1: git ls-remote -q origin in /root/go/pkg/mod/cache/vcs/49bf5caa92b4f9ff8c1e2713127b5413597f3869c253c1159d7d4bf7be68beab: exit status 128:
	fatal: unable to access 'https://github.com/opencontainers/selinux/': Failed to connect to github.com port 443 after 1015 ms: Could not connect to server) (typecheck)
	"github.com/opencontainers/selinux/go-selinux"
	^
pkg/selinux/selinux.go:13:21: undefined: selinux (typecheck)
	processLabel, _ := selinux.KVMContainerLabels()
	                   ^
pkg/selinux/selinux.go:14:2: undefined: selinux (typecheck)
	selinux.ReleaseLabel(processLabel)
	^
pkg/selinux/selinux.go:24:21: undefined: selinux (typecheck)
	processLabel, _ := selinux.InitContainerLabels()
	                   ^
pkg/selinux/selinux.go:25:2: undefined: selinux (typecheck)
	selinux.ReleaseLabel(processLabel)
	^
pkg/selinux/selinux.go:30:15: undefined: selinux (typecheck)
	dcon, err := selinux.NewContext(cLabel)
	             ^
pkg/selinux/selinux.go:34:15: undefined: selinux (typecheck)
	scon, err := selinux.NewContext(processLabel)
	             ^
7 issues:
* typecheck: 7
make[1]: *** [Makefile:291: golangci-lint] Error 1
make[1]: Leaving directory '/go/src/github.com/containers/podman'
make: *** [Makefile:345: .validatepr] Error 2
gmake: *** [Makefile:335: validatepr] Error 2
```
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
