### PR TITLE
[wontfix] Add --group-add flag to podman pod create

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -100,6 +100,10 @@ func init() {
 	shareParentFlagName := "share-parent"
 	flags.BoolVar(&shareParent, shareParentFlagName, true, "Set the pod's cgroup as the cgroup parent for all containers joining the pod")
 
+	groupAddFlagName := "group-add"
+	flags.StringSliceVar(&createOptions.GroupAdd, groupAddFlagName, []string{}, "Add additional groups to the primary container process. 'keep-groups' allows container processes to use supplementary groups.")
+	_ = createCommand.RegisterFlagCompletionFunc(groupAddFlagName, completion.AutocompleteNone)
+
 	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 

--- a/docs/source/markdown/options/group-add.md
+++ b/docs/source/markdown/options/group-add.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, create, farm build, run
+####>   podman build, create, farm build, pod create, run
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--group-add**=*group* | *keep-groups*

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -82,6 +82,8 @@ Set the exit policy of the pod when the last container exits.  Supported policie
 
 @@option gpus
 
+@@option group-add
+
 #### **--help**, **-h**
 
 Print usage statement.

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -105,6 +105,7 @@ type PodCreateOptions struct {
 	SecurityOpt        []string          `json:"security_opt,omitempty"`
 	Sysctl             []string          `json:"sysctl,omitempty"`
 	Uts                string            `json:"uts,omitempty"`
+	GroupAdd           []string          `json:"group_add,omitempty"`
 }
 
 // PodLogsOptions describes the options to extract pod logs.
@@ -392,7 +393,7 @@ func ToPodSpecGen(s specgen.PodSpecGenerator, p *PodCreateOptions) (*specgen.Pod
 		}
 	}
 	s.Sysctl = sysctl
-
+	s.GroupAdd = p.GroupAdd
 	return &s, nil
 }
 

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -248,6 +248,8 @@ type PodSecurityConfig struct {
 	// namespaces.
 	// Required if UserNS is private.
 	IDMappings *storageTypes.IDMappingOptions `json:"idmappings,omitempty"`
+	// GroupAdd contains additional groups that will be added to the pod
+	GroupAdd []string `json:"group_add,omitempty"`
 }
 
 // NewPodSpecGenerator creates a new pod spec

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -92,6 +92,22 @@ EOF
 
 
 # bats test_tags=ci:parallel
+@test "podman pod create - --group-add" {
+    local podname="pod-group-add-$(safename)"
+    local groupid="1234"
+
+    run_podman pod create --name $podname --group-add $groupid
+    podid="$output"
+
+    # Start a container in the pod and check groups
+    run_podman run --rm --pod $podname $IMAGE id -G
+    assert "$output" =~ "$groupid" "group $groupid should be in id -G output"
+
+    run_podman pod rm $podname
+}
+
+
+# bats test_tags=ci:parallel
 @test "podman pod create - custom infra image" {
     skip_if_remote "CONTAINERS_CONF_OVERRIDE only affects server side"
     image="i.do/not/exist:image"


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #27559` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Add --group-add flag to podman pod create, allowing the specification of supplementary groups for the pod.
```