### PR TITLE
[v5.7] Replace FindExecutablePeer with FindHelperBinary

### DIFF
--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/sockets"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/common/pkg/config"
 	"go.podman.io/storage/pkg/fileutils"
 )
 
@@ -132,7 +133,11 @@ func launchWinProxy(opts WinProxyOpts) (bool, string, error) {
 
 	globalName := PipeNameAvailable(GlobalNamedPipe, GlobalNameWait)
 
-	command, err := FindExecutablePeer(winSSHProxy)
+	cfg, err := config.Default()
+	if err != nil {
+		return globalName, "", err
+	}
+	command, err := cfg.FindHelperBinary(winSSHProxy, false)
 	if err != nil {
 		return globalName, "", err
 	}
@@ -239,20 +244,6 @@ func sendQuit(tid uint32) {
 	postMessage := user32.NewProc("PostThreadMessageW")
 	//nolint:dogsled
 	_, _, _ = postMessage.Call(uintptr(tid), WM_QUIT, 0, 0)
-}
-
-func FindExecutablePeer(name string) (string, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-
-	exe, err = EvalSymlinksOrClean(exe)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(filepath.Dir(exe), name), nil
 }
 
 func EvalSymlinksOrClean(filePath string) (string, error) {

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -9,12 +9,12 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/containers/podman/v5/pkg/machine/wsl/wutil"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/common/pkg/config"
 )
 
 const gvForwarderPath = "/usr/libexec/podman/gvforwarder"
@@ -78,7 +78,11 @@ func startUserModeNetworking(mc *vmconfigs.MachineConfig) error {
 		return nil
 	}
 
-	exe, err := machine.FindExecutablePeer(gvProxy)
+	cfg, err := config.Default()
+	if err != nil {
+		return err
+	}
+	exe, err := cfg.FindHelperBinary(gvProxy, false)
 	if err != nil {
 		return fmt.Errorf("could not locate %s, which is necessary for user-mode networking, please reinstall", gvProxy)
 	}


### PR DESCRIPTION
cherry-pick f71b9335f1df124cd0655d88c3df401793530aaa from main branch

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
