### PR TITLE
pkg/api/grpcpb: auto-format generated protobuf files

### DIFF
--- a/pkg/api/grpcpb/build.sh
+++ b/pkg/api/grpcpb/build.sh
@@ -10,3 +10,6 @@ for proto in *.proto ; do
 		--go-grpc_opt=paths=source_relative --go-grpc_out . \
 	${proto}
 done
+
+# Format generated files
+gofumpt -w -- *.pb.go

--- a/pkg/api/grpcpb/noop.pb.go
+++ b/pkg/api/grpcpb/noop.pb.go
@@ -7,11 +7,12 @@
 package grpcpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -134,11 +135,14 @@ func file_noop_proto_rawDescGZIP() []byte {
 	return file_noop_proto_rawDescData
 }
 
-var file_noop_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_noop_proto_goTypes = []any{
-	(*NoopRequest)(nil),  // 0: io.podman.v1.NoopRequest
-	(*NoopResponse)(nil), // 1: io.podman.v1.NoopResponse
-}
+var (
+	file_noop_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+	file_noop_proto_goTypes  = []any{
+		(*NoopRequest)(nil),  // 0: io.podman.v1.NoopRequest
+		(*NoopResponse)(nil), // 1: io.podman.v1.NoopResponse
+	}
+)
+
 var file_noop_proto_depIdxs = []int32{
 	0, // 0: io.podman.v1.Noop.Noop:input_type -> io.podman.v1.NoopRequest
 	1, // 1: io.podman.v1.Noop.Noop:output_type -> io.podman.v1.NoopResponse

--- a/pkg/api/grpcpb/noop_grpc.pb.go
+++ b/pkg/api/grpcpb/noop_grpc.pb.go
@@ -8,6 +8,7 @@ package grpcpb
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -51,7 +52,7 @@ func (c *noopClient) Noop(ctx context.Context, in *NoopRequest, opts ...grpc.Cal
 // All implementations must embed UnimplementedNoopServer
 // for forward compatibility.
 type NoopServer interface {
-	Noop(context.Context, *NoopRequest) (*NoopResponse, error)
+	Noop(ctx context.Context, in *NoopRequest) (*NoopResponse, error)
 	mustEmbedUnimplementedNoopServer()
 }
 
@@ -62,7 +63,7 @@ type NoopServer interface {
 // pointer dereference when methods are called.
 type UnimplementedNoopServer struct{}
 
-func (UnimplementedNoopServer) Noop(context.Context, *NoopRequest) (*NoopResponse, error) {
+func (UnimplementedNoopServer) Noop(ctx context.Context, in *NoopRequest) (*NoopResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Noop not implemented")
 }
 func (UnimplementedNoopServer) mustEmbedUnimplementedNoopServer() {}


### PR DESCRIPTION
Update build.sh to run gofumpt on generated .pb.go files, and apply formatting to existing generated files. This fixes gofumpt and inamedparam lint errors on macOS CI and ensures future regenerations will be automatically formatted.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
