### PR TITLE
A bunch of refactoring prerequisites to #28043 + a behavior change of `--registries-conf`

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -67,7 +67,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 		SignaturePolicyPath:   options.SignaturePolicyPath,
 		ReportWriter:          options.ReportWriter,
 		Squash:                options.Squash,
-		SystemContext:         c.runtime.imageContext,
+		SystemContext:         &c.runtime.imageContext,
 		PreferredManifestType: options.PreferredManifestType,
 		OverrideChanges:       append(append([]string{}, options.Changes...), options.CommitOptions.OverrideChanges...),
 		OverrideConfig:        options.CommitOptions.OverrideConfig,

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -512,7 +512,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 			}
 			c.config.Name = name
 		}
-		containerInfo, containerInfoErr = c.runtime.storageService.CreateContainerStorage(ctx, c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, options)
+		containerInfo, containerInfoErr = c.runtime.storageService.CreateContainerStorage(ctx, &c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, options)
 
 		if !generateName || !errors.Is(containerInfoErr, storage.ErrDuplicateName) {
 			break

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1108,7 +1108,7 @@ func (c *Container) createCheckpointImage(ctx context.Context, options Container
 
 	commitOptions := buildah.CommitOptions{
 		Squash:        true,
-		SystemContext: c.runtime.imageContext,
+		SystemContext: &c.runtime.imageContext,
 	}
 
 	// Create checkpoint image

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -25,7 +25,6 @@ import (
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/common/pkg/secrets"
 	"go.podman.io/image/v5/manifest"
-	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/idtools"
@@ -220,9 +219,6 @@ func WithRegistriesConf(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if err := fileutils.Exists(path); err != nil {
 			return fmt.Errorf("locating specified registries.conf: %w", err)
-		}
-		if rt.imageContext == nil {
-			rt.imageContext = &types.SystemContext{}
 		}
 
 		rt.imageContext.SystemRegistriesConfPath = path

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/podman/v6/libpod/define"
 	"github.com/containers/podman/v6/libpod/events"
 	"github.com/containers/podman/v6/pkg/namespaces"
@@ -223,9 +222,7 @@ func WithRegistriesConf(path string) RuntimeOption {
 			return fmt.Errorf("locating specified registries.conf: %w", err)
 		}
 		if rt.imageContext == nil {
-			rt.imageContext = &types.SystemContext{
-				BigFilesTemporaryDir: parse.GetTempDir(),
-			}
+			rt.imageContext = &types.SystemContext{}
 		}
 
 		rt.imageContext.SystemRegistriesConfPath = path

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -71,7 +71,7 @@ type Runtime struct {
 	state                  State
 	store                  storage.Store
 	storageService         *storageService
-	imageContext           *types.SystemContext
+	imageContext           types.SystemContext
 	defaultOCIRuntime      OCIRuntime
 	ociRuntimes            map[string]OCIRuntime
 	runtimeFlags           []string
@@ -436,10 +436,8 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	runtime.eventer = eventer
 
 	// Set up containers/image
-	if runtime.imageContext == nil {
-		runtime.imageContext = &types.SystemContext{
-			BigFilesTemporaryDir: parse.GetTempDir(),
-		}
+	if runtime.imageContext.BigFilesTemporaryDir == "" {
+		runtime.imageContext.BigFilesTemporaryDir = parse.GetTempDir()
 	}
 	runtime.imageContext.SignaturePolicyPath = runtime.config.Engine.SignaturePolicyPath
 
@@ -910,7 +908,7 @@ func (r *Runtime) configureStore() error {
 	r.storageService = getStorageService(r.store)
 
 	runtimeOptions := &libimage.RuntimeOptions{
-		SystemContext: r.imageContext,
+		SystemContext: &r.imageContext,
 	}
 	libimageRuntime, err := libimage.RuntimeFromStore(store, runtimeOptions)
 	if err != nil {

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -136,7 +136,7 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 			}
 			storageConfig.LabelOpts = []string{fmt.Sprintf("filetype:%s", context["type"])}
 		}
-		if _, err := r.storageService.CreateContainerStorage(ctx, r.imageContext, imgString, image.ID(), volume.config.StorageName, volume.config.StorageID, storageConfig); err != nil {
+		if _, err := r.storageService.CreateContainerStorage(ctx, &r.imageContext, imgString, image.ID(), volume.config.StorageName, volume.config.StorageID, storageConfig); err != nil {
 			return nil, fmt.Errorf("creating backing storage for image driver: %w", err)
 		}
 		defer func() {

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -155,7 +155,7 @@ func NewConnectionWithOptions(ctx context.Context, opts Options) (context.Contex
 		if !strings.HasPrefix(uri, "tcp://") {
 			return nil, errors.New("tcp URIs should begin with tcp://")
 		}
-		conn, err := tcpClient(_url, opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCAFile)
+		conn, err := tcpClient(_url, opts)
 		if err != nil {
 			return nil, newConnectError(err)
 		}
@@ -308,7 +308,9 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 	return connection, nil
 }
 
-func tcpClient(_url *url.URL, tlsCertFile, tlsKeyFile, tlsCAFile string) (Connection, error) {
+// tcpClient creates a TCP connection to _url.
+// opts are consulted for TLS options only.
+func tcpClient(_url *url.URL, opts Options) (Connection, error) {
 	connection := Connection{
 		URI: _url,
 	}
@@ -344,23 +346,23 @@ func tcpClient(_url *url.URL, tlsCertFile, tlsKeyFile, tlsCAFile string) (Connec
 		DialContext:        dialContext,
 		DisableCompression: true,
 	}
-	if len(tlsCAFile) != 0 || len(tlsCertFile) != 0 || len(tlsKeyFile) != 0 {
-		logrus.Debugf("using TLS cert=%s key=%s ca=%s", tlsCertFile, tlsKeyFile, tlsCAFile)
+	if len(opts.TLSCAFile) != 0 || len(opts.TLSCertFile) != 0 || len(opts.TLSKeyFile) != 0 {
+		logrus.Debugf("using TLS cert=%s key=%s ca=%s", opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCAFile)
 		transport.TLSClientConfig = &tls.Config{}
 		connection.tls = true
 	}
-	if len(tlsCAFile) != 0 {
-		pool, err := tlsutil.ReadCertBundle(tlsCAFile)
+	if len(opts.TLSCAFile) != 0 {
+		pool, err := tlsutil.ReadCertBundle(opts.TLSCAFile)
 		if err != nil {
 			return connection, fmt.Errorf("unable to read CA bundle: %w", err)
 		}
 		transport.TLSClientConfig.RootCAs = pool
 	}
-	if (len(tlsCertFile) == 0) != (len(tlsKeyFile) == 0) {
+	if (len(opts.TLSCertFile) == 0) != (len(opts.TLSKeyFile) == 0) {
 		return connection, fmt.Errorf("TLS Key and Certificate must both or neither be provided")
 	}
-	if len(tlsCertFile) != 0 && len(tlsKeyFile) != 0 {
-		keyPair, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+	if len(opts.TLSCertFile) != 0 && len(opts.TLSKeyFile) != 0 {
+		keyPair, err := tls.LoadX509KeyPair(opts.TLSCertFile, opts.TLSKeyFile)
 		if err != nil {
 			return connection, fmt.Errorf("unable to read TLS key pair: %w", err)
 		}

--- a/pkg/domain/infra/runtime.go
+++ b/pkg/domain/infra/runtime.go
@@ -1,0 +1,20 @@
+package infra
+
+import (
+	"context"
+
+	"github.com/containers/podman/v6/pkg/bindings"
+	"github.com/containers/podman/v6/pkg/domain/entities"
+)
+
+// For the meaning of "WithoutLock", compare runtime_tunnel.go:newConnection()
+func newConnectionWithoutLock(ctx context.Context, facts *entities.PodmanConfig) (context.Context, error) {
+	return bindings.NewConnectionWithOptions(ctx, bindings.Options{
+		URI:         facts.URI,
+		Identity:    facts.Identity,
+		TLSCertFile: facts.TLSCertFile,
+		TLSKeyFile:  facts.TLSKeyFile,
+		TLSCAFile:   facts.TLSCAFile,
+		Machine:     facts.MachineMode,
+	})
+}

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containers/podman/v6/pkg/bindings"
 	"github.com/containers/podman/v6/pkg/domain/entities"
 	"github.com/containers/podman/v6/pkg/domain/infra/tunnel"
 )
@@ -18,14 +17,7 @@ func NewContainerEngine(facts *entities.PodmanConfig) (entities.ContainerEngine,
 		r, err := NewLibpodRuntime(facts.FlagSet, facts)
 		return r, err
 	case entities.TunnelMode:
-		ctx, err := bindings.NewConnectionWithOptions(context.Background(), bindings.Options{
-			URI:         facts.URI,
-			Identity:    facts.Identity,
-			TLSCertFile: facts.TLSCertFile,
-			TLSKeyFile:  facts.TLSKeyFile,
-			TLSCAFile:   facts.TLSCAFile,
-			Machine:     facts.MachineMode,
-		})
+		ctx, err := newConnectionWithoutLock(context.Background(), facts)
 		return &tunnel.ContainerEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
@@ -39,14 +31,7 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 		return r, err
 	case entities.TunnelMode:
 		// TODO: look at me!
-		ctx, err := bindings.NewConnectionWithOptions(context.Background(), bindings.Options{
-			URI:         facts.URI,
-			Identity:    facts.Identity,
-			TLSCertFile: facts.TLSCertFile,
-			TLSKeyFile:  facts.TLSKeyFile,
-			TLSCAFile:   facts.TLSCAFile,
-			Machine:     facts.MachineMode,
-		})
+		ctx, err := newConnectionWithoutLock(context.Background(), facts)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", err, facts.URI)
 		}

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -229,8 +229,9 @@ func (o *OCIArtifactDisk) getDestArtifact() (types.ImageReference, digest.Digest
 		return nil, "", err
 	}
 	fmt.Printf("Looking up Podman Machine image at %s to create VM\n", imgRef.DockerReference())
-	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: o.pullOptions.skipTLSVerify,
+	sysCtx, err := o.pullOptions.systemContext()
+	if err != nil {
+		return nil, "", err
 	}
 	imgSrc, err := imgRef.NewImageSource(o.ctx, sysCtx)
 	if err != nil {

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -39,7 +39,7 @@ type OCIArtifactDisk struct {
 	imageEndpoint            string
 	machineVersion           *OSVersion
 	diskArtifactFileName     string
-	pullOptions              *PullOptions
+	pullOptions              *pullOptions
 	vmType                   define.VMType
 }
 
@@ -119,8 +119,8 @@ func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, endpoint 
 		imageEndpoint:    endpoint,
 		machineVersion:   artifactVersion,
 		name:             vmName,
-		pullOptions: &PullOptions{
-			SkipTLSVerify: skipTlsVerify,
+		pullOptions: &pullOptions{
+			skipTLSVerify: skipTlsVerify,
 		},
 		vmType: vmType,
 	}
@@ -230,7 +230,7 @@ func (o *OCIArtifactDisk) getDestArtifact() (types.ImageReference, digest.Digest
 	}
 	fmt.Printf("Looking up Podman Machine image at %s to create VM\n", imgRef.DockerReference())
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: o.pullOptions.SkipTLSVerify,
+		DockerInsecureSkipTLSVerify: o.pullOptions.skipTLSVerify,
 	}
 	imgSrc, err := imgRef.NewImageSource(o.ctx, sysCtx)
 	if err != nil {
@@ -274,7 +274,7 @@ func (o *OCIArtifactDisk) pull(destRef types.ImageReference, artifactDigest dige
 	if err != nil {
 		return err
 	}
-	return Pull(o.ctx, destRef, destFile, o.pullOptions)
+	return pull(o.ctx, destRef, destFile, o.pullOptions)
 }
 
 func (o *OCIArtifactDisk) unpack(diskArtifactHash digest.Digest) error {

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -87,7 +87,8 @@ func pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	}
 
 	copyOpts := copy.Options{
-		SourceCtx: sysCtx,
+		SourceCtx:      sysCtx,
+		DestinationCtx: sysCtx,
 	}
 	if !options.quiet {
 		copyOpts.ReportWriter = os.Stderr

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -16,23 +16,23 @@ import (
 	"go.podman.io/image/v5/types"
 )
 
-// PullOptions includes data to alter certain knobs when pulling a source
+// pullOptions includes data to alter certain knobs when pulling a source
 // image.
-type PullOptions struct {
+type pullOptions struct {
 	// Skip TLS verification when accessing the registry.
-	SkipTLSVerify types.OptionalBool
+	skipTLSVerify types.OptionalBool
 	// [username[:password] to use when connecting to the registry.
-	Credentials string
+	credentials string
 	// Quiet the progress bars when pushing.
-	Quiet bool
+	quiet bool
 }
 
 // noSignaturePolicy is a default policy if policy.json is not found on
 // the host machine.
 var noSignaturePolicy string = `{"default":[{"type":"insecureAcceptAnything"}]}`
 
-// Pull `imageInput` from a container registry to `sourcePath`.
-func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *define.VMFile, options *PullOptions) error {
+// pull `imageInput` from a container registry to `sourcePath`.
+func pull(ctx context.Context, imageInput types.ImageReference, localDestPath *define.VMFile, options *pullOptions) error {
 	var policy *signature.Policy
 	destRef, err := layout.ParseReference(localDestPath.GetPath())
 	if err != nil {
@@ -40,10 +40,10 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	}
 
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
+		DockerInsecureSkipTLSVerify: options.skipTLSVerify,
 	}
-	if options.Credentials != "" {
-		authConf, err := parse.AuthConfig(options.Credentials)
+	if options.credentials != "" {
+		authConf, err := parse.AuthConfig(options.credentials)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	copyOpts := copy.Options{
 		SourceCtx: sysCtx,
 	}
-	if !options.Quiet {
+	if !options.quiet {
 		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, destRef, imageInput, &copyOpts); err != nil {


### PR DESCRIPTION
This a collection of refactorings conceptually a part of #28043. The CI pipeline doesn’t like too many commits in a single PR, and these are hopefully uncontroversial and a small improvement either way, so I think it would save time to merge them now, while the design of #28043 is discussed further.

Should not change behavior (apart from fixing `ocipull.pullOptions.credentials`, but that’s not reachable).

See individual commit messages for details.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
