### PR TITLE
fix: use pointer types for optional ignition config fields to prevent empty objects in JSON

### DIFF
--- a/pkg/machine/ignition/ignition_schema.go
+++ b/pkg/machine/ignition/ignition_schema.go
@@ -94,7 +94,7 @@ type Ignition struct {
 
 type IgnitionConfig struct {
 	Merge   []Resource `json:"merge,omitempty"`
-	Replace Resource   `json:"replace"`
+	Replace *Resource  `json:"replace,omitempty"`
 }
 
 type Link struct {
@@ -200,10 +200,10 @@ type Raid struct {
 type RaidOption string
 
 type Resource struct {
-	Compression  *string      `json:"compression,omitempty"`
-	HTTPHeaders  HTTPHeaders  `json:"httpHeaders,omitempty"`
-	Source       *string      `json:"source,omitempty"`
-	Verification Verification `json:"verification"`
+	Compression  *string       `json:"compression,omitempty"`
+	HTTPHeaders  HTTPHeaders   `json:"httpHeaders,omitempty"`
+	Source       *string       `json:"source,omitempty"`
+	Verification *Verification `json:"verification,omitempty"`
 }
 
 type SSHAuthorizedKey string

--- a/pkg/machine/ignition/ignition_schema_test.go
+++ b/pkg/machine/ignition/ignition_schema_test.go
@@ -1,0 +1,143 @@
+//go:build amd64 || arm64
+
+package ignition
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestIgnitionConfigReplaceOmitEmpty verifies that when IgnitionConfig.Replace
+// is nil, it is omitted from the JSON output. This is important because an
+// empty "replace" object can cause ignition to behave unexpectedly.
+func TestIgnitionConfigReplaceOmitEmpty(t *testing.T) {
+	// Create an IgnitionConfig with nil Replace (the common case)
+	config := IgnitionConfig{
+		Merge:   nil,
+		Replace: nil,
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("failed to marshal IgnitionConfig: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// The "replace" field should not appear in the JSON output
+	if strings.Contains(jsonStr, "replace") {
+		t.Errorf("expected 'replace' to be omitted from JSON when nil, got: %s", jsonStr)
+	}
+}
+
+// TestResourceVerificationOmitEmpty verifies that when Resource.Verification
+// is nil, it is omitted from the JSON output.
+func TestResourceVerificationOmitEmpty(t *testing.T) {
+	// Create a Resource with nil Verification
+	resource := Resource{
+		Source:       nil,
+		Verification: nil,
+	}
+
+	data, err := json.Marshal(resource)
+	if err != nil {
+		t.Fatalf("failed to marshal Resource: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// The "verification" field should not appear in the JSON output
+	if strings.Contains(jsonStr, "verification") {
+		t.Errorf("expected 'verification' to be omitted from JSON when nil, got: %s", jsonStr)
+	}
+}
+
+// TestIgnitionConfigReplaceWithValue verifies that when IgnitionConfig.Replace
+// has a value, it is included in the JSON output.
+func TestIgnitionConfigReplaceWithValue(t *testing.T) {
+	source := "https://example.com/config.ign"
+	config := IgnitionConfig{
+		Replace: &Resource{
+			Source: &source,
+		},
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("failed to marshal IgnitionConfig: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// The "replace" field should appear in the JSON output
+	if !strings.Contains(jsonStr, "replace") {
+		t.Errorf("expected 'replace' to be present in JSON when set, got: %s", jsonStr)
+	}
+
+	// The source should be in the output
+	if !strings.Contains(jsonStr, source) {
+		t.Errorf("expected source URL to be present in JSON, got: %s", jsonStr)
+	}
+}
+
+// TestResourceVerificationWithValue verifies that when Resource.Verification
+// has a value, it is included in the JSON output.
+func TestResourceVerificationWithValue(t *testing.T) {
+	hash := "sha512-abc123"
+	resource := Resource{
+		Verification: &Verification{
+			Hash: &hash,
+		},
+	}
+
+	data, err := json.Marshal(resource)
+	if err != nil {
+		t.Fatalf("failed to marshal Resource: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// The "verification" field should appear in the JSON output
+	if !strings.Contains(jsonStr, "verification") {
+		t.Errorf("expected 'verification' to be present in JSON when set, got: %s", jsonStr)
+	}
+
+	// The hash should be in the output
+	if !strings.Contains(jsonStr, hash) {
+		t.Errorf("expected hash to be present in JSON, got: %s", jsonStr)
+	}
+}
+
+// TestFullConfigOmitsEmptyOptionalFields verifies that a full Config struct
+// with empty optional fields produces clean JSON without empty objects.
+func TestFullConfigOmitsEmptyOptionalFields(t *testing.T) {
+	config := Config{
+		Ignition: Ignition{
+			Version: "3.2.0",
+			Config:  IgnitionConfig{
+				// Both Merge and Replace are nil/empty
+			},
+		},
+		Passwd:  Passwd{},
+		Storage: Storage{},
+		Systemd: Systemd{},
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("failed to marshal Config: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// Should not contain "replace" when it's nil
+	if strings.Contains(jsonStr, "\"replace\":{}") {
+		t.Errorf("expected empty 'replace' object to be omitted, got: %s", jsonStr)
+	}
+
+	// Should contain the version
+	if !strings.Contains(jsonStr, "3.2.0") {
+		t.Errorf("expected version to be present in JSON, got: %s", jsonStr)
+	}
+}


### PR DESCRIPTION
Тhis PR fixes an issue where empty config.replace and verification objects were being serialized in the ignition config JSON, which could cause ignition to behave unexpectedly during VM boot.

**Problem**
When podman machine generates the ignition config, the IgnitionConfig.Replace field (type Resource) and Resource.Verification field (type Verification) are always serialized to JSON, even when empty:

`{"ignition":{"config":{"replace":{"verification":{}}}}}`

The presence of an empty replace object may cause ignition to interpret this as an instruction to replace the config, leading to boot failures on macOS with Apple Silicon.

**Solution**
Changed fields to pointer types with omitempty JSON tags:

```
IgnitionConfig.Replace: Resource -> *Resource
Resource.Verification: Verification -> *Verification
```
This ensures empty fields are omitted from JSON output.

Testing
Built and tested on macOS with Apple Silicon (M-series)
Verified podman machine starts successfully
Confirmed containers run correctly 