### PR TITLE
[WIP] machine: search for `qemu-kvm` binary on linux

### DIFF
--- a/pkg/machine/provider/platform_unix.go
+++ b/pkg/machine/provider/platform_unix.go
@@ -63,7 +63,7 @@ func IsInstalled(provider define.VMType) (bool, error) {
 		if cfg == nil {
 			return false, fmt.Errorf("error fetching getting default config")
 		}
-		_, err = cfg.FindHelperBinary(qemu.QemuCommand, true)
+		_, err = qemu.FindQEMUBinary()
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}

--- a/pkg/machine/qemu/options_linux_amd64.go
+++ b/pkg/machine/qemu/options_linux_amd64.go
@@ -2,7 +2,10 @@
 
 package qemu
 
-var QemuCommand = "qemu-system-x86_64"
+var (
+	QemuCommand        = "qemu-system-x86_64"
+	GenericQemuCommand = "qemu-kvm"
+)
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{

--- a/pkg/machine/qemu/options_linux_arm64.go
+++ b/pkg/machine/qemu/options_linux_arm64.go
@@ -9,6 +9,7 @@ import (
 )
 
 var QemuCommand = "qemu-system-aarch64"
+var GenericQemuCommand = "qemu-kvm"
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -52,7 +52,7 @@ func (q *QEMUStubber) RequireExclusiveActive() bool {
 }
 
 func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {
-	qemuBinary, err := findQEMUBinary()
+	qemuBinary, err := FindQEMUBinary()
 	if err != nil {
 		return err
 	}
@@ -118,11 +118,7 @@ func runStartVMCommand(cmd *exec.Cmd) error {
 	if err != nil {
 		// check if qemu was not found
 		// look up qemu again maybe the path was changed, https://github.com/containers/podman/issues/13394
-		cfg, err := config.Default()
-		if err != nil {
-			return err
-		}
-		qemuBinaryPath, err := cfg.FindHelperBinary(QemuCommand, true)
+		qemuBinaryPath, err := FindQEMUBinary()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If the `qemu-system-{x86_64, aarch64}` binary is unavailable on linux, search for `qemu-kvm` as well.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixes a bug on Linux where Podman doesn't search for `qemu-kvm` if `qemu-system-{x86_64, aarch64}` isn't installed
```
