### PR TITLE
fix(cmd/podman/quadlet): Indent all examples

### DIFF
--- a/cmd/podman/quadlet/install.go
+++ b/cmd/podman/quadlet/install.go
@@ -27,7 +27,7 @@ var (
 		},
 		ValidArgsFunction: completion.AutocompleteDefault,
 		Example: `podman quadlet install /path/to/myquadlet.container
-podman quadlet install https://github.com/containers/podman/blob/main/test/e2e/quadlet/basic.container`,
+  podman quadlet install https://github.com/containers/podman/blob/main/test/e2e/quadlet/basic.container`,
 	}
 
 	installOptions entities.QuadletInstallOptions

--- a/cmd/podman/quadlet/list.go
+++ b/cmd/podman/quadlet/list.go
@@ -24,8 +24,8 @@ var (
 		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example: `podman quadlet list
-podman quadlet list --format '{{ .UnitName }}'
-podman quadlet list --filter 'name=test*'`,
+  podman quadlet list --format '{{ .UnitName }}'
+  podman quadlet list --filter 'name=test*'`,
 	}
 
 	listOptions entities.QuadletListOptions

--- a/cmd/podman/quadlet/print.go
+++ b/cmd/podman/quadlet/print.go
@@ -20,8 +20,8 @@ var (
 		Aliases:           []string{"cat"},
 		Args:              cobra.ExactArgs(1),
 		Example: `podman quadlet print myquadlet.container
-podman quadlet print mypod.pod
-podman quadlet print myimage.build`,
+  podman quadlet print mypod.pod
+  podman quadlet print myimage.build`,
 	}
 )
 

--- a/cmd/podman/quadlet/remove.go
+++ b/cmd/podman/quadlet/remove.go
@@ -21,8 +21,8 @@ var (
 		RunE:              rm,
 		ValidArgsFunction: common.AutocompleteQuadlets,
 		Example: `podman quadlet rm test.container
-podman quadlet rm --force mysql.container
-podman quadlet rm --all --reload-systemd=false`,
+  podman quadlet rm --force mysql.container
+  podman quadlet rm --all --reload-systemd=false`,
 	}
 
 	removeOptions entities.QuadletRemoveOptions


### PR DESCRIPTION
Since these examples are multiline, we need to manually add padding to the start of the line, otherwise the lines are not aligned.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
