### PR TITLE
ci: add riscv64 cross-compilation to Cirrus CI alt-arch matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -261,6 +261,8 @@ alt_build_task:
       - env:
             ALT_NAME: 'Alt Arch. MIPS64 Cross'
       - env:
+            ALT_NAME: 'Alt Arch. RISCV64 Cross'
+      - env:
             ALT_NAME: 'Alt Arch. Other Cross'
     # This task cannot make use of the shared repo.tar.zst artifact.
     clone_script: *full_clone

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -304,6 +304,9 @@ function _run_altbuild() {
                 mips64le)
             _build_altbuild_archs "${arches[@]}"
             ;;
+        Alt*RISCV64*Cross)
+            _build_altbuild_archs "riscv64"
+            ;;
         *)
             die "Unknown/Unsupported \$$ALT_NAME '$ALT_NAME'"
     esac


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] Tests have been added/updated (or no tests are needed)
- [ ] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### What does this PR do?

Adds `GOARCH=riscv64` cross-compilation to the existing Cirrus CI alt-arch build matrix, alongside x86, ARM, MIPS, MIPS64, ppc64le, and s390x.

Two files changed:
- `.cirrus.yml`: new matrix entry `Alt Arch. RISCV64 Cross`
- `contrib/cirrus/runner.sh`: new case `Alt*RISCV64*Cross)` calling `_build_altbuild_archs "riscv64"`

This follows the existing pattern exactly and validates that podman compiles for riscv64 on every PR, catching any architecture-specific build regressions.

Per discussion in #28329 with @Luap99: cross-compilation in Cirrus CI is the preferred approach over native riscv64 runners.

Fixes #28329