### PR TITLE
auto-add user to Hyper-V Administrators group

### DIFF
--- a/pkg/machine/hyperv/hutil.go
+++ b/pkg/machine/hyperv/hutil.go
@@ -4,6 +4,9 @@ package hyperv
 
 import (
 	"errors"
+	"fmt"
+	"os/user"
+	"unsafe"
 
 	"github.com/containers/podman/v6/pkg/machine/windows"
 	"github.com/sirupsen/logrus"
@@ -16,9 +19,20 @@ var (
 	ErrHypervRegistryRemoveRequiresElevation = errors.New("removing this Hyper-V machine requires admin rights to clean up the Windows Registry. Please run Podman as an administrator")
 	ErrHypervRegistryUpdateRequiresElevation = errors.New("this machine's configuration requires additional Hyper-V networking (hvsock) entries in the Windows Registry. Please run Podman as an administrator")
 	ErrHypervLegacyMachineRequiresElevation  = errors.New("starting or stopping Hyper-V machines created with Podman 5.x or earlier requires admin rights. Please run Podman as an administrator")
+	ErrHypervPrepareHostForHyperV            = errors.New("podman needs to prepare the host to run Hyper-V machines without requiring Administrator rights in the future. This involves a one-time setup of the Windows Registry and adding your account to the 'Hyper-V Administrators' group")
+
+	// Lazily load the NetAPI32 DLL and the function we need
+	modnetapi32                 = syswindows.NewLazySystemDLL("netapi32.dll")
+	procNetLocalGroupAddMembers = modnetapi32.NewProc("NetLocalGroupAddMembers")
+	procNetLocalGroupGetMembers = modnetapi32.NewProc("NetLocalGroupGetMembers")
+	procNetApiBufferFree        = modnetapi32.NewProc("NetApiBufferFree")
 )
 
-func HasHyperVAdminRights() bool {
+type localGroupMembersInfo0 struct {
+	Sid *syswindows.SID
+}
+
+func IsHyperVAdminsGroupMember() bool {
 	sid, err := syswindows.CreateWellKnownSid(syswindows.WinBuiltinHyperVAdminsSid)
 	if err != nil {
 		return false
@@ -39,7 +53,153 @@ func HasHyperVAdminRights() bool {
 	return member
 }
 
-// HasHyperVPermissions checks if the user has either admin rights or Hyper-V admin rights.
-func HasHyperVPermissions() bool {
-	return windows.HasAdminRights() || HasHyperVAdminRights()
+// AddUserToHyperVAdminGroup adds the specified user to the local Hyper-V Administrators group.
+// The Win32 syscall logic used here is based on Microsoft's hcsshim implementation:
+// https://github.com/microsoft/hcsshim/blob/20ecf50b2ef0c8884448be87d4b6b58b8d62ce94/internal/winapi/user.go#L170
+func AddUserToHyperVAdminGroup(username string) error {
+	groupPtr, err := getHyperVAdminGroupNamePtr()
+	if err != nil {
+		return err
+	}
+
+	userSid, _, _, err := syswindows.LookupSID("", username)
+	if err != nil {
+		return fmt.Errorf("failed to look up SID for user %q: %w", username, err)
+	}
+
+	info := localGroupMembersInfo0{
+		Sid: userSid,
+	}
+
+	// C Signature: NET_API_STATUS NetLocalGroupAddMembers(LPCWSTR servername, LPCWSTR groupname, DWORD level, LPBYTE buf, DWORD totalentries)
+	ret, _, _ := procNetLocalGroupAddMembers.Call(
+		0,                                 // ServerName (0 = local machine)
+		uintptr(unsafe.Pointer(groupPtr)), // GroupName
+		0,                                 // Level 0 (we are passing a SID)
+		uintptr(unsafe.Pointer(&info)),    // Buffer containing our struct
+		1,                                 // Total Entries being added
+	)
+
+	errno := syswindows.Errno(ret)
+	// ERROR_MEMBER_IN_ALIAS = "The specified account name is already a member of the group."
+	// https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
+	if errno != syswindows.NO_ERROR && errno != syswindows.ERROR_MEMBER_IN_ALIAS {
+		return fmt.Errorf("NetLocalGroupAddMembers failed with error: %w", errno)
+	}
+
+	return nil
+}
+
+func getHyperVAdminGroupNamePtr() (*uint16, error) {
+	hypervAdminsSid, err := syswindows.CreateWellKnownSid(syswindows.WinBuiltinHyperVAdminsSid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create well-known SID for Hyper-V Admins: %w", err)
+	}
+
+	// Look up the localized name of the group from the SID
+	// (e.g., "Hyper-V Administrators" in EN, "Amministratori Hyper-V" in IT)
+	groupName, _, _, err := hypervAdminsSid.LookupAccount("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up group name for Hyper-V Admins: %w", err)
+	}
+
+	return syswindows.UTF16PtrFromString(groupName)
+}
+
+// getCurrentUserSID retrieves the SID of the user running the current process
+func getCurrentUserSID() (*syswindows.SID, error) {
+	u, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	userSid, _, _, err := syswindows.LookupSID("", u.Username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up SID for user %q: %w", u.Username, err)
+	}
+
+	return userSid, nil
+}
+
+func isUserInGroup(groupPtr *uint16, userSid *syswindows.SID) (bool, error) {
+	if userSid == nil {
+		return false, errors.New("provided userSid is nil")
+	}
+
+	var (
+		bufPtr    unsafe.Pointer
+		entries   uint32
+		total     uint32
+		resumeHnd uintptr
+	)
+
+	// Call NetLocalGroupGetMembers - it retrieves a list of the members of a particular local group
+	// See: https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netlocalgroupgetmembers
+	ret, _, _ := procNetLocalGroupGetMembers.Call(
+		0,
+		uintptr(unsafe.Pointer(groupPtr)),
+		0,
+		uintptr(unsafe.Pointer(&bufPtr)),
+		uintptr(0xFFFFFFFF),
+		uintptr(unsafe.Pointer(&entries)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&resumeHnd)),
+	)
+
+	defer func() {
+		// This buffer is allocated by the system and must be freed using the NetApiBufferFree function.
+		// Note that you must free the buffer even if the function fails with ERROR_MORE_DATA.
+		// See: https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netlocalgroupgetmembers
+		if bufPtr != nil {
+			_, _, _ = procNetApiBufferFree.Call(uintptr(bufPtr))
+		}
+	}()
+
+	if ret != 0 {
+		return false, fmt.Errorf("NetLocalGroupGetMembers failed with code: %d", ret)
+	}
+
+	if entries == 0 || bufPtr == nil {
+		return false, nil
+	}
+
+	// Converts the raw pointer into a slice of the given length
+	members := unsafe.Slice((*localGroupMembersInfo0)(bufPtr), entries)
+
+	for _, member := range members {
+		if member.Sid != nil && syswindows.EqualSid(member.Sid, userSid) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// VerifyHyperVPermissions returns `nil` if the user has the privileges to manage
+// Hyper-V VMs. This can be either because the command is run
+// as an administrator or because the user is a member of the Hyper-V Admins group.
+// It returns a specific error otherwise.
+// It gracefully detects if a user was added to the admin group but hasn't restarted their session.
+func VerifyHyperVPermissions() error {
+	if windows.HasAdminRights() || IsHyperVAdminsGroupMember() {
+		return nil
+	}
+
+	userSid, err := getCurrentUserSID()
+	if err != nil {
+		return fmt.Errorf("failed to look up SID for current user: %w", err)
+	}
+
+	groupPtr, err := getHyperVAdminGroupNamePtr()
+	if err != nil {
+		return fmt.Errorf("failed to get localized Hyper-V Admin group name: %w", err)
+	}
+
+	inGroup, _ := isUserInGroup(groupPtr, userSid)
+	if inGroup {
+		return errors.New("you have been added to the Hyper-V Administrators group, but your active session has not updated. Please log out of Windows and log back in to apply the permissions")
+	}
+
+	// They are not an Admin, not in the token, and not in the group database.
+	return ErrHypervUserNotInAdminGroup
 }

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio"
@@ -67,11 +68,24 @@ func (h HyperVStubber) CreateVM(_ define.CreateVMOpts, mc *vmconfigs.MachineConf
 		// If it returns ErrHypervRegistryInitRequiresElevation and we're not already re-executing,
 		// offer to elevate automatically if user is in admin group
 		if err == ErrHypervRegistryInitRequiresElevation && !windows.IsReExecuting() && windows.IsInAdministratorsGroup() {
-			message := "To initialize the first Hyper-V machine, Podman requires admin rights to set up the Windows Registry.\n\n" +
-				windows.UACConfirmationPrompt
+			message := fmt.Sprintf("%s.\n\n%s", ErrHypervPrepareHostForHyperV.Error(), windows.UACConfirmationPrompt)
 			return launchElevate(message)
 		}
 		return err
+	}
+
+	// Once here, we know the user has admin rights but may not be in
+	// the Hyper-V Administrators group yet. Add them if necessary so
+	// that future commands work without elevation.
+	if windows.IsReExecuting() && !IsHyperVAdminsGroupMember() {
+		u, err := user.Current()
+		if err != nil {
+			return err
+		}
+		logrus.Infof("Adding user %s to the Hyper-V Administrators group", u.Username)
+		if err := AddUserToHyperVAdminGroup(u.Username); err != nil {
+			return err
+		}
 	}
 
 	// count number of existing machines, used later to determine if Registry should be cleaned over a failure
@@ -165,6 +179,13 @@ func (h HyperVStubber) CreateVM(_ define.CreateVMOpts, mc *vmconfigs.MachineConf
 }
 
 func (h HyperVStubber) Exists(name string) (bool, error) {
+	// If the user lacks permissions, WMI will throw an access denied error.
+	// We return false to prevent breaking commands like `init`
+	// that loop over all providers to verify machine name uniqueness.
+	if err := VerifyHyperVPermissions(); err != nil {
+		return false, nil //nolint:nilerr
+	}
+
 	vmm := hypervctl.NewVirtualMachineManager()
 	exists, _, err := vmm.GetMachineExists(name)
 	return exists, err
@@ -246,10 +267,7 @@ func (h HyperVStubber) canCreate() error {
 	}
 	// at least 1 machine exists
 	// if user is member of the hyperv admin group, allow creation
-	if HasHyperVAdminRights() {
-		return nil
-	}
-	return ErrHypervUserNotInAdminGroup
+	return VerifyHyperVPermissions()
 }
 
 // launchElevate attempts to automatically re-run the command as administrator
@@ -304,8 +322,8 @@ func (h HyperVStubber) canRemove(mc *vmconfigs.MachineConfig) error {
 		return err
 	}
 	// more than 1 machine exists, allow removal if user has hyperv admin rights
-	if machines > 1 && HasHyperVAdminRights() {
-		return nil
+	if machines > 1 {
+		return VerifyHyperVPermissions()
 	}
 	return ErrHypervRegistryRemoveRequiresElevation
 }
@@ -320,6 +338,10 @@ func (h HyperVStubber) canStartOrStop(mc *vmconfigs.MachineConfig) error {
 	// if machine is legacy (machineName field), require admin rights to start or stop
 	if isLegacyMachine(mc) {
 		return ErrHypervLegacyMachineRequiresElevation
+	}
+
+	if err := VerifyHyperVPermissions(); err != nil {
+		return err
 	}
 
 	return nil
@@ -460,6 +482,12 @@ func (h HyperVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func(
 // state is determined by the VM itself.  normally this can be done with vm.State() and a conversion
 // but doing here as well.  this requires a little more interaction with the hypervisor
 func (h HyperVStubber) State(mc *vmconfigs.MachineConfig, _ bool) (define.Status, error) {
+	// If the user does not have permissions, WMI will fail with an error anyway.
+	// Just return Unknown.
+	if !windows.HasAdminRights() && !IsHyperVAdminsGroupMember() {
+		return define.Unknown, nil
+	}
+
 	_, vm, err := GetVMFromMC(mc)
 	if err != nil {
 		return define.Unknown, err
@@ -525,6 +553,10 @@ func stateConversion(s hypervctl.EnabledState) (define.Status, error) {
 }
 
 func (h HyperVStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.SetOptions) error {
+	if err := VerifyHyperVPermissions(); err != nil {
+		return err
+	}
+
 	var cpuChanged, memoryChanged bool
 
 	_, vm, err := GetVMFromMC(mc)
@@ -593,8 +625,7 @@ func (h HyperVStubber) PrepareIgnition(mc *vmconfigs.MachineConfig, _ *ignition.
 	if err != nil {
 		if !windows.HasAdminRights() {
 			if !windows.IsReExecuting() && windows.IsInAdministratorsGroup() {
-				message := "Initializing the first Hyper-V machine requires admin rights to set up the Windows Registry.\n\n" +
-					windows.UACConfirmationPrompt
+				message := fmt.Sprintf("%s.\n\n%s", ErrHypervPrepareHostForHyperV.Error(), windows.UACConfirmationPrompt)
 				return nil, launchElevate(message)
 			}
 			return nil, ErrHypervRegistryInitRequiresElevation

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -8,16 +8,10 @@ import (
 	"github.com/containers/podman/v6/pkg/machine/define"
 	"github.com/containers/podman/v6/pkg/machine/hyperv"
 	"github.com/containers/podman/v6/pkg/machine/vmconfigs"
-	"github.com/containers/podman/v6/pkg/machine/windows"
 	"github.com/containers/podman/v6/pkg/machine/wsl"
 	"github.com/containers/podman/v6/pkg/machine/wsl/wutil"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
-)
-
-// Variable to hold permission check function for testing purposes.
-var (
-	hasHyperVPermissionsFunc = hyperv.HasHyperVPermissions
 )
 
 func Get() (vmconfigs.VMProvider, error) {
@@ -44,12 +38,9 @@ func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
 	case define.WSLVirt:
 		return new(wsl.WSLStubber), nil
 	case define.HyperVVirt:
-		// Check permissions before returning the Hyper-V provider.
-		// Working with Hyper-V requires users to be at least members of the Hyper-V admin group.
-		// Init and remove actions have custom use cases and they are checked on the stubber.
-		if !hasHyperVPermissionsFunc() {
-			return nil, hyperv.ErrHypervUserNotInAdminGroup
-		}
+		// Permission checks for Hyper-V are handled at the stubber method level
+		// rather than here, because `init` needs to proceed even when the user is
+		// not yet in the Hyper-V admin group (it will add them to the group during CreateVM).
 		return new(hyperv.HyperVStubber), nil
 	default:
 	}
@@ -57,13 +48,10 @@ func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
 }
 
 func GetAll() []vmconfigs.VMProvider {
-	providers := []vmconfigs.VMProvider{
+	return []vmconfigs.VMProvider{
 		new(wsl.WSLStubber),
+		new(hyperv.HyperVStubber),
 	}
-	if hasHyperVPermissionsFunc() {
-		providers = append(providers, new(hyperv.HyperVStubber))
-	}
-	return providers
 }
 
 // SupportedProviders returns the providers that are supported on the host operating system
@@ -97,7 +85,11 @@ func HasPermsForProvider(provider define.VMType) bool {
 	case define.AppleHvVirt:
 		return false
 	case define.HyperVVirt:
-		return windows.HasAdminRights()
+		err := hyperv.VerifyHyperVPermissions()
+		if err != nil {
+			logrus.Warn(err)
+		}
+		return err == nil
 	}
 
 	return true

--- a/pkg/machine/provider/platform_windows_test.go
+++ b/pkg/machine/provider/platform_windows_test.go
@@ -6,103 +6,30 @@ import (
 	"testing"
 
 	"github.com/containers/podman/v6/pkg/machine/define"
-	"github.com/containers/podman/v6/pkg/machine/hyperv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// helper to setup mocks and ensure cleanup
-func mockPermissions(t *testing.T, hasHyperVPermissions bool) {
-	origHyperVPermissionsFunc := hasHyperVPermissionsFunc
-	t.Cleanup(func() {
-		hasHyperVPermissionsFunc = origHyperVPermissionsFunc
-	})
-
-	hasHyperVPermissionsFunc = func() bool { return hasHyperVPermissions }
-}
-
-func TestGetByVMType_HyperV(t *testing.T) {
-	tests := []struct {
-		name                 string
-		hasHyperVPermissions bool
-		expectError          bool
+func TestGetByVMType_Supported(t *testing.T) {
+	testCases := []struct {
+		name   string
+		vmType define.VMType
 	}{
-		{
-			name:                 "WithHyperVPermissions",
-			hasHyperVPermissions: true,
-			expectError:          false,
-		},
-		{
-			name:                 "WithoutPermissions",
-			hasHyperVPermissions: false,
-			expectError:          true,
-		},
+		{"HyperV", define.HyperVVirt},
+		{"WSL", define.WSLVirt},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockPermissions(t, tt.hasHyperVPermissions)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GetByVMType for supported types should always return a provider.
+			// Permission checks are handled at the stubber method level.
+			provider, err := GetByVMType(tc.vmType)
 
-			provider, err := GetByVMType(define.HyperVVirt)
-
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.Equal(t, err.Error(), hyperv.ErrHypervUserNotInAdminGroup.Error())
-				assert.Nil(t, provider)
-			} else {
-				require.NoError(t, err)
-				assert.NotNil(t, provider)
-				assert.Equal(t, define.HyperVVirt, provider.VMType())
-			}
+			require.NoError(t, err)
+			assert.NotNil(t, provider)
+			assert.Equal(t, tc.vmType, provider.VMType())
 		})
 	}
-}
-
-func TestGetAll_HyperV_Inclusion(t *testing.T) {
-	tests := []struct {
-		name                 string
-		hasHyperVPermissions bool
-		expectHyperV         bool
-	}{
-		{"WithHyperVPermissions", true, true},
-		{"WithoutHyperVPermissions", false, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockPermissions(t, tt.hasHyperVPermissions)
-
-			providers := GetAll()
-
-			// Check for HyperV presence
-			hasHyperV := false
-			for _, p := range providers {
-				if p.VMType() == define.HyperVVirt {
-					hasHyperV = true
-					break
-				}
-			}
-
-			assert.Equal(t, tt.expectHyperV, hasHyperV, "Hyper-V provider presence mismatch")
-
-			// WSL should always be present in these scenarios
-			hasWSL := false
-			for _, p := range providers {
-				if p.VMType() == define.WSLVirt {
-					hasWSL = true
-					break
-				}
-			}
-			assert.True(t, hasWSL, "GetAll should always include WSL provider")
-		})
-	}
-}
-
-func TestGetByVMType_WSL_AlwaysWorks(t *testing.T) {
-	provider, err := GetByVMType(define.WSLVirt)
-	require.NoError(t, err)
-	assert.NotNil(t, provider)
-	assert.Equal(t, define.WSLVirt, provider.VMType())
 }
 
 func TestGetByVMType_UnsupportedProvider(t *testing.T) {

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -862,11 +862,18 @@ func Reset(mps []vmconfigs.VMProvider, _ machine.ResetOptions) error {
 				resetErrors = multierror.Append(resetErrors, err)
 			}
 
-			if err := genericRm(); err != nil {
-				resetErrors = multierror.Append(resetErrors, err)
+			if genericRm != nil {
+				if err := genericRm(); err != nil {
+					resetErrors = multierror.Append(resetErrors, err)
+				}
 			}
-			if err := providerRm(); err != nil {
-				resetErrors = multierror.Append(resetErrors, err)
+			// We must check if the returned providerRm function is not nil before executing it.
+			// If a provider (like Hyper-V) encountered an error during the removal setup
+			// phase (e.g., a cancelled 'runas' elevation), it returns nil for the function.
+			if providerRm != nil {
+				if err := providerRm(); err != nil {
+					resetErrors = multierror.Append(resetErrors, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently, running Podman on Hyper-V as a non-administrator requires the user to be a member of the "Hyper-V Administrators" local group. If they are not, various WMI calls fail with access denied.

This commit automates the permission setup.
1. During podman machine init, if Podman is running with elevated privileges (required for registry/networking setup anyway), it will now automatically add the current user to the localized "Hyper-V Administrators" group
2. If a user is added to the group, the change is not reflected until the next login. We now detect this state and explicitly instruct the user to log out and back in.
3. Modified the Hyper-V stubber to handle permission checks at the method level rather than the provider selection level (GetAll). This allows init to continue far enough to perform the elevation and setting.

it fixes #25037 

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

Yes. During the initialization of the first Hyper-V machine, Podman will now silently handle the group assignment for the user. It also detects if the user has been added to the group but has not yet logged out, and will inform the user to do so to refresh the session tokens.

```release-note
Podman now automatically adds the user to the "Hyper-V Administrators" group during machine initialization and provides a clear notification if a logout is required to refresh permissions.
```
