### PR TITLE
test: Fix PODMAN_BATS_LEAK_CHECK

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -251,6 +251,9 @@ function defer-assertion-failures() {
 function basic_teardown() {
     echo "# [teardown]" >&2
 
+    PODMAN_CMD=("${PODMAN}")
+    add_podman_args PODMAN_CMD
+
     # Free any ports reserved by our test
     if [[ -d $PORT_LOCK_DIR ]]; then
         mylocks=$(grep -wlr $BATS_SUITE_TEST_NUMBER $PORT_LOCK_DIR || true)


### PR DESCRIPTION
This variable is set by `hack/bats` and it fails because `PODMAN_CMD` is unset in `basic_teardown`.  I could manually reproduce as well when calling bats directly with `PODMAN_BATS_LEAK_CHECK=1`.

Otherwise you get errors like this:
https://openqa-assets.opensuse.org/tests/5555887/file/podman-bats-user-local.tap.txt

```
# [teardown] $ podman pod rm -t 0 --all --force --ignore
# timeout: failed to run command ‘pod’: No such file or directory
# [teardown] $ podman rm -t 0 --all --force --ignore
# rm: invalid option -- 't' Try 'rm --help' for more information.
# [teardown] $ podman network prune --force
# timeout: failed to run command ‘network’: No such file or directory
# [teardown] $ podman volume rm -a -f
# timeout: failed to run command ‘volume’: No such file or directory
# setup(): removing stray external container error: (unknown)
# setup(): removing stray external container Usage: ()
# setup(): removing stray external container ps ([options])
# setup(): removing stray external container Try ('ps)
# setup(): removing stray external container or ('ps)
# setup(): removing stray external container for (additional)
# setup(): removing stray external container For (more)
# setup(): removing stray image timeout:
# setup(): removing stray image failed
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
