### PR TITLE
fix: generate correct error message if Wix is not installed

### DIFF
--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -112,9 +112,9 @@ if (! (Get-Command 'dotnet' -errorAction SilentlyContinue)) {
 Invoke-Expression 'dotnet tool list --global wix' `
     -ErrorAction SilentlyContinue | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "Required dep `"Wix Toolset`" is not installed. " `
+    Write-Error ("Required dep `"Wix Toolset`" is not installed. " `
         + 'Please install it with the command ' `
-        + "`"dotnet tool install --global wix`""
+        + "`"dotnet tool install --global wix`"")
     Exit 1
 }
 


### PR DESCRIPTION
Fixes #27955

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

None
