### PR TITLE
[skip-ci] Packit: Only create dist-git PRs for rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -152,12 +152,16 @@ jobs:
             context:
               revdeps: "yes"
 
+  # NOTE: Breaking changes related to Podman6 will only be shipped to Fedora
+  # Rawhide (to be Fedora 45) and newer.
+  # TODO: Update dist_git_branches as and when new Fedora releases are
+  # available.
   - job: propose_downstream
     trigger: release
     update_release: false
     packages: [podman-fedora]
     dist_git_branches: &fedora_targets
-      - fedora-all
+      - fedora-rawhide
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
We'll only be releasing breaking changes on rawhide so dist-git PRs should only be created for rawhide.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```

Related: https://github.com/containers/buildah/pull/6826 , https://github.com/containers/skopeo/pull/2865 and https://github.com/containers/container-libs/pull/808 