### PR TITLE
Respect user-specified `Restart=` policy in pod units

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1024,6 +1024,11 @@ By default, the Podman pod has the same name as the unit, but with a `systemd-` 
 a `$name.pod` file creates a `$name-pod.service` unit and a `systemd-$name` Podman pod. The
 `PodName` option allows for overriding this default name with a user-provided one.
 
+The generated service defaults to `Restart=on-failure`. Note that with `ExitPolicy=stop` (the
+default for Quadlet pods), the pod exits cleanly (exit code 0) when all its containers stop, so
+`on-failure` will **not** trigger a restart in that case. To have the pod automatically restart
+when containers exit, set `Restart=always` in the `[Service]` section of the `.pod` file.
+
 Valid options for `[Pod]` are listed below:
 
 | **[Pod] options**                   | **podman pod create equivalent**       |

--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1699,9 +1699,12 @@ func ConvertPod(podUnit *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, isU
 
 	service.Setv(ServiceGroup,
 		"Type", "forking",
-		"Restart", "on-failure",
 		"PIDFile", "%t/%N.pid",
 	)
+
+	if !podUnit.HasKey(ServiceGroup, "Restart") {
+		service.Set(ServiceGroup, "Restart", "on-failure")
+	}
 
 	return service, warnings, nil
 }

--- a/test/e2e/quadlet/basic.pod
+++ b/test/e2e/quadlet/basic.pod
@@ -1,6 +1,7 @@
 ## assert-key-is Unit RequiresMountsFor "%t/containers"
 ## assert-key-is Service Type forking
 ## assert-key-is Service SyslogIdentifier "%N"
+## assert-key-is Service Restart on-failure
 ## assert-key-is-regex Service ExecStartPre ".*/podman pod create --infra-conmon-pidfile=%t/%N.pid --replace --exit-policy stop --infra-name systemd-basic-infra --name systemd-basic"
 ## assert-key-is-regex Service ExecStart ".*/podman pod start systemd-basic"
 ## assert-key-is-regex Service ExecStop ".*/podman pod stop --ignore --time=10 systemd-basic"

--- a/test/e2e/quadlet/restart.pod
+++ b/test/e2e/quadlet/restart.pod
@@ -1,0 +1,8 @@
+## assert-key-is Unit RequiresMountsFor "%t/containers"
+## assert-key-is Service Type forking
+## assert-key-is Service Restart always
+
+[Pod]
+
+[Service]
+Restart=always

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1141,6 +1141,7 @@ BOGUS=foo
 		Entry("Pod - Shm Size", "shmsize.pod"),
 		Entry("Pod - StopTimeout", "stoptimeout.pod"),
 		Entry("Pod - Service Environment", "service-environment.pod"),
+		Entry("Pod - Restart policy override", "restart.pod"),
 	)
 
 	DescribeTable("Running expected warning quadlet test case",


### PR DESCRIPTION
The function `ConvertPod()` unconditionally sets `Restart=on-failure` via `Setv()`, overwriting any user-specified value. 

Only set `Restart=on-failure` as a default when the user hasn't specified a Restart policy in their `.pod` file's `[Service]` section.

Fixes: https://github.com/containers/podman/issues/28081

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Quadlet: respect user-specified `Restart=` policy in `.pod` files instead of unconditionally overwriting it with on-failure.
```
