### PR TITLE
Fix container clone with secret type=env

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -379,9 +379,11 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 
 	tmpSystemd := conf.Systemd
 	tmpMounts := conf.Mounts
+	tmpEnvSecrets := conf.EnvSecrets
 
 	conf.Systemd = nil
 	conf.Mounts = []string{}
+	conf.EnvSecrets = nil
 
 	if specg == nil {
 		specg = &specgen.SpecGenerator{}
@@ -401,6 +403,7 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 
 	conf.Systemd = tmpSystemd
 	conf.Mounts = tmpMounts
+	conf.EnvSecrets = tmpEnvSecrets
 
 	if conf.Spec != nil {
 		if conf.Spec.Linux != nil && conf.Spec.Linux.Resources != nil {
@@ -513,6 +516,14 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, containerID 
 	specg.HealthConfig = conf.HealthCheckConfig
 	specg.StartupHealthConfig = conf.StartupHealthCheckConfig
 	specg.HealthCheckOnFailureAction = conf.HealthCheckOnFailureAction
+
+	if len(tmpEnvSecrets) > 0 {
+		envSecrets := make(map[string]string, len(tmpEnvSecrets))
+		for target, secret := range tmpEnvSecrets {
+			envSecrets[target] = secret.Name
+		}
+		specg.EnvSecrets = envSecrets
+	}
 
 	specg.IDMappings = &conf.IDMappings
 	specg.ContainerCreateCommand = conf.CreateCommand

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -900,7 +900,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.RestartRetries = &retries
 	}
 
-	if len(s.Secrets) == 0 || len(c.Secrets) != 0 {
+	if (len(s.Secrets) == 0 && len(s.EnvSecrets) == 0) || len(c.Secrets) != 0 {
 		s.Secrets, s.EnvSecrets, err = parseSecrets(c.Secrets)
 		if err != nil {
 			return err


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixed `podman container clone` failing when the source container uses `--secret name,type=env`.
```

`podman container clone` fails with `json: cannot unmarshal object into Go struct field SpecGenerator.ContainerBasicConfig.secret_env of type string` when the source container uses `--secret name,type=env`.

`ConfigToSpec()` serializes the container config to JSON and deserializes it into a `SpecGenerator`. Both structs use the JSON tag `secret_env` but with incompatible types: the container config uses `map[string]*secrets.Secret` (complex objects with Name, ID, Labels, etc.) while the specgen uses `map[string]string` (env var name to secret name). The Secret objects serialize as JSON objects, which cannot be unmarshaled into string values.

This is fixed by saving and clearing `EnvSecrets` before JSON marshal (same pattern as existing `tmpSystemd`/`tmpMounts`), then converting the secret objects to name strings and assigning them to the specgen afterward. Additionally, `FillOutSpecGen` is fixed to not overwrite env secrets populated by `ConfigToSpec` when no new secrets are provided on the command line.

Fixes: #28130