### PR TITLE
libpod: fix build

### DIFF
--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/containers/podman/v6/libpod/define"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"go.podman.io/common/pkg/libartifact/store"
+	"go.podman.io/common/pkg/libartifact"
 	"go.podman.io/image/v5/docker"
 	"go.podman.io/image/v5/pkg/shortnames"
 	"go.podman.io/image/v5/transports/alltransports"
@@ -185,7 +185,7 @@ func (c *Container) validate() error {
 			return err
 		}
 		for _, artifactMount := range c.config.ArtifactVolumes {
-			asr, err := store.NewArtifactStorageReference(artifactMount.Source)
+			asr, err := libartifact.NewArtifactStorageReference(artifactMount.Source)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
In the currently used go.podman.io/common/pkg/libartifact version there is no store subpackage (yet),
and so build fails:

```console
[kir@kir-tp1 podman]$ make
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
	 \
	-ldflags '-X github.com/containers/podman/v6/libpod/define.gitCommit=2743ac34304cccfbfd3cb8903c07ad9ebb3b9955 -X github.com/containers/podman/v6/libpod/define.buildInfo=1770939650  -X github.com/containers/podman/v6/libpod/config._installPrefix=/usr/local -X github.com/containers/podman/v6/libpod/config._etcDir=/etc -X github.com/containers/podman/v6/pkg/systemd/quadlet._binDir=/usr/local/bin -X go.podman.io/image/v5/signature/internal/sequoia.sequoiaLibraryDir='""' -X go.podman.io/common/pkg/config.additionalHelperBinariesDir= ' \
	-tags "grpcnotrace   libsqlite3 systemd libsubid  seccomp " \
	-o bin/podman ./cmd/podman
libpod/container_validate.go:12:2: cannot find module providing package go.podman.io/common/pkg/libartifact/store: import lookup disabled by -mod=vendor
	(Go version in go.mod is at least 1.14 and vendor directory exists.)
make: *** [Makefile:391: bin/podman] Error 1
```

Fix the import statement and usage accordingly.

This fixes podman build broken by recently merged PR #27946.

Fixes: df0e3b6ec78 ("libpod: move artifact volume validation to creation phase"

----

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
NONE
```
