### PR TITLE
inspect: preserve secret target name in env masking

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -386,9 +386,9 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 			// env variables come in the style `name=value`
 			envName := strings.Split(envValue, "=")[0]
 
-			envSecret, ok := envSecrets[envName]
+			_, ok := envSecrets[envName]
 			if ok {
-				ctrConfig.Env[envIndex] = envSecret.Name + "=*******"
+				ctrConfig.Env[envIndex] = envName + "=*******"
 			}
 		}
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1607,12 +1607,12 @@ func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (retEr
 		return fmt.Errorf("unable to restart a container in a paused or unknown state: %w", define.ErrCtrStateInvalid)
 	}
 	if len(c.config.EnvSecrets) > 0 {
-		logrus.Infof("DEBUG: restartWithTimeout: EnvSecrets for %s:", c.ID())
+		logrus.Debugf("restartWithTimeout: EnvSecrets for %s:", c.ID())
 		for name, secr := range c.config.EnvSecrets {
-			logrus.Infof("  Target: %s, Source: %s", name, secr.Name)
+			logrus.Debugf("  Target: %s, Source: %s", name, secr.Name)
 		}
 	} else {
-		logrus.Infof("DEBUG: restartWithTimeout: No EnvSecrets for %s", c.ID())
+		logrus.Debugf("restartWithTimeout: No EnvSecrets for %s", c.ID())
 	}
 
 	c.newContainerEvent(events.Restart)

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1606,6 +1606,14 @@ func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (retEr
 	if !c.ensureState(define.ContainerStateConfigured, define.ContainerStateCreated, define.ContainerStateRunning, define.ContainerStateStopped, define.ContainerStateExited) {
 		return fmt.Errorf("unable to restart a container in a paused or unknown state: %w", define.ErrCtrStateInvalid)
 	}
+	if len(c.config.EnvSecrets) > 0 {
+		logrus.Infof("DEBUG: restartWithTimeout: EnvSecrets for %s:", c.ID())
+		for name, secr := range c.config.EnvSecrets {
+			logrus.Infof("  Target: %s, Source: %s", name, secr.Name)
+		}
+	} else {
+		logrus.Infof("DEBUG: restartWithTimeout: No EnvSecrets for %s", c.ID())
+	}
 
 	c.newContainerEvent(events.Restart)
 

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -3171,7 +3171,7 @@ func (c *Container) injectEnvSecrets(g *generate.Generator) error {
 			return err
 		}
 		for name, secr := range c.config.EnvSecrets {
-			logrus.Debugf("DEBUG: generateSpec: Injecting secret %s as env %s", secr.Name, name)
+			logrus.Debugf("generateSpec: Injecting secret %s as env %s", secr.Name, name)
 			_, data, err := manager.LookupSecretData(secr.Name)
 			if err != nil {
 				return err

--- a/libpod/container_secrets_test.go
+++ b/libpod/container_secrets_test.go
@@ -1,0 +1,109 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/common/pkg/secrets"
+)
+
+func TestInjectEnvSecrets(t *testing.T) {
+	// Setup a minimal runtime with a secrets manager
+	state, manager := getEmptySqliteState(t)
+	defer state.Close()
+
+	// ctx := context.Background()
+	runtime := &Runtime{
+		state:       state,
+		lockManager: manager,
+	}
+
+	// Create a temporary directory for secrets
+	secretsDir := t.TempDir()
+	secretsManager, err := secrets.NewManager(secretsDir)
+	require.NoError(t, err)
+	runtime.secretsManager = secretsManager
+
+	// Create a dummy secret
+	secretName := "test-secret"
+	secretData := []byte("secret-value")
+	_, err = secretsManager.Store(secretName, secretData, "file", secrets.StoreOptions{
+		DriverOpts: map[string]string{"path": secretsDir},
+	})
+	require.NoError(t, err)
+
+	// Define test cases
+	tests := []struct {
+		name          string
+		envSecrets    map[string]*secrets.Secret
+		expectedEnv   map[string]string
+		expectedError bool
+	}{
+		{
+			name: "Map secret to same name",
+			envSecrets: map[string]*secrets.Secret{
+				"test-secret": {Name: "test-secret"},
+			},
+			expectedEnv: map[string]string{
+				"test-secret": "secret-value",
+			},
+		},
+		{
+			name: "Map secret to different target",
+			envSecrets: map[string]*secrets.Secret{
+				"MY_TARGET": {Name: "test-secret"},
+			},
+			expectedEnv: map[string]string{
+				"MY_TARGET": "secret-value",
+			},
+		},
+		{
+			name: "Missing secret",
+			envSecrets: map[string]*secrets.Secret{
+				"MISSING_TARGET": {Name: "missing-secret"},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock container with EnvSecrets
+			c := &Container{
+				config: &ContainerConfig{
+					ContainerMiscConfig: ContainerMiscConfig{
+						EnvSecrets: tt.envSecrets,
+					},
+				},
+				runtime: runtime,
+			}
+
+			// Create a generator
+			g, err := generate.New("linux")
+			require.NoError(t, err)
+
+			// Execute injectEnvSecrets
+			err = c.injectEnvSecrets(&g)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				for key, val := range tt.expectedEnv {
+					found := false
+					for _, env := range g.Config.Process.Env {
+						if env == key+"="+val {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "Expected env %s=%s not found", key, val)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #28075

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #28075 ` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

When a container uses a secret with a custom target (e.g., --secret name=foo,target=BAR), podman inspect incorrectly masks the environment variable using the secret name (foo=*****) instead of the target name (BAR=*****). Fix: This patch updates generateInspectContainerConfig to use the environment variable key (envName) when constructing the masked string, ensuring the output matches the container's actual environment. Verification: Verified locally on Ubuntu 24.04. podman run ... --secret test,target=MY_VAR now correctly displays MY_VAR=***** in podman inspect.
