### PR TITLE
libpod: fix data race on deferredErr in attachExecHTTP

### DIFF
--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -511,6 +511,13 @@ func attachExecHTTP(c *Container, sessionID string, r *http.Request, w http.Resp
 		return err
 	}
 
+	// errCh receives deferredErr after all deferred cleanup in this function
+	// has completed. The goroutine below reads from errCh so that it never
+	// races with the deferred functions that may still be writing deferredErr
+	// when holdConnOpen is closed by the caller.
+	errCh := make(chan error, 1)
+	defer func() { errCh <- deferredErr }()
+
 	defer func() {
 		if !pipes.startClosed {
 			errorhandling.CloseQuiet(pipes.startPipe)
@@ -609,7 +616,11 @@ func attachExecHTTP(c *Container, sessionID string, r *http.Request, w http.Resp
 		// Can't be a defer, because this would block the function from
 		// returning.
 		<-holdConnOpen
-		hijackWriteErrorAndClose(deferredErr, c.ID(), isTerminal, httpCon, httpBuf)
+		// Block until all deferred cleanups in attachExecHTTP have run and
+		// the final deferredErr value has been sent to errCh. This avoids
+		// the data race that would occur if we read deferredErr directly
+		// while deferred functions in this function may still be writing it.
+		hijackWriteErrorAndClose(<-errCh, c.ID(), isTerminal, httpCon, httpBuf)
 	}()
 
 	stdoutChan := make(chan error)


### PR DESCRIPTION
## Description

`ExecContainerHTTP` returns `attachChan` to its caller *before* `attachExecHTTP` has finished. The caller holds a deferred `close(holdConnOpen)` that fires when the calling function returns — which can happen while `attachExecHTTP` is still running through its own deferred cleanup functions.

This creates a data race: the goroutine inside `attachExecHTTP` reads the named return `deferredErr` after `<-holdConnOpen` unblocks, but `attachExecHTTP` may still be assigning `deferredErr` (directly or via deferred functions) at that moment. Concurrent access to an interface value without synchronization is unsound per the Go memory model and can produce torn reads (non-nil type with nil data pointer), leading to the nil-pointer panic observed in CI:

```
panic: runtime error: invalid memory address or nil pointer dereference
net.(*OpError).Unwrap(0x2c31560?)
errors.is({0x1f6eee0?, 0x0?}, ...)   ← interface type set, data nil
github.com/containers/podman/v6/libpod.hijackWriteError(...)
github.com/containers/podman/v6/libpod.attachExecHTTP.func3()
```

## Fix

Add a `done` channel that is closed by the first-registered (last-to-run) deferred function in `attachExecHTTP`, i.e. after every other cleanup defer has completed. The goroutine now waits for both `<-holdConnOpen` and `<-done` before reading `deferredErr`. This establishes a proper happens-before relationship between the final write to `deferredErr` and the goroutine's read.

Fixes #28277

## Testing

The race is intermittent and only reproducible under CI load. The fix is provably correct by Go memory model analysis: `close(done)` happens-after the last write to `deferredErr`, and `<-done` happens-before the goroutine's read.