### PR TITLE
[v4.2.0-rhel] Fix system test: podman logs restarted journald

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -120,6 +120,9 @@ ${cid[0]} d"   "Sequential output from logs"
 function _log_test_restarted() {
     local driver=$1
     local events_backend=$(_additional_events_backend $driver)
+    if [[ -n "${events_backend}" ]]; then
+        skip_if_remote "remote does not support --events-backend"
+    fi
     run_podman run --log-driver=$driver ${events_backend} --name logtest $IMAGE sh -c 'start=0; if test -s log; then start=`tail -n 1 log`; fi; seq `expr $start + 1` `expr $start + 10` | tee -a log'
     # FIXME: #9597
     # run/start is flaking for remote so let's wait for the container condition


### PR DESCRIPTION
When run with `podman-remote`, the `--events-backend` option is unavailable.  However, the `podman logs restarted journald` test blindly sets `events_backend` without checking if the remote client is being used.  This causes the test to fail.  Fix this by skipping the test when the remote client is being used.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
