### PR TITLE
Swagger update:  Added missing documented params for already-supported api docs.

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -92,7 +92,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   - name: filters
 	//     in: query
 	//     description: |
-	//        A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+	//        JSON-encoded string containing filters as a `map[string][]string` to process on the images list. Available filters:
 	//        - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
 	//        - `dangling=true`
 	//        - `label=key` or `label="key=value"` of an image label
@@ -187,7 +187,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//        A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+	//        JSON-encoded string containing filters as a `map[string][]string` to process on the images list. Available filters:
 	//        - `is-automated=(true|false)`
 	//        - `is-official=(true|false)`
 	//        - `stars=<number>` Matches images that have at least 'number' stars.
@@ -232,6 +232,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: noprune
 	//    type: boolean
 	//    description: do not remove dangling parent images
+	//  - in: query
+	//    name: ignore
+	//    type: boolean
+	//    default: false
+	//    description: Ignore if a specified image does not exist and do not throw an error.
 	// produces:
 	//  - application/json
 	// responses:
@@ -900,7 +905,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   - name: filters
 	//     in: query
 	//     description: |
-	//        A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+	//        JSON-encoded string containing filters as a `map[string][]string` to process on the images list. Available filters:
 	//        - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
 	//        - `dangling=true`
 	//        - `label=key` or `label="key=value"` of an image label
@@ -1070,6 +1075,15 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: force
 	//    type: boolean
 	//    description: remove the image even if used by containers or has other tags
+	//  - in: query
+	//    name: ignore
+	//    type: boolean
+	//    default: false
+	//    description: Ignore if a specified image does not exist and do not throw an error.
+	//  - in: query
+	//    name: lookupManifest
+	//    type: boolean
+	//    description: Resolve to a manifest list instead of an image.
 	// produces:
 	// - application/json
 	// responses:
@@ -1207,7 +1221,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//        A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+	//        JSON-encoded string containing filters as a `map[string][]string` to process on the images list. Available filters:
 	//        - `is-automated=(true|false)`
 	//        - `is-official=(true|false)`
 	//        - `stars=<number>` Matches images that have at least 'number' stars.

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -23,6 +23,15 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: the name of the network
+	//  - in: query
+	//    name: force
+	//    type: boolean
+	//    default: false
+	//    description: Remove containers associated with the network.
+	//  - in: query
+	//    name: timeout
+	//    type: integer
+	//    description: Seconds to wait for container removal when force is set.
 	// produces:
 	// - application/json
 	// responses:
@@ -352,6 +361,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    description: attributes for creating a network
 	//    schema:
 	//      $ref: "#/definitions/networkCreateLibpod"
+	//  - in: query
+	//    name: ignoreIfExists
+	//    type: boolean
+	//    default: false
+	//    description: Ignore the request if a network with the same name already exists.
 	// responses:
 	//   200:
 	//     $ref: "#/responses/networkCreateResponse"

--- a/pkg/api/server/register_secrets.go
+++ b/pkg/api/server/register_secrets.go
@@ -30,11 +30,21 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//   - in: query
 	//     name: driveropts
 	//     type: string
-	//     description: Secret driver options
+	//     description: JSON-encoded string containing secret driver options as a `map[string]string`.
 	//   - in: query
 	//     name: labels
 	//     type: string
-	//     description: Labels on the secret
+	//     description: JSON-encoded string containing labels as a `map[string]string`.
+	//   - in: query
+	//     name: replace
+	//     type: boolean
+	//     default: false
+	//     description: Replace an existing secret with the same name.
+	//   - in: query
+	//     name: ignore
+	//     type: boolean
+	//     default: false
+	//     description: Ignore the request if a secret with the same name already exists.
 	//   - in: body
 	//     name: request
 	//     description: Secret


### PR DESCRIPTION
this is a list of missing already supported query for swagger. this won't required any tests coverage for scope (get our swagger in right place). 
```
Added missing documented params for already-supported behavior:

DELETE /containers/{name}: ignore, depend, timeout, volumes
POST /containers/{name}/stop: timeout, ignore
GET /libpod/containers/json: last, external
GET /libpod/containers/{name}/exists: external
DELETE /images/{name}: ignore
DELETE /libpod/images/{name}: ignore, lookupManifest
DELETE /networks/{name}: force, timeout
POST /libpod/networks/create: ignoreIfExists
POST /libpod/secrets/create: replace, ignore

Split changes swagger operations so compat path is emitted separately:
GET /containers/{name}/changes
GET /libpod/containers/{name}/changes

Normalized libpod stop param name in docs from Ignore to ignore.
```

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
