### PR TITLE
test/system: fix log timestamp work around

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -43,13 +43,6 @@ function _log_test_tail() {
     assert "$log1" =~ "^[0-9-]+T[0-9:.]+([\+-][0-9:]+|Z) test2" \
            "logs should only show last line"
 
-    # Sigh. I hate doing this, but podman-remote --timestamp only has 1-second
-    # resolution (regular podman has sub-second). For the timestamps-differ
-    # check below, we need to force a different second.
-    if is_remote; then
-        sleep 2
-    fi
-
     run_podman restart $cid
     run_podman wait $cid
 


### PR DESCRIPTION
We have the full nanosecond precision now also in the remote API after commit 60a5a476d5.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
