### PR TITLE
Remove network-cmd-path

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -582,12 +582,6 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 		pFlags.StringVar(&podmanConfig.ConmonPath, conmonFlagName, "", "Path of the conmon binary")
 		_ = cmd.RegisterFlagCompletionFunc(conmonFlagName, completion.AutocompleteDefault)
 
-		// TODO (6.0): --network-cmd-path is deprecated, remove this option with the next major release
-		// We need to find all the places that use r.config.Engine.NetworkCmdPath and remove it
-		networkCmdPathFlagName := "network-cmd-path"
-		pFlags.StringVar(&podmanConfig.ContainersConf.Engine.NetworkCmdPath, networkCmdPathFlagName, podmanConfig.ContainersConfDefaultsRO.Engine.NetworkCmdPath, "Path to the command for configuring the network")
-		_ = cmd.RegisterFlagCompletionFunc(networkCmdPathFlagName, completion.AutocompleteDefault)
-
 		networkConfigDirFlagName := "network-config-dir"
 		pFlags.StringVar(&podmanConfig.ContainersConf.Network.NetworkConfigDir, networkConfigDirFlagName, podmanConfig.ContainersConfDefaultsRO.Network.NetworkConfigDir, "Path of the configuration directory for networks")
 		_ = cmd.RegisterFlagCompletionFunc(networkConfigDirFlagName, completion.AutocompleteDefault)

--- a/docs/source/locale/ja/LC_MESSAGES/markdown.po
+++ b/docs/source/locale/ja/LC_MESSAGES/markdown.po
@@ -31333,10 +31333,6 @@ msgid ""
 "Windows (excluding WSL2) machines"
 msgstr ""
 
-#: ../../source/markdown/podman.1.md:98
-msgid "**--network-cmd-path**=*path*"
-msgstr ""
-
 #: ../../source/markdown/podman.1.md:99
 msgid ""
 "Path to the `slirp4netns(1)` command binary to use for setting up a "

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -104,11 +104,6 @@ Load the specified `containers.conf(5)` module.  Can be an absolute or relative 
 This flag is not supported on the remote client, including Mac and Windows (excluding WSL2) machines.
 Further note that the flag is a root-level flag and must be specified before any Podman sub-command.
 
-#### **--network-cmd-path**=*path*
-Path to the `slirp4netns(1)` command binary to use for setting up a slirp4netns network.
-If "" is used, then the binary will first be searched using the `helper_binaries_dir` option in `containers.conf`, and second using the `$PATH` environment variable.
-**Note:** This option is deprecated and will be removed with Podman 6.0. Use the `helper_binaries_dir` option in `containers.conf` instead.
-
 #### **--network-config-dir**=*directory*
 
 Path to the directory where network configuration files are located.

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -50,10 +50,7 @@ func (r *Runtime) setPlatformHostInfo(info *define.HostInfo) error {
 
 	info.CgroupsVersion = "v2"
 
-	slirp4netnsPath := r.config.Engine.NetworkCmdPath
-	if slirp4netnsPath == "" {
-		slirp4netnsPath, _ = r.config.FindHelperBinary(slirp4netns.BinaryName, true)
-	}
+	slirp4netnsPath, _ := r.config.FindHelperBinary(slirp4netns.BinaryName, true)
 	if slirp4netnsPath != "" {
 		ver, err := version.Program(slirp4netnsPath)
 		if err != nil {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -180,20 +180,6 @@ func WithConmonPath(path string) RuntimeOption {
 	}
 }
 
-// WithNetworkCmdPath specifies the path to the slirp4netns binary which manages the
-// runtime.
-func WithNetworkCmdPath(path string) RuntimeOption {
-	return func(rt *Runtime) error {
-		if rt.valid {
-			return define.ErrRuntimeFinalized
-		}
-
-		rt.config.Engine.NetworkCmdPath = path
-
-		return nil
-	}
-}
-
 // WithNetworkBackend specifies the name of the network backend.
 func WithNetworkBackend(name string) RuntimeOption {
 	return func(rt *Runtime) error {

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -164,9 +164,6 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 	if fs.Changed("tmpdir") {
 		options = append(options, libpod.WithTmpDir(cfg.ContainersConf.Engine.TmpDir))
 	}
-	if fs.Changed("network-cmd-path") {
-		options = append(options, libpod.WithNetworkCmdPath(cfg.ContainersConf.Engine.NetworkCmdPath))
-	}
 	if fs.Changed("network-backend") {
 		options = append(options, libpod.WithNetworkBackend(cfg.ContainersConf.Network.NetworkBackend))
 	}

--- a/test/e2e/quadlet/globalargs.network
+++ b/test/e2e/quadlet/globalargs.network
@@ -1,7 +1,5 @@
-## assert-podman-global-args "network" "--network-cmd-path=/usr/bin/network-cmd"
 ## assert-podman-global-args "network" "--network-config-dir=/etc/network-config"
 ## assert-podman-global-args "network" "--log-level=debug"
 
 [Network]
-GlobalArgs=--network-cmd-path=/usr/bin/network-cmd
 GlobalArgs=--network-config-dir=/etc/network-config --log-level=debug


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The --network-cmd-path option has been removed, as part of the slirp4netns removal.
```
