### PR TITLE
[v5.6-rhel] libpod: fix workdir MkdirAll() all check

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -845,51 +845,6 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	return g.Config, cleanupFunc, nil
 }
 
-// isWorkDirSymlink returns true if resolved workdir is symlink or a chain of symlinks,
-// and final resolved target is present either on  volume, mount or inside of container
-// otherwise it returns false. Following function is meant for internal use only and
-// can change at any point of time.
-func (c *Container) isWorkDirSymlink(resolvedPath string) bool {
-	// We cannot create workdir since explicit --workdir is
-	// set in config but workdir could also be a symlink.
-	// If it's a symlink, check if the resolved target is present in the container.
-	// If so, that's a valid use case: return nil.
-
-	maxSymLinks := 0
-	// Linux only supports a chain of 40 links.
-	// Reference: https://github.com/torvalds/linux/blob/master/include/linux/namei.h#L13
-	for maxSymLinks <= 40 {
-		resolvedSymlink, err := os.Readlink(resolvedPath)
-		if err != nil {
-			// End sym-link resolution loop.
-			break
-		}
-		if resolvedSymlink != "" {
-			_, resolvedSymlinkWorkdir, _, err := c.resolvePath(c.state.Mountpoint, resolvedSymlink)
-			if isPathOnVolume(c, resolvedSymlinkWorkdir) || isPathOnMount(c, resolvedSymlinkWorkdir) {
-				// Resolved symlink exists on external volume or mount
-				return true
-			}
-			if err != nil {
-				// Could not resolve path so end sym-link resolution loop.
-				break
-			}
-			if resolvedSymlinkWorkdir != "" {
-				resolvedPath = resolvedSymlinkWorkdir
-				err := fileutils.Exists(resolvedSymlinkWorkdir)
-				if err == nil {
-					// Symlink resolved successfully and resolved path exists on container,
-					// this is a valid use-case so return nil.
-					logrus.Debugf("Workdir is a symlink with target to %q and resolved symlink exists on container", resolvedSymlink)
-					return true
-				}
-			}
-		}
-		maxSymLinks++
-	}
-	return false
-}
-
 // resolveWorkDir resolves the container's workdir and, depending on the
 // configuration, will create it, or error out if it does not exist.
 // Note that the container must be mounted before.
@@ -904,7 +859,7 @@ func (c *Container) resolveWorkDir() error {
 		return nil
 	}
 
-	_, resolvedWorkdir, _, err := c.resolvePath(c.state.Mountpoint, workdir)
+	resolvedWorkdir, err := securejoin.SecureJoin(c.state.Mountpoint, workdir)
 	if err != nil {
 		return err
 	}
@@ -921,11 +876,17 @@ func (c *Container) resolveWorkDir() error {
 		// No need to create it (e.g., `--workdir=/foo`), so let's make sure
 		// the path exists on the container.
 		if errors.Is(err, os.ErrNotExist) {
-			// If resolved Workdir path gets marked as a valid symlink,
-			// return nil cause this is valid use-case.
-			if c.isWorkDirSymlink(resolvedWorkdir) {
+			// Check if path is a symlink, securejoin resolves and follows the links
+			// so the path will be different from the normal join if it is one.
+			if resolvedWorkdir != filepath.Join(c.state.Mountpoint, workdir) {
+				// Path must be a symlink to non existing directory.
+				// It could point to mounts that are only created later so that make
+				// an assumption here and let's just continue and let the oci runtime
+				// do its job.
 				return nil
 			}
+			// If they are the same we know there is no symlink/relative path involved.
+			// We can return a nicer error message without having to go through the OCI runtime.
 			return fmt.Errorf("workdir %q does not exist on container %s", workdir, c.ID())
 		}
 		// This might be a serious error (e.g., permission), so

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -932,7 +932,10 @@ func (c *Container) resolveWorkDir() error {
 		// we need to return the full error.
 		return fmt.Errorf("detecting workdir %q on container %s: %w", workdir, c.ID(), err)
 	}
-	if err := os.MkdirAll(resolvedWorkdir, 0755); err != nil {
+	if err := os.MkdirAll(resolvedWorkdir, 0o755); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return nil
+		}
 		return fmt.Errorf("creating container %s workdir: %w", c.ID(), err)
 	}
 

--- a/test/e2e/run_working_dir_test.go
+++ b/test/e2e/run_working_dir_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/containers/podman/v5/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
 var _ = Describe("Podman run", func() {
@@ -60,11 +61,32 @@ WORKDIR  /etc/foobar`, ALPINE)
 
 	It("podman run on an image with a symlinked workdir", func() {
 		dockerfile := fmt.Sprintf(`FROM %s
-RUN mkdir /A && ln -s /A /B
+RUN mkdir /A && ln -s /A /B && ln -s /vol/test /link
 WORKDIR /B`, ALPINE)
 		podmanTest.BuildImage(dockerfile, "test", "false")
 
 		session := podmanTest.PodmanExitCleanly("run", "test", "pwd")
 		Expect(session.OutputToString()).To(Equal("/A"))
+
+		path := filepath.Join(podmanTest.TempDir, "test")
+		err := os.Mkdir(path, 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		session = podmanTest.PodmanExitCleanly("run", "--workdir=/link", "--volume", podmanTest.TempDir+":/vol", "test", "pwd")
+		Expect(session.OutputToString()).To(Equal("/vol/test"))
+
+		// This will fail in the runtime since the target doesn't exists
+		session = podmanTest.Podman([]string{"run", "--workdir=/link", "test", "pwd"})
+		session.WaitWithDefaultTimeout()
+		var matcher types.GomegaMatcher
+		if filepath.Base(podmanTest.OCIRuntime) == "crun" {
+			matcher = ExitWithError(127, "chdir to `/link`: No such file or directory")
+		} else if filepath.Base(podmanTest.OCIRuntime) == "runc" {
+			matcher = ExitWithError(126, "mkdir /link: file exists")
+		} else {
+			// unknown runtime, just check it failed
+			matcher = Not(ExitCleanly())
+		}
+		Expect(session).Should(matcher)
 	})
 })

--- a/test/e2e/run_working_dir_test.go
+++ b/test/e2e/run_working_dir_test.go
@@ -57,4 +57,14 @@ WORKDIR  /etc/foobar`, ALPINE)
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToString()).To(Equal("/home/foobar"))
 	})
+
+	It("podman run on an image with a symlinked workdir", func() {
+		dockerfile := fmt.Sprintf(`FROM %s
+RUN mkdir /A && ln -s /A /B
+WORKDIR /B`, ALPINE)
+		podmanTest.BuildImage(dockerfile, "test", "false")
+
+		session := podmanTest.PodmanExitCleanly("run", "test", "pwd")
+		Expect(session.OutputToString()).To(Equal("/A"))
+	})
 })


### PR DESCRIPTION
This backports the commits from #27672 into the Podman v5.6-rhel branch.

Original PR Description text:

First commit fixes the regression, second commit improves the logic where I (@Luap99 ) noticed some issues

Fixes:  https://issues.redhat.com/browse/RHEL-142311, https://issues.redhat.com/browse/ACCELFIX-569
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
