### PR TITLE
Fix Docker compat `/wait` hanging for next-exit condition

### DIFF
--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -69,6 +69,23 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For next-exit, subscribe to "died" events BEFORE sending the 200
+	// status.  The Docker client (docker run) sends /wait, then
+	// /start, but it only sends /start after receiving the 200 from
+	// /wait.  By subscribing before the flush, the event listener is
+	// guaranteed to be ready before the container can start and exit.
+	// https://github.com/containers/podman/issues/28514
+	var eventChannel chan events.ReadResult
+	var cancelEvents context.CancelFunc
+	if condition == "next-exit" {
+		eventChannel, cancelEvents, err = subscribeContainerDied(ctx, name)
+		if err != nil {
+			InternalServerError(w, err)
+			return
+		}
+		defer cancelEvents()
+	}
+
 	// In docker compatibility mode we have to send headers in advance,
 	// otherwise docker client would freeze.
 	w.Header().Set("Content-Type", "application/json")
@@ -77,7 +94,7 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 	}
 
-	exitCode, err := waitDockerCondition(ctx, name, interval, condition)
+	exitCode, err := waitDockerCondition(ctx, name, eventChannel, interval, condition)
 	var errStruct *struct{ Message string }
 	if err != nil {
 		logrus.Errorf("While waiting on condition: %q", err)
@@ -182,6 +199,18 @@ func createContainerWaitFn(ctx context.Context, containerName string, interval t
 	}
 }
 
+func containerExists(ctx context.Context, name string) (bool, error) {
+	runtime := ctx.Value(api.RuntimeKey).(*libpod.Runtime)
+	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
+
+	var ctrExistsOpts entities.ContainerExistsOptions
+	ctrExistRep, err := containerEngine.ContainerExists(ctx, name, ctrExistsOpts)
+	if err != nil {
+		return false, err
+	}
+	return ctrExistRep.Value, nil
+}
+
 func isValidDockerCondition(cond string) bool {
 	switch cond {
 	case "next-exit", "removed", "not-running", "":
@@ -190,14 +219,14 @@ func isValidDockerCondition(cond string) bool {
 	return false
 }
 
-func waitDockerCondition(ctx context.Context, containerName string, interval time.Duration, dockerCondition string) (int32, error) {
+func waitDockerCondition(ctx context.Context, containerName string, eventChannel chan events.ReadResult, interval time.Duration, dockerCondition string) (int32, error) {
 	containerWait := createContainerWaitFn(ctx, containerName, interval)
 
 	var err error
 	var code int32
 	switch dockerCondition {
 	case "next-exit":
-		code, err = waitNextExit(ctx, containerName)
+		code, err = waitNextExit(eventChannel)
 	case "removed":
 		code, err = waitRemoved(containerWait)
 	case "not-running", "":
@@ -209,10 +238,11 @@ func waitDockerCondition(ctx context.Context, containerName string, interval tim
 }
 
 var notRunningStates = []define.ContainerStatus{
-	define.ContainerStateCreated,
-	define.ContainerStateRemoving,
-	define.ContainerStateExited,
 	define.ContainerStateConfigured,
+	define.ContainerStateCreated,
+	define.ContainerStateStopped,
+	define.ContainerStateExited,
+	define.ContainerStateRemoving,
 }
 
 func waitRemoved(ctrWait containerWaitFn) (int32, error) {
@@ -233,7 +263,11 @@ func waitRemoved(ctrWait containerWaitFn) (int32, error) {
 	return code, nil
 }
 
-func waitNextExit(ctx context.Context, containerName string) (int32, error) {
+// subscribeContainerDied starts listening for "died" events for the given
+// container and returns the event channel and a cancel function.
+//
+// The caller must call cancel when done to stop the background goroutine.
+func subscribeContainerDied(ctx context.Context, containerName string) (chan events.ReadResult, context.CancelFunc, error) {
 	runtime := ctx.Value(api.RuntimeKey).(*libpod.Runtime)
 	containerEngine := &abi.ContainerEngine{Libpod: runtime}
 	eventChannel := make(chan events.ReadResult)
@@ -242,42 +276,28 @@ func waitNextExit(ctx context.Context, containerName string) (int32, error) {
 		Filter:    []string{"event=died", fmt.Sprintf("container=%s", containerName)},
 		Stream:    true,
 	}
-
-	// ctx is used to cancel event watching goroutine
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	err := containerEngine.Events(ctx, opts)
-	if err != nil {
-		return -1, err
+	if err := containerEngine.Events(ctx, opts); err != nil {
+		cancel()
+		return nil, nil, err
 	}
+	return eventChannel, cancel, nil
+}
 
+func waitNextExit(eventChannel chan events.ReadResult) (int32, error) {
 	for evt := range eventChannel {
-		if evt.Error == nil {
-			if evt.Event.ContainerExitCode != nil {
-				return int32(*evt.Event.ContainerExitCode), nil
-			}
+		if evt.Error != nil {
+			return -1, evt.Error
+		}
+		if evt.Event.ContainerExitCode != nil {
+			return int32(*evt.Event.ContainerExitCode), nil
 		}
 	}
-	// if we are here then containerEngine.Events() has exited
-	// it may happen if request was canceled (e.g. client closed connection prematurely) or
-	// the server is in process of shutting down
 	return -1, nil
 }
 
 func waitNotRunning(ctrWait containerWaitFn) (int32, error) {
 	return ctrWait(notRunningStates...)
-}
-
-func containerExists(ctx context.Context, name string) (bool, error) {
-	runtime := ctx.Value(api.RuntimeKey).(*libpod.Runtime)
-	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
-
-	var ctrExistsOpts entities.ContainerExistsOptions
-	ctrExistRep, err := containerEngine.ContainerExists(ctx, name, ctrExistsOpts)
-	if err != nil {
-		return false, err
-	}
-	return ctrExistRep.Value, nil
 }
 
 // PSTitles merges CAPS headers from ps output. All PS headers are single words, except for

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -516,7 +516,9 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Wait on a container
-	// description: Block until a container stops or given condition is met.
+	// description: |
+	//   Block until a container stops or given condition is met.
+	//   This is a Docker-compatible endpoint.
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -526,19 +528,16 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: condition
 	//    type: string
+	//    default: not-running
 	//    description: |
-	//      wait until container is to a given condition. default is stopped. valid conditions are:
-	//        - configured
-	//        - created
-	//        - exited
-	//        - paused
-	//        - running
-	//        - stopped
-	//  - in: query
-	//    name: interval
-	//    type: string
-	//    default: "250ms"
-	//    description: Time Interval to wait before polling for completion.
+	//      Wait condition.  Valid values are:
+	//        - not-running (default) - return when the container is not running
+	//          (stopped, exited, or was never started).
+	//        - next-exit - wait for the next time the container stops.
+	//          If the container is running, block until it exits.
+	//          If the container is already stopped, block until
+	//          the next start-and-exit cycle.
+	//        - removed - wait until the container is removed.
 	// produces:
 	// - application/json
 	// responses:

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -64,3 +64,10 @@ t POST "libpod/containers/${cid}/wait?condition=running" 404
 t POST "libpod/containers/${CTR}/wait" 404
 t POST "libpod/containers/${cid}/wait" 200 \
  "3"
+
+CTR2="waitNextExit"
+podman run -d --name "${CTR2}" "${IMAGE}" sh -c "sleep 5; exit 42"
+t POST "containers/${CTR2}/wait?condition=next-exit" 200 \
+  .StatusCode=42 \
+  .Error=null
+podman rm -f "${CTR2}"


### PR DESCRIPTION
The issue is caused because the container exists before podman setups wainting for the event. 

Fixes: https://github.com/containers/podman/issues/28514

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a bug where Docker clients would hang indefinitely on `docker run` when using the Podman Docker-compatible API
```
