### PR TITLE
libpod: Validate that log tag requires journald driver

### DIFF
--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -179,6 +179,10 @@ func (c *Container) validate() error {
 		return fmt.Errorf("default rootfs-based infra container is set for non-infra container")
 	}
 
+	if c.config.LogTag != "" && c.config.LogDriver != define.JournaldLogging {
+		return fmt.Errorf("log tags can only be used with the journald log driver but driver is %q: %w", c.config.LogDriver, define.ErrInvalidArg)
+	}
+
 	if len(c.config.ArtifactVolumes) > 0 {
 		artStore, err := c.runtime.ArtifactStore()
 		if err != nil {

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -20,7 +20,6 @@ import (
 	"github.com/containers/podman/v6/pkg/signal"
 	"github.com/containers/podman/v6/pkg/specgen"
 	"github.com/openshift/imagebuilder"
-	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/image/v5/manifest"
@@ -332,16 +331,11 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		s.LogConfiguration.Driver = rtc.Containers.LogDriver
 	}
 	if len(rtc.Containers.LogTag) > 0 {
-		if s.LogConfiguration.Driver != define.JSONLogging {
-			if s.LogConfiguration.Options == nil {
-				s.LogConfiguration.Options = make(map[string]string)
-			}
-
-			if _, exists := s.LogConfiguration.Options["tag"]; !exists {
-				s.LogConfiguration.Options["tag"] = rtc.Containers.LogTag
-			}
-		} else {
-			logrus.Warnf("log_tag %q is not allowed with %q log_driver", rtc.Containers.LogTag, define.JSONLogging)
+		if s.LogConfiguration.Options == nil {
+			s.LogConfiguration.Options = make(map[string]string)
+		}
+		if _, exists := s.LogConfiguration.Options["tag"]; !exists {
+			s.LogConfiguration.Options["tag"] = rtc.Containers.LogTag
 		}
 	}
 

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -31,7 +31,6 @@ import (
 	"github.com/docker/docker/pkg/meminfo"
 	"github.com/docker/go-units"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/pkg/config"
@@ -265,17 +264,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			}
 			s.LogConfiguration.Size = logSize
 		default:
-			switch len(val) {
-			case 0:
+			if len(val) == 0 {
 				return nil, fmt.Errorf("invalid log option: %w", define.ErrInvalidArg)
-			default:
-				// tags for journald only
-				if s.LogConfiguration.Driver == "" || s.LogConfiguration.Driver == define.JournaldLogging {
-					s.LogConfiguration.Options[opt] = val
-				} else {
-					logrus.Warnf("Can only set tags with journald log driver but driver is %q", s.LogConfiguration.Driver)
-				}
 			}
+			s.LogConfiguration.Options[opt] = val
 		}
 	}
 

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -638,6 +638,12 @@ var _ = Describe("Podman logs", func() {
 		Expect(logc.OutputToString()).To(Equal("podman"))
 	})
 
+	It("log tag with non-journald driver fails", func() {
+		logc := podmanTest.Podman([]string{"run", "--log-driver", "k8s-file", "--log-opt", "tag=mytag", ALPINE, "true"})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc).To(ExitWithError(125, "log tags can only be used with the journald log driver"))
+	})
+
 	It("podman pod logs with container names", func() {
 		SkipIfRemote("Remote can only process one container at a time")
 		podName := "testPod"


### PR DESCRIPTION
Currently validation that log tag requires journald driver is done in several places and emits only warning. Making it an error and moving to `(c *Container) validate()` is a more correct approach.

#### Does this PR introduce a user-facing change?

```release-note
Using log options (`--log-opt tag=mytag`) together with non-journald driver now emits an error.
```
