### PR TITLE
chore(machine): remove unused EvalSymlinksOrClean function and tests

### DIFF
--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -246,28 +246,6 @@ func sendQuit(tid uint32) {
 	_, _, _ = postMessage.Call(uintptr(tid), WM_QUIT, 0, 0)
 }
 
-func EvalSymlinksOrClean(filePath string) (string, error) {
-	fileInfo, err := os.Lstat(filePath)
-	if err != nil {
-		return "", err
-	}
-	if fileInfo.Mode()&fs.ModeSymlink != 0 {
-		// Only call filepath.EvalSymlinks if it is a symlink.
-		// Starting with v1.23, EvalSymlinks returns an error for mount points.
-		// See https://go-review.googlesource.com/c/go/+/565136 for reference.
-		filePath, err = filepath.EvalSymlinks(filePath)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		// Call filepath.Clean when filePath is not a symlink. That's for
-		// consistency with the symlink case (filepath.EvalSymlinks calls
-		// Clean after evaluating filePath).
-		filePath = filepath.Clean(filePath)
-	}
-	return filePath, nil
-}
-
 func GetWinProxyStateDir(name string, vmtype define.VMType) (string, error) {
 	dir, err := env.GetDataDir(vmtype)
 	if err != nil {

--- a/pkg/machine/machine_windows_test.go
+++ b/pkg/machine/machine_windows_test.go
@@ -3,40 +3,12 @@
 package machine
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 
-	"golang.org/x/sys/windows"
-
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// shortPathToLongPath converts a Windows short path (C:\PROGRA~1) to its
-// long path equivalent (C:\Program Files). It returns an error if shortPath
-// doesn't exist.
-func shortPathToLongPath(shortPath string) (string, error) {
-	shortPathPtr, err := windows.UTF16PtrFromString(shortPath)
-	if err != nil {
-		return "", err
-	}
-	len, err := windows.GetLongPathName(shortPathPtr, nil, 0)
-	if err != nil {
-		return "", err
-	}
-	if len == 0 {
-		return "", fmt.Errorf("failed to get buffer size for path: %s", shortPath)
-	}
-	longPathPtr := &(make([]uint16, len)[0])
-	_, err = windows.GetLongPathName(shortPathPtr, longPathPtr, len)
-	if err != nil {
-		return "", err
-	}
-	return windows.UTF16PtrToString(longPathPtr), nil
-}
 
 // CreateNewItemWithPowerShell creates a new item using PowerShell.
 // It's an helper to easily create junctions on Windows (as well as other file types).
@@ -65,87 +37,4 @@ func CreateNewItemWithPowerShell(t *testing.T, path string, itemType string, tar
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	require.NoError(t, err)
-}
-
-// TestEvalSymlinksOrClean tests the EvalSymlinksOrClean function.
-// In particular it verifies that EvalSymlinksOrClean behaves as
-// filepath.EvalSymlink before Go 1.23 - with the exception of
-// files under a mount point (juntion) that aren't resolved
-// anymore.
-// The old behavior of filepath.EvalSymlinks can be tested with
-// the directive "//go:debug winsymlink=0" and replacing EvalSymlinksOrClean()
-// with filepath.EvalSymlink().
-func TestEvalSymlinksOrClean(t *testing.T) {
-	// Create a temporary directory to store the normal file
-	normalFileDir, err := shortPathToLongPath(t.TempDir())
-	require.NoError(t, err)
-
-	// Create a temporary directory to store the (hard/sym)link files
-	linkFilesDir, err := shortPathToLongPath(t.TempDir())
-	require.NoError(t, err)
-
-	// Create a temporary directory where the mount point will be created
-	mountPointDir, err := shortPathToLongPath(t.TempDir())
-	require.NoError(t, err)
-
-	// Create a normal file
-	normalFile := filepath.Join(normalFileDir, "testFile")
-	CreateNewItemWithPowerShell(t, normalFile, "File", "")
-
-	// Create a symlink file
-	symlinkFile := filepath.Join(linkFilesDir, "testSymbolicLink")
-	CreateNewItemWithPowerShell(t, symlinkFile, "SymbolicLink", normalFile)
-
-	// Create a hardlink file
-	hardlinkFile := filepath.Join(linkFilesDir, "testHardLink")
-	CreateNewItemWithPowerShell(t, hardlinkFile, "HardLink", normalFile)
-
-	// Create a mount point file
-	mountPoint := filepath.Join(mountPointDir, "testJunction")
-	mountPointFile := filepath.Join(mountPoint, "testFile")
-	CreateNewItemWithPowerShell(t, mountPoint, "Junction", normalFileDir)
-
-	// Replaces the backslashes with forward slashes in the normal file path
-	normalFileWithBadSeparators := filepath.ToSlash(normalFile)
-
-	tests := []struct {
-		name     string
-		filePath string
-		want     string
-	}{
-		{
-			name:     "Normal file",
-			filePath: normalFile,
-			want:     normalFile,
-		},
-		{
-			name:     "File under a mount point (juntion)",
-			filePath: mountPointFile,
-			want:     mountPointFile,
-		},
-		{
-			name:     "Symbolic link",
-			filePath: symlinkFile,
-			want:     normalFile,
-		},
-		{
-			name:     "Hard link",
-			filePath: hardlinkFile,
-			want:     hardlinkFile,
-		},
-		{
-			name:     "Bad separators in path",
-			filePath: normalFileWithBadSeparators,
-			want:     normalFile,
-		},
-	}
-
-	for _, tt := range tests {
-		assert := assert.New(t)
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := EvalSymlinksOrClean(tt.filePath)
-			require.NoError(t, err)
-			assert.Equal(tt.want, got)
-		})
-	}
 }


### PR DESCRIPTION
Related to https://github.com/containers/container-libs/pull/612

/cc @l0rd 

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
