### PR TITLE
Add --volume-mode flag for container/pod creation

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1155,6 +1155,13 @@ func AutocompleteImageVolume(_ *cobra.Command, _ []string, _ string) ([]string, 
 	return imageVolumes, cobra.ShellCompDirectiveNoFileComp
 }
 
+// AutocompleteVolumeMode - Autocomplete volume mode options.
+// -> "create", "fail"
+func AutocompleteVolumeMode(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	volumeModes := []string{"create", "fail"}
+	return volumeModes, cobra.ShellCompDirectiveNoFileComp
+}
+
 // AutocompleteLogDriver - Autocomplete log-driver options.
 // -> "journald", "none", "k8s-file", "passthrough", "passthrough-tty"
 func AutocompleteLogDriver(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -900,6 +900,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Mount volumes from the specified container(s)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(volumesFromFlagName, AutocompleteContainers)
+
+		volumeModeFlagName := "volume-mode"
+		createFlags.StringVar(
+			&cf.VolumeMode,
+			volumeModeFlagName, "",
+			`Control named volume behavior: "create" (default) auto-creates missing volumes, "fail" errors if volume doesn't exist`,
+		)
+		_ = cmd.RegisterFlagCompletionFunc(volumeModeFlagName, AutocompleteVolumeMode)
 	}
 
 	if mode == entities.CloneMode || mode == entities.CreateMode {

--- a/docs/source/markdown/options/volume-mode.md
+++ b/docs/source/markdown/options/volume-mode.md
@@ -1,0 +1,24 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--volume-mode**=*mode*
+
+Control the behavior when a named volume specified with **--volume** or **--mount** does not exist.
+
+Supported modes are:
+
+- **create**: Automatically create the volume if it doesn't exist. This is the default behavior.
+- **fail**: Return an error if the volume doesn't exist.
+
+This option only affects named volumes. Bind mounts (host paths) and anonymous volumes are not affected by this option.
+
+Example:
+
+```
+# Fail if volume doesn't exist
+podman run --volume-mode=fail -v myvolume:/data alpine
+
+# Explicitly use default behavior (auto-create)
+podman run --volume-mode=create -v myvolume:/data alpine
+```

--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -8,7 +8,7 @@ Create a bind mount. If `-v /HOST-DIR:/CONTAINER-DIR` is specified, Podman
 bind mounts `/HOST-DIR` from the host into `/CONTAINER-DIR` in the Podman
 container. Similarly, `-v SOURCE-VOLUME:/CONTAINER-DIR` mounts the named
 volume from the host into the container. If no such named volume exists,
-Podman creates one. If no source is given, the volume is created
+Podman creates one. This behavior can be changed with the **--volume-mode** option. If no source is given, the volume is created
 as an anonymously named volume with a randomly generated name, and is
 removed when the <<container|pod>> is removed via the `--rm` flag or
 the `podman rm --volumes` command.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -402,6 +402,8 @@ the container when it exits. The default is **false**.
 
 Use the **--group-add keep-groups** option to pass the user's supplementary group access into the container.
 
+@@option volume-mode
+
 @@option volumes-from
 
 @@option workdir

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -98,6 +98,8 @@ clone process has completed. All containers within the pod are started.
 
 @@option volume
 
+@@option volume-mode
+
 @@option volumes-from
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -183,6 +183,8 @@ Note: This option conflicts with the **--share=cgroup** option since that option
 
 @@option volume
 
+@@option volume-mode
+
 @@option volumes-from
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -443,6 +443,8 @@ echo "asdf" | podman run --rm -i someimage /bin/cat
 
 Use the **--group-add keep-groups** option to pass the user's supplementary group access into the container.
 
+@@option volume-mode
+
 @@option volumes-from
 
 @@option workdir

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -183,6 +183,10 @@ type ContainerRootFSConfig struct {
 	// treated as root directories. Standard bind mounts will be mounted
 	// into paths relative to these directories.
 	ChrootDirs []string `json:"chroot_directories,omitempty"`
+	// VolumeMode controls the behavior when a named volume is not found.
+	// "create" (default) creates the volume if it doesn't exist.
+	// "fail" causes an error if the volume doesn't exist.
+	VolumeMode define.VolumeMode `json:"volume_mode,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/libpod/define/volume_inspect.go
+++ b/libpod/define/volume_inspect.go
@@ -1,8 +1,36 @@
 package define
 
 import (
+	"fmt"
 	"time"
 )
+
+// VolumeMode controls the behavior when a named volume is not found during
+// container creation.
+type VolumeMode string
+
+const (
+	// VolumeModeCreate causes Podman to create the volume if it doesn't exist.
+	// This is the default behavior.
+	VolumeModeCreate VolumeMode = "create"
+	// VolumeModeFail causes Podman to fail if the volume doesn't exist.
+	VolumeModeFail VolumeMode = "fail"
+)
+
+// String returns the string representation of the VolumeMode.
+func (v VolumeMode) String() string {
+	return string(v)
+}
+
+// Validate checks if the VolumeMode is valid.
+func (v VolumeMode) Validate() error {
+	switch v {
+	case VolumeModeCreate, VolumeModeFail, "":
+		return nil
+	default:
+		return fmt.Errorf("invalid volume mode %q: must be %q or %q", v, VolumeModeCreate, VolumeModeFail)
+	}
+}
 
 // InspectVolumeData is the output of Inspect() on a volume. It is matched to
 // the format of 'docker volume inspect'.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1402,6 +1402,24 @@ func WithArtifactVolumes(volumes []*ContainerArtifactVolume) CtrCreateOption {
 	}
 }
 
+// WithVolumeMode sets the volume mode for the container.
+// This controls the behavior when a named volume is not found.
+func WithVolumeMode(mode define.VolumeMode) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		if err := mode.Validate(); err != nil {
+			return err
+		}
+
+		ctr.config.VolumeMode = mode
+
+		return nil
+	}
+}
+
 // WithHealthCheck adds the healthcheck to the container config
 func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -511,6 +511,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			} else if !errors.Is(err, define.ErrNoSuchVolume) {
 				return nil, fmt.Errorf("retrieving named volume %s for new container: %w", vol.Name, err)
 			}
+			// Volume does not exist - check if we should fail
+			if ctr.config.VolumeMode == define.VolumeModeFail {
+				return nil, fmt.Errorf("volume %s does not exist and --volume-mode is set to fail: %w", vol.Name, define.ErrNoSuchVolume)
+			}
 		}
 		if vol.IsAnonymous {
 			// If SetAnonymous is true, make this an anonymous volume

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -260,6 +260,7 @@ type ContainerCreateOptions struct {
 	UTS                  string
 	Mount                []string
 	Volume               []string `json:"volume,omitempty"`
+	VolumeMode           string   `json:"volume_mode,omitempty"`
 	VolumesFrom          []string `json:"volumes_from,omitempty"`
 	Workdir              string
 	SeccompPolicy        string

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -522,6 +522,10 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		options = append(options, libpod.WithArtifactVolumes(vols))
 	}
 
+	if len(s.VolumeMode) > 0 {
+		options = append(options, libpod.WithVolumeMode(define.VolumeMode(s.VolumeMode)))
+	}
+
 	if s.Command != nil {
 		options = append(options, libpod.WithCommand(s.Command))
 	}

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -358,6 +358,12 @@ type ContainerStorageConfig struct {
 	// into paths relative to these directories.
 	// Optional.
 	ChrootDirs []string `json:"chroot_directories,omitempty"`
+	// VolumeMode controls the behavior when a named volume is not found.
+	// Supported modes are "create" (create the volume if it doesn't exist,
+	// which is the default behavior) and "fail" (return an error if the
+	// volume doesn't exist).
+	// Optional.
+	VolumeMode string `json:"volume_mode,omitempty"`
 }
 
 // ContainerSecurityConfig is a container's security features, including

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -779,6 +779,10 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.VolumesFrom = c.VolumesFrom
 	}
 
+	if len(s.VolumeMode) == 0 || len(c.VolumeMode) != 0 {
+		s.VolumeMode = c.VolumeMode
+	}
+
 	// Only add read-only tmpfs mounts in case that we are read-only and the
 	// read-only tmpfs flag has been set.
 	containerMounts, err := parseVolumes(rtc, c.Volume, c.Mount, c.TmpFS)


### PR DESCRIPTION
Add a new --volume-mode flag that controls behavior when a named volume doesn't exist during container or pod creation.

Supported modes:
- create (default): auto-create missing named volumes
- fail: return an error if the volume doesn't exist

The flag is available on: podman create, podman run, podman pod create, and podman pod clone.

See: https://github.com/containers/podman/issues/27862

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
volume-mode: New command line argument for run, create and pod create to instruct podman to fail when a named volume does not exist instead of creating one.
```
