### PR TITLE
Bump Compat API version to supported v1.44

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -22,7 +22,7 @@ for i in /version version; do
       .Components[0].Details.APIVersion~6[0-9.-]\\+  \
       .Components[0].Details.MinAPIVersion=4.0.0     \
       .Components[0].Details.Os=linux                \
-      .ApiVersion=1.41                               \
+      .ApiVersion=1.44                               \
       .MinAPIVersion=1.24                            \
       .Os=linux
 done

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -30,6 +30,7 @@ t POST "containers/foo/attach?logs=true&stream=false" 200 \
   $'\001\031'$mytext
 
 # check old docker header
+t POST "/v1.40/containers/foo/attach?logs=true&stream=false" 200
 response_headers=$(cat "$WORKDIR/curl.headers.out")
 like "$response_headers" ".*Content-Type: application/vnd\.docker\.raw-stream.*" "vnd.docker.raw-stream docker v1.40"
 # check new vnd.docker.multiplexed-stream header
@@ -45,7 +46,7 @@ like "$response_headers" ".*Content-Type: application/vnd\.docker\.multiplexed-s
 
 t POST "containers/foo/attach?logs=true&stream=false" 101
 response_headers=$(cat "$WORKDIR/curl.headers.out")
-like "$response_headers" ".*Content-Type: application/vnd\.docker\.raw-stream.*" "hijacked connection header: Content-type: application/vnd.docker.raw-stream"
+like "$response_headers" ".*Content-Type: application/vnd\.docker\.multiplexed-stream.*" "hijacked connection header: Content-type: application/vnd.docker.multiplexed-stream"
 like "$response_headers" ".*Upgrade: tcp.*" "hijacked connection header: Upgrade: tcp"
 
 t POST "containers/foo/kill" 204

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -314,7 +314,7 @@ function t() {
         case "$path" in
         /*) url="$url$path" ;;
         libpod/*) url="$url/v6.0.0/$path" ;;
-        *)  url="$url/v1.41/$path" ;;
+        *)  url="$url/v1.44/$path" ;;
         esac
     fi
 

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // Version is the version of the build.
 var Version = semver.MustParse(rawversion.RawVersion)
 
-// See https://docs.docker.com/engine/api/v1.40/
+// See https://docs.docker.com/reference/api/engine/
 // libpod compat handlers are expected to honor docker API versions
 
 // APIVersion provides the current and minimal API versions for compat and libpod endpoint trees
@@ -40,7 +40,7 @@ var APIVersion = map[Tree]map[Level]semver.Version{
 		MinimalAPI: semver.MustParse("4.0.0"),
 	},
 	Compat: {
-		CurrentAPI: semver.MustParse("1.41.0"),
+		CurrentAPI: semver.MustParse("1.44.0"),
 		MinimalAPI: semver.MustParse("1.24.0"),
 	},
 }


### PR DESCRIPTION
All API versions before version 1.44 are now deprecated, starting with Docker client version 1.29 giving an error:

"API version 1.41 is not supported by this client"

Previously it was backward-compatible for more than 10 years, with version 1.24 being the version in classic Docker 1.12.

It seems like API code changes were already added?

Fixes #27890

The API version had not been updated since 2022:

Issue #14219

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
The Compat API now supports the v1.44 API.
```
