### PR TITLE
feat: allow dns flags with --network=container

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -315,7 +315,7 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 	if c.Flag("shm-size-systemd").Changed {
 		vals.ShmSizeSystemd = c.Flag("shm-size-systemd").Value.String()
 	}
-	if (c.Flag("dns").Changed || c.Flag("dns-option").Changed || c.Flag("dns-search").Changed) && vals.Net != nil && (vals.Net.Network.NSMode == specgen.NoNetwork || vals.Net.Network.IsContainer()) {
+	if (c.Flag("dns").Changed || c.Flag("dns-option").Changed || c.Flag("dns-search").Changed) && vals.Net != nil && vals.Net.Network.NSMode == specgen.NoNetwork {
 		return vals, errors.New("conflicting options: dns and the network mode: " + string(vals.Net.Network.NSMode))
 	}
 	noHosts, err := c.Flags().GetBool("no-hosts")

--- a/docs/source/markdown/options/dns-option.container.md
+++ b/docs/source/markdown/options/dns-option.container.md
@@ -4,4 +4,4 @@
 ####> are applicable to all of those.
 #### **--dns-option**=*option*
 
-Set custom DNS options. Invalid if using **--dns-option** with **--network** that is set to **none** or **container:**_id_.
+Set custom DNS options. Invalid if using **--dns-option** with **--network** that is set to **none**.

--- a/docs/source/markdown/options/dns-search.container.md
+++ b/docs/source/markdown/options/dns-search.container.md
@@ -4,5 +4,5 @@
 ####> are applicable to all of those.
 #### **--dns-search**=*domain*
 
-Set custom DNS search domains. Invalid if using **--dns-search** with **--network** that is set to **none** or **container:**_id_.
+Set custom DNS search domains. Invalid if using **--dns-search** with **--network** that is set to **none**.
 Use **--dns-search=.** to remove the search domain.

--- a/docs/source/markdown/options/dns.md
+++ b/docs/source/markdown/options/dns.md
@@ -14,5 +14,10 @@ is the case the **--dns** flag is necessary for every run.
 The special value **none** can be specified to disable creation of _/etc/resolv.conf_ in the container by Podman.
 The _/etc/resolv.conf_ file in the image is then used without changes.
 
+When used with **--network=container:**_id_ and DNS-related options
+(**--dns**, **--dns-search**, or **--dns-option**), Podman creates a dedicated
+_/etc/resolv.conf_ for the container. Without those DNS options, Podman reuses
+the dependency container's _/etc/resolv.conf_.
+
 Note that **ipaddr** may be added directly to the container's _/etc/resolv.conf_.
 This is not guaranteed though.  For example, passing a custom network whose *dns_enabled* is set to *true* to **--network** will result in _/etc/resolv.conf_ only referring to the aardvark-dns server.  aardvark-dns then forwards to the supplied **ipaddr** for all non-container name queries.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -267,7 +267,7 @@ pod when that pod is not running.
 
 @@option network
 
-Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none** or **container:**_id_.
+Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none**.
 
 If used together with **--pod**, the container does not join the pod's network namespace.
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -124,7 +124,7 @@ Assign a name to the pod.
 
 @@option network
 
-Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none** or **container:**_id_.
+Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none**.
 
 @@option network-alias
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -286,7 +286,7 @@ Print usage statement
 
 @@option network
 
-Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none** or **container:**_id_.
+Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none**.
 
 If used together with **--pod**, the container joins the pod's network namespace.
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -999,6 +999,12 @@ func (c *Container) completeNetworkSetup() error {
 		return c.addHosts()
 	}
 	if c.config.NetNsCtr != "" {
+		// With container network mode, we share the network namespace.
+		// If custom DNS options are set, populate the separate resolv.conf
+		// that was created in makeBindMounts.
+		if len(c.config.DNSServer) > 0 || len(c.config.DNSSearch) > 0 || len(c.config.DNSOption) > 0 {
+			return c.addResolvConf()
+		}
 		return nil
 	}
 	if c.config.PostConfigureNetNS {

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1973,7 +1973,7 @@ func (c *Container) makeBindMounts() error {
 			// We share a net namespace.
 			// We want /etc/resolv.conf and /etc/hosts from the
 			// other container. Unless we're not creating both of
-			// them.
+			// them or custom DNS options are specified.
 			depCtr, err := c.getRootNetNsDepCtr()
 			if err != nil {
 				return fmt.Errorf("fetching network namespace dependency container for container %s: %w", c.ID(), err)
@@ -1985,13 +1985,21 @@ func (c *Container) makeBindMounts() error {
 				return fmt.Errorf("fetching bind mounts from dependency %s of container %s: %w", depCtr.ID(), c.ID(), err)
 			}
 
+			customDNS := len(c.config.DNSServer) > 0 || len(c.config.DNSSearch) > 0 || len(c.config.DNSOption) > 0
+
 			// The other container may not have a resolv.conf or /etc/hosts
 			// If it doesn't, don't copy them
-			resolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]
-			if !c.config.UseImageResolvConf && exists {
-				err := c.mountIntoRootDirs(resolvconf.DefaultResolvConf, resolvPath)
-				if err != nil {
-					return fmt.Errorf("assigning mounts to container %s: %w", c.ID(), err)
+			if !c.config.UseImageResolvConf {
+				if customDNS {
+					// Custom DNS options specified, create a separate resolv.conf
+					if err := c.createResolvConf(); err != nil {
+						return fmt.Errorf("creating resolv.conf for container %s: %w", c.ID(), err)
+					}
+				} else if resolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]; exists {
+					err := c.mountIntoRootDirs(resolvconf.DefaultResolvConf, resolvPath)
+					if err != nil {
+						return fmt.Errorf("assigning mounts to container %s: %w", c.ID(), err)
+					}
 				}
 			}
 
@@ -2182,7 +2190,27 @@ func (c *Container) addResolvConf() error {
 	var (
 		networkNameServers   []string
 		networkSearchDomains []string
+		baseNameServers      []string
+		baseSearchDomains    []string
+		baseOptions          []string
 	)
+
+	if c.config.NetNsCtr != "" {
+		depCtr, err := c.getRootNetNsDepCtr()
+		if err != nil {
+			logrus.Warnf("Unable to get root network namespace dependency for container %s: %v", c.ID(), err)
+		} else {
+			bindMounts, err := depCtr.BindMounts()
+			if err != nil {
+				logrus.Warnf("Unable to get bind mounts from dependency container %s for container %s: %v", depCtr.ID(), c.ID(), err)
+			} else if depResolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]; exists {
+				baseNameServers, baseSearchDomains, baseOptions, err = readResolvConfEntries(depResolvPath)
+				if err != nil {
+					logrus.Warnf("Unable to read dependency resolv.conf %q for container %s: %v", depResolvPath, c.ID(), err)
+				}
+			}
+		}
+	}
 
 	netStatus := c.getNetworkStatus()
 	for _, status := range netStatus {
@@ -2221,7 +2249,11 @@ func (c *Container) addResolvConf() error {
 		// when no network name servers use host servers
 		// for aardvark dns we only want our single server in there
 		if len(networkNameServers) == 0 {
-			keepHostServers = true
+			if len(baseNameServers) > 0 {
+				nameservers = append(nameservers, baseNameServers...)
+			} else {
+				keepHostServers = true
+			}
 		}
 		if len(networkNameServers) > 0 {
 			// add the nameservers from the networks status
@@ -2235,12 +2267,15 @@ func (c *Container) addResolvConf() error {
 	// Set DNS search domains
 	var search []string
 	keepHostSearches := false
-	if len(c.config.DNSSearch) > 0 || len(c.runtime.config.Containers.DNSSearches.Get()) > 0 {
+	switch {
+	case len(c.config.DNSSearch) > 0 || len(c.runtime.config.Containers.DNSSearches.Get()) > 0:
 		customSearch := make([]string, 0, len(c.config.DNSSearch)+len(c.runtime.config.Containers.DNSSearches.Get()))
 		customSearch = append(customSearch, c.runtime.config.Containers.DNSSearches.Get()...)
 		customSearch = append(customSearch, c.config.DNSSearch...)
 		search = customSearch
-	} else {
+	case len(baseSearchDomains) > 0:
+		search = baseSearchDomains
+	default:
 		search = networkSearchDomains
 		keepHostSearches = true
 	}
@@ -2248,6 +2283,9 @@ func (c *Container) addResolvConf() error {
 	options := make([]string, 0, len(c.config.DNSOption)+len(c.runtime.config.Containers.DNSOptions.Get()))
 	options = append(options, c.runtime.config.Containers.DNSOptions.Get()...)
 	options = append(options, c.config.DNSOption...)
+	if len(options) == 0 && len(baseOptions) > 0 {
+		options = baseOptions
+	}
 
 	var namespaces []spec.LinuxNamespace
 	if c.config.Spec.Linux != nil {
@@ -2268,6 +2306,38 @@ func (c *Container) addResolvConf() error {
 	}
 
 	return nil
+}
+
+func readResolvConfEntries(path string) ([]string, []string, []string, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var (
+		nameservers []string
+		searches    []string
+		options     []string
+	)
+
+	for _, line := range strings.Split(string(contents), "\n") {
+		beforeComment, _, _ := strings.Cut(line, "#")
+		fields := strings.Fields(beforeComment)
+		if len(fields) < 2 {
+			continue
+		}
+
+		switch fields[0] {
+		case "nameserver":
+			nameservers = append(nameservers, fields[1])
+		case "search":
+			searches = fields[1:]
+		case "options":
+			options = fields[1:]
+		}
+	}
+
+	return nameservers, searches, options, nil
 }
 
 // Check if a container uses IPv6.

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2199,15 +2199,12 @@ func (c *Container) addResolvConf() error {
 		depCtr, err := c.getRootNetNsDepCtr()
 		if err != nil {
 			logrus.Warnf("Unable to get root network namespace dependency for container %s: %v", c.ID(), err)
-		} else {
-			bindMounts, err := depCtr.BindMounts()
+		} else if bindMounts, err := depCtr.BindMounts(); err != nil {
+			logrus.Warnf("Unable to get bind mounts from dependency container %s for container %s: %v", depCtr.ID(), c.ID(), err)
+		} else if depResolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]; exists {
+			baseNameServers, baseSearchDomains, baseOptions, err = readResolvConfEntries(depResolvPath)
 			if err != nil {
-				logrus.Warnf("Unable to get bind mounts from dependency container %s for container %s: %v", depCtr.ID(), c.ID(), err)
-			} else if depResolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]; exists {
-				baseNameServers, baseSearchDomains, baseOptions, err = readResolvConfEntries(depResolvPath)
-				if err != nil {
-					logrus.Warnf("Unable to read dependency resolv.conf %q for container %s: %v", depResolvPath, c.ID(), err)
-				}
+				logrus.Warnf("Unable to read dependency resolv.conf %q for container %s: %v", depResolvPath, c.ID(), err)
 			}
 		}
 	}
@@ -2251,7 +2248,8 @@ func (c *Container) addResolvConf() error {
 		if len(networkNameServers) == 0 {
 			if len(baseNameServers) > 0 {
 				nameservers = append(nameservers, baseNameServers...)
-			} else {
+			}
+			if len(nameservers) == 0 {
 				keepHostServers = true
 			}
 		}

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2198,13 +2198,16 @@ func (c *Container) addResolvConf() error {
 	if c.config.NetNsCtr != "" {
 		depCtr, err := c.getRootNetNsDepCtr()
 		if err != nil {
-			logrus.Warnf("Unable to get root network namespace dependency for container %s: %v", c.ID(), err)
-		} else if bindMounts, err := depCtr.BindMounts(); err != nil {
-			logrus.Warnf("Unable to get bind mounts from dependency container %s for container %s: %v", depCtr.ID(), c.ID(), err)
-		} else if depResolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]; exists {
+			return fmt.Errorf("getting root network namespace dependency for container %s: %w", c.ID(), err)
+		}
+		bindMounts, err := depCtr.BindMounts()
+		if err != nil {
+			return fmt.Errorf("getting bind mounts from dependency container %s for container %s: %w", depCtr.ID(), c.ID(), err)
+		}
+		if depResolvPath, exists := bindMounts[resolvconf.DefaultResolvConf]; exists {
 			baseNameServers, baseSearchDomains, baseOptions, err = readResolvConfEntries(depResolvPath)
 			if err != nil {
-				logrus.Warnf("Unable to read dependency resolv.conf %q for container %s: %v", depResolvPath, c.ID(), err)
+				return fmt.Errorf("reading dependency resolv.conf %q for container %s: %w", depResolvPath, c.ID(), err)
 			}
 		}
 	}
@@ -2246,9 +2249,7 @@ func (c *Container) addResolvConf() error {
 		// when no network name servers use host servers
 		// for aardvark dns we only want our single server in there
 		if len(networkNameServers) == 0 {
-			if len(baseNameServers) > 0 {
-				nameservers = append(nameservers, baseNameServers...)
-			}
+			nameservers = append(nameservers, baseNameServers...)
 			if len(nameservers) == 0 {
 				keepHostServers = true
 			}

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -75,21 +75,102 @@ var _ = Describe("Podman run dns", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("foobar"))
 	})
 
-	It("podman run mutually excludes --dns* and --network", func() {
-		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "container:ALPINE", ALPINE})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: container"))
-
-		session = podmanTest.Podman([]string{"run", "--dns-opt=1.2.3.4", "--network", "container:ALPINE", ALPINE})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: container"))
-
-		session = podmanTest.Podman([]string{"run", "--dns-search=foobar.com", "--network", "none", ALPINE})
+	It("podman run --dns with --network none is rejected", func() {
+		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "none", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: none"))
+	})
 
-		session = podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
+	It("podman run --dns-search with --network none is rejected", func() {
+		session := podmanTest.Podman([]string{"run", "--dns-search=foobar.com", "--network", "none", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: none"))
+	})
+
+	It("podman run --dns-opt with --network none is rejected", func() {
+		session := podmanTest.Podman([]string{"run", "--dns-opt=debug", "--network", "none", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError(125, "conflicting options: dns and the network mode: none"))
+	})
+
+	It("podman run --dns with --network host is allowed", func() {
+		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
+	})
+
+	It("podman run --dns with --network container works", func() {
+		ctrName := "dnsContainerSrc"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"run", "--dns=8.8.8.8", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 8.8.8.8")))
+		Expect(session.OutputToStringArray()).To(Not(ContainElement(HavePrefix("nameserver 1.1.1.1"))))
+	})
+
+	It("podman run --network container without dns flags keeps dependency resolv.conf", func() {
+		ctrName := "dnsContainerDefaultShareSrc"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"run", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.1.1.1")))
+	})
+
+	It("podman run --dns-search with --network container inherits dependency nameserver", func() {
+		ctrName := "dnsSearchContainerSrc"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"run", "--dns-search=example.com", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.1.1.1")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
+	})
+
+	It("podman run --dns-opt with --network container inherits dependency nameserver", func() {
+		ctrName := "dnsOptContainerSrc"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"run", "--dns-opt=debug", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.1.1.1")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
+	})
+
+	It("podman run combined dns flags with --network container works", func() {
+		ctrName := "dnsCombinedContainerSrc"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{
+			"run",
+			"--dns=8.8.8.8",
+			"--dns-search=example.com",
+			"--dns-opt=debug",
+			"--network",
+			"container:" + ctrName,
+			ALPINE,
+			"cat",
+			"/etc/resolv.conf",
+		})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 8.8.8.8")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
 	})
 })

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -10,16 +10,12 @@ import (
 
 var _ = Describe("Podman run dns", func() {
 	It("podman run add search domain", func() {
-		session := podmanTest.Podman([]string{"run", "--dns-search=foobar.com", ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns-search=foobar.com", ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search foobar.com")))
 	})
 
 	It("podman run remove all search domain", func() {
-		session := podmanTest.Podman([]string{"run", "--dns-search=.", ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns-search=.", ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(Not(ContainElement(HavePrefix("search"))))
 	})
 
@@ -30,16 +26,12 @@ var _ = Describe("Podman run dns", func() {
 	})
 
 	It("podman run add dns server", func() {
-		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns=1.2.3.4", ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.2.3.4")))
 	})
 
 	It("podman run add dns option", func() {
-		session := podmanTest.Podman([]string{"run", "--dns-opt=debug", ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns-opt=debug", ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
 	})
 
@@ -50,28 +42,20 @@ var _ = Describe("Podman run dns", func() {
 	})
 
 	It("podman run add host", func() {
-		session := podmanTest.Podman([]string{"run", "--add-host=foobar:1.1.1.1", "--add-host=foobaz:2001:db8::68", ALPINE, "cat", "/etc/hosts"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--add-host=foobar:1.1.1.1", "--add-host=foobaz:2001:db8::68", ALPINE, "cat", "/etc/hosts")
 		Expect(session.OutputToStringArray()).To(ContainElements(HavePrefix("1.1.1.1\tfoobar"), HavePrefix("2001:db8::68\tfoobaz")))
 	})
 
 	It("podman run add hostname", func() {
-		session := podmanTest.Podman([]string{"run", "--hostname=foobar", ALPINE, "cat", "/etc/hostname"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--hostname=foobar", ALPINE, "cat", "/etc/hostname")
 		Expect(string(session.Out.Contents())).To(Equal("foobar\n"))
 
-		session = podmanTest.Podman([]string{"run", "--hostname=foobar", ALPINE, "hostname"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session = podmanTest.PodmanExitCleanly("run", "--hostname=foobar", ALPINE, "hostname")
 		Expect(session.OutputToString()).To(Equal("foobar"))
 	})
 
 	It("podman run add hostname sets /etc/hosts", func() {
-		session := podmanTest.Podman([]string{"run", "--hostname=foobar", ALPINE, "cat", "/etc/hosts"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--hostname=foobar", ALPINE, "cat", "/etc/hosts")
 		Expect(session.OutputToString()).To(ContainSubstring("foobar"))
 	})
 
@@ -94,81 +78,59 @@ var _ = Describe("Podman run dns", func() {
 	})
 
 	It("podman run --dns with --network host is allowed", func() {
-		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "--dns=1.2.3.4", "--network", "host", ALPINE)
 	})
 
 	It("podman run --dns with --network container works", func() {
 		ctrName := "dnsContainerSrc"
-		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top")
 
-		session = podmanTest.Podman([]string{"run", "--dns=8.8.8.8", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns=8.8.8.8", "--network", "container:"+ctrName, ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 8.8.8.8")))
 		Expect(session.OutputToStringArray()).To(Not(ContainElement(HavePrefix("nameserver 1.1.1.1"))))
 	})
 
 	It("podman run --network container without dns flags keeps dependency resolv.conf", func() {
 		ctrName := "dnsContainerDefaultShareSrc"
-		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top")
 
-		session = podmanTest.Podman([]string{"run", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--network", "container:"+ctrName, ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.1.1.1")))
 	})
 
 	It("podman run --dns-search with --network container inherits dependency nameserver", func() {
 		ctrName := "dnsSearchContainerSrc"
-		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top")
 
-		session = podmanTest.Podman([]string{"run", "--dns-search=example.com", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns-search=example.com", "--network", "container:"+ctrName, ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.1.1.1")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
 	})
 
 	It("podman run --dns-opt with --network container inherits dependency nameserver", func() {
 		ctrName := "dnsOptContainerSrc"
-		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top")
 
-		session = podmanTest.Podman([]string{"run", "--dns-opt=debug", "--network", "container:" + ctrName, ALPINE, "cat", "/etc/resolv.conf"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("run", "--dns-opt=debug", "--network", "container:"+ctrName, ALPINE, "cat", "/etc/resolv.conf")
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 1.1.1.1")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
 	})
 
 	It("podman run combined dns flags with --network container works", func() {
 		ctrName := "dnsCombinedContainerSrc"
-		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, ALPINE, "top")
 
-		session = podmanTest.Podman([]string{
+		session := podmanTest.PodmanExitCleanly(
 			"run",
 			"--dns=8.8.8.8",
 			"--dns-search=example.com",
 			"--dns-opt=debug",
 			"--network",
-			"container:" + ctrName,
+			"container:"+ctrName,
 			ALPINE,
 			"cat",
 			"/etc/resolv.conf",
-		})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		)
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver 8.8.8.8")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -107,6 +107,43 @@ var _ = Describe("Podman run dns", func() {
 		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
 	})
 
+	It("podman run --dns-search with --network container works when dependency has --dns none", func() {
+		ctrName := "dnsNoneContainerSrc"
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns", "none", ALPINE, "top")
+
+		session := podmanTest.PodmanExitCleanly("run", "--dns-search=example.com", "--network", "container:"+ctrName, ALPINE, "cat", "/etc/resolv.conf")
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver ")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
+	})
+
+	It("podman run --dns-opt with --network container works when dependency has --dns none", func() {
+		ctrName := "dnsOptNoneContainerSrc"
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns", "none", ALPINE, "top")
+
+		session := podmanTest.PodmanExitCleanly("run", "--dns-opt=debug", "--network", "container:"+ctrName, ALPINE, "cat", "/etc/resolv.conf")
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver ")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
+	})
+
+	It("podman run --dns-search and --dns-opt with --network container work when dependency has --dns none", func() {
+		ctrName := "dnsCombinedNoneContainerSrc"
+		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns", "none", ALPINE, "top")
+
+		session := podmanTest.PodmanExitCleanly(
+			"run",
+			"--dns-search=example.com",
+			"--dns-opt=debug",
+			"--network",
+			"container:"+ctrName,
+			ALPINE,
+			"cat",
+			"/etc/resolv.conf",
+		)
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("nameserver ")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("search example.com")))
+		Expect(session.OutputToStringArray()).To(ContainElement(HavePrefix("options debug")))
+	})
+
 	It("podman run --dns-opt with --network container inherits dependency nameserver", func() {
 		ctrName := "dnsOptContainerSrc"
 		podmanTest.PodmanExitCleanly("run", "-d", "--name", ctrName, "--dns=1.1.1.1", ALPINE, "top")


### PR DESCRIPTION
## Summary

Allow `--dns`/`--dns-search`/`--dns-opt` with `--network=container` by using a per-container `resolv.conf` when joining another container's netns. Update docs and e2e coverage to match.

Fixes: #25386

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Allow --dns/--dns-search/--dns-opt with --network=container by creating a per-container resolv.conf.
```
