### PR TITLE
feat: print client info from `podman version` when the server is not available

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/podman/v6/cmd/podman/common"
 	"github.com/containers/podman/v6/cmd/podman/registry"
+	"github.com/containers/podman/v6/cmd/podman/system"
 	"github.com/containers/podman/v6/cmd/podman/validate"
 	"github.com/containers/podman/v6/libpod/define"
 	"github.com/containers/podman/v6/libpod/shutdown"
@@ -383,12 +384,22 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	// Prep the engines
 	if _, err := registry.NewImageEngine(cmd, args); err != nil {
 		// Note: this is gross, but it is the hand we are dealt
-		if registry.IsRemote() && errors.As(err, &bindings.ConnectError{}) && cmd.Name() == "info" && cmd.Parent() == cmd.Root() {
-			clientDesc, err := getClientInfo()
-			// we eat the error here. if this fails, they just don't any client info
-			if err == nil {
-				b, _ := yaml.Marshal(clientDesc)
-				fmt.Println(string(b))
+		if registry.IsRemote() && errors.As(err, &bindings.ConnectError{}) && cmd.Parent() == cmd.Root() {
+			switch cmd.Name() {
+			case "info":
+				clientDesc, err := getClientInfo()
+				// we eat the error here. if this fails, they just don't any client info
+				if err == nil {
+					b, _ := yaml.Marshal(clientDesc)
+					fmt.Println(string(b))
+				}
+			case "version":
+				versions, err := define.GetVersion()
+				if err == nil {
+					if printErr := system.PrintVersion(cmd, &entities.SystemVersionReport{Client: &versions}); printErr != nil {
+						logrus.Debugf("Failed to print client version information: %v", printErr)
+					}
+				}
 			}
 		}
 		return err

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -45,6 +45,11 @@ func version(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	return PrintVersion(cmd, versions)
+}
+
+func PrintVersion(cmd *cobra.Command, versions *entities.SystemVersionReport) error {
+	var err error
 
 	if report.IsJSON(versionFormat) {
 		s, err := json.MarshalToString(versions)

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -20,6 +20,16 @@ var _ = Describe("Podman version", func() {
 		Expect(session.Out.Contents()).Should(ContainSubstring(version.Version.String()))
 	})
 
+	It("podman version: check for client information when no system service", func() {
+		SkipIfNotRemote("testing only failed remote connections")
+		podmanTest.StopRemoteService()
+		defer podmanTest.StartRemoteService()
+		version := podmanTest.Podman([]string{"version"})
+		version.WaitWithDefaultTimeout()
+		Expect(version.OutputToString()).To(ContainSubstring("Client:"))
+		Expect(version).ToNot(ExitCleanly())
+	})
+
 	It("podman -v", func() {
 		session := podmanTest.Podman([]string{"-v"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
### What this PR does
In remote mode, `podman version` currently returns a connection error before printing any version information if it cannot connect to the service.

Introduce a reusable `PrintVersion` helper and invoke it at the root level when a `ConnectionError` is encountered. This ensures that client information is still shown even when the server cannot be reached.

### Before
```bash
# podman version
Cannot connect to Podman. Please verify your connection to the Linux system using `podman system connection list`, or try `podman machine init` and `podman machine start` to manage a new Linux VM
Error: unable to connect to Podman socket: failed to connect: dial tcp 127.0.0.1:62099: connect: connection refused
```

### After
```bash
# ./bin/darwin/podman version  
Client:       Podman Engine
Version:      6.0.0-dev
API Version:  6.0.0-dev
Go Version:   go1.24.6
Git Commit:   f7aefa46bbe5f0d8b1cfb0ff7b9fcd5fee2a9545-dirty
Built:        Wed Mar 11 16:36:32 2026
OS/Arch:      darwin/arm64
Cannot connect to Podman. Please verify your connection to the Linux system using `podman system connection list`, or try `podman machine init` and `podman machine start` to manage a new Linux VM
Error: unable to connect to Podman socket: failed to connect: dial tcp 127.0.0.1:64672: connect: connection refused
```

Fixes: #28222

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
