### PR TITLE
Remove Intel MacOS support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -271,7 +271,7 @@ alt_build_task:
 
 # Confirm building the remote client, natively on a Mac OS-X VM.
 osx_alt_build_task:
-    name: "Build for MacOS amd64+arm64" # N/B: Referenced by URLencoded strings elsewhere
+    name: "Build for MacOS arm64" # N/B: Referenced by URLencoded strings elsewhere
     alias: osx_alt_build
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: *no_rhel_release  # RHEL never releases podman mac installer binary
@@ -300,12 +300,8 @@ osx_alt_build_task:
         - make podman-mac-helper
     build_pkginstaller_script:
         - pushd contrib/pkginstaller
-        - make ARCH=amd64 NO_CODESIGN=1 pkginstaller
         - make ARCH=aarch64 NO_CODESIGN=1 pkginstaller
-        - make ARCH=universal NO_CODESIGN=1 pkginstaller
         - popd
-    build_amd64_script:
-        - make podman-remote-release-darwin_amd64.zip
     # Building arm podman needs to be the last thing built in this task
     # The Mac tests rely this Podman binary to run, and the CI Mac is ARM-based
     build_arm64_script:
@@ -899,7 +895,7 @@ podman_machine_mac_task:
     clone_script:  # artifacts from osx_alt_build_task
         - mkdir -p $CIRRUS_WORKING_DIR
         - cd $CIRRUS_WORKING_DIR
-        - $ARTCURL/Build%20for%20MacOS%20amd64%2Barm64/repo/repo.tar.zst
+        - $ARTCURL/Build%20for%20MacOS%20arm64/repo/repo.tar.zst
         - tar -xf repo.tar.zst
     # This host is/was shared with potentially many other CI tasks.
     # The previous task may have been canceled or aborted.
@@ -1214,7 +1210,7 @@ artifacts_task:
     osx_binaries_script:
         - mkdir -p /tmp/osx
         - cd /tmp/osx
-        - $ARTCURL/Build%20for%20MacOS%20amd64%2Barm64/repo/repo.tar.zst
+        - $ARTCURL/Build%20for%20MacOS%20arm64/repo/repo.tar.zst
         - tar -xf repo.tar.zst
         - mv ./podman-remote-release-darwin_*.zip $CIRRUS_WORKING_DIR/
         - mv ./contrib/pkginstaller/out/podman-installer-macos-*.pkg $CIRRUS_WORKING_DIR/

--- a/.github/workflows/mac-pkg.yml
+++ b/.github/workflows/mac-pkg.yml
@@ -74,8 +74,6 @@ jobs:
       run: |
         URI="https://github.com/containers/podman/releases/download/${VERSION}"
         ARM_FILE="podman-installer-macos-arm64.pkg"
-        AMD_FILE="podman-installer-macos-amd64.pkg"
-        UNIVERSAL_FILE="podman-installer-macos-universal.pkg"
 
         status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${ARM_FILE}")
         if [[ "$status" == "404" ]] ; then
@@ -84,27 +82,9 @@ jobs:
           echo "::warning::ARM installer already exists, skipping"
           echo "buildarm=false" >> $GITHUB_OUTPUT
         fi
-
-        status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${AMD_FILE}")
-        if [[ "$status" == "404" ]] ; then
-          echo "buildamd=true" >> $GITHUB_OUTPUT
-        else
-          echo "::warning::AMD installer already exists, skipping"
-          echo "buildamd=false" >> $GITHUB_OUTPUT
-        fi
-
-        status=$(curl -s -o /dev/null -w "%{http_code}" "${URI}/${UNIVERSAL_FILE}")
-        if [[ "$status" == "404" ]] ; then
-          echo "builduniversal=true" >> $GITHUB_OUTPUT
-        else
-          echo "::warning::Universal installer already exists, skipping"
-          echo "builduniversal=false" >> $GITHUB_OUTPUT
-        fi
     - name: Checkout Version
       if: >-
-        steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
-        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/checkout@v6
       with:
@@ -113,9 +93,7 @@ jobs:
     - name: Set up Go
       # Conditional duplication sucks - GHA doesn't grok YAML anchors/aliases
       if: >-
-        steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
-        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/setup-go@v6
       with:
@@ -123,9 +101,7 @@ jobs:
         cache: false
     - name: Create Keychain
       if: >-
-        steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
-        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       run: |
         echo $APPLICATION_CERTIFICATE | base64 --decode -o appcert.p12
@@ -145,23 +121,9 @@ jobs:
       run: |
         make ARCH=aarch64 notarize &> /dev/null
         cd out && shasum -a 256 podman-installer-macos-arm64.pkg >> shasums
-    - name: Build and Sign AMD
-      if: steps.check.outputs.buildamd == 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
-      working-directory: contrib/pkginstaller
-      run: |
-        make ARCH=amd64 notarize &> /dev/null
-        cd out && shasum -a 256 podman-installer-macos-amd64.pkg >> shasums
-    - name: Build and Sign Universal
-      if: steps.check.outputs.builduniversal == 'true' || steps.actual_dryrun.outputs.dryrun == 'true'
-      working-directory: contrib/pkginstaller
-      run: |
-        make ARCH=universal notarize &> /dev/null
-        cd out && shasum -a 256 podman-installer-macos-universal.pkg >> shasums
     - name: Artifact
       if: >-
-        steps.check.outputs.buildamd == 'true' ||
         steps.check.outputs.buildarm == 'true' ||
-        steps.check.outputs.builduniversal == 'true' ||
         steps.actual_dryrun.outputs.dryrun == 'true'
       uses: actions/upload-artifact@v5
       with:
@@ -172,9 +134,7 @@ jobs:
     - name: Upload to Release
       if: >-
         steps.actual_dryrun.outputs.dryrun == 'false' &&
-        (steps.check.outputs.buildamd == 'true' ||
-         steps.check.outputs.buildarm == 'true'||
-         steps.check.outputs.builduniversal == 'true' )
+        steps.check.outputs.buildarm == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VERSION: ${{ steps.getversion.outputs.version }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -85,8 +85,7 @@ jobs:
           VERSION: ${{ steps.getversion.outputs.version }}
         run: |
             URI="https://github.com/containers/podman/releases/download/${VERSION}"
-            for artifact in "podman-remote-release-darwin_amd64.zip darwin_amd" \
-                  'podman-remote-release-darwin_arm64.zip darwin_arm' \
+            for artifact in 'podman-remote-release-darwin_arm64.zip darwin_arm' \
                   'podman-remote-release-windows_amd64.zip windows_amd' \
                   'podman-remote-static-linux_amd64.tar.gz linux_amd' \
                   'podman-remote-static-linux_arm64.tar.gz linux_arm'
@@ -128,14 +127,6 @@ jobs:
           steps.check.outputs.buildartifacts == 'true' ||
           steps.actual_dryrun.outputs.dryrun == 'true'
         run: mkdir -p release/
-
-      - name: Build Darwin AMD
-        if: >-
-          steps.check.outputs.darwin_amd == 'true' ||
-          steps.actual_dryrun.outputs.dryrun == 'true'
-        run: |
-            make podman-remote-release-darwin_amd64.zip
-            mv podman-remote-release-darwin_amd64.zip release/
 
       - name: Build Darwin ARM
         if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,14 +138,6 @@ jobs:
       working-directory: contrib/pkginstaller
       run: |
         make ARCH=aarch64 notarize &> /dev/null
-    - name: Build and Sign AMD
-      working-directory: contrib/pkginstaller
-      run: |
-        make ARCH=amd64 notarize &> /dev/null
-    - name: Build and Sign Universal
-      working-directory: contrib/pkginstaller
-      run: |
-        make ARCH=universal notarize &> /dev/null
     - name: Artifact
       uses: actions/upload-artifact@v5
       with:

--- a/DOWNLOADS.md
+++ b/DOWNLOADS.md
@@ -41,14 +41,8 @@ matches corresponding changes in the artifacts task.
   [rootlessport](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/rootlessport) -
   Built on the latest supported Fedora release.
 * MacOS
-  [universal](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-installer-macos-universal.pkg)
-  ,
-  [x86_64](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-installer-macos-amd64.pkg)
-  , and
   [arm64](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-installer-macos-arm64.pkg)
-  installation packages.  Again, these are **not** signed, so expect warnings if you try to install them.
-  There's also binary release *ZIP-files* for
-  [darwin_amd64](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-darwin_amd64.zip)
-  and
+  installation package.  Again, this is **not** signed, so expect warnings if you try to install it.
+  There's also a binary release *ZIP-file* for
   [darwin_arm64](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-darwin_arm64.zip).
 * Windows [podman-remote](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip) for x86_64 only.

--- a/Makefile
+++ b/Makefile
@@ -1028,8 +1028,6 @@ install.tools: .install.golangci-lint ## Install needed tools
 .PHONY: release-artifacts
 release-artifacts: clean-binaries
 	mkdir -p release/
-	$(MAKE) podman-remote-release-darwin_amd64.zip
-	mv podman-remote-release-darwin_amd64.zip release/
 	$(MAKE) podman-remote-release-darwin_arm64.zip
 	mv podman-remote-release-darwin_arm64.zip release/
 	$(MAKE) podman-remote-release-windows_amd64.zip

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -198,12 +198,9 @@ spelled with complete minutiae.
       This action creates the GitHub release from the pushed tag,
       and automatically builds and uploads the binaries and installers to the release.
       1. The following artifacts should be attached to the release:
-         * podman-installer-macos-amd64.pkg
          * podman-installer-macos-arm64.pkg
-         * podman-installer-macos-universal.pkg
          * podman-installer-windows-amd64.exe
          * podman-installer-windows-arm64.exe
-         * podman-remote-release-darwin_amd64.zip
          * podman-remote-release-darwin_arm64.zip
          * podman-remote-release-windows_amd64.zip
          * podman-remote-release-windows_arm64.zip

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build (amd64 && !darwin) || arm64
 
 package machine
 

--- a/contrib/pkginstaller/README.md
+++ b/contrib/pkginstaller/README.md
@@ -1,13 +1,13 @@
 ## How to build
 
 ```sh
-$ make ARCH=<amd64 | aarch64 | universal> NO_CODESIGN=1 pkginstaller
+$ make ARCH=aarch64 NO_CODESIGN=1 pkginstaller
 
 # or to create signed pkg
-$ make ARCH=<amd64 | aarch64 | universal> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> pkginstaller
+$ make ARCH=aarch64 CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> pkginstaller
 
 # or to prepare a signed and notarized pkg for release
-$ make ARCH=<amd64 | aarch64 | universal> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> NOTARIZE_TEAM=<team-id> notarize
+$ make ARCH=aarch64 CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> NOTARIZE_TEAM=<team-id> notarize
 ```
 
 The generated pkg will be written to `out/podman-macos-installer-*.pkg`.

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -28,13 +28,7 @@ function build_podman() {
   cp -v docs/build/remote/darwin/*.1 "contrib/pkginstaller/out/packaging/${docDir}"
 
   case ${goArch} in
-  universal)
-    build_fat
-    cp "${tmpBin}/podman-universal"  "contrib/pkginstaller/out/packaging/${binDir}/podman"
-    cp "${tmpBin}/podman-mac-helper-universal" "contrib/pkginstaller/out/packaging/${binDir}/podman-mac-helper"
-    ;;
-
-  amd64 | arm64)
+  arm64)
     build_podman_arch ${goArch}
     cp "${tmpBin}/podman-${goArch}"  "contrib/pkginstaller/out/packaging/${binDir}/podman"
     cp "${tmpBin}/podman-mac-helper-${goArch}" "contrib/pkginstaller/out/packaging/${binDir}/podman-mac-helper"
@@ -53,17 +47,6 @@ function build_podman_arch(){
     mkdir -p "${tmpBin}"
     cp bin/darwin/podman "${tmpBin}/podman-$1"
     cp bin/darwin/podman-mac-helper "${tmpBin}/podman-mac-helper-$1"
-}
-
-function build_fat(){
-    echo "Building ARM Podman"
-    build_podman_arch "arm64"
-    echo "Building AMD Podman"
-    build_podman_arch "amd64"
-
-    echo "Creating universal binary"
-    lipo -create -output "${tmpBin}/podman-universal" "${tmpBin}/podman-arm64" "${tmpBin}/podman-amd64"
-    lipo -create -output "${tmpBin}/podman-mac-helper-universal" "${tmpBin}/podman-mac-helper-arm64" "${tmpBin}/podman-mac-helper-amd64"
 }
 
 function sign() {

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && arm64
 
 package libkrun
 

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -102,10 +101,6 @@ func appleHvInstalled() (bool, error) {
 }
 
 func libKrunInstalled() (bool, error) {
-	if runtime.GOARCH != "arm64" {
-		return false, nil
-	}
-
 	// need to verify that krunkit, virglrenderer, and libkrun-efi are installed
 	cfg, err := config.Default()
 	if err != nil {


### PR DESCRIPTION
This PR removes support for Intel Apple Macs. The removal includes impacts to code, tests, Makefile, builds, release builds, and so forth.

Fixes Jira: RUN-3621

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Drop support for Intel Macs
```
