### PR TITLE
[healthcheck] preserve arguments with spaces in healthcheck test

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -604,14 +604,13 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		cliOpts.OOMKillDisable = *cc.HostConfig.OomKillDisable
 	}
 	if cc.Config.Healthcheck != nil {
-		finCmd := ""
-		for _, str := range cc.Config.Healthcheck.Test {
-			finCmd = finCmd + str + " "
+		// Encode healthcheck test as JSON to preserve arguments with spaces.
+		// MakeHealthCheckFromCli will unmarshal this back to the original array.
+		cmdJSON, err := json.Marshal(cc.Config.Healthcheck.Test)
+		if err != nil {
+			return nil, nil, err
 		}
-		if len(finCmd) > 1 {
-			finCmd = finCmd[:len(finCmd)-1]
-		}
-		cliOpts.HealthCmd = finCmd
+		cliOpts.HealthCmd = string(cmdJSON)
 		if cc.Config.Healthcheck.Interval > 0 {
 			cliOpts.HealthInterval = cc.Config.Healthcheck.Interval.String()
 		}

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -986,7 +986,10 @@ func MakeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 
 	var concat string
 	if strings.ToUpper(cmdArr[0]) == define.HealthConfigTestCmd || strings.ToUpper(cmdArr[0]) == define.HealthConfigTestNone { // this is for compat, we are already split properly for most compat cases
-		cmdArr = strings.Fields(inCmd)
+		// Only re-split if the input was not already a JSON array (isArr == false); otherwise preserve the unmarshaled array structure
+		if !isArr {
+			cmdArr = strings.Fields(inCmd)
+		}
 	} else if strings.ToUpper(cmdArr[0]) != define.HealthConfigTestCmdShell { // this is for podman side of things, won't contain the keywords
 		if isArr && len(cmdArr) > 1 { // an array of consecutive commands
 			cmdArr = append([]string{define.HealthConfigTestCmd}, cmdArr...)

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -593,6 +593,31 @@ t GET containers/$cid/json 200 \
   .Config.Healthcheck.Timeout=30000000000 \
   .Config.Healthcheck.Retries=3
 
+t DELETE containers/$cid?v=true 204
+
+# Test Compat Create with healthcheck preserving arguments with spaces
+HEALTHCHECK_TMPD=$(mktemp -d podman-apiv2-test.healthcheck.XXXXXXXX)
+cat >$HEALTHCHECK_TMPD/create.json <<EOF
+{
+  "Image": "$IMAGE",
+  "Cmd": ["top"],
+  "Healthcheck": {
+    "Test": ["CMD", "/usr/bin/test", "--arg=value with spaces", "another arg"]
+  }
+}
+EOF
+t POST containers/create $HEALTHCHECK_TMPD/create.json 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Config.Healthcheck.Test[0]="CMD" \
+  .Config.Healthcheck.Test[1]="/usr/bin/test" \
+  .Config.Healthcheck.Test[2]="--arg=value with spaces" \
+  .Config.Healthcheck.Test[3]="another arg"
+
+t DELETE containers/$cid?v=true 204
+rm -rf $HEALTHCHECK_TMPD
+
 # compat api: Test for mount options support
 # Sigh, JSON can't handle octal. 0755(octal) = 493(decimal)
 payload='{"Mounts":[{"Type":"tmpfs","Target":"/mnt/scratch","TmpfsOptions":{"SizeBytes":1024,"Mode":493}}]}'


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed healthcheck arguments containing spaces being incorrectly split when creating containers via Docker-compatible API 
```


Summary
Healthcheck arguments containing spaces were being incorrectly split when creating containers via the Docker-compatible API.

## Problem

When using `docker-compose` or the Docker API to create containers with healthchecks, arguments with spaces were being split incorrectly:

```yaml
# Input
healthcheck:
  test: ["CMD", "/usr/bin/mysql", "--execute=SELECT 1;"]

# What was stored (broken)
["CMD", "/usr/bin/mysql", "--execute=SELECT", "1;"]

# What should be stored (fixed)
["CMD", "/usr/bin/mysql", "--execute=SELECT 1;"]
```

Fixes: #26519