### PR TITLE
[v5.6-rhel] test/system: remove apk from build

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -16,13 +16,11 @@ load helpers
     dockerfile=$tmpdir/Dockerfile
     cat >$dockerfile <<EOF
 FROM $IMAGE
-RUN apk add nginx
 RUN echo $rand_content > /$rand_filename
 EOF
 
-    # The 'apk' command can take a long time to fetch files; bump timeout
     imgname="b-$(safename)"
-    PODMAN_TIMEOUT=240 run_podman build -t $imgname --format=docker $tmpdir
+    run_podman build -t $imgname --format=docker $tmpdir
     is "$output" ".*COMMIT" "COMMIT seen in log"
 
     # $IMAGE is preloaded, so we should never re-pull


### PR DESCRIPTION
Backport the commit to resolve the flakes in test env

We do not use that package that we install for the test anyway and doing this networking connection is causing heavy flakes at the moment.

Fixes: https://issues.redhat.com/browse/RHEL-138650

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
- [ x ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ x ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ x ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ x ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ x ] All commits pass `make validatepr` (format/lint checks)
- [ x ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```None

```
