### PR TITLE
Install WiX v5.0.2 to build the Windows installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
         go-version: stable
         cache: false
     - name: Set up WiX
-      run: dotnet tool install --global wix
+      run: dotnet tool install --global wix --version 5.0.2
     - name: Setup Signature Tooling
       env:
         AZ_CERT_NAME: ${{ secrets.AZ_CERT_NAME }}

--- a/contrib/win-installer/build.ps1
+++ b/contrib/win-installer/build.ps1
@@ -49,7 +49,7 @@
 .NOTES
     Requirements:
       - .NET SDK (https://dotnet.microsoft.com/download)
-      - WiX Toolset (install: dotnet tool install --global wix)
+      - WiX Toolset (install: dotnet tool install --global wix --version 5.0.2)
 
     Environment Variables for signing (optional):
       $ENV:VAULT_ID $ENV:APP_ID $ENV:TENANT_ID
@@ -114,7 +114,7 @@ Invoke-Expression 'dotnet tool list --global wix' `
 if ($LASTEXITCODE -ne 0) {
     Write-Error ("Required dep `"Wix Toolset`" is not installed. " `
         + 'Please install it with the command ' `
-        + "`"dotnet tool install --global wix`"")
+        + "`"dotnet tool install --global wix --version 5.0.2`"")
     Exit 1
 }
 


### PR DESCRIPTION
To avoid failures such as

https://github.com/containers/podman/actions/runs/24401569105/job/71274410909#step:10:78

use version v5.0.2 of WiX as we do in CI images:

https://github.com/containers/automation_images/blob/fe80516848e8e3a1b93327e2f8a3e4d59c2db170/win_images/win_packaging.ps1#L27

Related to https://github.com/containers/podman/issues/27042

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
