### PR TITLE
api: fix missing return after error in SystemCheck handler

### DIFF
--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -96,6 +96,7 @@ func SystemCheck(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			utils.Error(w, http.StatusBadRequest,
 				fmt.Errorf("failed to parse unreferenced_layer_max_age parameter %q for %s: %w", query.UnreferencedLayerMaximumAge, r.URL.String(), err))
+			return
 		}
 		unreferencedLayerMaximumAge = &duration
 	}


### PR DESCRIPTION
## Summary

In `pkg/api/handlers/libpod/system.go`, the `SystemCheck` HTTP handler
parses the `unreferenced_layer_max_age` query parameter via
`time.ParseDuration`. When parsing fails, `utils.Error` is called to
send a 400 response, but execution falls through to:

```go
unreferencedLayerMaximumAge = &duration
```

where `duration` is the zero value from the failed parse. This means
the system check runs with a zero age limit instead of returning the
error to the client.

Add the missing `return` after the error response.

Fixes #28350