### PR TITLE
cleanup: run go fix on pkg/machine for windows

### DIFF
--- a/pkg/machine/e2e/init_windows_test.go
+++ b/pkg/machine/e2e/init_windows_test.go
@@ -174,7 +174,7 @@ var _ = Describe("podman machine init - windows only", func() {
 		newFileServerVsocks, err := vsock.LoadAllHVSockRegistryEntriesByPurpose(vsock.Fileserver)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newFileServerVsocks).To(HaveLen(countFileServerVsocks))
-		for i := 0; i < countFileServerVsocks; i++ {
+		for i := range countFileServerVsocks {
 			Expect(newFileServerVsocks[i].Port).To(Equal(fileServerVsocks[i].Port))
 		}
 

--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -174,7 +174,7 @@ func (hv *HVSockRegistryEntry) exists() (bool, error) {
 // already being used by another hvsock in the Windows registry.
 func findOpenHVSockPort() (uint64, error) {
 	// If we cannot find a free port in 10 attempts, something is wrong
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		port, err := utils.GetRandomPort()
 		if err != nil {
 			return 0, err

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -82,7 +82,7 @@ func PipeNameAvailable(pipeName string, maxWait time.Duration) bool {
 
 func WaitPipeExists(pipeName string, retries int, checkFailure func() error) error {
 	var err error
-	for i := 0; i < retries; i++ {
+	for range retries {
 		err = fileutils.Exists(`\\.\pipe\` + pipeName)
 		if err == nil {
 			break

--- a/pkg/machine/windows/util_windows.go
+++ b/pkg/machine/windows/util_windows.go
@@ -210,12 +210,7 @@ func wrapMaybef(err error, format string, args ...any) error {
 
 // IsReExecuting checks if the current process was re-executed with --reexec flag
 func IsReExecuting() bool {
-	for _, arg := range os.Args {
-		if arg == "--reexec" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(os.Args, "--reexec")
 }
 
 func CreateOrTruncateElevatedOutputFile() error {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
None

#### This PR addresses one part of #28367 by running `go fix` on the `pkg/machine` directory from a Windows host.

Changes include:
- Modernizing integer loops to use `for range <int>` (Go 1.22+).
- Replacing manual slice iteration with `slices.Contains`.

#### I verified by building `podman-remote` on Windows using `.\winmake.ps1 podman-remote`

#### I got into errors when `.\winmake.ps1 validatepr`. Details below,
```
Machine "podman-machine-default" started successfully
podman> .\winmake.ps1 validatepr
podman run --rm -v C:\Users\jacob\Documents\workbench\podman:/go/src/github.com/containers/podman --security-opt label=disable -t -w /go/src/github.com/containers/podman -e SKIP=check-executables-have-shebangs quay.io/libpod/validatepr:latest make .validatepr
Trying to pull quay.io/libpod/validatepr:latest...
Getting image source signatures
Copying blob sha256:12124f09860449ef5f509b6429455ab3fce6bd2ac74dc765b96ac0c8904e381c
Copying blob sha256:b90521936413d49c4e558fcbf1235c09f5d7c6ed5f35ac84312272c55b244283
Copying config sha256:9eb47bc841d157cdeaf57b005d34033403a37e059fa733365f93f2f818ca136d
Writing manifest to image destination
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
env BUILDTAGS="grpcnotrace       seccomp " REMOTETAGS="remote exclude_graphdriver_btrfs containers_image_openpgp" contrib/validatepr/validatepr.sh
env: 'contrib/validatepr/validatepr.sh': No such file or directory
make: *** [Makefile:348: .validatepr] Error 127
Exception: C:\Users\jacob\Documents\workbench\podman\contrib\cirrus\win-lib.ps1:79
Line |
  79 |          throw "Exit code = '$exitCode' running $command at $($caller. …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exit code = '2' running 'podman run --rm -v C:\Users\jacob\Documents\workbench\podman:/go/src/github.com/containers/podman --security-opt label=disable -t -w
     | /go/src/github.com/containers/podman -e SKIP=check-executables-have-shebangs quay.io/libpod/validatepr:latest make .validatepr' at
     | C:\Users\jacob\Documents\workbench\podman\winmake.ps1:278
```
#### I also ran `.\winmake.ps1 localunit` BEFORE and AFTER running `go fix`. There was 1 failure detected. Since it existed before I ran `go fix` I am assuming it has nothing to do with the new changes. Details below,
```
There were failures detected in the following suites:
  certificates .\pkg\machine\certificates

Test Suite Failed
Exception: C:\Users\jacob\Documents\workbench\podman\contrib\cirrus\win-lib.ps1:79
Line |
  79 |          throw "Exit code = '$exitCode' running $command at $($caller. …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exit code = '1' running './bin/ginkgo.exe -vv -r --tags "remote exclude_graphdriver_btrfs containers_image_openpgp" --timeout=15m --trace --no-color --skip-package
     | "hack,internal\domain\infra\abi,internal\domain\infra\tunnel,libpod\lock\shm,pkg\api\handlers\libpod,pkg\api\handlers\utils,pkg\bindings,pkg\domain\infra\abi,pkg\emulation,pkg\machine\apple,pkg\machine\applehv,pkg\machine\e2e,pkg\machine\libkrun,pkg\machine\proxyenv,pkg\machine\qemu,pkg\specgen\generate,pkg\systemd,test\e2e,test\utils,cmd\rootlessport,pkg\pidhandle"' at C:\Users\jacob\Documents\workbench\podman\winmake.ps1:74
```
