### PR TITLE
[v5.8] fix automatic migration bug

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -305,10 +305,23 @@ func getDBState(runtime *Runtime) (State, error) {
 
 	// get default boltdb path
 	boltDBPath := getBoltDBPath(runtime)
+	sqlitePath := sqliteStatePath(runtime)
 
 	switch backend {
 	case config.DBBackendDefault:
-		// for backwards compatibility check if boltdb exists, if it does not we use sqlite
+		// First check if we have a sqlite file, then we know we must use sqlite.
+		if err := fileutils.Exists(sqlitePath); err == nil {
+			// need to set DBBackend string so podman info will show the backend name correctly
+			runtime.config.Engine.DBBackend = config.DBBackendSQLite.String()
+			return NewSqliteState(runtime)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			// Return error here some other problem with the sqlite file, rather than silently
+			// switch to boltdb which would be hard to debug for the user return the error back
+			// as this likely a real bug.
+			return nil, err
+		}
+
+		// for backwards compatibility check if boltdb exists, if it does not we also use sqlite
 		if err := fileutils.Exists(boltDBPath); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				// need to set DBBackend string so podman info will show the backend name correctly

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -372,6 +372,9 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		return fmt.Errorf("creating runtime volume path directory: %w", err)
 	}
 
+	// Must be set before getDBState() as this will override it otherwise.
+	originalDBConfig := runtime.config.Engine.DBBackend
+
 	// Set up the state.
 	runtime.state, err = getDBState(runtime)
 	if err != nil {
@@ -642,10 +645,20 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		if err2 := runtime.refresh(ctx, runtimeAliveFile); err2 != nil {
 			return err2
 		}
-	} else if os.Getenv("SUPPRESS_BOLTDB_WARNING") == "" && os.Getenv("CI_DESIRED_DATABASE") != "boltdb" && runtime.state.Type() == "boltdb" {
-		// Only warn about the database if we're not refreshing the state.
-		// Refresh will attempt an automatic migration.
-		logrus.Warnf("The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs using the `podman system migrate --migrate-db` command. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message.")
+	} else if runtime.state.Type() == "boltdb" {
+		if originalDBConfig == "" && fileutils.Exists(sqliteStatePath(runtime)) == nil {
+			// Another process must have migrated to sqlite in parallel, boltdb is now invalid so switch the state to sqlite.
+			// Ignore errors as there is nothing we can do about them at this point.
+			_ = runtime.state.Close()
+			runtime.state, err = NewSqliteState(runtime)
+			if err != nil {
+				return fmt.Errorf("failed to load sqlite state after detecting database migration: %w", err)
+			}
+		} else if os.Getenv("SUPPRESS_BOLTDB_WARNING") == "" && os.Getenv("CI_DESIRED_DATABASE") != "boltdb" {
+			// Only warn about the database if we're not refreshing the state.
+			// Refresh will attempt an automatic migration.
+			logrus.Warnf("The deprecated BoltDB database driver is in use. This driver will be removed in the upcoming Podman 6.0 release in mid 2026. It is advised that you migrate to SQLite to avoid issues when this occurs using the `podman system migrate --migrate-db` command. Set SUPPRESS_BOLTDB_WARNING environment variable to remove this message.")
+		}
 	}
 
 	// Check current boot ID - will be written to the alive file.

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -139,8 +139,7 @@ func (r *Runtime) checkCanMigrate() error {
 
 func (r *Runtime) migrateDB() error {
 	// Does the SQLite state already exist?
-	dbBasePath, dbFilename := sqliteStatePath(r)
-	dbPath := filepath.Join(dbBasePath, dbFilename)
+	dbPath := sqliteStatePath(r)
 	if err := fileutils.Exists(dbPath); err == nil {
 		return fmt.Errorf("a SQLite database already exists at %s, refusing to overwrite", dbPath)
 	}

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -45,7 +45,7 @@ const (
 	sqliteOptionCaseSensitiveLike = "&_cslike=TRUE"
 
 	// Assembled sqlite options used when opening the database.
-	sqliteOptions = sqliteDbFilename + "?" +
+	sqliteOptions = "?" +
 		sqliteOptionLocation +
 		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
@@ -58,12 +58,12 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	logrus.Info("Using sqlite as database backend")
 	state := new(SQLiteState)
 
-	basePath, _ := sqliteStatePath(runtime)
+	dbPath := sqliteStatePath(runtime)
 
 	// c/storage is set up *after* the DB - so even though we use the c/s
 	// root (or, for transient, runroot) dir, we need to make the dir
 	// ourselves.
-	if err := os.MkdirAll(basePath, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating root directory: %w", err)
 	}
 
@@ -78,7 +78,7 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	}
 	sqliteOptionBusyTimeout := "&_busy_timeout=" + busyTimeout
 
-	conn, err := sql.Open("sqlite3", filepath.Join(basePath, sqliteOptions+sqliteOptionBusyTimeout))
+	conn, err := sql.Open("sqlite3", dbPath+sqliteOptions+sqliteOptionBusyTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("initializing sqlite database: %w", err)
 	}

--- a/libpod/sqlite_state_internal.go
+++ b/libpod/sqlite_state_internal.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/containers/podman/v5/libpod/define"
@@ -17,16 +18,15 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-// Returns two strings. First is base path - directory we'll create in.
-// Second is the filename of the database itself.
-func sqliteStatePath(runtime *Runtime) (string, string) {
+// sqliteStatePath returns the path to the sqlite file.
+func sqliteStatePath(runtime *Runtime) string {
 	basePath := runtime.storageConfig.GraphRoot
 	if runtime.storageConfig.TransientStore {
 		basePath = runtime.storageConfig.RunRoot
 	} else if !runtime.storageSet.StaticDirSet {
 		basePath = runtime.config.Engine.StaticDir
 	}
-	return basePath, sqliteDbFilename
+	return filepath.Join(basePath, sqliteDbFilename)
 }
 
 func initSQLiteDB(conn *sql.DB) (defErr error) {

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -196,12 +196,9 @@ var _ = Describe("Podman Info", func() {
 			// default should be sqlite
 			{arg: "", want: "sqlite"},
 			{arg: "boltdb", want: "boltdb"},
-			// now because a boltdb exists it should use boltdb when default is requested
-			{arg: "", want: "boltdb"},
+			// now when both boltdb and sqlite exists it should use sqlite when default is requested
+			{arg: "", want: "sqlite"},
 			{arg: "sqlite", want: "sqlite"},
-			// just because we requested sqlite doesn't mean it stays that way.
-			// once a boltdb exists, podman will forevermore stick with it
-			{arg: "", want: "boltdb"},
 		}
 
 		for _, tt := range backends {


### PR DESCRIPTION
Fixes #28216


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
This fixes a critical bug where the auto migration on first command after boot could leave things in a bad state where we have data in sqlite and boltdb at the same time. https://github.com/containers/podman/issues/28216
If you have encountered this on 5.8.0 there is no way to automatically recover. If you do not have persistent containers/pods/volumes (i.e. only using quadlets to mange them) then the easiest option is to delete the db.sql file (or maybe better move it elsewhere to store the config in case you need to recover something there) from our storage and reboot again with v5.8.1 to trigger the migration again. This time it should work correctly.
If you have problems with the migration please contact us and we try to help if possible.
```
