### PR TITLE
Cleanup from deterministic network order PR #28275

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -300,8 +300,11 @@ type ContainerNetworkConfig struct {
 	// Added in podman 6.0, previously LegacyNetworks was used. Make
 	// sure to not change the json tags.
 	Networks []types.NamedPerNetworkOptions `json:"orderedNetworks,omitempty"`
-	// LegacyNetworks is deprecated and should not be used.
-	// It is identify to Networks aside from being unordered.
+	// LegacyNetworks is identical to Networks aside from being unordered.
+	// Added in podman 4.0, previously NetworksDeprecated was used. Make
+	// sure to not change the json tags.
+	//
+	// Deprecated: Use Networks instead. This field exists only for DB backwards compat.
 	LegacyNetworks map[string]types.PerNetworkOptions `json:"newNetworks,omitempty"`
 	// Network names to add container to. Empty to use default network.
 	// Please note that these can be altered at runtime. The actual list is

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -417,12 +417,7 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, _ bool) error {
 	}
 	opts.PortMappings = c.convertPortMappings()
 
-	for _, net := range networks {
-		if net.Name == netName {
-			opts.Networks = []types.NamedPerNetworkOptions{net}
-			break
-		}
-	}
+	opts.Networks = []types.NamedPerNetworkOptions{network}
 
 	if err := c.runtime.teardownNetworkBackend(c.state.NetNS, opts); err != nil {
 		addContainerNetworkToDB()


### PR DESCRIPTION
Follow up: https://github.com/containers/podman/pull/28275
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
