### PR TITLE
feat: add support for changing default host IPs via containers.conf

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -308,6 +308,27 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 
 	ctr.runtime = r
 
+	// If `default_host_ips` is set and HostIP is empty
+	// Create port mappings for each non empty HostIP * DefaultHostIP
+	if len(ctr.config.PortMappings) > 0 {
+		defaultHostIPs := r.config.Network.DefaultHostIPs.Get()
+		if len(defaultHostIPs) > 0 {
+			expanded := make([]types.PortMapping, 0, len(ctr.config.PortMappings)*len(defaultHostIPs))
+			for _, pm := range ctr.config.PortMappings {
+				if pm.HostIP == "" {
+					for _, ip := range defaultHostIPs {
+						newPM := pm
+						newPM.HostIP = ip
+						expanded = append(expanded, newPM)
+					}
+				} else {
+					expanded = append(expanded, pm)
+				}
+			}
+			ctr.config.PortMappings = expanded
+		}
+	}
+
 	// Validate the container
 	if err := ctr.validate(); err != nil {
 		return nil, err

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -148,7 +148,6 @@ func CreatePortBindings(ports []string) ([]types.PortMapping, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		toReturn = append(toReturn, newPort)
 	}
 

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -177,15 +177,12 @@ func parseSplitPort(hostIP, hostPort *string, ctrPort string, protocol *string) 
 	if hostIP != nil {
 		if *hostIP == "" {
 			return newPort, errors.New("must provide a non-empty container host IP to publish")
-		} else if *hostIP != "0.0.0.0" {
-			// If hostIP is 0.0.0.0, leave it unset - netavark treats
-			// 0.0.0.0 and empty differently, Docker does not.
-			testIP := net.ParseIP(*hostIP)
-			if testIP == nil {
-				return newPort, fmt.Errorf("cannot parse %q as an IP address", *hostIP)
-			}
-			newPort.HostIP = testIP.String()
 		}
+		testIP := net.ParseIP(*hostIP)
+		if testIP == nil {
+			return newPort, fmt.Errorf("cannot parse %q as an IP address", *hostIP)
+		}
+		newPort.HostIP = testIP.String()
 	}
 	if hostPort != nil {
 		if *hostPort == "" {


### PR DESCRIPTION
Add support for `default_host_ips` in containers.conf to set default host IP(s) if no IP is set when forwarding ports. Multiple IPs can be configured, and passing an explicit IP with -p will always override the configured defaults.

Fixes #27186

Depends on https://github.com/containers/container-libs/pull/422