### PR TITLE
Fix remote exec ignoring empty --detach-keys string

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -27,10 +28,27 @@ import (
 func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		utils.InternalServerError(w, fmt.Errorf("reading request body: %w", err))
+		return
+	}
+
 	input := new(handlers.ExecCreateConfig)
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+	if err := json.Unmarshal(bodyBytes, &input); err != nil {
 		utils.InternalServerError(w, fmt.Errorf("decoding request body as JSON: %w", err))
 		return
+	}
+
+	// Determine whether DetachKeys was explicitly provided in the JSON body.
+	// We need to distinguish between "not set" (should use default detach keys)
+	// and "set to empty string" (should disable detach keys).
+	// Since the Docker API uses a plain string (not *string), both cases
+	// unmarshal to "", so we check the raw JSON for the field's presence.
+	detachKeysSet := false
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &rawFields); err == nil {
+		_, detachKeysSet = rawFields["DetachKeys"]
 	}
 
 	ctrName := utils.GetName(r)
@@ -46,7 +64,7 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	libpodConfig.AttachStdin = input.AttachStdin
 	libpodConfig.AttachStderr = input.AttachStderr
 	libpodConfig.AttachStdout = input.AttachStdout
-	if input.DetachKeys != "" {
+	if input.DetachKeys != "" || detachKeysSet {
 		libpodConfig.DetachKeys = &input.DetachKeys
 	}
 	libpodConfig.Environment = make(map[string]string)

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -464,10 +464,24 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 		attachHandleResize(ctx, winCtx, winChange, true, sessionID, terminalFile, terminalOutFile)
 	}
 
+	// Parse detach keys for client-side detach detection.
+	// If DetachKeys option is set, use it (empty string disables detaching).
+	// If not set, use empty byte slice (no client-side detach detection,
+	// server handles it).
+	detachKeysInBytes := []byte{}
+	if options.Changed("DetachKeys") {
+		if options.GetDetachKeys() != "" {
+			detachKeysInBytes, err = term.ToBytes(options.GetDetachKeys())
+			if err != nil {
+				return fmt.Errorf("invalid detach keys: %w", err)
+			}
+		}
+	}
+
 	if options.GetAttachInput() {
 		go func() {
 			logrus.Debugf("Copying STDIN to socket")
-			_, err := detach.Copy(socket, options.InputStream, []byte{})
+			_, err := detach.Copy(socket, options.InputStream, detachKeysInBytes)
 			// Ignore "closed network connection" as it occurs when the exec ends, which is expected.
 			// This avoids noisy logs but does not fix the goroutine leak
 			// https://github.com/containers/podman/issues/25344
@@ -488,7 +502,7 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 			return fmt.Errorf("exec session %s has a terminal and must have STDOUT enabled", sessionID)
 		}
 		// If not multiplex'ed, read from server and write to stdout
-		_, err := detach.Copy(options.GetOutputStream(), socket, []byte{})
+		_, err := detach.Copy(options.GetOutputStream(), socket, detachKeysInBytes)
 		if err != nil {
 			return err
 		}

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -313,6 +313,9 @@ type ExecStartAndAttachOptions struct {
 	// AttachInput is whether to attach to STDIN
 	// If false, stdout will not be attached
 	AttachInput *bool
+	// DetachKeys are keys that will be used to detach from the exec
+	// session. Empty string disables detaching.
+	DetachKeys *string
 }
 
 // ExistsOptions are optional options for checking if a container exists

--- a/pkg/bindings/containers/types_execstartandattach_options.go
+++ b/pkg/bindings/containers/types_execstartandattach_options.go
@@ -108,3 +108,18 @@ func (o *ExecStartAndAttachOptions) GetAttachInput() bool {
 	}
 	return *o.AttachInput
 }
+
+// WithDetachKeys set keys to detach from exec session
+func (o *ExecStartAndAttachOptions) WithDetachKeys(value string) *ExecStartAndAttachOptions {
+	o.DetachKeys = &value
+	return o
+}
+
+// GetDetachKeys returns value of keys to detach from exec session
+func (o *ExecStartAndAttachOptions) GetDetachKeys() string {
+	if o.DetachKeys == nil {
+		var z string
+		return z
+	}
+	return *o.DetachKeys
+}

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -644,6 +644,7 @@ func (ic *ContainerEngine) ContainerExec(_ context.Context, nameOrID string, opt
 		startAndAttachOptions.WithInputStream(*streams.InputStream)
 	}
 	startAndAttachOptions.WithAttachError(streams.AttachError).WithAttachOutput(streams.AttachOutput).WithAttachInput(streams.AttachInput)
+	startAndAttachOptions.WithDetachKeys(options.DetachKeys)
 	if err := containers.ExecStartAndAttach(ic.ClientCtx, sessionID, startAndAttachOptions); err != nil {
 		return 125, err
 	}

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -312,4 +312,17 @@ load helpers
 
     run_podman rm -f -t0 $cid
 }
+
+# Regression test for https://github.com/containers/podman/issues/28193
+# bats test_tags=ci:parallel
+@test "podman exec with empty --detach-keys" {
+    # Empty string should disable detaching, not error with "invalid detach keys"
+    run_podman run -d $IMAGE sleep 60
+    cid="$output"
+
+    run_podman exec --detach-keys="" $cid echo "success"
+    is "$output" "success" "empty detach-keys for exec should work"
+
+    run_podman rm -f -t0 $cid
+}
 # vim: filetype=sh


### PR DESCRIPTION
## Summary

Fixes #28193

When using `podman --remote exec --detach-keys ''`, the empty string should disable the detach key sequence (as documented). However, the exec session was still using the default `ctrl-p,ctrl-q` detach keys because:

1. **Server-side**: `ExecCreateHandler` used `input.DetachKeys != ""` to decide whether to set `libpodConfig.DetachKeys`. Since the Docker API's `ExecCreateRequest` uses a plain `string` (not `*string`), both "field absent" and "field set to empty" unmarshal to `""`, making them indistinguishable. The handler treated both as "not set" and left `DetachKeys` as `nil`, causing the server to fall back to the default `ctrl-p,ctrl-q`.

2. **Client-side**: `ExecStartAndAttach` hardcoded `[]byte{}` as the detach keys for `detach.Copy()`, never passing the user's detach key preference for client-side detection.

### Root Cause

In `pkg/api/handlers/compat/exec.go`, the condition:
```go
if input.DetachKeys != "" {
    libpodConfig.DetachKeys = &input.DetachKeys
}
```
fails to set `DetachKeys` when the user explicitly passes an empty string, because Go's zero value for `string` is also `""`.

Per the `ExecConfig.DetachKeys` documentation:
> `nil` will use the default detach keys, where a pointer to the empty string `("")` will disable detaching via detach keys.

### Fix

**Server-side** (`pkg/api/handlers/compat/exec.go`):
- Read the raw JSON body and check whether `DetachKeys` was explicitly present using `map[string]json.RawMessage`
- When the field is present (even if empty), set the `libpodConfig.DetachKeys` pointer

**Client-side** (`pkg/bindings/containers/attach.go`):
- Add `DetachKeys` field to `ExecStartAndAttachOptions`
- Parse and use detach keys in `ExecStartAndAttach` for client-side detection, matching the pattern already used by `Attach()` for `podman run`
- Pass detach keys from the tunnel's `ContainerExec` to `ExecStartAndAttach`

### Before
```
$ podman --remote exec --detach-keys '' -it <container> bash
# Pressing Ctrl-P,Ctrl-Q detaches (should not)
```

### After
```
$ podman --remote exec --detach-keys '' -it <container> bash
# Pressing Ctrl-P,Ctrl-Q does NOT detach (correct: detach keys are disabled)
```

## Test plan
- [x] Added regression test in `test/system/075-exec.bats` that verifies `podman exec --detach-keys=""` works without error
- [ ] Manual testing with `podman --remote exec --detach-keys '' -it <container> bash` to verify Ctrl-P,Ctrl-Q no longer detaches
- [ ] Verify that exec without `--detach-keys` still uses default ctrl-p,ctrl-q
- [ ] Verify that `podman exec --detach-keys='ctrl-a' -it <container> bash` works correctly with custom keys

```release-note
'None'
```

Generated with [Claude Code](https://claude.com/claude-code)