### PR TITLE
Fix .containerignore patterns with leading/trailing slashes

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -112,6 +112,10 @@ func ParseDockerignore(containerfiles []string, root string) ([]string, string, 
 		if len(e) == 0 || e[0] == '#' {
 			continue
 		}
+		e = strings.Trim(e, "/")
+		if len(e) == 0 {
+			continue
+		}
 		excludes = append(excludes, e)
 	}
 	return excludes, ignoreFile, nil

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"testing"
@@ -863,4 +865,32 @@ func TestGetRootlessStateDir(t *testing.T) {
 	dir, err := GetRootlessStateDir()
 	assert.NoError(t, err)
 	assert.NotEqual(t, dir, "libpod/tmp")
+}
+
+// https://github.com/containers/podman/issues/25458
+func TestParseDockerignoreLeadingTrailingSlashes(t *testing.T) {
+	contextDir := t.TempDir()
+
+	for _, tt := range []struct {
+		name     string
+		ignore   string
+		expected []string
+	}{
+		{"leading slash", "/.git/\n", []string{".git"}},
+		{"trailing slash", "target/\n", []string{"target"}},
+		{"both slashes", "/build/\n", []string{"build"}},
+		{"no slashes", "vendor\n", []string{"vendor"}},
+		{"slash only line", "/\n", []string{}},
+		{"multiple patterns", "/.git/\n/target/\nvendor\n", []string{".git", "target", "vendor"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ignorePath := filepath.Join(contextDir, ".containerignore")
+			err := os.WriteFile(ignorePath, []byte(tt.ignore), 0o644)
+			assert.NoError(t, err)
+
+			excludes, _, err := ParseDockerignore(nil, contextDir)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, excludes)
+		})
+	}
 }


### PR DESCRIPTION
I checked this with AI. It seems that localbuild takes a different path in the remote environment, causing ignored files to be copied to the server. This issue was largely resolved on Windows and macOS with the recent localapi improvements. However, pure remote builds were still affected. For example, when ignored files were large and ended up being copied to the remote server (not image).

Fixes: https://github.com/containers/podman/issues/25458

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed .containerignore/.dockerignore patterns with leading or trailing slashes being silently ignored during remote builds
```
