### PR TITLE
troubleshooting: document keep-id size option

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1449,7 +1449,9 @@ Using `--userns=auto` when creating new containers does not work as long as any 
 
 #### Solution
 
-Any existing containers that were created using `--userns=keep-id` or `--userns=nomap` must first be deleted before any new container can be created with `--userns=auto`
+Any existing containers that were created using `--userns=keep-id` or `--userns=nomap` must first be deleted before any new container can be created with `--userns=auto`.
+By default, the option `--userns=keep-id` allocates all unused IDs in the user namespace.
+To avoid this, specify the `size` option, for example `--userns=keep-id:size=2000`
 
 ### 44) `sudo podman run --userns=auto` fails with `Cannot find mappings for user "containers"`
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```

__side note__: I also tried  `--userns=nomap:size=2000` but such a `size` option does not exist.

```
$ podman run --rm -d --userns=nomap:size=2000 alpine sleep 3600
Error: unrecognized namespace mode nomap:size=2000 passed
```