### PR TITLE
compat: map internal states to Docker equivalents in LibpodToContainer

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -309,9 +309,16 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 	}
 	stateStr := state.String()
 
-	// Some docker states are not the same as ours. This makes sure the state string stays true to the Docker API
-	if state == define.ContainerStateCreated {
+	// Some docker states are not the same as ours. This makes sure the state string stays true to the Docker API.
+	// "stopped" and "stopping" are podman-internal states with no Docker equivalent;
+	// map them to the nearest Docker state so the compat API never leaks internal states.
+	switch state {
+	case define.ContainerStateCreated:
 		stateStr = define.ContainerStateConfigured.String()
+	case define.ContainerStateStopped:
+		stateStr = define.ContainerStateExited.String()
+	case define.ContainerStateStopping:
+		stateStr = define.ContainerStateRunning.String()
 	}
 
 	switch state {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -81,6 +81,7 @@ t GET /containers/json?all=true 200 \
   length=1 \
   .[0].Id~[0-9a-f]\\{64\\} \
   .[0].Image=$IMAGE \
+  .[0].State="exited" \
   .[0].Mounts~.*/tmp \
   .[0].NetworkSettings.$network_expect
 


### PR DESCRIPTION
## Description

The Docker compat `/containers/json` endpoint was leaking podman-internal container states (`stopped`, `stopping`) that are not part of the Docker API state vocabulary. Docker clients that strictly validate the `State` field against the documented set (`created`, `running`, `paused`, `restarting`, `exited`, `removing`, `dead`) would fail with deserialization errors like:

```
unknown variant `stopped`, expected one of ``, `created`, `running`, `paused`,
`restarting`, `exited`, `removing`, `dead`
```

`LibpodToContainerJSON` (used by `GET /containers/{name}/json`) already performs the correct mapping:
- `stopped` → `exited`
- `stopping` → `running`

This PR applies the same remapping in `LibpodToContainer` (used by `GET /containers/json`) so both endpoints behave consistently.

A test assertion is added to the compat list endpoint test to verify that a stopped container is reported with `State="exited"`.

Fixes #28359