### PR TITLE
Deterministically order pod inspect fields

### DIFF
--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/containers/podman/v6/libpod/define"
 	"github.com/containers/podman/v6/libpod/events"
@@ -620,6 +623,8 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			ctrStatuses[c.ID()] = c.state.State
 		}
 	}
+	slices.SortFunc(ctrs, func(a, b define.InspectPodContainerInfo) int { return strings.Compare(a.ID, b.ID) })
+
 	podState, err := createPodStatusResults(ctrStatuses)
 	if err != nil {
 		return nil, err
@@ -641,6 +646,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			sharesNS = append(sharesNS, nsStr)
 		}
 	}
+	sort.Strings(sharesNS)
 
 	// Infra config contains detailed information on the pod's infra
 	// container.

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -807,4 +807,12 @@ function thingy_with_unique_id() {
     done
 }
 
+@test "podman pod inspect ordering" {
+    local pod_name="p-$(safename)"
+    run_podman pod create $pod_name
+
+    run_podman pod inspect --format '{{ .SharedNamespaces }}' $pod_name
+    assert "$output" == "[ipc net uts]"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
There are two fields I'm worried about: shared namespaces and pod containers. Both are generated via loops over maps and are thus non-deterministic in ordering. Throw a sort on each to fix the order so we can actually diff `podman pod inspect` output.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
NONE
```
