### PR TITLE
Fix Wants=/Requires= in quadlet example

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -2412,8 +2412,8 @@ Exec=sh -c "echo 'setup starting'; sleep 2; echo 'setup complete'"
 `app.container`
 ```
 [Unit]
-Requires=startup-task.container
-After=startup-task.container
+Requires=startup-task.service
+After=startup-task.service
 
 [Container]
 Pod=test.pod


### PR DESCRIPTION
This used to say Wants=/Requires=startup-task.container, but these lines are copied into the produced unit file unmodified and systemd does not know about .container objects and throws something like:

    /run/systemd/generator/app.service:8: Failed to add dependency on startup-task.container, ignoring: Invalid argument

Instead, these directives should use the resulting .service name directly.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
None