### PR TITLE
Fix Docker API DeviceMapping for CDI devices

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -164,7 +164,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 	// Iterate devices and convert to CLI expected string
 	devices := make([]string, 0, len(cc.HostConfig.Devices))
 	for _, dev := range cc.HostConfig.Devices {
-		devices = append(devices, fmt.Sprintf("%s:%s:%s", dev.PathOnHost, dev.PathInContainer, dev.CgroupPermissions))
+		devices = append(devices, utils.DockerDeviceMappingString(dev))
 	}
 	for _, r := range cc.HostConfig.Resources.DeviceRequests {
 		if r.Driver == "cdi" {

--- a/pkg/api/handlers/utils/docker_device.go
+++ b/pkg/api/handlers/utils/docker_device.go
@@ -1,0 +1,34 @@
+//go:build !remote
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/moby/moby/api/types/container"
+	"tags.cncf.io/container-device-interface/pkg/parser"
+)
+
+// DockerDeviceMappingString maps Moby DeviceMapping to a podman --device string.
+func DockerDeviceMappingString(dev container.DeviceMapping) string {
+	// Inverse of docker/cli parseLinuxDevice (https://github.com/docker/cli/blob/master/cli/command/container/opts.go#L1007-L1039),
+	// building the podman --device string that pkg/specgen/generate.ParseDevice expects.
+
+	host := dev.PathOnHost
+	ctr := dev.PathInContainer
+	perm := dev.CgroupPermissions
+
+	switch {
+	case host != "" && parser.IsQualifiedName(host) && (ctr == "" || ctr == host):
+		return host
+	case host != "" && host == ctr && perm == "":
+		return host
+	case ctr == "" && perm == "":
+		return host
+	default:
+		if perm == "" {
+			perm = "rwm"
+		}
+		return fmt.Sprintf("%s:%s:%s", host, ctr, perm)
+	}
+}

--- a/pkg/api/handlers/utils/docker_device_test.go
+++ b/pkg/api/handlers/utils/docker_device_test.go
@@ -1,0 +1,119 @@
+//go:build !remote
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"tags.cncf.io/container-device-interface/pkg/parser"
+)
+
+func TestDockerDeviceMappingString(t *testing.T) {
+	tests := []struct {
+		name string
+		dev  container.DeviceMapping
+		want string
+	}{
+		{
+			name: "compose style CDI single token",
+			dev: container.DeviceMapping{
+				PathOnHost:        "nvidia.com/gpu=all",
+				PathInContainer:   "",
+				CgroupPermissions: "",
+			},
+			want: "nvidia.com/gpu=all",
+		},
+		{
+			name: "CDI host only with cgroup perms still single token",
+			dev: container.DeviceMapping{
+				PathOnHost:        "nvidia.com/gpu=all",
+				PathInContainer:   "",
+				CgroupPermissions: "rwm",
+			},
+			want: "nvidia.com/gpu=all",
+		},
+		{
+			name: "duplicate CDI host and container path",
+			dev: container.DeviceMapping{
+				PathOnHost:        "nvidia.com/gpu=all",
+				PathInContainer:   "nvidia.com/gpu=all",
+				CgroupPermissions: "rwm",
+			},
+			want: "nvidia.com/gpu=all",
+		},
+		{
+			name: "duplicate CDI host and container empty cgroup",
+			dev: container.DeviceMapping{
+				PathOnHost:        "nvidia.com/gpu=all",
+				PathInContainer:   "nvidia.com/gpu=all",
+				CgroupPermissions: "",
+			},
+			want: "nvidia.com/gpu=all",
+		},
+		{
+			name: "classic bind triple",
+			dev: container.DeviceMapping{
+				PathOnHost:        "/dev/null",
+				PathInContainer:   "/dev/zero",
+				CgroupPermissions: "rwm",
+			},
+			want: "/dev/null:/dev/zero:rwm",
+		},
+		{
+			name: "bind different paths empty cgroup defaults rwm",
+			dev: container.DeviceMapping{
+				PathOnHost:        "/dev/null",
+				PathInContainer:   "/dev/zero",
+				CgroupPermissions: "",
+			},
+			want: "/dev/null:/dev/zero:rwm",
+		},
+		{
+			name: "same bind path non-CDI empty cgroup",
+			dev: container.DeviceMapping{
+				PathOnHost:        "/dev/null",
+				PathInContainer:   "/dev/null",
+				CgroupPermissions: "",
+			},
+			want: "/dev/null",
+		},
+		{
+			name: "same bind path non-CDI explicit cgroup",
+			dev: container.DeviceMapping{
+				PathOnHost:        "/dev/null",
+				PathInContainer:   "/dev/null",
+				CgroupPermissions: "r",
+			},
+			want: "/dev/null:/dev/null:r",
+		},
+		{
+			name: "host path only empty container cgroup",
+			dev: container.DeviceMapping{
+				PathOnHost:        "/dev/foo",
+				PathInContainer:   "",
+				CgroupPermissions: "",
+			},
+			want: "/dev/foo",
+		},
+		{
+			name: "host path only with cgroup uses host::perm form",
+			dev: container.DeviceMapping{
+				PathOnHost:        "/dev/foo",
+				PathInContainer:   "",
+				CgroupPermissions: "rwm",
+			},
+			want: "/dev/foo::rwm",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DockerDeviceMappingString(tt.dev)
+			assert.Equal(t, tt.want, got)
+			if parser.IsQualifiedName(tt.want) {
+				assert.True(t, parser.IsQualifiedName(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Compat API Container create no longer turns CDI-qualified HostConfig.Devices entries into invalid `host:container:permissions` strings when optional fields are empty, so compose-style clients can pass CDI selectors reliably. DeviceRequests with driver cdi are now matched case-insensitively.
```
