### PR TITLE
Fix filtering with negated labels

### DIFF
--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -25,6 +25,8 @@ Supported filters:
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes containers with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes containers without the specified labels.
 
+**NOTE:** `label!` filters are combined with **AND**, so that the behavior is consistent with `label`, while in Docker, they are combined with **OR**.
+
 The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the machine’s time.
 
 #### **--force**, **-f**

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -43,6 +43,8 @@ Supported filters:
 
 The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which removes volumes with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which removes volumes without the specified labels.
 
+**NOTE:** `label!` filters are combined with **AND**, so that the behavior is consistent with `label`, while in Docker, they are combined with **OR**.
+
 The `until` *filter* can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the machine's time.
 
 #### **--force**, **-f**

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -32,7 +32,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		}, nil
 	case "label!":
 		return func(c *libpod.Container) bool {
-			return !filters.MatchLabelFilters(filterValues, c.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, c.Labels())
 		}, nil
 	case "name":
 		// we only have to match one name
@@ -309,7 +309,7 @@ func GeneratePruneContainerFilterFuncs(filter string, filterValues []string, _ *
 		}, nil
 	case "label!":
 		return func(c *libpod.Container) bool {
-			return !filters.MatchLabelFilters(filterValues, c.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, c.Labels())
 		}, nil
 	case "until":
 		return prepareUntilFilterFunc(filterValues)
@@ -478,7 +478,11 @@ func GenerateExternalContainerFilterFuncs(filter string, filterValues []string, 
 		}, nil
 	case "label":
 		return func(listContainer *types.ListContainer) bool {
-			return !filters.MatchLabelFilters(filterValues, listContainer.Labels)
+			return filters.MatchLabelFilters(filterValues, listContainer.Labels)
+		}, nil
+	case "label!":
+		return func(listContainer *types.ListContainer) bool {
+			return filters.MatchNegatedLabelFilters(filterValues, listContainer.Labels)
 		}, nil
 	case "pod":
 		var pods []*libpod.Pod

--- a/pkg/domain/filters/pods.go
+++ b/pkg/domain/filters/pods.go
@@ -122,7 +122,7 @@ func GeneratePodFilterFunc(filter string, filterValues []string, r *libpod.Runti
 	case "label!":
 		return func(p *libpod.Pod) bool {
 			labels := p.Labels()
-			return !filters.MatchLabelFilters(filterValues, labels)
+			return filters.MatchNegatedLabelFilters(filterValues, labels)
 		}, nil
 	case "until":
 		return func(p *libpod.Pod) bool {

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -35,7 +35,7 @@ func GenerateVolumeFilters(filter string, filterValues []string, runtime *libpod
 		}, nil
 	case "label!":
 		return func(v *libpod.Volume) bool {
-			return !filters.MatchLabelFilters(filterValues, v.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, v.Labels())
 		}, nil
 	case "opt":
 		return func(v *libpod.Volume) bool {
@@ -101,7 +101,7 @@ func GeneratePruneVolumeFilters(filter string, filterValues []string, runtime *l
 		}, nil
 	case "label!":
 		return func(v *libpod.Volume) bool {
-			return !filters.MatchLabelFilters(filterValues, v.Labels())
+			return filters.MatchNegatedLabelFilters(filterValues, v.Labels())
 		}, nil
 	case "until":
 		return createUntilFilterVolumeFunction(filterValues)

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Podman volume ls", func() {
 
 		vol1Name := session.OutputToString()
 
-		session = podmanTest.Podman([]string{"volume", "create", "--label", "b=c", "--label", "a=b", "vol2"})
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "a=b", "--label", "b=c", "--label", "d=e", "vol2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -208,11 +208,18 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol1Name))
 		Expect(session.OutputToStringArray()[1]).To(Equal(vol2Name))
 
-		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=c=d", "--filter", "label=b=c"})
+		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=b=c", "--filter", "label=c=d"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 		Expect(session.OutputToStringArray()[0]).To(Equal(vol3Name))
+
+		// Filters with label! key
+		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label!=c=d", "--filter", "label!=d=e"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToStringArray()[0]).To(Equal(vol1Name))
 
 		// Filters with different keys
 		session = podmanTest.Podman([]string{"volume", "ls", "-q", "--filter", "label=b=c", "--filter", "name=vol1"})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
`label!` filters are combined with AND, so that they are consistent with `label` filters.
```

While working on https://github.com/containers/podman/pull/28413, I found out that when filtering based on labels, the `label` filters are combined with AND, while `label!` filters are combined with OR. I thought it would make more sense to handle both labels with the same operation, as it would be unexpected otherwise, and the way it looks in the code `return !filters.MatchLabelFilters(filterValues, v.Labels())` makes it seem like a bug.

Currently, for podman this works correctly in `images`, and incorrectly for `containers`, `volumes`, and `pods`.

This is a breaking change and it may make podman more inconsistent with docker.

It looks like for docker, `label!` has the same problem in `volume prune`, so I reported it https://github.com/docker/cli/issues/6918.