### PR TITLE
Fix `unless-stopped` restart policy to match Docker behavior

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1808,7 +1808,18 @@ func AutocompletePsFilters(cmd *cobra.Command, _ []string, toComplete string) ([
 		"name=":    func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeNames) },
 		"network=": func(s string) ([]string, cobra.ShellCompDirective) { return getNetworks(cmd, s, completeDefault) },
 		"pod=":     func(s string) ([]string, cobra.ShellCompDirective) { return getPods(cmd, s, completeDefault) },
-		"since=":   func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
+		"restart-policy=": func(_ string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				define.RestartPolicyAlways,
+				define.RestartPolicyNo,
+				define.RestartPolicyOnFailure,
+				define.RestartPolicyUnlessStopped,
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+		"should-start-on-boot=": func(_ string) ([]string, cobra.ShellCompDirective) {
+			return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
+		},
+		"since=": func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
 		"status=": func(_ string) ([]string, cobra.ShellCompDirective) {
 			return containerStatuses, cobra.ShellCompDirectiveNoFileComp
 		},

--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -9,8 +9,8 @@ After=network-online.target
 Type=oneshot
 RemainAfterExit=true
 Environment=LOGGING="--log-level=info"
-ExecStart=@@PODMAN@@ $LOGGING start --all --filter restart-policy=always
-ExecStop=@@PODMAN@@  $LOGGING stop  --all --filter restart-policy=always
+ExecStart=@@PODMAN@@ $LOGGING start --all --filter should-start-on-boot=true
+ExecStop=@@PODMAN@@  $LOGGING stop  --all --filter should-start-on-boot=true
 
 [Install]
 WantedBy=default.target

--- a/docs/source/markdown/options/restart.md
+++ b/docs/source/markdown/options/restart.md
@@ -13,7 +13,7 @@ Valid _policy_ values are:
 - `never`                    : Synonym for **no**; do not restart containers on exit
 - `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
-- `unless-stopped`           : Identical to **always**
+- `unless-stopped`           : Restart containers when they exit, unless the container was explicitly stopped by the user. After a system reboot, containers with this policy will be restarted by podman-restart.service only if they were not explicitly stopped by the user before the reboot. This differs from **always**, which restarts containers after a system reboot regardless of whether they were user-stopped
 
 Podman provides a systemd unit file, podman-restart.service, which restarts containers after a system reboot.
 

--- a/docs/source/markdown/podman-pause.1.md.in
+++ b/docs/source/markdown/podman-pause.1.md.in
@@ -33,6 +33,7 @@ Valid filters are listed below:
 | id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
 | name       | [Name] Container's name (accepts regex)                                                         |
 | label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
 | exited     | [Int] Container's exit code                                                                     |
 | status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
 | ancestor   | [ImageName] Image or descendant used to create container                                        |
@@ -42,8 +43,10 @@ Valid filters are listed below:
 | health     | [Status] healthy or unhealthy                                                                   |
 | pod        | [Pod] name or full or partial ID of pod                                                         |
 | network    | [Network] name or full ID of network                                                            |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
 | until      | [DateTime] Containers created before the given duration or time.                                |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 @@option latest
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -62,6 +62,8 @@ Valid filters are listed below:
 | network    | [Network] name or full ID of network                                                            |
 | until      | [DateTime] container created before the given duration or time.                                 |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 #### **--format**=*format*
 
@@ -286,6 +288,14 @@ Filter containers by network.
 $ podman ps --filter network=web-net
 CONTAINER ID  IMAGE                         COMMAND     CREATED        STATUS        PORTS       NAMES
 5e3694604817  quay.io/centos/centos:latest  sleep 300   3 minutes ago  Up 3 minutes              centos-test
+```
+
+Filter containers that need to be restarted after system reboot.
+```
+$ podman ps -a --filter should-start-on-boot=true
+CONTAINER ID  IMAGE                           COMMAND               CREATED        STATUS                    PORTS                 NAMES
+ff660efda598  docker.io/library/nginx:latest  nginx -g daemon o...  3 minutes ago  Up 3 minutes              0.0.0.0:8080->80/tcp  webserver
+5693e934f4c6  docker.io/library/redis:latest  redis-server          3 minutes ago  Exited (0) 3 minutes ago  6379/tcp              cache
 ```
 
 Use custom format to show container and pod information.

--- a/docs/source/markdown/podman-restart.1.md.in
+++ b/docs/source/markdown/podman-restart.1.md.in
@@ -36,6 +36,7 @@ Valid filters are listed below:
 | id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
 | name       | [Name] Container's name (accepts regex)                                                         |
 | label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
 | exited     | [Int] Container's exit code                                                                     |
 | status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
 | ancestor   | [ImageName] Image or descendant used to create container                                        |
@@ -45,8 +46,10 @@ Valid filters are listed below:
 | health     | [Status] healthy or unhealthy                                                                   |
 | pod        | [Pod] name or full or partial ID of pod                                                         |
 | network    | [Network] name or full ID of network                                                            |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
 | until      | [DateTime] Containers created before the given duration or time.                                |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 @@option latest
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -40,6 +40,7 @@ Valid filters are listed below:
 | id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
 | name       | [Name] Container's name (accepts regex)                                                         |
 | label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
 | exited     | [Int] Container's exit code                                                                     |
 | status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
 | ancestor   | [ImageName] Image or descendant used to create container                                        |
@@ -49,8 +50,10 @@ Valid filters are listed below:
 | health     | [Status] healthy or unhealthy                                                                   |
 | pod        | [Pod] name or full or partial ID of pod                                                         |
 | network    | [Network] name or full ID of network                                                            |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
 | until      | [DateTime] Containers created before the given duration or time.                                |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-start.1.md.in
+++ b/docs/source/markdown/podman-start.1.md.in
@@ -27,7 +27,7 @@ starting multiple containers.
 
 @@option detach-keys
 
-#### **--filter**, **-f**
+#### **--filter**, **-f**=*filter*
 
 Filter what containers are going to be started from the given arguments.
 Multiple filters can be given with multiple uses of the --filter flag.
@@ -41,6 +41,7 @@ Valid filters are listed below:
 | id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
 | name       | [Name] Container's name (accepts regex)                                                         |
 | label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
 | exited     | [Int] Container's exit code                                                                     |
 | status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
 | ancestor   | [ImageName] Image or descendant used to create container                                        |
@@ -50,8 +51,10 @@ Valid filters are listed below:
 | health     | [Status] healthy or unhealthy                                                                   |
 | pod        | [Pod] name or full or partial ID of pod                                                         |
 | network    | [Network] name or full ID of network                                                            |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
 | until      | [DateTime] Containers created before the given duration or time.                                |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 @@option interactive
 

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -39,6 +39,7 @@ Valid filters are listed below:
 | id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
 | name       | [Name] Container's name (accepts regex)                                                         |
 | label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
 | exited     | [Int] Container's exit code                                                                     |
 | status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
 | ancestor   | [ImageName] Image or descendant used to create container                                        |
@@ -48,8 +49,10 @@ Valid filters are listed below:
 | health     | [Status] healthy or unhealthy                                                                   |
 | pod        | [Pod] name or full or partial ID of pod                                                         |
 | network    | [Network] name or full ID of network                                                            |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
 | until      | [DateTime] Containers created before the given duration or time.                                |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 @@option ignore
 

--- a/docs/source/markdown/podman-unpause.1.md.in
+++ b/docs/source/markdown/podman-unpause.1.md.in
@@ -33,6 +33,7 @@ Valid filters are listed below:
 | id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
 | name       | [Name] Container's name (accepts regex)                                                         |
 | label      | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
 | exited     | [Int] Container's exit code                                                                     |
 | status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
 | ancestor   | [ImageName] Image or descendant used to create container                                        |
@@ -42,8 +43,10 @@ Valid filters are listed below:
 | health     | [Status] healthy or unhealthy                                                                   |
 | pod        | [Pod] name or full or partial ID of pod                                                         |
 | network    | [Network] name or full ID of network                                                            |
+| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
 | until      | [DateTime] Containers created before the given duration or time.                                |
 | command    | [Command] the command the container is executing, only argv[0] is taken  |
+| should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |
 
 @@option latest
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -189,6 +189,7 @@ type ContainerState struct {
 	BindMounts map[string]string `json:"bindMounts,omitempty"`
 	// StoppedByUser indicates whether the container was stopped by an
 	// explicit call to the Stop() API.
+	// Warning: This field does persist across system reboots.
 	StoppedByUser bool `json:"stoppedByUser,omitempty"`
 	// RestartPolicyMatch indicates whether the conditions for restart
 	// policy have been met.

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -635,7 +635,6 @@ func resetContainerState(state *ContainerState) {
 	state.ExecSessions = make(map[string]*ExecSession)
 	state.LegacyExecSessions = nil
 	state.BindMounts = make(map[string]string)
-	state.StoppedByUser = false
 	state.RestartPolicyMatch = false
 	state.RestartCount = 0
 	state.Checkpointed = false

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -287,6 +287,18 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		return func(c *libpod.Container) bool {
 			return util.StringMatchRegexSlice(c.Command()[0], filterValues)
 		}, nil
+	case "should-start-on-boot":
+		wantRestart := false
+		var err error
+		for _, fv := range filterValues {
+			wantRestart, err = strconv.ParseBool(fv)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return func(c *libpod.Container) bool {
+			return c.ShouldStartOnBoot() == wantRestart
+		}, nil
 	}
 	return nil, fmt.Errorf("%s is an invalid filter", filter)
 }


### PR DESCRIPTION
- Update documentation: Differentiate `unless-stopped` from `always` - containers stopped by the user before a reboot will not restart.
- Add `should-start-on-boot` filter: Identify containers that require a restart after a system reboot.
- Update command documentation: Add `restart-policy` and `label!` filters to the documentation for container commands (rm, ps, start, stop, pause, unpause, restart).
- Add `restart-policy` and `shoud-start-on-boot` to completions.
- Update service: Update `podman-restart.service` to use the `needs-restart=true` filter.
- Preserve state: Preserve the `StoppedByUser` state across reboots.
- Update API: Add a `ShouldStartOnBoot()` method to the Container API.
- Update documentation: Add descriptions for the `should-start-on-boot` filter.

Fixes: https://issues.redhat.com/browse/RHEL-129405
Fixes: https://github.com/containers/podman/issues/20418

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The `unless-stopped` restart policy now correctly matches Docker behavior by preserving the user-stopped state across reboots, and includes a new `should-start-on-boot` filter.
```
