### PR TITLE
two small review fixes from storage.conf rework

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -143,10 +143,6 @@ case "$OS_RELEASE_ID" in
     *) die_unknown OS_RELEASE_ID
 esac
 
-# Remove packaged storage.conf as it hard codes a graphroot which
-# is not correct for rootless users based on our new config file parsing.
-rm -f /usr/share/containers/storage.conf
-
 # Force the requested storage driver for both system and e2e tests.
 # This is (sigh) different because e2e tests have their own special way
 # of ignoring system defaults.

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -154,7 +154,6 @@ EOF
     # pollute it for use by old-podman. We must keep that pristine
     # so old-podman is the first to write to it.
     #
-    # mount /etc/containers/storage.conf to use the same storage settings as on the host
     # mount /dev/shm because the container locks are stored there
     # mount /run/containers for the dnsname plugin
     #


### PR DESCRIPTION
Two small follow fixes as pointed out by @mtrmac in https://github.com/containers/podman/pull/28194

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
