### PR TITLE
healthcheck_linux: avoid failing transient units

### DIFF
--- a/docs/source/markdown/podman-healthcheck-run.1.md
+++ b/docs/source/markdown/podman-healthcheck-run.1.md
@@ -4,7 +4,7 @@
 podman\-healthcheck\-run - Run a container healthcheck
 
 ## SYNOPSIS
-**podman healthcheck run** *container*
+**podman healthcheck run** [*options*] *container*
 
 ## DESCRIPTION
 
@@ -25,6 +25,10 @@ Possible errors that can occur during the healthcheck are:
 
 Print usage statement
 
+#### **--ignore-result**
+
+Exit with code 0 regardless of the healthcheck result and if the container is
+still in the startup period. Other errors will not be ignored.
 
 ## EXAMPLES
 

--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -47,7 +47,7 @@ func (c *Container) createTimer(interval string, isStartup bool) error {
 		cmd = append(cmd, "--log-level=debug", "--syslog")
 	}
 
-	cmd = append(cmd, "healthcheck", "run", c.ID())
+	cmd = append(cmd, "healthcheck", "run", "--ignore-result", c.ID())
 
 	conn, err := systemd.ConnectToDBUS()
 	if err != nil {

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -161,6 +161,16 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
 	})
 
+	It("podman healthcheck --ignore-result exits 0 on failing healthcheck", func() {
+		session := podmanTest.Podman([]string{"run", "-q", "-dt", "--name", "hc", "quay.io/libpod/badhealthcheck:latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "--ignore-result", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc).Should(ExitWithError(0, ""))
+	})
+
 	It("podman healthcheck failed checks in start-period should not change status", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-start-period", "2m", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -101,12 +101,13 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\\\n\"
     run -0 systemctl list-units
     cidmatch=$(grep "$cid" <<<"$output")
     echo "$cidmatch"
-    assert "$cidmatch" =~ " $cid-[0-9a-f]+\.timer  *.*/podman healthcheck run $cid" \
+    assert "$cidmatch" =~ " $cid-[0-9a-f]+\.timer  *.*/podman healthcheck run --ignore-result $cid" \
            "Healthcheck systemd unit exists"
 
     # Check that the right service option is applied so we don't hit the systemd restart limit.
     # Even though the code sets StartLimitIntervalSec the systemd command prints StartLimitInterval*U*Sec
-    run -0 systemctl show "$cid-*.service"
+    # Use show --all otherwise the glob might not match the already inactive transient unit.
+    run -0 systemctl show --all "$cid-*.service"
     assert "$output" =~ "StartLimitIntervalUSec=0" "The hc service has the right interval set"
 
     current_time=$(date --iso-8601=ns)


### PR DESCRIPTION
Add a new flag `--ignore-result` to `podman healthcheck run` and use it in the transient services that trigger the healthchecks. The services only have to trigger the execution, their own state should not depend on the result of the healthchecks. This way there are no failing systemd services unless there is actually a fatal error.

Context:

A change was introduced in 88bacfc133cd7a2e388cf6c2f2e3be157d0f6e74 that skips execution of the healthcheck command during the startup period when the K8s `initialDelaySeconds` is defined for a liveness probe. A `HealthCheckDefined` is returned instead. This means that `podman healthcheck run` always exits with a non-zero code during that time and the transient systemd unit that triggers the healthcheck fails.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Avoid failures of transient healthcheck services
```
