### PR TITLE
Add cache volumes for validatepr builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,8 +332,12 @@ validate: validate-source validate-binaries
 # image in the future.
 .PHONY: validatepr
 validatepr: ## Go Format and lint, which all code changes must pass
-	$(PODMANCMD) run --rm \
+	$(PODMANCMD) run --rm --init --tmpfs /tmp \
 		-v $(CURDIR):/go/src/github.com/containers/podman \
+		-v validatepr-gocache:/root/.cache/go-build \
+		-v validatepr-gomodcache:/root/go/pkg/mod \
+		-v validatepr-lintcache:/root/.cache/golangci-lint \
+		-v validatepr-precommitcache:/root/.cache/pre-commit \
 		--security-opt label=disable \
 		--network=host \
 		-it \


### PR DESCRIPTION
This speeds up the build a lot (10x), the second time.

Also add `--init`, so that it is possible to cancel it.

---

Since it is building for 3 platforms and linting 3 targets, there is a _lot_ of cache data:

```
2,3G	/home/anders/.local/share/containers/storage/volumes/validatepr-gocache
499M	/home/anders/.local/share/containers/storage/volumes/validatepr-gomodcache
134M	/home/anders/.local/share/containers/storage/volumes/validatepr-lintcache
31M	/home/anders/.local/share/containers/storage/volumes/validatepr-precommitcache
```

The image is also quite big, so that also takes a while to download the first time:

```
REPOSITORY                 TAG         IMAGE ID      CREATED      SIZE
quay.io/libpod/validatepr  latest      6eaeda9bed07  7 weeks ago  892 MB
```

The description of the job is a bit misleading, since it does much more than just format/lint.

On my machine this speeds up the `make validatepr` time, from 8-10 minutes to 45-60 seconds.

Ironically, `make validatepr` then fails on the manpage checks... But the build and lint was fast!

```Makefile
.PHONY: validate
validate: validate-source validate-binaries
```

```console
$ make validate-binaries
...
Can't use string ("1") as a HASH ref while "strict refs" in use at hack/xref-helpmsgs-manpages line 309.
make: *** [Makefile:619: xref-helpmsgs-manpages] Fel 255
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
