### PR TITLE
test/system: Fix 260-sdnotify being silently skipped

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -17,14 +17,14 @@ function setup() {
     # Skip if systemd is not running
     systemctl list-units &>/dev/null || skip "systemd not available"
 
+    basic_setup
+
     # sdnotify fails with runc 1.0.0-3-dev2 on Ubuntu. Let's just
     # assume that we work only with crun, nothing else.
     runtime=$(podman_runtime)
     if [[ "$runtime" != "crun" ]]; then
         skip "this test only works with crun, not $runtime"
     fi
-
-    basic_setup
 }
 
 function teardown() {


### PR DESCRIPTION
Fix 260-sdnotify being silently skipped since podman v5.7.1

PODMAN_CMD is uninitialized until basic_setup() runs, causing podman_runtime() to invoke an empty command and fall back to [null].

Call basic_setup() before the runtime check to ensure PODMAN_CMD is populated before use.

Otherwise all the tests are silently skipped:
- https://api.cirrus-ci.com/v1/artifact/task/5685948077309952/html/sys-podman-fedora-42-root-host.log.html
- https://openqa-assets.opensuse.org/tests/5821036/file/podman-bats-root-local.tap.txt

```
ok 507 sdnotify : ignore # skip this test only works with crun, not [null]
ok 508 sdnotify : conmon # skip this test only works with crun, not [null]
ok 509 sdnotify : container # skip this test only works with crun, not [null]
ok 510 sdnotify : healthy # skip this test only works with crun, not [null]
ok 511 sdnotify : play kube - no policies # skip this test only works with crun, not [null]
ok 512 sdnotify : play kube - with policies # skip this test only works with crun, not [null]
ok 513 podman kube play - exit-code propagation # skip this test only works with crun, not [null]
ok 514 podman pull - EXTEND_TIMEOUT_USEC # skip this test only works with crun, not [null]
ok 515 podman system service # skip this test only works with crun, not [null]
```

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
