### PR TITLE
compat: Add Health field to /containers/json endpoint

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -25,6 +25,7 @@ import (
 	"go.podman.io/podman/v6/libpod/define"
 	"go.podman.io/podman/v6/pkg/api/handlers"
 	"go.podman.io/podman/v6/pkg/api/handlers/utils"
+	"go.podman.io/podman/v6/pkg/api/handlers/utils/apiutil"
 	api "go.podman.io/podman/v6/pkg/api/types"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/domain/filters"
@@ -165,8 +166,13 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	list := make([]*handlers.Container, 0, len(containers))
+	// only include health if API version is >= 1.52 or no version is given (latest)
+	includeHealth := false
+	if _, err := utils.SupportedVersion(r, ">= 1.52.0"); err == nil || errors.Is(err, apiutil.ErrVersionNotGiven) {
+		includeHealth = true
+	}
 	for _, ctnr := range containers {
-		api, err := LibpodToContainer(ctnr, query.Size)
+		api, err := LibpodToContainer(ctnr, query.Size, includeHealth)
 		if err != nil {
 			if errors.Is(err, define.ErrNoSuchCtr) {
 				// container was removed between the initial fetch of the list and conversion
@@ -293,7 +299,7 @@ func convertSecondaryIPPrefixLen(input *define.InspectNetworkSettings, output *h
 	}
 }
 
-func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error) {
+func LibpodToContainer(l *libpod.Container, sz bool, includeHealth bool) (*handlers.Container, error) {
 	imageID, imageName := l.Image()
 
 	var (
@@ -425,6 +431,28 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		return nil, err
 	}
 
+	var healthSummary *container.HealthSummary
+	if includeHealth {
+		healthSummary = &container.HealthSummary{
+			Status: container.NoHealthcheck,
+		}
+		if l.HasHealthCheck() {
+			switch state {
+			case define.ContainerStateRunning, define.ContainerStatePaused,
+				define.ContainerStateConfigured, define.ContainerStateCreated,
+				define.ContainerStateStopping:
+				if inspect.State.Health != nil && inspect.State.Health.Status != "" {
+					healthSummary.Status = container.HealthStatus(inspect.State.Health.Status)
+					healthSummary.FailingStreak = inspect.State.Health.FailingStreak
+				} else {
+					healthSummary.Status = container.Starting
+				}
+			default:
+				healthSummary.Status = container.NoHealthcheck
+			}
+		}
+	}
+
 	return &handlers.Container{
 		Summary: container.Summary{
 			ID:         l.ID(),
@@ -439,6 +467,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 			Labels:     l.Labels(),
 			State:      container.ContainerState(stateStr),
 			Status:     status,
+			Health:     healthSummary,
 			// FIXME: this seems broken, the field is never shown in the API output.
 			HostConfig: struct {
 				NetworkMode string            `json:",omitempty"`
@@ -496,10 +525,14 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*handlers.LegacyImageI
 		state.Status = "" // unknown state
 	}
 
-	if l.HasHealthCheck() && state.Status != "created" {
+	if l.HasHealthCheck() {
 		state.Health = &container.Health{}
 		if inspect.State.Health != nil {
-			state.Health.Status = container.HealthStatus(inspect.State.Health.Status)
+			if inspect.State.Health.Status != "" {
+				state.Health.Status = container.HealthStatus(inspect.State.Health.Status)
+			} else if state.Status == "running" || state.Status == "created" {
+				state.Health.Status = container.Starting
+			}
 			state.Health.FailingStreak = inspect.State.Health.FailingStreak
 			log := inspect.State.Health.Log
 

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -4,7 +4,7 @@
 #
 
 # NOTE: paths with a leading slash will be interpreted as-is;
-#       paths without will have '/v1.40/' prepended.
+#       paths without will have '/v1.44/' prepended.
 t GET  /_ping        200 OK
 t HEAD /_ping        200
 t GET  /libpod/_ping 200 OK

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -949,3 +949,43 @@ for runtime in "${oci_runtimes[@]}"; do
 done
 
 podman rmi -f $IMAGE
+
+# Test health status in /containers/json (GH #27786)
+podman create --name healthcheck-test-created --health-cmd "true" $IMAGE top
+t GET /v1.52/containers/json?all=true\&filters='{"name":["healthcheck-test-created"]}' 200 \
+  .[0].Health.Status="starting"
+podman rm -f healthcheck-test-created
+
+# Test health status is 'none' for containers without a healthcheck
+podman create --name no-healthcheck $IMAGE top
+t GET /v1.52/containers/json?all=true\&filters='{"name":["no-healthcheck"]}' 200 \
+  .[0].Health.Status="none"
+podman rm -f no-healthcheck
+
+# Test health status with explicit v1.52 API
+podman create --name healthcheck-v152 --health-cmd "true" $IMAGE top
+t GET /v1.52/containers/json?all=true\&filters='{"name":["healthcheck-v152"]}' 200 \
+  .[0].Health.Status="starting"
+podman rm -f healthcheck-v152
+
+# Test health status is HIDDEN for API versions < 1.52
+podman create --name healthcheck-v144 --health-cmd "true" $IMAGE top
+t GET /v1.44/containers/json?all=true\&filters='{"name":["healthcheck-v144"]}' 200 \
+  .[0].Health=null
+podman rm -f healthcheck-v144
+
+podman run -d --name healthcheck-test-running --health-cmd "true" --health-interval 1s $IMAGE top
+podman healthcheck run healthcheck-test-running
+t GET /v1.52/containers/json?filters='{"name":["healthcheck-test-running"]}' 200 \
+  .[0].Health.Status="healthy"
+t GET containers/healthcheck-test-running/json 200 \
+  .State.Health.Status="healthy"
+
+# Verify that health status is 'none' when container is stopped
+podman stop -t0 healthcheck-test-running
+t GET "/v1.52/containers/json?all=true&filters={\"name\":[\"healthcheck-test-running\"]}" 200 \
+  .[0].Health.Status="none"
+t GET containers/healthcheck-test-running/json 200 \
+  .State.Health.Status="healthy"
+
+podman rm -f healthcheck-test-running


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #27786` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Add Health field to /containers/json endpoint, providing container health status in the summary output.
```

Fixes: #27786