### PR TITLE
renovate: remove old c/{common, image, storage} config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,17 +42,5 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
       "schedule": "before 11am",
       "matchPackageNames": ["github.com/containers{/,}**"]
     },
-
-    // Updates for c/common, c/image, and c/storage should be grouped into a single PR.
-    {
-      "matchCategories": ["golang"],
-      "groupName": "common, image, and storage deps",
-      "schedule": "before 11am",
-      "matchPackageNames": [
-        "/^github.com/containers/common/",
-        "/^github.com/containers/image/",
-        "/^github.com/containers/storage/"
-      ]
-    }
   ],
 }


### PR DESCRIPTION
We no longer use these repos so we can drop this config.

In the meantime I added this for the new location in the global config. https://github.com/containers/automation/pull/259/commits/b49c089e5fa16be06f36b3abfa050f27dfee783b

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
