### PR TITLE
docs: fix misleading TimeoutStartSec information for oneshot services

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -88,8 +88,8 @@ and add the unit file to one of the above rootless unit search paths.
 When a Quadlet unit starts, Podman may need to pull or build container images, which can take significantly longer
 than systemd's default 90-second service startup limit. If this causes the unit to fail, you can either pre-pull the
 required images or increase the service's startup timeout using the *TimeoutStartSec* option. Keep in mind, however,
-that *TimeoutStartSec* cannot be used with units that specify `Type=oneshot` (their startup timeout is disabled by
-default). For further details on *TimeoutStartSec*, see `systemd.service(5)`.
+that for units that specify `Type=oneshot`, the startup timeout is disabled by default (set to infinity), so
+*TimeoutStartSec* must be explicitly configured if a timeout is desired. For further details on *TimeoutStartSec*, see `systemd.service(5)`.
 
 Adding the following snippet to a Quadlet file extends the startup timeout to 15 minutes.
 


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Update documentation for podman-system.unit(5)
```

The documentation incorrectly stated that `TimeoutStartSec` _"**cannot** be used"_ with `Type=oneshot` services. According to [`systemd.service(5)`](https://man7.org/linux/man-pages/man5/systemd.service.5.html), the startup timeout is simply disabled by default (set to infinity) for oneshot services, but `TimeoutStartSec` can still be explicitly configured if a timeout is desired.