### PR TITLE
idtools: avoid direct use of C.stderr to fix musl cgo build failures

### DIFF
--- a/vendor/go.podman.io/storage/pkg/idtools/idtools_supported.go
+++ b/vendor/go.podman.io/storage/pkg/idtools/idtools_supported.go
@@ -20,6 +20,10 @@ struct subid_range get_range(struct subid_range *ranges, int i)
     return ranges[i];
 }
 
+static FILE *subid_stderr(void) {
+    return stderr;
+}
+
 #if !defined(SUBID_ABI_MAJOR) || (SUBID_ABI_MAJOR < 4)
 # define subid_init libsubid_init
 # define subid_get_uid_ranges get_subuid_ranges
@@ -44,7 +48,7 @@ func readSubid(username string, isUser bool) (ranges, error) {
 	}
 
 	onceInit.Do(func() {
-		C.subid_init(C.CString("storage"), C.stderr)
+		C.subid_init(C.CString("storage"), C.subid_stderr())
 	})
 
 	cUsername := C.CString(username)


### PR DESCRIPTION
On musl-based systems, stderr is declared as FILE *const.

Referencing stderr directly from Go code (via C.stderr) causes cgo to generate assignment code for a const-qualified pointer, which is invalid C and fails to compile.

Both gcc and clang reject the generated code with error messages below:

clang:
> cgo-gcc-prolog:85:9: error: cannot assign to variable '_cgo_r' with const-qualified type 'typeof (_cgo_a->r)' (aka 'struct _IO_FILE *const')
> cgo-gcc-prolog:83:24: note: variable '_cgo_r' declared const here
> cgo-gcc-prolog:88:12: error: cannot assign to non-static data member 'r' with const-qualified type 'FILE *const' (aka 'struct _IO_FILE *const')
> cgo-gcc-prolog:80:15: note: non-static data member 'r' declared const here

gcc:
> cgo-gcc-prolog:85:9: error: assignment of read-only variable '_cgo_r'
> cgo-gcc-prolog:88:12: error: assignment of read-only member 'r'

This patch avoids referencing C.stderr from Go code and instead returns stderr from a small C helper function. This keeps the usage entirely in C and avoids cgo’s broken handling for const-qualified global objects.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
