### PR TITLE
[v5.4-rhel] Fix: Remove appending rw as the default mount option

### DIFF
--- a/pkg/util/mount_opts.go
+++ b/pkg/util/mount_opts.go
@@ -191,9 +191,6 @@ func processOptionsInternal(options []string, isTmpfs bool, sourcePath string, g
 		newOptions = append(newOptions, opt)
 	}
 
-	if !foundWrite {
-		newOptions = append(newOptions, "rw")
-	}
 	if !foundProp {
 		if recursiveBind {
 			newOptions = append(newOptions, "rprivate")

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -801,13 +801,13 @@ func TestProcessOptions(t *testing.T) {
 		{
 			name:       "default bind mount",
 			sourcePath: "/path/to/source",
-			expected:   []string{"nodev", "nosuid", "rbind", "rprivate", "rw"},
+			expected:   []string{"nodev", "nosuid", "rbind", "rprivate"},
 		},
 		{
 			name:       "default bind mount with bind",
 			sourcePath: "/path/to/source",
 			options:    []string{"bind"},
-			expected:   []string{"nodev", "nosuid", "bind", "private", "rw"},
+			expected:   []string{"nodev", "nosuid", "bind", "private"},
 		},
 	}
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -5820,7 +5820,7 @@ spec:
 		podmanTest.PodmanExitCleanly("kube", "play", outputFile)
 
 		inspectCtr2 := podmanTest.PodmanExitCleanly("inspect", "-f", "'{{ .HostConfig.Binds }}'", ctrNameInKubePod)
-		Expect(inspectCtr2.OutputToString()).To(ContainSubstring(":" + vol1 + ":rw"))
+		Expect(inspectCtr2.OutputToString()).To(ContainSubstring(":" + vol1))
 
 		inspectCtr1 := podmanTest.PodmanExitCleanly("inspect", "-f", "'{{ .HostConfig.Binds }}'", ctr1)
 		Expect(inspectCtr2.OutputToString()).To(Equal(inspectCtr1.OutputToString()))

--- a/test/python/docker/compat/test_containers.py
+++ b/test/python/docker/compat/test_containers.py
@@ -265,7 +265,7 @@ class TestContainers(common.DockerTestCase):
                 has_tried_pull = True
         self.assertFalse(has_tried_pull, "the build process has tried tried to pull the base image")
 
-    def test_mount_rw_by_default(self):
+    def test_mount_options_by_default(self):
         ctr: Optional[Container] = None
         vol: Optional[Volume] = None
 
@@ -282,7 +282,7 @@ class TestContainers(common.DockerTestCase):
             ctr_inspect = self.docker.api.inspect_container(ctr.id)
             binds: List[str] = ctr_inspect["HostConfig"]["Binds"]
             self.assertEqual(len(binds), 1)
-            self.assertEqual(binds[0], "test-volume:/vol-mnt:rw,rprivate,nosuid,nodev,rbind")
+            self.assertEqual(binds[0], "test-volume:/vol-mnt:rprivate,nosuid,nodev,rbind")
         finally:
             if ctr is not None:
                 ctr.remove()

--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -931,7 +931,7 @@ EOF
     service_setup $QUADLET_SERVICE_NAME
 
     run_podman container inspect  --format '{{index .HostConfig.Tmpfs "/tmpfs1"}}' $QUADLET_CONTAINER_NAME
-    is "$output" "rw,rprivate,nosuid,nodev,tmpcopyup" "regular tmpfs mount"
+    is "$output" "rprivate,nosuid,nodev,tmpcopyup" "regular tmpfs mount"
 
     run_podman container inspect  --format '{{index .HostConfig.Tmpfs "/tmpfs2"}}' $QUADLET_CONTAINER_NAME
     is "$output" "ro,rprivate,nosuid,nodev,tmpcopyup" "read-only tmpfs mount"


### PR DESCRIPTION
The backstory for this is that runc 1.2 (opencontainers/runc#3967) fixed a long-standing bug in our mount flag handling (a bug that crun still has). Before runc 1.2, when dealing with locked mount flags that user namespaced containers cannot clear, trying to explicitly clearing locked flags (like rw clearing MS_RDONLY) would silently ignore the rw flag in most cases and would result in a read-only mount. This is obviously not what the user expects.

What runc 1.2 did is that it made it so that passing clearing flags like rw would always result in an attempt to clear the flag (which was not the case before), and would (in all cases) explicitly return an error if we try to clear locking flags. (This also let us finally fix a bunch of other long-standing issues with locked mount flags causing seemingly spurious errors).

The problem is that podman sets rw on all mounts by default (even if the user doesn't specify anything). This is actually a no-op in runc 1.1 and crun because of a bug in how clearing flags were handled (rw is the absence of MS_RDONLY but until runc 1.2 we didn't correctly track clearing flags like that, meaning that rw would literally be handled as if it were not set at all by users) but in runc 1.2 leads to unfortunate breakages and a subtle change in behaviour (before, a ro mount being bind-mounted into a container would also be ro -- though due to the above bug even setting rw explicitly would result in ro in most cases -- but with runc 1.2 the mount will always be rw even if the user didn't explicitly request it which most users would find surprising). By the way, this "always set rw" behaviour is a departure from Docker and it is not necesssary.

Fixes: https://issues.redhat.com/browse/RHEL-152635, https://issues.redhat.com/browse/RHEL-152631


(cherry picked from commit bf7dcd5619b9600d7fdf93da16c8d0258e58f896)

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
