### PR TITLE
compat/api: honor VolumeOptions.Subpath for HostConfig.Mounts

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -255,6 +255,9 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 				addField(&builder, "tmpfs-mode", strconv.FormatUint(uint64(m.TmpfsOptions.Mode), 8))
 			}
 		case mount.TypeVolume:
+			if m.VolumeOptions != nil {
+				addField(&builder, "subpath", m.VolumeOptions.Subpath)
+			}
 			// All current VolumeOpts are handled above
 			// See vendor/github.com/containers/common/pkg/parse/parse.go:ValidateVolumeOpts()
 		}

--- a/test/apiv2/44-mounts.at
+++ b/test/apiv2/44-mounts.at
@@ -37,3 +37,24 @@ t POST libpod/containers/create \
   500 \
   .cause="invalid mount option" \
   .message~"the 'noatime' option is only allowed with tmpfs mounts"
+
+# Compat API: HostConfig.Mounts.VolumeOptions.Subpath mounts only the selected volume subdirectory
+subpath_vol="apiv2-subpath-vol"
+podman volume create "$subpath_vol"
+podman run --rm -v "$subpath_vol":/mnt "$IMAGE" sh -c "mkdir -p /mnt/test1 /mnt/test2; touch /mnt/test1/hello1; touch /mnt/test2/hello2"
+
+t POST containers/create?name=compat_mount_subpath_test \
+  Image=$IMAGE \
+  Cmd='["ls","-1","/test1"]' \
+  HostConfig='{"Mounts":[{"Type":"volume","Source":"'$subpath_vol'","Target":"/test1","VolumeOptions":{"Subpath":"test1"}}]}' \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+t POST containers/${cid}/start 204
+t POST containers/${cid}/wait 200
+t GET  containers/${cid}/logs?stdout=true 200
+like "$(tr -d \\0 <$WORKDIR/curl.result.out)" ".*hello1$" "compat mount subpath returns only selected subdir"
+
+t DELETE containers/${cid}?v=true 204
+podman volume rm "$subpath_vol"


### PR DESCRIPTION
fixes: #27171

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [X] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [X] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [X] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [X] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [X] All commits pass `make validatepr` (format/lint checks)
- [X] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```
- Corrects subpath mount behavior when using the Podman API/compatibility socket
```
