### PR TITLE
cirrus: bump linux machine aarch64 test timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -800,7 +800,7 @@ podman_machine_aarch64_task:
     depends_on: *build
     ec2_instance:
         <<: *standard_build_ec2_aarch64
-    timeout_in: 40m
+    timeout_in: 60m
     env:
         TEST_FLAVOR: "machine-linux"
         TEST_BUILD_TAGS: ""


### PR DESCRIPTION
Bump the timeout to 60 minutes. We already bumped to 40 minutes a while ago in commit 623cb5f but it seems this is not enough.

The x86_64 test needs only 25 minutes so I am confused why aarch64 got so much slower, they used to be around the same time. Of course our tests should not take that long so we really need to figure out what is actually causing this slow down.

Looking at logs a test that boots and stops a VM takes 30s on x86_64 while it takes 50s on aarch64.
However at the same time the aarch64 test on the macs with libkrun and applehv are quite fast (15-17m) so it seems unlikely to me that it is something inside the aarch64 machine image that causes but rather related to the host side.


<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
