### PR TITLE
fix: add validation for --publish flag in container restore

### DIFF
--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -150,6 +150,10 @@ func restore(cmd *cobra.Command, args []string) error {
 	}
 	restoreOptions.PublishPorts = inputPorts
 
+	if notImport && len(restoreOptions.PublishPorts) > 0 {
+		return fmt.Errorf("--publish can only be used with image or --import")
+	}
+
 	argLen := len(args)
 	if restoreOptions.Import != "" {
 		if restoreOptions.All || restoreOptions.Latest {

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -148,7 +148,9 @@ The default is **false**.
 Replaces the ports that the *container* publishes, as configured during the
 initial *container* start, with a new set of port forwarding rules.
 
-For more details, see **[podman run --publish](podman-run.1.md#--publish)**.
+For more details, see **[podman run --publish](podman-run.1.md#--publish)**.\
+*IMPORTANT: This OPTION is only available for a checkpoint image or in combination
+with __--import, -i__.*
 
 #### **--tcp-close**
 

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -75,6 +75,31 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(session).Should(ExitWithError(125, "no such container or image"))
 	})
 
+	It("podman restore --publish without --import should fail", func() {
+		localRunString := getRunString([]string{ALPINE, "top"})
+		session := podmanTest.Podman(localRunString)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"container", "checkpoint", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+
+		result = podmanTest.Podman([]string{"container", "restore", "-p", "8080:8080", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitWithError(125, "--publish can only be used with image or --import"))
+
+		// Clean up
+		result = podmanTest.Podman([]string{"container", "restore", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+
+		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(ExitCleanly())
+	})
+
 	It("podman checkpoint a running container by id", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
 		session := podmanTest.Podman(localRunString)


### PR DESCRIPTION
Add validation for --publish flag in container restore
#### Checklist

Fixes: #28031

The `--publish` flag for `podman container restore` only works when used with `--import` or a checkpoint image, but was silently ignored when used with regular in-place container restores. 

This PR adds:
1. **Validation check** in the CLI to return a clear error when `--publish` is used without `--import`
2. **Documentation update** to the man page to clarify the restriction (matching the pattern used by other import-dependent flags like `--name` and `--pod`)
3. **Integration test** to verify the error is returned correctly

The behavior now matches other import-dependent options (`--name`, `--pod`, `--ignore-rootfs`, etc.) which all return helpful error messages when misused.


- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
podman container restore --publish now returns an error when used without --import or a checkpoint image, instead of silently ignoring the flag
```
