### PR TITLE
[v5.8] Bump Buildah to 1.43.1, c/common v0.67.1, c/image v5.39.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/checkpoint-restore/checkpointctl v1.4.0
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0
 	github.com/containernetworking/plugins v1.8.0
-	github.com/containers/buildah v1.43.0
+	github.com/containers/buildah v1.43.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.8
 	github.com/containers/libhvee v0.10.1-0.20250829163521-178d10e67860
@@ -65,8 +65,8 @@ require (
 	github.com/vbauerster/mpb/v8 v8.10.2
 	github.com/vishvananda/netlink v1.3.1
 	go.etcd.io/bbolt v1.4.3
-	go.podman.io/common v0.67.0
-	go.podman.io/image/v5 v5.39.1
+	go.podman.io/common v0.67.1
+	go.podman.io/image/v5 v5.39.2
 	go.podman.io/storage v1.62.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/net v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEm
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.8.0 h1:WjGbV/0UQyo8A4qBsAh6GaDAtu1hevxVxsEuqtBqUFk=
 github.com/containernetworking/plugins v1.8.0/go.mod h1:JG3BxoJifxxHBhG3hFyxyhid7JgRVBu/wtooGEvWf1c=
-github.com/containers/buildah v1.43.0 h1:FuWSdqxQMR7X5d254MyDl7KOGcRDvYxvvmpRbBhlWho=
-github.com/containers/buildah v1.43.0/go.mod h1:ilRk19r/+1lGdcZsxeldZU/mMB2paQ6AnRWusS+M8WI=
+github.com/containers/buildah v1.43.1 h1:hZO/b0BxDTu38vVc3CaUhe1q3s+q2Y3goeY6QRqm4Qg=
+github.com/containers/buildah v1.43.1/go.mod h1:LSi6Syf+ntc1g0WcUa7yb5dT1W2KzA//+aW+TLgj1os=
 github.com/containers/common v0.62.2 h1:xO45OOoeq17EZMIDZoSyRqg7GXGcRHa9sXlrr75zH+U=
 github.com/containers/common v0.62.2/go.mod h1:veFiR9iq2j3CHXtB4YnPHuOkSRdhIQ3bAY8AFMP/5bE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
@@ -468,10 +468,10 @@ go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKr
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.podman.io/common v0.67.0 h1:6Ci5oU1ek08OAxBLkHEqSyWmjNh5zf03PRqZ04cPdwU=
-go.podman.io/common v0.67.0/go.mod h1:sB9L8LMtmf5Hpek2qkEyRrcSzpb+gYpG3vq5Khima3U=
-go.podman.io/image/v5 v5.39.1 h1:loIw4qHzZzBlUguYZau40u8HbR5MrTPQhwT4Hy6sCm0=
-go.podman.io/image/v5 v5.39.1/go.mod h1:SlaR6Pra1ATIx4BcuZ16oafb3QcCHISaKcJbtlN/G/0=
+go.podman.io/common v0.67.1 h1:HddYLJfkfFUmFJ0V3PVoewguFM9eHkqk0g+fOc2B9R4=
+go.podman.io/common v0.67.1/go.mod h1:XVmSLtnhJwGb+ImYn6BXiozxVE3mYZJgiiBuDOiOquk=
+go.podman.io/image/v5 v5.39.2 h1:EJua/pRtvgLV/a5y8/RvA+ekKukZh0UuKMvLdTmEWFk=
+go.podman.io/image/v5 v5.39.2/go.mod h1:SlaR6Pra1ATIx4BcuZ16oafb3QcCHISaKcJbtlN/G/0=
 go.podman.io/storage v1.62.0 h1:0QjX1XlzVmbiaulb+aR/CG6p9+pzaqwIeZPe3tEjHbY=
 go.podman.io/storage v1.62.0/go.mod h1:A3UBK0XypjNZ6pghRhuxg62+2NIm5lcUGv/7XyMhMUI=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Changelog
 
+## v1.43.1 (2026-04-07)
+
+    [release-1.43] Bump c/common v0.67.1, c/image v5.39.2
+    update module github.com/go-jose/go-jose/v4 to v4.1.4 [security]
+    ignore ErrLayerUnknown in cache lookup
+    fix setting of gid
+    fix call to chown
+
 ## v1.43.0 (2026-02-05)
 
     [release-1.43] Bump common 0.67.0, image 5.39.1, storage 1.62.0

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.43.1 (2026-04-07)
+  * [release-1.43] Bump c/common v0.67.1, c/image v5.39.2
+  * update module github.com/go-jose/go-jose/v4 to v4.1.4 [security]
+  * ignore ErrLayerUnknown in cache lookup
+  * fix setting of gid
+  * fix call to chown
+
 - Changelog for v1.43.0 (2026-02-05)
   * [release-1.43] Bump common 0.67.0, image 5.39.1, storage 1.62.0
   * [release-1.43] Bump dest branch in cirrus to 1.43

--- a/vendor/github.com/containers/buildah/copier/copier.go
+++ b/vendor/github.com/containers/buildah/copier/copier.go
@@ -2329,7 +2329,7 @@ func copierHandlerEnsure(req request, idMappings *idtools.IDMappings) *response 
 	for _, item := range req.EnsureOptions.Paths {
 		uid, gid := 0, 0
 		if item.Chown != nil {
-			uid, gid = item.Chown.UID, item.Chown.UID
+			uid, gid = item.Chown.UID, item.Chown.GID
 		}
 		var mode os.FileMode
 		switch item.Typeflag {
@@ -2405,7 +2405,7 @@ func copierHandlerEnsure(req request, idMappings *idtools.IDMappings) *response 
 					createdLeaf = strings.TrimPrefix(createdLeaf, string(os.PathSeparator))
 				}
 				created = append(created, createdLeaf)
-				if err = chown(filepath.Join(req.Root, leaf), uid, uid); err != nil {
+				if err = chown(filepath.Join(req.Root, leaf), uid, gid); err != nil {
 					return errorResponse("copier: ensure: error setting owner of %q to %d:%d: %v", leaf, uid, gid, err)
 				}
 				if err = chmod(filepath.Join(req.Root, leaf), mode); err != nil {

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.43.0"
+	Version = "1.43.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
@@ -2318,6 +2318,9 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		if image.TopLayer != "" {
 			imageTopLayer, err = s.executor.store.Layer(image.TopLayer)
 			if err != nil {
+				if errors.Is(err, storage.ErrLayerUnknown) {
+					continue
+				}
 				return "", fmt.Errorf("getting top layer info: %w", err)
 			}
 			// Figure out which layer from this image we should

--- a/vendor/go.podman.io/common/version/version.go
+++ b/vendor/go.podman.io/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.67.0"
+const Version = "0.67.1"

--- a/vendor/go.podman.io/image/v5/docker/docker_client.go
+++ b/vendor/go.podman.io/image/v5/docker/docker_client.go
@@ -35,6 +35,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/homedir"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -86,8 +87,19 @@ type extensionSignatureList struct {
 	Signatures []extensionSignature `json:"signatures"`
 }
 
-// bearerToken records a cached token we can use to authenticate.
+// bearerToken records a cached token we can use to authenticate, or a pending process to obtain one.
+//
+// The goroutine obtaining the token holds lock to block concurrent token requests, and fills the structure (err and possibly the other fields)
+// before releasing the lock.
+// Other goroutines obtain lock to block on the token request, if any; and then inspect err to see if the token is usable.
+// If it is not, they try to get a new one.
 type bearerToken struct {
+	// lock is held while obtaining the token. Potentially nested inside dockerClient.tokenCacheLock.
+	// This is a counting semaphore only because we need a cancellable lock operation.
+	lock *semaphore.Weighted
+
+	// The following fields can only be accessed with lock held.
+	err            error // nil if the token was successfully obtained (but may be expired); an error if the next lock holder _must_ obtain a new token.
 	token          string
 	expirationTime time.Time
 }
@@ -116,8 +128,9 @@ type dockerClient struct {
 	challenges         []challenge
 	supportsSignatures bool
 
-	// Private state for setupRequestAuth (key: string, value: bearerToken)
-	tokenCache sync.Map
+	// Private state for setupRequestAuth
+	tokenCacheLock sync.Mutex // Protects tokenCache.
+	tokenCache     map[string]*bearerToken
 	// Private state for detectProperties:
 	detectPropertiesOnce  sync.Once // detectPropertiesOnce is used to execute detectProperties() at most once.
 	detectPropertiesError error     // detectPropertiesError caches the initial error.
@@ -274,6 +287,7 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 		registry:         registry,
 		userAgent:        userAgent,
 		tlsClientConfig:  tlsClientConfig,
+		tokenCache:       map[string]*bearerToken{},
 		reportedWarnings: set.New[string](),
 	}, nil
 }
@@ -716,50 +730,11 @@ func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope
 			req.SetBasicAuth(c.auth.Username, c.auth.Password)
 			return nil
 		case "bearer":
-			registryToken := c.registryToken
-			if registryToken == "" {
-				cacheKey := ""
-				scopes := []authScope{c.scope}
-				if extraScope != nil {
-					// Using ':' as a separator here is unambiguous because getBearerToken below
-					// uses the same separator when formatting a remote request (and because
-					// repository names that we create can't contain colons, and extraScope values
-					// coming from a server come from `parseAuthScope`, which also splits on colons).
-					cacheKey = fmt.Sprintf("%s:%s:%s", extraScope.resourceType, extraScope.remoteName, extraScope.actions)
-					if colonCount := strings.Count(cacheKey, ":"); colonCount != 2 {
-						return fmt.Errorf(
-							"Internal error: there must be exactly 2 colons in the cacheKey ('%s') but got %d",
-							cacheKey,
-							colonCount,
-						)
-					}
-					scopes = append(scopes, *extraScope)
-				}
-				var token bearerToken
-				t, inCache := c.tokenCache.Load(cacheKey)
-				if inCache {
-					token = t.(bearerToken)
-				}
-				if !inCache || time.Now().After(token.expirationTime) {
-					var (
-						t   *bearerToken
-						err error
-					)
-					if c.auth.IdentityToken != "" {
-						t, err = c.getBearerTokenOAuth2(req.Context(), challenge, scopes)
-					} else {
-						t, err = c.getBearerToken(req.Context(), challenge, scopes)
-					}
-					if err != nil {
-						return err
-					}
-
-					token = *t
-					c.tokenCache.Store(cacheKey, token)
-				}
-				registryToken = token.token
+			token, err := c.obtainBearerToken(req.Context(), challenge, extraScope)
+			if err != nil {
+				return err
 			}
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", registryToken))
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			return nil
 		default:
 			logrus.Debugf("no handler for %s authentication", challenge.Scheme)
@@ -769,16 +744,94 @@ func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope
 	return nil
 }
 
-func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge challenge,
-	scopes []authScope) (*bearerToken, error) {
+// obtainBearerToken gets an "Authorization: Bearer" token if one is available, or obtains a fresh one.
+func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challenge, extraScope *authScope) (string, error) {
+	if c.registryToken != "" {
+		return c.registryToken, nil
+	}
+
+	cacheKey := ""
+	scopes := []authScope{c.scope}
+	if extraScope != nil {
+		// Using ':' as a separator here is unambiguous because getBearerToken below
+		// uses the same separator when formatting a remote request (and because
+		// repository names that we create can't contain colons, and extraScope values
+		// coming from a server come from `parseAuthScope`, which also splits on colons).
+		cacheKey = fmt.Sprintf("%s:%s:%s", extraScope.resourceType, extraScope.remoteName, extraScope.actions)
+		if colonCount := strings.Count(cacheKey, ":"); colonCount != 2 {
+			return "", fmt.Errorf(
+				"Internal error: there must be exactly 2 colons in the cacheKey ('%s') but got %d",
+				cacheKey,
+				colonCount,
+			)
+		}
+		scopes = append(scopes, *extraScope)
+	}
+
+	token, newEntry, err := func() (*bearerToken, bool, error) { // A scope for defer
+		c.tokenCacheLock.Lock()
+		defer c.tokenCacheLock.Unlock()
+		token, ok := c.tokenCache[cacheKey]
+		if ok {
+			return token, false, nil
+		} else {
+			token = &bearerToken{
+				lock: semaphore.NewWeighted(1),
+			}
+			// If this is a new *bearerToken, lock the entry before adding it to the cache, so that any other goroutine that finds
+			// this entry blocks until we obtain the token for the first time, and does not see an empty object
+			// (and does not try to obtain the token itself when we are going to do so).
+			if err := token.lock.Acquire(ctx, 1); err != nil {
+				// We do not block on this Acquire, so we don’t really expect to fail here — but if ctx is canceled,
+				// there is no point in trying to continue anyway.
+				return nil, false, err
+			}
+			c.tokenCache[cacheKey] = token
+			return token, true, nil
+		}
+	}()
+	if err != nil {
+		return "", err
+	}
+	if !newEntry {
+		// If this is an existing *bearerToken, obtain the lock only after releasing c.tokenCacheLock,
+		// so that users of other cacheKey values are not blocked for the whole duration of our HTTP roundtrip.
+		if err := token.lock.Acquire(ctx, 1); err != nil {
+			return "", err
+		}
+	}
+
+	defer token.lock.Release(1)
+
+	if !newEntry && token.err == nil && !time.Now().After(token.expirationTime) {
+		return token.token, nil // We have a usable token already.
+	}
+
+	if c.auth.IdentityToken != "" {
+		err = c.getBearerTokenOAuth2(ctx, token, challenge, scopes)
+	} else {
+		err = c.getBearerToken(ctx, token, challenge, scopes)
+	}
+	token.err = err
+	if token.err != nil {
+		return "", token.err
+	}
+	return token.token, nil
+}
+
+// getBearerTokenOAuth2 obtains an "Authorization: Bearer" token using a pre-existing identity token per
+// https://github.com/distribution/distribution/blob/main/docs/spec/auth/oauth.md for challenge and scopes,
+// and writes it into dest.
+func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, dest *bearerToken, challenge challenge,
+	scopes []authScope) error {
 	realm, ok := challenge.Parameters["realm"]
 	if !ok {
-		return nil, errors.New("missing realm in bearer auth challenge")
+		return errors.New("missing realm in bearer auth challenge")
 	}
 
 	authReq, err := http.NewRequestWithContext(ctx, http.MethodPost, realm, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Make the form data required against the oauth2 authentication
@@ -803,26 +856,29 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.Redacted())
 	res, err := c.client.Do(authReq)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer res.Body.Close()
 	if err := httpResponseToError(res, "Trying to obtain access token"); err != nil {
-		return nil, err
+		return err
 	}
 
-	return newBearerTokenFromHTTPResponseBody(res)
+	return dest.readFromHTTPResponseBody(res)
 }
 
-func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
-	scopes []authScope) (*bearerToken, error) {
+// getBearerToken obtains an "Authorization: Bearer" token using a GET request, per
+// https://github.com/distribution/distribution/blob/main/docs/spec/auth/token.md for challenge and scopes,
+// and writes it into dest.
+func (c *dockerClient) getBearerToken(ctx context.Context, dest *bearerToken, challenge challenge,
+	scopes []authScope) error {
 	realm, ok := challenge.Parameters["realm"]
 	if !ok {
-		return nil, errors.New("missing realm in bearer auth challenge")
+		return errors.New("missing realm in bearer auth challenge")
 	}
 
 	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, realm, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	params := authReq.URL.Query()
@@ -850,22 +906,22 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.Redacted())
 	res, err := c.client.Do(authReq)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer res.Body.Close()
 	if err := httpResponseToError(res, "Requesting bearer token"); err != nil {
-		return nil, err
+		return err
 	}
 
-	return newBearerTokenFromHTTPResponseBody(res)
+	return dest.readFromHTTPResponseBody(res)
 }
 
-// newBearerTokenFromHTTPResponseBody parses a http.Response to obtain a bearerToken.
+// readFromHTTPResponseBody sets token data by parsing a http.Response.
 // The caller is still responsible for ensuring res.Body is closed.
-func newBearerTokenFromHTTPResponseBody(res *http.Response) (*bearerToken, error) {
+func (bt *bearerToken) readFromHTTPResponseBody(res *http.Response) error {
 	blob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxAuthTokenBodySize)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	var token struct {
@@ -881,12 +937,10 @@ func newBearerTokenFromHTTPResponseBody(res *http.Response) (*bearerToken, error
 		if len(bodySample) > bodySampleLength {
 			bodySample = bodySample[:bodySampleLength]
 		}
-		return nil, fmt.Errorf("decoding bearer token (last URL %q, body start %q): %w", res.Request.URL.Redacted(), string(bodySample), err)
+		return fmt.Errorf("decoding bearer token (last URL %q, body start %q): %w", res.Request.URL.Redacted(), string(bodySample), err)
 	}
 
-	bt := &bearerToken{
-		token: token.Token,
-	}
+	bt.token = token.Token
 	if bt.token == "" {
 		bt.token = token.AccessToken
 	}
@@ -899,7 +953,7 @@ func newBearerTokenFromHTTPResponseBody(res *http.Response) (*bearerToken, error
 		token.IssuedAt = time.Now().UTC()
 	}
 	bt.expirationTime = token.IssuedAt.Add(time.Duration(token.ExpiresIn) * time.Second)
-	return bt, nil
+	return nil
 }
 
 // detectPropertiesHelper performs the work of detectProperties which executes

--- a/vendor/go.podman.io/image/v5/version/version.go
+++ b/vendor/go.podman.io/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 39
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.8.0
 ## explicit; go 1.24.2
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.43.0
+# github.com/containers/buildah v1.43.1
 ## explicit; go 1.24.2
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -752,7 +752,7 @@ go.opentelemetry.io/otel/trace
 go.opentelemetry.io/otel/trace/embedded
 go.opentelemetry.io/otel/trace/internal/telemetry
 go.opentelemetry.io/otel/trace/noop
-# go.podman.io/common v0.67.0
+# go.podman.io/common v0.67.1
 ## explicit; go 1.24.2
 go.podman.io/common/internal
 go.podman.io/common/internal/attributedstring
@@ -822,7 +822,7 @@ go.podman.io/common/pkg/umask
 go.podman.io/common/pkg/util
 go.podman.io/common/pkg/version
 go.podman.io/common/version
-# go.podman.io/image/v5 v5.39.1
+# go.podman.io/image/v5 v5.39.2
 ## explicit; go 1.24.0
 go.podman.io/image/v5/copy
 go.podman.io/image/v5/directory


### PR DESCRIPTION
As the title says.  Bump:

Buildah to v1.43.1
c/common to v0.67.1
c/image to v5.39.2

Fixes: https://redhat.atlassian.net/browse/RHEL-164030, https://redhat.atlassian.net/browse/RHEL-95964

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
N/A
```
