### PR TITLE
test: remove outdated checkpoint skip

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -336,7 +336,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with established tcp connections", func() {
-		Skip("FIXME: #26289 - Rawhide only issue, skip for now")
 		localRunString := getRunString([]string{REDIS_IMAGE})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
@@ -406,8 +405,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman restore container with tcp-close", func() {
-		Skip("FIXME: #26289 - Rawhide only issue, skip for now")
-
 		// Start a container with redis (which listens on tcp port)
 		localRunString := getRunString([]string{REDIS_IMAGE})
 		session := podmanTest.Podman(localRunString)
@@ -1113,7 +1110,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint and restore container with different port mappings", func() {
-		Skip("FIXME: #26289 - Rawhide only issue, skip for now")
 		randomPort, err := utils.GetRandomPort()
 		Expect(err).ShouldNot(HaveOccurred())
 		localRunString := getRunString([]string{"-p", fmt.Sprintf("%d:6379", randomPort), "--rm", REDIS_IMAGE})
@@ -1417,7 +1413,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint and restore containers with --print-stats", func() {
-		Skip("FIXME: #26289 - Rawhide only issue, skip for now")
 		session1 := podmanTest.Podman(getRunString([]string{REDIS_IMAGE}))
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(ExitCleanly())

--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -134,6 +134,7 @@ function setup() {
 
 # bats test_tags=ci:parallel
 @test "podman checkpoint --export, with volumes" {
+    skip_if_aarch64 "FIXME #28576: selinux problem only on aarch64"
     skip_if_remote "Test uses --root/--runroot, which are N/A over remote"
 
     local p_opts="$(podman_isolation_opts ${PODMAN_TMPDIR}) --events-backend file"

--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -134,7 +134,6 @@ function setup() {
 
 # bats test_tags=ci:parallel
 @test "podman checkpoint --export, with volumes" {
-    skip "FIXME: #26289 - Rawhide only issue, skip for now"
     skip_if_remote "Test uses --root/--runroot, which are N/A over remote"
 
     local p_opts="$(podman_isolation_opts ${PODMAN_TMPDIR}) --events-backend file"


### PR DESCRIPTION
This should work again with the latest VM images.

Fixes: #26289

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
