### PR TITLE
quadlet: allow empty Entrypoint to clear image default

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -679,11 +679,17 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 		podman.add("--cgroups=split")
 	}
 
+	// Entrypoint needs special handling: an empty value is valid and means
+	// "clear the image entrypoint" (podman run --entrypoint ""), so it
+	// cannot go through lookupAndAddString which skips empty values.
+	if val, ok := container.Lookup(ContainerGroup, KeyEntrypoint); ok {
+		podman.addf("--entrypoint=%s", val)
+	}
+
 	stringKeys := map[string]string{
 		KeyTimezone:    "--tz",
 		KeyPidsLimit:   "--pids-limit",
 		KeyShmSize:     "--shm-size",
-		KeyEntrypoint:  "--entrypoint",
 		KeyWorkingDir:  "--workdir",
 		KeyIP:          "--ip",
 		KeyIP6:         "--ip6",

--- a/test/e2e/quadlet/entrypoint-empty.container
+++ b/test/e2e/quadlet/entrypoint-empty.container
@@ -1,6 +1,6 @@
 ## assert-podman-final-args localhost/imagename
-## assert-podman-args "--entrypoint=top -b"
+## assert-podman-args "--entrypoint="
 
 [Container]
 Image=localhost/imagename
-Entrypoint=top -b
+Entrypoint=

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -935,6 +935,7 @@ BOGUS=foo
 		Entry("env-host.container", "env-host.container"),
 		Entry("env.container", "env.container"),
 		Entry("entrypoint.container", "entrypoint.container"),
+		Entry("entrypoint-empty.container", "entrypoint-empty.container"),
 		Entry("escapes.container", "escapes.container"),
 		Entry("exec.container", "exec.container"),
 		Entry("group-add.container", "group-add.container"),


### PR DESCRIPTION
Fixes #28213

Setting `Entrypoint=` in a .container file currently does nothing — `lookupAndAddString` skips empty values (`len(val) > 0` check on line 2078). This means there's no way to clear an image's default entrypoint through quadlet without resorting to `PodmanArgs=--entrypoint=`.

Moved the Entrypoint key out of the generic `stringKeys` map and gave it its own lookup block that doesn't skip empty strings. An empty value now correctly produces `--entrypoint ""` in the generated podman command.

Added `entrypoint-empty.container` test case to cover this.