### PR TITLE
Set architecture for validatepr builds

### DIFF
--- a/contrib/validatepr/validatepr.sh
+++ b/contrib/validatepr/validatepr.sh
@@ -16,7 +16,7 @@ build() {
     fi
 
     echo "Building darwin"
-    if ! GOOS=darwin CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/podman-remote-darwin ./cmd/podman; then
+    if ! GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -tags "$REMOTETAGS" -o bin/podman-remote-darwin ./cmd/podman; then
         err+="\n - Darwin "
     fi
 


### PR DESCRIPTION
It was failing on darwin, because amd64 is no longer supported.

"build constraints exclude all Go files" in pkg/machine/libkrun

commit f87cefc262f37164467621ba9969440d07494e59

~~And not testing windows, where amd64 is the common target still.~~

Try to test the local architecture for windows, for podman-remote

`GOOS=windows` 

----

This is the full error:

```
+ err=
+ echo 'Building windows'
Building windows
+ GOOS=windows
+ CGO_ENABLED=0
+ go build -tags 'remote exclude_graphdriver_btrfs containers_image_openpgp' -o bin/podman-remote-windows ./cmd/podman
+ echo 'Building darwin'
Building darwin
+ GOOS=darwin
+ CGO_ENABLED=0
+ go build -tags 'remote exclude_graphdriver_btrfs containers_image_openpgp' -o bin/podman-remote-darwin ./cmd/podman
package github.com/containers/podman/v6/cmd/podman
	imports github.com/containers/podman/v6/cmd/podman/artifact
	imports github.com/containers/podman/v6/cmd/podman/common
	imports github.com/containers/podman/v6/cmd/podman/registry
	imports github.com/containers/podman/v6/pkg/domain/infra
	imports github.com/containers/podman/v6/pkg/domain/infra/tunnel
	imports github.com/containers/podman/v6/internal/localapi
	imports github.com/containers/podman/v6/pkg/machine/provider
	imports github.com/containers/podman/v6/pkg/machine/libkrun: build constraints exclude all Go files in /go/src/github.com/containers/podman/pkg/machine/libkrun
+ err+='\n - Darwin '
+ echo 'Building podman binaries'
Building podman binaries
+ make binaries
```

```console
$ uname -ms
Linux x86_64
$ podman images quay.io/libpod/validatepr:latest
REPOSITORY                 TAG         IMAGE ID      CREATED      SIZE
quay.io/libpod/validatepr  latest      6eaeda9bed07  7 weeks ago  892 MB
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
