### PR TITLE
Fix missing newlines in stderr error messages

### DIFF
--- a/cmd/podman-testing/store_supported.go
+++ b/cmd/podman-testing/store_supported.go
@@ -42,7 +42,7 @@ func init() {
 func storeBefore() error {
 	defaultStoreOptions, err := storage.DefaultStoreOptions()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "selecting storage options: %v", err)
+		fmt.Fprintf(os.Stderr, "selecting storage options: %v\n", err)
 		return nil
 	}
 	globalStorageOptions = defaultStoreOptions

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -443,16 +443,16 @@ func configHook() {
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			// Cases where the folder does not exist are allowed, BUT cases where some other Stat() error
 			// is returned should fail
-			fmt.Fprintf(os.Stderr, "Supplied --config folder (%s) exists but is not accessible: %s", dockerConfig, err.Error())
+			fmt.Fprintf(os.Stderr, "Supplied --config folder (%s) exists but is not accessible: %s\n", dockerConfig, err.Error())
 			os.Exit(1)
 		}
 		if err == nil && !statInfo.IsDir() {
 			// Cases where it does exist but is a file should fail
-			fmt.Fprintf(os.Stderr, "Supplied --config file (%s) is not a directory", dockerConfig)
+			fmt.Fprintf(os.Stderr, "Supplied --config file (%s) is not a directory\n", dockerConfig)
 			os.Exit(1)
 		}
 		if err := os.Setenv("DOCKER_CONFIG", dockerConfig); err != nil {
-			fmt.Fprintf(os.Stderr, "cannot set DOCKER_CONFIG=%s: %s", dockerConfig, err.Error())
+			fmt.Fprintf(os.Stderr, "cannot set DOCKER_CONFIG=%s: %s\n", dockerConfig, err.Error())
 			os.Exit(1)
 		}
 	}

--- a/cmd/podman/syslog_unsupported.go
+++ b/cmd/podman/syslog_unsupported.go
@@ -15,6 +15,6 @@ func syslogHook() {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "Logging to Syslog is not supported on %s", runtime.GOOS)
+	fmt.Fprintf(os.Stderr, "Logging to Syslog is not supported on %s\n", runtime.GOOS)
 	os.Exit(1)
 }

--- a/pkg/farm/farm.go
+++ b/pkg/farm/farm.go
@@ -351,7 +351,7 @@ func (f *Farm) Build(ctx context.Context, schedule Schedule, options entities.Bu
 	buildResults.Range(func(_, v any) bool {
 		result, ok := v.(buildResult)
 		if !ok {
-			fmt.Fprintf(os.Stderr, "report %v not a build result?", v)
+			fmt.Fprintf(os.Stderr, "report %v not a build result?\n", v)
 			return false
 		}
 		perArchBuilds[result.report] = result.builder

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -101,7 +101,8 @@ var _ = Describe("Podman run", func() {
 		tempFileName := tempFile.Name()
 		session := podmanTest.Podman([]string{"--config", tempFileName, "run", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitWithError(1, fmt.Sprintf(`Supplied --config file (%s) is not a directory`, tempFileName)))
+		// Note: ErrorToString() uses strings.Fields() which normalizes whitespace, so we're not testing the trailing newline
+		Expect(session).Should(ExitWithError(1, fmt.Sprintf("Supplied --config file (%s) is not a directory", tempFileName)))
 	})
 
 	It("podman run from manifest list", func() {


### PR DESCRIPTION
I happened to run `podman run --config=/path/to/file` and got an error without a trailing newline, which was a bit jarring.

Fix the instances I noticed.

Assisted-by: OpenCode (Claude Opus 4.5)

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
