### PR TITLE
storage.conf config file rework prep work and and design doc updates

### DIFF
--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -126,7 +126,6 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 	maybeMoveToSubCgroup()
 
 	maybeStartServiceReaper()
-	infra.StartWatcher(libpodRuntime)
 	server, err := api.NewServerWithSettings(libpodRuntime, listener, opts)
 	if err != nil {
 		return err

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -144,7 +144,6 @@ registries:
   - docker.io
   - quay.io
 store:
-  configFile: /home/dwalsh/.config/containers/storage.conf
   containerStore:
     number: 9
     paused: 0

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -123,7 +123,6 @@ type OCIRuntimeInfo struct {
 // StoreInfo describes the container storage and its
 // attributes
 type StoreInfo struct {
-	ConfigFile      string         `json:"configFile"`
 	ContainerStore  ContainerStore `json:"containerStore"`
 	GraphDriverName string         `json:"graphDriverName"`
 	GraphOptions    map[string]any `json:"graphOptions"`

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/version"
 	"go.podman.io/image/v5/pkg/sysregistriesv2"
-	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/system"
 )
 
@@ -213,10 +212,6 @@ func (r *Runtime) getContainerStoreInfo() (define.ContainerStore, error) {
 // top-level "store" info
 func (r *Runtime) storeInfo() (*define.StoreInfo, error) {
 	// let's say storage driver in use, number of images, number of containers
-	configFile, err := storage.DefaultConfigFile()
-	if err != nil {
-		return nil, err
-	}
 	images, err := r.store.Images()
 	if err != nil {
 		return nil, fmt.Errorf("getting number of images: %w", err)
@@ -244,7 +239,6 @@ func (r *Runtime) storeInfo() (*define.StoreInfo, error) {
 		GraphDriverName:    r.store.GraphDriverName(),
 		GraphOptions:       nil,
 		VolumePath:         r.config.Engine.VolumePath,
-		ConfigFile:         configFile,
 		TransientStore:     r.store.TransientStore(),
 	}
 

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -16,9 +16,7 @@ import (
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/libnetwork/types"
 	blobinfocache "go.podman.io/image/v5/pkg/blobinfocache"
-	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/lockfile"
-	stypes "go.podman.io/storage/types"
 )
 
 // removeAllDirs removes all Podman storage directories. It is intended to be
@@ -260,23 +258,6 @@ func (r *Runtime) Reset(ctx context.Context) error {
 	}
 
 	if err := blobinfocache.CleanupDefaultCache(nil); err != nil {
-		if prevError != nil {
-			logrus.Error(prevError)
-		}
-		prevError = err
-	}
-
-	if storageConfPath, err := storage.DefaultConfigFile(); err == nil {
-		switch storageConfPath {
-		case stypes.SystemConfigFile:
-			break
-		default:
-			if _, err = os.Stat(storageConfPath); err == nil {
-				fmt.Printf(" A %q config file exists.\n", storageConfPath)
-				fmt.Println("Remove this file if you did not modify the configuration.")
-			}
-		}
-	} else {
 		if prevError != nil {
 			logrus.Error(prevError)
 		}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -38,7 +38,6 @@ import (
 	artStore "go.podman.io/common/pkg/libartifact"
 	"go.podman.io/common/pkg/secrets"
 	systemdCommon "go.podman.io/common/pkg/systemd"
-	"go.podman.io/image/v5/pkg/sysregistriesv2"
 	is "go.podman.io/image/v5/storage"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
@@ -1047,42 +1046,6 @@ func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) {
 
 func (r *Runtime) EnableLabeling() bool {
 	return r.config.Containers.EnableLabeling
-}
-
-// Reload reloads the configurations files
-func (r *Runtime) Reload() error {
-	if err := r.reloadContainersConf(); err != nil {
-		return err
-	}
-	if err := r.reloadStorageConf(); err != nil {
-		return err
-	}
-	// Invalidate the registries.conf cache. The next invocation will
-	// reload all data.
-	sysregistriesv2.InvalidateCache()
-	return nil
-}
-
-// reloadContainersConf reloads the containers.conf
-func (r *Runtime) reloadContainersConf() error {
-	config, err := config.Reload()
-	if err != nil {
-		return err
-	}
-	r.config = config
-	logrus.Infof("Applied new containers configuration: %v", config)
-	return nil
-}
-
-// reloadStorageConf reloads the storage.conf
-func (r *Runtime) reloadStorageConf() error {
-	configFile, err := storage.DefaultConfigFile()
-	if err != nil {
-		return err
-	}
-	storage.ReloadConfigurationFile(configFile, &r.storageConfig)
-	logrus.Infof("Applied new storage configuration: %v", r.storageConfig)
-	return nil
 }
 
 // getVolumePlugin gets a specific volume plugin.

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/signal"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/containers/podman/v6/libpod"
 	"github.com/containers/podman/v6/pkg/domain/entities"
@@ -286,25 +284,4 @@ func ParseIDMapping(mode namespaces.UsernsMode, uidMapSlice, gidMapSlice []strin
 		options.HostGIDMapping = false
 	}
 	return &options, nil
-}
-
-// StartWatcher starts a new SIGHUP go routine for the current config.
-func StartWatcher(rt *libpod.Runtime) {
-	// Set up the signal notifier
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGHUP)
-
-	go func() {
-		for {
-			// Block until the signal is received
-			logrus.Debugf("waiting for SIGHUP to reload configuration")
-			<-ch
-			if err := rt.Reload(); err != nil {
-				logrus.Errorf("Unable to reload configuration: %v", err)
-				continue
-			}
-		}
-	}()
-
-	logrus.Debugf("registered SIGHUP watcher for config")
 }

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -48,7 +48,6 @@ host.networkBackendInfo   | .*dns.*package.*
 host.ociRuntime.path      | $expr_path
 host.pasta                | .*executable.*package.*
 host.rootlessNetworkCmd   | pasta
-store.configFile          | $expr_path
 store.graphDriverName     | [a-z0-9]\\\+\\\$
 store.graphRoot           | $expr_path
 store.imageStore.number   | 1


### PR DESCRIPTION
see commits


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
podman info no longer shows the storage.conf configfile location in its output
podman system service is no longer able to reload config files on SIGHUP
```
