### PR TITLE
[Governance] Move inactive maintainers to alumni and clarify Github permissions

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -52,6 +52,7 @@ Description: A Contributor supports the project and adds value to it. Contributi
 * Privileges:
     * Invitations to contributor events
     * Eligible to become a Reviewer
+	* For repositories hosted on Github, Contributors receive Read privileges by default. Contributors who are active in answering questions and assisting with bug reports upstream may request Triage privileges from the repository's maintainers.
 
 ### Reviewer
 Description: A Reviewer has responsibility for the triage of issues and review of pull requests on the Podman project or a subproject, consisting of one or more of the Git repositories that form the project. They are collectively responsible, with other Reviewers, for reviewing changes to the repository or repositories and indicating whether those changes are ready to merge. They have a track record of contribution and review in the project.
@@ -74,6 +75,7 @@ Reviewers have all the rights and responsibilities of a Contributor, plus:
     * Has rights to approve pull requests in the Podman project or a subproject, marking them as ready for a Maintainer to review and merge
     * Can recommend and review other contributors to become Reviewers
     * Has permissions to change labels on Github to aid in triage
+	* For repositories hosted on Github, Reviewers receive Triage privileges
 
 In repositories using an OWNERS file, Reviewers are listed as Reviewers in that file.
 
@@ -106,6 +108,7 @@ A Maintainer must meet the responsibilities and requirements of a Reviewer, plus
     * Represent the project in public as a senior project member
     * Represent the project in interactions with the CNCF
     * Have a voice, but not a vote, in Core Maintainer decision-making meetings
+	* For repositories hosted on Github, Maintainers receive Maintain privileges by default. If they have a legitimate reason to require Admin privileges (e.g. working on project CI systems), a Maintainer can petition a Core Maintainer to be granted these additional privileges in Github.
 
 #### Process of becoming a maintainer:
 1. A current reviewer must be sponsored by a Maintainer of the repository in question or a Core Maintainer. The Maintainer or Core Maintainer will open a PR against the repository and add the nominee as a Maintainer in the [MAINTAINERS.md](./MAINTAINERS.md) file. The need for a sponsor is removed for Emeritus Maintainers, who may open this pull request themselves.
@@ -130,6 +133,7 @@ Description: As the Podman project is composed of a number of subprojects, most 
     * Represent the project in public as a senior project member
     * Represent the project in interactions with the CNCF
     * Have a vote in Core Maintainer decision-making meetings
+	* For all repositories hosted on Github, Core Maintainers receive Admin privileges.
 
 #### Process of becoming a Core Maintainer:
 1. A current maintainer must be sponsored by Core Maintainer. The Core Maintainer will open a PR against the main Podman repository and add the nominee as a Core Maintainer in the [MAINTAINERS.md](./MAINTAINERS.md) file.
@@ -156,6 +160,7 @@ Description: Community managers are responsible for the project’s community in
     * Represent the project in public
     * Represent the project in interactions with the CNCF
     * Have a voice, but not a vote, in Core Maintainer decision-making meetings
+	* For all repositories hosted on Github, Community Managers receive Triage privileges.
 
 #### Process of becoming a Community Manager:
 1. Community Managers must be sponsored by a Core Maintainer. The Core Maintainer will open a PR against the main Podman repository and add the nominee as a Community Manager in the [MAINTAINERS.md](./MAINTAINERS.md) file.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,16 +30,17 @@ Maintainers and Reviewers for the Skopeo and Buildah projects are found in their
 | Jhon Honce        | [jwhonce](https://github.com/jwhonce)                    | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Jan Kaluza        | [jankaluza](https://github.com/jankaluza)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Craig Loewen      | [craigloewen-msft](https://github.com/craigloewen-msft)  | Reviewer                         | [Microsoft](https://github.com/microsoft)    |
-| Urvashi Mohnani   | [umohnani8](https://github.com/umohnani8)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Aditya Rajan      | [flouthoc](https://github.com/flouthoc)                  | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
-| Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Lewis Roy         | [ninja-quokka](https://github.com/ninja-quokka)          | Reviewer                         | Independent                                  |
 | Nicola Sella      | [inknos](https://github.com/inknos)                      | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 | Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
 
 ## Alumni
 
-None at present
+| Maintainer        | GitHub ID                                 | Project Roles | Affiliation                                  |
+|-------------------|-------------------------------------------|---------------|----------------------------------------------|
+| Urvashi Mohnani   | [umohnani8](https://github.com/umohnani8) | Reviewer      | [Red Hat](https://github.com/RedHatOfficial) |
+| Valentin Rothberg | [vrothberg](https://github.com/vrothberg) | Reviewer      | [Red Hat](https://github.com/RedHatOfficial) |
 
 ## Credits
 


### PR DESCRIPTION
Two commits, which I have batched together because I don't think they are controversial but can separate if desired.

First: move Urvashi and Valentin to Alumni, as they are no longer active in the project. I have contacted both and they have agreed.

Second: explicitly spell out the Github permissions each level of the contributor hierarchy has access to, as agreed to in core maintainer discussion.

```release-note
NONE
```
