### PR TITLE
[v5.4-rhel] podman rm: handle case where conmon was killed

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1518,7 +1518,7 @@ func (c *Container) waitForConmonToExitAndSave() error {
 				logrus.Errorf("Error cleaning up container %s after Conmon exited prematurely: %v", c.ID(), err)
 			}
 
-			return fmt.Errorf("container %s conmon exited prematurely, exit code could not be retrieved: %w", c.ID(), define.ErrInternal)
+			return fmt.Errorf("container %s conmon exited prematurely, exit code could not be retrieved: %w", c.ID(), define.ErrConmonDead)
 		}
 
 		return c.save()

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -538,7 +538,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 			// ErrNoSuchCtr is non-fatal, other errors will be
 			// treated as fatal.
 			if errors.Is(err, define.ErrNoSuchCtr) {
-				errs = append(errs, fmt.Errorf("no such container %s", name))
+				errs = append(errs, fmt.Errorf("no such container %q", name))
 				continue
 			}
 			return nil, nil, err
@@ -549,7 +549,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 			// ErrNoSuchCtr is non-fatal, other errors will be
 			// treated as fatal.
 			if errors.Is(err, define.ErrNoSuchCtr) {
-				errs = append(errs, fmt.Errorf("no such container %s", name))
+				errs = append(errs, fmt.Errorf("no such container %q", name))
 				continue
 			}
 			return nil, nil, err

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -188,11 +188,7 @@ var _ = Describe("Podman inspect", func() {
 
 		ctrInspect := podmanTest.Podman([]string{"container", "inspect", ALPINE})
 		ctrInspect.WaitWithDefaultTimeout()
-		if IsRemote() {
-			Expect(ctrInspect).To(ExitWithError(125, fmt.Sprintf("no such container %q", ALPINE)))
-		} else {
-			Expect(ctrInspect).To(ExitWithError(125, fmt.Sprintf("no such container %s", ALPINE)))
-		}
+		Expect(ctrInspect).To(ExitWithError(125, fmt.Sprintf("no such container %q", ALPINE)))
 
 		imageInspect := podmanTest.Podman([]string{"image", "inspect", ALPINE})
 		imageInspect.WaitWithDefaultTimeout()
@@ -399,11 +395,7 @@ var _ = Describe("Podman inspect", func() {
 
 		inspect := podmanTest.Podman([]string{"inspect", "--type", "container", podName})
 		inspect.WaitWithDefaultTimeout()
-		if IsRemote() {
-			Expect(inspect).To(ExitWithError(125, fmt.Sprintf("no such container %q", podName)))
-		} else {
-			Expect(inspect).To(ExitWithError(125, fmt.Sprintf("no such container %s", podName)))
-		}
+		Expect(inspect).To(ExitWithError(125, fmt.Sprintf("no such container %q", podName)))
 	})
 
 	It("podman inspect --type network on a container should fail", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1702,7 +1702,7 @@ search               | $IMAGE           |
     # Unclear why `-t0` is required here, works locally without.
     # But it shouldn't hurt and does make the test pass...
     PODMAN_TIMEOUT=5 run_podman 125 stop -t0 $cname
-    is "$output" "Error: container .* conmon exited prematurely, exit code could not be retrieved: internal libpod error" "correct error on missing conmon"
+    is "$output" "Error: container .* conmon exited prematurely, exit code could not be retrieved: conmon process killed" "correct error on missing conmon"
 
     # This should be safe because stop is guaranteed to call cleanup?
     run_podman inspect --format "{{ .State.Status }}" $cname

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -202,4 +202,20 @@ function __run_healthcheck_container() {
     die "Container never entered 'stopping' state"
 }
 
+# bats test_tags=ci:parallel
+@test "podman rm after killed conmon" {
+    cname=c_$(safename)
+    run_podman run -d --name $cname $IMAGE sleep 1000
+
+    run_podman inspect --format '{{ .State.ConmonPid }}' $cname
+    conmon_pid=$output
+
+    kill -9 ${conmon_pid}
+
+    run_podman rm -f -t0 $cname
+
+    run_podman 125 container inspect $cname
+    assert "$output" =~ "no such container \"$cname\"" "Container should be removed"
+}
+
 # vim: filetype=sh

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -1024,7 +1024,7 @@ EOF
           is "$output" "$exit_code_prop" \
              "$basename: service container has the expected policy set in its annotations"
       else
-          assert "$output" =~ "no such container $service_container" \
+          assert "$output" =~ "no such container \"$service_container\"" \
                  "$basename: unexpected error from podman container inspect"
       fi
 


### PR DESCRIPTION
Adding this commit from #26643 to v5.4-rhel as after PR #27910 failed QE testing.  The error `ErrConmonDead` was added sometime after Podman v5.4-rhel and before v5.6-rhel was released. New tests for the issue in #27910 are failing here in 5.4-rhel due to that renamed error.

This will hopefully finally

Fixes: https://issues.redhat.com/browse/RHEL-141490

Original PR text for this change from @Luap99

When conmon was killed podman rm -f currently fails but running it again then works which doesn't really makes sense. We should properly remove the contianer even if conmon is dead.

In fact the code already handles ErrConmonDead as stop error when we remove the container but this error was never thrown anywhere. To fix this throw ErrConmonDead instead of ErrInternal because that is not an intenral error if something else killed conmon.

With this we can correctly cleanup and remove the container. The fact that this works on the first try is important for quadlet units as they only run the ExecStopPost= command once to remove it.

Fixes: #26640

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
