### PR TITLE
DNM cirrus: enable Spot instances for z1d.metal

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -779,6 +779,7 @@ podman_machine_task:
         image: "${VM_IMAGE_NAME}"
         type: "${EC2_INST_TYPE}"
         region: us-east-1
+        spot: true
     timeout_in: 30m
     env:
       EC2_INST_TYPE: "m5zn.metal"  # Bare-metal instance is required
@@ -841,6 +842,7 @@ podman_machine_windows_task:
         <<: *windows
         type: z1d.metal
         platform: windows
+        spot: true
     timeout_in: 60m
     env: *winenv
     matrix:


### PR DESCRIPTION
Enable AWS Spot instances for z1d.metal in podman_machine_windows_task to reduce EC2 costs by approximately 75%.
why ??
```AWS Spot Instances let you use unused EC2 capacity at steep discounts. Instead of paying full On-Demand prices, you
  access the same hardware at a fraction of the cost. The tradeoff: AWS can reclaim the instance with a 2-minute
  warning when capacity is needed.
```

reference link: https://cloudprice.net/aws/ec2/instances/z1d.metal

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
