### PR TITLE
fix(markdown-preprocess): preserve unknown tokens in render()

### DIFF
--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -109,6 +109,11 @@ class Preprocessor():
                     raise ValueError(f"Invalid inline if/else syntax: {inner}") from e
                 continue
 
+            # Unrecognized token (e.g. `<<a|b>>` for replace_type, or `<<subcommand>>`):
+            # preserve verbatim so downstream processing can handle it.
+            if is_active():
+                out.append(m.group(0))
+
         # trailing literal
         if is_active():
             out.append(text[pos:])

--- a/hack/markdown-preprocess.t
+++ b/hack/markdown-preprocess.t
@@ -82,5 +82,62 @@ class TestPodmanSubcommand(unittest.TestCase):
         self.assertEqual(pp.podman_subcommand(), "rm")
         self.assertEqual(pp.podman_subcommand("full"), "pod rm")
 
+class TestRender(unittest.TestCase):
+    def test_if_then_endif(self):
+        """basic if/endif conditional"""
+        text = 'before <<if is_quadlet>>quadlet text<<endif>> after'
+        self.assertEqual(pp.render(text, {'is_quadlet': True}),
+                         'before quadlet text after')
+        self.assertEqual(pp.render(text, {'is_quadlet': False}),
+                         'before  after')
+
+    def test_if_else_endif(self):
+        """if/else/endif"""
+        text = '<<if is_quadlet>>q<<else>>c<<endif>>'
+        self.assertEqual(pp.render(text, {'is_quadlet': True}), 'q')
+        self.assertEqual(pp.render(text, {'is_quadlet': False}), 'c')
+
+    def test_if_not(self):
+        """if not variable"""
+        text = '<<if not is_quadlet>>c<<endif>>'
+        self.assertEqual(pp.render(text, {'is_quadlet': True}), '')
+        self.assertEqual(pp.render(text, {'is_quadlet': False}), 'c')
+
+    def test_inline_if_else(self):
+        """inline X if cond else Y"""
+        text = '<<"q" if is_quadlet else "c">>'
+        self.assertEqual(pp.render(text, {'is_quadlet': True}), 'q')
+        self.assertEqual(pp.render(text, {'is_quadlet': False}), 'c')
+
+    def test_preserves_pod_container_substitution(self):
+        """`<<a|b>>` tokens are passed through render verbatim for replace_type"""
+        text = '<<container|pod>> writable filesystem'
+        self.assertEqual(pp.render(text, {'is_quadlet': False}),
+                         '<<container|pod>> writable filesystem')
+
+    def test_preserves_subcommand_token(self):
+        """`<<subcommand>>` tokens are passed through render verbatim"""
+        text = 'Use podman <<subcommand>> --foo'
+        self.assertEqual(pp.render(text, {'is_quadlet': False}),
+                         'Use podman <<subcommand>> --foo')
+
+    def test_preserves_pod_container_starting_with_if(self):
+        """`<<if ...|...>>` substitutions where one side starts with 'if' are
+        preserved (not silently consumed by the conditional matcher).
+
+        Regression test for containers/podman#28645: text starting with 'if'
+        inside a `<<a|b>>` substitution was being interpreted as the start of
+        an `<<if VAR>>` conditional and dropped.
+        """
+        text = ('Note: <<if using the **--ipc=host** option|'
+                'if the ipc namespace is not shared within the pod>>, '
+                'the above sysctls are not allowed.')
+        self.assertEqual(pp.render(text, {'is_quadlet': False}), text)
+
+    def test_unclosed_if_raises(self):
+        """unclosed if blocks still raise"""
+        with self.assertRaisesRegex(ValueError, "unclosed"):
+            pp.render('<<if is_quadlet>>q', {'is_quadlet': True})
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Issue

Closes #28645

## Cause

The Quadlet documentation rewrite (commit `7612af4c`) added a `render()` pass that interprets `<<if VAR>>...<<endif>>` and `<<X if cond else Y>>` conditionals. It runs before the existing `<<a|b>>` substitution (`replace_type`) and the `<<subcommand>>` replacement in `insert_file()`.

When a `<<...>>` token did not match any of the conditional patterns, the loop silently advanced past it without appending anything to the output. Any substitution token whose content didn't fit the conditional grammar was dropped.

The line called out in the issue:

```
Note: <<if using the **--ipc=host** option|if the ipc namespace is not shared within the pod>>, the above sysctls are not allowed.
```

Both halves start with `if`. The inner matches `inner.startswith(\"if \")` but the conditional matcher requires the variable name to be 1 or 2 space-separated tokens, so it falls through. With nothing matching, the token is consumed and the surrounding text becomes `Note: , the above sysctls are not allowed.` — exactly the symptom shown in the bug report.

The same fall-through also dropped `<<subcommand>>` tokens, even though `insert_file()` calls `opt_line.replace('<<subcommand>>', ...)` after rendering.

## Fix

When none of the conditional / inline-if branches match in `render()`, append the original `<<...>>` token verbatim so downstream processing can handle it.

## Tests

`hack/markdown-preprocess.t` previously covered `replace_type` and `podman_subcommand` but had no tests for `render`. This PR adds 8 tests covering:

- Basic `if`/`endif`
- `if`/`else`/`endif`
- `if not VAR`
- Inline `X if cond else Y`
- `<<a|b>>` passes through unchanged
- `<<subcommand>>` passes through unchanged
- Regression case from #28645 (`<<if ...|if ...>>`)
- Unclosed `if` still raises

All 16 tests pass:

```
$ python3 hack/markdown-preprocess.t
................
Ran 16 tests in 0.000s
OK
```

## End-to-end verification

Rendered every file in `docs/source/markdown/options/` (307 files) in both `is_quadlet=True` and `is_quadlet=False` contexts. No regressions.

For the original `sysctl.md` line, the output is now correct in both contexts:

```
container: Note: if using the **--ipc=host** option, the above sysctls are not allowed.
pod:       Note: if the ipc namespace is not shared within the pod, the above sysctls are not allowed.
```