### PR TITLE
Fixes #27651 - Fix health inspect/ps for rootfs containers with empty…

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1321,7 +1321,20 @@ func (c *Container) HostNetwork() bool {
 // HasHealthCheck returns bool as to whether there is a health check
 // defined for the container
 func (c *Container) HasHealthCheck() bool {
-	return c.config.HealthCheckConfig != nil
+	// Consider a healthcheck present only when a HealthCheckConfig exists
+	// and the Test field contains a meaningful command. Treat an empty
+	// Test slice or the special ["NONE"] sentinel as "no healthcheck".
+	if c.config.HealthCheckConfig == nil {
+		return false
+	}
+	test := c.config.HealthCheckConfig.Test
+	if len(test) == 0 {
+		return false
+	}
+	if len(test) == 1 && strings.ToUpper(test[0]) == define.HealthConfigTestNone {
+		return false
+	}
+	return true
 }
 
 // HealthCheckConfig returns the command and timing attributes of the health check

--- a/libpod/container_healthcheck_test.go
+++ b/libpod/container_healthcheck_test.go
@@ -1,0 +1,36 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	manifest "go.podman.io/image/v5/manifest"
+)
+
+func TestHasHealthCheckCases(t *testing.T) {
+	ctr := &Container{config: &ContainerConfig{}}
+
+	// nil HealthCheckConfig -> false
+	ctr.config.HealthCheckConfig = nil
+	assert.False(t, ctr.HasHealthCheck(), "nil HealthCheckConfig should not be considered a healthcheck")
+
+	// Test == nil -> false
+	ctr.config.HealthCheckConfig = &manifest.Schema2HealthConfig{Test: nil}
+	assert.False(t, ctr.HasHealthCheck(), "nil Test slice should not be considered a healthcheck")
+
+	// empty slice -> false
+	ctr.config.HealthCheckConfig = &manifest.Schema2HealthConfig{Test: []string{}}
+	assert.False(t, ctr.HasHealthCheck(), "empty Test slice should not be considered a healthcheck")
+
+	// NONE sentinel -> false (case-insensitive)
+	ctr.config.HealthCheckConfig = &manifest.Schema2HealthConfig{Test: []string{"NONE"}}
+	assert.False(t, ctr.HasHealthCheck(), "[\"NONE\"] sentinel should not be considered a healthcheck")
+	ctr.config.HealthCheckConfig = &manifest.Schema2HealthConfig{Test: []string{"none"}}
+	assert.False(t, ctr.HasHealthCheck(), "[\"none\"] sentinel should not be considered a healthcheck")
+
+	// valid CMD form -> true
+	ctr.config.HealthCheckConfig = &manifest.Schema2HealthConfig{Test: []string{"CMD-SHELL", "echo hi"}}
+	assert.True(t, ctr.HasHealthCheck(), "non-empty Test with command should be considered a healthcheck")
+}

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -192,10 +192,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		data.OCIConfigPath = c.state.ConfigPath
 	}
 
-	// Check if healthcheck is not nil and --no-healthcheck option is not set.
-	// If --no-healthcheck is set Test will be always set to `[NONE]`, so the
-	// inspect status should be set to nil.
-	if c.config.HealthCheckConfig != nil && (len(c.config.HealthCheckConfig.Test) != 1 || c.config.HealthCheckConfig.Test[0] != "NONE") {
+	if c.HasHealthCheck() {
 		// This container has a healthcheck defined in it; we need to add its state
 		healthCheckState, err := c.readHealthCheckLog()
 		if err != nil {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1310,10 +1310,7 @@ func (c *Container) start() error {
 		}
 	}
 
-	// Check if healthcheck is not nil and --no-healthcheck option is not set.
-	// If --no-healthcheck is set Test will be always set to `[NONE]` so no need
-	// to update status in such case.
-	if c.config.HealthCheckConfig != nil && (len(c.config.HealthCheckConfig.Test) != 1 || c.config.HealthCheckConfig.Test[0] != "NONE") {
+	if c.HasHealthCheck() {
 		if err := c.updateHealthStatus(define.HealthCheckStarting); err != nil {
 			return fmt.Errorf("update healthcheck status: %w", err)
 		}


### PR DESCRIPTION
… healthcheck

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

None


This fixes https://github.com/containers/podman/issues/27651, which raises the issue in which containers hold a stale "starting" status even though no healthchecks are configured.

As @mheon pointed out, the bug lies in the following condition:

`if c.config.HealthCheckConfig != nil && (len(c.config.HealthCheckConfig.Test) != 1 || c.config.HealthCheckConfig.Test[0] != "NONE")`

In the case of a non-nil HealthCheckConfig and a nil or empty HealthCheckConfig.Test, the condition incorrectly enters the code path that handles when a health check is actually configured.

These conditions seem to arise when building a container with `--rootfs` as opposed to building from an image.

I extended HasHealthCheck() to correctly evaluate the various combinations of HealthCheckConfig and HealthCheckConfig.Test, and used this function to replace repeated, incorrect code causing both `podman inspect rootfs-test --format '{{json .State.Health}}'` and `podman ps` to incorrectly return stale statuses.

I also included a unit test for HasHealthCheck 
