### PR TITLE
add missing O_CLOEXEC to open calls

### DIFF
--- a/cmd/rootlessport/main.go
+++ b/cmd/rootlessport/main.go
@@ -202,7 +202,7 @@ outer:
 		_ = os.Remove(socketfile)
 		// workaround to bypass the 108 char socket path limit
 		// open the fd and use the path to the fd as bind argument
-		fd, err := unix.Open(socketDir, unix.O_PATH, 0)
+		fd, err := unix.Open(socketDir, unix.O_PATH|unix.O_CLOEXEC, 0)
 		if err != nil {
 			return err
 		}

--- a/libpod/oci_conmon_attach_linux.go
+++ b/libpod/oci_conmon_attach_linux.go
@@ -10,7 +10,7 @@ import (
 )
 
 func openUnixSocket(path string) (*net.UnixConn, error) {
-	fd, err := unix.Open(path, unix.O_PATH, 0)
+	fd, err := unix.Open(path, unix.O_PATH|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pidhandle/pidhandle_linux.go
+++ b/pkg/pidhandle/pidhandle_linux.go
@@ -118,7 +118,7 @@ func NewPIDHandleFromString(pid int, pidData string) (PIDHandle, error) {
 			return nil, err
 		}
 		defer unix.Close(fd)
-		pidfd, err := openByHandleAt(fd, fh, 0)
+		pidfd, err := openByHandleAt(fd, fh, unix.O_CLOEXEC)
 		if err != nil {
 			if err == unix.ESTALE {
 				h.normalHandle.pidData = noSuchProcessID

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -153,7 +153,7 @@ func addDevice(g *generate.Generator, device string) error {
 	} else if src == "/dev/fuse" {
 		// if the user is asking for fuse inside the container
 		// make sure the module is loaded.
-		f, err := unix.Open(src, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+		f, err := unix.Open(src, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
 		if err == nil {
 			unix.Close(f)
 		}


### PR DESCRIPTION
The go std os package to will always make sure to use O_CLOEXEC, however in cases where we directly call unix.Open() we need to pass that flag explicitly.

I looked at this as there was a report of a leaked fd on the pasta list, though I am not sure this will address it.

But anyway doing this should be rather safe and avoid leaks into other processes.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
