### PR TITLE
Use tmp context dir when building with process substitution

### DIFF
--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -223,6 +223,15 @@ func ParseBuildOpts(cmd *cobra.Command, args []string, buildOpts *BuildFlagsWrap
 				return nil, fmt.Errorf("determining path to file %q: %w", containerFiles[i], err)
 			}
 			contextDir = filepath.Dir(absFile)
+			// /dev/fd cannot be used as an overlay mount lower layer, use a tmp context dir instead
+			if contextDir == "/dev/fd" || contextDir == "/proc/self/fd" {
+				tempDir, err := os.MkdirTemp("", "podman-build-context-")
+				if err != nil {
+					return nil, fmt.Errorf("creating temporary context directory: %w", err)
+				}
+				apiBuildOpts.TmpDirToClose = tempDir
+				contextDir = tempDir
+			}
 			containerFiles[i] = absFile
 			break
 		}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -585,6 +585,18 @@ func prepareContainerFiles(containerFiles []string, contextDir string, stdinDest
 				return nil, fmt.Errorf("processing stdin: %w", err)
 			}
 			c = stdinFile
+		} else if strings.HasPrefix(c, "/dev/fd/") || strings.HasPrefix(c, "/proc/self/fd") {
+			// Handle process substitution: read from the file descriptor and create a temp file
+			fdFile, err := os.Open(c)
+			if err != nil {
+				return nil, fmt.Errorf("opening file descriptor %q: %w", c, err)
+			}
+			tempFile, err := tempManager.CreateTempFileFromReader(stdinDestination, "podman-build-fd-*", fdFile)
+			fdFile.Close()
+			if err != nil {
+				return nil, fmt.Errorf("processing file descriptor %q: %w", c, err)
+			}
+			c = tempFile
 		}
 		c = filepath.Clean(c)
 		cfDir := filepath.Dir(c)

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -336,9 +336,13 @@ skip "FIXME: 2024-05-28 new VMs from #338" \
 skip_if_remote "FIXME: 2025-04-01 git related errors returning wrong exit code" \
                "bud with ADD with git repository source"
 #
-# 2026-02-02 buildah's overlay-over-context-directory fails with process substitution
+
+# 2026-05-08 FIXME: Tests that specifically requires bit-identical tar outputs and uses process substitution
+# Podman creates random temp dirs (/tmp/podman-build-context-*)
+# for /dev/fd context, which causes different build outputs each time.
 # FIXME: Don't use process substitution for Containerfile in buildah tests
-skip "process substitution with overlay context not supported" \
+
+skip "Requires bit-identical tar outputs when using process substitution" \
      "build-with-timestamp-applies-to-oci-archive" \
      "build-with-timestamp-applies-to-oci-archive-with-base" \
      "build-with-run-mount" \

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -1272,6 +1272,14 @@ EOF
     run_podman rmi -f $imgname
 }
 
+@test "podman build with process substitution" {
+    imgname="b-$(safename)"
+    run_podman build -t $imgname -f <(echo "FROM scratch")
+    is "$output" ".*COMMIT" "COMMIT seen in log"
+
+    run_podman rmi -f $imgname
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
Podman defaults to the directory of the Containerfile when no context dir is explicitly provided. When running podman build with process subsituiton,  `podman build -f <(echo "FROM scratch")`, the Containerfile path expands to `/dev/fd/<NUM>`, which makes `/dev/fd` the context dir. When building, Buildah attempts to create an overlay mount on top of the `/dev/fd` context dir, which fails.

In these cases, use a temp context dir instead: `$TMPDIR/podman-build-context-$randnum`

Fixes: https://github.com/containers/podman/issues/28113

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
When building an image with process substitution, such as `podman build -f <(<<<"FROM scratch")` , an empty tmp dir is now used as the context dir.
```
