### PR TITLE
libpod: move artifact volume validation to creation phase

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -306,6 +306,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctr.config.Networks = normalizeNetworks
 	}
 
+	ctr.runtime = r
+
 	// Validate the container
 	if err := ctr.validate(); err != nil {
 		return nil, err
@@ -337,8 +339,6 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 
 	ctr.valid = true
 	ctr.state.State = define.ContainerStateConfigured
-	ctr.runtime = r
-
 	if ctr.config.OCIRuntime == "" {
 		ctr.ociRuntime = r.defaultOCIRuntime
 	} else {

--- a/test/system/702-artifact.bats
+++ b/test/system/702-artifact.bats
@@ -151,5 +151,14 @@ function teardown() {
     run_podman artifact rm "$artifact_name"
 }
 
+@test "podman artifact volume validation at creation" {
+    # Issue #27747: Artifact volume validation should fail at creation, not start
+    local artifact_name="localhost/test/nonexistent-artifact"
+
+    # Creation should fail if the artifact does not exist
+    run_podman 125 create --name test-artifact-fail --mount type=artifact,source=$artifact_name,target=/tmp $IMAGE
+    assert "$output" = "Error: $artifact_name:latest: artifact does not exist" "creation should fail for nonexistent artifact"
+}
+
 
 # vim: filetype=sh


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #27747` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Move artifact volume validation from start to creation phase.
```

Fixes: #27747