### PR TITLE
Quadlet - do not link pod service units to quadlet templates

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -929,6 +929,11 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 	return service, warnings, nil
 }
 
+func isTemplateUnit(unit *parser.UnitFile) bool {
+	base := strings.TrimSuffix(unit.Filename, filepath.Ext(unit.Filename))
+	return strings.HasSuffix(base, "@")
+}
+
 // Get the unresolved container name that may contain '%'.
 func getContainerName(container *parser.UnitFile) string {
 	containerName, ok := container.Lookup(ContainerGroup, KeyContainerName)
@@ -2198,7 +2203,8 @@ func handlePod(quadletUnitFile, serviceUnitFile *parser.UnitFile, groupName stri
 
 		// If we want to start the container with the pod, we add it to this list.
 		// This creates corresponding Wants=/Before= statements in the pod service.
-		if quadletUnitFile.LookupBooleanWithDefault(groupName, KeyStartWithPod, true) {
+		// Do not add this for template units as dependency cannot be created for them.
+		if !isTemplateUnit(quadletUnitFile) && quadletUnitFile.LookupBooleanWithDefault(groupName, KeyStartWithPod, true) {
 			podInfo.ContainersToStart = append(podInfo.ContainersToStart, serviceUnitFile.Filename)
 		}
 	}

--- a/test/e2e/quadlet/startwithpod.pod
+++ b/test/e2e/quadlet/startwithpod.pod
@@ -1,7 +1,13 @@
-## assert-last-key-contains "Unit" "Wants" "startwithpod_yes.service"
-## assert-last-key-contains "Unit" "Before" "startwithpod_yes.service"
+## assert-key-contains "Unit" "Before" "startwithpod_yes.service"
+## assert-key-contains "Unit" "Wants" "startwithpod_yes.service"
 
-## assert-last-key-not-contains "Unit" "Wants" "startwithpod_no.service"
-## assert-last-key-not-contains "Unit" "Before" "startwithpod_no.service"
+## assert-key-not-contains "Unit" "Wants" "startwithpod_no.service"
+## assert-key-not-contains "Unit" "Before" "startwithpod_no.service"
+
+## assert-key-not-contains "Unit" "Wants" "startwithpod@.service"
+## assert-key-not-contains "Unit" "Before" "startwithpod@.service"
+
+## assert-key-contains "Unit" "Wants" "startwithpod@foo.service"
+## assert-key-contains "Unit" "Before" "startwithpod@foo.service"
 
 [Pod]

--- a/test/e2e/quadlet/startwithpod@.container
+++ b/test/e2e/quadlet/startwithpod@.container
@@ -1,0 +1,6 @@
+# assert-last-key-contains "Unit" "After" "startwithpod-pod.service"
+# assert-last-key-contains "Unit" "BindsTo" "startwithpod-pod.service"
+
+[Container]
+Image=localhost/image
+Pod=startwithpod.pod

--- a/test/e2e/quadlet/startwithpod@foo.container
+++ b/test/e2e/quadlet/startwithpod@foo.container
@@ -1,0 +1,6 @@
+# assert-last-key-contains "Unit" "After" "startwithpod-pod.service"
+# assert-last-key-contains "Unit" "BindsTo" "startwithpod-pod.service"
+
+[Container]
+Image=localhost/image
+Pod=startwithpod.pod

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -212,6 +212,25 @@ func (t *quadletTestcase) assertKeyIsRegex(args []string, unit *parser.UnitFile)
 	return true
 }
 
+func (t *quadletTestcase) assertKeyContains(args []string, unit *parser.UnitFile) bool {
+	Expect(args).To(HaveLen(3))
+	group := args[0]
+	key := args[1]
+	value := args[2]
+
+	realValues := unit.LookupAll(group, key)
+	for _, realValue := range realValues {
+		if strings.Contains(realValue, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *quadletTestcase) assertKeyNotContains(args []string, unit *parser.UnitFile) bool {
+	return !t.assertKeyContains(args, unit)
+}
+
 func (t *quadletTestcase) assertLastKeyIsRegex(args []string, unit *parser.UnitFile) bool {
 	Expect(len(args)).To(BeNumerically(">=", 3))
 	group := args[0]
@@ -557,6 +576,10 @@ func (t *quadletTestcase) doAssert(check []string, unit *parser.UnitFile, sessio
 		ok = t.assertKeyIsEmpty(args, unit)
 	case "assert-key-is-regex":
 		ok = t.assertKeyIsRegex(args, unit)
+	case "assert-key-contains":
+		ok = t.assertKeyContains(args, unit)
+	case "assert-key-not-contains":
+		ok = t.assertKeyNotContains(args, unit)
 	case "assert-last-key-contains":
 		ok = t.assertLastKeyContains(args, unit)
 	case "assert-last-key-not-contains":
@@ -1288,7 +1311,16 @@ BOGUS=foo
 		Entry("Pod - Quadlet Volume", "volume.pod", []string{"basic.volume"}),
 		Entry("Pod - Quadlet Network overriding service name", "network.servicename.quadlet.pod", []string{"service-name.network"}),
 		Entry("Pod - Quadlet Volume overriding service name", "volume.servicename.pod", []string{"service-name.volume"}),
-		Entry("Pod - Do not autostart a container with pod", "startwithpod.pod", []string{"startwithpod_no.container", "startwithpod_yes.container"}),
+		Entry(
+			"Pod - Do not autostart a container with pod",
+			"startwithpod.pod",
+			[]string{
+				"startwithpod_no.container",
+				"startwithpod_yes.container",
+				"startwithpod@.container",
+				"startwithpod@foo.container",
+			},
+		),
 		Entry(
 			"Pod - Dependency between quadlet units",
 			"dependent.pod",


### PR DESCRIPTION
When a template container unit is linked to a pod do not add its service to the pod units dependency

Resolves: https://github.com/containers/podman/issues/27844

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Quadlet - Do not link pod service units to template container service units
```
