### PR TITLE
compat: return 409 Conflict when container name is already in use

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -127,6 +127,10 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)
 	if err != nil {
+		if errors.Is(err, define.ErrCtrExists) || errors.Is(err, storage.ErrDuplicateName) {
+			utils.Error(w, http.StatusConflict, fmt.Errorf("container create: %w", err))
+			return
+		}
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("container create: %w", err))
 		return
 	}

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -278,6 +278,23 @@ class ContainerTestCase(APITestCase):
         # is zero.  I think the test needs some rewrite.
         # self.assertIsNotNone(prune_payload["ImagesDeleted"][1]["Deleted"])
 
+    def test_create_duplicate_name(self):
+        name = f"Container_{random.getrandbits(160):x}"
+        payload = {"Cmd": ["top"], "Image": "alpine:latest"}
+
+        r = requests.post(
+            self.podman_url + f"/v1.40/containers/create?name={name}", json=payload
+        )
+        self.assertEqual(r.status_code, 201, r.text)
+        container_id = r.json()["Id"]
+
+        r = requests.post(
+            self.podman_url + f"/v1.40/containers/create?name={name}", json=payload
+        )
+        self.assertEqual(r.status_code, 409, r.text)
+
+        requests.delete(self.podman_url + f"/v1.40/containers/{container_id}?force=true")
+
     def test_status(self):
         r = requests.post(
             self.podman_url + "/v1.40/containers/create?name=topcontainer",


### PR DESCRIPTION
## Description

The Docker API spec defines HTTP 409 for `POST /containers/create` when the requested name is already in use. The compat handler was returning 500 for all errors from `ContainerCreate`, including `define.ErrCtrExists`.

## Reproducer

```
# Create a container with a given name
docker create --name foo alpine top

# Try to create another with the same name — should return 409, returns 500
docker create --name foo alpine top
# Error response from daemon: container create: ... the container name "foo" is already in use
```

## Impact

This breaks buildx parallel builds. In `driver/docker-container/driver.go`, buildx checks for a conflict response to safely converge multiple concurrent builders onto the already-running BuildKit container:

```go
_, err := d.DockerAPI.ContainerCreate(ctx, ...)
if err != nil && !cerrdefs.IsConflict(err) {
    return err
}
```

`cerrdefs.IsConflict` maps HTTP 409 → true, HTTP 500 → false. With Podman returning 500, all but the first parallel build fail fatally. This is visible when running `docker compose build` with multiple custom-built services — they all race to create `buildx_buildkit_default` and all but one fail.

## Fix

Check for `define.ErrCtrExists` before the catch-all 500 and return 409 instead. This follows the same pattern already used in the rename handler (`containers.go`):

```go
if errors.Is(err, define.ErrPodExists) || errors.Is(err, define.ErrCtrExists) {
    utils.Error(w, http.StatusConflict, err)
    return
}
```

The swagger annotation for this endpoint already documents the 409 response — it just wasn't being returned.

## Testing

Added `test_create_duplicate_name` to the compat API test suite.