### PR TITLE
Use explicit download-artifact name and path for win-installer release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,9 @@ jobs:
         persist-credentials: false
     - name: Download Windows zip artifact
       uses: actions/download-artifact@v6
+      with:
+        name: release-artifacts
+        path: ${{ github.workspace }}\release-artifacts
     - name: Set up Go
       uses: actions/setup-go@v6
       with:


### PR DESCRIPTION
The v5.7.1 windows installer release job failed because the path where the action `download-artifact@v5` downloaded the artifacts changed compared to v5.7.0:

In v5.7.0, two artifacts are downloaded, each in [its folder](https://github.com/containers/podman/actions/runs/19275518090/job/55114909734#step:4:16):

```log
Starting download of artifact to: D:\a\podman\podman\release-artifacts
```

In v5.7.0, only one artifact is downloaded in the [parent folder:](https://github.com/containers/podman/actions/runs/20102680056/job/57678629770#step:4:15)

```log
Starting download of artifact to: D:\a\podman\podman
```

To avoid that we set an explicit name (so only one artifact is downloaded) and path (to make sure that it matches the path passed to the windows installer build scipt). 

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
