### PR TITLE
rootless: use nsfs file handles to persist namespaces

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -301,6 +301,11 @@ otherwise in the home directory of the user under
 
 In Rootless mode temporary configuration data is stored in `${XDG_RUNTIME_DIR}/containers`.
 
+#### **PODMAN_NO_PAUSE_PROCESS**
+
+In Rootless mode, when set to a value other than "0", Podman does not use a pause process.
+Namespace file handles are stored to allow rejoining the existing user and mount namespace if they are still alive.
+
 ## Remote Access
 
 The Podman command can be used with remote services using the `--remote` flag. Connections can

--- a/pkg/rootless/rootless_test.go
+++ b/pkg/rootless/rootless_test.go
@@ -1,12 +1,26 @@
 package rootless
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/moby/sys/user"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestGetNamespaceHandlesPath(t *testing.T) {
+	stateDir := "libpod"
+	result := GetNamespaceHandlesPath(stateDir)
+	assert.Equal(t, filepath.Join(stateDir, "ns_handles"), result)
+}
+
+func TestGetPausePidPath(t *testing.T) {
+	stateDir := "libpod"
+	result := GetPausePidPath(stateDir)
+	assert.Equal(t, filepath.Join(stateDir, "pause.pid"), result)
+}
 
 func TestMaybeSplitMappings(t *testing.T) {
 	mappings := []spec.LinuxIDMapping{

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -25,15 +25,15 @@ func GetRootlessConfigHomeDir() (string, error) {
 	return homedir.GetConfigHome()
 }
 
-// GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
-// the pause process.
-func GetRootlessPauseProcessPidPath() (string, error) {
+// GetRootlessStateDir returns the directory that holds the rootless state
+// (pause.pid and ns_handles files).
+func GetRootlessStateDir() (string, error) {
 	runtimeDir, err := homedir.GetRuntimeDir()
 	if err != nil {
 		return "", err
 	}
-	// Note this path must be kept in sync with pkg/rootless/rootless_linux.go
+	// Note this path must be kept in sync with pkg/rootless/rootless_linux.c
 	// We only want a single pause process per user, so we do not want to use
 	// the tmpdir which can be changed via --tmpdir.
-	return filepath.Join(runtimeDir, "libpod", "tmp", "pause.pid"), nil
+	return filepath.Join(runtimeDir, "libpod", "tmp"), nil
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -833,11 +833,11 @@ func TestProcessOptions(t *testing.T) {
 	}
 }
 
-func TestGetRootlessPauseProcessPidPath(t *testing.T) {
+func TestGetRootlessStateDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Not implemented on Windows")
 	}
-	dir, err := GetRootlessPauseProcessPidPath()
+	dir, err := GetRootlessStateDir()
 	assert.NoError(t, err)
-	assert.NotEqual(t, dir, "libpod/tmp/pause.pid")
+	assert.NotEqual(t, dir, "libpod/tmp")
 }

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -23,10 +23,10 @@ func GetContainerPidInformationDescriptors() ([]string, error) {
 	return nil, fmt.Errorf("GetContainerPidInformationDescriptors: %w", errNotImplemented)
 }
 
-// GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
-// the pause process
-func GetRootlessPauseProcessPidPath() (string, error) {
-	return "", fmt.Errorf("GetRootlessPauseProcessPidPath: %w", errNotImplemented)
+// GetRootlessStateDir returns the directory that holds the rootless state
+// (pause.pid and ns_handles files).
+func GetRootlessStateDir() (string, error) {
+	return "", fmt.Errorf("GetRootlessStateDir: %w", errNotImplemented)
 }
 
 // GetRootlessRuntimeDir returns the runtime directory

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -212,7 +212,9 @@ function __run_healthcheck_container() {
 
     kill -9 ${conmon_pid}
 
-    run_podman rm -f -t0 $cname
+    # When conmon is killed, the ns_handles may become stale and produce a warning
+    # about creating a new rootless user namespace. This is expected behavior.
+    run_podman 0+w rm -f -t0 $cname
 
     run_podman 125 container inspect $cname
     assert "$output" =~ "no such container \"$cname\"" "Container should be removed"


### PR DESCRIPTION
use name_to_handle_at and open_by_handle_at to persist rootless namespaces without needing a pause process.

The namespace file handles are stored in a file and can be used to rejoin the namespaces, as long as the namespaces still exist.

Fall back to the pause process approach only when the kernel doesn't support nsfs handles (EOPNOTSUPP).

These changes in the kernel are required (landed in Linux 6.18):

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3ab378cfa793

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
From Linux 6.18, rootless Podman won't create a "pause" process to keep the user and mount namespaces alive.  It is gated behind the drop-pause-process environment variable
```
