### PR TITLE
Fix `podman info` to use resolved `Store.ImageCopyTmpDir`

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -67,7 +67,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 		SignaturePolicyPath:   options.SignaturePolicyPath,
 		ReportWriter:          options.ReportWriter,
 		Squash:                options.Squash,
-		SystemContext:         c.runtime.imageContext,
+		SystemContext:         &c.runtime.imageContext,
 		PreferredManifestType: options.PreferredManifestType,
 		OverrideChanges:       append(append([]string{}, options.Changes...), options.CommitOptions.OverrideChanges...),
 		OverrideConfig:        options.CommitOptions.OverrideConfig,

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -512,7 +512,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 			}
 			c.config.Name = name
 		}
-		containerInfo, containerInfoErr = c.runtime.storageService.CreateContainerStorage(ctx, c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, options)
+		containerInfo, containerInfoErr = c.runtime.storageService.CreateContainerStorage(ctx, &c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, options)
 
 		if !generateName || !errors.Is(containerInfoErr, storage.ErrDuplicateName) {
 			break

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1108,7 +1108,7 @@ func (c *Container) createCheckpointImage(ctx context.Context, options Container
 
 	commitOptions := buildah.CommitOptions{
 		Squash:        true,
-		SystemContext: c.runtime.imageContext,
+		SystemContext: &c.runtime.imageContext,
 	}
 
 	// Create checkpoint image

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -228,9 +228,15 @@ func (r *Runtime) storeInfo() (*define.StoreInfo, error) {
 	}
 	bsize := uint64(grStats.Bsize) //nolint:unconvert,nolintlint // Bsize is not always uint64 on Linux.
 	allocated := bsize * grStats.Blocks
+
+	imageCopyTmpDir, err := r.config.ImageCopyTmpDir()
+	if err != nil {
+		return nil, err
+	}
+
 	info := define.StoreInfo{
 		ImageStore:         imageInfo,
-		ImageCopyTmpDir:    os.Getenv("TMPDIR"),
+		ImageCopyTmpDir:    imageCopyTmpDir,
 		ContainerStore:     conInfo,
 		GraphRoot:          r.store.GraphRoot(),
 		GraphRootAllocated: allocated,

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/podman/v6/libpod/define"
 	"github.com/containers/podman/v6/libpod/events"
 	"github.com/containers/podman/v6/pkg/namespaces"
@@ -26,7 +25,6 @@ import (
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/common/pkg/secrets"
 	"go.podman.io/image/v5/manifest"
-	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/idtools"
@@ -221,11 +219,6 @@ func WithRegistriesConf(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if err := fileutils.Exists(path); err != nil {
 			return fmt.Errorf("locating specified registries.conf: %w", err)
-		}
-		if rt.imageContext == nil {
-			rt.imageContext = &types.SystemContext{
-				BigFilesTemporaryDir: parse.GetTempDir(),
-			}
 		}
 
 		rt.imageContext.SystemRegistriesConfPath = path

--- a/libpod/runtime_volume_common.go
+++ b/libpod/runtime_volume_common.go
@@ -136,7 +136,7 @@ func (r *Runtime) newVolume(ctx context.Context, noCreatePluginVolume bool, opti
 			}
 			storageConfig.LabelOpts = []string{fmt.Sprintf("filetype:%s", context["type"])}
 		}
-		if _, err := r.storageService.CreateContainerStorage(ctx, r.imageContext, imgString, image.ID(), volume.config.StorageName, volume.config.StorageID, storageConfig); err != nil {
+		if _, err := r.storageService.CreateContainerStorage(ctx, &r.imageContext, imgString, image.ID(), volume.config.StorageName, volume.config.StorageID, storageConfig); err != nil {
 			return nil, fmt.Errorf("creating backing storage for image driver: %w", err)
 		}
 		defer func() {

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -155,7 +155,7 @@ func NewConnectionWithOptions(ctx context.Context, opts Options) (context.Contex
 		if !strings.HasPrefix(uri, "tcp://") {
 			return nil, errors.New("tcp URIs should begin with tcp://")
 		}
-		conn, err := tcpClient(_url, opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCAFile)
+		conn, err := tcpClient(_url, opts)
 		if err != nil {
 			return nil, newConnectError(err)
 		}
@@ -308,7 +308,9 @@ func sshClient(_url *url.URL, uri string, identity string, machine bool) (Connec
 	return connection, nil
 }
 
-func tcpClient(_url *url.URL, tlsCertFile, tlsKeyFile, tlsCAFile string) (Connection, error) {
+// tcpClient creates a TCP connection to _url.
+// opts are consulted for TLS options only.
+func tcpClient(_url *url.URL, opts Options) (Connection, error) {
 	connection := Connection{
 		URI: _url,
 	}
@@ -344,23 +346,23 @@ func tcpClient(_url *url.URL, tlsCertFile, tlsKeyFile, tlsCAFile string) (Connec
 		DialContext:        dialContext,
 		DisableCompression: true,
 	}
-	if len(tlsCAFile) != 0 || len(tlsCertFile) != 0 || len(tlsKeyFile) != 0 {
-		logrus.Debugf("using TLS cert=%s key=%s ca=%s", tlsCertFile, tlsKeyFile, tlsCAFile)
+	if len(opts.TLSCAFile) != 0 || len(opts.TLSCertFile) != 0 || len(opts.TLSKeyFile) != 0 {
+		logrus.Debugf("using TLS cert=%s key=%s ca=%s", opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCAFile)
 		transport.TLSClientConfig = &tls.Config{}
 		connection.tls = true
 	}
-	if len(tlsCAFile) != 0 {
-		pool, err := tlsutil.ReadCertBundle(tlsCAFile)
+	if len(opts.TLSCAFile) != 0 {
+		pool, err := tlsutil.ReadCertBundle(opts.TLSCAFile)
 		if err != nil {
 			return connection, fmt.Errorf("unable to read CA bundle: %w", err)
 		}
 		transport.TLSClientConfig.RootCAs = pool
 	}
-	if (len(tlsCertFile) == 0) != (len(tlsKeyFile) == 0) {
+	if (len(opts.TLSCertFile) == 0) != (len(opts.TLSKeyFile) == 0) {
 		return connection, fmt.Errorf("TLS Key and Certificate must both or neither be provided")
 	}
-	if len(tlsCertFile) != 0 && len(tlsKeyFile) != 0 {
-		keyPair, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+	if len(opts.TLSCertFile) != 0 && len(opts.TLSKeyFile) != 0 {
+		keyPair, err := tls.LoadX509KeyPair(opts.TLSCertFile, opts.TLSKeyFile)
 		if err != nil {
 			return connection, fmt.Errorf("unable to read TLS key pair: %w", err)
 		}

--- a/pkg/domain/infra/runtime.go
+++ b/pkg/domain/infra/runtime.go
@@ -1,0 +1,20 @@
+package infra
+
+import (
+	"context"
+
+	"github.com/containers/podman/v6/pkg/bindings"
+	"github.com/containers/podman/v6/pkg/domain/entities"
+)
+
+// For the meaning of "WithoutLock", compare runtime_tunnel.go:newConnection()
+func newConnectionWithoutLock(ctx context.Context, facts *entities.PodmanConfig) (context.Context, error) {
+	return bindings.NewConnectionWithOptions(ctx, bindings.Options{
+		URI:         facts.URI,
+		Identity:    facts.Identity,
+		TLSCertFile: facts.TLSCertFile,
+		TLSKeyFile:  facts.TLSKeyFile,
+		TLSCAFile:   facts.TLSCAFile,
+		Machine:     facts.MachineMode,
+	})
+}

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containers/podman/v6/pkg/bindings"
 	"github.com/containers/podman/v6/pkg/domain/entities"
 	"github.com/containers/podman/v6/pkg/domain/infra/tunnel"
 )
@@ -18,14 +17,7 @@ func NewContainerEngine(facts *entities.PodmanConfig) (entities.ContainerEngine,
 		r, err := NewLibpodRuntime(facts.FlagSet, facts)
 		return r, err
 	case entities.TunnelMode:
-		ctx, err := bindings.NewConnectionWithOptions(context.Background(), bindings.Options{
-			URI:         facts.URI,
-			Identity:    facts.Identity,
-			TLSCertFile: facts.TLSCertFile,
-			TLSKeyFile:  facts.TLSKeyFile,
-			TLSCAFile:   facts.TLSCAFile,
-			Machine:     facts.MachineMode,
-		})
+		ctx, err := newConnectionWithoutLock(context.Background(), facts)
 		return &tunnel.ContainerEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
@@ -39,14 +31,7 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 		return r, err
 	case entities.TunnelMode:
 		// TODO: look at me!
-		ctx, err := bindings.NewConnectionWithOptions(context.Background(), bindings.Options{
-			URI:         facts.URI,
-			Identity:    facts.Identity,
-			TLSCertFile: facts.TLSCertFile,
-			TLSKeyFile:  facts.TLSKeyFile,
-			TLSCAFile:   facts.TLSCAFile,
-			Machine:     facts.MachineMode,
-		})
+		ctx, err := newConnectionWithoutLock(context.Background(), facts)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", err, facts.URI)
 		}

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -229,8 +229,9 @@ func (o *OCIArtifactDisk) getDestArtifact() (types.ImageReference, digest.Digest
 		return nil, "", err
 	}
 	fmt.Printf("Looking up Podman Machine image at %s to create VM\n", imgRef.DockerReference())
-	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: o.pullOptions.skipTLSVerify,
+	sysCtx, err := o.pullOptions.systemContext()
+	if err != nil {
+		return nil, "", err
 	}
 	imgSrc, err := imgRef.NewImageSource(o.ctx, sysCtx)
 	if err != nil {

--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -39,7 +39,7 @@ type OCIArtifactDisk struct {
 	imageEndpoint            string
 	machineVersion           *OSVersion
 	diskArtifactFileName     string
-	pullOptions              *PullOptions
+	pullOptions              *pullOptions
 	vmType                   define.VMType
 }
 
@@ -119,8 +119,8 @@ func NewOCIArtifactPull(ctx context.Context, dirs *define.MachineDirs, endpoint 
 		imageEndpoint:    endpoint,
 		machineVersion:   artifactVersion,
 		name:             vmName,
-		pullOptions: &PullOptions{
-			SkipTLSVerify: skipTlsVerify,
+		pullOptions: &pullOptions{
+			skipTLSVerify: skipTlsVerify,
 		},
 		vmType: vmType,
 	}
@@ -230,7 +230,7 @@ func (o *OCIArtifactDisk) getDestArtifact() (types.ImageReference, digest.Digest
 	}
 	fmt.Printf("Looking up Podman Machine image at %s to create VM\n", imgRef.DockerReference())
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: o.pullOptions.SkipTLSVerify,
+		DockerInsecureSkipTLSVerify: o.pullOptions.skipTLSVerify,
 	}
 	imgSrc, err := imgRef.NewImageSource(o.ctx, sysCtx)
 	if err != nil {
@@ -274,7 +274,7 @@ func (o *OCIArtifactDisk) pull(destRef types.ImageReference, artifactDigest dige
 	if err != nil {
 		return err
 	}
-	return Pull(o.ctx, destRef, destFile, o.pullOptions)
+	return pull(o.ctx, destRef, destFile, o.pullOptions)
 }
 
 func (o *OCIArtifactDisk) unpack(diskArtifactHash digest.Digest) error {

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -87,7 +87,8 @@ func pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	}
 
 	copyOpts := copy.Options{
-		SourceCtx: sysCtx,
+		SourceCtx:      sysCtx,
+		DestinationCtx: sysCtx,
 	}
 	if !options.quiet {
 		copyOpts.ReportWriter = os.Stderr

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -16,23 +16,23 @@ import (
 	"go.podman.io/image/v5/types"
 )
 
-// PullOptions includes data to alter certain knobs when pulling a source
+// pullOptions includes data to alter certain knobs when pulling a source
 // image.
-type PullOptions struct {
+type pullOptions struct {
 	// Skip TLS verification when accessing the registry.
-	SkipTLSVerify types.OptionalBool
+	skipTLSVerify types.OptionalBool
 	// [username[:password] to use when connecting to the registry.
-	Credentials string
+	credentials string
 	// Quiet the progress bars when pushing.
-	Quiet bool
+	quiet bool
 }
 
 // noSignaturePolicy is a default policy if policy.json is not found on
 // the host machine.
 var noSignaturePolicy string = `{"default":[{"type":"insecureAcceptAnything"}]}`
 
-// Pull `imageInput` from a container registry to `sourcePath`.
-func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *define.VMFile, options *PullOptions) error {
+// pull `imageInput` from a container registry to `sourcePath`.
+func pull(ctx context.Context, imageInput types.ImageReference, localDestPath *define.VMFile, options *pullOptions) error {
 	var policy *signature.Policy
 	destRef, err := layout.ParseReference(localDestPath.GetPath())
 	if err != nil {
@@ -40,10 +40,10 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	}
 
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
+		DockerInsecureSkipTLSVerify: options.skipTLSVerify,
 	}
-	if options.Credentials != "" {
-		authConf, err := parse.AuthConfig(options.Credentials)
+	if options.credentials != "" {
+		authConf, err := parse.AuthConfig(options.credentials)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	copyOpts := copy.Options{
 		SourceCtx: sysCtx,
 	}
-	if !options.Quiet {
+	if !options.quiet {
 		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, destRef, imageInput, &copyOpts); err != nil {

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -569,6 +569,20 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		Expect(session.OutputToString()).To(Equal(profile))
 	})
 
+	It("podman info Store.ImageCopyTmpDir fails on invalid config", func() {
+		SkipIfRemote("server env is not under test control")
+
+		configPath := filepath.Join(podmanTest.TempDir, "containers.conf")
+		Expect(os.WriteFile(configPath, []byte("[engine]\nimage_copy_tmp_dir=\"relative\""), os.ModePerm)).To(Succeed())
+		env := append(slices.DeleteFunc(slices.Clip(os.Environ()), func(s string) bool {
+			return strings.HasPrefix(s, "CONTAINERS_CONF=")
+		}), "CONTAINERS_CONF="+configPath)
+
+		session := podmanTest.PodmanWithOptions(PodmanExecOptions{Env: env}, "info", "--format", "{{.Store.ImageCopyTmpDir}}")
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "invalid image_copy_tmp_dir value \"relative\" (relative paths are not accepted)"))
+	})
+
 	It("add image_copy_tmp_dir", func() {
 		// Prevents overwriting of TMPDIR environment
 		if cacheDir, found := os.LookupEnv("TMPDIR"); found {


### PR DESCRIPTION
Update `podman info` to use the fully resolved configuration for `Store.ImageCopyTmpDir` rather than relying solely on the `TMPDIR` environment variable.
Additionally, ensure errors are propagated for an invalid `image_copy_tmp_dir` so that podman info exits with code 125 immediately.

Related PR: https://github.com/containers/podman/pull/28168


> Note: I will rebase on main and clean up the history once the CI passes. I want to verify the fix for #28168 first.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
