### PR TITLE
Allow installing systemd units without systemd build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -964,7 +964,6 @@ install.docker-docs:
 install.docker-full: install.docker install.docker-docs
 
 .PHONY: install.systemd
-ifneq (,$(findstring systemd,$(BUILDTAGS)))
 PODMAN_GENERATED_UNIT_FILES = contrib/systemd/system/podman-auto-update.service \
 		    contrib/systemd/system/podman.service \
 		    contrib/systemd/system/podman-restart.service \
@@ -994,9 +993,6 @@ install.systemd: $(PODMAN_GENERATED_UNIT_FILES)
 	install ${SELINUXOPT} -m 644 contrib/systemd/user/podman-user-wait-network-online.service \
 		$(DESTDIR)${USERSYSTEMDDIR}/podman-user-wait-network-online.service
 	rm -f $^
-else
-install.systemd:
-endif
 
 .PHONY: install.tools
 install.tools: .install.golangci-lint ## Install needed tools


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The install.systemd target now installs sytemd units even when built without the systemd build tag
```
