### PR TITLE
Reject `--cpus` above host CPU count on podman machine init and set

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"slices"
 
 	"github.com/containers/podman/v6/cmd/podman/registry"
@@ -257,6 +258,9 @@ func initMachine(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	if err := checkMaxCPUs(initOpts.CPUS); err != nil {
+		return err
+	}
 
 	// initOpts.SkipTlsVerify defaults to OptionalBoolUndefined, which means the backend library
 	// decides whether to verify TLS. We only explicitly set it if the user specifies the
@@ -317,6 +321,15 @@ func checkMaxMemory(newMem strongunits.MiB) error {
 	}
 	if total := strongunits.B(memStat.Total); strongunits.B(memStat.Total) < newMem.ToBytes() {
 		return fmt.Errorf("requested amount of memory (%d MB) greater than total system memory (%d MB)", newMem, strongunits.ToMib(total))
+	}
+	return nil
+}
+
+// checkMaxCPUs compares requested CPUs to the host (runtime.NumCPU).
+func checkMaxCPUs(requestedCPUs uint64) error {
+	hostCPUs := uint64(runtime.NumCPU())
+	if requestedCPUs > hostCPUs {
+		return fmt.Errorf("requested number of CPUs (%d) greater than number of host CPUs (%d)", requestedCPUs, hostCPUs)
 	}
 	return nil
 }

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -253,10 +253,8 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		initOpts.UserModeNetworking = &initOptionalFlags.UserModeNetworking
 	}
 
-	if cmd.Flags().Changed("memory") {
-		if err := checkMaxMemory(strongunits.MiB(initOpts.Memory)); err != nil {
-			return err
-		}
+	if err := checkMaxMemory(strongunits.MiB(initOpts.Memory)); err != nil {
+		return err
 	}
 	if err := checkMaxCPUs(initOpts.CPUS); err != nil {
 		return err

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -98,6 +98,9 @@ func setMachine(cmd *cobra.Command, args []string) error {
 		setOpts.Rootful = &setFlags.Rootful
 	}
 	if cmd.Flags().Changed("cpus") {
+		if err := checkMaxCPUs(setFlags.CPUs); err != nil {
+			return err
+		}
 		setOpts.CPUs = &setFlags.CPUs
 	}
 	if cmd.Flags().Changed("memory") {

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -81,6 +81,12 @@ var _ = Describe("podman machine init", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(badMemSession.errorToString()).To(ContainSubstring(fmt.Sprintf("greater than total system memory (%d MB)", systemMem)))
 		Expect(badMemSession).To(Exit(125))
+
+		badCPU := initMachine{}
+		badCPUSession, err := mb.setCmd(badCPU.withCPUs(9999999)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(badCPUSession).To(Exit(125))
+		Expect(badCPUSession.errorToString()).To(ContainSubstring("greater than number of host CPUs"))
 	})
 
 	It("init volume check", func() {

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -13,6 +13,21 @@ import (
 )
 
 var _ = Describe("podman machine set", func() {
+	It("machine set rejects excessive cpus", func() {
+		skipIfWSL("WSL cannot change cpus via set")
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		badSet := setMachine{}
+		badCPUSession, err := mb.setName(name).setCmd(badSet.withCPUs(9999999)).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(badCPUSession).To(Exit(125))
+		Expect(badCPUSession.errorToString()).To(ContainSubstring("greater than number of host CPUs"))
+	})
+
 	It("set machine cpus, disk, memory", func() {
 		skipIfWSL("WSL cannot change set properties of disk, processor, or memory")
 		name := randomString()


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/28322

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The `podman machine init` and `podman machine set` now reject `--cpus` values larger than the number of logical CPUs on the host, with a clear error instead of accepting an invalid value.
```
