### PR TITLE
chore(api): add swagger docs for undocumented API parameters

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1128,7 +1128,10 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: t
 	//    type: integer
-	//    default: 10
+	//    description: number of seconds to wait before killing container (Docker compatibility)
+	//  - in: query
+	//    name: timeout
+	//    type: integer
 	//    description: number of seconds to wait before killing container
 	// produces:
 	// - application/json
@@ -1220,6 +1223,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: integer
 	//    default: 5
 	//    description: Time in seconds between stats reports
+	//  - in: query
+	//    name: all
+	//    type: boolean
+	//    default: false
+	//    description: Provide statistics for all running containers
 	// produces:
 	// - application/json
 	// responses:
@@ -1560,6 +1568,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: integer
 	//    required: false
 	//    description: Width to set for the terminal, in characters
+	//  - in: query
+	//    name: running
+	//    type: boolean
+	//    required: false
+	//    description: Ignore containers not running errors
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -316,6 +316,10 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//    name: w
 	//    type: integer
 	//    description: Width of the TTY session in characters
+	//  - in: query
+	//    name: running
+	//    type: boolean
+	//    description: Ignore containers not running errors
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_generate.go
+++ b/pkg/api/server/register_generate.go
@@ -102,6 +102,11 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	//        type: string
 	//    default: []
 	//    description: Set environment variables to the systemd unit files.
+	//  - in: query
+	//    name: templateUnitFile
+	//    type: boolean
+	//    default: false
+	//    description: Add template specifier for the systemd unit file names.
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -55,6 +55,14 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: platform
 	//    type: string
 	//    description: Platform in the format os[/arch[/variant]]
+	//  - in: query
+	//    name: retry
+	//    type: integer
+	//    description: Number of times to retry in case of failure when performing pull.
+	//  - in: query
+	//    name: retryDelay
+	//    type: string
+	//    description: Delay between retries in case of pull failures.
 	//  - in: body
 	//    name: inputImage
 	//    schema:
@@ -102,6 +110,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   - name: digests
 	//     in: query
 	//     description: Not supported
+	//     type: boolean
+	//     default: false
+	//   - name: shared-size
+	//     in: query
+	//     description: Compute and show shared size as a SharedSize field on each image.
 	//     type: boolean
 	//     default: false
 	// produces:

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -93,7 +93,11 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: force
 	//    type: boolean
-	//    description : force removal of a running pod by first stopping all containers, then removing all containers in the pod
+	//    description: force removal of a running pod by first stopping all containers, then removing all containers in the pod
+	//  - in: query
+	//    name: timeout
+	//    type: integer
+	//    description: number of seconds to wait before killing containers in pod
 	// responses:
 	//   200:
 	//     $ref: '#/responses/podRmResponse'
@@ -339,6 +343,16 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//    type: array
 	//    items:
 	//      type: string
+	//  - in: query
+	//    name: stream
+	//    type: boolean
+	//    default: false
+	//    description: Stream the output
+	//  - in: query
+	//    name: delay
+	//    type: integer
+	//    default: 5
+	//    description: Time in seconds between stats reports
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -65,6 +65,31 @@ func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
 	// tags:
 	//   - system
 	// summary: Prune unused data
+	// parameters:
+	//   - in: query
+	//     name: all
+	//     type: boolean
+	//     description: Remove all unused data, not just dangling data
+	//   - in: query
+	//     name: volumes
+	//     type: boolean
+	//     description: Prune volumes
+	//   - in: query
+	//     name: external
+	//     type: boolean
+	//     description: Remove images used by external containers (e.g., build containers)
+	//   - in: query
+	//     name: build
+	//     type: boolean
+	//     description: Remove build cache
+	//   - in: query
+	//     name: filters
+	//     type: string
+	//     description: |
+	//       JSON encoded value of filters (a map[string][]string) to match data against before pruning.
+	//       Available filters:
+	//         - `until=<timestamp>` Prune data created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine's time.
+	//         - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune data with (or without, in case `label!=...` is used) the specified labels.
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -135,6 +135,10 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    name: force
 	//    type: boolean
 	//    description: force removal
+	//  - in: query
+	//    name: timeout
+	//    type: integer
+	//    description: timeout before forcibly killing any containers using the volume
 	// produces:
 	// - application/json
 	// responses:
@@ -299,6 +303,10 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//      Force removal of the volume. This actually only causes errors due
 	//      to the names volume not being found to be suppressed, which is the
 	//      behaviour Docker implements.
+	//  - in: query
+	//    name: timeout
+	//    type: integer
+	//    description: timeout before forcibly killing any containers using the volume
 	// produces:
 	// - application/json
 	// responses:


### PR DESCRIPTION
Add documentation for undocumented API parameters across multiple endpoints:
---
System:
- POST /libpod/system/prune: all, volumes, external, build, filters

Pods:
- DELETE /libpod/pods/{name}: timeout
- GET /libpod/pods/stats: stream, delay

Volumes:
- DELETE /volumes/{name}: timeout
- DELETE /libpod/volumes/{name}: timeout

Containers:
- GET /libpod/containers/stats: all
- POST /libpod/containers/{name}/restart: timeout
- POST /libpod/containers/{name}/resize: running

Images:
- POST /images/create: retry, retryDelay
- GET /images/json: shared-size

Exec:
- POST /libpod/exec/{id}/resize: running

Generate:
- GET /libpod/generate/{name}/systemd: templateUnitFile
---
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
