### PR TITLE
[skip-ci] Update actions/github-script action to v9

### DIFF
--- a/.github/workflows/first_contrib_cert_generator.yml
+++ b/.github/workflows/first_contrib_cert_generator.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check for first merged PR
         id: check_first_pr
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const author = context.payload.pull_request.user.login;
@@ -120,7 +120,7 @@ jobs:
       # Step 7: Upload certificate image to separate repository
       - name: Upload certificate to separate repository
         if: ${{ github.event_name == 'workflow_dispatch' || steps.check_first_pr.outputs.is_first_pr == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           CONTRIBUTOR_USERNAME: ${{ github.event.inputs.contributor_username }}
           USER_LOGIN: ${{ github.event.pull_request.user.login }}
@@ -223,7 +223,7 @@ jobs:
       # Step 8: Comment on Pull Request with embedded image
       - name: Comment with embedded certificate image
         if: ${{ github.event_name == 'workflow_dispatch' || steps.check_first_pr.outputs.is_first_pr == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           CONTRIBUTOR_USERNAME: ${{ github.event.inputs.contributor_username }}
           USER_LOGIN: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
Pin actions/github-script@v9 to commit hash to satisfy zizmor security requirements. This addresses the unpinned-uses failures in PR #28484.
    
Ref: https://github.com/actions/github-script/releases/tag/v9.0.0

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
