### PR TITLE
Fix shell driver DriverOpts cross-contamination in secret creation

### DIFF
--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -33,7 +33,7 @@ func (ic *ContainerEngine) SecretCreate(_ context.Context, name string, reader i
 	if options.Driver == "" {
 		options.Driver = cfg.Secrets.Driver
 	}
-	if len(options.DriverOpts) == 0 {
+	if len(options.DriverOpts) == 0 && options.Driver == cfg.Secrets.Driver {
 		options.DriverOpts = cfg.Secrets.Opts
 	}
 	if options.DriverOpts == nil {

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -504,6 +504,25 @@ var _ = Describe("Podman secret", func() {
 		Expect(exists).Should(ExitWithError(1, ""))
 	})
 
+	It("podman secret create with non-default driver does not inherit default driver opts", func() {
+		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a secret with driver=shell but no --driver-opts.
+		// Before the fix, the file driver's default "path" opt bled
+		// into the shell driver, causing "invalid shell driver option".
+		// After the fix, the shell driver correctly receives no
+		// foreign opts and fails only because its required commands
+		// (store, lookup, list, delete) are not configured.
+		session := podmanTest.Podman([]string{
+			"secret", "create", "-d", "shell",
+			"shell-secret", secretFilePath,
+		})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "missing config value"))
+	})
+
 	It("podman secret create from stdin", func() {
 		secretData := "mysecretdata"
 		secretName := "stdin-secret-" + stringid.GenerateRandomID()


### PR DESCRIPTION
When creating a secret with driver=shell via the API, the file driver's default DriverOpts (including path) were applied because DriverOpts was empty. The shell driver rejects path as an unknown option, making it impossible to create shell-driver secrets via the REST API or podman-remote.

Only apply default DriverOpts from config when the requested driver matches the configured default driver.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
