### PR TITLE
libpod: simplify unnecessary loops

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -541,12 +542,7 @@ func (c *Container) Dependencies() []string {
 		return []string{}
 	}
 
-	depends := make([]string, 0, len(dependsCtrs))
-	for ctr := range dependsCtrs {
-		depends = append(depends, ctr)
-	}
-
-	return depends
+	return slices.Collect(maps.Keys(dependsCtrs))
 }
 
 // NewNetNS returns whether the container will create a new network namespace

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -180,14 +180,7 @@ func (c *Container) getUniqueExecSessionID() string {
 	found := true
 	// This really ought to be a do-while, but Go doesn't have those...
 	for found {
-		found = false
-		for id := range c.state.ExecSessions {
-			if id == sessionID {
-				found = true
-				break
-			}
-		}
-		if found {
+		if _, found = c.state.ExecSessions[sessionID]; found {
 			sessionID = stringid.GenerateRandomID()
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

This PR changes a few spots in `libpod` where loops are currently used for extracting keys from a map into a slice, or for checking the existence of a key in a map. These can simplified to remove the loop. There should be no change in behavior and I doubt that there would be performance differences; the intended improvement here is on readability.

There are other similar changes that could be made, but the changes here are the most 'obvious'/agreeable of them.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable) (none)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed) (no expected behavior changes)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed) (no expected behavior changes)
- [ ] All commits pass `make validatepr` (format/lint checks) - When running locally, failed to build Darwin `podman-machine` - for libkrun, `build constraints exclude all Go files in ...`, pretty sure unrelated
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

None

```release-note

```
