### PR TITLE
test/system: fix pod inspect ordering test leak

### DIFF
--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -813,6 +813,8 @@ function thingy_with_unique_id() {
 
     run_podman pod inspect --format '{{ .SharedNamespaces }}' $pod_name
     assert "$output" == "[ipc net uts]"
+
+    run_podman pod rm $pod_name
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
Add missing cleanup to fix container leak in pod inspect ordering test.

This was not caught by your CI because you don't set `PODMAN_BATS_LEAK_CHECK`.

Otherwise the test fails with:

https://openqa.opensuse.org/tests/5697617/logfile?filename=podman-bats-root-local.tap.txt

```
not ok 397 [200] podman pod inspect ordering # in 546 ms
# (from function `basic_teardown' in file test/system/helpers.bash, line 301,
#  from function `teardown' in test file test/system/200-pod.bats, line 14)
#   `basic_teardown' failed with status 2
# 
# [14:55:21.562811508] # /usr/bin/podman  pod create p-t397-eyctwdxu
# [14:55:21.625502478] c21c242d2b3246fe2fa8aa07d1e3aceab191f97906e170d07a4ee5d5b758906a
# 
# [14:55:21.632550729] # /usr/bin/podman  pod inspect --format {{ .SharedNamespaces }} p-t397-eyctwdxu
# [14:55:21.667431326] [ipc net uts]
# # [teardown]
# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# *** Leaked pod: c21c242d2b32 p-t397-eyctwdxu status=Created (1 containers)
# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# *** Leaked container: 88db60fcb1c8  c21c242d2b32-infra  Created
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
