### PR TITLE
`podman volume prune`: match Docker defaults, add `--all` flag

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1920,15 +1920,30 @@ func AutocompleteVolumeFilters(cmd *cobra.Command, _ []string, toComplete string
 	}
 	getImg := func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) }
 	kv := keyValueCompletion{
-		"after=":    getImg,
-		"dangling=": getBoolCompletion,
-		"driver=":   local,
-		"label=":    nil,
-		"name=":     func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
-		"opt=":      nil,
-		"scope=":    local,
-		"since=":    getImg,
-		"until=":    nil,
+		"after=":     getImg,
+		"anonymous=": getBoolCompletion,
+		"dangling=":  getBoolCompletion,
+		"driver=":    local,
+		"label=":     nil,
+		"name=":      func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
+		"opt=":       nil,
+		"scope=":     local,
+		"since=":     getImg,
+		"until=":     nil,
+	}
+	return completeKeyValues(toComplete, kv)
+}
+
+// AutocompleteVolumePruneFilters - Autocomplete volume prune --filter options.
+func AutocompleteVolumePruneFilters(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	getImg := func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) }
+	kv := keyValueCompletion{
+		"after=":     getImg,
+		"all=":       getBoolCompletion,
+		"anonymous=": getBoolCompletion,
+		"label=":     nil,
+		"since=":     getImg,
+		"until=":     nil,
 	}
 	return completeKeyValues(toComplete, kv)
 }

--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -18,14 +18,13 @@ import (
 )
 
 var (
-	volumePruneDescription = `Volumes that are not currently owned by a container will be removed.
-
-  The command prompts for confirmation which can be overridden with the --force flag.
-  Note all data will be destroyed.`
+	volumePruneDescription = `By default, only anonymous (unnamed) unused volumes are removed.
+  Use --all to remove all unused volumes (anonymous and named).
+  The command prompts for confirmation which can be overridden with the --force flag.`
 	pruneCommand = &cobra.Command{
 		Use:               "prune [options]",
 		Args:              validate.NoArgs,
-		Short:             "Remove all unused volumes",
+		Short:             "Remove unused volumes",
 		Long:              volumePruneDescription,
 		RunE:              prune,
 		ValidArgsFunction: completion.AutocompleteNone,
@@ -42,8 +41,9 @@ func init() {
 
 	filterFlagName := "filter"
 	flags.StringArrayVar(&filter, filterFlagName, []string{}, "Provide filter values (e.g. 'label=<key>=<value>')")
-	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteVolumeFilters)
+	_ = pruneCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteVolumePruneFilters)
 	flags.BoolP("force", "f", false, "Do not prompt for confirmation")
+	flags.BoolP("all", "a", false, "Remove all unused volumes, both anonymous and named")
 }
 
 func prune(cmd *cobra.Command, _ []string) error {
@@ -61,28 +61,55 @@ func prune(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	// --all adds filter all=true (Docker-compatible; behavior is filter-only)
+	allFlag, _ := cmd.Flags().GetBool("all")
+	if allFlag {
+		pruneOptions.Filters.Set("all", "true")
+	}
+
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Println("WARNING! This will remove all volumes not used by at least one container. The following volumes will be removed:")
+		if allFlag {
+			fmt.Println("WARNING! This will remove all volumes not used by at least one container. The following volumes will be removed:")
+		} else {
+			fmt.Println("WARNING! This will remove anonymous local volumes not used by at least one container. The following volumes will be removed:")
+		}
 		listOptions.Filter, err = parse.FilterArgumentsIntoFilters(filter)
 		if err != nil {
 			return err
 		}
-		// filter all the dangling volumes
-		unusedOptions.Filter = make(map[string][]string, 1)
-		unusedOptions.Filter["dangling"] = []string{"true"}
-		unusedVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), unusedOptions)
-		if err != nil {
-			return err
-		}
-		// filter volumes based on user input
 		filteredVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), listOptions)
 		if err != nil {
 			return err
 		}
-		finalVolumes := getIntersection(unusedVolumes, filteredVolumes)
+		var finalVolumes []*entities.VolumeListReport
+		if allFlag {
+			unusedOptions.Filter = map[string][]string{"dangling": {"true"}}
+			unusedVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), unusedOptions)
+			if err != nil {
+				return err
+			}
+			finalVolumes = getIntersection(unusedVolumes, filteredVolumes)
+		} else {
+			danglingOptions := entities.VolumeListOptions{Filter: map[string][]string{"dangling": {"true"}}}
+			anonymousOptions := entities.VolumeListOptions{Filter: map[string][]string{"anonymous": {"true"}}}
+			danglingVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), danglingOptions)
+			if err != nil {
+				return err
+			}
+			anonymousVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), anonymousOptions)
+			if err != nil {
+				return err
+			}
+			finalVolumes = getIntersection(getIntersection(danglingVolumes, anonymousVolumes), filteredVolumes)
+		}
 		if len(finalVolumes) < 1 {
-			fmt.Println("No dangling volumes found")
+			if allFlag {
+				fmt.Println("No dangling volumes found")
+			} else {
+				fmt.Println("No dangling anonymous volumes found")
+			}
 			return nil
 		}
 		for _, fv := range finalVolumes {

--- a/docs/source/markdown/options/filter.volume-ls.md
+++ b/docs/source/markdown/options/filter.volume-ls.md
@@ -13,9 +13,11 @@ Volumes can be filtered by the following attributes:
 
 | **Filter**  | **Description**                                                                       |
 | ----------  | ------------------------------------------------------------------------------------- |
+| anonymous   | [Bool] Matches anonymous volumes (true) or named volumes (false)                      |
 | dangling    | [Dangling] Matches all volumes not referenced by any containers                       |
 | driver      | [Driver] Matches volumes based on their driver                                        |
 | label       | [Key] or [Key=Value] Label assigned to a volume                                       |
+| label!      | [Key] or [Key=Value] Volumes without the specified label                              |
 | name        | [Name] Volume name (accepts regex)                                                    |
 | opt         | Matches a storage driver options                                                      |
 | scope       | Filters volume by scope                                                               |

--- a/docs/source/markdown/options/filter.volume-prune.md
+++ b/docs/source/markdown/options/filter.volume-prune.md
@@ -8,12 +8,10 @@ Supported filters:
 
 | Filter      | Description                                                                                                |
 |:-----------:|------------------------------------------------------------------------------------------------------------|
-| dangling    | [Bool] Only remove volumes not referenced by any containers                                                |
-| driver      | [String] Only remove volumes with the given driver                                                         |
+| all         | [Bool] When true, remove all unused volumes (same as **--all**). When false or unset, only anonymous volumes are considered. |
+| anonymous   | [Bool] Only remove volumes that are anonymous (true) or named (false).                                     |
 | label       | [String] Only remove volumes, with (or without, in the case of label!=[...] is used) the specified labels. |
-| name        | [String] Only remove volume with the given name                                                            |
-| opt         | [String] Only remove volumes created with the given options                                                |
-| scope       | [String] Only remove volumes with the given scope                                                          |
+| label!      | [String] Only remove volumes without the specified labels.                                                  |
 | until       | [DateTime] Only remove volumes created before given timestamp.                                             |
 | after/since | [Volume] Filter by volumes created after the given VOLUME (name or tag)                                    |
 

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -1,19 +1,25 @@
 % podman-volume-prune 1
 
 ## NAME
-podman\-volume\-prune - Remove all unused volumes
+podman\-volume\-prune - Remove unused volumes
 
 ## SYNOPSIS
 **podman volume prune** [*options*]
 
 ## DESCRIPTION
 
-Removes unused volumes. By default all unused volumes are removed, the **--filter** flag can
-be used to filter specific volumes. Users are prompted to confirm the removal of all the
-unused volumes. To bypass the confirmation, use the **--force** flag.
+Remove unused volumes. By default only **anonymous** (unnamed) unused volumes are removed.
+Anonymous volumes are those created with a container (e.g. **podman run -v /path** without a volume name).
+Use **--all** (or **-a**) to remove all unused volumes, including named ones.
 
+The **--filter** flag can be used to restrict which volumes are considered. Users are prompted to confirm
+removal unless **--force** is used.
 
 ## OPTIONS
+
+#### **--all**, **-a**
+
+Remove all unused volumes (anonymous and named). Without this option, only anonymous unused volumes are removed.
 
 #### **--filter**
 
@@ -25,18 +31,16 @@ Supported filters:
 
 | Filter      | Description                                                                                                |
 |:-----------:|------------------------------------------------------------------------------------------------------------|
-| dangling    | [Bool] Only remove volumes not referenced by any containers                                                |
-| driver      | [String] Only remove volumes with the given driver                                                         |
+| all         | [Bool] When true, remove all unused volumes (same as **--all**). When false or unset, only anonymous volumes are considered. |
+| anonymous   | [Bool] Only remove volumes that are anonymous (true) or named (false).                                     |
 | label       | [String] Only remove volumes, with (or without, in the case of label!=[...] is used) the specified labels. |
-| name        | [String] Only remove volume with the given name                                                            |
-| opt         | [String] Only remove volumes created with the given options                                                |
-| scope       | [String] Only remove volumes with the given scope                                                          |
+| label!      | [String] Only remove volumes without the specified labels.                                                 |
 | until       | [DateTime] Only remove volumes created before given timestamp.                                             |
 | after/since | [Volume] Filter by volumes created after the given VOLUME (name or tag)                                    |
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes volumes with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes volumes without the specified labels.
 
-The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the machine’s time.
+The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the machine's time.
 
 #### **--force**, **-f**
 
@@ -49,20 +53,44 @@ Print usage statement
 
 ## EXAMPLES
 
-
-Prune all unused volumes.
+Prune only anonymous unused volumes (default).
 ```
 $ podman volume prune
 ```
 
-Prune all volumes. Note: this command will also remove all containers that are using a volume.
+Prune only anonymous unused volumes without confirmation.
 ```
 $ podman volume prune --force
 ```
 
-Prune all volumes that contain the specified label.
+Prune all unused volumes (anonymous and named).
+```
+$ podman volume prune --all --force
+```
+
+Prune all unused volumes using the filter (equivalent to **--all**).
+```
+$ podman volume prune --filter all=true --force
+```
+
+Prune unused volumes that have the specified label.
 ```
 $ podman volume prune --filter label=mylabel=mylabelvalue
+```
+
+Prune unused volumes that do NOT have a specific label key/value:
+```
+$ podman volume prune --filter label!=mylabel=mylabelvalue
+```
+
+Prune unused volumes that have a specific label key (regardless of value):
+```
+$ podman volume prune --filter label=environment
+```
+
+Prune unused volumes that do NOT have a specific label key:
+```
+$ podman volume prune --filter label!=environment
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-volume.1.md
+++ b/docs/source/markdown/podman-volume.1.md
@@ -20,7 +20,7 @@ podman volume is a set of subcommands that manage volumes.
 | inspect | [podman-volume-inspect(1)](podman-volume-inspect.1.md) | Get detailed information on one or more volumes.                               |
 | ls      | [podman-volume-ls(1)](podman-volume-ls.1.md)           | List all the available volumes.                                                |
 | mount   | [podman-volume-mount(1)](podman-volume-mount.1.md)     | Mount a volume filesystem.                                                     |
-| prune   | [podman-volume-prune(1)](podman-volume-prune.1.md)     | Remove all unused volumes.                                                     |
+| prune   | [podman-volume-prune(1)](podman-volume-prune.1.md)     | Remove unused volumes.                                                         |
 | reload  | [podman-volume-reload(1)](podman-volume-reload.1.md)   | Reload all volumes from volumes plugins.                                       |
 | rm      | [podman-volume-rm(1)](podman-volume-rm.1.md)           | Remove one or more volumes.                                                    |
 | unmount | [podman-volume-unmount(1)](podman-volume-unmount.1.md) | Unmount a volume.                                                     |

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1729,10 +1729,10 @@ func WithVolumeDisableQuota() VolumeCreateOption {
 	}
 }
 
-// withSetAnon sets a bool notifying libpod that this volume is anonymous and
+// WithVolumeAnonymous sets a bool notifying libpod that this volume is anonymous and
 // should be removed when containers using it are removed and volumes are
 // specified for removal.
-func withSetAnon() VolumeCreateOption {
+func WithVolumeAnonymous() VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
 			return define.ErrVolumeFinalized

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -530,7 +530,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			WithVolumeMountLabel(ctr.MountLabel()),
 		}
 		if isAnonymous {
-			volOptions = append(volOptions, withSetAnon())
+			volOptions = append(volOptions, WithVolumeAnonymous())
 		}
 
 		// If volume-opts are set, parse and add driver opts.

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -285,7 +285,7 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	f := (url.Values)(*filterMap)
+	f := util.NormalizeVolumePruneFilters(url.Values(*filterMap))
 	filterFuncs := []libpod.VolumeFilter{}
 	for filter, filterValues := range f {
 		filterFunc, err := filters.GeneratePruneVolumeFilters(filter, filterValues, runtime)

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -149,6 +149,8 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 
 	if len(input.Name) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeName(input.Name))
+	} else {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeAnonymous())
 	}
 	if len(input.Driver) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeDriver(input.Driver))

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -150,7 +150,7 @@ func pruneVolumesHelper(r *http.Request) ([]*reports.PruneReport, error) {
 		return nil, err
 	}
 
-	f := (url.Values)(*filterMap)
+	f := util.NormalizeVolumePruneFilters(url.Values(*filterMap))
 	filterFuncs := []libpod.VolumeFilter{}
 	for filter, filterValues := range f {
 		filterFunc, err := filters.GeneratePruneVolumeFilters(filter, filterValues, runtime)

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -47,6 +47,8 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 
 	if len(input.Name) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeName(input.Name))
+	} else {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeAnonymous())
 	}
 	if len(input.Driver) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeDriver(input.Driver))

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -91,6 +91,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    description: |
 	//      JSON encoded value of filters (a map[string][]string) to match volumes against before pruning.
 	//      Available filters:
+	//        - `all` When true, prune all unused volumes; when false or unset, only anonymous unused volumes.
+	//        - `anonymous` When true/false, restrict to anonymous or named volumes only.
 	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
 	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
 	// responses:
@@ -333,8 +335,9 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//      JSON encoded value of filters (a map[string][]string) to match volumes against before pruning.
+	//      JSON encoded value of filters (a map[string][]string). Docker API 1.42+ - by default only anonymous (unnamed) unused volumes are pruned; use filter all=true to prune all unused volumes.
 	//      Available filters:
+	//        - `all` When true, prune all unused volumes (anonymous and named). When false or unset, only anonymous unused volumes are pruned.
 	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
 	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
 	// responses:

--- a/pkg/bindings/test/volumes_test.go
+++ b/pkg/bindings/test/volumes_test.go
@@ -140,6 +140,9 @@ var _ = Describe("Podman volumes", func() {
 	})
 
 	It("prune unused volume", func() {
+		allVolumesOptions := volumes.PruneOptions{
+			Filters: map[string][]string{"all": {"true"}},
+		}
 		// Pruning when no volumes present should be ok
 		_, err := volumes.Prune(connText, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -147,7 +150,7 @@ var _ = Describe("Podman volumes", func() {
 		// Removing an unused volume should work
 		_, err = volumes.Create(connText, entities.VolumeCreateOptions{}, nil)
 		Expect(err).ToNot(HaveOccurred())
-		vols, err := volumes.Prune(connText, nil)
+		vols, err := volumes.Prune(connText, &allVolumesOptions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vols).To(HaveLen(1))
 
@@ -157,7 +160,7 @@ var _ = Describe("Podman volumes", func() {
 		Expect(err).ToNot(HaveOccurred())
 		session := bt.runPodman([]string{"run", "-dt", "-v", fmt.Sprintf("%s:/homer", "homer"), "--name", "vtest", alpine.name, "top"})
 		session.Wait(45)
-		vols, err = volumes.Prune(connText, nil)
+		vols, err = volumes.Prune(connText, &allVolumesOptions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(reports.PruneReportsIds(vols)).To(HaveLen(1))
 		_, err = volumes.Inspect(connText, "homer", nil)
@@ -199,5 +202,28 @@ var _ = Describe("Podman volumes", func() {
 		vols, err = volumes.Prune(connText, options)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vols).To(HaveLen(2))
+
+		// Pruning volumes without filters should remove all anonymous unused volumes
+		namedVolume := "named-keep"
+		ctrName := "anon-prune-test-ctr"
+
+		session = bt.runPodman([]string{"create", "--name", ctrName, "-v", "/anon", alpine.name, "top"})
+		session.Wait(45)
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = bt.runPodman([]string{"rm", ctrName})
+		session.Wait(45)
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = bt.runPodman([]string{"create", "-v", "/anon2", alpine.name, "top"})
+		session.Wait(45)
+		Expect(session.ExitCode()).To(BeZero())
+
+		_, err = volumes.Create(connText, entities.VolumeCreateOptions{Name: namedVolume}, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		pruned, err := volumes.Prune(connText, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pruned).To(HaveLen(1))
 	})
 })

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -23,8 +23,10 @@ type VolumeRmReport = types.VolumeRmReport
 
 type VolumeInspectReport = types.VolumeInspectReport
 
-// VolumePruneOptions describes the options needed
-// to prune a volume from the CLI
+// VolumePruneOptions describes the options needed to prune volumes.
+// Behavior is determined only by filters (Docker API 1.42+):
+// - when filter "all" is not set or not truthy, only anonymous unused volumes are pruned (default);
+// - when filter "all" is true, all unused volumes are pruned.
 type VolumePruneOptions struct {
 	Filters url.Values `json:"filters" schema:"filters"`
 }

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -83,6 +83,8 @@ func GenerateVolumeFilters(filter string, filterValues []string, runtime *libpod
 			}
 			return false
 		}, nil
+	case "anonymous":
+		return createAnonymousFilterVolumeFunction(filterValues)
 	}
 	return nil, fmt.Errorf("%q is an invalid volume filter", filter)
 }
@@ -91,6 +93,8 @@ func GeneratePruneVolumeFilters(filter string, filterValues []string, runtime *l
 	switch filter {
 	case "after", "since":
 		return createAfterFilterVolumeFunction(filterValues, runtime)
+	case "anonymous":
+		return createAnonymousFilterVolumeFunction(filterValues)
 	case "label":
 		return func(v *libpod.Volume) bool {
 			return filters.MatchLabelFilters(filterValues, v.Labels())
@@ -103,6 +107,29 @@ func GeneratePruneVolumeFilters(filter string, filterValues []string, runtime *l
 		return createUntilFilterVolumeFunction(filterValues)
 	}
 	return nil, fmt.Errorf("%q is an invalid volume filter", filter)
+}
+
+func createAnonymousFilterVolumeFunction(filterValues []string) (libpod.VolumeFilter, error) {
+	for _, val := range filterValues {
+		switch strings.ToLower(val) {
+		case "true", "1", "false", "0":
+		default:
+			return nil, fmt.Errorf("%q is not a valid value for the \"anonymous\" filter - must be true or false", val)
+		}
+	}
+	return func(v *libpod.Volume) bool {
+		for _, val := range filterValues {
+			anon := v.Anonymous()
+			invert := strings.ToLower(val) == "false" || val == "0"
+			if invert {
+				anon = !anon
+			}
+			if anon {
+				return true
+			}
+		}
+		return false
+	}, nil
 }
 
 func createUntilFilterVolumeFunction(filterValues []string) (libpod.VolumeFilter, error) {

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -161,6 +161,10 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 			volumePruneOptions := entities.VolumePruneOptions{}
 			volumePruneOptions.Filters = (url.Values)(options.Filters)
 
+			if len(volumePruneOptions.Filters) == 0 {
+				volumePruneOptions.Filters.Set("all", "true")
+			}
+
 			volumePruneReports, err := ic.VolumePrune(ctx, volumePruneOptions)
 			if err != nil {
 				return nil, err

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/podman/v6/pkg/domain/entities/reports"
 	"github.com/containers/podman/v6/pkg/domain/filters"
 	"github.com/containers/podman/v6/pkg/domain/infra/abi/parse"
+	"github.com/containers/podman/v6/pkg/util"
 )
 
 func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
@@ -134,7 +135,7 @@ func (ic *ContainerEngine) VolumeInspect(_ context.Context, namesOrIds []string,
 
 func (ic *ContainerEngine) VolumePrune(ctx context.Context, options entities.VolumePruneOptions) ([]*reports.PruneReport, error) {
 	funcs := []libpod.VolumeFilter{}
-	for filter, filterValues := range options.Filters {
+	for filter, filterValues := range util.NormalizeVolumePruneFilters(options.Filters) {
 		filterFunc, err := filters.GenerateVolumeFilters(filter, filterValues, ic.Libpod)
 		if err != nil {
 			return nil, err

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -21,6 +21,8 @@ func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.Volum
 	var volumeOptions []libpod.VolumeCreateOption
 	if len(opts.Name) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeName(opts.Name))
+	} else {
+		volumeOptions = append(volumeOptions, libpod.WithVolumeAnonymous())
 	}
 	if len(opts.Driver) > 0 {
 		volumeOptions = append(volumeOptions, libpod.WithVolumeDriver(opts.Driver))

--- a/pkg/util/filters.go
+++ b/pkg/util/filters.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -54,6 +55,29 @@ func FiltersFromRequest(r *http.Request) ([]string, error) {
 	}
 
 	return libpodFilters, nil
+}
+
+// NormalizeVolumePruneFilters mutates f in place (non-empty maps); if f is empty/nil it
+// returns a new map—always use the return value. If "all" is true/1, all keys are removed;
+// else "all" is deleted and anonymous=true is set only when no other keys remain.
+func NormalizeVolumePruneFilters(f url.Values) url.Values {
+	if len(f) == 0 {
+		f = make(url.Values)
+	}
+	allValue := f.Get("all")
+	if strings.EqualFold(allValue, "true") || allValue == "1" {
+		for key := range f {
+			f.Del(key)
+		}
+		return f
+	}
+	f.Del("all")
+
+	if len(f) > 0 {
+		return f
+	}
+	f.Set("anonymous", "true")
+	return f
 }
 
 // PrepareFilters prepares a *map[string][]string of filters to be later searched

--- a/pkg/util/filters_test.go
+++ b/pkg/util/filters_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net/url"
 	"testing"
 
 	"go.podman.io/common/pkg/filters"
@@ -77,4 +78,47 @@ func TestMatchLabelFilters(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalizeVolumePruneFilters(t *testing.T) {
+	t.Parallel()
+	t.Run("empty means anonymous true", func(t *testing.T) {
+		t.Parallel()
+		got := NormalizeVolumePruneFilters(url.Values{})
+		if got.Get("anonymous") != "true" {
+			t.Fatalf("expected anonymous=true, got %q", got.Get("anonymous"))
+		}
+	})
+	t.Run("all true drops all and no anonymous", func(t *testing.T) {
+		t.Parallel()
+		got := NormalizeVolumePruneFilters(url.Values{"all": {"true"}})
+		if got.Has("all") || got.Has("anonymous") {
+			t.Fatalf("got %#v, want no all/anonymous keys", got)
+		}
+	})
+	t.Run("label without anonymous key does not inject anonymous", func(t *testing.T) {
+		t.Parallel()
+		in := url.Values{"label": {"k=v"}}
+		got := NormalizeVolumePruneFilters(in)
+		if got.Has("anonymous") {
+			t.Fatal("must not inject anonymous alongside label (OR would ignore label for anonymous volumes)")
+		}
+		if got.Get("label") != "k=v" {
+			t.Fatalf("label got %q", got.Get("label"))
+		}
+	})
+	t.Run("explicit anonymous skips injection branch", func(t *testing.T) {
+		t.Parallel()
+		got := NormalizeVolumePruneFilters(url.Values{"anonymous": {"false"}})
+		if got.Get("anonymous") != "false" {
+			t.Fatalf("got %q", got.Get("anonymous"))
+		}
+	})
+	t.Run("until does not inject anonymous", func(t *testing.T) {
+		t.Parallel()
+		got := NormalizeVolumePruneFilters(url.Values{"until": {"1h"}})
+		if got.Has("anonymous") {
+			t.Fatal("must not inject anonymous alongside until")
+		}
+	})
 }

--- a/test/apiv2/python/rest_api/test_v2_0_0_volume.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_volume.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import unittest
@@ -55,9 +56,9 @@ class VolumeTestCase(APITestCase):
         rm = requests.delete(self.podman_url + f"/v1.40/volumes/{name}")
         self.assertEqual(rm.status_code, 204, rm.text)
 
-        # recreate volume with data and then prune it
+        # Recreate volume with data and verify default prune behavior.
         r = requests.post(self.podman_url + "/v1.40/volumes/create", json={"Name": name})
-        self.assertEqual(create.status_code, 201, create.text)
+        self.assertEqual(r.status_code, 201, r.text)
 
         create = r.json()
         with open(os.path.join(create["Mountpoint"], "test_prune"), "w") as file:
@@ -67,8 +68,19 @@ class VolumeTestCase(APITestCase):
         self.assertEqual(prune.status_code, 200, prune.text)
 
         payload = prune.json()
-        self.assertIn(name, payload["VolumesDeleted"])
-        self.assertGreater(payload["SpaceReclaimed"], 0)
+        self.assertNotIn(name, payload["VolumesDeleted"])
+
+        # Current Docker/Podman behavior: named volumes are pruned when
+        # the all=true filter is set.
+        prune_all = requests.post(
+            self.podman_url + "/v1.40/volumes/prune",
+            params={"filters": json.dumps({"all": {"true": True}})},
+        )
+        self.assertEqual(prune_all.status_code, 200, prune_all.text)
+
+        payload_all = prune_all.json()
+        self.assertIn(name, payload_all["VolumesDeleted"])
+        self.assertGreater(payload_all["SpaceReclaimed"], 0)
 
     def test_volume_label(self):
         name = f"Volume_{random.getrandbits(160):x}"

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Podman volume prune", func() {
 		podmanTest.CleanupVolume()
 	})
 
-	It("podman prune volume", func() {
+	It("podman prune volume -a removes all unused volumes", func() {
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
@@ -31,7 +31,7 @@ var _ = Describe("Podman volume prune", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "--force"})
+		session = podmanTest.Podman([]string{"volume", "prune", "-a", "--force"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -39,6 +39,30 @@ var _ = Describe("Podman volume prune", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
+	})
+
+	It("podman volume prune", func() {
+		session := podmanTest.PodmanExitCleanly("create", "-v", "/anon", ALPINE, "top")
+		podmanTest.PodmanExitCleanly("rm", session.OutputToString())
+
+		podmanTest.PodmanExitCleanly("volume", "create", "named_vol")
+
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		Expect(session.OutputToStringArray()).To(HaveLen(3))
+
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force")
+
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+		Expect(session.OutputToString()).To(ContainSubstring("named_vol"))
+	})
+
+	It("podman volume prune --filter all=true removes all unused volumes", func() {
+		podmanTest.PodmanExitCleanly("volume", "create", "prune_filter_all_test")
+		podmanTest.PodmanExitCleanly("volume", "prune", "--filter", "all=true", "--force")
+
+		session := podmanTest.PodmanExitCleanly("volume", "ls")
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
 	})
 
 	It("podman prune volume --filter until", func() {

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	. "github.com/containers/podman/v6/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -14,30 +13,16 @@ var _ = Describe("Podman volume prune", func() {
 	})
 
 	It("podman prune volume -a removes all unused volumes", func() {
-		session := podmanTest.Podman([]string{"volume", "create"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "create")
+		podmanTest.PodmanExitCleanly("volume", "create")
+		podmanTest.PodmanExitCleanly("create", "-v", "myvol:/myvol", ALPINE, "ls")
 
-		session = podmanTest.Podman([]string{"volume", "create"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "-a", "--force"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "-a", "--force")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 	})
 
@@ -66,126 +51,64 @@ var _ = Describe("Podman volume prune", func() {
 	})
 
 	It("podman prune volume --filter until", func() {
-		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "label1=value1", "myvol1")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=50"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "until=50")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(2))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=5000000000"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "until=5000000000")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 	})
 
 	It("podman prune volume --filter", func() {
-		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "label1=value1", "myvol1")
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "sharedlabel1=slv1", "myvol2")
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "sharedlabel1=slv2", "myvol3")
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "sharedlabel1", "myvol4")
+		podmanTest.PodmanExitCleanly("create", "-v", "myvol5:/myvol5", ALPINE, "ls")
+		podmanTest.PodmanExitCleanly("create", "-v", "myvol6:/myvol6", ALPINE, "ls")
 
-		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv1", "myvol2"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv2", "myvol3"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1", "myvol4"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"create", "-v", "myvol5:/myvol5", ALPINE, "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"create", "-v", "myvol6:/myvol6", ALPINE, "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(7))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=label1=value1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label=label1=value1")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(6))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1=slv1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label=sharedlabel1=slv1")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(5))
 
-		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label=sharedlabel1")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(3))
 
-		session = podmanTest.Podman([]string{"volume", "create", "--label", "testlabel", "myvol7"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label!=testlabel"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "testlabel", "myvol7")
+		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label!=testlabel")
 	})
 
 	It("podman system prune --volume", func() {
 		useCustomNetworkDir(podmanTest, tempdir)
-		session := podmanTest.Podman([]string{"volume", "create"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "create")
+		podmanTest.PodmanExitCleanly("volume", "create")
+		podmanTest.PodmanExitCleanly("create", "-v", "myvol:/myvol", ALPINE, "ls")
 
-		session = podmanTest.Podman([]string{"volume", "create"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(4))
 
-		session = podmanTest.Podman([]string{"system", "prune", "--force", "--volumes"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("system", "prune", "--force", "--volumes")
 
-		session = podmanTest.Podman([]string{"volume", "ls"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 	})
 
@@ -194,24 +117,13 @@ var _ = Describe("Podman volume prune", func() {
 		vol2 := "vol2"
 		vol3 := "vol3"
 
-		session := podmanTest.Podman([]string{"volume", "create", vol1})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "create", vol1)
+		podmanTest.PodmanExitCleanly("volume", "create", vol2)
+		podmanTest.PodmanExitCleanly("volume", "create", vol3)
 
-		session = podmanTest.Podman([]string{"volume", "create", vol2})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitCleanly())
+		podmanTest.PodmanExitCleanly("volume", "prune", "-f", "--filter", "since="+vol1)
 
-		session = podmanTest.Podman([]string{"volume", "create", vol3})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "prune", "-f", "--filter", "since=" + vol1})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitCleanly())
-
-		session = podmanTest.Podman([]string{"volume", "ls", "-q"})
-		session.WaitWithDefaultTimeout()
+		session := podmanTest.PodmanExitCleanly("volume", "ls", "-q")
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol1))
 	})

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -378,13 +378,13 @@ EOF
     run_podman run --name c2 --volume ${v[2]}:/vol2 -v ${v[3]}:/vol3 \
                $IMAGE date
 
-    # List available volumes for pruning after using 1,2,3
+    # List available volumes for pruning after using 1,2,3 (without -a only anonymous are listed; we have none)
     run_podman volume prune <<< N
-    is "$(echo $(sort <<<${lines[*]:1:3}))" "${v[4]} ${v[5]} ${v[6]}" "volume prune, with 1,2,3 in use, lists 4,5,6"
+    is "${lines[1]}" "No dangling anonymous volumes found" "volume prune without -a lists no volumes when only named volumes exist"
 
-    # List available volumes for pruning after using 1,2,3 and filtering; see #8913
+    # List available volumes for pruning after using 1,2,3 and filtering; see #8913 (without -a only anonymous; we have none)
     run_podman volume prune --filter label=mylabel <<< N
-    is "$(echo $(sort <<<${lines[*]:1:2}))" "${v[5]} ${v[6]}" "volume prune, with 1,2,3 in use and 4 filtered out, lists 5,6"
+    is "${lines[1]}" "No dangling anonymous volumes found" "volume prune without -a and filter: no anonymous volumes to list"
 
     # prune with -a should remove named unused volumes v4, v5, v6
     run_podman volume prune --force -a
@@ -419,14 +419,44 @@ EOF
     run_podman run --name c1 --volume ${v[1]}:/vol1 $IMAGE date
 
     run_podman volume prune <<< N
-    is "$(echo $(sort <<<${lines[*]:1:2}))" "${v[2]} ${v[3]}" \
-       "volume prune without -a lists named unused volumes"
+    is "${lines[1]}" "No dangling anonymous volumes found" \
+       "volume prune without -a does not list named volumes"
 
     run_podman volume prune --force
     is "$output" "" "volume prune without -a does not delete named volumes"
 
     run_podman volume exists ${v[2]}
     run_podman volume exists ${v[3]}
+}
+
+@test "podman volume prune removes only anonymous unused volumes" {
+    # Start clean: create two named volumes and one anonymous (no name)
+    local suffix=$(random_string)
+    local named1=named1_${suffix}
+    local named2=named2_${suffix}
+
+    run_podman volume create $named1
+    is "$output" "$named1" "volume create named1"
+
+    run_podman volume create $named2
+    is "$output" "$named2" "volume create named2"
+
+    run_podman volume create
+    anon_vol=$(echo "$output" | tr -d '\n\r')
+    assert "$anon_vol" != "" "anonymous volume create returns a name"
+
+    run_podman volume ls --format '{{.Name}}'
+    assert "$output" =~ "$named1" "volume ls includes named1"
+    assert "$output" =~ "$named2" "volume ls includes named2"
+    assert "$output" =~ "$anon_vol" "volume ls includes anonymous volume"
+
+    run_podman volume prune --force
+    assert "$output" =~ "$anon_vol" "volume prune removes the anonymous volume"
+
+    run_podman volume ls --format '{{.Name}}'
+    assert "$output" =~ "$named1" "after prune: named1 still present"
+    assert "$output" =~ "$named2" "after prune: named2 still present"
+    assert "$output" !~ "$anon_vol" "after prune: anonymous volume removed"
 }
 
 @test "podman volume type=bind" {

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -386,26 +386,47 @@ EOF
     run_podman volume prune --filter label=mylabel <<< N
     is "$(echo $(sort <<<${lines[*]:1:2}))" "${v[5]} ${v[6]}" "volume prune, with 1,2,3 in use and 4 filtered out, lists 5,6"
 
-    # prune should remove v4
-    run_podman volume prune --force
+    # prune with -a should remove named unused volumes v4, v5, v6
+    run_podman volume prune --force -a
     is "$(echo $(sort <<<$output))" "${v[4]} ${v[5]} ${v[6]}" \
        "volume prune, with 1, 2, 3 in use, deletes only 4, 5, 6"
 
     # Remove the container using v2 and v3. Prune should now remove those.
     # The 'echo sort' is to get the output sorted and in one line.
     run_podman rm c2
-    run_podman volume prune --force
+    run_podman volume prune --force -a
     is "$(echo $(sort <<<$output))" "${v[2]} ${v[3]}" \
        "volume prune, after rm c2, deletes volumes 2 and 3"
 
     # Remove the final container. Prune should now remove v1.
     run_podman rm c1
-    run_podman volume prune --force
+    run_podman volume prune --force -a
     is "$output"  "${v[1]}" "volume prune, after rm c2 & c1, deletes volume 1"
 
     # Further prunes are NOPs
-    run_podman volume prune --force
+    run_podman volume prune --force -a
     is "$output"  "" "no more volumes to prune"
+}
+
+@test "podman volume prune without -a keeps named volumes" {
+    local -a v=()
+    for i in 1 2 3;do
+        vol=myvol${i}$(random_string)
+        v[$i]=$vol
+        run_podman volume create $vol
+    done
+
+    run_podman run --name c1 --volume ${v[1]}:/vol1 $IMAGE date
+
+    run_podman volume prune <<< N
+    is "$(echo $(sort <<<${lines[*]:1:2}))" "${v[2]} ${v[3]}" \
+       "volume prune without -a lists named unused volumes"
+
+    run_podman volume prune --force
+    is "$output" "" "volume prune without -a does not delete named volumes"
+
+    run_podman volume exists ${v[2]}
+    run_podman volume exists ${v[3]}
 }
 
 @test "podman volume type=bind" {


### PR DESCRIPTION
The `podman volume prune` now matches *Docker behavior* by pruning only anonymous unused volumes by default, adds `--all` to prune `named` and `anonymous` volumes, and aligns filter docs/completion, volume prune e2e tests were also refactored to use `PodmanExitCleanly` with no functional change.

Fixes: https://github.com/containers/podman/issues/24597
Fixes: https://issues.redhat.com/browse/RUN-4404

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Breaking change: `podman volume prune` now defaults to pruning only anonymous unused volumes (Docker-compatible), adds `--all` for pruning all unused volumes.
```
