### PR TITLE
Write DefaultEnvironment proxy values to /etc/systemd/user.conf.d/default-env.conf

### DIFF
--- a/pkg/machine/proxyenv/env.go
+++ b/pkg/machine/proxyenv/env.go
@@ -15,16 +15,19 @@ import (
 
 const proxySetupScriptTemplate = `#!/bin/bash
 
-SYSTEMD_CONF=/etc/systemd/system.conf.d/default-env.conf
+SYSTEMD_SYSTEM_CONF=/etc/systemd/system.conf.d/default-env.conf
+SYSTEMD_USER_CONF=/etc/systemd/user.conf.d/default-env.conf
 ENVD_CONF=/etc/environment.d/default-env.conf
 PROFILE_CONF=/etc/profile.d/default-env.sh
 
-mkdir -p /etc/profile.d /etc/environment.d /etc/systemd/system.conf.d/
-rm -f $SYSTEMD_CONF $ENVD_CONF $PROFILE_CONF
+mkdir -p /etc/profile.d /etc/environment.d /etc/systemd/system.conf.d/ /etc/systemd/user.conf.d/
+rm -f $SYSTEMD_SYSTEM_CONF $SYSTEMD_USER_CONF $ENVD_CONF $PROFILE_CONF
 
-echo "[Manager]" >> $SYSTEMD_CONF
+echo "[Manager]" >> $SYSTEMD_SYSTEM_CONF
+echo "[Manager]" >> $SYSTEMD_USER_CONF
 for proxy in %s; do
-	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_CONF
+	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_SYSTEM_CONF
+	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_USER_CONF
 	printf "%%q\n" "$proxy"  >> $ENVD_CONF
 	printf "export %%q\n" "$proxy" >> $PROFILE_CONF
 done

--- a/pkg/machine/proxyenv/env.go
+++ b/pkg/machine/proxyenv/env.go
@@ -28,8 +28,8 @@ echo "[Manager]" >> $SYSTEMD_USER_CONF
 for proxy in %s; do
 	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_SYSTEM_CONF
 	printf "DefaultEnvironment=\"%%s\"\n" "$proxy"  >> $SYSTEMD_USER_CONF
-	printf "%%q\n" "$proxy"  >> $ENVD_CONF
-	printf "export %%q\n" "$proxy" >> $PROFILE_CONF
+	printf "%%s\n" "$proxy"  >> $ENVD_CONF
+	printf "export %%s\n" "$proxy" >> $PROFILE_CONF
 done
 
 systemctl daemon-reload

--- a/pkg/machine/proxyenv/env_test.go
+++ b/pkg/machine/proxyenv/env_test.go
@@ -44,16 +44,19 @@ func Test_getProxyScript(t *testing.T) {
 			},
 			want: `#!/bin/bash
 
-SYSTEMD_CONF=/etc/systemd/system.conf.d/default-env.conf
+SYSTEMD_SYSTEM_CONF=/etc/systemd/system.conf.d/default-env.conf
+SYSTEMD_USER_CONF=/etc/systemd/user.conf.d/default-env.conf
 ENVD_CONF=/etc/environment.d/default-env.conf
 PROFILE_CONF=/etc/profile.d/default-env.sh
 
-mkdir -p /etc/profile.d /etc/environment.d /etc/systemd/system.conf.d/
-rm -f $SYSTEMD_CONF $ENVD_CONF $PROFILE_CONF
+mkdir -p /etc/profile.d /etc/environment.d /etc/systemd/system.conf.d/ /etc/systemd/user.conf.d/
+rm -f $SYSTEMD_SYSTEM_CONF $SYSTEMD_USER_CONF $ENVD_CONF $PROFILE_CONF
 
-echo "[Manager]" >> $SYSTEMD_CONF
+echo "[Manager]" >> $SYSTEMD_SYSTEM_CONF
+echo "[Manager]" >> $SYSTEMD_USER_CONF
 for proxy in "http_proxy=proxy1" "https_proxy=sproxy1" "no_proxy=no1,no2"; do
-	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_CONF
+	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_SYSTEM_CONF
+	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_USER_CONF
 	printf "%q\n" "$proxy"  >> $ENVD_CONF
 	printf "export %q\n" "$proxy" >> $PROFILE_CONF
 done

--- a/pkg/machine/proxyenv/env_test.go
+++ b/pkg/machine/proxyenv/env_test.go
@@ -2,9 +2,11 @@ package proxyenv
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.podman.io/common/pkg/config"
 )
 
 func Test_getProxyScript(t *testing.T) {
@@ -60,6 +62,13 @@ systemctl daemon-reload
 `,
 		},
 	}
+
+	// Unset all proxy env vars first
+	for _, envVar := range config.ProxyEnv {
+		t.Setenv(envVar, "") // needed for restoral during cleanup
+		os.Unsetenv(envVar)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, e := range tt.args.envs {

--- a/pkg/machine/proxyenv/env_test.go
+++ b/pkg/machine/proxyenv/env_test.go
@@ -57,8 +57,8 @@ echo "[Manager]" >> $SYSTEMD_USER_CONF
 for proxy in "http_proxy=proxy1" "https_proxy=sproxy1" "no_proxy=no1,no2"; do
 	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_SYSTEM_CONF
 	printf "DefaultEnvironment=\"%s\"\n" "$proxy"  >> $SYSTEMD_USER_CONF
-	printf "%q\n" "$proxy"  >> $ENVD_CONF
-	printf "export %q\n" "$proxy" >> $PROFILE_CONF
+	printf "%s\n" "$proxy"  >> $ENVD_CONF
+	printf "export %s\n" "$proxy" >> $PROFILE_CONF
 done
 
 systemctl daemon-reload


### PR DESCRIPTION
Otherwise, the proxy values aren't passed to rootless podman.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
_I can't execute that on aarch64 ("WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)")_
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
