### PR TITLE
Look for rootless quadlets in /usr/share/containers/systemd/users

### DIFF
--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -32,6 +32,8 @@ Quadlet files for non-root users can be placed in the following directories:
  * $XDG_CONFIG_HOME/containers/systemd/ or ~/.config/containers/systemd/
  * /etc/containers/systemd/users/${UID}
  * /etc/containers/systemd/users/
+ * /usr/share/containers/systemd/users/${UID}
+ * /usr/share/containers/systemd/users/
 
 ### Using symbolic links
 
@@ -71,13 +73,15 @@ further down the hierarchy override those further up (`foo-bar-baz.container.d/1
 to alter or add configuration settings for a unit, without having to modify unit files.
 
 For rootless containers, when administrators place Quadlet files in the
-/etc/containers/systemd/users directory, all users' sessions execute the
-Quadlet when the login session begins. If the administrator places a Quadlet
-file in the /etc/containers/systemd/users/${UID}/ directory, then only the
-user with the matching UID executes the Quadlet when the login
-session gets started. For unit files placed in subdirectories within
-/etc/containers/systemd/user/${UID}/ and the other user unit search paths,
-Quadlet will recursively search and run the unit files present in these subdirectories.
+/etc/containers/systemd/users or /usr/share/containers/users directories,
+all users' sessions execute the Quadlet when the login session begins.
+If the administrator places a Quadlet file in the
+/etc/containers/systemd/users/${UID}/ or /usr/share/containers/users/${UID}
+directory, then only the user with the matching UID executes the Quadlet
+when the login session gets started. For unit files placed in subdirectories within
+/etc/containers/systemd/user/${UID}/, /usr/share/containers/users/${UID} and
+the other user unit search paths, Quadlet will recursively search and run the
+unit files present in these subdirectories.
 
 Note that Quadlet units do not support running as a non-root user by defining the
 [User, Group](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#User=),

--- a/pkg/systemd/quadlet/unitdirs.go
+++ b/pkg/systemd/quadlet/unitdirs.go
@@ -38,7 +38,7 @@ func GetInstallUnitDirPath(rootless bool) string {
 // This returns the directories where we read quadlet .container and .volumes from
 // For system generators these are in /usr/share/containers/systemd (for distro files)
 // and /etc/containers/systemd (for sysadmin files).
-// For user generators these can live in $XDG_RUNTIME_DIR/containers/systemd, /etc/containers/systemd/users, /etc/containers/systemd/users/$UID, and $XDG_CONFIG_HOME/containers/systemd
+// For user generators these can live in $XDG_RUNTIME_DIR/containers/systemd, /etc/containers/systemd/users, /etc/containers/systemd/users/$UID, /usr/share/containers/systemd/users/${UID}, /usr/share/containers/systemd/users/ and $XDG_CONFIG_HOME/containers/systemd
 func GetUnitDirs(rootless bool) []string {
 	paths := NewSearchPaths()
 
@@ -229,19 +229,24 @@ func getRootlessDirs(paths *searchPaths, nonNumericFilter, userLevelFilter func(
 	}
 	AppendSubPaths(paths, path.Join(configDir, "containers/systemd"), false, nil)
 
+	basePaths := []string{UnitDirAdmin, UnitDirDistro}
 	u, err := user.Current()
 	if err == nil {
-		AppendSubPaths(paths, filepath.Join(UnitDirAdmin, "users"), true, nonNumericFilter)
-		AppendSubPaths(paths, filepath.Join(UnitDirAdmin, "users", u.Uid), true, userLevelFilter)
+		for _, basePath := range basePaths {
+			AppendSubPaths(paths, filepath.Join(basePath, "users"), true, nonNumericFilter)
+			AppendSubPaths(paths, filepath.Join(basePath, "users", u.Uid), true, userLevelFilter)
+		}
 	} else {
 		logiface.Errorf("Warning: %v", err)
-		// Add the base directory even if the UID was not found
-		paths.Add(filepath.Join(UnitDirAdmin, "users"))
+		// Add the base directories even if the UID was not found
+		for _, basePath := range basePaths {
+			paths.Add(filepath.Join(basePath, "users"))
+		}
 	}
 }
 
 func getRootDirs(paths *searchPaths, userLevelFilter func(string, bool) bool) {
 	AppendSubPaths(paths, UnitDirTemp, false, userLevelFilter)
 	AppendSubPaths(paths, UnitDirAdmin, false, userLevelFilter)
-	AppendSubPaths(paths, UnitDirDistro, false, nil)
+	AppendSubPaths(paths, UnitDirDistro, false, userLevelFilter)
 }

--- a/pkg/systemd/quadlet/unitdirs_test.go
+++ b/pkg/systemd/quadlet/unitdirs_test.go
@@ -49,6 +49,8 @@ func TestUnitDirs(t *testing.T) {
 		AppendSubPaths(rootlessPaths, path.Join(configDir, "containers/systemd"), false, nil)
 		AppendSubPaths(rootlessPaths, filepath.Join(UnitDirAdmin, "users"), true, nonNumericFilter)
 		AppendSubPaths(rootlessPaths, filepath.Join(UnitDirAdmin, "users", u.Uid), true, userLevelFilter)
+		AppendSubPaths(rootlessPaths, filepath.Join(UnitDirDistro, "users"), true, nonNumericFilter)
+		AppendSubPaths(rootlessPaths, filepath.Join(UnitDirDistro, "users", u.Uid), true, userLevelFilter)
 
 		unitDirs = GetUnitDirs(true)
 		assert.Equal(t, rootlessPaths.GetSortedPaths(), unitDirs, "rootless unit dirs should match")
@@ -180,10 +182,12 @@ func TestUnitDirs(t *testing.T) {
 		err = syscall.Chroot(symLinkTestBaseDir)
 		assert.NoError(t, err)
 
-		err = os.MkdirAll(UnitDirAdmin, 0o755)
-		assert.NoError(t, err)
-		err = os.RemoveAll(UnitDirAdmin)
-		assert.NoError(t, err)
+		for _, v := range []string{UnitDirAdmin, UnitDirDistro} {
+			err = os.MkdirAll(v, 0o755)
+			assert.NoError(t, err)
+			err = os.RemoveAll(v)
+			assert.NoError(t, err)
+		}
 
 		createDir := func(path, name string) string {
 			dirName := filepath.Join(path, name)
@@ -207,17 +211,31 @@ func TestUnitDirs(t *testing.T) {
 		uidDir2 := createDir(userDir, strconv.Itoa(uidInt+1))
 		userInternalDir := createDir(userDir, "internal")
 
+		distroSystemdDir := createDir("/", "systemd2")
+		distroUserDir := createDir("/", "users2")
+		linkDir(distroSystemdDir, "users", distroUserDir)
+		linkDir(UnitDirDistro, "", distroSystemdDir)
+
+		distroUidDir := createDir(distroUserDir, u.Uid)
+		distroUidDir2 := createDir(distroUserDir, strconv.Itoa(uidInt+1))
+		distroInternalDir := createDir(distroUserDir, "internal")
+
 		// Make sure QUADLET_UNIT_DIRS is not set
 		t.Setenv("QUADLET_UNIT_DIRS", "")
 		// Test Rootful
 		unitDirs := GetUnitDirs(false)
 		assert.NotContains(t, unitDirs, userDir, "rootful should not contain rootless")
 		assert.NotContains(t, unitDirs, userInternalDir, "rootful should not contain rootless")
+		assert.NotContains(t, unitDirs, distroUserDir, "rootful should not contain distro rootless")
+		assert.NotContains(t, unitDirs, distroInternalDir, "rootful should not contain distro rootless")
 
 		// Test Rootless
 		unitDirs = GetUnitDirs(true)
 		assert.NotContains(t, unitDirs, uidDir2, "rootless should not contain other users'")
 		assert.Contains(t, unitDirs, userInternalDir, "rootless should contain sub-directories of users dir")
 		assert.Contains(t, unitDirs, uidDir, "rootless should contain the directory for its UID")
+		assert.NotContains(t, unitDirs, distroUidDir2, "rootless should not contain other distro users' dirs")
+		assert.Contains(t, unitDirs, distroInternalDir, "rootless should contain sub-directories of distro users dir")
+		assert.Contains(t, unitDirs, distroUidDir, "rootless should contain the distro directory for its UID")
 	}
 }


### PR DESCRIPTION
This is a useful place for packagers to put quadlets which they want to make available for all users.

Fixes: #27843

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The /usr/share/containers/systemd/users and /usr/share/containers/systemd/users/${UID} directories are now checked for quadlets. This should be useful for packagers and distributions who want to add quadlets for users. 
```
