### PR TITLE
fix: use localhost for host.containers.internal in host network mode 

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1301,7 +1301,16 @@ func (c *Container) NetworkDisabled() (bool, error) {
 }
 
 func (c *Container) HostNetwork() bool {
-	if c.config.CreateNetNS || c.config.NetNsCtr != "" {
+	// If container shares network namespace with another container, check that container
+	if c.config.NetNsCtr != "" {
+		netNsCtr, err := c.runtime.state.Container(c.config.NetNsCtr)
+		if err != nil {
+			return false
+		}
+		return netNsCtr.HostNetwork()
+	}
+
+	if c.config.CreateNetNS {
 		return false
 	}
 	if c.config.Spec.Linux != nil {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2427,6 +2427,7 @@ func (c *Container) addHosts() error {
 		NetworkInterface: c.runtime.network,
 		Exclude:          exclude,
 		PreferIP:         preferIP,
+		HostNetwork:      c.HostNetwork(),
 	})
 
 	return etchosts.New(&etchosts.Params{


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
With `--network=host`, `host.containers.internal` now resolves to `127.0.0.1` (localhost) instead of an external IP address that may change or not exist.
```

---

### Description

When using `--network=host`, the container shares the host's network namespace, so localhost (127.0.0.1) is always reachable. This change uses `127.0.0.1` for `host.containers.internal` instead of trying to find an external IP address.

This fixes issues where:
- The host IP address changes (e.g., DHCP lease renewal, roaming to a different network)
- The host has no non-loopback IP addresses configured

### How was it tested?

```bash
$ sudo ./bin/podman run --rm --network=host alpine cat /etc/hosts
127.0.0.1       localhost localhost.localdomain localhost4 localhost4.localdomain4
::1     localhost localhost.localdomain localhost6 localhost6.localdomain6
127.0.0.1       host.containers.internal host.docker.internal
```

Added a system test in `test/system/500-networking.bats` to verify the behavior.

Fixes #27823