### PR TITLE
keep pod hostname when a container is stopped

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2334,7 +2334,7 @@ func (c *Container) removeNameserver(ips []string) error {
 }
 
 func getLocalhostHostEntry(c *Container) etchosts.HostEntries {
-	return etchosts.HostEntries{{IP: "127.0.0.1", Names: []string{c.Hostname(), c.config.Name}}}
+	return etchosts.HostEntries{{IP: "127.0.0.1", Names: []string{c.config.Name}}}
 }
 
 // getHostsEntries returns the container ip host entries for the correct netmode

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -159,27 +159,45 @@ load helpers.network
     run_podman rm $cid
 }
 
-# bats test_tags=ci:parallel
-@test "podman pod manages /etc/hosts correctly" {
-    local pod_name=pod-$(safename)
-    local infra_name=infra-$(safename)
+
+# run_pod_etc_hosts_test() - Run tests involving /etc/hosts inside Pods
+#
+# This helper function is invoked with pod_name, infra_name, pod_fqdn and expected_infra
+# With pod_fqdn not-empty, additional tests assert the survival of the pod fqdn hostname across container stops/starts
+function run_pod_etc_hosts_test(){
+    local pod_name=$1
+    local infra_name=$2
     local con1_name=con1-$(safename)
     local con2_name=con2-$(safename)
-    run_podman pod create --name $pod_name  --infra-name $infra_name
+    local pod_fqdn=$3
+    local expected_infra=$4
+    local additional_host=""
+    if [ -n "$pod_fqdn" ]; then
+      additional_host="--add-host \"$pod_fqdn;$pod_name:127.0.0.1\""
+    fi
+    run_podman pod create --name $pod_name  --infra-name $infra_name $additional_host
     pid="$output"
     run_podman run --rm --pod $pod_name --name $con1_name $IMAGE cat /etc/hosts
-    assert "$output" =~ ".*\s$pod_name $infra_name.*" \
+    assert "$output" =~ ".*\s$expected_infra*" \
            "Pod hostname in /etc/hosts"
     assert "$output" =~ ".*127.0.0.1\s$con1_name.*" \
            "Container1 name in /etc/hosts"
+    if [ -n "$pod_fqdn" ]; then
+        assert "$output" =~ ".*127.0.0.1\s$pod_fqdn $pod_name.*" \
+               "Pod FQDN name in /etc/hosts"
+    fi
     # get the length of the hosts file
     old_lines=${#lines[@]}
 
     # since the first container should be cleaned up now we should only see the
     # new host entry and the old one should be removed (lines check)
     run_podman run --pod $pod_name --name $con2_name $IMAGE cat /etc/hosts
-    assert "$output" =~ ".*\s$pod_name $infra_name.*" \
+    assert "$output" =~ ".*\s$expected_infra*" \
            "Pod hostname in /etc/hosts"
+    if [ -n "$pod_fqdn" ]; then
+        assert "$output" =~ ".*127.0.0.1\s$pod_fqdn $pod_name.*" \
+               "Pod FQDN name in /etc/hosts"
+    fi
     assert "$output" =~ ".*127.0.0.1\s$con2_name.*" \
            "Container2 name in /etc/hosts"
     assert "$output" !~ "$con1_name" \
@@ -187,12 +205,38 @@ load helpers.network
     is "${#lines[@]}" "$old_lines" \
        "Number of hosts lines is equal"
 
-    run_podman run --pod $pod_name  $IMAGE sh -c  "hostname && cat /etc/hostname"
+    if [ -n "$pod_fqdn" ]; then
+        run_podman run --pod $pod_name  $IMAGE sh -c  "hostname && cat /etc/hostname && hostname -f"
+    else
+        run_podman run --pod $pod_name  $IMAGE sh -c  "hostname && cat /etc/hostname"
+    fi
     is "${lines[0]}" "$pod_name" "hostname is the pod hostname"
     is "${lines[1]}" "$pod_name" "/etc/hostname contains correct pod hostname"
+    if [ -n "$pod_fqdn" ]; then
+        is "${lines[2]}" "$pod_fqdn" "fqdn hostname is the correct hostname with fqdn"
+    fi
 
     run_podman pod rm -f -t0 $pod_name
     is "$output" "$pid" "Only ID in output (no extra errors)"
+}
+
+# bats test_tags=ci:parallel
+@test "podman pod manages /etc/hosts correctly" {
+    local pod_name=pod-$(safename)
+    local infra_name=infra-$(safename)
+    local pod_fqdn=""
+    local expected_infra="$pod_name $infra_name"
+
+    run_pod_etc_hosts_test "$pod_name" "$infra_name" "$pod_fqdn" "$expected_infra"
+}
+# bats test_tags=ci:parallel
+@test "podman pod manages /etc/hosts correctly with fqdn" {
+    local pod_name=pod-$(safename)
+    local infra_name=infra-$(safename)
+    local pod_fqdn="${pod_name}.fqdn"
+    local expected_infra="$infra_name"
+
+    run_pod_etc_hosts_test "$pod_name" "$infra_name" "$pod_fqdn" "$expected_infra"
 }
 
 # "network create" now works rootless, with the help of a special container


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```


## Problem
When a Pod is configured with additional hosts containing an FQDN for the pod hostname, the FQDN entry is removed when any container is stopped.

## Root Cause
`etchosts.Remove()` is called with an array containing the container hostname. In Pods, the container hostname is configured on pod level.

## Fix
Omit the hostname during remove

## Test
### Preparations
```
# Containerfile for my-whoami
FROM traefik/whoami:v1.11 as whoami
FROM alpine:3.11
COPY --from=whoami /whoami /whoami
CMD /whoami
```
`mkdir -p /my/run/`

### Create pod
```
HOST_IP=192.168.122.171
podman pod create --infra-conmon-pidfile /my/run/pod.pid --infra-name my-pod-infra --pod-id-file /my/run/pod.pod-id --name my-pod --hostname myhost--my-pod --add-host "myhost.my.domain;myhost:${HOST_IP}" --add-host "myhost--m
y-pod.my.domain;myhost--my-pod:127.0.0.1" --add-host "host.container.internal:${HOST_IP}" --replace
```

### Start containers
```
podman run --cidfile=/my/run/container_a.id --pod-id-file=/my/run/pod.pod-id --cgroups=no-conmon --replace -d -t --name my-pod-contA my-whoami /whoami --port=80
podman run --cidfile=/my/run/container_b.id --pod-id-file=/my/run/pod.pod-id --cgroups=no-conmon --replace -d -t --name my-pod-contB my-whoami /whoami --port=81
```

### Verify
`podman exec my-pod-contA hostname -f`-> `myhost--my-pod.my.domain`
`podman stop my-pod-contB`
`podman exec my-pod-contA hostname -f`-> `hostname: myhost--my-pod: Host not found`
