### PR TITLE
secrets/create: remove pipe check and allow interactive stdin

### DIFF
--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -82,13 +82,6 @@ func create(_ *cobra.Command, args []string) error {
 		}
 		reader = strings.NewReader(envValue)
 	case path == "-" || path == "/dev/stdin":
-		stat, err := os.Stdin.Stat()
-		if err != nil {
-			return err
-		}
-		if (stat.Mode() & os.ModeNamedPipe) == 0 {
-			return errors.New("if `-` is used, data must be passed into stdin")
-		}
 		reader = os.Stdin
 	default:
 		file, err := os.Open(path)

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -5,11 +5,14 @@ package integration
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	. "github.com/containers/podman/v6/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 	"go.podman.io/storage/pkg/stringid"
 )
 
@@ -499,5 +502,26 @@ var _ = Describe("Podman secret", func() {
 		exists := podmanTest.Podman([]string{"secret", "exists", secretName})
 		exists.WaitWithDefaultTimeout()
 		Expect(exists).Should(ExitWithError(1, ""))
+	})
+
+	It("podman secret create from stdin", func() {
+		secretData := "mysecretdata"
+		secretName := "stdin-secret-" + stringid.GenerateRandomID()
+
+		args := []string{"secret", "create", secretName, "-"}
+		podmanOptions := podmanTest.MakeOptions(args, PodmanExecOptions{})
+		cmd := exec.Command(podmanTest.PodmanBinary, podmanOptions...)
+		cmd.Stdin = strings.NewReader(secretData)
+		session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+		podmanSession := &PodmanSession{Session: session}
+		podmanSession.WaitWithDefaultTimeout()
+		Expect(podmanSession).Should(ExitCleanly())
+		secrID := podmanSession.OutputToString()
+
+		inspect := podmanTest.Podman([]string{"secret", "inspect", "--showsecret", "--format", "{{.SecretData}}", secrID})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		Expect(inspect.OutputToString()).To(Equal(secretData))
 	})
 })


### PR DESCRIPTION
Previously, `secret create` required stdin to be a pipe when using `-`, blocking interactive stdin forcing users to use insecure patterns like `echo "secret" | podman secret create <name>`.

Remove the pipe check to allow interactive stdin.

Closes #18591, #27879