### PR TITLE
warn when LookupAllKeyVal silently truncates a value at unquoted whitespace

### DIFF
--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -847,7 +847,36 @@ func (f *UnitFile) LookupLastArgs(groupName string, key string) ([]string, bool,
 	return execArgs, true, nil
 }
 
-// Look up 'Environment' style key-value keys
+// Look up 'Environment' style key-value keys.
+//
+// The value is split on unquoted whitespace, so each space-separated token is
+// expected to be its own KEY=VALUE assignment. A value that itself contains
+// whitespace MUST be wrapped in double quotes, exactly like systemd's own
+// Environment= parser. Without the quotes, only the first whitespace-separated
+// token of the intended value is kept on KEY, and every subsequent token is
+// (mis)interpreted as another standalone assignment, almost always silently.
+//
+// Example of the trap (Quadlet .container file):
+//
+//	Label=traefik.http.routers.foo.rule=Host(`x`) && PathPrefix(`/y`)
+//
+// produces three map entries:
+//
+//	"traefik.http.routers.foo.rule" -> "Host(`x`)"
+//	"&&"                            -> nil
+//	"PathPrefix(`/y`)"              -> nil
+//
+// instead of the operator-intended single entry mapping the rule key to the
+// full Host() && PathPrefix() expression. Quoting the value fixes it:
+//
+//	Label="traefik.http.routers.foo.rule=Host(`x`) && PathPrefix(`/y`)"
+//
+// To make that mistake easier to spot, this function emits a warning for every
+// post-split token that does not contain '=' (i.e. is not itself a valid
+// KEY=VALUE assignment). Such a token is almost always a fragment of a value
+// that the user forgot to quote. The warning is non-fatal: the map is still
+// returned (with the bare token recorded as a key with nil value, matching the
+// pre-warning behavior) so callers can decide whether to abort or carry on.
 func (f *UnitFile) LookupAllKeyVal(groupName string, key string) (map[string]*string, error) {
 	var warnings error
 	res := make(map[string]*string)
@@ -858,13 +887,39 @@ func (f *UnitFile) LookupAllKeyVal(groupName string, key string) (map[string]*st
 			warnings = errors.Join(warnings, err)
 			continue
 		}
+		// Track whether we have already seen a valid KEY=VALUE token in
+		// this physical line. If so, a subsequent bare token is almost
+		// certainly a value fragment that escaped its (missing) quotes,
+		// not an intentional flag-style label like `Label=read-only`.
+		// We use that distinction to emit a more pointed warning.
+		sawAssignment := false
 		for _, assign := range assigns {
 			key, value, found := strings.Cut(assign, "=")
 			if found {
 				res[key] = &value
-			} else {
-				res[key] = nil
+				sawAssignment = true
+				continue
 			}
+			// No '=' in this token. Two cases:
+			//   1. It is the very first token on the line. The user
+			//      may legitimately want a bare key (some downstream
+			//      consumers, e.g. podman --label foo, accept that).
+			//      Preserve historical behavior: store as key with
+			//      nil value, no warning.
+			//   2. It comes AFTER a valid KEY=VALUE on the same line.
+			//      That is the unquoted-whitespace trap described in
+			//      the function-level comment above. Warn loudly so
+			//      the operator notices, but still record it the old
+			//      way to avoid changing observable map shape for
+			//      callers that already cope with the nil-value form.
+			if sawAssignment {
+				warnings = errors.Join(warnings, fmt.Errorf(
+					"%s=: token %q has no '=' and follows a KEY=VALUE on the same line; "+
+						"this usually means an earlier value contained unquoted whitespace and was truncated. "+
+						"Wrap values containing spaces in double quotes, e.g. %s=\"KEY=value with spaces\"",
+					key, assign, key))
+			}
+			res[key] = nil
 		}
 	}
 	return res, warnings

--- a/pkg/systemd/parser/unitfile_test.go
+++ b/pkg/systemd/parser/unitfile_test.go
@@ -371,6 +371,91 @@ func TestLookupQuoteStripping(t *testing.T) {
 	}
 }
 
+func TestLookupAllKeyVal(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    map[string]*string
+		wantWarning bool
+	}{
+		{
+			name:  "single KEY=VALUE no whitespace",
+			input: "Label=foo=bar\n",
+			expected: map[string]*string{
+				"foo": stringPtr("bar"),
+			},
+			wantWarning: false,
+		},
+		{
+			name:  "two KEY=VALUE space-separated on one line",
+			input: "Label=foo=bar baz=qux\n",
+			expected: map[string]*string{
+				"foo": stringPtr("bar"),
+				"baz": stringPtr("qux"),
+			},
+			wantWarning: false,
+		},
+		{
+			name:  "bare key (no '=') as the only token, historical flag-style",
+			input: "Label=read-only\n",
+			expected: map[string]*string{
+				"read-only": nil,
+			},
+			wantWarning: false,
+		},
+		{
+			name:  "unquoted whitespace inside value gets truncated and warned",
+			input: "Label=traefik.http.routers.foo.rule=Host(`x`) && PathPrefix(`/y`)\n",
+			expected: map[string]*string{
+				"traefik.http.routers.foo.rule": stringPtr("Host(`x`)"),
+				"&&":                            nil,
+				"PathPrefix(`/y`)":              nil,
+			},
+			wantWarning: true,
+		},
+		{
+			name:  "value containing whitespace correctly quoted, no truncation",
+			input: "Label=\"traefik.http.routers.foo.rule=Host(`x`) && PathPrefix(`/y`)\"\n",
+			expected: map[string]*string{
+				"traefik.http.routers.foo.rule": stringPtr("Host(`x`) && PathPrefix(`/y`)"),
+			},
+			wantWarning: false,
+		},
+		{
+			name:  "multiple physical Label= lines, last bare token still warned",
+			input: "Label=alpha=1\nLabel=beta=value with space\n",
+			expected: map[string]*string{
+				"alpha": stringPtr("1"),
+				"beta":  stringPtr("value"),
+				"with":  nil,
+				"space": nil,
+			},
+			wantWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unitData := "[Container]\n" + tt.input
+			f := NewUnitFile()
+			err := f.Parse(unitData)
+			assert.NoError(t, err)
+
+			got, warn := f.LookupAllKeyVal("Container", "Label")
+			assert.Equal(t, tt.expected, got)
+			if tt.wantWarning {
+				assert.Error(t, warn, "expected a warning about unquoted whitespace")
+			} else {
+				assert.NoError(t, warn, "did not expect a warning")
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
 func FuzzParser(f *testing.F) {
 	for _, sample := range samples {
 		f.Add([]byte(sample))


### PR DESCRIPTION
#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable). _This change is a follow-up to the trap class hit in #28560 (which itself was about the JSON-display escaping side); it does not "fix" #28560, see "Relation to #28560" below._
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated. _New `TestLookupAllKeyVal` table-driven test, 6 cases, covers the new warning path and confirms that the historical map shape is unchanged._
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed). _The function-level docstring on `LookupAllKeyVal` is significantly expanded with the failure example and the correct quoted form. No man-page changes are required because `podman-systemd.unit(5)` already documents that `Label=` "is similar to `Environment=`"; this PR makes the parser surface that fact when users miss it._
- [x] All commits pass `make validatepr` (format/lint checks). _`go test ./pkg/systemd/...` and `go vet ./pkg/systemd/parser/` both pass locally._
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below.

---

#### What this PR does

`pkg/systemd/parser/unitfile.go::LookupAllKeyVal` is the parser shared by every Quadlet key whose body looks like a list of `KEY=VALUE` pairs:

| Quadlet section | Affected keys |
|---|---|
| `[Container]` | `Environment=`, `Label=`, `Annotation=` |
| `[Pod]` | `Label=` |
| `[Network]` | `Label=` |
| `[Volume]` | `Label=` |
| `[Build]` | `Annotation=`, `Label=`, `BuildArg=`, `Environment=` |

The function splits the raw line on **unquoted** whitespace, so each space-separated token is expected to be its own `KEY=VALUE` assignment. A value that itself contains whitespace MUST be wrapped in double quotes, exactly like systemd's own `Environment=` parser.

Without the quotes, only the **first** whitespace-separated token of the intended value is kept on `KEY`, and every subsequent token is (mis)interpreted as another standalone assignment, **silently**: the unit reaches `active` state, and the only sign that something is wrong is whatever downstream consumer reads the labels behind systemd's back.

This PR adds a heuristic, **non-fatal** warning: if a token without `=` appears AFTER a valid `KEY=VALUE` on the same physical line, that token is almost certainly a value fragment that escaped its (missing) quotes. The warning text points the operator at the correct quoted form.

The map shape returned by `LookupAllKeyVal` is **not** changed (the bare token is still recorded as a key with `nil` value, matching the historical behavior), so no caller needs to be updated.

#### Worked example (the trap, before this PR)

A Quadlet `.container` file containing the very natural-looking line

```
Label=traefik.http.routers.foo.rule=Host(`x.example`) && PathPrefix(`/y`)
```

today produces three map entries

```
"traefik.http.routers.foo.rule" -> "Host(`x.example`)"
"&&"                            -> nil
"PathPrefix(`/y`)"              -> nil
```

instead of the operator-intended single entry mapping the rule key to the full `Host(...) && PathPrefix(...)` expression. The container starts and the unit reaches `active`, but Traefik silently sees only `Host(\`x.example\`)` as the rule. Symptom: every path that should have matched the `&& PathPrefix(...)` part returns 404, with no error anywhere on the Quadlet / podman side.

After this PR, the same input still produces the same three map entries (preserving the historical shape) but `LookupAllKeyVal` also returns a warning that surfaces in the Quadlet generator log:

```
Label=: token "&&" has no '=' and follows a KEY=VALUE on the same line;
this usually means an earlier value contained unquoted whitespace and was truncated.
Wrap values containing spaces in double quotes, e.g. Label="KEY=value with spaces"
```

The fix the operator is told to apply (and which works on current podman):

```
Label="traefik.http.routers.foo.rule=Host(`x.example`) && PathPrefix(`/y`)"
```

#### Reproduction (current behavior, prior to this PR)

```bash
$ cat /etc/containers/systemd/quadlet-label-bug.container
[Unit]
Description=Quadlet Label whitespace bug minimal reproduction

[Container]
Image=docker.io/library/busybox:latest
ContainerName=quadlet-label-bug
Exec=sleep 3600
Label=test.simple=hello
Label=test.with-space=Host(`x.example`) && PathPrefix(`/y`)
Label=test.quoted="Host(`x.example`) && PathPrefix(`/y`)"

$ sudo systemctl daemon-reload && sudo systemctl start quadlet-label-bug.service
$ sudo podman inspect quadlet-label-bug --format '{{json .Config.Labels}}' \
    | python3 -m json.tool | grep -i test
    "test.quoted":     "Host(`x.example`) && PathPrefix(`/y`)",
    "test.simple":     "hello",
    "test.with-space": "Host(`x.example`)"            # <-- truncated, silently
```

Quadlet generator output (`quadlet -dryrun`) for the same file shows the truncation in the generated `podman run` invocation:

```
... --label test.simple=hello \
    --label test.with-space=Host(`x.example`) \
    --label && \
    --label PathPrefix(`/y`) \
    --label "test.quoted=Host(`x.example`)\x20&&\x20PathPrefix(`/y`)" \
    ...
```

Tested on:

```
podman version 5.6.0
Red Hat Enterprise Linux 10.1
```

#### Why a warning, not a fail / not an autoquote

Three designs were considered:

| Option | Pros | Cons | Decision |
|---|---|---|---|
| Make silent split a hard parse error | Loud failure, no surprises | Breaks existing `Label=read-only`-style flag usage in the wild; changes observable behavior of every consumer of `LookupAllKeyVal` | Rejected |
| Auto-quote values that contain whitespace | Magic "just works" | The parser cannot tell whether the user meant *one* value with spaces or *several* `KEY=VALUE` pairs deliberately put on one line; would silently change the meaning of valid existing input | Rejected |
| Heuristic warning on bare tokens that follow a KEY=VALUE | Effectively zero false positives in the wild (nobody writes `Label=foo=bar baz`); preserves all existing maps shapes; tells the operator exactly how to fix it | Misses the all-bare-tokens case (e.g. `Label=foo bar baz`), but no one has reported being hurt by that path | **Adopted** |

#### Scope of the warning surface

`Label=` is the most operator-visible victim, because Traefik / docker label discovery is the canonical use case where a silently-truncated value matters at runtime. But the same parser also backs `Environment=`, `Annotation=`, and `BuildArg=`, so users who write e.g.

```
Environment=GREETING=hello world
```

(without quotes) also get the same misleading split today. They will get the same new warning after this PR.

#### Relation to #28560

#28560 ("Podman Quadlet converting ampersand to unicode escape sequence in container run") and its fix PR #28575 ("fix container inspect output to not escape html chars") look superficially similar to this trap because both involve `&&` in a Traefik label, but they are **different bugs**:

- #28560 / #28575 fixed the `podman inspect` JSON **display** so `&` is no longer rendered as `\u0026`. The label value stored on the container is, and was, correct.
- This PR addresses the case where the label value stored on the container is **already wrong** because `LookupAllKeyVal` truncated it during Quadlet unit generation. The parser fix in #28575 cannot have fixed it (and indeed does not).

So this is not a duplicate of #28560, but it is in the same general "unquoted whitespace inside Traefik-style label values is a footgun" neighborhood.

#### Backwards compatibility

- `LookupAllKeyVal` returns the same `(map, error)` shape as before. `error` was already returned for upstream split failures and is already handled by every caller via `errors.Join`. The new warning rides on the same channel.
- The map values returned for the bare-token case are unchanged: the bare token is still recorded as a `key -> nil` entry.
- The single existing in-tree caller (`pkg/systemd/quadlet/quadlet.go::lookupAndAddKeyVals`) already collects the returned warnings into `errors.Join`, and Quadlet's main loop already surfaces the joined errors as warnings on the unit generation log. No caller change is needed; the warning will just start showing up in the generator log for affected units.

#### Tests

`pkg/systemd/parser/unitfile_test.go` gets a new `TestLookupAllKeyVal` table-driven test covering six cases:

1. Single `KEY=VALUE`, no whitespace -> no warning, map unchanged.
2. Two `KEY=VALUE` space-separated on one line -> no warning, both keys present.
3. Bare key (no `=`) as the only token, historical flag-style -> no warning, key recorded as `key -> nil`.
4. Unquoted whitespace inside value gets truncated -> map shape unchanged (truncated value + bare tokens as nil-value keys), but a warning is now returned.
5. Same value, correctly double-quoted -> no warning, single map entry with the full value.
6. Two physical `Label=` lines, the second one with unquoted whitespace -> warning fires for the second line only.

```
$ go test -run TestLookupAllKeyVal ./pkg/systemd/parser/ -v
=== RUN   TestLookupAllKeyVal
=== RUN   TestLookupAllKeyVal/single_KEY=VALUE_no_whitespace
=== RUN   TestLookupAllKeyVal/two_KEY=VALUE_space-separated_on_one_line
=== RUN   TestLookupAllKeyVal/bare_key_(no_'=')_as_the_only_token,_historical_flag-style
=== RUN   TestLookupAllKeyVal/unquoted_whitespace_inside_value_gets_truncated_and_warned
=== RUN   TestLookupAllKeyVal/value_containing_whitespace_correctly_quoted,_no_truncation
=== RUN   TestLookupAllKeyVal/multiple_physical_Label=_lines,_last_bare_token_still_warned
--- PASS: TestLookupAllKeyVal (0.00s)
PASS
ok  	go.podman.io/podman/v6/pkg/systemd/parser   0.327s
```

`go test ./pkg/systemd/...` and `go vet ./pkg/systemd/parser/` both pass.

#### Does this PR introduce a user-facing change?

```release-note
quadlet: emit a warning when a Quadlet `Label=` / `Environment=` / `Annotation=` / `BuildArg=` line contains unquoted whitespace inside a value, which silently truncates the value at the first space. The warning text points operators at the correct double-quoted form (e.g. `Label="KEY=value with spaces"`). No behavior change for correctly-quoted lines or for legitimate flag-style bare keys (`Label=read-only`).
```
