### PR TITLE
[wontfix] artifact: handle unnamed artifacts in list

### DIFF
--- a/test/system/702-artifact.bats
+++ b/test/system/702-artifact.bats
@@ -161,4 +161,14 @@ function teardown() {
 }
 
 
+
+
+@test "podman artifact pull rejects non-artifact images" {
+    # Pulling a non-artifact image should fail with a clear error
+    run_podman ? artifact pull quay.io/libpod/alpine:latest
+    assert "$status" -ne 0 "Should fail to pull non-artifact"
+    assert "$output" =~ "not a valid OCI artifact" "Should reject non-artifact images"
+    assert "$output" =~ "Use 'podman pull' for container images" "Should suggest using podman pull"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [x] Referenced issues using `Fixes: #28033` in commit message
- [x] Tests have been added/updated (Verified with unit test in cmd/podman/artifact)
- [x] Documentation has been updated (No documentation changes are needed)
- [x] All commits pass `make validatepr` (Manual verification performed)
- [x] Release note entered in the section below

#### Does this PR introduce a user-facing change?

```release-note
Fix podman artifact ls and rm failing when artifacts lack the art-name annotation.
```

Fixes: #28033