### PR TITLE
Remove deprecated --macvlan flag from network create

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v6/cmd/podman/parse"
 	"github.com/containers/podman/v6/cmd/podman/registry"
 	"github.com/containers/podman/v6/pkg/domain/entities"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/libnetwork/util"
@@ -59,12 +58,6 @@ func networkCreateFlags(cmd *cobra.Command) {
 	ipRangeFlagName := "ip-range"
 	flags.StringArrayVar(&networkCreateOptions.Ranges, ipRangeFlagName, nil, "allocate container IP from range")
 	_ = cmd.RegisterFlagCompletionFunc(ipRangeFlagName, completion.AutocompleteNone)
-
-	// TODO consider removing this for 4.0
-	macvlanFlagName := "macvlan"
-	flags.StringVar(&networkCreateOptions.MacVLAN, macvlanFlagName, "", "create a Macvlan connection based on this device")
-	// This option is deprecated
-	_ = flags.MarkHidden(macvlanFlagName)
 
 	labelFlagName := "label"
 	flags.StringArrayVar(&labels, labelFlagName, nil, "set metadata on a network")
@@ -136,12 +129,7 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// old --macvlan option
-	if networkCreateOptions.MacVLAN != "" {
-		logrus.Warn("The --macvlan option is deprecated, use `--driver macvlan --opt parent=<device>` instead")
-		network.Driver = types.MacVLANNetworkDriver
-		network.NetworkInterface = networkCreateOptions.MacVLAN
-	} else if networkCreateOptions.Driver == types.MacVLANNetworkDriver || networkCreateOptions.Driver == types.IPVLANNetworkDriver {
+	if networkCreateOptions.Driver == types.MacVLANNetworkDriver || networkCreateOptions.Driver == types.IPVLANNetworkDriver {
 		// new -d macvlan --opt parent=... syntax
 		if parent, ok := network.Options["parent"]; ok {
 			network.NetworkInterface = parent

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -39,7 +39,6 @@ type NetworkCreateOptions struct {
 	Gateways          []net.IP
 	Internal          bool
 	Labels            map[string]string
-	MacVLAN           string
 	NetworkDNSServers []string
 	Ranges            []string
 	Subnets           []string

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -550,19 +550,6 @@ var _ = Describe("Podman network", func() {
 		Expect(c3).Should(ExitCleanly())
 	})
 
-	It("podman network create/remove macvlan", func() {
-		net := "macvlan" + stringid.GenerateRandomID()
-		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
-		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeNetwork(net)
-		// Cannot ExitCleanly(): "The --macvlan option is deprecated..."
-		Expect(nc).Should(Exit(0))
-
-		nc = podmanTest.Podman([]string{"network", "rm", net})
-		nc.WaitWithDefaultTimeout()
-		Expect(nc).Should(ExitCleanly())
-	})
-
 	It("podman network create/remove macvlan as driver (-d) no device name", func() {
 		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})


### PR DESCRIPTION
This PR removes the deprecated `--macvlan` flag from `podman network create` command. The flag was deprecated in Podman 3.x and was scheduled for removal in version 4.0. Since we're now at version 6.0.0-dev, it's time to complete the cleanup.
```release-note
None
```
