### PR TITLE
Use AND to combine different volume filter keys

### DIFF
--- a/docs/source/markdown/options/filter.images.md
+++ b/docs/source/markdown/options/filter.images.md
@@ -6,7 +6,7 @@
 
 Provide filter values.
 
-The *filters* argument format is of `key=value` or `key!=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/options/filter.network-ls.md
+++ b/docs/source/markdown/options/filter.network-ls.md
@@ -6,7 +6,7 @@
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *name=test* **--filter** *driver=bridge*.
 
 Supported filters:
 

--- a/docs/source/markdown/options/filter.network-prune.md
+++ b/docs/source/markdown/options/filter.network-prune.md
@@ -2,7 +2,7 @@
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/options/filter.pod-ps.md
+++ b/docs/source/markdown/options/filter.pod-ps.md
@@ -6,7 +6,7 @@
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/options/filter.quadlet-list.md
+++ b/docs/source/markdown/options/filter.quadlet-list.md
@@ -2,7 +2,7 @@
 
 Filter output based on conditions given.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *name=test* **--filter** *status=active/running*.
 
 Supported filters:
 

--- a/docs/source/markdown/options/filter.volume-ls.md
+++ b/docs/source/markdown/options/filter.volume-ls.md
@@ -6,7 +6,7 @@
 
 Filter what volumes are shown in the output.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *name=test* **--filter** *driver=local*.
 
 Filters with the same key work inclusive, with the only exception being `label`
 which is exclusive. Filters with different keys always work exclusive.

--- a/docs/source/markdown/options/filter.volume-ls.md
+++ b/docs/source/markdown/options/filter.volume-ls.md
@@ -5,7 +5,9 @@
 #### **--filter**, **-f**=*filter*
 
 Filter what volumes are shown in the output.
-Multiple filters can be given with multiple uses of the --filter flag.
+
+The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+
 Filters with the same key work inclusive, with the only exception being `label`
 which is exclusive. Filters with different keys always work exclusive.
 

--- a/docs/source/markdown/options/filter.volume-prune.md
+++ b/docs/source/markdown/options/filter.volume-prune.md
@@ -2,7 +2,7 @@
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -14,7 +14,7 @@ podman\-container\-prune - Remove all stopped containers from local storage
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -29,7 +29,7 @@ Remove images even when they are used by external containers (e.g., build contai
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/podman-network-prune.1.md
+++ b/docs/source/markdown/podman-network-prune.1.md
@@ -17,7 +17,7 @@ the so-called default network which goes by the name of *podman*.
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/podman-quadlet-list.1.md.in
+++ b/docs/source/markdown/podman-quadlet-list.1.md.in
@@ -16,7 +16,7 @@ List all Quadlets configured for the current user.
 
 Filter output based on conditions give.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *name=test* **--filter** *status=active/running*.
 
 Supported filters:
 

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -38,7 +38,7 @@ This option is incompatible with **--all** and **--filter** and drops the defaul
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Supported filters:
 

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -25,7 +25,7 @@ Remove all unused volumes (anonymous and named). Without this option, only anony
 
 Provide filter values.
 
-The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
+If there is more than one filter, the `--filter` option should be passed multiple times: **--filter** *label=test* **--filter** *until=10m*.
 
 Filters with the same key work inclusive, with the only exception being `label`
 which is exclusive. Filters with different keys always work exclusive.

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -27,6 +27,9 @@ Provide filter values.
 
 The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
 
+Filters with the same key work inclusive, with the only exception being `label`
+which is exclusive. Filters with different keys always work exclusive.
+
 Supported filters:
 
 | Filter      | Description                                                                                                |

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -71,7 +71,7 @@ func (r *Runtime) HasVolume(name string) (bool, error) {
 // Volumes retrieves all volumes
 // Filters can be provided which will determine which volumes are included in the
 // output. If multiple filters are used, a volume will be returned if
-// any of the filters are matched
+// all of the filters are matched
 func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 	if !r.valid {
 		return nil, define.ErrRuntimeStopped
@@ -88,9 +88,9 @@ func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 
 	volsFiltered := make([]*Volume, 0, len(vols))
 	for _, vol := range vols {
-		include := false
+		include := true
 		for _, filter := range filters {
-			include = include || filter(vol)
+			include = include && filter(vol)
 		}
 
 		if include {

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -213,6 +213,13 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol3Name))
+
+		// Filters with different keys
+		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=b=c", "--filter", "name=vol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToStringArray()[0]).To(Equal(vol1Name))
 	})
 
 	It("podman ls volume with --filter since/after", func() {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/26786

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Volume filters with different keys are combined with AND instead of OR
```
