### PR TITLE
docs: fix parameter name for podman-network-create

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -9,7 +9,7 @@ podman\-network-create - Create a Podman network
 ## DESCRIPTION
 Create a network configuration for use with Podman. By default, Podman creates a bridge connection.
 A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan or
-ipvlan can be designated with the *-o parent=`<device>`* or *--network-interface=`<device>`* option.
+ipvlan can be designated with the *-o parent=`<device>`* or *--interface-name=`<device>`* option.
 
 If no options are provided, Podman assigns a free subnet and name for the network.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

The docs for [`podman-network-create`](https://docs.podman.io/en/latest/markdown/podman-network-create.1.html) claim that:
> _"A parent device for macvlan or ipvlan can be designated with the -o parent=<device> or --network-interface=<device> option."_

But the `--network-interface` option does not really exist, there's [`--interface-name`](https://docs.podman.io/en/latest/markdown/podman-network-create.1.html#interface-name-name) instead.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

It's not clear to me based on the release notes guide whether documentation updates count as user-facing changes.