### PR TITLE
SQLite verify that a Volume config was actually deleted

### DIFF
--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -1992,7 +1992,7 @@ func (s *SQLiteState) RemoveVolume(volume *Volume) (defErr error) {
 	}
 	defer func() {
 		if defErr != nil {
-			if err := tx.Rollback(); err != nil {
+			if err = tx.Rollback(); err != nil {
 				logrus.Errorf("Rolling back transaction to remove volume %s: %v", volume.Name(), err)
 			}
 		}
@@ -2007,24 +2007,30 @@ func (s *SQLiteState) RemoveVolume(volume *Volume) (defErr error) {
 	var ctrs []string
 	for rows.Next() {
 		var ctr string
-		if err := rows.Scan(&ctr); err != nil {
+		if err = rows.Scan(&ctr); err != nil {
 			return fmt.Errorf("error scanning row for containers using volume %s: %w", volume.Name(), err)
 		}
 		ctrs = append(ctrs, ctr)
 	}
-	if err := rows.Err(); err != nil {
+	if err = rows.Err(); err != nil {
 		return err
 	}
 	if len(ctrs) > 0 {
 		return fmt.Errorf("volume %s is in use by containers %s: %w", volume.Name(), strings.Join(ctrs, ","), define.ErrVolumeBeingUsed)
 	}
 
-	// TODO TODO TODO:
-	// Need to verify that at least 1 row was deleted from VolumeConfig.
-	// Otherwise return ErrNoSuchVolume
-
-	if _, err := tx.Exec("DELETE FROM VolumeConfig WHERE Name=?;", volume.Name()); err != nil {
+	result, err := tx.Exec("DELETE FROM VolumeConfig WHERE Name=?;", volume.Name())
+	if err != nil {
 		return fmt.Errorf("removing volume %s config from DB: %w", volume.Name(), err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("getting rows affected for volume %q remove: %w", volume.Name(), err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("no volume with name %q found in DB: %w", volume.Name(), define.ErrNoSuchVolume)
 	}
 
 	if _, err := tx.Exec("DELETE FROM VolumeState WHERE Name=?;", volume.Name()); err != nil {

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -2430,3 +2430,17 @@ func TestGetContainerConfigNonExistentIDFails(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestRemoveVolumeNotInDB(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, _ lock.Manager) {
+		v := &Volume{
+			config: &VolumeConfig{
+				Name: "Test",
+			},
+			valid: true,
+		}
+		err := state.RemoveVolume(v)
+		require.Error(t, err)
+		require.ErrorIs(t, err, define.ErrNoSuchVolume)
+	})
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

This PR checks the result from the volume config deletion to verify rows were actually affected. If no rows were deleted, return ErrNoSuchVolume.

Fixes #28376 

> [!IMPORTANT]
> ~~Tests have been omitted because this is a defensive code change. Testing this edge case would require removing the volume from the database between the volume lookup and the RemoveVolume call to simulate a race condition. The normal "volume not found" case is already covered by existing tests in test/e2e/volume_rm_test.go.~~

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
