### PR TITLE
feat: remove reference to `--help` from artifact man pages. Resolves:…

### DIFF
--- a/docs/source/markdown/podman-artifact-add.1.md.in
+++ b/docs/source/markdown/podman-artifact-add.1.md.in
@@ -32,10 +32,6 @@ Append files to an existing artifact. This option cannot be used with the **--ty
 
 Set the media type of the artifact file instead of allowing detection to determine the type
 
-#### **--help**
-
-Print usage statement.
-
 #### **--replace**
 
 If an artifact with the same name already exists, replace and remove it. The default is **false**.

--- a/docs/source/markdown/podman-artifact-extract.1.md
+++ b/docs/source/markdown/podman-artifact-extract.1.md
@@ -30,10 +30,6 @@ If the target is a directory then the digest is always used as file name instead
 when the title annotation exists on the blob.
 Conflicts with **--title**.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--title**=**title**
 
 When extracting blobs from the artifact only use the one with the specified title.

--- a/docs/source/markdown/podman-artifact-inspect.1.md
+++ b/docs/source/markdown/podman-artifact-inspect.1.md
@@ -35,10 +35,6 @@ Valid placeholders for the Go template are listed below:
 | .Name            | Artifact name (string)                 |
 | .TotalSizeBytes  | Total Size of the artifact in bytes    |
 
-#### **--help**, **-h**
-
-Print usage statement
-
 ## EXAMPLES
 
 Inspect an OCI image in the local store.

--- a/docs/source/markdown/podman-artifact-rm.1.md
+++ b/docs/source/markdown/podman-artifact-rm.1.md
@@ -18,10 +18,6 @@ qualified artifact name or a full or partial artifact digest.
 Remove all artifacts in the local store.  The use of this option conflicts with
 providing a name or digest of the artifact.
 
-#### **--help**
-
-Print usage statement.
-
 #### **--ignore**, **-i**
 
 Remove artifacts in the local store, ignoring errors when trying to remove artifacts that do not exist.


### PR DESCRIPTION
… 

Fixes: #28373

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
