### PR TITLE
CI: add aarch64 e2e integration test job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -949,6 +949,24 @@ local_system_test_task: &local_system_test_task
     always: *logs_artifacts
 
 
+local_integration_test_aarch64_task:
+    name: *std_name_fmt
+    alias: local_integration_test_aarch64
+    only_if: *only_if_int_test
+    depends_on: *build
+    ec2_instance: *standard_build_ec2_aarch64
+    timeout_in: 35m
+    env:
+        <<: *stdenvars_aarch64
+        TEST_FLAVOR: int
+        TEST_BUILD_TAGS: ""
+        DISTRO_NV: ${FEDORA_AARCH64_NAME}
+    clone_script: *get_gosrc_aarch64
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
+
 local_system_test_aarch64_task: &local_system_test_task_aarch64
     name: *std_name_fmt
     alias: local_system_test_aarch64
@@ -1154,6 +1172,7 @@ success_task:
         - apiv2_test
         - compose_test
         - local_integration_test
+        - local_integration_test_aarch64
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test


### PR DESCRIPTION
Adds a Cirrus CI task to run the e2e integration test suite on aarch64.

Fixes: #28274

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
