### PR TITLE
[WIP] add resource limit options to podman exec command

### DIFF
--- a/docs/source/markdown/options/cpu-shares.md
+++ b/docs/source/markdown/options/cpu-shares.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container clone, create, farm build, pod clone, pod create, run, update
+####>   podman build, container clone, create, exec, farm build, pod clone, pod create, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--cpu-shares**, **-c**=*shares*

--- a/docs/source/markdown/options/cpus.container.md
+++ b/docs/source/markdown/options/cpus.container.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman create, run, update
+####>   podman create, exec, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--cpus**=*number*

--- a/docs/source/markdown/options/cpuset-cpus.md
+++ b/docs/source/markdown/options/cpuset-cpus.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container clone, create, farm build, pod clone, pod create, run, update
+####>   podman build, container clone, create, exec, farm build, pod clone, pod create, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--cpuset-cpus**=*number*

--- a/docs/source/markdown/options/cpuset-mems.md
+++ b/docs/source/markdown/options/cpuset-mems.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container clone, create, farm build, pod clone, pod create, run, update
+####>   podman build, container clone, create, exec, farm build, pod clone, pod create, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--cpuset-mems**=*nodes*

--- a/docs/source/markdown/options/memory-swap.md
+++ b/docs/source/markdown/options/memory-swap.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container clone, create, farm build, pod clone, pod create, run, update
+####>   podman build, container clone, create, exec, farm build, pod clone, pod create, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--memory-swap**=*number[unit]*

--- a/docs/source/markdown/options/memory.md
+++ b/docs/source/markdown/options/memory.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container clone, create, farm build, pod clone, pod create, run, update
+####>   podman build, container clone, create, exec, farm build, pod clone, pod create, run, update
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--memory**, **-m**=*number[unit]*

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -17,7 +17,7 @@ podman\-exec - Execute a command in a running container
 
 Read the ID of the target container from the specified *file*.
 
-@@option cpus
+@@option cpus.container
 
 @@option cpu-shares
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -17,6 +17,14 @@ podman\-exec - Execute a command in a running container
 
 Read the ID of the target container from the specified *file*.
 
+@@option cpus
+
+@@option cpu-shares
+
+@@option cpuset-cpus
+
+@@option cpuset-mems
+
 #### **--detach**, **-d**
 
 Start the exec session, but do not attach to it. The command runs in the background, and the exec session is automatically removed when it completes. The **podman exec** command prints the ID of the exec session and exits immediately after it starts.
@@ -30,6 +38,10 @@ Start the exec session, but do not attach to it. The command runs in the backgro
 @@option interactive
 
 @@option latest
+
+@@option memory
+
+@@option memory-swap
 
 @@option no-session
 
@@ -94,6 +106,18 @@ Execute command but do not attach to the exec session leaving the command runnin
 ```
 $ podman exec -d ctrID find /path/to/search -name yourfile
 ```
+
+Execute command with resource limits (requires crun >= 1.9 or runc >= 1.2):
+```
+$ podman exec --cpus=0.5 --memory=256m ctrID stress-ng --vm 1 --vm-bytes 200M
+```
+
+## NOTES
+
+Resource limit options (--cpus, --memory, --cpu-shares, --cpuset-cpus,
+--cpuset-mems, --memory-swap) require OCI runtime support. These options
+create a temporary sub-cgroup for the exec session with the specified
+resource limits. Supported by crun >= 1.9 and runc >= 1.2.
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-run(1)](podman-run.1.md)**

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/containers/podman/v6/libpod/define"
-	"github.com/opencontainers/runtime-spec/specs-go"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"go.podman.io/common/pkg/resize"
 )
 
@@ -165,7 +165,7 @@ type OCIRuntime interface { //nolint:interfacebloat
 	RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeInfo, error)
 
 	// UpdateContainer updates the given container's cgroup configuration.
-	UpdateContainer(ctr *Container, res *specs.LinuxResources) error
+	UpdateContainer(ctr *Container, res *spec.LinuxResources) error
 }
 
 // AttachOptions are options used when attached to a container or an exec
@@ -230,6 +230,12 @@ type ExecOptions struct {
 	ExitCommandDelay uint
 	// Privileged indicates the execed process will be launched in Privileged mode
 	Privileged bool
+	// CgroupPath is the path to a sub-cgroup to create for the exec session.
+	// If empty, no cgroup will be created.
+	CgroupPath string
+	// Resources are the resource limits to apply to the exec session's cgroup.
+	// Only used if CgroupPath is set.
+	Resources *spec.LinuxResources
 }
 
 // HTTPAttachStreams informs the HTTPAttach endpoint which of the container's

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -427,6 +427,15 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 	args = append(args, "--exec-attach")
 	args = append(args, "--exec-process-spec", processFile.Name())
 
+	// If a cgroup path is specified for resource limits, pass it to the runtime.
+	// The value of options.CgroupPath is interpreted as relative to the
+	// container's existing cgroup, not as an absolute cgroup path. The OCI
+	// runtime is expected to resolve this by joining the provided value with
+	// the container's cgroup path in the cgroup hierarchy.
+	if options.CgroupPath != "" && options.Resources != nil {
+		args = append(args, "--cgroup", options.CgroupPath)
+	}
+
 	if len(options.ExitCommand) > 0 {
 		args = append(args, "--exit-command", options.ExitCommand[0])
 		for _, arg := range options.ExitCommand[1:] {

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -293,6 +293,13 @@ type ExecOptions struct {
 	Tty         bool
 	User        string
 	WorkDir     string
+	// Resource limits for the exec session
+	CPUs       string // Number of CPUs (e.g., "0.5", "2")
+	Memory     string // Memory limit (e.g., "256m", "1g")
+	CPUShares  uint64 // CPU shares (relative weight)
+	CPUSetCPUs string // CPUs in which to allow execution (0-3, 0,1)
+	CPUSetMems string // Memory nodes (MEMs) in which to allow execution (0-3, 0,1)
+	MemorySwap string // Total memory (memory + swap)
 }
 
 // ContainerExistsOptions describes the cli values to check if a container exists


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add resource limit options (--cpus, --memory, --cpu-shares, --cpuset-cpus, --cpuset-mems, --memory-swap) to podman exec command. Requires OCI runtime support (crun >= 1.9 or runc >= 1.2).
```

## Changes

- Added CLI flags: `--cpus`, `--memory`, `--cpu-shares`, `--cpuset-cpus`, `--cpuset-mems`, `--memory-swap`
- Implemented resource limit parsing and cgroup creation for exec sessions
- Added integration and system tests with runtime support detection
- Updated man page documentation

## Requirements

- Requires OCI runtime support: crun >= 1.9 or runc >= 1.2
- Resource limits create a temporary sub-cgroup for the exec session

## Testing

```bash
podman run -d --name test alpine top
podman exec --cpus=0.5 --memory=256m test stress-ng --vm 1 --vm-bytes 200M
```
fixes #26875