### PR TITLE
bindings: fix handling of env secrets in remote builds

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -99,6 +99,15 @@ var _ = Describe("Podman build", func() {
 		Expect(session).Should(ExitCleanly())
 	})
 
+	It("podman build with a secret from env", func() {
+		os.Setenv("MYSECRET", "somesecret")
+		defer os.Unsetenv("MYSECRET")
+		session := podmanTest.PodmanExitCleanly("build", "-f", "build/Containerfile.with-secret", "-t", "secret-test", "--secret", "id=mysecret,env=MYSECRET", "build/")
+		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
+
+		podmanTest.PodmanExitCleanly("rmi", "secret-test")
+	})
+
 	It("podman build with multiple secrets from files", func() {
 		session := podmanTest.Podman([]string{"build", "-f", "build/Containerfile.with-multiple-secret", "-t", "multiple-secret-test", "--secret", "id=mysecret,src=build/secret.txt", "--secret", "id=mysecret2,src=build/anothersecret.txt", "build/"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Previously, using --secret=id=foo,env=BAR in remote mode would fail because the client sent the env var name to the server, which tried to resolve it locally. This patch modifies the client to resolve the environment variable locally, write it to a temp file, and send it as a file-based secret.

This aligns Podman's remote behavior with Docker's behavior and ensures secrets are correctly passed to the build container.

Test to verify fix:
`export MYSECRET='qwerty'
podman build --secret=id=mysecret,env=MYSECRET -f - . <<EOF
FROM alpine
RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
EOF`

Before (Remote Client): The secret is empty because the server cannot find MYSECRET in its environment.
`STEP 1/2: FROM alpine
STEP 2/2: RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
COMMIT
--> 256d6061a45d`

After (Remote Client): The client resolves MYSECRET to qwerty and sends it to the server.
`STEP 1/2: FROM alpine
STEP 2/2: RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
qwerty
COMMIT
--> d5c40b8863ce`

Fixes #27494

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where `podman build --secret ... env=VAR` failed in remote mode (e.g., macOS) by correctly resolving environment variables on the client side.
```
