### PR TITLE
[v5.7] Use explicit download-artifact name and path for win-installer release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,10 @@ jobs:
     - name: Checkout Podman
       uses: actions/checkout@v5
     - name: Download Windows zip artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v6
+      with:
+        name: release-artifacts
+        path: ${{ github.workspace }}\release-artifacts
     - name: Set up Go
       uses: actions/setup-go@v6
       with:


### PR DESCRIPTION
(cherry picked from commit 22b10fa1538392663062a2812d219fca8ed9b1f9)



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
