### PR TITLE
test/e2e: Skip privileged container test if NoNewPrivs is set

### DIFF
--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -143,16 +143,23 @@ var _ = Describe("Podman privileged container tests", func() {
 			Skip("Can't determine NoNewPrivs")
 		}
 
+		fields := strings.Fields(cap.OutputToString())
+		if fields[1] != "0" {
+			Skip("NoNewPrivs set")
+		}
+
 		session := podmanTest.Podman([]string{"run", BB, "grep", "NoNewPrivs", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		privs := strings.Split(session.OutputToString(), ":")
+		privs := strings.Fields(session.OutputToString())
+		Expect(privs[1]).To(Equal("0"), "NoNewPrivs should be 0 without security-opt")
+
 		session = podmanTest.Podman([]string{"run", "--security-opt", "no-new-privileges", BB, "grep", "NoNewPrivs", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		noprivs := strings.Split(session.OutputToString(), ":")
-		Expect(privs[1]).To(Not(Equal(noprivs[1])))
+		noprivs := strings.Fields(session.OutputToString())
+		Expect(noprivs[1]).To(Equal("1"), "NoNewPrivs should be 1 with security-opt")
 	})
 })


### PR DESCRIPTION
Skip privileged container test if NoNewPrivs is set.

Otherwise the test for https://www.thkukuk.de/blog/no_new_privs/ will fail:
https://openqa.opensuse.org/tests/5575293

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
