### PR TITLE
Notify users that a BoltDB database still exists

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -292,6 +292,15 @@ func getDBState(runtime *Runtime) (State, error) {
 	case config.DBBackendBoltDB:
 		return nil, fmt.Errorf("the BoltDB database backend was removed in Podman 6.0")
 	case config.DBBackendDefault:
+		// Look for a legacy BoltDB database
+		baseDir := runtime.config.Engine.StaticDir
+		if runtime.storageConfig.TransientStore {
+			baseDir = runtime.config.Engine.TmpDir
+		}
+		boltDBPath := filepath.Join(baseDir, "bolt_state.db")
+		if err := fileutils.Exists(boltDBPath); err == nil {
+			return nil, fmt.Errorf("a legacy BoltDB database was detected. Support for BoltDB was removed in Podman 6. Please downgrade to Podman 5.8 to migrate to the new SQLite database. If migration is not necessary, you can suppress this warning by removing or renaming the BoltDB database located at %q", boltDBPath)
+		}
 		fallthrough
 	case config.DBBackendSQLite:
 		return NewSqliteState(runtime)


### PR DESCRIPTION
With Podman 6, we removed all BoltDB support. To try and ease the transition, Podman 5.8 is capable migrating a Bolt database to the new SQLite database that we've defaulted to since late in the Podman 4.x release series. However - what happens if someone goes from Podman 5.7 or lower, straight to Podman 6.x? No migration will occur, and the user loses all their containers.

Step 1 of a fix is just to tell folks that they have a legacy database in place, and they really need to go back to 5.8 and do a migration. Step 2 is to introduce some sort of migration binary (probably a very stripped-down Podman 5.8?) that we can ship alongside Podman 6 (maybe as a subpackage?) so that folks can migrate without a downgrade.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

We already cover this in the Podman 6 BoltDB removal PR, so...

```release-note
NONE
```
