### PR TITLE
`ps`, `pod ps`, `volume ls`: format labels as comma-separated `key=value` for Docker compatibility

### DIFF
--- a/cmd/podman/common/format.go
+++ b/cmd/podman/common/format.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"slices"
+	"strings"
+)
+
+// FormatLabels converts a map of labels to a sorted, comma-separated list
+// of key=value pairs, matching Docker CLI output format.
+func FormatLabels(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	list := make([]string, 0, len(keys))
+	for _, k := range keys {
+		list = append(list, k+"="+labels[k])
+	}
+	return strings.Join(list, ",")
+}

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -342,7 +342,13 @@ func (l psReporter) ImageID() string {
 	return l.ListContainer.ImageID
 }
 
-// Label returns a map of the pod's labels
+// Labels returns the container's labels as a sorted, comma-separated list of
+// key=value pairs, matching Docker CLI output format.
+func (l psReporter) Labels() string {
+	return common.FormatLabels(l.ListContainer.Labels)
+}
+
+// Label returns the value of a single container label by name.
 func (l psReporter) Label(name string) string {
 	return l.ListContainer.Labels[name]
 }

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -151,13 +150,10 @@ type ListPrintReports struct {
 	types.Network
 }
 
-// Labels returns any labels added to a Network
+// Labels returns the network's labels as a sorted, comma-separated list of
+// key=value pairs, matching Docker CLI output format.
 func (n ListPrintReports) Labels() string {
-	list := make([]string, 0, len(n.Network.Labels))
-	for k, v := range n.Network.Labels {
-		list = append(list, k+"="+v)
-	}
-	return strings.Join(list, ",")
+	return common.FormatLabels(n.Network.Labels)
 }
 
 // ID returns the Podman Network ID

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -194,9 +194,10 @@ func (l ListPodReporter) Created() string {
 	return units.HumanDuration(time.Since(l.ListPodsReport.Created)) + " ago"
 }
 
-// Labels returns a map of the pod's labels
-func (l ListPodReporter) Labels() map[string]string {
-	return l.ListPodsReport.Labels
+// Labels returns the pod's labels as a sorted, comma-separated list of
+// key=value pairs, matching Docker CLI output format.
+func (l ListPodReporter) Labels() string {
+	return common.FormatLabels(l.ListPodsReport.Labels)
 }
 
 // Label returns a map of the pod's labels

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -113,7 +113,21 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.VolumeListReport) 
 			return fmt.Errorf("failed to write report column headers: %w", err)
 		}
 	}
-	return rpt.Execute(responses)
+	reporters := make([]volumeReporter, 0, len(responses))
+	for _, r := range responses {
+		reporters = append(reporters, volumeReporter{r})
+	}
+	return rpt.Execute(reporters)
+}
+
+type volumeReporter struct {
+	*entities.VolumeListReport
+}
+
+// Labels returns the volume's labels as a sorted, comma-separated list of
+// key=value pairs, matching Docker CLI output format.
+func (v volumeReporter) Labels() string {
+	return common.FormatLabels(v.VolumeListReport.Labels)
 }
 
 func outputJSON(vols []*entities.VolumeListReport) error {

--- a/docs/source/markdown/podman-pod-ps.1.md.in
+++ b/docs/source/markdown/podman-pod-ps.1.md.in
@@ -58,7 +58,7 @@ Valid placeholders for the Go template are listed below:
 | .ID                 | Container ID                                         |
 | .InfraID            | Pod infra container ID                               |
 | .Label *string*     | Specified label of the pod                           |
-| .Labels ...         | All the labels assigned to the pod                   |
+| .Labels             | All the labels assigned to the pod                   |
 | .Name               | Name of pod                                          |
 | .Networks           | Show all networks connected to the infra container   |
 | .NumberOfContainers | Show the number of containers attached to pod        |

--- a/docs/source/markdown/podman-ps.1.md.in
+++ b/docs/source/markdown/podman-ps.1.md.in
@@ -61,7 +61,7 @@ Valid placeholders for the Go template are listed below:
 | .ImageID           | Image ID                                     |
 | .IsInfra           | "true" if infra container                    |
 | .Label *string*    | Specified label of the container             |
-| .Labels ...        | All the labels assigned to the container     |
+| .Labels            | All the labels assigned to the container     |
 | .Mounts            | Volumes mounted in the container             |
 | .Names             | Name of container                            |
 | .Networks          | Show all networks connected to the container |

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -239,6 +239,43 @@ load helpers
     run_podman pod rm -t 0 -f test
 }
 
+@test "podman ps --format json Labels is a string" {
+    rand_value=$(random_string 10)
+
+    run_podman run -d --label mylabel=$rand_value $IMAGE sleep inf
+    cid=$output
+
+    # {{json .Labels}} should produce a JSON string ("key=val,..."), not a JSON object
+    run_podman ps --format '{{json .Labels}}'
+    assert "$output" =~ "\".*mylabel=${rand_value}.*\"" "json .Labels should be a quoted string, not a JSON object"
+    assert "$output" !~ "{" "json .Labels should not contain braces (not a JSON object)"
+
+    # Plain {{.Labels}} should produce key=value format
+    run_podman ps --format '{{.Labels}}'
+    assert "$output" =~ "mylabel=${rand_value}" ".Labels should contain key=value pair"
+    assert "$output" !~ "map\[" ".Labels should not use Go map format"
+
+    run_podman rm -t 0 -f $cid
+}
+
+@test "podman pod ps --format json Labels is a string" {
+    rand_value=$(random_string 10)
+
+    run_podman pod create --label mylabel=${rand_value} test
+
+    # {{json .Labels}} should produce a JSON string, not a JSON object
+    run_podman pod ps --format '{{json .Labels}}'
+    assert "$output" =~ "\".*mylabel=${rand_value}.*\"" "json .Labels should be a quoted string, not a JSON object"
+    assert "$output" !~ "{" "json .Labels should not contain braces (not a JSON object)"
+
+    # Plain {{.Labels}} should produce key=value format
+    run_podman pod ps --format '{{.Labels}}'
+    assert "$output" =~ "mylabel=${rand_value}" ".Labels should contain key=value pair"
+    assert "$output" !~ "map\["  ".Labels should not use Go map format"
+
+    run_podman pod rm -t 0 -f test
+}
+
 @test "podman ps --format PodName" {
     rand_value=$(random_string 10)
 

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -666,4 +666,23 @@ EOF
     run_podman volume rm $volume_name --force
 }
 
+@test "podman volume ls --format Labels is a string" {
+    rand_value=$(random_string 10)
+    volume_name="v-$(safename)"
+
+    run_podman volume create --label mylabel=$rand_value $volume_name
+
+    # {{json .Labels}} should produce a JSON string, not a JSON object
+    run_podman volume ls --format '{{json .Labels}}'
+    assert "$output" =~ "\".*mylabel=${rand_value}.*\"" "json .Labels should be a quoted string, not a JSON object"
+    assert "$output" !~ "{" "json .Labels should not contain braces (not a JSON object)"
+
+    # Plain {{.Labels}} should produce key=value format
+    run_podman volume ls --format '{{.Labels}}'
+    assert "$output" =~ "mylabel=${rand_value}" ".Labels should contain key=value pair"
+    assert "$output" !~ "map\[" ".Labels should not use Go map format"
+
+    run_podman volume rm $volume_name
+}
+
 # vim: filetype=sh

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -309,7 +309,7 @@ EOF
 
     # pod ps
     run_podman pod ps --format '{{.ID}} {{.Name}} {{.Status}} {{.Labels}}'
-    assert "$output" =~ "${pod_id:0:12} $podname Running map\[${labelname}:${labelvalue}]"  "pod ps"
+    assert "$output" =~ "${pod_id:0:12} $podname Running ${labelname}=${labelvalue}"  "pod ps"
 
     run_podman pod ps --no-trunc --filter "label=${labelname}=${labelvalue}" --format '{{.ID}}'
     is "$output" "$pod_id" "pod ps --filter label=..."

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -213,10 +213,10 @@ EOF
 
 @test "ps -a : shows all containers" {
     run_podman ps -a \
-               --format '{{.Names}}--{{.Status}}--{{.Ports}}--{{.Labels.mylabel}}' \
+               --format '{{.Names}}--{{.Status}}--{{.Ports}}--{{.Label "mylabel"}}' \
                --sort=created
     assert "${lines[0]}" == "mycreatedcontainer--Created----$LABEL_CREATED" "line 0, created"
-    assert "${lines[1]}" =~ "mydonecontainer--Exited \(0\).*----<no value>"   "line 1, done"
+    assert "${lines[1]}" =~ "mydonecontainer--Exited \(0\).*----"   "line 1, done"
     assert "${lines[2]}" =~ "myfailedcontainer--Exited \(17\) .*----$LABEL_FAILED" "line 2, fail"
 
     # Port order is not guaranteed
@@ -224,7 +224,7 @@ EOF
     assert "${lines[3]}" =~ ".*--.*0\.0\.0\.0:$HOST_PORT->80\/tcp.*--.*"  "line 3, first port forward"
     assert "${lines[3]}" =~ ".*--.*127\.0\.0\.1\:9090-9092->8080-8082\/tcp.*--.*" "line 3, second port forward"
 
-    assert "${lines[4]}" =~ ".*-infra--Created----<no value>" "line 4, infra container"
+    assert "${lines[4]}" =~ ".*-infra--Created----" "line 4, infra container"
 
     # For debugging: dump containers and IDs
     if [[ -n "$PODMAN_UPGRADE_TEST_DEBUG" ]]; then


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/21847
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
The --format '{{.Labels}}' output for ps, pod ps, and volume ls now produces comma-separated key=value pairs, matching Docker CLI behavior.
```
