### PR TITLE
libpod: fix Volume.Mount() returning empty path for plugin volumes

### DIFF
--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -284,7 +284,7 @@ func (v *Volume) Mount() (string, error) {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 	err := v.mount()
-	return v.config.MountPoint, err
+	return v.mountPoint(), err
 }
 
 func (v *Volume) Unmount() error {

--- a/libpod/volume_test.go
+++ b/libpod/volume_test.go
@@ -1,0 +1,130 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"testing"
+
+	"github.com/containers/podman/v6/libpod/define"
+	"github.com/stretchr/testify/assert"
+	"go.podman.io/common/pkg/config"
+)
+
+// Regression test for issue #27858.
+func TestVolumeMountPointReturnsCorrectPath(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := &config.Config{
+		Engine: config.EngineConfig{
+			VolumePlugins: map[string]string{},
+		},
+	}
+	runtime := &Runtime{config: runtimeConfig}
+
+	testCases := []struct {
+		name           string
+		driver         string
+		configMount    string
+		stateMount     string
+		expectedResult string
+	}{
+		{
+			name:           "local driver uses config mountpoint",
+			driver:         define.VolumeDriverLocal,
+			configMount:    "/var/lib/containers/storage/volumes/testvol/_data",
+			stateMount:     "",
+			expectedResult: "/var/lib/containers/storage/volumes/testvol/_data",
+		},
+		{
+			name:           "empty driver uses config mountpoint",
+			driver:         "",
+			configMount:    "/var/lib/containers/storage/volumes/testvol/_data",
+			stateMount:     "",
+			expectedResult: "/var/lib/containers/storage/volumes/testvol/_data",
+		},
+		{
+			name:           "plugin driver uses state mountpoint",
+			driver:         "volume-fs",
+			configMount:    "",
+			stateMount:     "/run/containers/storage/volumes/plugin-vol",
+			expectedResult: "/run/containers/storage/volumes/plugin-vol",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			vol := &Volume{
+				config: &VolumeConfig{
+					Name:       "test-volume",
+					Driver:     tc.driver,
+					MountPoint: tc.configMount,
+				},
+				state: &VolumeState{
+					MountPoint: tc.stateMount,
+				},
+				runtime: runtime,
+			}
+
+			result := vol.mountPoint()
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+// Regression test for issue #27858: plugin volumes must use state.MountPoint.
+func TestVolumeMountPointPluginConsistency(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := &config.Config{
+		Engine: config.EngineConfig{
+			VolumePlugins: map[string]string{},
+		},
+	}
+	runtime := &Runtime{config: runtimeConfig}
+
+	vol := &Volume{
+		config: &VolumeConfig{
+			Name:       "plugin-volume",
+			Driver:     "volume-fs",
+			MountPoint: "",
+		},
+		state: &VolumeState{
+			MountPoint: "/run/containers/storage/volumes/plugin-vol",
+		},
+		runtime: runtime,
+	}
+
+	assert.True(t, vol.UsesVolumeDriver())
+	result := vol.mountPoint()
+	assert.NotEmpty(t, result)
+	assert.Equal(t, vol.state.MountPoint, result)
+}
+
+func TestVolumeLocalDriverDoesNotUseVolumeDriver(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := &config.Config{
+		Engine: config.EngineConfig{
+			VolumePlugins: map[string]string{},
+		},
+	}
+	runtime := &Runtime{config: runtimeConfig}
+
+	vol := &Volume{
+		config: &VolumeConfig{
+			Name:       "local-volume",
+			Driver:     define.VolumeDriverLocal,
+			MountPoint: "/var/lib/containers/storage/volumes/local-vol/_data",
+		},
+		state: &VolumeState{
+			MountPoint: "",
+		},
+		runtime: runtime,
+	}
+
+	assert.False(t, vol.UsesVolumeDriver())
+	result := vol.mountPoint()
+	assert.Equal(t, vol.config.MountPoint, result)
+}


### PR DESCRIPTION
Fixes: #27858

## Problem

The `Mount()` function was returning `v.config.MountPoint` which is empty for volumes using plugin drivers. For plugin volumes, the mount point is stored in `v.state.MountPoint` instead.

**Why `config.MountPoint` is empty for plugins:** Plugin volumes get their mount path dynamically from the plugin at mount time, which is stored in `state.MountPoint`. The `config.MountPoint` field is only set for local volumes where the path is known at creation time.

## Solution

Use the existing `mountPoint()` helper which correctly handles both local and plugin volumes, matching the pattern already used in `Export()` and `Import()` functions.

**Backward compatibility:** This change does not affect local volumes, since `mountPoint()` returns the same value previously returned by `v.config.MountPoint` for non-plugin drivers.

**Other functions verified:** `Unmount()`, `Inspect()`, and the internal `mount()`/`unmount()` functions in `volume_internal_common.go` already handle plugin volumes correctly by checking `UsesVolumeDriver()` before using `config.MountPoint`. Only `Mount()` was missing this logic.

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [x] Referenced issues using `Fixes: #00000` in commit message
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below

#### Does this PR introduce a user-facing change?

```release-note
Fixed Volume.Mount() returning empty path for volumes using plugin drivers.
```