### PR TITLE
Quadlet Volume - allow setting mount option without a device

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -1186,14 +1186,10 @@ func ConvertVolume(volume *parser.UnitFile, unitsInfoMap map[string]*UnitInfo, i
 
 		mountOpts, ok := volume.Lookup(VolumeGroup, KeyOptions)
 		if ok && len(mountOpts) != 0 {
-			if devValid {
-				if opts.Len() > 2 {
-					opts.WriteString(",")
-				}
-				opts.WriteString(mountOpts)
-			} else {
-				return nil, warnings, fmt.Errorf("key Options can't be used without Device")
+			if opts.Len() > 2 {
+				opts.WriteString(",")
 			}
+			opts.WriteString(mountOpts)
 		}
 	}
 

--- a/test/e2e/quadlet/mount-options.volume
+++ b/test/e2e/quadlet/mount-options.volume
@@ -1,0 +1,7 @@
+## assert-last-key-contains Service ExecStart " --opt o=uid=0,gid=11,rw,compress=zstd "
+
+[Volume]
+# Test usernames too
+User=root
+Group=11
+Options=rw,compress=zstd

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -1017,6 +1017,7 @@ BOGUS=foo
 		Entry("Volume - global args", "globalargs.volume"),
 		Entry("Volume - Containers Conf Modules", "containersconfmodule.volume"),
 		Entry("Volume - Type=bind", "device-bind.volume"),
+		Entry("mount-options.volume", "mount-options.volume"),
 
 		Entry("Absolute Path", "absolute.path.kube"),
 		Entry("Basic kube", "basic.kube"),


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
Yes

```release-note
Quadlet Volume - support mount options without setting a device
```

Fixes: #28132