### PR TITLE
DNM [CI]: distribute GCE tasks across multiple regions 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -661,7 +661,9 @@ compose_test_task:
         changesInclude('test/compose/**') ||
         (changesInclude('**/*.go', '**/*.c', '**/*.h') && !changesIncludeOnly('test/**', 'pkg/machine/e2e/**'))
     depends_on: *build
-    gce_instance: *standardvm
+    gce_instance:
+        <<: *standardvm
+        zone: "us-east1-a"
     matrix:
       - env:
             PRIV_NAME: root
@@ -716,6 +718,9 @@ local_integration_test_task: &local_integration_test_task
 remote_integration_test_task:
     <<: *local_integration_test_task
     alias: remote_integration_test
+    gce_instance:
+        <<: *fastvm
+        zone: "us-east1-a"
     env:
         TEST_FLAVOR: int
         PODBIN_NAME: remote
@@ -753,7 +758,9 @@ rootless_integration_test_task:
     only_if: *only_if_int_test
     depends_on: *build
     matrix: *platform_axis
-    gce_instance: *fastvm
+    gce_instance:
+        <<: *fastvm
+        zone: "us-west1-a"
     env:
         TEST_FLAVOR: int
         PRIV_NAME: rootless
@@ -939,7 +946,9 @@ local_system_test_task: &local_system_test_task
         (changesInclude('**/*.go', '**/*.c', '**/*.h') && !changesIncludeOnly('test/**', 'pkg/machine/e2e/**'))
     depends_on: *build
     matrix: *platform_axis
-    gce_instance: *fastvm
+    gce_instance:
+        <<: *fastvm
+        zone: "us-east1-a"
     timeout_in: 25m
     env:
         TEST_FLAVOR: sys
@@ -971,6 +980,9 @@ local_system_test_aarch64_task: &local_system_test_task_aarch64
 remote_system_test_task:
     <<: *local_system_test_task
     alias: remote_system_test
+    gce_instance:
+        <<: *fastvm
+        zone: "us-west1-a"
     env:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
@@ -994,7 +1006,9 @@ rootless_remote_system_test_task:
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
     <<: *local_system_test_task
     alias: rootless_remote_system_test
-    gce_instance: *fastvm
+    gce_instance:
+        <<: *fastvm
+        zone: "us-west1-a"
     timeout_in: 25m
     env:
         TEST_FLAVOR: sys
@@ -1009,7 +1023,9 @@ rootless_system_test_task:
     only_if: *only_if_system_test
     depends_on: *build
     matrix: *platform_axis
-    gce_instance: *fastvm
+    gce_instance:
+        <<: *fastvm
+        zone: "us-west1-a"
     timeout_in: 25m
     env:
         TEST_FLAVOR: sys
@@ -1034,7 +1050,9 @@ farm_test_task:
         changesInclude('test/farm/**', 'test/system/*.bash') ||
         (changesInclude('**/*.go', '**/*.c', '**/*.h') && !changesIncludeOnly('test/**', 'pkg/machine/e2e/**'))
     depends_on: *build
-    gce_instance: *standardvm
+    gce_instance:
+        <<: *standardvm
+        zone: "us-east1-a"
     env:
         <<: *stdenvars
         TEST_FLAVOR: farm
@@ -1067,7 +1085,9 @@ buildah_bud_test_task:
             PODBIN_NAME: podman
         - env:
             PODBIN_NAME: remote
-    gce_instance: *fastvm
+    gce_instance:
+        <<: *fastvm
+        zone: "us-west1-a"
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main
@@ -1092,7 +1112,9 @@ upgrade_test_task:
               PODMAN_UPGRADE_FROM: v5.3.1
         - env:
               PODMAN_UPGRADE_FROM: v5.6.2
-    gce_instance: *standardvm
+    gce_instance:
+        <<: *standardvm
+        zone: "us-west1-a"
     env:
         TEST_FLAVOR: upgrade_test
         TEST_BUILD_TAGS: ""


### PR DESCRIPTION
Distribute GCE instance creation across us-central1-a, us-central1-b, and us-central1-f zones to avoid  GCP's concurrent operations quota.
---
1. All us-central1-* zones have similar capacity
2. for images: GCP images are global resources
3. network: Each task is independent, no cross-zone communication
---
new distribution:
* us-central1-a: build , validate-source, swagger, docker-py, unit_test, apiv2_test, local_integration_test, container_integration_test
* us-central1-b: remote_integration_test, local_system_test, compose_test, farm_test
* rootless_integration_test, rootless_system_test, remote_system_test, rootless_remote_system_test, buildah_bud_test, upgrade_test


Fixes: #28212

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
