### PR TITLE
Add Repository and Tag fields to image list --format JSON output

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -161,8 +161,11 @@ func writeID(imgs []imageReporter) error {
 func writeJSON(images []imageReporter) error {
 	type image struct {
 		entities.ImageSummary
-		Created   int64
-		CreatedAt string
+		Created    int64
+		CreatedAt  string
+		Repository string   `json:"Repository,omitempty"`
+		Tag        string   `json:"Tag,omitempty"`
+		RepoTags   []string `json:",omitempty"`
 	}
 
 	imgs := make([]image, 0, len(images))
@@ -171,6 +174,10 @@ func writeJSON(images []imageReporter) error {
 		h.ImageSummary = e.ImageSummary
 		h.Created = e.ImageSummary.Created
 		h.CreatedAt = e.created().Format(time.RFC3339Nano)
+		h.Repository = e.Repository
+		h.Tag = e.Tag
+		// This field is redundant with Repository and Tag
+		// but embedded from entities.ImageSummary
 		h.RepoTags = nil
 
 		imgs = append(imgs, h)

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -80,7 +81,20 @@ var _ = Describe("Podman images", func() {
 		session := podmanTest.Podman([]string{"images", "--format=json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(BeValidJSON())
+
+		output := session.OutputToString()
+		Expect(output).To(BeValidJSON())
+
+		images := []map[string]interface{}{}
+		err := json.Unmarshal([]byte(output), &images)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(images).ToNot(BeEmpty())
+
+		for _, image := range images {
+			Expect(image).To(HaveKey("Repository"))
+			Expect(image).To(HaveKey("Tag"))
+		}
 	})
 
 	It("podman images in GO template format", func() {


### PR DESCRIPTION
Fixes: #27632

Adds two fields to the output of `podman image list --format json`, "Repository" and "Tag." Consequently makes the existing embedded field "RepoTag" redundant, and in current implementation is always `nil`. Adds `json:",omitempty"` to improve program output.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add "Repository" and "Tag" fields to output of `podman image list --format json`
```
