### PR TITLE
Fixes: #28374 de-deuplicated quiet option (docs)

### DIFF
--- a/docs/source/markdown/options/quiet.md
+++ b/docs/source/markdown/options/quiet.md
@@ -4,4 +4,4 @@
 ####> are applicable to all of those.
 #### **--quiet**, **-q**
 
-Suppress output messages (which indicate which instruction is being processed, and progress of the instruction).
+Suppress informational output messages (which indicate which instruction is being processed, and the progress of the instruction).  Print only the final error message or successful completion information, such as the image or container ID.

--- a/docs/source/markdown/options/quiet.md
+++ b/docs/source/markdown/options/quiet.md
@@ -1,7 +1,7 @@
 ####> This option file is used in:
-####>   podman build, farm build
+####>   podman artifact pull, artifact push, build, farm build, pull, push
 ####> If file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--quiet**, **-q**
 
-Suppress output messages which indicate which instruction is being processed, and of progress when pulling images from a registry, and when writing the output image.
+Suppress output messages (which indicate which instruction is being processed, and progress of the instruction).

--- a/docs/source/markdown/podman-artifact-pull.1.md.in
+++ b/docs/source/markdown/podman-artifact-pull.1.md.in
@@ -34,9 +34,7 @@ $ podman artifact pull quay.io/foobar/artifact:special
 
 Print the usage statement.
 
-#### **--quiet**, **-q**
-
-Suppress output information when pulling images
+@@option quiet
 
 @@option retry
 

--- a/docs/source/markdown/podman-artifact-push.1.md.in
+++ b/docs/source/markdown/podman-artifact-push.1.md.in
@@ -24,9 +24,7 @@ $ podman artifact push quay.io/artifact/foobar1:latest
 
 @@option digestfile
 
-#### **--quiet**, **-q**
-
-When writing the output image, suppress progress output
+@@option quiet
 
 @@option retry
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -78,9 +78,7 @@ Pull image policy. The default is **always**.
 - `never`: Never pull the image; only use the local version. Throw an error if the image is not present locally.
 - `newer`: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
-#### **--quiet**, **-q**
-
-Suppress output information when pulling images
+@@option quiet
 
 @@option retry
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -76,9 +76,7 @@ The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7
 
 Manifest Type (oci, v2s2, or v2s1) to use when pushing an image.
 
-#### **--quiet**, **-q**
-
-When writing the output image, suppress progress output
+@@option quiet
 
 #### **--remove-signatures**
 


### PR DESCRIPTION
De-duplicates quiet option on `podman push`, `podman pull`, `podman artifact push`, and `podman artifact pull`. Also made quiet option wording more generic so it makes sense with the new dependent docs.

Fixes: #28374

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
Yes, to the wording on the documentation.

```release-note
De-deuplicated `--quiet` option and improved wording.
```