### PR TITLE
[replaced] Fix CLI output (RawInput to ID) for containers and pods

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -136,8 +136,6 @@ func checkpoint(cmd *cobra.Command, args []string) error {
 			errs = append(errs, r.Err)
 		case checkpointOptions.PrintStats:
 			statistics.ContainerStatistics = append(statistics.ContainerStatistics, r)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -94,8 +94,6 @@ func cleanup(_ *cobra.Command, args []string) error {
 		case r.CleanErr != nil:
 			logrus.Errorf("Cleaning up container: %v", r.CleanErr)
 			errs = append(errs, r.CleanErr)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -74,8 +74,6 @@ func initContainer(_ *cobra.Command, args []string) error {
 		switch {
 		case r.Err != nil:
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -113,8 +113,6 @@ func kill(_ *cobra.Command, args []string) error {
 		switch {
 		case r.Err != nil:
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -115,8 +115,6 @@ func pause(_ *cobra.Command, args []string) error {
 		switch {
 		case r.Err != nil:
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -127,8 +127,6 @@ func restart(cmd *cobra.Command, args []string) error {
 		switch {
 		case r.Err != nil:
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -186,8 +186,6 @@ func restore(cmd *cobra.Command, args []string) error {
 			errs = append(errs, r.Err)
 		case restoreOptions.PrintStats:
 			statistics.ContainerStatistics = append(statistics.ContainerStatistics, r)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -162,10 +162,6 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 				setExitCode(r.Err)
 			}
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			if !quiet {
-				fmt.Println(r.RawInput)
-			}
 		default:
 			if !quiet {
 				fmt.Println(r.Id)

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -141,8 +141,6 @@ func start(cmd *cobra.Command, args []string) error {
 		case startOptions.Attach:
 			// Implement the exitcode when the only one container is enabled attach
 			registry.SetExitCode(r.ExitCode)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -132,8 +132,6 @@ func stop(cmd *cobra.Command, args []string) error {
 		switch {
 		case r.Err != nil:
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -114,8 +114,6 @@ func unpause(_ *cobra.Command, args []string) error {
 		switch {
 		case r.Err != nil:
 			errs = append(errs, r.Err)
-		case r.RawInput != "":
-			fmt.Println(r.RawInput)
 		default:
 			fmt.Println(r.Id)
 		}

--- a/cmd/podman/pods/start.go
+++ b/cmd/podman/pods/start.go
@@ -73,7 +73,7 @@ func start(_ *cobra.Command, args []string) error {
 	// in the cli, first we print out all the successful attempts
 	for _, r := range responses {
 		if len(r.Errs) == 0 {
-			fmt.Println(r.RawInput)
+			fmt.Println(r.Id)
 		} else {
 			errs = append(errs, r.Errs...)
 		}

--- a/cmd/podman/pods/stop.go
+++ b/cmd/podman/pods/stop.go
@@ -89,7 +89,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	// in the cli, first we print out all the successful attempts
 	for _, r := range responses {
 		if len(r.Errs) == 0 {
-			fmt.Println(r.RawInput)
+			fmt.Println(r.Id)
 		} else {
 			errs = append(errs, r.Errs...)
 		}

--- a/test/e2e/cleanup_test.go
+++ b/test/e2e/cleanup_test.go
@@ -39,17 +39,18 @@ var _ = Describe("Podman container cleanup", func() {
 		session = podmanTest.Podman([]string{"container", "cleanup", shortID})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal(shortID))
+		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman cleanup container by name", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "foo", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
+		cid := session.OutputToString()
 		session = podmanTest.Podman([]string{"container", "cleanup", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal("foo"))
+		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman cleanup all containers", func() {

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Podman kill", func() {
 		result := podmanTest.Podman([]string{"container", "kill", cid[:5]})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
-		Expect(result.OutputToString()).To(Equal(cid[:5]))
+		Expect(result.OutputToString()).To(Equal(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Podman pod start", func() {
 
 	It("podman pod start single pod by name", func() {
 		name := "foobar99"
-		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}})
+		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {name}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", name, ALPINE, "ls"})
@@ -46,7 +46,7 @@ var _ = Describe("Podman pod start", func() {
 		session = podmanTest.Podman([]string{"pod", "start", name})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).Should(ContainSubstring(name))
+		Expect(session.OutputToString()).Should(ContainSubstring(podid))
 	})
 
 	It("podman pod start multiple pods", func() {
@@ -68,8 +68,8 @@ var _ = Describe("Podman pod start", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
-		Expect(session.OutputToString()).Should(ContainSubstring("foobar99"))
-		Expect(session.OutputToString()).Should(ContainSubstring("foobar100"))
+		Expect(session.OutputToString()).Should(ContainSubstring(podid1))
+		Expect(session.OutputToString()).Should(ContainSubstring(podid2))
 	})
 
 	It("multiple pods in conflict", func() {

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -84,10 +84,11 @@ var _ = Describe("Podman start", func() {
 		session := podmanTest.Podman([]string{"create", "--name", name, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
+		cid := session.OutputToString()
 		session = podmanTest.Podman([]string{"start", name})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal(name))
+		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman start single container with attach and test the signal", func() {

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Podman stop", func() {
 		session = podmanTest.Podman([]string{"stop", shortID})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Equal(shortID))
+		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman stop container by name", func() {

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -101,11 +101,12 @@ load helpers
     run_podman start --all
     is "$output" "$ctrID"
 
-    # start $input must print $input
+    # start $input must print the id of $input
     cname=$(random_string)
     run_podman create --name $cname $IMAGE top
+    ctrID="$output"
     run_podman start $cname
-    is "$output" $cname
+    is "$output" "$ctrID"
 
     run_podman rm -t 0 -f $ctrID $cname
 }

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -89,11 +89,12 @@ load helpers
     run_podman stop -t0 --all
     is "$output" "$ctrID"
 
-    # stop $input must print $input
+    # stop $input must print the id of $input
     cname=$(random_string)
     run_podman run -d --name $cname $IMAGE top
+    ctrID="$output"
     run_podman stop -t0 $cname
-    is "$output" $cname
+    is "$output" "$ctrID"
 
     run_podman rm -t 0 -f $ctrID $cname
 }

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -8,7 +8,8 @@ load helpers
 # bats test_tags=ci:parallel
 @test "podman rm" {
     cname=c-$(safename)
-    run_podman run --name $cname $IMAGE /bin/true
+    run_podman run --name $cname -d $IMAGE /bin/true
+    cid="$output"
 
     # Don't care about output, just check exit status (it should exist)
     run_podman 0 inspect $cname
@@ -19,7 +20,7 @@ load helpers
 
     # Remove container; now 'inspect' should fail
     run_podman rm $cname
-    is "$output" "$cname" "display raw input"
+    is "$output" "$cid" "display raw input"
     run_podman 125 inspect $cname
     is "$output" "\[\].Error: no such object: \"$cname\""
     run_podman 125 wait $cname

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -109,11 +109,12 @@ load helpers
     run_podman kill -a
     is "$output" "$ctrID"
 
-    # kill $input must print $input
+    # kill $input must print the id of $input
     cname=c-$(safename)
     run_podman run --rm -d --name $cname $IMAGE top
+    ctrID="$output"
     run_podman kill $cname
-    is "$output" $cname
+    is "$output" "$ctrID"
     # Wait for the container to get removed to avoid the leak check from triggering,
     # since it might have already been removed here ignore the exit code check.
     run_podman '?' wait --condition=removing $cname


### PR DESCRIPTION
This PR structurally replaces the ambiguous RawInput usage with actual Container/Pod IDs across podman commands (`start`, `stop`, `kill`, `rm`, `pause`, `unpause`, `init`, `restore`, `checkpoint`, `cleanup`). E2E and System tests have been updated accordingly to expect the exact CID, fixing the regression and ambiguous output issues reported.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Podman container and pod commands (start, stop, kill, rm, pause, unpause, init, restore, checkpoint, cleanup) now consistently return the Container ID or Pod ID in their output, removing the ambiguous usage of RawInput.
```
