### PR TITLE
fix: remove unnecessary -t flag from podman run commands in docs

### DIFF
--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -611,7 +611,7 @@ flag. For example, an httpd port 80 can be mapped to the host port 8080 using th
 following:
 
 ```
-$ podman run -p 8080:80 -d -i -t fedora/httpd
+$ podman run -p 8080:80 -d fedora/httpd
 ```
 
 ### Mounting External Volumes

--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -122,13 +122,13 @@ outside the host as both rootful and rootless.  It will also show how an outside
 client can connect to the container.
 
 ```
-(rootful) $ sudo podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
+(rootful) $ sudo podman run -d --name webserver -p 8080:80 quay.io/libpod/banner
 00f3440c7576aae2d5b193c40513c29c7964e96bf797cf0cc352c2b68ccbe66a
 ```
 
 Now run the container.
 ```
-$ podman run -dt --name webserver --network podman1 -p 8081:80 quay.io/libpod/banner
+$ podman run -d --name webserver --network podman1 -p 8081:80 quay.io/libpod/banner
 269fd0d6b2c8ed60f2ca41d7beceec2471d72fb9a33aa8ca45b81dc9a0abbb12
 ```
 Note in the above run command, the container’s port 80 (where the Nginx server is
@@ -216,7 +216,7 @@ Note that depending on the distribution, the binary location may differ.
 
 Now run the container and be certain to attach it to the network we created earlier.
 ```
-$ sudo podman run -dt --name webserver --network webnetwork quay.io/libpod/banner
+$ sudo podman run -d --name webserver --network webnetwork quay.io/libpod/banner
 03d82083c434d7e937fc0b87c25401f46ab5050007df403bf988e25e52c5cc40
 [baude@localhost ~]$ sudo podman exec webserver ip address show eth0
 2: eth0@if3: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state
@@ -270,7 +270,7 @@ network can communicate with the rootless web server.
 First, run the rootless web server and map port 80 from the container to a non-privileged
 port like 8080.
 ```
-$ podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
+$ podman run -d --name webserver -p 8080:80 quay.io/libpod/banner
 17ea33ccd7f55ff45766b3ec596b990a5f2ba66eb9159cb89748a85dc3cebfe0
 ```
 Because rootless containers cannot communicate with each other directly with TCP/IP

--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -21,7 +21,7 @@ For installing or building Podman, see the [installation instructions](https://p
 This sample container will run a very basic httpd server (named basic_httpd) that serves only its index
 page.
 ```console
-podman run --name basic_httpd -dt -p 8080:80/tcp docker.io/nginx
+podman run --name basic_httpd -d -p 8080:80/tcp docker.io/nginx
 ```
 Because the container is being run in detached mode, represented by the *-d* in the `podman run` command, Podman
 will print the container ID after it has run. Note that we use port forwarding to be able to

--- a/docs/tutorials/podman_tutorial_cn.md
+++ b/docs/tutorials/podman_tutorial_cn.md
@@ -23,7 +23,7 @@ Podman是由libpod库提供一个实用的程序，可以被用于创建和管�
 这个示例容器会运行一个简单的只有主页的 httpd 服务器。
 
 ```console
-podman run --name basic_httpd -dt -p 8080:80/tcp docker.io/nginx
+podman run --name basic_httpd -d -p 8080:80/tcp docker.io/nginx
 ```
 
 因为命令中的 *-d* 参数表明容器以 "detached" 模式运行，所以 Podman 会在容器运行后打印容器的 ID。


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
fixes #27605