### PR TITLE
docs: fix incorrect page name

### DIFF
--- a/docs/MANPAGE_SYNTAX.md
+++ b/docs/MANPAGE_SYNTAX.md
@@ -1,4 +1,4 @@
-% podman-command(1)
+% podman-command 1
 
 ## NAME
 podman\-command - short description

--- a/docs/source/markdown/podman-build.unit.5.md.in
+++ b/docs/source/markdown/podman-build.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-build.unit(5)
+% podman-build.unit 5
 
 # NAME
 

--- a/docs/source/markdown/podman-container.unit.5.md.in
+++ b/docs/source/markdown/podman-container.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-container.unit(5)
+% podman-container.unit 5
 
 # NAME
 

--- a/docs/source/markdown/podman-image.unit.5.md.in
+++ b/docs/source/markdown/podman-image.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-image.unit(5)
+% podman-image.unit 5
 
 # NAME
 

--- a/docs/source/markdown/podman-kube.unit.5.md.in
+++ b/docs/source/markdown/podman-kube.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-kube.unit(5)
+% podman-kube.unit 5
 
 # NAME
 

--- a/docs/source/markdown/podman-network.unit.5.md.in
+++ b/docs/source/markdown/podman-network.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-network.unit(5)
+% podman-network.unit 5
 
 # NAME
 

--- a/docs/source/markdown/podman-pod.unit.5.md.in
+++ b/docs/source/markdown/podman-pod.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-pod.unit(5)
+% podman-pod.unit 5
 
 # NAME
 

--- a/docs/source/markdown/podman-quadlet-basic-usage.7.md
+++ b/docs/source/markdown/podman-quadlet-basic-usage.7.md
@@ -1,4 +1,4 @@
-% podman-quadlet-basic-usage(7)
+% podman-quadlet-basic-usage 7
 
 # NAME
 

--- a/docs/source/markdown/podman-volume.unit.5.md.in
+++ b/docs/source/markdown/podman-volume.unit.5.md.in
@@ -1,4 +1,4 @@
-% podman-volume.unit(5)
+% podman-volume.unit 5
 
 # NAME
 


### PR DESCRIPTION
The syntax used here was wrong, see all the other existing pages.

Like this the man page gets rendered as "podman-container.unit(5)()" and the HTML web page title will just be "NAME — Podman documentation" instead of the proper man page name.

Fix this by using the right syntax.

Fixes: 7612af4c0e ("Rewrite the Quadlet documentation")

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
