### PR TITLE
[v5.8] Add migration code for BoltDB to SQLite

### DIFF
--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -3,6 +3,8 @@
 package system
 
 import (
+	"os"
+
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/cmd/podman/validate"
 	"github.com/containers/podman/v5/pkg/domain/entities"
@@ -46,8 +48,13 @@ func init() {
 	newRuntimeFlagName := "new-runtime"
 	flags.StringVar(&migrateOptions.NewRuntime, newRuntimeFlagName, "", "Specify a new runtime for all containers")
 	_ = migrateCommand.RegisterFlagCompletionFunc(newRuntimeFlagName, completion.AutocompleteNone)
+
+	flags.BoolVar(&migrateOptions.MigrateDB, "migrate-db", false, "Migrate database from BoltDB to SQLite")
 }
 
 func migrate(_ *cobra.Command, _ []string) error {
+	// HACK: do not warn about a database migration being needed, when we are about to migrate the database.
+	os.Setenv("SUPPRESS_BOLTDB_WARNING", "1")
+
 	return registry.ContainerEngine().Migrate(registry.Context(), migrateOptions)
 }

--- a/docs/source/markdown/podman-system-migrate.1.md
+++ b/docs/source/markdown/podman-system-migrate.1.md
@@ -26,6 +26,15 @@ newly configured mappings.
 
 ## OPTIONS
 
+#### **--migrate-db**
+
+Migrate from the legacy BoltDB database to SQLite.
+Support for BoltDB will be removed in Podman 6.0.
+Podman will display a warning if this migration is necessary.
+To ensure complete migration, all other Podman commands should be shut down before database migration.
+In particular, systemd-activated services like **podman system service** and Quadlets should be manually stopped prior to migration.
+The legacy database will not be removed, so no data loss should occur even on failure.
+
 #### **--new-runtime**=*runtime*
 
 Set a new OCI runtime for all containers.

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -96,11 +96,6 @@ func NewBoltState(path string, runtime *Runtime) (State, error) {
 		logrus.Debugf("Allowing deprecated database backend due to CI_DESIRED_DATABASE.")
 	}
 
-	// TODO: Up this to ERROR level in 5.8
-	if os.Getenv("SUPPRESS_BOLTDB_WARNING") == "" && ciDesiredDB != "boltdb" {
-		logrus.Warnf("The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message.")
-	}
-
 	db, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		return nil, fmt.Errorf("opening database %s: %w", path, err)
@@ -444,6 +439,10 @@ func (s *BoltState) Refresh() error {
 		return nil
 	})
 	return err
+}
+
+func (s *BoltState) Type() string {
+	return "boltdb"
 }
 
 // GetDBConfig retrieves runtime configuration fields that were created when

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -111,7 +111,7 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 	info := define.HostInfo{
 		Arch:               runtime.GOARCH,
 		BuildahVersion:     buildah.Version,
-		DatabaseBackend:    r.config.Engine.DBBackend,
+		DatabaseBackend:    r.state.Type(),
 		Linkmode:           linkmode.Linkmode(),
 		CPUs:               runtime.NumCPU(),
 		CPUUtilization:     cpuUtil,

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/libpod/events"
@@ -633,6 +636,8 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			ctrStatuses[c.ID()] = c.state.State
 		}
 	}
+	slices.SortFunc(ctrs, func(a, b define.InspectPodContainerInfo) int { return strings.Compare(a.ID, b.ID) })
+
 	podState, err := createPodStatusResults(ctrStatuses)
 	if err != nil {
 		return nil, err
@@ -654,6 +659,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			sharesNS = append(sharesNS, nsStr)
 		}
 	}
+	sort.Strings(sharesNS)
 
 	// Infra config contains detailed information on the pod's infra
 	// container.

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -3,17 +3,21 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/common/pkg/config"
+	"go.podman.io/storage/pkg/fileutils"
 )
 
 // Migrate stops the rootless pause process and performs any necessary database
 // migrations that are required. It can also migrate all containers to a new OCI
 // runtime, if requested.
-func (r *Runtime) Migrate(newRuntime string) error {
+func (r *Runtime) Migrate(newRuntime string, migrateDB bool) error {
 	// Acquire the alive lock and hold it.
 	// Ensures that we don't let other Podman commands run while we are
 	// rewriting things in the DB.
@@ -84,5 +88,162 @@ func (r *Runtime) Migrate(newRuntime string) error {
 		}
 	}
 
+	if migrateDB {
+		if err := r.checkCanMigrate(); err != nil {
+			switch {
+			case errors.Is(err, errCannotMigrateSqlite):
+				fmt.Printf("No migration is necessary: %v", err)
+				return r.stopPauseProcess()
+			case errors.Is(err, errCannotMigrateHardcodedBolt):
+				logrus.Errorf("In containers.conf, database_backend is manually set to \"boltdb\" - comment this line out and run `podman system migrate --migrate-db` to complete migration to SQLite")
+				return fmt.Errorf("unable to migrate to SQLite database as database backend manually set")
+			default:
+				return err
+			}
+		}
+
+		if err := r.migrateDB(); err != nil {
+			return fmt.Errorf("migrating database from BoltDB to SQLite: %w", err)
+		}
+	}
+
 	return r.stopPauseProcess()
+}
+
+var (
+	errCannotMigrateSqlite        = errors.New("backing database is already SQLite")
+	errCannotMigrateHardcodedBolt = errors.New("database_backend in containers.conf is manually set to \"boltdb\"")
+)
+
+func (r *Runtime) checkCanMigrate() error {
+	if r.state.Type() == "sqlite" {
+		return errCannotMigrateSqlite
+	}
+
+	// Necessary as database configuration is overwritten when the state is set up.
+	// So we need a completely new state from disk to see what the user set.
+	newCfg, err := config.New(nil)
+	if err != nil {
+		return fmt.Errorf("reloading configuration to check database backend in use")
+	}
+	backend, err := config.ParseDBBackend(newCfg.Engine.DBBackend)
+	if err != nil {
+		return fmt.Errorf("invalid DB backend configured - please change containers.conf database_backend to \"sqlite\"")
+	}
+	if backend == config.DBBackendBoltDB {
+		return errCannotMigrateHardcodedBolt
+	}
+
+	return nil
+}
+
+func (r *Runtime) migrateDB() error {
+	// Does the SQLite state already exist?
+	dbBasePath, dbFilename := sqliteStatePath(r)
+	dbPath := filepath.Join(dbBasePath, dbFilename)
+	if err := fileutils.Exists(dbPath); err == nil {
+		return fmt.Errorf("a SQLite database already exists at %s, refusing to overwrite", dbPath)
+	}
+
+	sqlState, err := NewSqliteState(r)
+	if err != nil {
+		return fmt.Errorf("creating SQLite database: %w", err)
+	}
+
+	// Recreate the cached paths in the new database
+	if err := sqlState.ValidateDBConfig(r); err != nil {
+		return fmt.Errorf("recreating config table: %w", err)
+	}
+
+	// Migrate volumes, then pods, then containers.
+	// Containers must be last as the pods they are part of and volumes they use must already exist.
+	allVolumes, err := r.state.AllVolumes()
+	if err != nil {
+		return fmt.Errorf("retrieving volumes from boltdb: %w", err)
+	}
+	for _, vol := range allVolumes {
+		if err := sqlState.AddVolume(vol); err != nil {
+			return err
+		}
+		if err := vol.update(); err != nil {
+			return err
+		}
+		if err := sqlState.SaveVolume(vol); err != nil {
+			return err
+		}
+	}
+
+	allPods, err := r.state.AllPods()
+	if err != nil {
+		return fmt.Errorf("retrieving pods from boltdb: %w", err)
+	}
+	for _, pod := range allPods {
+		if err := sqlState.AddPod(pod); err != nil {
+			return err
+		}
+		if err := pod.updatePod(); err != nil {
+			return err
+		}
+		if err := sqlState.SavePod(pod); err != nil {
+			return err
+		}
+	}
+
+	// Containers must be done as a graph due to dependencies.
+	// The state will error if we add a container before its dependencies.
+	allCtrs, err := r.state.AllContainers(true)
+	if err != nil {
+		return fmt.Errorf("retrieving containers from boltdb: %w", err)
+	}
+
+	// BoltDB doesn't actually populate container networks on initial pull
+	// from the database, that needs to be done separately.
+	for _, ctr := range allCtrs {
+		ctrNetworks, err := r.state.GetNetworks(ctr)
+		if err != nil {
+			return err
+		}
+		ctr.config.Networks = ctrNetworks
+	}
+
+	graph, err := BuildContainerGraph(allCtrs)
+	if err != nil {
+		return err
+	}
+
+	ctrErrors := make(map[string]error)
+	ctrsVisited := make(map[string]bool)
+
+	for _, node := range graph.noDepNodes {
+		migrateNodeDatabase(node, false, ctrErrors, ctrsVisited, sqlState)
+	}
+	var ctrError error
+	for id, err := range ctrErrors {
+		if ctrError != nil {
+			logrus.Errorf("Migrating containers to SQLite: %v", ctrError)
+		}
+		ctrError = fmt.Errorf("migrating container %s: %w", id, err)
+	}
+	if ctrError != nil {
+		return ctrError
+	}
+
+	boltState := r.state
+	r.state = sqlState
+
+	// Move the Bolt database so it is not reused, but preserve so data is not lost.
+	boltDBPath := getBoltDBPath(r)
+	newBoltDBPath := fmt.Sprintf("%s-old", boltDBPath)
+	if err := os.Rename(boltDBPath, newBoltDBPath); err != nil {
+		// Restore the old state. Migration has failed.
+		r.state = boltState
+
+		return fmt.Errorf("renaming old database %s to %s: %w", boltDBPath, newBoltDBPath, err)
+	}
+	fmt.Printf("Old database has been renamed to %s and will no longer be used\n", newBoltDBPath)
+
+	// Only after we handle all failure cases that could require a revert.
+	boltState.Close()
+
+	return nil
 }

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -31,6 +31,8 @@ type SQLiteState struct {
 }
 
 const (
+	// Name of the actual database file
+	sqliteDbFilename = "db.sql"
 	// Deal with timezone automatically.
 	sqliteOptionLocation = "_loc=auto"
 	// Force an fsync after each transaction (https://www.sqlite.org/pragma.html#pragma_synchronous).
@@ -43,7 +45,7 @@ const (
 	sqliteOptionCaseSensitiveLike = "&_cslike=TRUE"
 
 	// Assembled sqlite options used when opening the database.
-	sqliteOptions = "db.sql?" +
+	sqliteOptions = sqliteDbFilename + "?" +
 		sqliteOptionLocation +
 		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
@@ -56,12 +58,7 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	logrus.Info("Using sqlite as database backend")
 	state := new(SQLiteState)
 
-	basePath := runtime.storageConfig.GraphRoot
-	if runtime.storageConfig.TransientStore {
-		basePath = runtime.storageConfig.RunRoot
-	} else if !runtime.storageSet.StaticDirSet {
-		basePath = runtime.config.Engine.StaticDir
-	}
+	basePath, _ := sqliteStatePath(runtime)
 
 	// c/storage is set up *after* the DB - so even though we use the c/s
 	// root (or, for transient, runroot) dir, we need to make the dir
@@ -274,6 +271,10 @@ func (s *SQLiteState) Refresh() (defErr error) {
 	}
 
 	return nil
+}
+
+func (s *SQLiteState) Type() string {
+	return "sqlite"
 }
 
 // GetDBConfig retrieves runtime configuration fields that were created when

--- a/libpod/sqlite_state_internal.go
+++ b/libpod/sqlite_state_internal.go
@@ -17,6 +17,18 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// Returns two strings. First is base path - directory we'll create in.
+// Second is the filename of the database itself.
+func sqliteStatePath(runtime *Runtime) (string, string) {
+	basePath := runtime.storageConfig.GraphRoot
+	if runtime.storageConfig.TransientStore {
+		basePath = runtime.storageConfig.RunRoot
+	} else if !runtime.storageSet.StaticDirSet {
+		basePath = runtime.config.Engine.StaticDir
+	}
+	return basePath, sqliteDbFilename
+}
+
 func initSQLiteDB(conn *sql.DB) (defErr error) {
 	// Start with a transaction to avoid "database locked" errors.
 	// See https://github.com/mattn/go-sqlite3/issues/274#issuecomment-1429054597

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -25,6 +25,9 @@ type State interface { //nolint:interfacebloat
 	// Refresh clears container and pod states after a reboot
 	Refresh() error
 
+	// Type returns the type of state in use
+	Type() string
+
 	// GetDBConfig retrieves several paths configured within the database
 	// when it was created - namely, Libpod root and tmp dirs, c/storage
 	// root and tmp dirs, and c/storage graph driver.

--- a/pkg/domain/entities/types/system.go
+++ b/pkg/domain/entities/types/system.go
@@ -63,6 +63,7 @@ type SystemPruneReport struct {
 // cli to migrate runtimes of containers
 type SystemMigrateOptions struct {
 	NewRuntime string
+	MigrateDB  bool
 }
 
 // SystemDfOptions describes the options for getting df information

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -307,7 +307,7 @@ func (ic *ContainerEngine) Renumber(_ context.Context) error {
 }
 
 func (ic *ContainerEngine) Migrate(_ context.Context, options entities.SystemMigrateOptions) error {
-	return ic.Libpod.Migrate(options.NewRuntime)
+	return ic.Libpod.Migrate(options.NewRuntime, options.MigrateDB)
 }
 
 func unshareEnv(graphroot, runroot string) []string {

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -809,4 +809,12 @@ function thingy_with_unique_id() {
     done
 }
 
+@test "podman pod inspect ordering" {
+    local pod_name="p-$(safename)"
+    run_podman pod create $pod_name
+
+    run_podman pod inspect --format '{{ .SharedNamespaces }}' $pod_name
+    assert "$output" == "[ipc net uts]"
+}
+
 # vim: filetype=sh

--- a/test/system/555-migration.bats
+++ b/test/system/555-migration.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "Podman - BoltDB to SQLite migration" {
+    skip_if_remote "migration is only possible with local Podman"
+
+    # Force BoltDB
+    safe_opts=$(podman_isolation_opts ${PODMAN_TMPDIR})
+    CI_DESIRED_DATABASE=boltdb run_podman $safe_opts --db-backend=boltdb info
+    export SUPPRESS_BOLTDB_WARNING=true
+
+    run_podman info $safe_opts --format '{{.Host.DatabaseBackend}}'
+    is "$output" "boltdb"
+
+    # Create objects to migrate
+    volume_1_name="myvol"
+    volume_2_name="myvol2"
+    run_podman $safe_opts volume create $volume_1_name
+    run_podman $safe_opts volume create $volume_2_name
+
+    pod_name="mypod"
+    run_podman $safe_opts pod create $pod_name
+
+    ctr_1_name="myctr"
+    ctr_2_name="myctr2"
+    run_podman $safe_opts create --name $ctr_1_name --pod $pod_name --volume $volume_1_name:/test $IMAGE ls /
+    run_podman $safe_opts create --name $ctr_2_name --volume $volume_2_name:/test $IMAGE ls /
+
+    # Gather data to compare after migration
+    run_podman $safe_opts volume ls -q
+    volumes="$output"
+    run_podman $safe_opts pod ps -q
+    pods="$output"
+    run_podman $safe_opts ps -aq
+    ctrs="$output"
+
+    run_podman $safe_opts volume inspect $volume_1_name
+    v1_inspect="$output"
+    run_podman $safe_opts volume inspect $volume_2_name
+    v2_inspect="$output"
+    run_podman $safe_opts pod inspect $pod_name
+    pod_inspect="$output"
+    run_podman $safe_opts container inspect $ctr_1_name
+    ctr1_inspect="$output"
+    run_podman $safe_opts container inspect $ctr_2_name
+    ctr2_inspect="$output"
+
+    # Perform migration
+    if [[ "$CI_DESIRED_DATABASE" == "boltdb" ]]; then
+        # Podman will print an extra warning here because containers.conf is set to boltdb
+        run_podman 125 $safe_opts system migrate --migrate-db
+        assert "$output" =~ "Error: unable to migrate to SQLite database as database backend manually set" "migration error due to manually set database backend"
+
+        run_podman $safe_opts rm -af
+        run_podman $safe_opts pod rm -af
+        run_podman $safe_opts volume rm -af
+        run_podman $safe_opts rmi -af
+
+        skip "Remainder of test requires successful migration"
+    else
+        run_podman $safe_opts system migrate --migrate-db
+    fi
+
+    # Ensure it took affect
+    run_podman info $safe_opts --format '{{.Host.DatabaseBackend}}'
+    assert "$output" == "sqlite"
+
+    # Ensure containers, pods, volumes migrated correctly
+    run_podman $safe_opts volume ls -q
+    assert "$output" == "$volumes"
+    run_podman $safe_opts pod ps -q
+    assert "$output" == "$pods"
+    run_podman $safe_opts ps -aq
+    is "$output" "$ctrs"
+
+    run_podman $safe_opts volume inspect $volume_1_name
+    assert "$output" == "$v1_inspect"
+    run_podman $safe_opts volume inspect $volume_2_name
+    assert "$output" == "$v2_inspect"
+    run_podman $safe_opts pod inspect $pod_name
+    assert "$output" == "$pod_inspect"
+    run_podman $safe_opts container inspect $ctr_1_name
+    assert "$output" == "$ctr1_inspect"
+    run_podman $safe_opts container inspect $ctr_2_name
+    assert "$output" == "$ctr2_inspect"
+
+    unset SUPPRESS_BOLTDB_WARNING
+
+    run_podman $safe_opts rm -af
+    run_podman $safe_opts pod rm -af
+    run_podman $safe_opts volume rm -af
+    run_podman $safe_opts rmi -af
+}


### PR DESCRIPTION
This is gated behind a new option in `podman system migrate`, `--migrate-db`.

The basic logic is simple:
* Podman is already configured to use BoltDB
* Open a new, fresh SQLite database to write into
* Migrate all database contents as they exist in BoltDB, to SQLite. ** Do this as simply as possible: grab the object from the old DB
   and write it into the new DB using the standard Add and Save
   functions.
* Set the new database in the Runtime, close the old one.
* Move the old database file so it won't be reused
* Show a warning if the user explicitly configured BoltDB in containers.conf

Our ability to test complex migration scenarios is limited, but this should handle simple migrations easily.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Added the ability to migrate from the legacy BoltDB database to SQLite via a new option to `podman system migrate`, `--migrate-db`.
```
