### PR TITLE
add artifact validation during container creation 

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -47,6 +47,15 @@ import (
 	"go.podman.io/storage/pkg/unshare"
 )
 
+// ArtifactMountValidation contains the minimal information needed to validate
+// an artifact mount without requiring the full ContainerArtifactVolume structure.
+// This type is used to pass validation data to Runtime.ValidateArtifactMounts.
+type ArtifactMountValidation struct {
+	Source string
+	Title  string
+	Digest string
+}
+
 // Set up the JSON library for all of Libpod
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -24,8 +24,6 @@ import (
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/libnetwork/pasta"
 	"go.podman.io/common/libnetwork/slirp4netns"
-	"go.podman.io/common/pkg/libartifact/store"
-	libartTypes "go.podman.io/common/pkg/libartifact/types"
 	"tags.cncf.io/container-device-interface/pkg/parser"
 )
 
@@ -512,7 +510,15 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 
 	if len(s.ArtifactVolumes) != 0 {
 		// Validate artifacts exist before creating the container
-		if err := validateArtifactVolumes(ctx, rt, s.ArtifactVolumes); err != nil {
+		mounts := make([]libpod.ArtifactMountValidation, len(s.ArtifactVolumes))
+		for i, av := range s.ArtifactVolumes {
+			mounts[i] = libpod.ArtifactMountValidation{
+				Source: av.Source,
+				Title:  av.Title,
+				Digest: av.Digest,
+			}
+		}
+		if err := rt.ValidateArtifactMounts(ctx, mounts); err != nil {
 			return nil, err
 		}
 
@@ -761,40 +767,4 @@ func Inherit(infra *libpod.Container, s *specgen.SpecGenerator, rt *libpod.Runti
 		s.ShmSize = nil
 	}
 	return options, infraSpec, compatibleOptions, nil
-}
-
-// validateArtifactVolumes checks that all artifacts exist and are accessible
-// at container creation time, preventing creation of containers that can never start.
-func validateArtifactVolumes(ctx context.Context, rt *libpod.Runtime, artifactVolumes []*specgen.ArtifactVolume) error {
-	if len(artifactVolumes) == 0 {
-		return nil
-	}
-
-	artStore, err := rt.ArtifactStore()
-	if err != nil {
-		return fmt.Errorf("accessing artifact store: %w", err)
-	}
-
-	for _, artifactMount := range artifactVolumes {
-		// Use the same artifact store resolution logic as at start time
-		// to ensure consistent validation behavior
-		asr, err := store.NewArtifactStorageReference(artifactMount.Source)
-		if err != nil {
-			return fmt.Errorf("invalid artifact reference %q: %w", artifactMount.Source, err)
-		}
-
-		// Validate artifact exists using the same logic as container start.
-		// This ensures consistent behavior between creation and start time.
-		_ /*paths*/, err = artStore.BlobMountPaths(ctx, asr, &libartTypes.BlobMountPathOptions{
-			FilterBlobOptions: libartTypes.FilterBlobOptions{
-				Title:  artifactMount.Title,
-				Digest: artifactMount.Digest,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("validating artifact %q: %w", artifactMount.Source, err)
-		}
-	}
-
-	return nil
 }

--- a/test/e2e/artifact_mount_test.go
+++ b/test/e2e/artifact_mount_test.go
@@ -257,18 +257,13 @@ var _ = Describe("Podman artifact mount", func() {
 		}
 		session := podmanTest.Podman(cmd)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		// Verify error comes from our validation code
-		Expect(session.ErrorToString()).To(SatisfyAll(
-			ContainSubstring("validating artifact"),
-			ContainSubstring("nonexistent-artifact"),
-		))
+		Expect(session).To(ExitWithError(125, "validating artifact"))
+		Expect(session.ErrorToString()).To(ContainSubstring("nonexistent-artifact"))
 
 		// Ensure container was not created
 		rmSession := podmanTest.Podman([]string{"rm", "test-nonexistent"})
 		rmSession.WaitWithDefaultTimeout()
-		Expect(rmSession).Should(Exit(1))
-		Expect(rmSession.ErrorToString()).To(ContainSubstring("no such container"))
+		Expect(rmSession).To(ExitWithError(1, "no such container"))
 	})
 
 	It("podman run should fail with non-existent artifact", func() {
@@ -282,17 +277,13 @@ var _ = Describe("Podman artifact mount", func() {
 		}
 		session := podmanTest.Podman(cmd)
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
-		// Verify error comes from our validation code
-		Expect(session.ErrorToString()).To(SatisfyAll(
-			ContainSubstring("validating artifact"),
-			ContainSubstring("invalid-artifact-ref"),
-		))
+		Expect(session).To(ExitWithError(125, "validating artifact"))
+		Expect(session.ErrorToString()).To(ContainSubstring("invalid-artifact-ref"))
 
 		// Ensure container was not created
 		psSession := podmanTest.Podman([]string{"ps", "-a", "--filter", "name=test-run-nonexistent"})
 		psSession.WaitWithDefaultTimeout()
-		Expect(psSession).Should(Exit(0))
+		Expect(psSession).Should(ExitCleanly())
 		Expect(psSession.OutputToString()).ToNot(ContainSubstring("test-run-nonexistent"))
 	})
 })


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Container creation now validates artifact mounts exist, preventing creation of containers that cannot start due to missing artifacts.
```

Fixes #27747
