### PR TITLE
adding assign github action

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,41 @@
+name: Assign Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign:
+    # Only run on issue comments (not PR comments)
+    if: "!github.event.issue.pull_request && contains(github.event.comment.body, '/assign')"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Self-assign if unassigned
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          # Check if issue has any assignees
+          ASSIGNEES=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json assignees -q '.assignees | length')
+
+          if [ "$ASSIGNEES" -eq 0 ]; then
+            # Use API directly to assign (works for any GitHub user, not just collaborators)
+            if gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/assignees" -X POST -f "assignees[]=${COMMENTER}" --silent; then
+              echo "Successfully assigned @${COMMENTER} to issue #${ISSUE_NUMBER}"
+            else
+              echo "Failed to assign @${COMMENTER} to issue #${ISSUE_NUMBER}"
+              exit 1
+            fi
+          else
+            # Add commenter as an additional assignee
+            if gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/assignees" -X POST -f "assignees[]=${COMMENTER}" --silent; then
+              echo "Successfully added @${COMMENTER} as an additional assignee to issue #${ISSUE_NUMBER}"
+            else
+              echo "Failed to add @${COMMENTER} as an additional assignee to issue #${ISSUE_NUMBER}"
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
### Adds a GitHub Action that allows contributors to self-assign issues by commenting /assign on any issue. ###
```
- Trigger: Fires on issue comments containing /assign
  - Scope: Only works on issues (not pull requests)
  - Behavior:
    - If issue has no assignees → assigns the commenter
    - If issue already has assignees → adds the commenter as an additional assignee
 ```

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
None
```release-note

```
