### PR TITLE
fix(#28429): OCIRuntime field in SpecGenerator is ignored when called through HTTP Rest API

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -165,7 +165,9 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		return nil, nil, nil, err
 	}
 
-	if imageData != nil {
+	if len(s.OCIRuntime) > 0 {
+		options = append(options, libpod.WithCtrOCIRuntime(s.OCIRuntime))
+	} else if imageData != nil {
 		ociRuntimeVariant := rtc.Engine.ImagePlatformToRuntime(imageData.Os, imageData.Architecture)
 		// Don't unnecessarily set and invoke additional libpod
 		// option if OCI runtime is still default.

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -914,4 +914,23 @@ t POST containers/create?platform=linux/amd64 \
 t POST containers/create?platform=linux/aarch64 \
   Image=$IMAGE \
   404
+
+# test apiv2 create container with oci_runtime option :- https://github.com/containers/podman/issues/28429
+oci_runtimes=('runc' 'crun')
+
+# Create, Check and Delete for provided runtime container
+for runtime in "${oci_runtimes[@]}"; do
+    t POST libpod/containers/create \
+            Image=$IMAGE \
+            "oci_runtime"="$runtime" \
+            201 \
+            .Id~[0-9a-f]\\{64\\}
+
+    cid=$(jq -r '.Id' <<<"$output")
+    t GET libpod/containers/$cid/json 200 \
+    .OCIRuntime="$runtime"
+
+    t DELETE containers/$cid 204
+done
+
 podman rmi -f $IMAGE


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [X] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [X] Referenced issues using `Fixes: #28429 ` in commit message (if applicable)
- [X] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [X] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [X] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

Fixes: #28429

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
