### PR TITLE
fix: add trailing newline to /etc/subgid for shadow-utils >= 4.19.0 (F44+)

### DIFF
--- a/pkg/machine/ignition/ignition.go
+++ b/pkg/machine/ignition/ignition.go
@@ -283,7 +283,7 @@ pids_limit=0
 	if uid >= subUID && uid < (subUID+subUIDs) {
 		subUID = uid + 1
 	}
-	etcSubUID := fmt.Sprintf(`%s:%d:%d`, usrName, subUID, subUIDs)
+	etcSubUID := fmt.Sprintf("%s:%d:%d\n", usrName, subUID, subUIDs)
 
 	// Set containers.conf up for core user to use networks
 	// by default


### PR DESCRIPTION
issue on : https://github.com/containers/podman-machine-os/issues/226

This is a POSIX compliance fix - text files should end with a newline. The fix is backward compatible with older shadow-utils versions.

1. i opened the issue in shadow, maintainer stated he has no plan to fix it now but adding the warning message
2. i replicate this bug in f44 with shadow 4.19 and cannot reproduce it on f43 with 4.18
3. the new line change i added, i verified on the f44 image. working as expected now.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
