### PR TITLE
move old registries.conf v1 files to v2

### DIFF
--- a/hack/podman-socat
+++ b/hack/podman-socat
@@ -54,16 +54,6 @@ trap "cleanup $TMPDIR" EXIT
 # Need locations to store stuff
 mkdir -p "${TMPDIR}"/{podman,crio,crio-run,cni/net.d,ctnr,tunnel}
 
-export CONTAINERS_REGISTRIES_CONF=${TMPDIR}/registry.conf
-cat >"$CONTAINERS_REGISTRIES_CONF" <<-EOT
-  [registries.search]
-    registries = ['docker.io']
-  [registries.insecure]
-    registries = []
-  [registries.block]
-    registries = []
-EOT
-
 export CNI_CONFIG_PATH=${TMPDIR}/cni/net.d
 cat >"$CNI_CONFIG_PATH"/87-podman-bridge.conflist <<-EOT
 {

--- a/test/apiv2/python/rest_api/fixtures/podman.py
+++ b/test/apiv2/python/rest_api/fixtures/podman.py
@@ -25,18 +25,23 @@ class Podman:
         self.cmd.append("--runroot=" + os.path.join(self.anchor_directory, "crio-run"))
 
         os.environ["CONTAINERS_REGISTRIES_CONF"] = os.path.join(
-            self.anchor_directory, "registry.conf"
+            self.anchor_directory, "registries.conf"
         )
-        p = configparser.ConfigParser()
-        p.read_dict(
-            {
-                "registries.search": {"registries": "['quay.io']"},
-                "registries.insecure": {"registries": "[]"},
-                "registries.block": {"registries": "[]"},
-            }
-        )
-        with open(os.environ["CONTAINERS_REGISTRIES_CONF"], "w") as w:
-            p.write(w)
+
+        # Assume developer-mode testing by default
+        reg_conf_source_path="./test/registries.conf"
+
+        # When operating in a CI environment, use the local registry server.
+        # Ref: https://github.com/containers/automation_images/pull/357
+        #      https://github.com/containers/podman/pull/22726
+        if os.getenv("CI_USE_REGISTRY_CACHE"):
+            reg_conf_source_path = "./test/registries-cached.conf"
+
+        with open(os.path.join(reg_conf_source_path)) as file:
+            conf = file.read()
+
+        with open(os.environ["CONTAINERS_REGISTRIES_CONF"], "w") as file:
+            file.write(conf)
 
     def open(self, command, *args, **kwargs):
         """Podman initialized instance to run a given command

--- a/test/apiv2/python/rest_api/test_v2_0_0_artifact.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_artifact.py
@@ -531,13 +531,17 @@ class ArtifactTestCase(APITestCase):
         r = requests.post(url, params=parameters)
         rjson = r.json()
 
-        # Assert correct response code
-        self.assertEqual(r.status_code, 401, r.text)
+        # Assert correct response code, depending on the registry it may give the real 404 error or unauthorized
+        self.assertIn(r.status_code, (401, 404), r.text)
 
         # Assert return error response is json and contains correct message
+        message = "unauthorized: access to the requested resource is not authorized"
+        if r.status_code == 404:
+            message = "manifest unknown: manifest unknown"
+
         self.assertEqual(
             rjson["cause"],
-            "unauthorized: access to the requested resource is not authorized",
+            message,
         )
 
     def test_pull_missing_fails(self):

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -35,7 +35,7 @@ class ImageTestCase(APITestCase):
             self.assertIn("sha256:",item['Id'])
 
     def test_inspect(self):
-        r = requests.get(self.podman_url + "/v1.40/images/alpine/json")
+        r = requests.get(self.podman_url + "/v1.40/images/quay.io/libpod/testimage:20241011/json")
         self.assertEqual(r.status_code, 200, r.text)
 
         # See https://docs.docker.com/engine/api/v1.40/#operation/ImageInspect
@@ -152,7 +152,7 @@ class ImageTestCase(APITestCase):
 
     def test_create(self):
         r = requests.post(
-            self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8",
+            self.podman_url + "/v1.40/images/create?fromImage=quay.io/libpod/testimage:20241011&platform=linux/amd64/v8",
             timeout=15,
         )
         self.assertEqual(r.status_code, 200, r.text)

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Podman login and logout", func() {
 		port := GetPort()
 		server = strings.Join([]string{"localhost", strconv.Itoa(port)}, ":")
 
-		registriesConfWithSearch = fmt.Appendf(nil, "[registries.search]\nregistries = ['%s']", server)
+		registriesConfWithSearch = fmt.Appendf(nil, "unqualified-search-registries = ['%s']", server)
 
 		testImg = strings.Join([]string{server, "test-alpine"}, "/")
 

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -28,19 +28,19 @@ func (e *endpoint) Address() string {
 
 var _ = Describe("Podman search", func() {
 	const regFileContents = `
-[registries.search]
-registries = ['{{.Host}}:{{.Port}}']
-
-[registries.insecure]
-registries = ['{{.Host}}:{{.Port}}']`
+unqualified-search-registries = ["{{.Host}}:{{.Port}}"]
+[[registry]]
+location = "{{.Host}}:{{.Port}}"
+insecure = true
+`
 	registryFileTmpl := template.Must(template.New("registryFile").Parse(regFileContents))
 
 	const badRegFileContents = `
-[registries.search]
-registries = ['{{.Host}}:{{.Port}}']
-# empty
-[registries.insecure]
-registries = []`
+unqualified-search-registries = ["{{.Host}}:{{.Port}}"]
+[[registry]]
+location = "{{.Host}}:{{.Port}}"
+insecure = false
+`
 	registryFileBadTmpl := template.Must(template.New("registryFileBad").Parse(badRegFileContents))
 
 	mockFakeRegistryServerAsContainer := func(name string) endpoint {

--- a/test/python/docker/__init__.py
+++ b/test/python/docker/__init__.py
@@ -42,7 +42,7 @@ class PodmanAPI:
         self.cmd.append("--runroot=" + os.path.join(self.anchor_directory, "crio-run"))
 
         os.environ["CONTAINERS_REGISTRIES_CONF"] = os.path.join(
-            self.anchor_directory, "registry.conf"
+            self.anchor_directory, "registries.conf"
         )
 
         # Entry verified by compat/test_system.py


### PR DESCRIPTION
The v1 syntax will no longer accepted with recent image changes.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
