### PR TITLE
setting UID and GID for volumes in quadlet

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1601,6 +1601,7 @@ Valid options for `[Volume]` are listed below:
 | Copy=true                           | --opt copy                                |
 | Device=tmpfs                        | --opt device=tmpfs                        |
 | Driver=image                        | --driver=image                            |
+| GID=5678                            | --gid 5678                                |
 | GlobalArgs=--log-level=debug        | --log-level=debug                         |
 | Group=192                           | --opt "o=group=192"                       |
 | Image=quay.io/centos/centos\:latest | --opt image=quay.io/centos/centos\:latest |
@@ -1608,6 +1609,7 @@ Valid options for `[Volume]` are listed below:
 | Options=XYZ                         | --opt "o=XYZ"                             |
 | PodmanArgs=--driver=image           | --driver=image                            |
 | Type=type                           | Filesystem type of Device                 |
+| UID=1234                            | --uid 1234                                |
 | User=123                            | --opt "o=uid=123"                         |
 | VolumeName=foo                      | podman volume create foo                  |
 
@@ -1634,6 +1636,10 @@ Specify the volume driver name. When set to `image`, the `Image` key must also b
 
 This is equivalent to the Podman `--driver` option.
 
+### `GID=`
+
+The GID that the volume will be created as. Differently than `Group=`, the specified value is not passed to the mount operation. The specified GID will own the volume's mount point directory and affects the volume chown operation.
+
 ### `GlobalArgs=`
 
 This key contains a list of arguments passed directly between `podman` and `volume`
@@ -1648,7 +1654,7 @@ This key can be listed multiple times.
 
 ### `Group=`
 
-The host (numeric) GID, or group name to use as the group for the volume
+The host (numeric) GID, or group name to use as the group for the volume. Differently than `GID`, the specified value is passed to the mount operation.
 
 ### `Image=`
 
@@ -1692,9 +1698,13 @@ This key can be listed multiple times.
 
 The filesystem type of `Device` as used by the **mount(8)** commands `-t` option.
 
+### `UID=`
+
+The UID that the volume will be created as. Differently than `User`, the specified value is not passed to the mount operation. The specified UID will own the volume's mount point directory and affects the volume chown operation.
+
 ### `User=`
 
-The host (numeric) UID, or user name to use as the owner for the volume
+The host (numeric) UID, or user name to use as the owner for the volume. Differently than `UID`, the specified value is passed to the mount operation.
 
 ### `VolumeName=`
 

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -95,6 +95,7 @@ const (
 	KeyFile                  = "File"
 	KeyForceRM               = "ForceRM"
 	KeyGateway               = "Gateway"
+	KeyGID                   = "GID"
 	KeyGIDMap                = "GIDMap"
 	KeyGlobalArgs            = "GlobalArgs"
 	KeyGroup                 = "Group"
@@ -182,6 +183,7 @@ const (
 	KeyTLSVerify             = "TLSVerify"
 	KeyTmpfs                 = "Tmpfs"
 	KeyType                  = "Type"
+	KeyUID                   = "UID"
 	KeyUIDMap                = "UIDMap"
 	KeyUlimit                = "Ulimit"
 	KeyUnmask                = "Unmask"
@@ -359,6 +361,8 @@ var (
 				KeyType:                 true,
 				KeyUser:                 true,
 				KeyVolumeName:           true,
+				KeyUID:                  true,
+				KeyGID:                  true,
 			},
 		},
 		NetworkGroup: {
@@ -1101,6 +1105,16 @@ func ConvertVolume(volume *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, i
 	podman := createBasePodmanCommand(volume, VolumeGroup)
 
 	podman.add("volume", "create", "--ignore")
+
+	uid, ok := volume.Lookup(VolumeGroup, KeyUID)
+	if ok {
+		podman.add("--uid", uid)
+	}
+
+	gid, ok := volume.Lookup(VolumeGroup, KeyGID)
+	if ok {
+		podman.add("--gid", gid)
+	}
 
 	driver, ok := volume.Lookup(VolumeGroup, KeyDriver)
 	if ok {

--- a/test/e2e/quadlet/volume-uid-gid.volume
+++ b/test/e2e/quadlet/volume-uid-gid.volume
@@ -1,0 +1,6 @@
+## assert-last-key-contains Service ExecStart " --uid 1234 "
+## assert-last-key-contains Service ExecStart " --gid 5678 "
+
+[Volume]
+UID=1234
+GID=5678

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1012,6 +1012,7 @@ BOGUS=foo
 		Entry("name.volume", "name.volume"),
 		Entry("podmanargs.volume", "podmanargs.volume"),
 		Entry("uid.volume", "uid.volume"),
+		Entry("volume-uid-gid.volume", "volume-uid-gid.volume"),
 		Entry("image.volume", "image.volume"),
 		Entry("Volume - global args", "globalargs.volume"),
 		Entry("Volume - Containers Conf Modules", "containersconfmodule.volume"),

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -405,6 +405,32 @@ EOF
     run_podman volume rm $volume_name
 }
 
+@test "quadlet - volume - uid - gid" {
+    local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).volume
+    cat > $quadlet_file <<EOF
+[Volume]
+UID=1234
+GID=5678
+EOF
+
+    run_quadlet "$quadlet_file"
+
+    service_setup $QUADLET_SERVICE_NAME
+
+    local volume_name=systemd-$(basename $quadlet_file .volume)
+    run_podman volume ls
+    is "$output" ".*local.*${volume_name}.*"
+
+    run_podman volume inspect  --format "{{.UID}}" $volume_name
+    is "$output" "1234"
+
+    run_podman volume inspect  --format "{{.GID}}" $volume_name
+    is "$output" "5678"
+
+    service_cleanup $QUADLET_SERVICE_NAME inactive
+    run_podman volume rm $volume_name
+}
+
 # A quadlet container depends on a quadlet volume
 @test "quadlet - volume dependency" {
     # Save the unit name to use as the volume for the container


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/RHEL-145863

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Added the possibility of setting UID and GID for volumes in quadlet.
```
