### PR TITLE
quadlet: support empty Entrypoint= to clear image defaults

### DIFF
--- a/pkg/systemd/quadlet/quadlet.go
+++ b/pkg/systemd/quadlet/quadlet.go
@@ -683,7 +683,6 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 		KeyTimezone:    "--tz",
 		KeyPidsLimit:   "--pids-limit",
 		KeyShmSize:     "--shm-size",
-		KeyEntrypoint:  "--entrypoint",
 		KeyWorkingDir:  "--workdir",
 		KeyIP:          "--ip",
 		KeyIP6:         "--ip6",
@@ -696,6 +695,19 @@ func ConvertContainer(container *parser.UnitFile, unitsInfoMap map[string]*UnitI
 		KeyRetryDelay:  "--retry-delay",
 	}
 	lookupAndAddString(container, ContainerGroup, stringKeys, podman)
+
+	// Handle Entrypoint separately from stringKeys to support empty values.
+	// An empty Entrypoint= means "clear the image's default entrypoint",
+	// but lookupAndAddString() skips empty values (len check).
+	if val, ok := container.Lookup(ContainerGroup, KeyEntrypoint); ok {
+		if val == "" {
+			// Use --entrypoint= form because the systemd parser
+			// discards empty string arguments (--entrypoint="").
+			podman.addf("--entrypoint=%s", val)
+		} else {
+			podman.add("--entrypoint", val)
+		}
+	}
 
 	allStringsKeys := map[string]string{
 		KeyNetworkAlias: "--network-alias",

--- a/test/e2e/quadlet/entrypoint-empty.container
+++ b/test/e2e/quadlet/entrypoint-empty.container
@@ -1,0 +1,6 @@
+## assert-podman-final-args localhost/imagename
+## assert-podman-args "--entrypoint="
+
+[Container]
+Image=localhost/imagename
+Entrypoint=

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -935,6 +935,7 @@ BOGUS=foo
 		Entry("env-host.container", "env-host.container"),
 		Entry("env.container", "env.container"),
 		Entry("entrypoint.container", "entrypoint.container"),
+		Entry("entrypoint-empty.container", "entrypoint-empty.container"),
 		Entry("escapes.container", "escapes.container"),
 		Entry("exec.container", "exec.container"),
 		Entry("group-add.container", "group-add.container"),


### PR DESCRIPTION
Previously, users setting Entrypoint= (empty value) in a .container file was silently ignored. This is because of a length check on value (""). This change handles --entrypoint separately, and further enforces `=` usage for empty string (because of how the systemd parser is implemented).

Fixes: #28213 

Signed-off-by: Danish Prakash <contact@danishpraka.sh>

---

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Empty entrypoint should now start working
```
