### PR TITLE
rootlessnetns: handle empty pid file gracefully

### DIFF
--- a/vendor/go.podman.io/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/vendor/go.podman.io/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -310,18 +310,33 @@ func (n *Netns) setupSlirp4netns(nsPath string) error {
 
 func (n *Netns) cleanupRootlessNetns() error {
 	pidFile := n.getPath(rootlessNetNsConnPidFile)
+
+	// Resolve any symlinks to ensure the path doesn't escape
+	resolvedPath, err := filepath.EvalSymlinks(pidFile)
+	if err == nil {
+		pidFile = resolvedPath
+	}
+	// Ensure the path is local to prevent escape via symlinks
+	if !filepath.IsLocal(pidFile) {
+		logrus.Warnf("Rootless netns conn pid file is not local: %s", pidFile)
+		return nil
+	}
+
 	pid, err := readPidFile(pidFile)
-	// do not hard error if the file dos not exists, cleanup should be idempotent
+	// do not hard error if the file does not exist, cleanup should be idempotent
 	if errors.Is(err, fs.ErrNotExist) {
 		logrus.Debugf("Rootless netns conn pid file does not exists %s", pidFile)
 		return nil
 	}
-	if err == nil {
-		// kill the slirp/pasta process so we do not leak it
-		err = unix.Kill(pid, unix.SIGTERM)
-		if err == unix.ESRCH {
-			err = nil
-		}
+	// if the pid file is empty, pasta failed to start so there is nothing to clean up
+	if err != nil {
+		logrus.Warnf("Rootless netns conn pid file is empty or invalid: %v", err)
+		return nil
+	}
+	// kill the slirp/pasta process so we do not leak it
+	err = unix.Kill(pid, unix.SIGTERM)
+	if err == unix.ESRCH {
+		err = nil
 	}
 	return err
 }
@@ -652,7 +667,11 @@ func readPidFile(path string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(strings.TrimSpace(string(b)))
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return 0, fmt.Errorf("pid file %q is empty", path)
+	}
+	return strconv.Atoi(s)
 }
 
 func (n *Netns) serializeInfo() error {


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #28441` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/write-a-blog-post/) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
Fixes error when using --gateway in pasta_options configuration
```
Fixes: #28441
