### PR TITLE
specgen: skip /dev/mqueue mount if not available

### DIFF
--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -3,9 +3,11 @@
 package generate
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -19,6 +21,24 @@ import (
 	"go.podman.io/podman/v6/pkg/specgen"
 	"golang.org/x/sys/unix"
 )
+
+const devMqueue = "/dev/mqueue"
+
+func isMqueueSupported() bool {
+	f, err := os.Open("/proc/filesystems")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) > 0 && fields[len(fields)-1] == "mqueue" {
+			return true
+		}
+	}
+	return false
+}
 
 func setProcOpts(s *specgen.SpecGenerator, g *generate.Generator) {
 	if s.ProcOpts == nil {
@@ -166,12 +186,15 @@ func SpecGenToOCI(_ context.Context, s *specgen.SpecGenerator, rt *libpod.Runtim
 
 	inUserNS := isRootless || isNewUserns
 
-	if inUserNS && s.IpcNS.IsHost() {
-		g.RemoveMount("/dev/mqueue")
+	// Check /proc/filesystems to see if the kernel supports mqueue.
+	if !isMqueueSupported() {
+		g.RemoveMount(devMqueue)
+	} else if inUserNS && s.IpcNS.IsHost() {
+		g.RemoveMount(devMqueue)
 		devMqueue := spec.Mount{
-			Destination: "/dev/mqueue",
-			Type:        define.TypeBind, // constant ?
-			Source:      "/dev/mqueue",
+			Destination: devMqueue,
+			Type:        define.TypeBind,
+			Source:      devMqueue,
 			Options:     []string{define.TypeBind, "nosuid", "noexec", "nodev"},
 		}
 		g.AddMount(devMqueue)


### PR DESCRIPTION
do not add/dev/mqueue to the container if the device is not present on the host.  This can happen if the kernel doesn't have support for mqueue, as it is the case with the libkrunfw kernel.

Closes: https://github.com/containers/crun/issues/2080
Closes: https://github.com/containers/libkrun/issues/653

I've not added any new tests as it requires a system where /dev/mqueue is not present.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
