### PR TITLE
remove isolate option from docker compat API

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"net/http"
 	"net/netip"
@@ -141,12 +140,6 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi
 	if changeDefaultName && name == runtime.Network().DefaultNetworkName() {
 		name = nettypes.BridgeNetworkDriver
 	}
-	// Make sure to clone the map as we have access to the map stored in
-	// the network backend and will overwrite it which is not good.
-	options := maps.Clone(network.Options)
-	// bridge always has isolate set in the compat API but we should not return it to not confuse callers
-	// https://github.com/containers/podman/issues/15580
-	delete(options, nettypes.IsolateOption)
 
 	report := dockerNetwork.Inspect{
 		Network: dockerNetwork.Network{
@@ -163,7 +156,7 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, statuses []abi
 			Ingress:    false,
 			ConfigFrom: dockerNetwork.ConfigReference{},
 			ConfigOnly: false,
-			Options:    options,
+			Options:    network.Options,
 			Labels:     network.Labels,
 			Peers:      nil,
 		},
@@ -234,11 +227,6 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	network.Options = make(map[string]string)
-
-	// dockers bridge networks are always isolated from each other
-	if network.Driver == nettypes.BridgeNetworkDriver {
-		network.Options[nettypes.IsolateOption] = "true"
-	}
 
 	for opt, optVal := range networkCreate.Options {
 		switch opt {

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -192,22 +192,6 @@ t DELETE libpod/networks/macvlan1 200 \
   .[0].Name~macvlan1 \
   .[0].Err=null
 
-
-# create network with isolate option and make sure it is not shown in docker compat endpoint
-podman network create --opt isolate=true isolate-test
-# Note the order of both list calls is important to test for https://github.com/containers/podman/issues/22330
-# First call the compat endpoint, then the libpod one. Previously this would have removed
-# the internal option for the libpod endpoint as well.
-t GET networks?filters='{"name":["isolate-test"]}' 200 \
-  .[0].Name=isolate-test \
-  .[0].Options="{}"
-
-t GET libpod/networks/json?filters='{"name":["isolate-test"]}' 200 \
-  .[0].name=isolate-test \
-  .[0].options.isolate="true"
-
-t DELETE libpod/networks/isolate-test 200
-
 #
 # test networks with containers
 #


### PR DESCRIPTION
With netavark v2 we start to default to strict isolation mode in netavark[1] as such that already matches the docker behavior.

Therefore no longer hard code the isolate option in the compat api.

Podman v6 is requires netavark v2 for other changes already so we do not need to worry about podman 6 + older netavark here.

[1] https://github.com/containers/netavark/pull/1438

Fixes: #27349

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Netavark v2 defaults to strict network isolation mode so that containers on different bridge networks will not be able to reach other anymore. As such the special work around for the docker compatibility API which hard coded the isolation mode was removed.
```
