### PR TITLE
Add `podman machine restart` subcommand

### DIFF
--- a/cmd/podman/machine/restart.go
+++ b/cmd/podman/machine/restart.go
@@ -1,0 +1,67 @@
+//go:build amd64 || arm64
+
+package machine
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/libpod/events"
+	"go.podman.io/podman/v6/pkg/machine"
+	"go.podman.io/podman/v6/pkg/machine/shim"
+)
+
+var (
+	restartCmd = &cobra.Command{
+		Use:               "restart [options] [MACHINE]",
+		Short:             "Restart an existing machine",
+		Long:              "Restart a managed virtual machine",
+		PersistentPreRunE: machinePreRunE,
+		RunE:              restart,
+		Args:              cobra.MaximumNArgs(1),
+		Example:           `podman machine restart podman-machine-default`,
+		ValidArgsFunction: AutocompleteMachine,
+	}
+	restartOpts = machine.StartOptions{}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: restartCmd,
+		Parent:  machineCmd,
+	})
+
+	flags := restartCmd.Flags()
+	noInfoFlagName := "no-info"
+	flags.BoolVar(&restartOpts.NoInfo, noInfoFlagName, false, "Suppress informational tips")
+
+	quietFlagName := "quiet"
+	flags.BoolVarP(&restartOpts.Quiet, quietFlagName, "q", false, "Suppress machine restarting status output")
+}
+
+func restart(_ *cobra.Command, args []string) error {
+	restartOpts.NoInfo = restartOpts.Quiet || restartOpts.NoInfo
+	vmName := defaultMachineName
+	if len(args) > 0 && len(args[0]) > 0 {
+		vmName = args[0]
+	}
+
+	mc, vmProvider, err := shim.VMExists(vmName)
+	if err != nil {
+		return err
+	}
+
+	if !restartOpts.Quiet {
+		fmt.Printf("Restarting machine %q\n", vmName)
+	}
+
+	updateConnection := false
+	if err := shim.StopThenStart(mc, vmProvider, false, restartOpts, &updateConnection); err != nil {
+		return err
+	}
+	fmt.Printf("Machine %q restarted successfully\n", vmName)
+
+	newMachineEvent(events.Restart, events.Event{Name: vmName})
+	return nil
+}

--- a/docs/source/markdown/podman-machine-restart.1.md
+++ b/docs/source/markdown/podman-machine-restart.1.md
@@ -1,0 +1,46 @@
+% podman-machine-restart 1
+
+## NAME
+podman\-machine\-restart - Restart a virtual machine
+
+## SYNOPSIS
+**podman machine restart** [*options*] [*name*]
+
+## DESCRIPTION
+
+Restarts a virtual machine for Podman.
+
+The default machine name is `podman-machine-default`. If a machine name is not specified as an argument,
+then `podman-machine-default` will be restarted.
+
+Stopping an already stopped virtual machine is not considered an error so running restart on a stopped
+virtual machine just starts it from a stopped state.
+
+**podman machine restart** stops and then starts a Linux virtual machine where containers are run.
+
+## OPTIONS
+
+#### **--help**
+
+Print usage statement.
+
+#### **--no-info**
+
+Suppress informational tips.
+
+#### **--quiet**, **-q**
+
+Suppress machine restarting status output.
+
+## EXAMPLES
+
+Restart a podman machine named myvm.
+```
+$ podman machine restart myvm
+```
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-machine(1)](podman-machine.1.md)**, **[podman-machine-start(1)](podman-machine-start.1.md)**, **[podman-machine-stop(1)](podman-machine-stop.1.md)**
+
+## HISTORY
+May 2026, Originally compiled by Jait Jacob <jai8.jacob@gmail.com>

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -44,6 +44,7 @@ supported by platform.  The asterisk denotes the default provider for the platfo
 | list    | [podman-machine-list(1)](podman-machine-list.1.md)       | List virtual machines                                           |
 | os      | [podman-machine-os(1)](podman-machine-os.1.md)           | Manage a Podman virtual machine's OS                            |
 | reset   | [podman-machine-reset(1)](podman-machine-reset.1.md)     | Reset Podman machines and environment                           |
+| restart | [podman-machine-restart(1)](podman-machine-restart.1.md) | Restart a virtual machine                                       |
 | rm      | [podman-machine-rm(1)](podman-machine-rm.1.md)           | Remove a virtual machine                                        |
 | set     | [podman-machine-set(1)](podman-machine-set.1.md)         | Set a virtual machine setting                                   |
 | ssh     | [podman-machine-ssh(1)](podman-machine-ssh.1.md)         | SSH into a virtual machine                                      |
@@ -51,7 +52,7 @@ supported by platform.  The asterisk denotes the default provider for the platfo
 | stop    | [podman-machine-stop(1)](podman-machine-stop.1.md)       | Stop a virtual machine                                          |
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-machine-cp(1)](podman-machine-cp.1.md)**, **[podman-machine-info(1)](podman-machine-info.1.md)**, **[podman-machine-init(1)](podman-machine-init.1.md)**, **[podman-machine-list(1)](podman-machine-list.1.md)**, **[podman-machine-os(1)](podman-machine-os.1.md)**, **[podman-machine-rm(1)](podman-machine-rm.1.md)**, **[podman-machine-ssh(1)](podman-machine-ssh.1.md)**, **[podman-machine-start(1)](podman-machine-start.1.md)**, **[podman-machine-stop(1)](podman-machine-stop.1.md)**, **[podman-machine-inspect(1)](podman-machine-inspect.1.md)**, **[podman-machine-reset(1)](podman-machine-reset.1.md)**, **[containers.conf(5)](https://github.com/containers/container-libs/blob/main/common/docs/containers.conf.5.md)**
+**[podman(1)](podman.1.md)**, **[podman-machine-cp(1)](podman-machine-cp.1.md)**, **[podman-machine-info(1)](podman-machine-info.1.md)**, **[podman-machine-init(1)](podman-machine-init.1.md)**, **[podman-machine-list(1)](podman-machine-list.1.md)**, **[podman-machine-os(1)](podman-machine-os.1.md)**, **[podman-machine-rm(1)](podman-machine-rm.1.md)**, **[podman-machine-ssh(1)](podman-machine-ssh.1.md)**, **[podman-machine-start(1)](podman-machine-start.1.md)**, **[podman-machine-stop(1)](podman-machine-stop.1.md)**, **[podman-machine-inspect(1)](podman-machine-inspect.1.md)**, **[podman-machine-reset(1)](podman-machine-reset.1.md)**, **[podman-machine-restart(1)](podman-machine-restart.1.md)**, **[containers.conf(5)](https://github.com/containers/container-libs/blob/main/common/docs/containers.conf.5.md)**
 
 ### Troubleshooting
 

--- a/pkg/machine/e2e/config_restart_test.go
+++ b/pkg/machine/e2e/config_restart_test.go
@@ -1,0 +1,11 @@
+package e2e_test
+
+type restartMachine struct{}
+
+func (r restartMachine) buildCmd(m *machineTestBuilder) []string {
+	cmd := []string{"machine", "restart"}
+	if len(m.name) > 0 {
+		cmd = append(cmd, m.name)
+	}
+	return cmd
+}

--- a/pkg/machine/e2e/restart_test.go
+++ b/pkg/machine/e2e/restart_test.go
@@ -1,0 +1,66 @@
+package e2e_test
+
+import (
+	"fmt"
+
+	"go.podman.io/podman/v6/pkg/machine/define"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("podman machine restart", func() {
+	It("should tell you when trying to restart a machine that doesn't exist", func() {
+		r := restartMachine{}
+		name := "aVMThatDoesntExist"
+		session, err := mb.setName(name).setCmd(r).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(125))
+		Expect(session.errorToString()).To(ContainSubstring("VM does not exist"))
+	})
+
+	It("should restart a running machine", func() {
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withNow().withVolume("")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		r := restartMachine{}
+		restartSession, err := mb.setName(name).setCmd(r).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(restartSession).To(Exit(0))
+		Expect(restartSession.outputToString()).To(ContainSubstring(fmt.Sprintf("Machine %q restarted successfully", name)))
+
+		inspect := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspect.withFormat("{{.State}}")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		Expect(inspectSession.outputToString()).To(Equal(define.Running))
+	})
+
+	It("should start a stopped machine", func() {
+		name := randomString()
+		i := new(initMachine)
+		session, err := mb.setName(name).setCmd(i.withImage(mb.imagePath).withVolume("")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		inspect := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspect.withFormat("{{.State}}")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		Expect(inspectSession.outputToString()).To(Equal(define.Stopped))
+
+		r := restartMachine{}
+		restartSession, err := mb.setName(name).setCmd(r).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(restartSession).To(Exit(0))
+
+		inspectSession, err = mb.setName(name).setCmd(inspect.withFormat("{{.State}}")).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inspectSession).To(Exit(0))
+		Expect(inspectSession.outputToString()).To(Equal(define.Running))
+	})
+})

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -439,23 +439,29 @@ func StopThenStart(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, hardSto
 	}
 	mc.Lock()
 	defer mc.Unlock()
-	if err := mc.Refresh(); err != nil {
-		return fmt.Errorf("reload config: %w", err)
-	}
-
-	if err := stopLocked(mc, mp, dirs, hardStop); err != nil {
+	err = mc.Refresh()
+	if err != nil {
+		err = fmt.Errorf("reload config: %w", err)
 		return err
 	}
 
-	if err := mc.Refresh(); err != nil {
-		return fmt.Errorf("reload config: %w", err)
+	err = stopLocked(mc, mp, dirs, hardStop)
+	if err != nil {
+		return err
+	}
+
+	err = mc.Refresh()
+	if err != nil {
+		err = fmt.Errorf("reload config: %w", err)
+		return err
 	}
 
 	callbackFuncs := machine.CleanUp()
 	defer callbackFuncs.CleanIfErr(&err)
 	go callbackFuncs.CleanOnSignal(opts.Quiet)
 
-	return startLocked(mc, mp, dirs, opts, updateSystemConn, &callbackFuncs)
+	err = startLocked(mc, mp, dirs, opts, updateSystemConn, &callbackFuncs)
+	return err
 }
 
 // stopLocked stops the machine and expects the caller to hold the machine's lock.
@@ -537,11 +543,14 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 		defer func() { _ = mcunlock() }()
 	}
 
-	if err = mc.Refresh(); err != nil {
-		return fmt.Errorf("reload config: %w", err)
+	err = mc.Refresh()
+	if err != nil {
+		err = fmt.Errorf("reload config: %w", err)
+		return err
 	}
 
-	return startLocked(mc, mp, dirs, opts, updateSystemConn, &callbackFuncs)
+	err = startLocked(mc, mp, dirs, opts, updateSystemConn, &callbackFuncs)
+	return err
 }
 
 // startLocked starts the machine and expects the caller to hold the machine's lock.

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -431,6 +431,33 @@ func Stop(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, hardStop bool) e
 	return stopLocked(mc, mp, dirs, hardStop)
 }
 
+// StopThenStart stops and starts the machine while holding its lock.
+func StopThenStart(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, hardStop bool, opts machine.StartOptions, updateSystemConn *bool) error {
+	dirs, err := env.GetMachineDirs(mp.VMType())
+	if err != nil {
+		return err
+	}
+	mc.Lock()
+	defer mc.Unlock()
+	if err := mc.Refresh(); err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
+
+	if err := stopLocked(mc, mp, dirs, hardStop); err != nil {
+		return err
+	}
+
+	if err := mc.Refresh(); err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
+
+	callbackFuncs := machine.CleanUp()
+	defer callbackFuncs.CleanIfErr(&err)
+	go callbackFuncs.CleanOnSignal(opts.Quiet)
+
+	return startLocked(mc, mp, dirs, opts, updateSystemConn, &callbackFuncs)
+}
+
 // stopLocked stops the machine and expects the caller to hold the machine's lock.
 func stopLocked(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDefine.MachineDirs, hardStop bool) error {
 	state, err := mp.State(mc, false)
@@ -476,28 +503,17 @@ func stopLocked(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *mach
 }
 
 func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.StartOptions, updateSystemConn *bool) error {
-	var (
-		err                     error
-		updateDefaultConnection bool
-	)
+	dirs, err := env.GetMachineDirs(mp.VMType())
+	if err != nil {
+		return err
+	}
 
-	defaultBackoff := 500 * time.Millisecond
-	maxBackoffs := 6
-
-	// startup rollaback functions
-	// called if an error occurs or if a
-	// a termination signal is sent
 	callbackFuncs := machine.CleanUp()
 	defer callbackFuncs.CleanIfErr(&err)
 	// The following goroutine will block waiting
 	// for a termination signal. If no signal is received
 	// the routine is aborted when the main goroutine terminates.
 	go callbackFuncs.CleanOnSignal(opts.Quiet)
-
-	dirs, err := env.GetMachineDirs(mp.VMType())
-	if err != nil {
-		return err
-	}
 
 	if !opts.ReExec {
 		mc.Lock()
@@ -524,6 +540,16 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 	if err = mc.Refresh(); err != nil {
 		return fmt.Errorf("reload config: %w", err)
 	}
+
+	return startLocked(mc, mp, dirs, opts, updateSystemConn, &callbackFuncs)
+}
+
+// startLocked starts the machine and expects the caller to hold the machine's lock.
+func startLocked(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDefine.MachineDirs, opts machine.StartOptions, updateSystemConn *bool, callbackFuncs *machine.CleanupCallback) error {
+	var updateDefaultConnection bool
+
+	defaultBackoff := 500 * time.Millisecond
+	maxBackoffs := 6
 
 	connName := mc.Name
 	if mc.HostUser.Rootful {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Yes? No action needed when upgrading?
```
Fixes #28366

This PR implements `podman machine restart` subcommand.

Here's how I tested it,
1. Locally build `podman` binary using `make BUILDTAGS="selinux seccomp" PREFIX=/usr`
2. `cd bin/`
3. Run `./podman machine restart --help` & verify help text displays correctly.
```
jaitjacob@fedora:~/Documents/workbench/podman/bin$ ./podman machine restart --help
Restart an existing machine

Description:
  Restart a managed virtual machine

Usage:
  podman machine restart [MACHINE]

Examples:
  podman machine restart podman-machine-default
```
5. Run `./podman machine list`
```
jaitjacob@fedora:~/Documents/workbench/podman/bin$ ./podman machine list
NAME                     VM TYPE     CREATED      LAST UP            CPUS        MEMORY      DISK SIZE
podman-machine-default*  qemu        3 hours ago  About an hour ago  2           2GiB        10GiB
```
6. Run `./podman machine start`
```
jaitjacob@fedora:~/Documents/workbench/podman/bin$ ./podman machine start
Starting machine "podman-machine-default"

This machine is currently configured in rootless mode. If your containers
require root permissions (e.g. ports < 1024), or if you run into compatibility
issues with non-podman clients, you can switch using the following command:

        podman machine set --rootful

Mounting volume... /home/jaitjacob:/home/jaitjacob
API forwarding listening on: /run/user/1000/podman/podman-machine-default-api.sock
You can connect Docker API clients by setting DOCKER_HOST using the
following command in your terminal session:

        export DOCKER_HOST='unix:///run/user/1000/podman/podman-machine-default-api.sock'

Machine "podman-machine-default" started successfully
```
7. SSH into VM and check `uptime`
```
jaitjacob@fedora:~/Documents/workbench/podman/bin$ ./podman machine ssh
Connecting to vm podman-machine-default. To close connection, use `~.` or `exit`
Fedora CoreOS 43.20260316.3.1
Tracker: https://github.com/coreos/fedora-coreos-tracker
Discuss: https://discussion.fedoraproject.org/tag/coreos

Last login: Mon May 11 22:26:20 2026 from 192.168.127.1
core@localhost:~$ uptime -p
up 0 minutes
core@localhost:~$ uptime -s
2026-05-12 00:36:59
```
8.  Wait couple mins and run `./podman machine restart`
```
jaitjacob@fedora:~/Documents/workbench/podman/bin$ ./podman machine restart
Waiting for VM to exit...
Machine "podman-machine-default" stopped successfully

This machine is currently configured in rootless mode. If your containers
require root permissions (e.g. ports < 1024), or if you run into compatibility
issues with non-podman clients, you can switch using the following command:

        podman machine set --rootful

Mounting volume... /home/jaitjacob:/home/jaitjacob
API forwarding listening on: /run/user/1000/podman/podman-machine-default-api.sock
You can connect Docker API clients by setting DOCKER_HOST using the
following command in your terminal session:

        export DOCKER_HOST='unix:///run/user/1000/podman/podman-machine-default-api.sock'

Machine "podman-machine-default" started successfully
```
10. SSH into VM and Check `uptime` again
```
jaitjacob@fedora:~/Documents/workbench/podman/bin$ ./podman machine ssh
Connecting to vm podman-machine-default. To close connection, use `~.` or `exit`
Fedora CoreOS 43.20260316.3.1
Tracker: https://github.com/coreos/fedora-coreos-tracker
Discuss: https://discussion.fedoraproject.org/tag/coreos

Last login: Tue May 12 00:37:17 2026 from 192.168.127.1
core@localhost:~$ uptime -p
up 0 minutes
core@localhost:~$ uptime -s
2026-05-12 00:39:14
```

I also built the docs locally and viewed in browser,
<img width="615" height="538" alt="1" src="https://github.com/user-attachments/assets/0690d536-7231-461f-8d91-6feb8e36a0f0" />

<img width="615" height="538" alt="2" src="https://github.com/user-attachments/assets/a692508f-3275-4718-acbd-705b1b1c2da2" />




