### PR TITLE
Add nocreate option for named volumes

### DIFF
--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -8,10 +8,11 @@ Create a bind mount. If `-v /HOST-DIR:/CONTAINER-DIR` is specified, Podman
 bind mounts `/HOST-DIR` from the host into `/CONTAINER-DIR` in the Podman
 container. Similarly, `-v SOURCE-VOLUME:/CONTAINER-DIR` mounts the named
 volume from the host into the container. If no such named volume exists,
-Podman creates one. If no source is given, the volume is created
-as an anonymously named volume with a randomly generated name, and is
-removed when the <<container|pod>> is removed via the `--rm` flag or
-the `podman rm --volumes` command.
+Podman creates one. The **nocreate** option can be used to disable this
+behavior and require the volume to already exist. If no source is given,
+the volume is created as an anonymously named volume with a randomly
+generated name, and is removed when the <<container|pod>> is removed via
+the `--rm` flag or the `podman rm --volumes` command.
 
 (Note when using the remote client, including Mac and Windows (excluding WSL2) machines, the volumes are mounted from the remote server, not necessarily the client machine.)
 
@@ -28,6 +29,7 @@ The _OPTIONS_ is a comma-separated list and can be one or more of:
 * [**r**]**bind**
 * [**r**]**shared**|[**r**]**slave**|[**r**]**private**[**r**]**unbindable** <sup>[[1]](#Footnote1)</sup>
 * **idmap**[=**options**]
+* **nocreate**
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The volume
 is mounted into the container at this directory.
@@ -42,6 +44,13 @@ Any source that does not begin with a `.` or `/` is treated as the name of
 a named volume. If a volume with that name does not exist, it is created.
 Volumes created with names are not anonymous, and they are not removed by the `--rm`
 option and the `podman rm --volumes` command.
+
+The **nocreate** option can be specified for named volumes to prevent automatic
+volume creation. If **nocreate** is set and the volume does not exist, Podman
+returns an error instead of creating the volume. This is useful when you want
+to ensure that a volume was explicitly created before use.
+
+    $ podman <<fullsubcommand>> -v myvolume:/data:nocreate alpine
 
 Specify multiple **-v** options to mount one or more volumes into a
 <<container|pod>>.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -255,6 +255,9 @@ type ContainerNamedVolume struct {
 	IsAnonymous bool `json:"setAnonymous,omitempty"`
 	// SubPath determines which part of the Source will be mounted in the container
 	SubPath string `json:",omitempty"`
+	// NoCreate indicates that the volume must already exist and should not
+	// be created automatically if it doesn't exist.
+	NoCreate bool `json:"noCreate,omitempty"`
 }
 
 // ContainerOverlayVolume is an overlay volume that will be mounted into the

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1330,7 +1330,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 		}
 
 		for _, vol := range volumes {
-			mountOpts, err := util.ProcessOptions(vol.Options, false, "")
+			mountOpts, noCreate, err := util.ProcessOptions(vol.Options, false, "")
 			if err != nil {
 				return fmt.Errorf("processing options for named volume %q mounted at %q: %w", vol.Name, vol.Dest, err)
 			}
@@ -1341,6 +1341,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 				Options:     mountOpts,
 				IsAnonymous: vol.IsAnonymous,
 				SubPath:     vol.SubPath,
+				NoCreate:    noCreate,
 			})
 		}
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -511,6 +511,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			} else if !errors.Is(err, define.ErrNoSuchVolume) {
 				return nil, fmt.Errorf("retrieving named volume %s for new container: %w", vol.Name, err)
 			}
+			// Volume does not exist - check if nocreate option is set
+			if vol.NoCreate {
+				return nil, fmt.Errorf("volume %s does not exist and nocreate option is set: %w", vol.Name, define.ErrNoSuchVolume)
+			}
 		}
 		if vol.IsAnonymous {
 			// If SetAnonymous is true, make this an anonymous volume

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -443,13 +443,13 @@ func InitFSMounts(mounts []spec.Mount) error {
 	for i, m := range mounts {
 		switch {
 		case m.Type == define.TypeBind:
-			opts, err := util.ProcessOptions(m.Options, false, m.Source)
+			opts, _, err := util.ProcessOptions(m.Options, false, m.Source)
 			if err != nil {
 				return err
 			}
 			mounts[i].Options = opts
 		case m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev":
-			opts, err := util.ProcessOptions(m.Options, true, "")
+			opts, _, err := util.ProcessOptions(m.Options, true, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -504,6 +504,11 @@ func parseMountOptions(mountType string, args []string) (*universalMount, error)
 				return nil, fmt.Errorf("%q option not supported for %q mount types", name, mountType)
 			}
 			mnt.mount.Options = append(mnt.mount.Options, arg)
+		case "nocreate":
+			if mountType != define.TypeVolume {
+				return nil, fmt.Errorf("%q option not supported for %q mount types", name, mountType)
+			}
+			mnt.mount.Options = append(mnt.mount.Options, "nocreate")
 		default:
 			return nil, fmt.Errorf("%s: %w", name, util.ErrBadMntOption)
 		}


### PR DESCRIPTION
Add a per-volume 'nocreate' option that prevents automatic creation of named volumes when they don't exist. When specified, Podman will fail if the volume is not found instead of creating it automatically.

Usage: -v myvolume:/data:nocreate
       --mount type=volume,src=myvolume,dst=/data,nocreate

See: #27862

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Add nocreate option for named volumes to instruct podman to fail when a named volume does not exist instead of creating one.
```
