### PR TITLE
avoid potential nil ptr deref in image rm

### DIFF
--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -87,7 +87,7 @@ func rm(_ *cobra.Command, args []string) error {
 			}
 		}
 	}
-	if len(rmErrors) > 0 {
+	if len(rmErrors) > 0 && report != nil {
 		registry.SetExitCode(report.ExitCode)
 	}
 


### PR DESCRIPTION
Hello!

I used SAST tool Svace to analyze source code and encountered possible nil deref.

In function rm variable `report` might be initialized as nil as a result of call
`registry.ImageEngine().Remove(registry.Context(), args, imageOpts)`. Then, there is a call `registry.SetExitCode(report.ExitCode)` without explicit nil check before. Check `len(rmErrors) > 0` doesn't guarantee that report is a non-nil value.
So such call may lead to nil deref.

This PR adds check `report` for nil before its dereference.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
