### PR TITLE
Fix Quadlet `Lookup()` stripping unmatched quotes

### DIFF
--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -611,14 +611,20 @@ func (f *UnitFile) LookupLast(groupName string, key string) (string, bool) {
 }
 
 // Look up the last instance of the named key in the group (if any)
-// The result have no trailing whitespace and line continuations are applied
+// The result have no trailing whitespace and line continuations are applied.
+// Surrounding matched double-quote pairs are stripped, but unmatched quotes
+// are preserved to avoid mangling embedded shell syntax.
 func (f *UnitFile) Lookup(groupName string, key string) (string, bool) {
 	v, ok := f.LookupLast(groupName, key)
 	if !ok {
 		return "", false
 	}
 
-	return strings.Trim(strings.TrimRightFunc(v, unicode.IsSpace), "\""), true
+	v = strings.TrimRightFunc(v, unicode.IsSpace)
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		v = v[1 : len(v)-1]
+	}
+	return v, true
 }
 
 // Lookup the last instance of a key and convert the value to a bool

--- a/pkg/systemd/parser/unitfile_test.go
+++ b/pkg/systemd/parser/unitfile_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -339,6 +340,35 @@ Name=my-container
 	assert.Len(t, comments, 2)
 	assert.Equal(t, "# comment", comments[0])
 	assert.Equal(t, "; another comment", comments[1])
+}
+
+func TestLookupQuoteStripping(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"hello"`, "hello"},
+		{`hello`, "hello"},
+		{`"hello`, `"hello`},
+		{`/bin/sh -c "echo "hello""`, `/bin/sh -c "echo "hello""`},
+		{`"/bin/sh -c "echo "hello"""`, `/bin/sh -c "echo "hello""`},
+		{`""`, ""},
+		{`hello"`, `hello"`},
+		{`/bin/sh -c "echo 'hello world!'"`, `/bin/sh -c "echo 'hello world!'"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Lookup(%q)", tt.input), func(t *testing.T) {
+			unitData := "[Container]\nKey=" + tt.input + "\n"
+			f := NewUnitFile()
+			err := f.Parse(unitData)
+			assert.NoError(t, err)
+
+			val, ok := f.Lookup("Container", "Key")
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, val)
+		})
+	}
 }
 
 func FuzzParser(f *testing.F) {

--- a/test/e2e/quadlet/health-cmd-shell-quotes.container
+++ b/test/e2e/quadlet/health-cmd-shell-quotes.container
@@ -1,0 +1,4 @@
+[Container]
+Image=localhost/imagename
+## assert-podman-args "--health-cmd" "/bin/sh -c \"echo 'hello world!'\""
+HealthCmd=/bin/sh -c "echo 'hello world!'"

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -940,6 +940,7 @@ BOGUS=foo
 		Entry("exec.container", "exec.container"),
 		Entry("group-add.container", "group-add.container"),
 		Entry("health.container", "health.container"),
+		Entry("health-cmd-shell-quotes.container", "health-cmd-shell-quotes.container"),
 		Entry("host.container", "host.container"),
 		Entry("httpproxy-false.container", "httpproxy-false.container"),
 		Entry("httpproxy-true.container", "httpproxy-true.container"),


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/28409

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed Quadlet `HealthCmd` failing with shell embedded quotes due to `Lookup()` stripping unmatched `"` characters from values 
```
