### PR TITLE
Makefile: fail early with a clear message on Intel Mac

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ These instructions are geared towards using a Linux development machine, which i
 Development for the Windows and Mac clients can also be done on those operating systems.
 Check out these instructions for building the Podman client on [MacOSX](./build_osx.md) or [Windows](./build_windows.md).
 
+> **Note:** Podman 6 dropped support for darwin/amd64 (Intel Mac) binaries. The macOS client is only available for darwin/arm64 (Apple Silicon). Attempting to build with `GOOS=darwin GOARCH=amd64` will fail on any host.
+
 ### Prepare your environment
 
 Read the [install documentation to see how to install dependencies](https://podman.io/getting-started/installation#build-and-run-dependencies).

--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,9 @@ $(SRCBINDIR):
 
 # '|' is to ignore SRCBINDIR mtime; see: info make 'Types of Prerequisites'
 $(SRCBINDIR)/podman$(BINSFX): $(SOURCES) go.mod go.sum | $(SRCBINDIR)
+ifeq ($(GOOS)/$(GOARCH),darwin/amd64)
+	$(error Podman 6 dropped darwin/amd64 support. Use an ARM64 Mac or cross-compile for a different GOOS/GOARCH.)
+endif
 	$(GOCMD) build \
 		$(BUILDFLAGS) \
 		$(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' \


### PR DESCRIPTION
Building on darwin/amd64 currently fails deep in the Go toolchain with
"all Go files in directory excluded by build constraints" because
Podman 6 dropped Intel Mac support. The error gives no indication of
what actually went wrong, which is a bad experience for someone who
just cloned the repo and ran make.

This adds a $(error) guard in the Makefile that fires when
GOOS/GOARCH is darwin/amd64, producing a one-liner that says Intel Mac
is no longer supported and suggests alternatives.

Also added a note in CONTRIBUTING.md under the contributing section.

Tested by overriding GOOS/GOARCH in a standalone Makefile snippet —
darwin/amd64 triggers the error, darwin/arm64 and linux/amd64 pass
through.

Fixes #28416