### PR TITLE
check err returned by newGenericDecompressor

### DIFF
--- a/pkg/machine/compression/uncompressed.go
+++ b/pkg/machine/compression/uncompressed.go
@@ -10,6 +10,9 @@ type uncompressedDecompressor struct {
 
 func newUncompressedDecompressor(compressedFilePath string) (*uncompressedDecompressor, error) {
 	d, err := newGenericDecompressor(compressedFilePath)
+	if err != nil {
+		return nil, err
+	}
 	return &uncompressedDecompressor{*d}, err
 }
 

--- a/pkg/machine/compression/zip.go
+++ b/pkg/machine/compression/zip.go
@@ -16,6 +16,9 @@ type zipDecompressor struct {
 
 func newZipDecompressor(compressedFilePath string) (*zipDecompressor, error) {
 	d, err := newGenericDecompressor(compressedFilePath)
+	if err != nil {
+		return nil, err
+	}
 	return &zipDecompressor{*d, nil, nil}, err
 }
 


### PR DESCRIPTION
Hello!

I used SAST tool Svace and found a couple of newGenericDecompressor function usages, where returned possibly non-nil `err` is not checked before dereferencing returned decompressor. It may lead to nil ptr dereferencing.

This PR adds check for `err` to prevent dereferencing potentially nullable decompressor.

Found by Linux Verification Center (linuxtesting.org) with SVACE

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
