### PR TITLE
[v5.6-rhel] Backport aws OIDC

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,7 +74,10 @@ timeout_in: 20m
 
 gcp_credentials: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e42f55e097e897ab63ee78369dae141dcf0b46a9d0cdd]
 
-aws_credentials: ENCRYPTED[b4127fef212e5bc38dd3d96eff17440f2c62d6d04219fa97fa7acdcd81475352e70a34863705b5e01289fdc4012d5ee2]
+aws_credentials:
+  role_arn: arn:aws:iam::449134212816:role/podman-ci-role
+  role_session_name: cirrus
+  region: us-east-1
 
 
 validate-source_task:


### PR DESCRIPTION
Switch from encrypted AWS credentials to OIDC authentication for Cirrus CI AWS EC2 instances (aarch64 builds).

This fixes the Build for fedora-42-aarch64 CI failures on v5.6-rhel branch PRs (e.g., #28530).

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [x] Referenced issues using Fixes: #00000 in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass make validatepr (format/lint checks)
- [x] Release note entered in the section below (or None if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```