### PR TITLE
fix(cmd/podman/quadlet): Behave like container ls

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -54,6 +54,7 @@ podman-port.1.md
 podman-ps.1.md
 podman-pull.1.md
 podman-push.1.md
+podman-quadlet-list.1.md
 podman-restart.1.md
 podman-rm.1.md
 podman-run.1.md

--- a/docs/source/markdown/options/noheading.md
+++ b/docs/source/markdown/options/noheading.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman artifact ls, image trust, images, machine list, network ls, pod ps, secret ls, volume ls
+####>   podman artifact ls, image trust, images, machine list, network ls, pod ps, quadlet list, secret ls, volume ls
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--noheading**, **-n**

--- a/docs/source/markdown/podman-quadlet-list.1.md.in
+++ b/docs/source/markdown/podman-quadlet-list.1.md.in
@@ -38,6 +38,8 @@ Print results with a Go template.
 | .Status         | Quadlet status corresponding to systemd unit     |
 | .UnitName       | Systemd unit name corresponding to quadlet       |
 
+@@option noheading
+
 ## EXAMPLES
 
 Simple list command
@@ -61,7 +63,6 @@ test-service-quadlet.container  test-service-quadlet.service  /home/user/.config
 Format list output for a specific field.
 ```
 $ podman quadlet list --format '{{ .UnitName }}'
-UNIT NAME
 test-service-quadlet.service
 sample-quadlet.service
 ```

--- a/test/system/253-podman-quadlet.bats
+++ b/test/system/253-podman-quadlet.bats
@@ -371,7 +371,7 @@ EOF
     # Test custom Go template format - extract only names
     run_podman quadlet list --format '{{range .}}{{.Name}}{{"\n"}}{{end}}'
     assert $status -eq 0 "quadlet list with custom format should succeed"
-    assert "$output" = $'NAME\nformat-test.container' "custom format should show only the name"
+    assert "$output" = $'format-test.container' "custom format should show only the name"
 
     # Test custom Go template format - extract multiple fields
     run_podman quadlet list --format '{{range .}}Name:{{.Name}} Status:{{.Status}}{{"\n"}}{{end}}'
@@ -382,10 +382,48 @@ EOF
     # Test format with specific field extraction
     run_podman quadlet list --format '{{.Name}}'
     assert $status -eq 0 "quadlet list with field format should succeed"
-    assert "$output" = $'NAME\nformat-test.container' "field format should extract just the name"
+    assert "$output" = $'format-test.container' "field format should extract just the name"
 
     # Clean up
     run_podman quadlet rm format-test.container
+}
+
+@test "quadlet verb - list with --noheading option" {
+    run_podman quadlet list
+    assert $status -eq 0 "baseline: quadlet list should succeed"
+    assert "$output" =~ "^NAME" "baseline: default format should start with a heading"
+    assert "${#lines[@]}" -eq 1 "baseline: list with no quadlets should contain exactly one line"
+
+    run_podman quadlet list --noheading
+    assert $status -eq 0 "baseline: quadlet list --noheading should succeed"
+    assert "$output" == "" "baseline: empty results from quadlet list --noheading"
+
+    # Create a test quadlet file
+    local quadlet_file=$PODMAN_TMPDIR/noheading-test.container
+    cat > $quadlet_file <<EOF
+[Container]
+Image=$IMAGE
+Exec=sh -c "echo STARTED CONTAINER FOR FORMAT TEST; trap 'exit' SIGTERM; while :; do sleep 0.1; done"
+EOF
+
+    # Install the quadlet
+    run_podman quadlet install "$quadlet_file"
+
+    # Test default format (should show tabular output)
+    run_podman quadlet list
+    assert $status -eq 0 "quadlet list should succeed"
+    assert "$output" =~ "^NAME" "default format should start with a heading"
+    assert "$output" =~ "noheading-test.container" "default format should contain quadlet name"
+    assert "${#lines[@]}" -eq 2 "list output should contain exactly two lines"
+
+    # Test output without heading
+    run_podman quadlet list --noheading
+    assert $status -eq 0 "quadlet list --noheading should succeed"
+    assert "$output" =~ "^noheading-test.container" "noheading should should contain only the quadlet name"
+    assert "${#lines[@]}" -eq 1 "list output should contain exactly one line"
+
+    # Clean up
+    run_podman quadlet rm noheading-test.container
 }
 
 @test "quadlet verb - rm --all and --ignore options" {


### PR DESCRIPTION
Quadlet list always reports the table header, even when using custom formatting strings. This doesn't follow the behavior of other podman list commands. Borrow some logic and the "--noheading" flag from the container list command to make this behavior uniform.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
A new flag `--noheading` has been added to quadlet list to align with the container list command behavior.
If any change is made to the `--format` string then the header is automatically removed.
```
