### PR TITLE
Discover GPU vendor from CDI spec before injecting GPU for --gpus option

### DIFF
--- a/docs/source/markdown/options/gpus.md
+++ b/docs/source/markdown/options/gpus.md
@@ -4,5 +4,4 @@
 ####> are applicable to all of those.
 #### **--gpus**=*ENTRY*
 
-GPU devices to add to the container ('all' to pass all GPUs) Currently only
-Nvidia devices are supported.
+Start the container with GPU support. Where `ENTRY` can be `all` to request all GPUs, or a vendor-specific identifier. Currently, NVIDIA and AMD devices are supported. If both NVIDIA and AMD devices are present, the NVIDIA devices will be preferred, and a CDI device name must be specified using the `--device` flag to request a set of GPUs from a *specific* vendor.

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -442,6 +442,8 @@ type ContainerMiscConfig struct {
 	PidFile string `json:"pid_file,omitempty"`
 	// CDIDevices contains devices that use the CDI
 	CDIDevices []string `json:"cdiDevices,omitempty"`
+	// GPUs contains gpus which eventually get resolved to CDI devices
+	GPUs []string `json:"gpus,omitempty"`
 	// DeviceHostSrc contains the original source on the host
 	DeviceHostSrc []spec.LinuxDevice `json:"device_host_src,omitempty"`
 	// EnvSecrets are secrets that are set as environment variables

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -270,6 +270,17 @@ func WithCDI(devices []string) CtrCreateOption {
 	}
 }
 
+// WithGPUs sets the devices to check for CDI configuration.
+func WithGPUs(gpus []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.GPUs = gpus
+		return nil
+	}
+}
+
 func WithCDISpecDirs(cdiSpecDirs []string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -246,6 +246,9 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		logrus.Debugf("setting container name %s", s.Name)
 		options = append(options, libpod.WithName(s.Name))
 	}
+	if len(s.GPUs) > 0 {
+		options = append(options, libpod.WithGPUs(s.GPUs))
+	}
 	if len(s.Devices) > 0 {
 		opts = ExtractCDIDevices(s)
 		options = append(options, opts...)

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -318,6 +318,10 @@ type ContainerStorageConfig struct {
 	DevicesFrom []string `json:"devices_from,omitempty"`
 	// HostDeviceList is used to recreate the mounted device on inherited containers
 	HostDeviceList []spec.LinuxDevice `json:"host_device_list,omitempty"`
+	// GPUs contains GPU device identifiers for CDI resolution.
+	// These will be resolved to full CDI device paths on the server side.
+	// Optional.
+	GPUs []string `json:"gpus,omitempty"`
 	// IpcNS is the container's IPC namespace.
 	// Default is private.
 	// Conflicts with ShmSize if not set to private.

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -812,12 +812,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.ArtifactVolumes = containerMounts.artifactVolumes
 	}
 
-	devices := c.Devices
-	for _, gpu := range c.GPUs {
-		devices = append(devices, "nvidia.com/gpu="+gpu)
-	}
+	s.GPUs = c.GPUs
 
-	for _, dev := range devices {
+	for _, dev := range c.Devices {
 		s.Devices = append(s.Devices, specs.LinuxDevice{Path: dev})
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
This gets the `--gpus` option working in `podman run` (or `podman create`) commands with AMD gpus by discovering the vendor from CDI specs to construct device id for the GPU to inject into the container.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
Yes
<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
--gpus option now supports AMD GPUs
