### PR TITLE
fix: respect OCIRuntime field in SpecGenerator

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -165,7 +165,9 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		return nil, nil, nil, err
 	}
 
-	if imageData != nil {
+	if s.OCIRuntime != "" {
+		options = append(options, libpod.WithCtrOCIRuntime(s.OCIRuntime))
+	} else if imageData != nil {
 		ociRuntimeVariant := rtc.Engine.ImagePlatformToRuntime(imageData.Os, imageData.Architecture)
 		// Don't unnecessarily set and invoke additional libpod
 		// option if OCI runtime is still default.

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -915,3 +915,9 @@ t POST containers/create?platform=linux/aarch64 \
   Image=$IMAGE \
   404
 podman rmi -f $IMAGE
+
+# Regression test for #28429: OCIRuntime in SpecGenerator should be respected
+t POST libpod/containers/create name=ociruntime_test image=$IMAGE oci_runtime=crun 201
+t GET libpod/containers/ociruntime_test/json 200 \
+  .OCIRuntime=crun
+podman rm -f ociruntime_test


### PR DESCRIPTION
## Description

When creating containers via the API with `OCIRuntime` set in the SpecGenerator, the field was silently ignored. The container always used the default runtime from `containers.conf` instead of the one specified in the API request.

The issue is in `pkg/specgen/generate/container_create.go` at line 168: the code only considered the image-platform-based runtime selection (`ImagePlatformToRuntime`) but never checked `s.OCIRuntime`.

## Changes

The fix gives the user's explicit `OCIRuntime` choice priority over the automatic image-platform-based selection, and falls back to the existing behavior when not set:

```go
if s.OCIRuntime != "" {
    options = append(options, libpod.WithCtrOCIRuntime(s.OCIRuntime))
} else if imageData != nil {
    // existing image-platform-based logic
}
```

This is consistent with how the CLI `--runtime` flag works, which correctly passes the runtime through.

## Test plan

- [ ] Create container via API with `OCIRuntime` set to a non-default runtime
- [ ] Verify the container uses the specified runtime instead of the default
- [ ] Create container via API without `OCIRuntime` set — verify existing behavior unchanged
- [ ] Verify `--runtime` CLI flag still works as before

Fixes #28429