### PR TITLE
test: Use yq for yaml2json when available

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -45,6 +45,7 @@ The test currently depend on:
  - tar
  - docker
  - systemd/systemctl
+ - yq
 
 Most of these are only required for a few tests so it is not a big issue if not everything is installed. Only a few test should fail then.
 

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -14,10 +14,14 @@ capabilities='{"drop":["CAP_FOWNER","CAP_SETFCAP"]}'
 
 # filter: convert yaml to json, because bash+yaml=madness
 function yaml2json() {
-    python3 -c 'import yaml
+    if command -v yq >/dev/null; then
+        yq -p yaml -o json
+    else
+        python3 -c 'import yaml
 import json
 import sys
 json.dump(yaml.safe_load(sys.stdin), sys.stdout)'
+    fi
 }
 
 ###############################################################################


### PR DESCRIPTION
Use yq for yaml2json instead of PyYAML.  This pulls less tests dependencies.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
