### PR TITLE
Fix container export emitting incorrect event type.

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -545,7 +545,7 @@ func (c *Container) Export(out io.Writer) error {
 		return fmt.Errorf("cannot mount container %s as it is being removed: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
-	defer c.newContainerEvent(events.Mount)
+	defer c.newContainerEvent(events.Export)
 	return c.export(out)
 }
 

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -51,4 +51,22 @@ var _ = Describe("Podman export", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).To(ExitWithError(125, "invalid filename (should not contain ':')"))
 	})
+
+	It("podman export emits export event", func() {
+		_, ec, cid := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+
+		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
+		result := podmanTest.Podman([]string{"export", "-o", outfile, cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+
+		eventsResult := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=export", "--since", "30s"})
+		eventsResult.WaitWithDefaultTimeout()
+		Expect(eventsResult).Should(ExitCleanly())
+		events := eventsResult.OutputToStringArray()
+		Expect(events).ToNot(BeEmpty(), "export event should be present")
+		Expect(events[0]).To(ContainSubstring("export"))
+		Expect(events[0]).To(ContainSubstring(cid))
+	})
 })


### PR DESCRIPTION
## Problem

The `Container.Export()` method was incorrectly emitting a `mount` event instead of an `export` event. This breaks event filtering for users who expect to filter on `export` events as documented in `podman-events(1)`.

Changed the event emitted by `Container.Export()` from `events.Mount` to `events.Export` to match the user-facing operation.
The internal `export()` function does mount the container filesystem if needed, but that is an implementation detail. The event should reflect what the user requested (export), not the internal mechanism (mount).

```release-note
None
```
