### PR TITLE
test/e2e: fix broken checkpoint tests

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -49,17 +49,13 @@ var _ = Describe("Podman checkpoint", func() {
 			Skip(fmt.Sprintf("check CRIU version error: %v", err))
 		}
 
-		session := podmanTest.Podman([]string{"network", "create"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly("network", "create")
 		netname = session.OutputToString()
 	})
 
 	AfterEach(func() {
 		if netname != "" {
-			session := podmanTest.Podman([]string{"network", "rm", "-f", netname})
-			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitCleanly())
+			podmanTest.PodmanExitCleanly("network", "rm", "-f", netname)
 		}
 	})
 
@@ -77,16 +73,12 @@ var _ = Describe("Podman checkpoint", func() {
 
 	It("podman checkpoint a running container by id", func() {
 		localRunString := getRunString([]string{ALPINE, "top"})
-		session := podmanTest.Podman(localRunString)
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly(localRunString...)
 		cid := session.OutputToString()
 
 		// Check if none of the checkpoint/restore specific information is displayed
 		// for newly started containers.
-		inspect := podmanTest.Podman([]string{"inspect", cid})
-		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(ExitCleanly())
+		inspect := podmanTest.PodmanExitCleanly("inspect", cid)
 		inspectOut := inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -94,24 +86,19 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(inspectOut[0].State).To(HaveField("CheckpointLog", ""))
 		Expect(inspectOut[0].State).To(HaveField("RestoreLog", ""))
 
-		result := podmanTest.Podman([]string{
+		result := podmanTest.PodmanExitCleanly(
 			"container",
 			"checkpoint",
 			"--keep",
 			cid,
-		})
-		result.WaitWithDefaultTimeout()
-
-		Expect(result).Should(ExitCleanly())
+		)
 		Expect(result.OutputToString()).To(Equal(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		// For a checkpointed container we expect the checkpoint related information
 		// to be populated.
-		inspect = podmanTest.Podman([]string{"inspect", cid})
-		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(ExitCleanly())
+		inspect = podmanTest.PodmanExitCleanly("inspect", cid)
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeTrue(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -124,22 +111,17 @@ var _ = Describe("Podman checkpoint", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitWithError(125, "--publish can only be used with image or --import"))
 
-		result = podmanTest.Podman([]string{
+		result = podmanTest.PodmanExitCleanly(
 			"container",
 			"restore",
 			"--keep",
 			cid,
-		})
-		result.WaitWithDefaultTimeout()
-
-		Expect(result).Should(ExitCleanly())
+		)
 		Expect(result.OutputToString()).To(Equal(cid))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
-		inspect = podmanTest.Podman([]string{"inspect", cid})
-		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(ExitCleanly())
+		inspect = podmanTest.PodmanExitCleanly("inspect", cid)
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Restored).To(BeTrue(), ".State.Restored")
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
@@ -150,21 +132,17 @@ var _ = Describe("Podman checkpoint", func() {
 		podmanTest.StopContainer(cid)
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
-		result = podmanTest.Podman([]string{
+		podmanTest.PodmanExitCleanly(
 			"container",
 			"start",
 			cid,
-		})
-		result.WaitWithDefaultTimeout()
+		)
 
-		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		// Stopping and starting the container should remove all checkpoint
 		// related information from inspect again.
-		inspect = podmanTest.Podman([]string{"inspect", cid})
-		inspect.WaitWithDefaultTimeout()
-		Expect(inspect).Should(ExitCleanly())
+		inspect = podmanTest.PodmanExitCleanly("inspect", cid)
 		inspectOut = inspect.InspectContainerToJSON()
 		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
 		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
@@ -337,17 +315,13 @@ var _ = Describe("Podman checkpoint", func() {
 
 	It("podman checkpoint container with established tcp connections", func() {
 		localRunString := getRunString([]string{REDIS_IMAGE})
-		session := podmanTest.Podman(localRunString)
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly(localRunString...)
 		cid := session.OutputToString()
 		if !WaitContainerReady(podmanTest, cid, "Ready to accept connections", 20, 1) {
 			Fail("Container failed to get ready")
 		}
 
-		IP := podmanTest.Podman([]string{"inspect", cid, fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").IPAddress}}", netname)})
-		IP.WaitWithDefaultTimeout()
-		Expect(IP).Should(ExitCleanly())
+		IP := podmanTest.PodmanExitCleanly("inspect", cid, fmt.Sprintf("--format={{(index .NetworkSettings.Networks \"%s\").IPAddress}}", netname))
 
 		// Open a network connection to the redis server
 		conn, err := net.DialTimeout("tcp4", IP.OutputToString()+":6379", time.Duration(3)*time.Second)
@@ -364,10 +338,8 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
 		// Now it should work thanks to "--tcp-established"
-		result = podmanTest.Podman([]string{"container", "checkpoint", cid, "--tcp-established"})
-		result.WaitWithDefaultTimeout()
+		podmanTest.PodmanExitCleanly("container", "checkpoint", cid, "--tcp-established")
 
-		Expect(result).Should(ExitCleanly())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
@@ -389,17 +361,9 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
 		// Now it should work thanks to "--tcp-established"
-		result = podmanTest.Podman([]string{"container", "restore", cid, "--tcp-established"})
-		result.WaitWithDefaultTimeout()
-
-		Expect(result).Should(ExitCleanly())
+		podmanTest.PodmanExitCleanly("container", "restore", cid, "--tcp-established")
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
-
-		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
-		result.WaitWithDefaultTimeout()
-		Expect(result).Should(ExitCleanly())
-		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		conn.Close()
 	})
@@ -407,9 +371,7 @@ var _ = Describe("Podman checkpoint", func() {
 	It("podman restore container with tcp-close", func() {
 		// Start a container with redis (which listens on tcp port)
 		localRunString := getRunString([]string{REDIS_IMAGE})
-		session := podmanTest.Podman(localRunString)
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(ExitCleanly())
+		session := podmanTest.PodmanExitCleanly(localRunString...)
 		cid := session.OutputToString()
 		if !WaitContainerReady(podmanTest, cid, "Ready to accept connections", 20, 1) {
 			Fail("Container failed to get ready")

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -347,16 +347,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result = podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
 
-		// default message when using crun
-		expectStderr := "crun: CRIU restoring failed -52. Please check CRIU logfile"
+		// Some older versions print "CRIU restoring failed: -52" while others
+		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
+		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
 		if podmanTest.OCIRuntime == "runc" {
 			expectStderr = "runc: criu failed: type NOTIFY errno 0"
 		}
-		if !IsRemote() {
-			// This part is only seen with podman local, never remote
-			expectStderr = "OCI runtime error: " + expectStderr
-		}
-		Expect(result).Should(ExitWithError(125, expectStderr))
+		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 
@@ -394,16 +391,13 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "restore", cid})
 		result.WaitWithDefaultTimeout()
 
-		// default message when using crun
-		expectStderr := "crun: CRIU restoring failed -52. Please check CRIU logfile"
+		// Some older versions print "CRIU restoring failed: -52" while others
+		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
+		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
 		if podmanTest.OCIRuntime == "runc" {
 			expectStderr = "runc: criu failed: type NOTIFY errno 0"
 		}
-		if !IsRemote() {
-			// This part is only seen with podman local, never remote
-			expectStderr = "OCI runtime error: " + expectStderr
-		}
-		Expect(result).Should(ExitWithError(125, expectStderr))
+		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
 


### PR DESCRIPTION
On main these tests fail right now due the parallel merge of commit
https://github.com/containers/podman/commit/d01cd46830ce78d7258e09d2f9ec37f9791bc7f2 ("test: remove outdated checkpoint skip") and commit
https://github.com/containers/podman/commit/1b99ae56b0e1b3ec48855fa26754c15e2e33ee7e ("New images 2026-04-24").

The new crun and/or criu versions in the CI images changed the error
message so adapt to that.

The new full error is:
Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
