### PR TITLE
systemd: update podman-restart.service description

### DIFF
--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Podman Start All Containers With Restart Policy Set To Always
+Description=Podman Start All Containers With Restart Policy Set To Always Or Unless-Stopped
 Documentation=man:podman-start(1)
 StartLimitIntervalSec=0
 Wants=network-online.target


### PR DESCRIPTION
#### Checklist

- [x] Commits are signed (`git commit -s`)
- [x] Referenced issues using `Fixes: #27908` in commit message
- [ ] Tests have been added/updated (no tests needed for documentation change)
- [x] Documentation has been updated
- [ ] All commits pass `make validatepr`
- [x] Release note entered below

#### Does this PR introduce a user-facing change?

```release-note
None
```

---

Update the podman-restart.service systemd unit description to reflect that it now also restarts containers with `unless-stopped` restart policy, not just `always`.

This was changed in PR #27619 but the description was not updated.

Fixes #27908