### PR TITLE
tests/e2e: Do not try to list /proc/acpi on non-amd64

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -495,10 +495,12 @@ var _ = Describe("Podman run", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).Should(HaveLen(1))
 
-		session = podmanTest.Podman([]string{"run", "--security-opt", "unmask=/proc/a*", ALPINE, "ls", "/proc/acpi"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
-		Expect(session.OutputToString()).To(Not(BeEmpty()))
+		if podmanTest.Host.Arch == "amd64" {
+			session = podmanTest.Podman([]string{"run", "--security-opt", "unmask=/proc/a*", ALPINE, "ls", "/proc/acpi"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(ExitCleanly())
+			Expect(session.OutputToString()).To(Not(BeEmpty()))
+		}
 	})
 
 	It("podman run powercap is masked", func() {
@@ -2264,9 +2266,7 @@ WORKDIR /madethis`, BB)
 	})
 
 	It("podman run check personality support", func() {
-		if podmanTest.Host.Arch != "amd64" {
-			Skip("test only valid on amd64")
-		}
+		SkipIfNotAMD64()
 		session := podmanTest.Podman([]string{"run", "--personality=LINUX32", "--name=testpersonality", ALPINE, "uname", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())


### PR DESCRIPTION
Fixes https://github.com/containers/podman/pull/28266

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
