### PR TITLE
libpod: modernize state test

### DIFF
--- a/libpod/runtime_test.go
+++ b/libpod/runtime_test.go
@@ -3,17 +3,13 @@
 package libpod
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_generateName(t *testing.T) {
-	state, path, _, err := getEmptySqliteState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+	state, _ := getEmptySqliteState(t)
 
 	r := &Runtime{
 		state: state,


### PR DESCRIPTION
Use `t.Helper`, `t.TempDir`, and `t.Cleanup` in `getEmptySqliteState`,
simplifying its code and its users.
    
Simplify `runForAllStates`: remove redundant `t.Fail` call, and move
getEmptySqliteState call under t.Run.

(This was part of something I worked a while back and haven't finished, but it makes sense per se)

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

None

```release-note
None
```
