### PR TITLE
List all status values in status filter documentation

### DIFF
--- a/docs/source/markdown/options/filter.container.md
+++ b/docs/source/markdown/options/filter.container.md
@@ -11,22 +11,22 @@ Filters with the same key work inclusive with the only exception being
 
 Valid filters are listed below:
 
-| **Filter** | **Description**                                                                                 |
-|------------|-------------------------------------------------------------------------------------------------|
-| id         | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
-| name       | [Name] Container's name (accepts regex)                                                         |
-| label      | [Key] or [Key=Value] Label assigned to a container                                              |
-| label!     | [Key] or [Key=Value] Label NOT assigned to a container                                          |
-| exited     | [Int] Container's exit code                                                                     |
-| status     | [Status] Container's status: 'created', 'initialized', 'exited', 'paused', 'running', 'unknown' |
-| ancestor   | [ImageName] Image or descendant used to create container (accepts regex)                        |
-| before     | [ID] or [Name] Containers created before this container                                         |
-| since      | [ID] or [Name] Containers created since this container                                          |
-| volume     | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
-| health     | [Status] healthy or unhealthy                                                                   |
-| pod        | [Pod] name or full or partial ID of pod                                                         |
-| network    | [Network] name or full ID of network                                                            |
-| restart-policy | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
-| until      | [DateTime] Containers created before the given duration or time.                                |
-| command    | [Command] the command the container is executing, only argv[0] is taken                         |
+| **Filter**           | **Description**                                                                                 |
+|----------------------|-------------------------------------------------------------------------------------------------|
+| id                   | [ID] Container's ID (CID prefix match by default; accepts regex)                                |
+| name                 | [Name] Container's name (accepts regex)                                                         |
+| label                | [Key] or [Key=Value] Label assigned to a container                                              |
+| label!               | [Key] or [Key=Value] Label NOT assigned to a container                                          |
+| exited               | [Int] Container's exit code                                                                     |
+| status               | [Status] Container's status: 'created', 'initialized', 'running', 'stopped', 'paused', 'exited', 'removing', 'stopping', 'unknown' |
+| ancestor             | [ImageName] Image or descendant used to create container (accepts regex)                        |
+| before               | [ID] or [Name] Containers created before this container                                         |
+| since                | [ID] or [Name] Containers created since this container                                          |
+| volume               | [VolumeName] or [MountpointDestination] Volume mounted in container                             |
+| health               | [Status] healthy or unhealthy                                                                   |
+| pod                  | [Pod] name or full or partial ID of pod                                                         |
+| network              | [Network] name or full ID of network                                                            |
+| restart-policy       | [Policy] Container's restart policy (e.g., 'no', 'on-failure', 'always', 'unless-stopped')  |
+| until                | [DateTime] Containers created before the given duration or time.                                |
+| command              | [Command] the command the container is executing, only argv[0] is taken                         |
 | should-start-on-boot | [Bool] Containers that need to be restarted after system reboot. True for containers with restart policy 'always', or 'unless-stopped' that were not explicitly stopped by the user |

--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -89,6 +89,8 @@ func StringToContainerStatus(status string) (ContainerStatus, error) {
 		return ContainerStateExited, nil
 	case ContainerStateRemoving.String():
 		return ContainerStateRemoving, nil
+	case ContainerStateStopping.String():
+		return ContainerStateStopping, nil
 	default:
 		return ContainerStateUnknown, fmt.Errorf("unknown container state: %s: %w", status, ErrInvalidArg)
 	}

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -73,10 +73,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 				return false
 			}
 			state := status.String()
-			switch status {
-			case define.ContainerStateConfigured:
-				state = "created"
-			case define.ContainerStateStopped:
+			if status == define.ContainerStateStopped {
 				state = "exited"
 			}
 			for _, filterValue := range filterValues {
@@ -446,17 +443,15 @@ func GenerateExternalContainerFilterFuncs(filter string, filterValues []string, 
 			}
 		}
 		return func(listContainer *types.ListContainer) bool {
-			status := listContainer.State
-			if status == define.ContainerStateConfigured.String() {
-				status = "created"
-			} else if status == define.ContainerStateStopped.String() {
-				status = "exited"
+			state := listContainer.State
+			if state == define.ContainerStateStopped.String() {
+				state = "exited"
 			}
 			for _, filterValue := range filterValues {
 				if filterValue == "stopped" {
 					filterValue = "exited"
 				}
-				if status == filterValue {
+				if state == filterValue {
 					return true
 				}
 			}


### PR DESCRIPTION
The documentation for the `status` filter lists the valid status values, but was missing a couple of values. 

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
