### PR TITLE
Fix docs --mount source not mandatory for type=volume

### DIFF
--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -11,7 +11,8 @@ Current supported mount TYPEs are **artifact**, **bind**, **devpts**, **glob**, 
 Options common to all mount types:
 
 - *src*, *source*: mount source spec for **bind**, **glob**, and **volume**.
-  Mandatory for **artifact**, **bind**, **glob**, **image** and **volume**.
+  Mandatory for **artifact**, **bind**, **glob**, and **image**.
+  Optional for **volume**; if omitted, an anonymous volume is created.
 
 - *dst*, *dest*, *destination*, *target*: mount destination spec.
 
@@ -141,5 +142,7 @@ Examples:
 - `type=artifact,src=quay.io/libpod/testartifact:20250206-single,dst=/data`
 
 - `type=artifact,src=quay.io/libpod/testartifact:20250206-multi,dst=/data,title=test1`
+
+- `type=volume,destination=/path/in/container`
 
 - `type=volume,src=test_vol,dst=/data,subpath=/code/docs`


### PR DESCRIPTION
Folow up: https://github.com/containers/podman/issues/28497

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
