### PR TITLE
update golangci-lint to v2.11.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ BUILDTAGS += ${EXTRA_BUILDTAGS}
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 2.10.1
+GOLANGCI_LINT_VERSION := 2.11.3
 PYTHON ?= $(shell command -v python3 python|head -n1)
 PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -148,8 +148,6 @@ func stringMaptoArray(m map[string]string) []string {
 // cliOpts converts a compat input struct to cliopts
 func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.ContainerCreateOptions, []string, error) {
 	var (
-		capAdd     []string
-		cappDrop   []string
 		entrypoint *string
 		init       bool
 		specPorts  []types.PortMapping
@@ -416,8 +414,8 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 	cliOpts := entities.ContainerCreateOptions{
 		// Attach:            nil, // don't need?
 		Authfile:     "",
-		CapAdd:       append(capAdd, cc.HostConfig.CapAdd...),
-		CapDrop:      append(cappDrop, cc.HostConfig.CapDrop...),
+		CapAdd:       cc.HostConfig.CapAdd,
+		CapDrop:      cc.HostConfig.CapDrop,
 		CgroupParent: cc.HostConfig.CgroupParent,
 		CIDFile:      cc.HostConfig.ContainerIDFile,
 		CPUPeriod:    uint64(cc.HostConfig.CPUPeriod),

--- a/pkg/machine/apple/vfkit.go
+++ b/pkg/machine/apple/vfkit.go
@@ -62,7 +62,6 @@ func GetDefaultDevices(mc *vmconfigs.MachineConfig) ([]vfConfig.VirtioDevice, *d
 }
 
 func GetDebugDevices() ([]vfConfig.VirtioDevice, error) {
-	var devices []vfConfig.VirtioDevice
 	gpu, err := vfConfig.VirtioGPUNew()
 	if err != nil {
 		return nil, err
@@ -75,7 +74,7 @@ func GetDebugDevices() ([]vfConfig.VirtioDevice, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(devices, gpu, mouse, kb), nil
+	return []vfConfig.VirtioDevice{gpu, mouse, kb}, nil
 }
 
 func GetIgnitionVsockDevice(path string) (vfConfig.VirtioDevice, error) {

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -28,7 +28,8 @@ type QemuCmd []string
 // starting with the qemu binary, architecture specific options, and propagated
 // proxy and SSL settings
 func NewQemuBuilder(binary string, options []string) QemuCmd {
-	q := QemuCmd{binary}
+	q := make(QemuCmd, 0, 1+len(options))
+	q = append(q, binary)
 	return append(q, options...)
 }
 

--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -91,7 +91,8 @@ func (g *unitGroup) addLine(line *unitLine) {
 }
 
 func (g *unitGroup) prependLine(line *unitLine) {
-	n := []*unitLine{line}
+	n := make([]*unitLine, 0, 1+len(g.lines))
+	n = append(n, line)
 	g.lines = append(n, g.lines...)
 }
 
@@ -100,7 +101,8 @@ func (g *unitGroup) addComment(line *unitLine) {
 }
 
 func (g *unitGroup) prependComment(line *unitLine) {
-	n := []*unitLine{line}
+	n := make([]*unitLine, 0, 1+len(g.comments))
+	n = append(n, line)
 	g.comments = append(n, g.comments...)
 }
 


### PR DESCRIPTION
fix new lint issues from prealloc

Fix a few new issues reported by the linter update.

There is no need to copy the capAdd/capDrop slice in the compat create
endpoint as they are only read and not modified.
For the other code preallocate the slices so we safe memory allocations.





#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
