### PR TITLE
Fix typos and standardize terminology in documentation files

### DIFF
--- a/DOWNLOADS.md
+++ b/DOWNLOADS.md
@@ -23,7 +23,7 @@ don't take them beyond that.
   archive](https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary.zip)
   containing every binary produced in CI from the most recent successful run.
   *Warning*: This file is pretty large, expect a 700+MB download.  However,
-  it's guaranteed to contain everything, where as the items below can change
+  it's guaranteed to contain everything, whereas the items below can change
   or become unavailable due to somebody forgetting to update this doc.
 
 <!--


### PR DESCRIPTION
### PR description

This PR corrects several typographical errors and standardizes terminology across documentation files to improve clarity and professionalism.

### Changes made:
Downloads.md

Fixed grammatical error: where as → whereas

RELEASE.md

Fixed spelling error: abbrieviated → abbreviated

ISSUE.md

Fixed spelling errors: repoducer → reproducer (2 instances)

Standardized time zone reference: UT → UTC for consistency with technical documentation conventions