### PR TITLE
make curl error on non success status codes

### DIFF
--- a/.github/workflows/machine-os-pr.yml
+++ b/.github/workflows/machine-os-pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get version
         id: getversion
         run: |
-          VERSION=$(curl "https://raw.githubusercontent.com/$PODMAN_REPO/$SHA/version/rawversion/version.go" | sed -n 's/^const RawVersion = \"\([0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\|-dev\)\?\)"$/\1/p')
+          VERSION=$(curl --fail "https://raw.githubusercontent.com/$PODMAN_REPO/$SHA/version/rawversion/version.go" | sed -n 's/^const RawVersion = \"\([0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\|-dev\)\?\)"$/\1/p')
           # ignore -dev version bumps unless on main
           if [[ -z "$VERSION" ]] ; then
             echo "::error:: Invalid version string"
@@ -48,7 +48,7 @@ jobs:
       - name: Check machine-os-branch
         if: steps.getversion.outputs.update == 'true'
         run: |
-          if ! curl -s "https://api.github.com/repos/$UPSTREAM_MACHINE_OS/branches" | jq -e --arg branch "${GITHUB_BASE_REF}" '.[] | select(.name==$branch)'; then
+          if ! curl --fail -s "https://api.github.com/repos/$UPSTREAM_MACHINE_OS/branches" | jq -e --arg branch "${GITHUB_BASE_REF}" '.[] | select(.name==$branch)'; then
             echo "::error:: Release branch does not exist."
             echo "::error:: Please push $branch to $UPSTREAM_MACHINE_OS, then re-run this task."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
           title="${title/rc/"RC"}"
         else
           # check if this version should not be marked latest
-          prevrelease=$(curl --retry 3 --silent -m 10 --connect-timeout 5 "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")
+          prevrelease=$(curl --fail --retry 3 --silent -m 10 --connect-timeout 5 "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")
           prevvers=$(echo "$prevrelease" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -e "s/^v//")
           vers=${VERSION#"v"}
           echo "${prevvers},${vers}"

--- a/Makefile
+++ b/Makefile
@@ -852,8 +852,8 @@ win-gvproxy-%: test/version/version
 	$(eval GVPROXY_FILENAME := $(if $(filter arm64,$(GOARCH)), gvproxy-windows-arm64.exe,gvproxy-windowsgui.exe))
 	$(eval SSHPROXY_FILENAME :=  $(if $(filter arm64,$(GOARCH)), win-sshproxy-arm64.exe, win-sshproxy.exe))
 	mkdir -p bin/windows/
-	curl -sSL -o bin/windows/gvproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/$(GVPROXY_FILENAME)
-	curl -sSL -o bin/windows/win-sshproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/$(SSHPROXY_FILENAME)
+	curl --fail -sSL -o bin/windows/gvproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/$(GVPROXY_FILENAME)
+	curl --fail -sSL -o bin/windows/win-sshproxy.exe --retry 5 https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/$(SSHPROXY_FILENAME)
 
 .PHONY: rpm
 rpm:  ## Build rpm packages

--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -70,7 +70,7 @@ query="{
 }\"
 }"
 
-result=$(curl -s -H "Authorization: bearer $CIRRUS_REPO_CLONE_TOKEN" -H "Accept: application/vnd.github.antiope-preview+json" -H "Content-Type: application/json" -X POST --data @- https://api.github.com/graphql <<<"$query")
+result=$(curl --fail -s -H "Authorization: bearer $CIRRUS_REPO_CLONE_TOKEN" -H "Accept: application/vnd.github.antiope-preview+json" -H "Content-Type: application/json" -X POST --data @- https://api.github.com/graphql <<<"$query")
 
 labels=$(jq -r '.data.repository.pullRequest.labels.nodes[].name' <<<"$result")
 

--- a/contrib/cirrus/pr-should-link-jira
+++ b/contrib/cirrus/pr-should-link-jira
@@ -52,7 +52,7 @@ query="{
 }\"
 }"
 
-result=$(curl -s -H "Authorization: bearer $CIRRUS_REPO_CLONE_TOKEN" -H "Accept: application/vnd.github.antiope-preview+json" -H "Content-Type: application/json" -X POST --data @- https://api.github.com/graphql <<<"$query")
+result=$(curl --fail -s -H "Authorization: bearer $CIRRUS_REPO_CLONE_TOKEN" -H "Accept: application/vnd.github.antiope-preview+json" -H "Content-Type: application/json" -X POST --data @- https://api.github.com/graphql <<<"$query")
 
 labels=$(jq -r '.data.repository.pullRequest.labels.nodes[]?.name' <<<"$result")
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -360,7 +360,7 @@ case "$TEST_FLAVOR" in
         ;;
     compose_v2)
         showrun dnf -y remove docker-compose
-        showrun curl -SL https://github.com/docker/compose/releases/download/v2.32.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+        showrun curl --fail -SL https://github.com/docker/compose/releases/download/v2.32.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
         showrun chmod +x /usr/local/bin/docker-compose
         ;& # Continue with next item
     apiv2)

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -25,15 +25,15 @@ podman_version:
 
 $(TMP_BIN)/gvproxy:
 	mkdir -p $(TMP_BIN)
-	cd $(TMP_BIN) && curl -sLo gvproxy $(GVPROXY_RELEASE_URL)
+	cd $(TMP_BIN) && curl --fail -sLo gvproxy $(GVPROXY_RELEASE_URL)
 
 $(TMP_BIN)/vfkit:
 	mkdir -p $(TMP_BIN)
-	cd $(TMP_BIN) && curl -sLo vfkit $(VFKIT_RELEASE_URL)
+	cd $(TMP_BIN) && curl --fail -sLo vfkit $(VFKIT_RELEASE_URL)
 
 $(TMP_BIN)/krunkit.tgz:
 	mkdir -p $(TMP_BIN)
-	cd $(TMP_BIN) && curl -sLo krunkit.tgz $(KRUNKIT_RELEASE_URL)
+	cd $(TMP_BIN) && curl --fail -sLo krunkit.tgz $(KRUNKIT_RELEASE_URL)
 
 packagedir: podman_version package_root Distribution welcome.html
 	mkdir -p $(PACKAGE_DIR)

--- a/winmake.ps1
+++ b/winmake.ps1
@@ -106,12 +106,12 @@ function Win-SSHProxy {
     }
     Write-Host "Downloading gvproxy version $version"
     if ($architecture -eq 'amd64') {
-        curl.exe -sSL -o './bin/windows/gvproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windowsgui.exe"
-        curl.exe -sSL -o './bin/windows/win-sshproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy.exe"
+        curl.exe --fail -sSL -o './bin/windows/gvproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windowsgui.exe"
+        curl.exe --fail -sSL -o './bin/windows/win-sshproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy.exe"
     }
     else {
-        curl.exe -sSL -o './bin/windows/gvproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windows-arm64.exe"
-        curl.exe -sSL -o './bin/windows/win-sshproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy-arm64.exe"
+        curl.exe --fail -sSL -o './bin/windows/gvproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/gvproxy-windows-arm64.exe"
+        curl.exe --fail -sSL -o './bin/windows/win-sshproxy.exe' --retry 5 "https://github.com/containers/gvisor-tap-vsock/releases/download/$Version/win-sshproxy-arm64.exe"
     }
 }
 


### PR DESCRIPTION
By default something like a 404 will not make curl exit with an error code. This is problematic for obvious reasons and instead of the file you want you may now have some 404 html text instead.

I noticed this in #28003 which well just build fine installers except the binary downloaded by the installer Makefile simply did not exist.

So to address that add --fail to most curl commands.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
