### PR TITLE
Error on WSL machine os apply|upgrade

### DIFF
--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -38,6 +38,9 @@ func NewOSManager(opts ManagerOpts) (pkgOS.Manager, error) {
 		return nil, err
 	}
 
+	if vmProvider.VMType() == define.WSLVirt {
+		return nil, errors.New("this command is not supported for WSL")
+	}
 	return &pkgOS.MachineOS{
 		VM:       mc,
 		Provider: vmProvider,

--- a/pkg/machine/e2e/config_os_apply_test.go
+++ b/pkg/machine/e2e/config_os_apply_test.go
@@ -1,27 +1,28 @@
 package e2e_test
 
-// type applyMachineOS struct {
-// 	restart bool
+type applyMachineOS struct {
+	imageName string
+	restart   bool
 
-// 	cmd []string
-// }
+	cmd []string
+}
 
-// func (a *applyMachineOS) buildCmd(m *machineTestBuilder) []string {
-// 	cmd := []string{"machine", "os", "apply"}
-// 	if a.restart {
-// 		cmd = append(cmd, "--restart")
-// 	}
+func (a *applyMachineOS) buildCmd(m *machineTestBuilder) []string {
+	cmd := []string{"machine", "os", "apply"}
+	if a.restart {
+		cmd = append(cmd, "--restart")
+	}
+	cmd = append(cmd, a.imageName, m.name)
+	a.cmd = cmd
+	return cmd
+}
 
-// 	a.cmd = cmd
-// 	return cmd
-// }
+func (a *applyMachineOS) withRestart() *applyMachineOS {
+	a.restart = true
+	return a
+}
 
-// func (a *applyMachineOS) withRestart() *applyMachineOS {
-// 	a.restart = true
-// 	return a
-// }
-
-// func (a *applyMachineOS) args(cmd []string) *applyMachineOS {
-// 	a.cmd = cmd
-// 	return a
-// }
+func (a *applyMachineOS) withImage(i string) *applyMachineOS {
+	a.imageName = i
+	return a
+}

--- a/pkg/machine/e2e/os_test.go
+++ b/pkg/machine/e2e/os_test.go
@@ -1,48 +1,32 @@
 package e2e_test
 
-// import (
-// 	. "github.com/onsi/ginkgo/v2"
-// 	. "github.com/onsi/gomega"
-// 	. "github.com/onsi/gomega/gexec"
-// )
+import (
+	"fmt"
 
-// var _ = Describe("podman machine os apply", func() {
+	"github.com/containers/podman/v6/pkg/machine/define"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
 
-// 	It("apply machine", func() {
-// 		i := new(initMachine)
-// 		foo1, err := mb.setName("foo1").setCmd(i.withImage(mb.imagePath)).run()
-// 		Expect(err).ToNot(HaveOccurred())
-// 		Expect(foo1).To(Exit(0))
-
-// 		apply := new(applyMachineOS)
-// 		applySession, err := mb.setName("foo1").setCmd(apply.args([]string{"quay.io/baude/podman_next"})).run()
-// 		Expect(err).ToNot(HaveOccurred())
-// 		Expect(applySession).To(Exit(0))
-// 	})
-
-// 	It("apply machine from containers-storage", func() {
-// 		i := new(initMachine)
-// 		foo1, err := mb.setName("foo1").setCmd(i.withImage(mb.imagePath)).run()
-// 		Expect(err).ToNot(HaveOccurred())
-// 		Expect(foo1).To(Exit(0))
-
-// 		ssh := &sshMachine{}
-// 		sshSession, err := mb.setName("foo1").setCmd(ssh.withSSHComand([]string{"podman", "pull", "quay.io/baude/podman_next"})).run()
-// 		Expect(err).ToNot(HaveOccurred())
-// 		Expect(sshSession).To(Exit(0))
-
-// 		apply := new(applyMachineOS)
-// 		applySession, err := mb.setName("foo1").setCmd(apply.args([]string{"quay.io/baude/podman_next"})).run()
-// 		Expect(err).ToNot(HaveOccurred())
-// 		Expect(applySession).To(Exit(0))
-// 		Expect(applySession.outputToString()).To(ContainSubstring("Pulling from: containers-storage"))
-// 	})
-
-// 	It("apply machine not exist", func() {
-// 		apply := new(applyMachineOS)
-// 		applySession, err := mb.setName("foo1").setCmd(apply.args([]string{"quay.io/baude/podman_next", "notamachine"})).run()
-// 		Expect(err).ToNot(HaveOccurred())
-// 		Expect(applySession).To(Exit(125))
-// 		Expect(applySession.errorToString()).To(ContainSubstring("not exist"))
-// 	})
-// })
+var _ = Describe("podman machine os apply", func() {
+	It("apply machine", func() {
+		machineName := "foobar"
+		if p := testProvider.VMType(); p == define.WSLVirt {
+			i := new(initMachine)
+			session, err := mb.setName(machineName).setCmd(i.withFakeImage(mb)).run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session).To(Exit(0))
+		}
+		a := new(applyMachineOS)
+		applySession, err := mb.setName(machineName).setCmd(a.withImage("quay.io/foobar:latest").withRestart()).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(applySession.ExitCode()).To(Equal(125))
+		switch testProvider.VMType() {
+		case define.WSLVirt:
+			Expect(applySession.errorToString()).To(ContainSubstring("this command is not supported for WSL"))
+		default:
+			Expect(applySession.errorToString()).To(ContainSubstring(fmt.Sprintf("%s: VM does not exist", machineName)))
+		}
+	})
+})


### PR DESCRIPTION
Given that apply and upgrade do not work on WSL, we should error out with an error as such.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
WSL will error immediately when calling `podman machine os apply|upgrade`.
```
