### PR TITLE
Add LLM (AI) Policy.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,18 @@ Below summarizes the processes that we follow.
 
 ## Topics
 
+* [LLM ("AI") Policy](#llm-ai-policy)
 * [Reporting Issues](#reporting-issues)
 * [Working On Issues](#working-on-issues)
 * [Contributing to Podman](#contributing-to-podman)
 * [Continuous Integration](#continuous-integration) [![Build Status](https://api.cirrus-ci.com/github/containers/podman.svg)](https://cirrus-ci.com/github/containers/podman/main)
 * [Submitting Pull Requests](#submitting-pull-requests)
 * [Communications](#communications)
+
+## LLM ("AI") Policy
+
+If your contribution is aided by LLMs or other AI tools, please read the [LLM Policy](LLM_POLICY.md).
+This includes comments, issues, PRs and any other interactions with the Podman team.
 
 ## Reporting Issues
 

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -1,0 +1,80 @@
+![PODMAN logo](https://raw.githubusercontent.com/containers/common/main/logos/podman-logo-full-vert.png)
+# Podman LLM (AI) Development Policy
+
+This document is based on [Jellyfin LLM Policy](https://jellyfin.org/docs/general/contributing/llm-policies/)
+and licensed under [CC-BY-ND-4.0](http://creativecommons.org/licenses/by-nd/4.0/).
+
+LLMs such as Claude and ChatGPT are powerful development tools. They can
+help both experienced and new developers. However, they also introduce risks.
+
+Podman has always prioritized code quality (readability, simplicity, and conciseness)
+and friendly communication. Our small team maintains these standards manually. As LLM
+usage grows within the Podman community, this policy clarifies our expectations for
+contributions and communication across all official projects and spaces.
+
+## No LLM-Generated Direct Communication
+
+LLM output must **not** be used verbatim in:
+
+* Issues or comments
+* Pull request bodies, comments, or commit messages.
+* Forum or chat posts
+* Security and vulnerability reports
+
+All communication must be written in your own words. You must understand what you are submitting.
+
+LLM-written content is often long, impersonal, and error-prone. As a small team with limited
+resources, we are unable to spend time reviewing unclear submissions or responding to impersonal
+comments.
+
+* Exception: If you use an LLM to translate your thoughts into English, clearly state this
+  (e.g., “Translated with an LLM from MyLanguage”).
+* Exception: The LLM-based bot can be configured by the maintainers to review the PRs
+  and suggest changes. These changes are only suggestions and might be wrong. It’s up
+  to the contributor and maintainer to decide whether the particular suggestion makes sense.
+
+Repeated violations may result in the closure or deletion of the submission or in a permanent ban from Podman projects.
+
+## LLM Code Contributions
+
+LLMs may assist with code, but you are fully responsible for what you submit.
+
+### Requirements
+
+* Follow all guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
+* Keep changes concise and focused.
+* Match existing formatting and quality standards.
+* Remove unnecessary comments, poor structure, whitespace issues, and editor/LLM metadata files (e.g., .claude configs).
+* The code must build, run, and pass tests before review begins.
+* Explicitly test the functionality you modify.
+
+### Understanding and Ownership
+
+You must:
+* Review all generated code.
+* Clearly explain (in your own words) what the change does and why in both the PR body and commit message.
+* Be able to discuss and justify your changes during review.
+
+Submitting “vibe-coded” or poorly understood changes will result in rejection after a few attempts to correct them.
+
+### Handling Review Feedback
+
+Do not paste reviewer feedback into an LLM and resubmit whatever it generates.
+
+Please engage in the review process by:
+* Responding thoughtfully to feedback using your own words.
+* Making minimal, targeted changes to address comments.
+* Understanding the implementation of required changes.
+
+### Final Discretion
+Maintainers have final discretion. PRs that are too large, overly complex, poorly structured,
+or difficult to review may be rejected after a few attempts to correct them — regardless
+of whether LLMs were used.
+
+Violations may result in the closure or deletion of the submission, or in a permanent ban from Podman projects.
+
+## The Golden Rule
+Do not prompt an LLM vaguely. Do not commit the LLM results unchanged. And do not submit them as-is.
+
+Using LLMs as a tool is completely fine. Using them as a replacement for understanding,
+responsibility, and craftsmanship is not.

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -67,6 +67,7 @@ Please engage in the review process by:
 * Understanding the implementation of required changes.
 
 ### Final Discretion
+
 Maintainers have final discretion. PRs that are too large, overly complex, poorly structured,
 or difficult to review may be rejected after a few attempts to correct them — regardless
 of whether LLMs were used.


### PR DESCRIPTION
This commit adds new LLM_POLICY.md which contains our LLM Policy. It is based on https://docs.google.com/document/d/1VxYDXT3kIiBAFJHY4fsyFRrddtgIKCrFt_juI7ofsXo which has been discussed on the previous Podman Community Meeting.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
