### PR TITLE
fix(artifact): show :latest tag in ls output when no explicit tag given

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -104,6 +104,9 @@ func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) erro
 		if !ok {
 			return fmt.Errorf("%q is an invalid artifact name", artifactName)
 		}
+		// Normalize the reference so artifacts stored without an explicit tag
+		// display ":latest" instead of an empty TAG column, matching container image behaviour.
+		named = reference.TagNameOnly(named)
 		if tagged, ok := named.(reference.Tagged); ok {
 			tag = tagged.Tag()
 		}

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -742,6 +742,23 @@ var _ = Describe("Podman artifact", func() {
 		session = podmanTest.PodmanExitCleanly("artifact", "inspect", artifactDigest[:12], "-f", "{{.Name}}")
 		Expect(session.OutputToString()).To(Equal(artifact1Name))
 	})
+
+	It("podman artifact ls shows latest tag for untagged artifact", func() {
+		artifactFile, err := createArtifactFile(1024)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Add artifact without an explicit tag — podman should default to :latest
+		artifactName := "localhost/test/untagged-artifact"
+		podmanTest.PodmanExitCleanly("artifact", "add", artifactName, artifactFile)
+
+		// Verify the TAG column shows "latest" in the default ls output
+		listSession := podmanTest.PodmanExitCleanly("artifact", "ls")
+		Expect(listSession.OutputToString()).To(ContainSubstring("latest"))
+
+		// Confirm via --format that the Tag field is "latest"
+		tagSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Tag}}")
+		Expect(tagSession.OutputToString()).To(Equal("latest"))
+	})
 })
 
 func digestToFilename(digest string) string {


### PR DESCRIPTION
## Description

Fixes #27083

When an artifact is added without an explicit tag (e.g. `quay.io/myimage/myartifact`), the `TAG` column in `podman artifact ls` was empty instead of showing `latest`, unlike container images which default to `:latest`.

## Fix

Add a call to `reference.TagNameOnly()` after parsing the stored artifact name in `outputTemplate`, so the reference is normalised before the tag is extracted. `reference.TagNameOnly` is already imported and used elsewhere in the codebase — this is a one-line display-side fix consistent with how `NewArtifactReference` already normalises on the storage side.

```go
// Before
named, ok := repo.(reference.Named)
...
if tagged, ok := named.(reference.Tagged); ok {
    tag = tagged.Tag()
}
// tag == "" for untagged artifacts → empty TAG column

// After
named = reference.TagNameOnly(named) // normalise: adds :latest if no tag present
if tagged, ok := named.(reference.Tagged); ok {
    tag = tagged.Tag()
}
// tag == "latest" ✓
```

## Testing

```bash
podman artifact add quay.io/myimage/myartifact /tmp/file.txt
podman artifact ls
# REPOSITORY                    TAG     DIGEST         CREATED       SIZE
# quay.io/myimage/myartifact    latest  sha256:abc...  1 minute ago  1.2 kB
```