### PR TITLE
ci: add non-blocking riscv64 build job using RISE runners

### DIFF
--- a/.github/workflows/alt-arch-riscv64.yml
+++ b/.github/workflows/alt-arch-riscv64.yml
@@ -1,0 +1,39 @@
+name: Alt Arch Riscv64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Podman (riscv64)
+    runs-on: ubuntu-24.04-riscv
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs go-md2man uidmap slirp4netns \
+            libapparmor-dev libglib2.0-dev libgpgme-dev libseccomp-dev \
+            libsystemd-dev pkg-config golang-go
+
+      - name: Build binaries
+        run: |
+          go version
+          make binaries
+
+      - name: Verify
+        run: |
+          ./bin/podman --version
+
+      - name: Build remote client
+        run: |
+          make podman-remote
+          ./bin/podman-remote --version


### PR DESCRIPTION
## What does this PR do?

Add a non-blocking `Alt Arch Riscv64` CI workflow that builds podman and podman-remote on native RISE riscv64 runners. As requested by @lsm5 in #28329.

## Changes

- New `.github/workflows/alt-arch-riscv64.yml` workflow
- Uses native RISE runner (`ubuntu-24.04-riscv`)
- Non-blocking (`continue-on-error: true`)
- Builds both `podman` and `podman-remote`

## Evidence

- Native build on BananaPi F3: SUCCESS (18 min)
- RISE runner build: SUCCESS (17 min) - https://github.com/gounthar/podman/actions/runs/23318754735
- podman 6.0.0-dev verified on riscv64

Fixes #28329

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve software ecosystem support on riscv64 platforms.