### PR TITLE
test/system: fix some teardown error logging

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -433,7 +433,7 @@ function clean_setup() {
         #   yet because too many tests don't clean up their containers
         if [[ $status -ne 0 ]]; then
             echo "# [teardown] $_LOG_PROMPT podman $action" >&3
-            for line in "${lines[*]}"; do
+            for line in "${lines[@]}"; do
                 echo "# $line" >&3
             done
 
@@ -441,7 +441,7 @@ function clean_setup() {
             if [[ $status -eq 124 ]]; then
                 echo "# [teardown] $_LOG_PROMPT podman system locks" >&3
                 run "${PODMAN_CMD[@]}" system locks
-                for line in "${lines[*]}"; do
+                for line in "${lines[@]}"; do
                     echo "# $line" >&3
                 done
             fi


### PR DESCRIPTION
Statement

	for line in "${lines[*]}"

does not make sense since line will be a single value consisting of all elements of lines array, space-separated.

It should be

	for line in "${lines[@]}"

if we want to iterate through each value.

Fixes: 00292ae1c47 ("systests: test instrumentation")
Fixes: c33ba70f95c ("system tests: instrument, to try to catch unlinkat-ebusy")

Cc: @edsantiago 

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
NONE
```
