### PR TITLE
test: Fix --hostuser octal UID test flakiness

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -939,30 +939,28 @@ EOF
     run_podman 1 run --rm $IMAGE grep $user /etc/passwd
     run_podman run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
 
-    # find a user with a uid > 100 that is a valid octal
     # Issue #19800
-    octal_user=$(awk -F\: '$1!="nobody" && $3>100 && $3~/^[0-7]+$/ {print $1 " " $3; exit}' /etc/passwd)
-    # test only if a valid user was found
-    if test -n "$octal_user"; then
-        read octal_username octal_userid <<< $octal_user
-        run_podman run --user=$octal_username --hostuser=$octal_username --rm $IMAGE id -u
-        is "$output" "$octal_userid"
+    # Use the rootless user ID which is likely to be octal on CI as new user IDs start with 1000.
+    userid=$(id -u)
+    if [[ $userid =~ ^[0-7]+$ ]]; then
+        run_podman run --user=$user --hostuser=$user --rm $IMAGE id -u
+        is "$output" "$userid"
     fi
 
-    user=$(id -u)
-
-    userspec=$(id -un):$(id -g)
-    run_podman run --hostuser=$user --user $userspec --rm $IMAGE sh -c 'echo $(id -un):$(id -g)'
+    group=$(id -gn)
+    groupid=$(id -g)
+    userspec=$user:$groupid
+    run_podman run --hostuser=$userid --user $userspec --rm $IMAGE sh -c 'echo $(id -un):$(id -g)'
     is "$output" "$userspec"
 
-    run_podman run --hostuser=$user --user $userspec --group-entry="$(id -gn):x:$(id -g):" --rm $IMAGE sh -c 'echo $(id -un):$(id -gn)'
-    is "$output" "$(id -un):$(id -gn)"
+    run_podman run --hostuser=$userid --user $userspec --group-entry="$group:x:$groupid:" --rm $IMAGE sh -c 'echo $(id -un):$(id -gn)'
+    is "$output" "$user:$group"
 
-    run_podman 126 run --hostuser=$user --user "$(id -un):$(id -gn)" --rm $IMAGE sh -c 'echo $(id -un):$(id -gn)'
+    run_podman 126 run --hostuser=$userid --user "$user:$group" --rm $IMAGE sh -c 'echo $(id -un):$(id -gn)'
     is "$output" "Error:.* no matching entries in group file"
 
-    run_podman run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
-    run_podman run --hostuser=$user --user $user --rm $IMAGE grep $user /etc/passwd
+    run_podman run --hostuser=$userid --rm $IMAGE grep $userid /etc/passwd
+    run_podman run --hostuser=$userid --user $userid --rm $IMAGE grep $userid /etc/passwd
     user=bogus
     run_podman 126 run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
 }


### PR DESCRIPTION
The test for issue #19800 depended on finding a system user with an octal UID. This approach was fragile because system users found on the host may have a different UID in the testing image.

Use the rootless user ID instead which is likely to be octal anyway as new user IDs start with 1000.

Related failure:
https://openqa-assets.opensuse.org/tests/5535030/file/podman-bats-user-local.tap.txt

```
not ok 88 [030] podman run --hostuser tests # in 1306 ms
# tags: ci:parallel
# (from function `bail-now' in file test/system/helpers.bash, line 187,
#  from function `is' in file test/system/helpers.bash, line 1112,
#  in test file test/system/030-run.bats, line 910)
#   `is "$output" "$octal_userid"' failed
# 
# [09:01:00.631245040] $ /usr/bin/podman run --rm quay.io/libpod/testimage:20241011 grep bernhard /etc/passwd
# [09:01:00.967856561] [ rc=1 (expected) ]
# 
# [09:01:00.973939665] $ /usr/bin/podman run --hostuser=bernhard --rm quay.io/libpod/testimage:20241011 grep bernhard /etc/passwd
# [09:01:01.291043165] bernhard:*:1000:1000:bernhard:/home/podman:/bin/sh
# 
# [09:01:01.301488137] $ /usr/bin/podman run --user=sshd --hostuser=sshd --rm quay.io/libpod/testimage:20241011 id -u
# [09:01:01.651440214] 22
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: podman run --user=sshd --hostuser=sshd --rm quay.io/libpod/testimage:20241011 id -u
# #| expected: '476'
# #|   actual: '22'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # [teardown]
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
