### PR TITLE
test/system: fix quadlet - rootfs on kernel 7.1

### DIFF
--- a/test/system/252-quadlet.bats
+++ b/test/system/252-quadlet.bats
@@ -929,11 +929,7 @@ EOF
     skip_if_no_selinux
     skip_if_rootless
 
-    # Mount a container image to use as rootfs. Because we (may) run in
-    # parallel, mount a working container, not $IMAGE
-    cname="c-$(safename)"
-    run_podman run -d --name $cname $IMAGE top
-    run_podman container mount $cname
+    run_podman image mount $IMAGE
     mountpoint="$output"
 
     local quadlet_file=$PODMAN_TMPDIR/basic_$(safename).container
@@ -951,8 +947,7 @@ EOF
 
     # Done. Clean up.
     service_cleanup $QUADLET_SERVICE_NAME failed
-    run_podman container unmount $cname
-    run_podman rm -f -t0 $cname
+    run_podman image unmount $IMAGE
 }
 
 @test "quadlet - selinux disable" {


### PR DESCRIPTION
As found in fedora openQA testing on the kernel update this test fails due a selinux denial.

The kernel now correctly checks the backing fs selinux context in all cases. See kernel commit 82544d36b172 (selinux: fix overlayfs mmap() and mprotect() access checks).

The test tries to access another container so the selinux level will be different from the quadlet roofs container and therefore fail to access the files.

To fix this we should be able to just use the regular image mount which has a level all containers can access. The comment that this is not parallel safe is untrue, mounts are reference counted so this should not get unmounted all of the sudden by another test.

In fact we have another  --rootfs test case where we do this and it passed in openQA, see "podman run - check workdir".

Fixes: #28602

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
