### PR TITLE
Bump bundled krunkit from 1.1.1 to 1.2.1

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -9,7 +9,7 @@ else
 endif
 GVPROXY_VERSION=$(shell $(GO) list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
 VFKIT_VERSION ?= 0.6.1
-KRUNKIT_VERSION ?= 1.1.1
+KRUNKIT_VERSION ?= 1.2.1
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
 KRUNKIT_RELEASE_URL ?= https://github.com/containers/krunkit/releases/download/v$(KRUNKIT_VERSION)/krunkit-podman-unsigned-$(KRUNKIT_VERSION).tgz

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -74,7 +74,7 @@ sign "${binDir}/vfkit"
 sign "${binDir}/podman-mac-helper"
 
 sign "${binDir}/krunkit"
-sign "${libDir}/libkrun-efi.dylib"
+sign "${libDir}/libkrun.dylib"
 sign "${libDir}/libvirglrenderer.1.dylib"
 sign "${libDir}/libepoxy.0.dylib"
 sign "${libDir}/libMoltenVK.dylib"


### PR DESCRIPTION
Bump bundled krunkit to 1.2.1, which comes with libkrun 1.17.4.

The highlights for podman in this release of libkrun are a number of virtio-fs behavioural fixes, specially when running non-root users within a container, along with better disk performance and lower space consumption thanks to support for F_DISCARD and F_WRITE_ZEROES.

This release of krunkit also introduces the "--timesync" flag, with the same behavior as the vfkit counterpart, meaning it's now possible to enable clock synchronization with this mechanism.

Fixes: https://github.com/containers/podman/discussions/27679