### PR TITLE
[wontfix] fix: prevent path traversal in CRRemoveDeletedFiles

### DIFF
--- a/pkg/checkpoint/crutils/checkpoint_restore_utils_test.go
+++ b/pkg/checkpoint/crutils/checkpoint_restore_utils_test.go
@@ -1,0 +1,101 @@
+package crutils
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCRRemoveDeletedFiles(t *testing.T) {
+	containerRoot := t.TempDir()
+
+	checkpointDir := t.TempDir()
+
+	legitFile := filepath.Join(containerRoot, "legit.txt")
+	if err := os.WriteFile(legitFile, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	targetFile := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(targetFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	relPath, err := filepath.Rel(containerRoot, targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deletedFiles := []string{
+		"/legit.txt",
+		relPath,
+	}
+
+	deletedFilesContent, err := json.Marshal(deletedFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(checkpointDir, "deleted.files"), deletedFilesContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = CRRemoveDeletedFiles("test-container", checkpointDir, containerRoot)
+	if err != nil {
+		t.Fatalf("CRRemoveDeletedFiles returned unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(legitFile); !os.IsNotExist(err) {
+		t.Errorf("legitFile was not deleted")
+	}
+
+	if _, err := os.Stat(targetFile); os.IsNotExist(err) {
+		t.Errorf("SECURITY FAIL: targetFile was deleted! Path traversal successful.")
+	}
+}
+
+func TestCRRemoveDeletedFilesPathTraversal(t *testing.T) {
+	containerRoot := t.TempDir()
+
+	checkpointDir := t.TempDir()
+
+	safeFile := filepath.Join(containerRoot, "safe.txt")
+	if err := os.WriteFile(safeFile, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	externalFile := filepath.Join(t.TempDir(), "external.txt")
+	if err := os.WriteFile(externalFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	relPath, err := filepath.Rel(containerRoot, externalFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deletedFiles := []string{relPath}
+
+	deletedFilesContent, err := json.Marshal(deletedFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(checkpointDir, "deleted.files"), deletedFilesContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = CRRemoveDeletedFiles("test-container", checkpointDir, containerRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(safeFile); os.IsNotExist(err) {
+		t.Errorf("safeFile was incorrectly deleted")
+	}
+
+	if _, err := os.Stat(externalFile); os.IsNotExist(err) {
+		t.Errorf("SECURITY FAIL: externalFile was deleted! Path traversal successful.")
+	}
+}


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes #27977` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Security fix: Prevented path traversal in checkpoint/restore functionality.
```

Fixes #27977
