### PR TITLE
Fix inconsistencies between --all and --filter=all in volume prune

### DIFF
--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -3,6 +3,7 @@ package volumes
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -64,6 +65,11 @@ func prune(cmd *cobra.Command, _ []string) error {
 
 	// --all adds filter all=true (Docker-compatible; behavior is filter-only)
 	allFlag, _ := cmd.Flags().GetBool("all")
+	filterAllFlag := strings.EqualFold(pruneOptions.Filters.Get("all"), "true")
+	if allFlag && filterAllFlag {
+		return errors.New("--all and --filter all cannot be used together")
+	}
+	allFlag = allFlag || filterAllFlag
 	if allFlag {
 		pruneOptions.Filters.Set("all", "true")
 	}
@@ -79,6 +85,7 @@ func prune(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
+		delete(listOptions.Filter, "all") // list does not support --filter all
 		filteredVolumes, err := registry.ContainerEngine().VolumeList(context.Background(), listOptions)
 		if err != nil {
 			return err

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -42,12 +42,24 @@ var _ = Describe("Podman volume prune", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("named_vol"))
 	})
 
+	It("podman volume prune --all removes all unused volumes", func() {
+		podmanTest.PodmanExitCleanly("volume", "create", "prune_all_test")
+		podmanTest.PodmanExitCleanly("volume", "prune", "--all", "--force")
+
+		session := podmanTest.PodmanExitCleanly("volume", "ls")
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+	})
+
 	It("podman volume prune --filter all=true removes all unused volumes", func() {
 		podmanTest.PodmanExitCleanly("volume", "create", "prune_filter_all_test")
 		podmanTest.PodmanExitCleanly("volume", "prune", "--filter", "all=true", "--force")
 
 		session := podmanTest.PodmanExitCleanly("volume", "ls")
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
+	})
+
+	It("podman volume prune --filter all=true does not crash without --force", func() {
+		podmanTest.PodmanExitCleanly("volume", "prune", "--filter", "all=true")
 	})
 
 	It("podman prune volume --filter until", func() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The `volume prune` options `--all` and `--filter=all` no longer has different behavior.
```