### PR TITLE
RUN-3620: Document dropped support

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -42,4 +42,8 @@ For Linux, we test the latest versions of Fedora and Debian.
 
 Operating systems and hardware outside our automated testing is considered "best effort".
 In many cases, we are unable to test, triage, and develop for combinations outside what
-our automated testing covers. For example, Podman on Intel-based Macs.
+our automated testing covers.
+
+As of Podman 6, we no longer support Windows 10 nor Intel Macs.  While no code was removed
+to drop support of Windows 10, code for Intel Macs was removed and will no longer compile
+for that platform.


### PR DESCRIPTION
Add small documentation that notes that we no longer support Intel Macs and Windows 10.

Fixes: RUN-3620

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
