### PR TITLE
ci: bump golangci-lint to v2.9.0, fix or suppress new warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,9 @@ linters:
       - linters:
           - recvcheck
         path: pkg/k8s.io/
+      - path: _test\.go
+        linters:
+          - prealloc
 
 issues:
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 2.6.0
+GOLANGCI_LINT_VERSION := 2.9.0
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -115,9 +115,10 @@ func doCopy(funcA func() error, funcB func() error) error {
 	go func() {
 		errChan <- funcA()
 	}()
-	var copyErrors []error
-	copyErrors = append(copyErrors, funcB())
-	copyErrors = append(copyErrors, <-errChan)
+	copyErrors := []error{
+		funcB(),
+		<-errChan,
+	}
 	return errorhandling.JoinErrors(copyErrors)
 }
 

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -145,7 +145,7 @@ func jsonOut(responses []entities.ListContainer) error {
 		entities.ListContainer
 		Created int64
 	}
-	r := make([]jsonFormat, 0)
+	r := make([]jsonFormat, 0, len(responses))
 	for _, con := range responses {
 		con.CreatedAt = units.HumanDuration(time.Since(con.Created)) + " ago"
 		con.Status = psReporter{con}.Status()

--- a/cmd/podman/machine/cp.go
+++ b/cmd/podman/machine/cp.go
@@ -127,10 +127,12 @@ func localhostSSHCopy(opts *cpOptions) error {
 		destPath = username + destPath
 	}
 
-	args := []string{"-r", "-i", sshConfig.IdentityPath, "-P", strconv.Itoa(sshConfig.Port)}
-	args = append(args, machine.LocalhostSSHArgs()...) // Warning: This MUST NOT be generalized to allow communication over untrusted networks.
-	args = append(args, []string{srcPath, destPath}...)
-
+	args := append(
+		machine.LocalhostSSHArgs(), // Warning: This MUST NOT be generalized to allow communication over untrusted networks.
+		"-r",
+		"-i", sshConfig.IdentityPath,
+		"-P", strconv.Itoa(sshConfig.Port),
+		srcPath, destPath)
 	cmd := exec.Command("scp", args...)
 	if !opts.Quiet {
 		cmd.Stdout = os.Stdout

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -103,8 +103,9 @@ func AutocompleteMachine(cmd *cobra.Command, args []string, toComplete string) (
 }
 
 func autocompleteMachineProvider(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	suggestions := make([]string, 0)
-	for _, p := range provider2.GetAll() {
+	providers := provider2.GetAll()
+	suggestions := make([]string, 0, len(providers))
+	for _, p := range providers {
 		suggestions = append(suggestions, p.VMType().String())
 	}
 	return suggestions, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -67,9 +67,8 @@ func df(cmd *cobra.Command, _ []string) error {
 
 func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 	var (
-		dfSummaries []*dfSummary
-		active      int
-		used        int64
+		active int
+		used   int64
 	)
 
 	visitedImages := make(map[string]bool)
@@ -91,7 +90,6 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 		RawSize:        reports.ImagesSize,        // The "raw" size is the sum of all layer sizes
 		RawReclaimable: reports.ImagesSize - used, // We can reclaim the date of "unused" images (i.e., the ones without containers)
 	}
-	dfSummaries = append(dfSummaries, &imageSummary)
 
 	// Containers
 	var (
@@ -113,7 +111,6 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 		RawSize:        conSize,
 		RawReclaimable: conReclaimable,
 	}
-	dfSummaries = append(dfSummaries, &containerSummary)
 
 	// Volumes
 	var (
@@ -133,7 +130,11 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 		RawSize:        volumesSize,
 		RawReclaimable: volumesReclaimable,
 	}
-	dfSummaries = append(dfSummaries, &volumeSummary)
+	dfSummaries := []*dfSummary{
+		&imageSummary,
+		&containerSummary,
+		&volumeSummary,
+	}
 
 	// need to give un-exported fields
 	hdrs := report.Headers(dfSummary{}, map[string]string{

--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -135,9 +135,8 @@ func loadUnitDropins(unit *parser.UnitFile, sourcePaths []string) error {
 		prevError = err
 	}
 
-	dropinDirs := []string{}
 	unitDropinPaths := unit.GetUnitDropinPaths()
-
+	dropinDirs := make([]string, 0, len(unitDropinPaths))
 	for _, dropinPath := range unitDropinPaths {
 		for _, sourcePath := range sourcePaths {
 			dropinDirs = append(dropinDirs, path.Join(sourcePath, dropinPath))

--- a/cmd/winpath/main.go
+++ b/cmd/winpath/main.go
@@ -144,8 +144,6 @@ func removePathFromRegistry(path string) error {
 		return err
 	}
 
-	// No point preallocating we can't know how big the array needs to be.
-	//nolint:prealloc
 	var elements []string
 	for element := range strings.SplitSeq(existing, ";") {
 		if strings.EqualFold(element, path) {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -464,7 +464,7 @@ func (c *Container) StaticDir() string {
 // The name of each is guaranteed to point to a valid libpod Volume present in
 // the state.
 func (c *Container) NamedVolumes() []*ContainerNamedVolume {
-	volumes := []*ContainerNamedVolume{}
+	volumes := make([]*ContainerNamedVolume, 0, len(c.config.NamedVolumes))
 	for _, vol := range c.config.NamedVolumes {
 		newVol := new(ContainerNamedVolume)
 		newVol.Name = vol.Name

--- a/libpod/container_top_freebsd.go
+++ b/libpod/container_top_freebsd.go
@@ -79,11 +79,7 @@ func (c *Container) Top(descriptors []string) ([]string, error) {
 		return nil, fmt.Errorf("getting jail name: %w", err)
 	}
 
-	args := []string{
-		"-J",
-		jailName,
-	}
-	args = append(args, psDescriptors...)
+	args := append([]string{"-J", jailName}, psDescriptors...)
 
 	output, err := execPS(args)
 	if err != nil {

--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -128,8 +128,7 @@ func podmanTopInner() error {
 		C.set_userns()
 	}
 
-	args := []string{psPath}
-	args = append(args, os.Args[4:]...)
+	args := append([]string{psPath}, os.Args[4:]...)
 
 	C.create_argv(C.int(len(args)))
 	for i, arg := range args {

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -441,7 +441,7 @@ type YAMLContainer struct {
 
 // ConvertV1PodToYAMLPod takes k8s API core Pod and returns a pointer to YAMLPod
 func ConvertV1PodToYAMLPod(pod *v1.Pod) *YAMLPod {
-	cs := []*YAMLContainer{}
+	cs := make([]*YAMLContainer, 0, len(pod.Spec.Containers))
 	for _, cc := range pod.Spec.Containers {
 		var res *v1.ResourceRequirements
 		if len(cc.Resources.Limits) > 0 || len(cc.Resources.Requests) > 0 {

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -133,7 +133,6 @@ func (m *InMemoryManager) AvailableLocks() (*uint32, error) {
 // Get any locks that are presently being held.
 // Useful for debugging deadlocks.
 func (m *InMemoryManager) LocksHeld() ([]uint32, error) {
-	//nolint:prealloc
 	var locks []uint32
 
 	for _, lock := range m.locks {

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -245,9 +245,8 @@ func (r *ConmonOCIRuntime) UpdateContainer(ctr *Container, resources *spec.Linux
 }
 
 func generateResourceFile(res *spec.LinuxResources) (string, []string, error) {
-	flags := []string{}
 	if res == nil {
-		return "", flags, nil
+		return "", nil, nil
 	}
 
 	f, err := os.CreateTemp("", "podman")
@@ -265,7 +264,7 @@ func generateResourceFile(res *spec.LinuxResources) (string, []string, error) {
 		return "", nil, err
 	}
 
-	flags = append(flags, "--resources="+f.Name())
+	flags := []string{"--resources=" + f.Name()}
 	return f.Name(), flags, nil
 }
 

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -263,7 +263,7 @@ func GetLimits(resource *spec.LinuxResources) (runcconfig.Resources, error) {
 	final.Devices = devs
 
 	// HugepageLimits
-	pageLimits := []*runcconfig.HugepageLimit{}
+	pageLimits := make([]*runcconfig.HugepageLimit, 0, len(resource.HugepageLimits))
 	for _, entry := range resource.HugepageLimits {
 		pageLimits = append(pageLimits, &runcconfig.HugepageLimit{
 			Pagesize: entry.Pagesize,

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -106,9 +106,7 @@ func (r *storageService) CreateContainerStorage(ctx context.Context, systemConte
 	}
 
 	// Build the container.
-	names := []string{containerName}
-
-	container, err := r.store.CreateContainer(containerID, names, imageID, "", string(mdata), &options)
+	container, err := r.store.CreateContainer(containerID, []string{containerName}, imageID, "", string(mdata), &options)
 	if err != nil {
 		logrus.Debugf("Failed to create container %s(%s): %v", metadata.ContainerName, containerID, err)
 
@@ -132,7 +130,7 @@ func (r *storageService) CreateContainerStorage(ctx context.Context, systemConte
 	// Add a name to the container's layer so that it's easier to follow
 	// what's going on if we're just looking at the storage-eye view of things.
 	layerName := metadata.ContainerName + "-layer"
-	names, err = r.store.Names(container.LayerID)
+	names, err := r.store.Names(container.LayerID)
 	if err != nil {
 		return ContainerInfo{}, err
 	}

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -626,8 +626,8 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 	}
 
 	// specgen assumes the image name is arg[0]
-	cmd := []string{cc.Config.Image}
-	cmd = append(cmd, cc.Config.Cmd...)
+	cmd := append([]string{cc.Config.Image}, cc.Config.Cmd...)
+
 	return &cliOpts, cmd, nil
 }
 

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -163,7 +163,7 @@ func createContainerWaitFn(ctx context.Context, containerName string, interval t
 	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
 
 	return func(conditions ...define.ContainerStatus) (int32, error) {
-		var rawConditions []string
+		rawConditions := make([]string, 0, len(conditions))
 		for _, con := range conditions {
 			rawConditions = append(rawConditions, con.String())
 		}

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -209,7 +209,6 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		return nil, err
 	}
 
-	var containers []*libpod.Container
 	if container == nil {
 		return nil, nil
 	}
@@ -228,6 +227,5 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		}
 	}
 
-	containers = append(containers, container)
-	return containers, nil
+	return []*libpod.Container{container}, nil
 }

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -37,7 +37,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 	case "name":
 		// we only have to match one name
 		return func(c *libpod.Container) bool {
-			var filters []string
+			filters := make([]string, 0, len(filterValues))
 			for _, f := range filterValues {
 				filters = append(filters, strings.ReplaceAll(f, "/", ""))
 			}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -210,7 +210,7 @@ func (ic *ContainerEngine) VolumeMounted(_ context.Context, nameOrID string) (*e
 }
 
 func (ic *ContainerEngine) VolumeMount(_ context.Context, nameOrIDs []string) ([]*entities.VolumeMountReport, error) {
-	reports := []*entities.VolumeMountReport{}
+	reports := make([]*entities.VolumeMountReport, 0, len(nameOrIDs))
 	for _, name := range nameOrIDs {
 		report := entities.VolumeMountReport{Id: name}
 		vol, err := ic.Libpod.LookupVolume(name)
@@ -226,7 +226,7 @@ func (ic *ContainerEngine) VolumeMount(_ context.Context, nameOrIDs []string) ([
 }
 
 func (ic *ContainerEngine) VolumeUnmount(_ context.Context, nameOrIDs []string) ([]*entities.VolumeUnmountReport, error) {
-	reports := []*entities.VolumeUnmountReport{}
+	reports := make([]*entities.VolumeUnmountReport, 0, len(nameOrIDs))
 	for _, name := range nameOrIDs {
 		report := entities.VolumeUnmountReport{Id: name}
 		vol, err := ic.Libpod.LookupVolume(name)

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -598,7 +598,7 @@ func (ic *ContainerEngine) ContainerAttach(ctx context.Context, nameOrID string,
 }
 
 func makeExecConfig(options entities.ExecOptions) *handlers.ExecCreateConfig {
-	env := []string{}
+	env := make([]string, 0, len(options.Envs))
 	for k, v := range options.Envs {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/pkg/emulation/emulation.go
+++ b/pkg/emulation/emulation.go
@@ -7,12 +7,10 @@ import "github.com/sirupsen/logrus"
 // Registered returns a list of platforms for which we think we have user
 // space emulation available.
 func Registered() []string {
-	var registered []string
-	binfmt, err := registeredBinfmtMisc()
+	registered, err := registeredBinfmtMisc()
 	if err != nil {
 		logrus.Warnf("registeredBinfmtMisc(): %v", err)
 		return nil
 	}
-	registered = append(registered, binfmt...)
 	return registered
 }

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -56,18 +56,17 @@ func pgrep(n string) (string, error) {
 	return strOut, nil
 }
 
-func runWslCommand(cmdArgs []string) (*machineSession, error) {
+func runWslCommand(cmdArgs []string) *machineSession {
 	binary := "wsl"
 	GinkgoWriter.Println(binary + " " + strings.Join(cmdArgs, " "))
 	c := exec.Command(binary, cmdArgs...)
 	session, err := Start(c, GinkgoWriter, GinkgoWriter)
 	if err != nil {
 		Fail(fmt.Sprintf("Unable to start session: %q", err))
-		return nil, err
 	}
 	ms := machineSession{session}
 	ms.waitWithTimeout(defaultTimeout)
-	return &ms, nil
+	return &ms
 }
 
 // withFakeImage should be used in tests where the machine is

--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -27,15 +27,8 @@ var _ = Describe("podman machine init - windows only", func() {
 		Expect(session).To(Exit(0))
 
 		defer func() {
-			_, err := runWslCommand([]string{"--terminate", "podman-net-usermode"})
-			if err != nil {
-				fmt.Println("unable to terminate podman-net-usermode")
-			}
-
-			_, err = runWslCommand([]string{"--unregister", "podman-net-usermode"})
-			if err != nil {
-				fmt.Println("unable to unregister podman-net-usermode")
-			}
+			runWslCommand([]string{"--terminate", "podman-net-usermode"})
+			runWslCommand([]string{"--unregister", "podman-net-usermode"})
 		}()
 
 		inspect := new(inspectMachine)
@@ -105,20 +98,15 @@ var _ = Describe("podman machine init - windows only", func() {
 		// a vm outside the context of podman-machine and also
 		// so we dont have to download a distribution from microsoft
 		// servers
-		exportSession, err := runWslCommand([]string{"--export", "podman-foobarexport", exportedPath})
-		Expect(err).ToNot(HaveOccurred())
+		exportSession := runWslCommand([]string{"--export", "podman-foobarexport", exportedPath})
 		Expect(exportSession).To(Exit(0))
 
 		// importing the machine and creating a vm
-		importSession, err := runWslCommand([]string{"--import", distName, distrDir, exportedPath})
-		Expect(err).ToNot(HaveOccurred())
+		importSession := runWslCommand([]string{"--import", distName, distrDir, exportedPath})
 		Expect(importSession).To(Exit(0))
 
 		defer func() {
-			_, err := runWslCommand([]string{"--unregister", distName})
-			if err != nil {
-				fmt.Println("unable to remove bogus wsl instance")
-			}
+			runWslCommand([]string{"--unregister", distName})
 		}()
 
 		// Trying to make a vm with the same name as an existing name should result in a 125

--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -422,7 +422,7 @@ func RemoveAllHVSockRegistryEntries() error {
 		return err
 	}
 
-	allSocks := []*HVSockRegistryEntry{}
+	allSocks := make([]*HVSockRegistryEntry, 0, len(networkSocks)+len(eventsSocks)+len(fileserverSocks))
 	allSocks = append(allSocks, networkSocks...)
 	allSocks = append(allSocks, eventsSocks...)
 	allSocks = append(allSocks, fileserverSocks...)

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -357,17 +357,20 @@ func (q *QEMUStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, quiet bool) 
 		if err != nil {
 			return err
 		}
-		// NOTE: The mount type q.Type was previously serialized as 9p for older Linux versions,
-		// but we ignore it now because we want the mount type to be dynamic, not static.  Or
-		// in other words we don't want to make people unnecessarily reprovision their machines
-		// to upgrade from 9p to virtiofs.
-		mountOptions := []string{"-t", "virtiofs"}
-		mountOptions = append(mountOptions, []string{mount.Tag, strconv.Quote(mount.Target)}...)
+
 		mountFlags := fmt.Sprintf("context=\"%s\"", machine.NFSSELinuxContext)
 		if mount.ReadOnly {
 			mountFlags += ",ro"
 		}
-		mountOptions = append(mountOptions, "-o", mountFlags)
+		// NOTE: The mount type q.Type was previously serialized as 9p for older Linux versions,
+		// but we ignore it now because we want the mount type to be dynamic, not static.  Or
+		// in other words we don't want to make people unnecessarily reprovision their machines
+		// to upgrade from 9p to virtiofs.
+		mountOptions := []string{
+			"-t", "virtiofs",
+			mount.Tag, strconv.Quote(mount.Target),
+			"-o", mountFlags,
+		}
 		err = machine.LocalhostSSH(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, append([]string{"sudo", "mount"}, mountOptions...))
 		if err != nil {
 			return err

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -127,7 +127,10 @@ func localhostNativeSSH(username, identityPath, name string, sshPort int, inputA
 	port := strconv.Itoa(sshPort)
 	interactive := true
 
-	args := append([]string{"-i", identityPath, "-p", port, sshDestination}, LocalhostSSHArgs()...) // WARNING: This MUST NOT be generalized to allow communication over untrusted networks.
+	args := append(LocalhostSSHArgs(), // WARNING: This MUST NOT be generalized to allow communication over untrusted networks.
+		"-i", identityPath,
+		"-p", port,
+		sshDestination)
 	if len(inputArgs) > 0 {
 		// on the other condition, the term is forced
 		// anyway

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -460,17 +460,22 @@ func withUser(s string, user string) string {
 	return strings.ReplaceAll(s, "[USER]", user)
 }
 
-func wslInvoke(dist string, arg ...string) error {
-	newArgs := []string{"-u", "root", "-d", dist}
+func wslCmd(dist string, arg ...string) *exec.Cmd {
+	preArgs := []string{"-u", "root", "-d", dist}
+	newArgs := make([]string, 0, len(preArgs)+len(arg))
+	newArgs = append(newArgs, preArgs...)
 	newArgs = append(newArgs, arg...)
-	cmd := wutil.NewWSLCommand(newArgs...)
+
+	return wutil.NewWSLCommand(newArgs...)
+}
+
+func wslInvoke(dist string, arg ...string) error {
+	cmd := wslCmd(dist, arg...)
 	return runCmdPassThrough(cmd)
 }
 
 func wslPipe(input string, dist string, arg ...string) error {
-	newArgs := []string{"-u", "root", "-d", dist}
-	newArgs = append(newArgs, arg...)
-	cmd := wutil.NewWSLCommand(newArgs...)
+	cmd := wslCmd(dist, arg...)
 	return pipeCmdPassThrough(cmd, input)
 }
 

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -844,8 +844,8 @@ func makeHealthCheck(inCmd string, interval int32, retries int32, timeout int32,
 		err := json.Unmarshal([]byte(inCmd), &cmd)
 		if err != nil {
 			// ...otherwise pass it to "/bin/sh -c" inside the container
-			cmd = []string{define.HealthConfigTestCmdShell}
-			cmd = append(cmd, strings.Split(inCmd, " ")...)
+			args := strings.Split(inCmd, " ")
+			cmd = append([]string{define.HealthConfigTestCmdShell}, args...)
 		} else {
 			cmd = append([]string{define.HealthConfigTestCmd}, cmd...)
 		}

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -242,10 +242,7 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 		spec.BaseHostsFile = p.HostsFile
 	}
 	if len(p.DNSServer) > 0 {
-		var dnsServers []net.IP
-		dnsServers = append(dnsServers, p.DNSServer...)
-
-		spec.DNSServers = dnsServers
+		spec.DNSServers = slices.Clone(p.DNSServer)
 	}
 	if len(p.DNSOption) > 0 {
 		spec.DNSOptions = p.DNSOption

--- a/pkg/trust/trust.go
+++ b/pkg/trust/trust.go
@@ -78,7 +78,7 @@ func getPolicyShowOutput(policyContentStruct policyContent, systemRegistriesDirP
 
 // descriptionsOfPolicyRequirements turns reqs into user-readable policy entries, with Transport/Name/Reponame coming from template, potentially looking up scope (which may be "") in registryConfigs.
 func descriptionsOfPolicyRequirements(reqs []repoContent, template Policy, registryConfigs *registryConfiguration, scope string, idReader gpgIDReader) []*Policy {
-	res := []*Policy{}
+	res := make([]*Policy, 0, len(reqs))
 
 	var lookasidePath string
 	registryNamespace := registriesDConfigurationForScope(registryConfigs, scope)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -612,13 +612,13 @@ func getAvailableIDRanges(fullRanges, usedRanges [][2]int) (availableRanges [][2
 // multirange of unassigned subordinated ids.
 func getAvailableIDRangesFromMappings(idmap []idtools.IDMap, parentMapping []ruser.IDMap) (availableRanges [][2]int) {
 	// Get all subordinated ids from parentMapping:
-	fullRanges := [][2]int{} // {Multirange: [start, end), [start, end), ...}
+	fullRanges := make([][2]int, 0, len(parentMapping)) // {Multirange: [start, end), [start, end), ...}
 	for _, mapPiece := range parentMapping {
 		fullRanges = append(fullRanges, [2]int{int(mapPiece.ID), int(mapPiece.ID + mapPiece.Count)})
 	}
 
 	// Get the ids already mapped:
-	usedRanges := [][2]int{}
+	usedRanges := make([][2]int, 0, len(idmap))
 	for _, mapPiece := range idmap {
 		usedRanges = append(usedRanges, [2]int{mapPiece.HostID, mapPiece.HostID + mapPiece.Size})
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -220,8 +220,7 @@ func (p *PodmanTest) NumberOfPods() int {
 // GetContainerStatus returns the containers state.
 // This function assumes only one container is active.
 func (p *PodmanTest) GetContainerStatus() string {
-	podmanArgs := []string{"ps"}
-	podmanArgs = append(podmanArgs, "--all", "--format={{.Status}}")
+	podmanArgs := []string{"ps", "--all", "--format={{.Status}}"}
 	session := p.PodmanExecBaseWithOptions(podmanArgs, PodmanExecOptions{
 		NoCache: true,
 	})


### PR DESCRIPTION
This fixes or suppresses (in _test.go code) new prealloc warnings,
and bumps golangci-lint from v2.6.0 to v 2.9.0.

See individual commits for more details.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
