### PR TITLE
Add note that build secrets do not work on macOS and Windows

### DIFF
--- a/docs/source/markdown/options/secret.image.md
+++ b/docs/source/markdown/options/secret.image.md
@@ -21,3 +21,5 @@ The location of the secret in the container can be overridden using the
 `RUN --mount=type=secret,id=mysecret,target=/run/secrets/myothersecret cat /run/secrets/myothersecret`
 
 Note: changing the contents of secret files will not trigger a rebuild of layers that use said secrets.
+Note: on macOS and Windows, build secrets are not currently supported via environment variables,
+specified by the "env" option.


### PR DESCRIPTION
See https://github.com/containers/podman/issues/17382
Until that issue is resolved, the docs seem to indicate this will work.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

None (or does documentation count as user-facing?
