### PR TITLE
adding --zip/-O  flag

### DIFF
--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -1,9 +1,11 @@
 package images
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -78,6 +80,8 @@ func init() {
 func saveFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
+	flags.BoolVar(&saveOpts.Zip, "zip", false, "Compress the output image using gzip")
+
 	flags.BoolVar(&saveOpts.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")
 
 	flags.BoolVar(&saveOpts.OciAcceptUncompressedLayers, "uncompressed", false, "Accept uncompressed layers when copying OCI images")
@@ -104,6 +108,61 @@ func save(cmd *cobra.Command, args []string) (finalErr error) {
 		tags      []string
 		succeeded = false
 	)
+	// If --zip is used, we need to manually create a writer that gzips the content.
+	if saveOpts.Zip {
+		// Determine the final output writer (stdout or a file)
+		var out io.Writer = os.Stdout
+		if len(saveOpts.Output) > 0 {
+			f, err := os.Create(saveOpts.Output)
+			if err != nil {
+				return fmt.Errorf("could not create output file %s: %w", saveOpts.Output, err)
+			}
+			// Defer closing the file until the function returns
+			defer f.Close()
+			out = f
+		} else {
+			// Suppress progress output if writing to stdout
+			saveOpts.Quiet = true
+			if term.IsTerminal(int(os.Stdout.Fd())) {
+				return errors.New("refusing to save to terminal. Use -o flag or redirect")
+			}
+		}
+
+		// Create a temporary pipe. The image engine will write uncompressed data to the pipe's writer.
+		r, w, err := os.Pipe()
+		if err != nil {
+			return fmt.Errorf("could not create pipe: %w", err)
+		}
+		// Set the save operation's output to the pipe's writer end.
+		saveOpts.Output = w.Name()
+
+		// Create a gzip writer that writes to our final destination (file or stdout)
+		gzw := gzip.NewWriter(out)
+
+		// This goroutine will read from the pipe, compress the data, and write to the final destination.
+		done := make(chan error)
+		go func() {
+			defer r.Close()
+			defer gzw.Close()
+			_, err := io.Copy(gzw, r)
+			done <- err
+		}()
+
+		// Now, call the image engine. It will write the uncompressed tar to the pipe.
+		saveErr := registry.ImageEngine().Save(context.Background(), args[0], args[1:], saveOpts)
+
+		// Close the writer end of the pipe to signal EOF to the reader goroutine.
+		w.Close()
+
+		// Wait for the compression goroutine to finish and check for errors.
+		compressErr := <-done
+
+		if saveErr != nil {
+			return saveErr
+		}
+		return compressErr
+	}
+
 	if cmd.Flag("compress").Changed && saveOpts.Format != define.V2s2ManifestDir {
 		return errors.New("--compress can only be set when --format is 'docker-dir'")
 	}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -272,6 +272,7 @@ type ImageImportReport = entitiesTypes.ImageImportReport
 
 // ImageSaveOptions provide options for saving images.
 type ImageSaveOptions struct {
+	// 
 	// Compress layers when saving to a directory.
 	Compress bool
 	// Format of saving the image: oci-archive, oci-dir (directory with oci
@@ -289,6 +290,8 @@ type ImageSaveOptions struct {
 	// Quiet - suppress output when copying images
 	Quiet           bool
 	SignaturePolicy string
+	// Zip - zip output tarball 
+	Zip bool
 }
 
 // ImageScpOptions provides options for ImageEngine.Scp()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

This is my first Pull Request to a larger project, so please let me know if I'm doing something incorrect! 

Fixes #28420 

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
`podman save` now allows for the user to use `--zip` to directly write to a `.tar.gz` file instead of having to pipe this into gzip. 

Before:
```
$ podman save imagename:1 | gzip > outfile.tar.gz
```
Now:
```
$ podman save --zip imagename:1 > outfile.tar.gz 
```

(Working on adding a feature to auto-name the output file)

```release-note

```
