### PR TITLE
[play_kube] Add validation to container image field

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -219,6 +219,14 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		return nil, errors.New("got empty pod name on container creation when playing kube")
 	}
 
+	// We do validate against the Container spec however it has Image set as optional to allow
+	// higher level config management to default or override container images. Image is
+	// required for pods so we must manually validate here.
+	// https://github.com/kubernetes/kubernetes/pull/48406
+	if opts.Container.Image == "" {
+		return nil, fmt.Errorf("container %q is missing the required 'image' field", opts.Container.Name)
+	}
+
 	if opts.NoPodPrefix {
 		s.Name = opts.Container.Name
 	} else {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -283,6 +283,20 @@ spec:
     - containerPort: 80
 `
 
+var podWithoutAnImage = `
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: podDoesntHaveAnImage
+  name: podDoesntHaveAnImage
+spec:
+  containers:
+  - name: podDoesntHaveAnImage
+    ports:
+    - containerPort: 80
+`
+
 var subpathTestNamedVolume = `
 apiVersion: v1
 kind: Pod
@@ -2635,6 +2649,15 @@ var _ = Describe("Podman kube play", func() {
 		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(ExitWithError(125, "pod does not have a name"))
+	})
+
+	It("should error if pod doesn't have an image", func() {
+		err := writeYaml(podWithoutAnImage, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(ExitWithError(125, `container "podDoesntHaveAnImage" is missing the required 'image' field`))
 	})
 
 	It("support container liveness probe", func() {


### PR DESCRIPTION
Fixes: #27784

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Added validation to `podman play kube` command to detect when the mandatory container image field is missing
```
