### PR TITLE
pod create: add --group-add flag

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -149,14 +149,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(exposeFlagName, completion.AutocompleteNone)
 
-		groupAddFlagName := "group-add"
-		createFlags.StringSliceVar(
-			&cf.GroupAdd,
-			groupAddFlagName, []string{},
-			"Add additional groups to the primary container process. 'keep-groups' allows container processes to use supplementary groups.",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(groupAddFlagName, completion.AutocompleteNone)
-
 		createFlags.BoolVar(
 			&cf.HTTPProxy,
 			"http-proxy", podmanConfig.ContainersConfDefaultsRO.Containers.HTTPProxy,
@@ -771,6 +763,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		gpuFlagName := "gpus"
 		createFlags.StringSliceVar(&cf.GPUs, gpuFlagName, []string{}, "GPU devices to add to the container ('all' to pass all GPUs)")
 		_ = cmd.RegisterFlagCompletionFunc(gpuFlagName, completion.AutocompleteNone)
+
+		groupAddFlagName := "group-add"
+		createFlags.StringSliceVar(
+			&cf.GroupAdd,
+			groupAddFlagName, []string{},
+			"Add additional groups to the primary container process. 'keep-groups' allows container processes to use supplementary groups.",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(groupAddFlagName, completion.AutocompleteNone)
 
 		uidmapFlagName := "uidmap"
 		createFlags.StringSliceVar(

--- a/docs/source/markdown/options/group-add.md
+++ b/docs/source/markdown/options/group-add.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, create, farm build, run
+####>   podman build, create, farm build, pod create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--group-add**=*group* | *keep-groups*

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -82,6 +82,8 @@ Set the exit policy of the pod when the last container exits.  Supported policie
 
 @@option gpus
 
+@@option group-add
+
 #### **--help**, **-h**
 
 Print usage statement.


### PR DESCRIPTION
## Summary
- Add `--group-add` flag to `podman pod create` command
- Allows passing supplementary groups to the infra container
- Supports `keep-groups` argument for preserving host groups in rootless scenarios

Fixes #27559

## Changes
- Move `--group-add` flag definition to `InfraMode || CreateMode` block in `cmd/podman/common/create.go`
- Add documentation reference in `docs/source/markdown/podman-pod-create.1.md.in`
- Update `docs/source/markdown/options/group-add.md` header to include pod create

🤖 Generated with [Claude Code](https://claude.com/claude-code)