### PR TITLE
rootless podman units: wait for podman-user-wait-network-online.service

### DIFF
--- a/contrib/systemd/user/podman-kube@.service.in
+++ b/contrib/systemd/user/podman-kube@.service.in
@@ -1,1 +1,17 @@
-../system/podman-kube@.service.in
+[Unit]
+Description=A template for running K8s workloads via podman-kube-play
+Documentation=man:podman-kube-play(1)
+Wants=podman-user-wait-network-online.service
+After=podman-user-wait-network-online.service
+RequiresMountsFor=%t/containers
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+TimeoutStopSec=70
+ExecStart=@@PODMAN@@ kube play --replace --service-container=true %I
+ExecStop=@@PODMAN@@ kube down %I
+Type=notify
+NotifyAccess=all
+
+[Install]
+WantedBy=default.target

--- a/contrib/systemd/user/podman-restart.service.in
+++ b/contrib/systemd/user/podman-restart.service.in
@@ -1,1 +1,16 @@
-../system/podman-restart.service.in
+[Unit]
+Description=Podman Start All Containers With Restart Policy Set To Always Or Unless-Stopped
+Documentation=man:podman-start(1)
+StartLimitIntervalSec=0
+Wants=podman-user-wait-network-online.service
+After=podman-user-wait-network-online.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+Environment=LOGGING="--log-level=info"
+ExecStart=@@PODMAN@@ $LOGGING start --all --filter should-start-on-boot=true
+ExecStop=@@PODMAN@@  $LOGGING stop --service --all
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Make sure that the **user** `podman-restart.service` and `podman-kube@.service` services are started only after the `podman-user-wait-network-online.service` service, rather than after the system target `network-online.target` which is not available to user units.

I tried this locally with an overwrite because some containers failed to restart without it (following reboot).

Fixes: #24637
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Rootless `podman-restart.service` and `podman-kube@.service` now wait for `podman-user-wait-network-online.service`.
```