### PR TITLE
test: relax rootless runc pid namespace assertion

### DIFF
--- a/test/system/195-run-namespaces.bats
+++ b/test/system/195-run-namespaces.bats
@@ -41,7 +41,7 @@ uts    | uts
             if [[ "$option" = "pid" ]] && is_rootless && ! is_remote && [[ "$(podman_runtime)" = "runc" ]]; then
                 # Replace "pid:[1234567]" with "pid:\[1234567\]"
                 con1_ns_esc="${con1_ns//[\[\]]/\\&}"
-                assert "$con2_ns" =~ "${con1_ns_esc}.*warning .*" "($name) namespace matches (type: $type)"
+                assert "$con2_ns" =~ "${con1_ns_esc}" "($name) namespace matches (type: $type)"
             else
                 assert "$con1_ns" == "$con2_ns" "($name) namespace matches (type: $type)"
             fi


### PR DESCRIPTION
runc may or may not issue a warning here due to https://github.com/opencontainers/runc/issues/4732

Otherwise test may fail on SLES 16.0 with podman v5.4.2 & runc v1.3.4 on s390x like:

```
#/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
#|     FAIL: (pid) namespace matches (type: private)
#| expected: =~ pid:\\\[4026532082\\\].\*warning .\*
#|   actual:    pid:\[4026532082\]
#\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
