### PR TITLE
specgen: apply env_merge from containers.conf

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -187,7 +187,9 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		defaultEnvs["TERM"] = "xterm"
 	}
 
-	for _, e := range s.EnvMerge {
+	envMergeList := append(rtc.Containers.EnvMerge, s.EnvMerge...)
+
+	for _, e := range envMergeList {
 		processedWord, err := imagebuilder.ProcessWord(e, envLib.Slice(defaultEnvs))
 		if err != nil {
 			return nil, fmt.Errorf("unable to process variables for --env-merge %s: %w", e, err)

--- a/test/e2e/config/containers.conf
+++ b/test/e2e/config/containers.conf
@@ -22,6 +22,10 @@ env = [
     "foo=bar",
 ]
 
+env_merge = [
+	"PODMAN_TEST_VAR=${PODMAN_TEST_VAR}-merged"
+]
+
 # container engines use container separation using MAC(SELinux) labeling.
 # Flag is ignored on label disabled systems.
 #

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -116,6 +116,18 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("foo=bar"))
 	})
 
+	It("having env_merge from containers.conf", func() {
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+	ENV PODMAN_TEST_VAR=original
+	`
+		podmanTest.BuildImage(dockerfile, "test-env-merge", "false")
+
+		session := podmanTest.Podman([]string{"run", "--rm", "test-env-merge", "printenv", "PODMAN_TEST_VAR"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		Expect(session.OutputToString()).To(Equal("original-merged"))
+	})
+
 	It("additional devices", func() {
 		// containers.conf devices includes notone
 		session := podmanTest.Podman([]string{"run", "--device", "/dev/null:/dev/bar", ALPINE, "ls", "/dev"})


### PR DESCRIPTION
Read `env_merge` values from `containers.conf` and apply them before processing CLI `--env-merge` flags.

Fixes: #28410 
Depends on: containers/container-libs#791

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
