### PR TITLE
Revert #28401, show :latest tag in artifact ls output when no explicit tag given

### DIFF
--- a/cmd/podman/artifact/list.go
+++ b/cmd/podman/artifact/list.go
@@ -104,9 +104,6 @@ func outputTemplate(cmd *cobra.Command, lrs []*entities.ArtifactListReport) erro
 		if !ok {
 			return fmt.Errorf("%q is an invalid artifact name", artifactName)
 		}
-		// Normalize the reference so artifacts stored without an explicit tag
-		// display ":latest" instead of an empty TAG column, matching container image behaviour.
-		named = reference.TagNameOnly(named)
 		if tagged, ok := named.(reference.Tagged); ok {
 			tag = tagged.Tag()
 		}

--- a/test/e2e/artifact_test.go
+++ b/test/e2e/artifact_test.go
@@ -742,23 +742,6 @@ var _ = Describe("Podman artifact", func() {
 		session = podmanTest.PodmanExitCleanly("artifact", "inspect", artifactDigest[:12], "-f", "{{.Name}}")
 		Expect(session.OutputToString()).To(Equal(artifact1Name))
 	})
-
-	It("podman artifact ls shows latest tag for untagged artifact", func() {
-		artifactFile, err := createArtifactFile(1024)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Add artifact without an explicit tag — podman should default to :latest
-		artifactName := "localhost/test/untagged-artifact"
-		podmanTest.PodmanExitCleanly("artifact", "add", artifactName, artifactFile)
-
-		// Verify the TAG column shows "latest" in the default ls output
-		listSession := podmanTest.PodmanExitCleanly("artifact", "ls")
-		Expect(listSession.OutputToString()).To(ContainSubstring("latest"))
-
-		// Confirm via --format that the Tag field is "latest"
-		tagSession := podmanTest.PodmanExitCleanly("artifact", "ls", "--format", "{{.Tag}}")
-		Expect(tagSession.OutputToString()).To(Equal("latest"))
-	})
 })
 
 func digestToFilename(digest string) string {


### PR DESCRIPTION
As discussed on https://github.com/containers/podman/pull/28401 we should revert these changes.


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
