### PR TITLE
Podman 6: Automatic BoltDB to SQLite migration

### DIFF
--- a/cmd/podman/registry/registry.go
+++ b/cmd/podman/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -71,6 +72,16 @@ func NewContainerEngine(cmd *cobra.Command, _ []string) (entities.ContainerEngin
 		if cmd.Name() == "renumber" && cmd.Parent().Name() == "system" {
 			logrus.Debugf("Performing system renumber, runtime validation checks will be relaxed")
 			podmanOptions.IsRenumber = true
+		}
+		if cmd.Name() == "migrate" && cmd.Parent().Name() == "system" {
+			isMigrateDB, err := cmd.Flags().GetBool("migrate-db")
+			if err != nil {
+				return nil, errors.New("system migrate command missing flag migrate-db")
+			}
+			if isMigrateDB {
+				podmanOptions.IsMigrateDB = true
+				logrus.Debugf("Performing database migration, BoltDB checks will be relaxed")
+			}
 		}
 		engine, err := infra.NewContainerEngine(&podmanOptions)
 		if err != nil {

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -382,7 +382,10 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prep the engines
-	if _, err := registry.NewImageEngine(cmd, args); err != nil {
+	// Container engine MUST be first.
+	// We have special handling in there for passing flags to the runtime, that is ignored by the image engine.
+	// Which creates a container engine, because there isn't an entrypoint to Libimage that isn't Libpod.
+	if _, err := registry.NewContainerEngine(cmd, args); err != nil {
 		// Note: this is gross, but it is the hand we are dealt
 		if registry.IsRemote() && errors.As(err, &bindings.ConnectError{}) && cmd.Parent() == cmd.Root() {
 			switch cmd.Name() {
@@ -404,7 +407,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
-	if _, err := registry.NewContainerEngine(cmd, args); err != nil {
+	if _, err := registry.NewImageEngine(cmd, args); err != nil {
 		return err
 	}
 

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -44,6 +44,8 @@ func init() {
 	newRuntimeFlagName := "new-runtime"
 	flags.StringVar(&migrateOptions.NewRuntime, newRuntimeFlagName, "", "Specify a new runtime for all containers")
 	_ = migrateCommand.RegisterFlagCompletionFunc(newRuntimeFlagName, completion.AutocompleteNone)
+
+	flags.BoolVar(&migrateOptions.MigrateDB, "migrate-db", false, "Migrate database from BoltDB to SQLite")
 }
 
 func migrate(_ *cobra.Command, _ []string) error {

--- a/docs/source/markdown/podman-system-migrate.1.md
+++ b/docs/source/markdown/podman-system-migrate.1.md
@@ -26,6 +26,17 @@ newly configured mappings.
 
 ## OPTIONS
 
+#### **--migrate-db**
+
+Migrate from the legacy BoltDB database to SQLite.
+Support for BoltDB has been removed in Podman 6.0, and existing BoltDB databases must be migrated to continue using the containers, pods, and volumes stored in them.
+This is also done automatically on system reboot.
+Migrating as part of a reboot is generally preferred as there is less potential for race conditions caused by other Podman processes running at the same time.
+If a migration is necessary, Podman will fail to run with a descriptive error indicating this command must be used or the system must be rebooted.
+To ensure complete migration, all other Podman commands should be shut down before database migration.
+In particular, systemd-activated services like **podman system service** and Quadlets should be manually stopped prior to migration.
+The legacy database will not be removed, so no data loss should occur even on failure.
+
 #### **--new-runtime**=*runtime*
 
 Set a new OCI runtime for all containers.

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vbauerster/mpb/v8 v8.12.0
 	github.com/vishvananda/netlink v1.3.1
+	go.etcd.io/bbolt v1.4.3
 	go.podman.io/buildah v1.42.1-0.20260501153811-377cf64e213b
 	go.podman.io/common v0.67.2-0.20260504145149-b5d50461d3b9
 	go.podman.io/image/v5 v5.39.3-0.20260504145149-b5d50461d3b9
@@ -171,7 +172,6 @@ require (
 	github.com/vbatts/tar-split v0.12.3 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.etcd.io/bbolt v1.4.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1,0 +1,598 @@
+//go:build !remote && (linux || freebsd)
+
+package libpod
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
+	"go.podman.io/common/libnetwork/types"
+	"go.podman.io/podman/v6/libpod/define"
+	"go.podman.io/storage/pkg/fileutils"
+)
+
+// BoltState is a state implementation backed by a Bolt DB
+type BoltState struct {
+	valid   bool
+	dbPath  string
+	dbLock  sync.Mutex
+	runtime *Runtime
+}
+
+// A brief description of the format of the BoltDB state:
+// At the top level, the following buckets are created:
+// - idRegistryBkt: Maps ID to Name for containers and pods.
+//   Used to ensure container and pod IDs are globally unique.
+// - nameRegistryBkt: Maps Name to ID for containers and pods.
+//   Used to ensure container and pod names are globally unique.
+// - ctrBkt: Contains a sub-bucket for each container in the state.
+//   Each sub-bucket has config and state keys holding the container's JSON
+//   encoded configuration and state (respectively), an optional netNS key
+//   containing the path to the container's network namespace, a dependencies
+//   bucket containing the container's dependencies, and an optional pod key
+//   containing the ID of the pod the container is joined to.
+//   After updates to include exec sessions, may also include an exec bucket
+//   with the IDs of exec sessions currently in use by the container.
+// - allCtrsBkt: Map of ID to name containing only containers. Used for
+//   container lookup operations.
+// - podBkt: Contains a sub-bucket for each pod in the state.
+//   Each sub-bucket has config and state keys holding the pod's JSON encoded
+//   configuration and state, plus a containers sub bucket holding the IDs of
+//   containers in the pod.
+// - allPodsBkt: Map of ID to name containing only pods. Used for pod lookup
+//   operations.
+// - execBkt: Map of exec session ID to container ID - used for resolving
+//   exec session IDs to the containers that hold the exec session.
+// - networksBkt: Contains all network names as key with their options json
+//   encoded as value.
+// - aliasesBkt - Deprecated, use the networksBkt. Used to contain a bucket
+//   for each CNI network which contain a map of network alias (an extra name
+//   for containers in DNS) to the ID of the container holding the alias.
+//   Aliases must be unique per-network, and cannot conflict with names
+//   registered in nameRegistryBkt.
+// - runtimeConfigBkt: Contains configuration of the libpod instance that
+//   initially created the database. This must match for any further instances
+//   that access the database, to ensure that state mismatches with
+//   containers/storage do not occur.
+// - exitCodeBucket/exitCodeTimeStampBucket: (#14559) exit codes must be part
+//   of the database to resolve a previous race condition when one process waits
+//   for the exit file to be written and another process removes it along with
+//   the container during auto-removal.  The same race would happen trying to
+//   read the exit code from the containers bucket.  Hence, exit codes go into
+//   their own bucket.  To avoid the rather expensive JSON (un)marshalling, we
+//   have two buckets: one for the exit codes, the other for the timestamps.
+
+// NewBoltState creates a new bolt-backed state database
+func NewBoltState(path string, runtime *Runtime) (*BoltState, error) {
+	logrus.Info("Using boltdb as database backend")
+	state := new(BoltState)
+	state.dbPath = path
+	state.runtime = runtime
+
+	logrus.Debugf("Opening legacy boltdb state at %s", path)
+
+	if err := fileutils.Exists(path); err != nil && errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("boltdb database %s does not exist", path)
+	}
+
+	db, err := bolt.Open(path, 0o600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("opening database %s: %w", path, err)
+	}
+	// Everywhere else, we use s.deferredCloseDBCon(db) to ensure the state's DB
+	// mutex is also unlocked.
+	// However, here, the mutex has not been locked, since we just created
+	// the DB connection, and it hasn't left this function yet - no risk of
+	// concurrent access.
+	// As such, just a db.Close() is fine here.
+	defer db.Close()
+
+	state.valid = true
+
+	return state, nil
+}
+
+// Close closes the state and prevents further use
+func (s *BoltState) Close() error {
+	s.valid = false
+	return nil
+}
+
+// UpdateContainer updates a container's state from the database
+func (s *BoltState) UpdateContainer(ctr *Container) error {
+	if !s.valid {
+		return define.ErrDBClosed
+	}
+
+	if !ctr.valid {
+		return define.ErrCtrRemoved
+	}
+
+	ctrID := []byte(ctr.ID())
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	return db.View(func(tx *bolt.Tx) error {
+		ctrBucket, err := getCtrBucket(tx)
+		if err != nil {
+			return err
+		}
+		return s.getContainerStateDB(ctrID, ctr, ctrBucket)
+	})
+}
+
+// AllContainers retrieves all the containers in the database
+// If `loadState` is set, the containers' state will be loaded as well.
+func (s *BoltState) AllContainers(loadState bool) ([]*Container, error) {
+	if !s.valid {
+		return nil, define.ErrDBClosed
+	}
+
+	ctrs := []*Container{}
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return nil, err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	err = db.View(func(tx *bolt.Tx) error {
+		allCtrsBucket, err := getAllCtrsBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		ctrBucket, err := getCtrBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		return allCtrsBucket.ForEach(func(id, _ []byte) error {
+			// If performance becomes an issue, this check can be
+			// removed. But the error messages that come back will
+			// be much less helpful.
+			ctrExists := ctrBucket.Bucket(id)
+			if ctrExists == nil {
+				return fmt.Errorf("state is inconsistent - container ID %s in all containers, but container not found: %w", string(id), define.ErrInternal)
+			}
+
+			ctr := new(Container)
+			ctr.config = new(ContainerConfig)
+			ctr.state = new(ContainerState)
+
+			if err := s.getContainerFromDB(id, ctr, ctrBucket, loadState); err != nil {
+				logrus.Errorf("Error retrieving container from database: %v", err)
+			} else {
+				ctrs = append(ctrs, ctr)
+			}
+
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ctrs, nil
+}
+
+// GetNetworks returns the networks this container is a part of.
+func (s *BoltState) GetNetworks(ctr *Container) (map[string]types.PerNetworkOptions, error) {
+	if !s.valid {
+		return nil, define.ErrDBClosed
+	}
+
+	if !ctr.valid {
+		return nil, define.ErrCtrRemoved
+	}
+
+	// if the network mode is not bridge return no networks
+	if !ctr.config.NetMode.IsBridge() {
+		return nil, nil
+	}
+
+	ctrID := []byte(ctr.ID())
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return nil, err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	networks := make(map[string]types.PerNetworkOptions)
+
+	var convertDB bool
+
+	err = db.View(func(tx *bolt.Tx) error {
+		ctrBucket, err := getCtrBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		dbCtr := ctrBucket.Bucket(ctrID)
+		if dbCtr == nil {
+			ctr.valid = false
+			return fmt.Errorf("container %s does not exist in database: %w", ctr.ID(), define.ErrNoSuchCtr)
+		}
+
+		ctrNetworkBkt := dbCtr.Bucket(networksBkt)
+		if ctrNetworkBkt == nil {
+			// convert if needed
+			convertDB = true
+			return nil
+		}
+
+		return ctrNetworkBkt.ForEach(func(network, v []byte) error {
+			opts := types.PerNetworkOptions{}
+			if err := json.Unmarshal(v, &opts); err != nil {
+				// special case for backwards compat
+				// earlier version used the container id as value so we set a
+				// special error to indicate the we have to migrate the db
+				if !bytes.Equal(v, ctrID) {
+					return err
+				}
+				convertDB = true
+			}
+			networks[string(network)] = opts
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	if convertDB {
+		err = db.Update(func(tx *bolt.Tx) error {
+			ctrBucket, err := getCtrBucket(tx)
+			if err != nil {
+				return err
+			}
+
+			dbCtr := ctrBucket.Bucket(ctrID)
+			if dbCtr == nil {
+				ctr.valid = false
+				return fmt.Errorf("container %s does not exist in database: %w", ctr.ID(), define.ErrNoSuchCtr)
+			}
+
+			var networkList []string
+
+			ctrNetworkBkt := dbCtr.Bucket(networksBkt)
+			if ctrNetworkBkt == nil {
+				ctrNetworkBkt, err = dbCtr.CreateBucket(networksBkt)
+				if err != nil {
+					return fmt.Errorf("creating networks bucket for container %s: %w", ctr.ID(), err)
+				}
+				// the container has no networks in the db lookup config and write to the db
+				networkList = ctr.config.NetworksDeprecated
+				// if there are no networks we have to add the default
+				if len(networkList) == 0 {
+					networkList = []string{ctr.runtime.config.Network.DefaultNetwork}
+				}
+			} else {
+				err = ctrNetworkBkt.ForEach(func(network, _ []byte) error {
+					networkList = append(networkList, string(network))
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			// the container has no networks in the db lookup config and write to the db
+			for i, network := range networkList {
+				var intName string
+				if ctr.state.NetInterfaceDescriptions != nil {
+					eth, exists := ctr.state.NetInterfaceDescriptions[network]
+					if !exists {
+						return fmt.Errorf("no network interface name for container %s on network %s", ctr.config.ID, network)
+					}
+					intName = fmt.Sprintf("eth%d", eth)
+				} else {
+					intName = fmt.Sprintf("eth%d", i)
+				}
+				getAliases := func(network string) []string {
+					var aliases []string
+					ctrAliasesBkt := dbCtr.Bucket(aliasesBkt)
+					if ctrAliasesBkt == nil {
+						return nil
+					}
+					netAliasesBkt := ctrAliasesBkt.Bucket([]byte(network))
+					if netAliasesBkt == nil {
+						// No aliases for this specific network.
+						return nil
+					}
+
+					// let's ignore the error here there is nothing we can do
+					_ = netAliasesBkt.ForEach(func(alias, _ []byte) error {
+						aliases = append(aliases, string(alias))
+						return nil
+					})
+					// also add the short container id as alias
+					return aliases
+				}
+
+				netOpts := &types.PerNetworkOptions{
+					InterfaceName: intName,
+					// we have to add the short id as alias for docker compat
+					Aliases: append(getAliases(network), ctr.config.ID[:12]),
+				}
+
+				optsBytes, err := json.Marshal(netOpts)
+				if err != nil {
+					return err
+				}
+				// insert into network map because we need to return this
+				networks[network] = *netOpts
+
+				err = ctrNetworkBkt.Put([]byte(network), optsBytes)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return networks, nil
+}
+
+// GetContainerConfig returns a container config from the database by full ID
+func (s *BoltState) GetContainerConfig(id string) (*ContainerConfig, error) {
+	if len(id) == 0 {
+		return nil, define.ErrEmptyID
+	}
+
+	if !s.valid {
+		return nil, define.ErrDBClosed
+	}
+
+	config := new(ContainerConfig)
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return nil, err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	err = db.View(func(tx *bolt.Tx) error {
+		ctrBucket, err := getCtrBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		return s.getContainerConfigFromDB([]byte(id), config, ctrBucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// UpdateVolume updates the volume's state from the database.
+func (s *BoltState) UpdateVolume(volume *Volume) error {
+	if !s.valid {
+		return define.ErrDBClosed
+	}
+
+	if !volume.valid {
+		return define.ErrVolumeRemoved
+	}
+
+	newState := new(VolumeState)
+	volumeName := []byte(volume.Name())
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	err = db.View(func(tx *bolt.Tx) error {
+		volBucket, err := getVolBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		volToUpdate := volBucket.Bucket(volumeName)
+		if volToUpdate == nil {
+			volume.valid = false
+			return fmt.Errorf("no volume with name %s found in database: %w", volume.Name(), define.ErrNoSuchVolume)
+		}
+
+		stateBytes := volToUpdate.Get(stateKey)
+		if stateBytes == nil {
+			// Having no state is valid.
+			// Return nil, use the empty state.
+			return nil
+		}
+
+		if err := json.Unmarshal(stateBytes, newState); err != nil {
+			return fmt.Errorf("unmarshalling volume %s state: %w", volume.Name(), err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	volume.state = newState
+
+	return nil
+}
+
+// AllVolumes returns all volumes present in the state
+func (s *BoltState) AllVolumes() ([]*Volume, error) {
+	if !s.valid {
+		return nil, define.ErrDBClosed
+	}
+
+	volumes := []*Volume{}
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return nil, err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	err = db.View(func(tx *bolt.Tx) error {
+		allVolsBucket, err := getAllVolsBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		volBucket, err := getVolBucket(tx)
+		if err != nil {
+			return err
+		}
+		err = allVolsBucket.ForEach(func(id, _ []byte) error {
+			volExists := volBucket.Bucket(id)
+			// This check can be removed if performance becomes an
+			// issue, but much less helpful errors will be produced
+			if volExists == nil {
+				return fmt.Errorf("inconsistency in state - volume %s is in all volumes bucket but volume not found: %w", string(id), define.ErrInternal)
+			}
+
+			volume := new(Volume)
+			volume.config = new(VolumeConfig)
+			volume.state = new(VolumeState)
+
+			if err := s.getVolumeFromDB(id, volume, volBucket); err != nil {
+				if !errors.Is(err, define.ErrNSMismatch) {
+					logrus.Errorf("Retrieving volume %s from the database: %v", string(id), err)
+				}
+			} else {
+				volumes = append(volumes, volume)
+			}
+
+			return nil
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
+}
+
+// UpdatePod updates a pod's state from the database
+func (s *BoltState) UpdatePod(pod *Pod) error {
+	if !s.valid {
+		return define.ErrDBClosed
+	}
+
+	if !pod.valid {
+		return define.ErrPodRemoved
+	}
+
+	newState := new(podState)
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	podID := []byte(pod.ID())
+
+	err = db.View(func(tx *bolt.Tx) error {
+		podBkt, err := getPodBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		podDB := podBkt.Bucket(podID)
+		if podDB == nil {
+			pod.valid = false
+			return fmt.Errorf("no pod with ID %s found in database: %w", pod.ID(), define.ErrNoSuchPod)
+		}
+
+		// Get the pod state JSON
+		podStateBytes := podDB.Get(stateKey)
+		if podStateBytes == nil {
+			return fmt.Errorf("pod %s is missing state key in DB: %w", pod.ID(), define.ErrInternal)
+		}
+
+		if err := json.Unmarshal(podStateBytes, newState); err != nil {
+			return fmt.Errorf("unmarshalling pod %s state JSON: %w", pod.ID(), err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	pod.state = newState
+
+	return nil
+}
+
+// AllPods returns all pods present in the state
+func (s *BoltState) AllPods() ([]*Pod, error) {
+	if !s.valid {
+		return nil, define.ErrDBClosed
+	}
+
+	pods := []*Pod{}
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return nil, err
+	}
+	defer s.deferredCloseDBCon(db)
+
+	err = db.View(func(tx *bolt.Tx) error {
+		allPodsBucket, err := getAllPodsBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		podBucket, err := getPodBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		err = allPodsBucket.ForEach(func(id, _ []byte) error {
+			podExists := podBucket.Bucket(id)
+			// This check can be removed if performance becomes an
+			// issue, but much less helpful errors will be produced
+			if podExists == nil {
+				return fmt.Errorf("inconsistency in state - pod %s is in all pods bucket but pod not found: %w", string(id), define.ErrInternal)
+			}
+
+			pod := new(Pod)
+			pod.config = new(PodConfig)
+			pod.state = new(podState)
+
+			if err := s.getPodFromDB(id, pod, podBucket); err != nil {
+				if !errors.Is(err, define.ErrNSMismatch) {
+					logrus.Errorf("Retrieving pod %s from the database: %v", string(id), err)
+				}
+			} else {
+				pods = append(pods, pod)
+			}
+
+			return nil
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return pods, nil
+}

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -1,0 +1,395 @@
+//go:build !remote && (linux || freebsd)
+
+package libpod
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
+	"go.podman.io/common/libnetwork/types"
+	"go.podman.io/podman/v6/libpod/define"
+)
+
+const (
+	ctrName        = "ctr"
+	allCtrsName    = "all-ctrs"
+	podName        = "pod"
+	allPodsName    = "allPods"
+	volName        = "vol"
+	allVolsName    = "allVolumes"
+	execName       = "exec"
+	aliasesName    = "aliases"
+	volumeCtrsName = "volume-ctrs"
+
+	configName   = "config"
+	stateName    = "state"
+	netNSName    = "netns"
+	networksName = "networks"
+)
+
+var (
+	ctrBkt      = []byte(ctrName)
+	allCtrsBkt  = []byte(allCtrsName)
+	podBkt      = []byte(podName)
+	allPodsBkt  = []byte(allPodsName)
+	volBkt      = []byte(volName)
+	allVolsBkt  = []byte(allVolsName)
+	aliasesBkt  = []byte(aliasesName)
+	networksBkt = []byte(networksName)
+
+	configKey = []byte(configName)
+	stateKey  = []byte(stateName)
+	netNSKey  = []byte(netNSName)
+)
+
+// Open a connection to the database.
+// Must be paired with a `defer closeDBCon()` on the returned database, to
+// ensure the state is properly unlocked
+func (s *BoltState) getDBCon() (*bolt.DB, error) {
+	// We need an in-memory lock to avoid issues around POSIX file advisory
+	// locks as described in the link below:
+	// https://www.sqlite.org/src/artifact/c230a7a24?ln=994-1081
+	s.dbLock.Lock()
+
+	db, err := bolt.Open(s.dbPath, 0o600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("opening database %s: %w", s.dbPath, err)
+	}
+
+	return db, nil
+}
+
+// deferredCloseDBCon closes the bolt db but instead of returning an
+// error it logs the error. it is meant to be used within the confines
+// of a defer statement only
+func (s *BoltState) deferredCloseDBCon(db *bolt.DB) {
+	if err := s.closeDBCon(db); err != nil {
+		logrus.Errorf("Failed to close libpod db: %q", err)
+	}
+}
+
+// Close a connection to the database.
+// MUST be used in place of `db.Close()` to ensure proper unlocking of the
+// state.
+func (s *BoltState) closeDBCon(db *bolt.DB) error {
+	err := db.Close()
+
+	s.dbLock.Unlock()
+
+	return err
+}
+
+func getCtrBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(ctrBkt)
+	if bkt == nil {
+		return nil, fmt.Errorf("containers bucket not found in DB: %w", define.ErrDBBadConfig)
+	}
+	return bkt, nil
+}
+
+func getAllCtrsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(allCtrsBkt)
+	if bkt == nil {
+		return nil, fmt.Errorf("all containers bucket not found in DB: %w", define.ErrDBBadConfig)
+	}
+	return bkt, nil
+}
+
+func getPodBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(podBkt)
+	if bkt == nil {
+		return nil, fmt.Errorf("pods bucket not found in DB: %w", define.ErrDBBadConfig)
+	}
+	return bkt, nil
+}
+
+func getAllPodsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(allPodsBkt)
+	if bkt == nil {
+		return nil, fmt.Errorf("all pods bucket not found in DB: %w", define.ErrDBBadConfig)
+	}
+	return bkt, nil
+}
+
+func getVolBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(volBkt)
+	if bkt == nil {
+		return nil, fmt.Errorf("volumes bucket not found in DB: %w", define.ErrDBBadConfig)
+	}
+	return bkt, nil
+}
+
+func getAllVolsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(allVolsBkt)
+	if bkt == nil {
+		return nil, fmt.Errorf("all volumes bucket not found in DB: %w", define.ErrDBBadConfig)
+	}
+	return bkt, nil
+}
+
+func (s *BoltState) getContainerConfigFromDB(id []byte, config *ContainerConfig, ctrsBkt *bolt.Bucket) error {
+	ctrBkt := ctrsBkt.Bucket(id)
+	if ctrBkt == nil {
+		return fmt.Errorf("container %s not found in DB: %w", string(id), define.ErrNoSuchCtr)
+	}
+
+	configBytes := ctrBkt.Get(configKey)
+	if configBytes == nil {
+		return fmt.Errorf("container %s missing config key in DB: %w", string(id), define.ErrInternal)
+	}
+
+	if err := json.Unmarshal(configBytes, config); err != nil {
+		return fmt.Errorf("unmarshalling container %s config: %w", string(id), err)
+	}
+
+	// convert ports to the new format if needed
+	if len(config.ContainerNetworkConfig.OldPortMappings) > 0 && len(config.ContainerNetworkConfig.PortMappings) == 0 {
+		config.ContainerNetworkConfig.PortMappings = ocicniPortsToNetTypesPorts(config.ContainerNetworkConfig.OldPortMappings)
+		// keep the OldPortMappings in case an user has to downgrade podman
+
+		// indicate that the config was modified and should be written back to the db when possible
+		config.rewrite = true
+	}
+
+	return nil
+}
+
+func (s *BoltState) getContainerStateDB(id []byte, ctr *Container, ctrsBkt *bolt.Bucket) error {
+	newState := new(ContainerState)
+	ctrToUpdate := ctrsBkt.Bucket(id)
+	if ctrToUpdate == nil {
+		ctr.valid = false
+		return fmt.Errorf("container %s does not exist in database: %w", ctr.ID(), define.ErrNoSuchCtr)
+	}
+
+	newStateBytes := ctrToUpdate.Get(stateKey)
+	if newStateBytes == nil {
+		return fmt.Errorf("container %s does not have a state key in DB: %w", ctr.ID(), define.ErrInternal)
+	}
+
+	if err := json.Unmarshal(newStateBytes, newState); err != nil {
+		return fmt.Errorf("unmarshalling container %s state: %w", ctr.ID(), err)
+	}
+
+	// backwards compat, previously we used an extra bucket for the netns so try to get it from there
+	netNSBytes := ctrToUpdate.Get(netNSKey)
+	if netNSBytes != nil && newState.NetNS == "" {
+		newState.NetNS = string(netNSBytes)
+	}
+
+	// New state compiled successfully, swap it into the current state
+	ctr.state = newState
+	return nil
+}
+
+func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.Bucket, loadState bool) error {
+	if err := s.getContainerConfigFromDB(id, ctr.config, ctrsBkt); err != nil {
+		return err
+	}
+
+	if loadState {
+		if err := s.getContainerStateDB(id, ctr, ctrsBkt); err != nil {
+			return err
+		}
+	}
+
+	// Get the lock
+	lock, err := s.runtime.lockManager.RetrieveLock(ctr.config.LockID)
+	if err != nil {
+		return fmt.Errorf("retrieving lock for container %s: %w", string(id), err)
+	}
+	ctr.lock = lock
+
+	if ctr.config.OCIRuntime == "" {
+		ctr.ociRuntime = s.runtime.defaultOCIRuntime
+	} else {
+		// Handle legacy containers which might use a literal path for
+		// their OCI runtime name.
+		runtimeName := ctr.config.OCIRuntime
+		ociRuntime, ok := s.runtime.ociRuntimes[runtimeName]
+		if !ok {
+			runtimeSet := false
+
+			// If the path starts with a / and exists, make a new
+			// OCI runtime for it using the full path.
+			if strings.HasPrefix(runtimeName, "/") {
+				if stat, err := os.Stat(runtimeName); err == nil && !stat.IsDir() {
+					newOCIRuntime, err := newConmonOCIRuntime(runtimeName, []string{runtimeName}, s.runtime.conmonPath, s.runtime.runtimeFlags, s.runtime.config)
+					if err == nil {
+						// The runtime lock should
+						// protect against concurrent
+						// modification of the map.
+						ociRuntime = newOCIRuntime
+						s.runtime.ociRuntimes[runtimeName] = ociRuntime
+						runtimeSet = true
+					}
+				}
+			}
+
+			if !runtimeSet {
+				// Use a MissingRuntime implementation
+				ociRuntime = getMissingRuntime(runtimeName, s.runtime)
+			}
+		}
+		ctr.ociRuntime = ociRuntime
+	}
+
+	ctr.runtime = s.runtime
+	ctr.valid = true
+
+	return nil
+}
+
+func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error {
+	podDB := podBkt.Bucket(id)
+	if podDB == nil {
+		return fmt.Errorf("pod with ID %s not found: %w", string(id), define.ErrNoSuchPod)
+	}
+
+	podConfigBytes := podDB.Get(configKey)
+	if podConfigBytes == nil {
+		return fmt.Errorf("pod %s is missing configuration key in DB: %w", string(id), define.ErrInternal)
+	}
+
+	if err := json.Unmarshal(podConfigBytes, pod.config); err != nil {
+		return fmt.Errorf("unmarshalling pod %s config from DB: %w", string(id), err)
+	}
+
+	// Get the lock
+	lock, err := s.runtime.lockManager.RetrieveLock(pod.config.LockID)
+	if err != nil {
+		return fmt.Errorf("retrieving lock for pod %s: %w", string(id), err)
+	}
+	pod.lock = lock
+
+	pod.runtime = s.runtime
+	pod.valid = true
+
+	return nil
+}
+
+func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bucket) error {
+	volDB := volBkt.Bucket(name)
+	if volDB == nil {
+		return fmt.Errorf("volume with name %s not found: %w", string(name), define.ErrNoSuchVolume)
+	}
+
+	volConfigBytes := volDB.Get(configKey)
+	if volConfigBytes == nil {
+		return fmt.Errorf("volume %s is missing configuration key in DB: %w", string(name), define.ErrInternal)
+	}
+
+	if err := json.Unmarshal(volConfigBytes, volume.config); err != nil {
+		return fmt.Errorf("unmarshalling volume %s config from DB: %w", string(name), err)
+	}
+
+	// Volume state is allowed to be nil for legacy compatibility
+	volStateBytes := volDB.Get(stateKey)
+	if volStateBytes != nil {
+		if err := json.Unmarshal(volStateBytes, volume.state); err != nil {
+			return fmt.Errorf("unmarshalling volume %s state from DB: %w", string(name), err)
+		}
+	}
+
+	// Need this for UsesVolumeDriver() so set it now.
+	volume.runtime = s.runtime
+
+	// Retrieve volume driver
+	if volume.UsesVolumeDriver() {
+		plugin, err := s.runtime.getVolumePlugin(volume.config)
+		if err != nil {
+			// We want to fail gracefully here, to ensure that we
+			// can still remove volumes even if their plugin is
+			// missing. Otherwise, we end up with volumes that
+			// cannot even be retrieved from the database and will
+			// cause things like `volume ls` to fail.
+			logrus.Errorf("Volume %s uses volume plugin %s, but it cannot be accessed - some functionality may not be available: %v", volume.Name(), volume.config.Driver, err)
+		} else {
+			volume.plugin = plugin
+		}
+	}
+
+	// Get the lock
+	lock, err := s.runtime.lockManager.RetrieveLock(volume.config.LockID)
+	if err != nil {
+		return fmt.Errorf("retrieving lock for volume %q: %w", string(name), err)
+	}
+	volume.lock = lock
+
+	volume.valid = true
+
+	return nil
+}
+
+// ocicniPortsToNetTypesPorts convert the old port format to the new one
+// while deduplicating ports into ranges
+//
+//nolint:staticcheck
+func ocicniPortsToNetTypesPorts(ports []types.OCICNIPortMapping) []types.PortMapping {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	newPorts := make([]types.PortMapping, 0, len(ports))
+
+	// first sort the ports
+	sort.Slice(ports, func(i, j int) bool {
+		return compareOCICNIPorts(ports[i], ports[j])
+	})
+
+	// we already check if the slice is empty so we can use the first element
+	currentPort := types.PortMapping{
+		HostIP:        ports[0].HostIP,
+		HostPort:      uint16(ports[0].HostPort),
+		ContainerPort: uint16(ports[0].ContainerPort),
+		Protocol:      ports[0].Protocol,
+		Range:         1,
+	}
+
+	for i := 1; i < len(ports); i++ {
+		if ports[i].HostIP == currentPort.HostIP &&
+			ports[i].Protocol == currentPort.Protocol &&
+			ports[i].HostPort-int32(currentPort.Range) == int32(currentPort.HostPort) &&
+			ports[i].ContainerPort-int32(currentPort.Range) == int32(currentPort.ContainerPort) {
+			currentPort.Range++
+		} else {
+			newPorts = append(newPorts, currentPort)
+			currentPort = types.PortMapping{
+				HostIP:        ports[i].HostIP,
+				HostPort:      uint16(ports[i].HostPort),
+				ContainerPort: uint16(ports[i].ContainerPort),
+				Protocol:      ports[i].Protocol,
+				Range:         1,
+			}
+		}
+	}
+	newPorts = append(newPorts, currentPort)
+	return newPorts
+}
+
+// compareOCICNIPorts will sort the ocicni ports by
+// 1) host ip
+// 2) protocol
+// 3) hostPort
+// 4) container port
+//
+//nolint:staticcheck
+func compareOCICNIPorts(i, j types.OCICNIPortMapping) bool {
+	if i.HostIP != j.HostIP {
+		return i.HostIP < j.HostIP
+	}
+
+	if i.Protocol != j.Protocol {
+		return i.Protocol < j.Protocol
+	}
+
+	if i.HostPort != j.HostPort {
+		return i.HostPort < j.HostPort
+	}
+
+	return i.ContainerPort < j.ContainerPort
+}

--- a/libpod/container_graph.go
+++ b/libpod/container_graph.go
@@ -289,6 +289,67 @@ func startNode(ctx context.Context, node *containerNode, setError bool, ctrError
 	}
 }
 
+// Migrates all nodes from BoltDB to SQLite
+func migrateNodeDatabase(node *containerNode, setError bool, ctrErrors map[string]error, ctrsVisited map[string]bool, sqliteState State) {
+	// First, check if we have already visited the node
+	if ctrsVisited[node.id] {
+		return
+	}
+
+	// If setError is true, a dependency of us failed
+	// Mark us as failed and recurse
+	if setError {
+		// Mark us as visited, and set an error
+		ctrsVisited[node.id] = true
+		ctrErrors[node.id] = fmt.Errorf("a dependency of container %s failed to migrate: %w", node.id, define.ErrCtrStateInvalid)
+
+		// Hit anyone who depends on us, and set errors on them too
+		for _, successor := range node.dependedOn {
+			migrateNodeDatabase(successor, true, ctrErrors, ctrsVisited, sqliteState)
+		}
+
+		return
+	}
+
+	// Have all our dependencies started?
+	// If not, don't visit the node yet
+	depsVisited := true
+	for _, dep := range node.dependsOn {
+		depsVisited = depsVisited && ctrsVisited[dep.id]
+	}
+	if !depsVisited {
+		// Don't visit us yet, all dependencies are not up
+		// We'll hit the dependencies eventually, and when we do it will
+		// recurse here
+		return
+	}
+
+	// Going to try to migrate the container, mark us as visited
+	ctrsVisited[node.id] = true
+
+	ctrErrored := false
+
+	// Add and save the container
+	if err := sqliteState.AddContainer(node.container); err != nil {
+		if errors.Is(err, define.ErrCtrExists) {
+			logrus.Warnf("Container with name %s already exists in the SQLite database; refusing to migrate from BoltDB", node.container.Name())
+		} else {
+			ctrErrored = true
+			ctrErrors[node.id] = err
+		}
+	} else {
+		if err := sqliteState.SaveContainer(node.container); err != nil {
+			ctrErrored = true
+			ctrErrors[node.id] = err
+		}
+	}
+
+	// Recurse to anyone who depends on us and start them
+	for _, successor := range node.dependedOn {
+		migrateNodeDatabase(successor, ctrErrored, ctrErrors, ctrsVisited, sqliteState)
+	}
+}
+
 // Contains all details required for traversing the container graph.
 type nodeTraversal struct {
 	// Optional. but *MUST* be locked.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -350,26 +350,6 @@ func WithNetworkConfigDir(dir string) RuntimeOption {
 	}
 }
 
-// WithNamespace sets the namespace for libpod.
-// Namespaces are used to create scopes to separate containers and pods
-// in the state.
-// When namespace is set, libpod will only view containers and pods in
-// the same namespace. All containers and pods created will default to
-// the namespace set here.
-// A namespace of "", the empty string, is equivalent to no namespace,
-// and all containers and pods will be visible.
-func WithNamespace(ns string) RuntimeOption {
-	return func(rt *Runtime) error {
-		if rt.valid {
-			return define.ErrRuntimeFinalized
-		}
-
-		rt.config.Engine.Namespace = ns
-
-		return nil
-	}
-}
-
 // WithVolumePath sets the path under which all named volumes
 // should be created.
 // The path changes based on whether the user is running as root or not.
@@ -446,6 +426,9 @@ func WithEnableSDNotify() RuntimeOption {
 // WithSyslog sets a runtime option so we know that we have to log to the syslog as well
 func WithSyslog() RuntimeOption {
 	return func(rt *Runtime) error {
+		if rt.valid {
+			return define.ErrRuntimeFinalized
+		}
 		rt.syslog = true
 		return nil
 	}
@@ -458,6 +441,20 @@ func WithRuntimeFlags(runtimeFlags []string) RuntimeOption {
 			return define.ErrRuntimeFinalized
 		}
 		rt.runtimeFlags = runtimeFlags
+		return nil
+	}
+}
+
+// WithNoBoltError suppresses errors when a Bolt database exists, which would
+// otherwise prevent creation of a runtime. Useful when migrating the BoltDB
+// database to SQLite, which is otherwise impossible as we'll error before
+// getting to the migration code.
+func WithNoBoltError() RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return define.ErrRuntimeFinalized
+		}
+		rt.noBoltError = true
 		return nil
 	}
 }

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -107,6 +108,10 @@ type Runtime struct {
 	// errors related to lock initialization so a renumber can be performed
 	// if something has gone wrong.
 	doRenumber bool
+	// Do not error on a BoltDB database existing. Useful for commanding
+	// a database migration, as we can't actually get to the migration code
+	// with an existing Bolt database otherwise.
+	noBoltError bool
 
 	// valid indicates whether the runtime is ready to use.
 	// valid is set to true when a runtime is returned from GetRuntime(),
@@ -278,6 +283,8 @@ func getLockManager(runtime *Runtime) (lock.Manager, error) {
 	return manager, nil
 }
 
+var errBoltExists = errors.New("legacy database exists")
+
 func getDBState(runtime *Runtime) (State, error) {
 	// TODO - if we further break out the state implementation into
 	// libpod/state, the config could take care of the code below.  It
@@ -290,8 +297,24 @@ func getDBState(runtime *Runtime) (State, error) {
 
 	switch backend {
 	case config.DBBackendBoltDB:
-		return nil, fmt.Errorf("the BoltDB database backend was removed in Podman 6.0")
+		return nil, fmt.Errorf("the BoltDB database backend was removed in Podman 6.0 - please comment out the `database_backend` line in containers.conf and migrate to SQLite by rebooting the system or using the `podman system migrate --migrate-db` command")
 	case config.DBBackendDefault:
+		if !runtime.noBoltError {
+			boltDBPath := getBoltDBPath(runtime)
+			if err := fileutils.Exists(boltDBPath); err == nil {
+				// We need to return a valid state.
+				// The error below can be discarded if we are performing a state refresh - in which case we migrate the BoltDB database.
+				// Problem: We cannot know if a refresh is happening until almost the end of runtime init.
+				// And we can't really change that - it has to be after the database is set up.
+				// (We need paths from the state to know where to check for the alive file).
+				// Solution is to return a valid state, and defer handling the errBoltExists error until we are sure we are/are not refreshing.
+				sqliteState, err := NewSqliteState(runtime)
+				if err != nil {
+					return nil, err
+				}
+				return sqliteState, fmt.Errorf("a BoltDB database exists but is no longer being used. BoltDB support was removed in the Podman 6.0 release. The legacy database can be migrated to SQLite by rebooting and running Podman again or using the `podman system migrate --migrate-db` command. IMPORTANT: Only use the `system migrate` command when you can ensure there are no other Podman processes running. If you are not absolutely sure of this, it is strongly recommended that you reboot. If you do not care about the contents of the legacy database, you can rename or remove the legacy database at %q to suppress this error: %w", boltDBPath, errBoltExists)
+			}
+		}
 		fallthrough
 	case config.DBBackendSQLite:
 		return NewSqliteState(runtime)
@@ -341,10 +364,44 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		return fmt.Errorf("creating runtime volume path directory: %w", err)
 	}
 
+	// Check if a SQLite DB exists prior to getting a DB.
+	// If it does not, and we have a Bolt database, we may need to remove the SQLite DB
+	// that is created below if we are not performing a database migration.
+	// This ensures that reverting to Podman 5.8.2 will not default to SQLite and break things.
+	sqliteDBExists := checkSQLiteDBExists(runtime)
+
 	// Set up the state.
+	boltExists := false
+	var boltError error
 	runtime.state, err = getDBState(runtime)
 	if err != nil {
-		return err
+		if errors.Is(err, errBoltExists) {
+			boltExists = true
+			boltError = err
+		} else {
+			return err
+		}
+	}
+
+	// We did not have a SQLite DB before Podman ran.
+	// Remove the one that was created (if one was created) so we don't break reverting to 5.8
+	removeSQLite := false
+	if !sqliteDBExists && boltExists {
+		removeSQLite = true
+		defer func() {
+			if removeSQLite {
+				// Do a final check that the BoltDB state still exists.
+				// If it doesn't, someone else probably performed a migration to SQLite before we got here.
+				// In that case, it'd be bad to remove the now in use database.
+				if err := fileutils.Exists(getBoltDBPath(runtime)); err != nil {
+					return
+				}
+				sqlitePath := sqliteStatePath(runtime)
+				if err := os.Remove(sqlitePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+					logrus.Errorf("Error removing SQLite DB %s created during Podman init: %v", sqlitePath, err)
+				}
+			}
+		}()
 	}
 
 	// Grab config from the database so we can reset some defaults
@@ -572,8 +629,18 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		// As such, it's not really a performance concern
 		if errors.Is(err, os.ErrNotExist) {
 			doRefresh = true
+			removeSQLite = false
 		} else {
 			return fmt.Errorf("reading runtime status file %s: %w", runtimeAliveFile, err)
+		}
+	}
+
+	if !doRefresh && boltExists {
+		// If the BoltDB database still exists, throw an error.
+		// If it doesn't: assume that migration happened in the background.
+		// In that case, safe to proceed.
+		if err := fileutils.Exists(getBoltDBPath(runtime)); err == nil || !errors.Is(err, fs.ErrNotExist) {
+			return boltError
 		}
 	}
 
@@ -791,6 +858,14 @@ func (r *Runtime) Shutdown(force bool) error {
 // Does not check validity as the runtime is not valid until after this has run
 func (r *Runtime) refresh(ctx context.Context, alivePath string) error {
 	logrus.Debugf("Podman detected system restart - performing state refresh")
+
+	// Only error that can be returned is no BoltDB present.
+	// In that case, no need to do anything.
+	if err := r.checkCanMigrate(); err == nil {
+		if err := r.migrateDB(); err != nil {
+			logrus.Errorf("Automatic migration from BoltDB to SQLite failed: %v", err)
+		}
+	}
 
 	// Clear state of database if not running in container
 	if !graphRootMounted() {

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -3,19 +3,22 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/podman/v6/libpod/define"
 	"go.podman.io/podman/v6/pkg/namespaces"
+	"go.podman.io/storage/pkg/fileutils"
 )
 
 // Migrate stops the rootless pause process and performs any necessary database
 // migrations that are required. It can also migrate all containers to a new OCI
 // runtime, if requested.
-func (r *Runtime) Migrate(newRuntime string) error {
+func (r *Runtime) Migrate(newRuntime string, migrateDB bool) error {
 	// Acquire the alive lock and hold it.
 	// Ensures that we don't let other Podman commands run while we are
 	// rewriting things in the DB.
@@ -97,5 +100,138 @@ func (r *Runtime) Migrate(newRuntime string) error {
 		}
 	}
 
+	if migrateDB {
+		if err := r.checkCanMigrate(); err != nil {
+			switch {
+			case errors.Is(err, errCannotMigrateNoBolt):
+				fmt.Printf("No migration is necessary: %v\n", err)
+				return r.stopPauseProcess()
+			default:
+				return err
+			}
+		}
+
+		if err := r.migrateDB(); err != nil {
+			return fmt.Errorf("migrating database from BoltDB to SQLite: %w", err)
+		}
+	}
+
 	return r.stopPauseProcess()
+}
+
+var errCannotMigrateNoBolt = errors.New("no BoltDB database to migrate")
+
+func (r *Runtime) checkCanMigrate() error {
+	boltPath := getBoltDBPath(r)
+	if err := fileutils.Exists(boltPath); err != nil {
+		return errCannotMigrateNoBolt
+	}
+
+	return nil
+}
+
+func (r *Runtime) migrateDB() error {
+	boltPath := getBoltDBPath(r)
+	// Get us a Bolt database
+	oldState, err := NewBoltState(boltPath, r)
+	if err != nil {
+		return fmt.Errorf("opening legacy Bolt database at %s: %w", boltPath, err)
+	}
+
+	// Migrate volumes, then pods, then containers.
+	// Containers must be last as the pods they are part of and volumes they use must already exist.
+	allVolumes, err := oldState.AllVolumes()
+	if err != nil {
+		return fmt.Errorf("retrieving volumes from boltdb: %w", err)
+	}
+	for _, vol := range allVolumes {
+		if err := r.state.AddVolume(vol); err != nil {
+			if errors.Is(err, define.ErrVolumeExists) {
+				logrus.Warnf("Volume with name %s already exists in the SQLite database; refusing to migrate from BoltDB", vol.Name())
+				continue
+			}
+			return err
+		}
+		if err := oldState.UpdateVolume(vol); err != nil {
+			return err
+		}
+		if err := r.state.SaveVolume(vol); err != nil {
+			return err
+		}
+	}
+
+	allPods, err := oldState.AllPods()
+	if err != nil {
+		return fmt.Errorf("retrieving pods from boltdb: %w", err)
+	}
+	for _, pod := range allPods {
+		if err := r.state.AddPod(pod); err != nil {
+			if errors.Is(err, define.ErrPodExists) {
+				logrus.Warnf("Pod with name %s already exists in the SQLite database; refusing to migrate from BoltDB", pod.Name())
+				continue
+			}
+			return err
+		}
+		if err := oldState.UpdatePod(pod); err != nil {
+			return err
+		}
+		if err := r.state.SavePod(pod); err != nil {
+			return err
+		}
+	}
+
+	// Containers must be done as a graph due to dependencies.
+	// The state will error if we add a container before its dependencies.
+	allCtrs, err := oldState.AllContainers(true)
+	if err != nil {
+		return fmt.Errorf("retrieving containers from boltdb: %w", err)
+	}
+
+	// BoltDB doesn't actually populate container networks on initial pull
+	// from the database, that needs to be done separately.
+	for _, ctr := range allCtrs {
+		ctrNetworks, err := oldState.GetNetworks(ctr)
+		if err != nil {
+			return err
+		}
+		ctr.config.Networks = convertLegacyNetworks(ctrNetworks)
+	}
+
+	graph, err := BuildContainerGraph(allCtrs)
+	if err != nil {
+		return err
+	}
+
+	ctrErrors := make(map[string]error)
+	ctrsVisited := make(map[string]bool)
+
+	for _, node := range graph.noDepNodes {
+		migrateNodeDatabase(node, false, ctrErrors, ctrsVisited, r.state)
+	}
+	if len(ctrErrors) > 0 {
+		newErrors := make([]error, 0, len(ctrErrors))
+		for id, err := range ctrErrors {
+			newErrors = append(newErrors, fmt.Errorf("migrating container %s: %w", id, err))
+		}
+		return errors.Join(newErrors...)
+	}
+
+	oldState.Close()
+
+	// Move the Bolt database so it is not reused, but preserve so data is not lost.
+	newBoltDBPath := fmt.Sprintf("%s-old", boltPath)
+	if err := os.Rename(boltPath, newBoltDBPath); err != nil {
+		return fmt.Errorf("renaming old database %s to %s: %w", boltPath, newBoltDBPath, err)
+	}
+	fmt.Printf("Old database has been renamed to %s and will no longer be used\n", newBoltDBPath)
+
+	return nil
+}
+
+func getBoltDBPath(runtime *Runtime) string {
+	baseDir := runtime.config.Engine.StaticDir
+	if runtime.storageConfig.TransientStore {
+		baseDir = runtime.config.Engine.TmpDir
+	}
+	return filepath.Join(baseDir, "bolt_state.db")
 }

--- a/libpod/sqlite_state.go
+++ b/libpod/sqlite_state.go
@@ -32,6 +32,8 @@ type SQLiteState struct {
 }
 
 const (
+	// Name of the actual database file
+	sqliteDbFilename = "db.sql"
 	// Deal with timezone automatically.
 	sqliteOptionLocation = "_loc=auto"
 	// Force an fsync after each transaction (https://www.sqlite.org/pragma.html#pragma_synchronous).
@@ -44,7 +46,7 @@ const (
 	sqliteOptionCaseSensitiveLike = "&_cslike=TRUE"
 
 	// Assembled sqlite options used when opening the database.
-	sqliteOptions = "db.sql?" +
+	sqliteOptions = "?" +
 		sqliteOptionLocation +
 		sqliteOptionSynchronous +
 		sqliteOptionForeignKeys +
@@ -57,17 +59,12 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	logrus.Info("Using sqlite as database backend")
 	state := new(SQLiteState)
 
-	basePath := runtime.storageConfig.GraphRoot
-	if runtime.storageConfig.TransientStore {
-		basePath = runtime.storageConfig.RunRoot
-	} else if !runtime.storageSet.StaticDirSet {
-		basePath = runtime.config.Engine.StaticDir
-	}
+	dbPath := sqliteStatePath(runtime)
 
 	// c/storage is set up *after* the DB - so even though we use the c/s
 	// root (or, for transient, runroot) dir, we need to make the dir
 	// ourselves.
-	if err := os.MkdirAll(basePath, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating root directory: %w", err)
 	}
 
@@ -82,7 +79,7 @@ func NewSqliteState(runtime *Runtime) (_ State, defErr error) {
 	}
 	sqliteOptionBusyTimeout := "&_busy_timeout=" + busyTimeout
 
-	conn, err := sql.Open("sqlite3", filepath.Join(basePath, sqliteOptions+sqliteOptionBusyTimeout))
+	conn, err := sql.Open("sqlite3", dbPath+sqliteOptions+sqliteOptionBusyTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("initializing sqlite database: %w", err)
 	}

--- a/libpod/sqlite_state_internal.go
+++ b/libpod/sqlite_state_internal.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -14,10 +15,29 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/podman/v6/libpod/define"
+	"go.podman.io/storage/pkg/fileutils"
 
 	// SQLite backend for database/sql
 	_ "github.com/mattn/go-sqlite3"
 )
+
+// sqliteStatePath returns the path to the sqlite file.
+func sqliteStatePath(runtime *Runtime) string {
+	basePath := runtime.storageConfig.GraphRoot
+	if runtime.storageConfig.TransientStore {
+		basePath = runtime.storageConfig.RunRoot
+	} else if !runtime.storageSet.StaticDirSet {
+		basePath = runtime.config.Engine.StaticDir
+	}
+	return filepath.Join(basePath, sqliteDbFilename)
+}
+
+func checkSQLiteDBExists(runtime *Runtime) bool {
+	if err := fileutils.Exists(sqliteStatePath(runtime)); err != nil {
+		return false
+	}
+	return true
+}
 
 func initSQLiteDB(conn *sql.DB) (defErr error) {
 	// Start with a transaction to avoid "database locked" errors.

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -43,6 +43,7 @@ type PodmanConfig struct {
 	TLSDetailsFile           string   // Path to a containers-tls-details.yaml(5) file
 	IsRenumber               bool     // Is this a system renumber command? If so, a number of checks will be relaxed
 	IsReset                  bool     // Is this a system reset command? If so, a number of checks will be skipped/omitted
+	IsMigrateDB              bool     // Is this a system migrate --migrate-db command? If so, certain BoltDB related errors will be suppressed
 	MaxWorks                 int      // maximum number of parallel threads
 	MemoryProfile            string   // Hidden: Should memory profile be taken
 	RegistriesConf           string   // allows for specifying a custom registries.conf

--- a/pkg/domain/entities/types/system.go
+++ b/pkg/domain/entities/types/system.go
@@ -63,6 +63,7 @@ type SystemPruneReport struct {
 // cli to migrate runtimes of containers
 type SystemMigrateOptions struct {
 	NewRuntime string
+	MigrateDB  bool
 }
 
 // SystemDfOptions describes the options for getting df information

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -309,7 +309,7 @@ func (ic *ContainerEngine) Renumber(_ context.Context) error {
 }
 
 func (ic *ContainerEngine) Migrate(_ context.Context, options entities.SystemMigrateOptions) error {
-	return ic.Libpod.Migrate(options.NewRuntime)
+	return ic.Libpod.Migrate(options.NewRuntime, options.MigrateDB)
 }
 
 func unshareEnv(graphroot, runroot string) []string {

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -32,20 +32,22 @@ var (
 )
 
 type engineOpts struct {
-	withFDS  bool
-	reset    bool
-	renumber bool
-	config   *entities.PodmanConfig
+	withFDS     bool
+	reset       bool
+	renumber    bool
+	noBoltError bool
+	config      *entities.PodmanConfig
 }
 
 // GetRuntime generates a new libpod runtime configured by command line options
 func GetRuntime(ctx context.Context, flags *flag.FlagSet, cfg *entities.PodmanConfig) (*libpod.Runtime, error) {
 	runtimeSync.Do(func() {
 		runtimeLib, runtimeErr = getRuntime(ctx, flags, &engineOpts{
-			withFDS:  true,
-			reset:    cfg.IsReset,
-			renumber: cfg.IsRenumber,
-			config:   cfg,
+			withFDS:     true,
+			reset:       cfg.IsReset,
+			renumber:    cfg.IsRenumber,
+			noBoltError: cfg.IsMigrateDB,
+			config:      cfg,
 		})
 	})
 	return runtimeLib, runtimeErr
@@ -132,6 +134,9 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 	if opts.renumber {
 		options = append(options, libpod.WithRenumber())
 	}
+	if opts.noBoltError {
+		options = append(options, libpod.WithNoBoltError())
+	}
 
 	if len(cfg.RuntimeFlags) > 0 {
 		runtimeFlags := []string{}
@@ -148,10 +153,6 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 
 	// TODO CLI flags for image config?
 	// TODO CLI flag for signature policy?
-
-	if len(cfg.ContainersConf.Engine.Namespace) > 0 {
-		options = append(options, libpod.WithNamespace(cfg.ContainersConf.Engine.Namespace))
-	}
 
 	if fs.Changed("runtime") {
 		options = append(options, libpod.WithOCIRuntime(cfg.RuntimePath))


### PR DESCRIPTION
@Luap99 I don't *think* we are vulnerable to the issues we have in 5.8 as there is no possibility of ever getting a BoltDB backend for Podman, but eyes on this would be appreciated.

This is an alternative to https://github.com/chttps://github.com/containers/podman/pull/28553ontainers/podman/pull/28553 and, instead of warning folks to use an external binary or downgrade, adds just enough BoltDB back in to do a migration.

The bad news: I don't think we can actually test this in CI. The ability to make new Bolt databases, and to interact with them in a meaningful way, is entirely gone. Though, now that I think about it, maybe I can ship a Bolt database in the tests directory and do a test migration off it?

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The BoltDB to SQLite migration possible in 5.8, which was planned to be removed in 6.0, has been left in place to ensure users are still able to recover their data if they move from Podman 5.7 or earlier to Podman 6.0 without stopping at Podman 5.8 for a migration.
```
