### PR TITLE
test: Add API test for partial pull with pullProgress flag

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -550,4 +550,58 @@ done
 # Clean up
 podman rmi -f quay.io/libpod/alpine:latest >/dev/null 2>&1 || true
 
+# Test pullProgress=true with zstd:chunked image from local registry
+# Restart service with a custom storage.conf (enable_partial_images = "true")
+stop_service
+CONTAINERS_STORAGE_CONF=$TESTS_DIR/storage.partial-pull.conf start_service
+start_registry
+
+# Build the image
+CHUNKED_TMPD=$(mktemp -d podman-apiv2-test.chunked.XXXXXXXX)
+echo "$(random_string 256)" > $CHUNKED_TMPD/content1
+echo "$(random_string 256)" > $CHUNKED_TMPD/content2
+echo "$(random_string 256)" > $CHUNKED_TMPD/content3
+cat > $CHUNKED_TMPD/Containerfile << EOF
+FROM scratch
+ADD content1 /content1
+ADD content2 /content2
+ADD content3 /content3
+EOF
+podman image build -t chunked-test:latest $CHUNKED_TMPD
+
+# Push it to the local registry
+podman push --tls-verify=false --force-compression \
+    --compression-format=zstd:chunked \
+    chunked-test:latest docker://localhost:$REGISTRY_PORT/chunked-test:latest
+
+# Remove the local image to force a fresh pull
+podman rmi -f chunked-test:latest >/dev/null 2>&1 || true
+
+# Pull via API with pullProgress=true
+t POST "libpod/images/pull?reference=localhost:$REGISTRY_PORT/chunked-test:latest&pullProgress=true&tlsVerify=false" 200 \
+  .status~".*success.*" \
+  .stream~".*Starting to pull artifact.*" \
+  .stream~".*Artifact pulled successfully.*"
+
+# Get layer digests (output has the 'sha256:' prefix) for verification
+layer_digests=$(skopeo inspect --tls-verify=false \
+    docker://localhost:$REGISTRY_PORT/chunked-test:latest | jq -r '.Layers[]')
+
+# Verify each layer digest appears as a progressComponentID in the pullProgress stream
+for layer_id in $layer_digests; do
+    like "$output" ".*\"total\":[1-9][0-9]*,\"progressComponentID\":\"${layer_id}\".*" \
+         "pullProgress reports total for layer $layer_id"
+    like "$output" ".*\"current\":[1-9][0-9]*,\"total\":[1-9][0-9]*,\"progressComponentID\":\"${layer_id}\".*" \
+         "pullProgress reports current for layer $layer_id"
+done
+
+# Clean up
+podman rmi -f localhost:$REGISTRY_PORT/chunked-test:latest >/dev/null 2>&1 || true
+rm -rf $CHUNKED_TMPD
+stop_registry
+
+# Restart service without modified storage.conf
+stop_service
+start_service
+
 # vim: filetype=sh

--- a/test/apiv2/storage.partial-pull.conf
+++ b/test/apiv2/storage.partial-pull.conf
@@ -1,0 +1,2 @@
+[storage.options.pull_options]
+enable_partial_images = "true"

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -580,7 +580,7 @@ function start_registry() {
            ${REGISTRY_IMAGE}
 
     wait_for_port localhost $REGISTRY_PORT 10
-    echo "# started registry (auth=$auth) on port $PORT"
+    echo "# started registry (auth=$auth) on port $REGISTRY_PORT"
 }
 
 function stop_registry() {
@@ -595,7 +595,7 @@ function stop_registry() {
         if [[ "$1" = "--cleanup" ]]; then
             podman $OPTS rmi -f -a
         fi
-        echo "# stopped registry on port $PORT"
+        echo "# stopped registry on port $REGISTRY_PORT"
     fi
 
     REGISTRY_PORT=

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -482,7 +482,8 @@ function start_service() {
         $PODMAN_BIN unshare true
     fi
 
-    CONTAINERS_REGISTRIES_CONF=$registries_conf_path \
+    env CONTAINERS_REGISTRIES_CONF=$registries_conf_path \
+        ${CONTAINERS_STORAGE_CONF:+CONTAINERS_STORAGE_CONF=$CONTAINERS_STORAGE_CONF} \
         $PODMAN_BIN \
         --root $WORKDIR/server_root --syslog=true \
         system service \
@@ -655,6 +656,7 @@ function wait_for_port() {
 function podman() {
     echo "\$ $PODMAN_BIN $*"                           >>$WORKDIR/output.log
     env CONTAINERS_REGISTRIES_CONF=$registries_conf_path \
+        ${CONTAINERS_STORAGE_CONF:+CONTAINERS_STORAGE_CONF=$CONTAINERS_STORAGE_CONF} \
         $PODMAN_BIN --root $WORKDIR/server_root "$@"   >>$WORKDIR/output.log 2>&1
 }
 


### PR DESCRIPTION
- Progress reporting in `container-libs/image` did not update the progress channel for chunked layers. 
This PR adds a test that builds a new image with chunked layers, pulls it using the REST API `images/pull` endpoint with the `pullProgress` flag introduced in https://github.com/containers/podman/pull/28224 and verifies that the progress stream contains events for partial pulls too.

The fix for the container-libs bug needs to be merged first. ~~The test currently fails as expected.~~ EDIT: Vendored latest `c/image`.
Depends-on: https://github.com/podman-container-tools/container-libs/pull/848

- Log a correct container registry port in `start_registry`.

## Current outcome of the test:
```
ok 336 [10-images] POST libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true [-d {}] : .status ('pulling') ~ .*success.*
ok 337 [10-images] POST libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true [-d {}] : .stream ('Trying to pull quay.io/libpod/alpine:latest...') ~ .*Artifact pulled successfully.*
ok 338 [10-images] pullProgress shows layer ID 161a397ac5ee9e631cd79cdfb5f0b36a861071d42e67afe98ed3cb69155ea5ff ('{"status":"pulling","stream":"Trying to pull quay.io/libpod/alpine:latest...
"}') ~ .*161a397ac5ee9e631cd79cdfb5f0b36a861071d42e67afe98ed3cb69155ea5ff.*
...+......+.....+...+....+.....+......+..........+.........+..+................+...+.....+....+...+++++++++++++++++++++++++++++++++++++++++++++*.......+.+..+....+......+.....+.........+.+...+.........+..+.+.....+.......+......+++++++++++++++++++++++++++++++++++++++++++++*..+.......+........+.......+...+..+.+......+...+..................+........+......+.........+.......+........+.+...+..+...............+.............+...+...+......+...+..+.....................+...+.......+........+.........+.......+...+.................................+..................+......+.........+..+.........+....+............+..............+..........+......+...+............+..+.......+...+.....+.+.....+....+...+........+.......+.........+.....+........................+......+................+.....+............+...............+.+...............+.....+.........+...+............+............+.+............+......+..+...........................+.......+...+...+...+++++
...........+........+++++++++++++++++++++++++++++++++++++++++++++*....+....+..+.......+++++++++++++++++++++++++++++++++++++++++++++*.....+...+..+.+..+............+....+..+...............+...+......+......+...+.........+.+..+....+...+........+.......+........+...+......+................+........+......+.+..+...+..........+........+..........+......+.........+..+............+..........+..+...............+....+.........+........+........................+...+..........+......+..+...+.........+.............+..+......+...............+.+........+...+...............+...+......+....+.................+....+........+..........+...+..................+..+....+......+.....+...+....+......+..+...+......+...............+...+.+............+..+..........+......+......+.........+......+.....+.+........+......+.+...............+..+.......+........+.+......+...+...+.....+.........................+............+..+...+......+..........+..+.........+.+...+...........+..........+.........+..............................+.....+.......+.........+...+..+....+..+.........+.+..+.....................+............+....+........+.............+........+....+..................+............+.....+.......+........+..........+...+..+.+..+....+....................+...............+...+.......+...........+..........+.....+....+.........+..+...+.+....................+...+.+............+........+.......+..+..........+...+..............+.+.................+.............+...+.........+...+..+.............+...+..+...............+.........+....+.....+....+..+....+..+............+..........+......+..+..................+.+..................+...+..............+.........+.....................+....+......+....................+...+.+..........................+.........+.+.........+.....+......+.+..+.+...........+......+...............+...+.......+.........+........+.......+.....+.+.....+....+...+...+...+.....+......+.............+.....+...............+.......+...+...+........+.+.....+..........+...+........+...+....+...+...+.....+......+.+............+............+........+..........+...+..............+..........+......+..+............+.+............+......+......+...+..+......+...+....+.................+....+..............+...............+.............+...+..+..........+.................+......+.........+...+...+......+...+.....................+......+...+......+....+......+..+.......+......+..+..................+....+...+.........+.....+...+.+......+.....+....+......+.............................................+..............+....+...+.........+.........+...............+..+..........+..+.......+.....+.+.....+...+......+....+.........+......+......+...+...............+..+.........+......+.........+................+..................+...............+.....+......+....+...+..................+............+..+............+...+......+.+.....+.........+................+..............+.......+.....+.......+..+++++
-----
# started registry (auth=none) on port 8081
ok 339 [10-images] POST libpod/images/pull?reference=localhost:5328/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : status=200
ok 340 [10-images] POST libpod/images/pull?reference=localhost:5328/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : .status ('pulling') ~ .*success.*
ok 341 [10-images] POST libpod/images/pull?reference=localhost:5328/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : .stream ('Trying to pull localhost:5328/chunked-test:latest...') ~ .*Starting to pull artifact.*
ok 342 [10-images] POST libpod/images/pull?reference=localhost:5328/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : .stream ('Trying to pull localhost:5328/chunked-test:latest...') ~ .*Artifact pulled successfully.*
not ok 343 [10-images] pullProgress reports sha256:d684db2c15374e8c5797c138c5211bb8a0db426663c34042f14ff91519c4ba06 as progressComponentID
#  expected: ~ .*progressComponentID.*sha256:d684db2c15374e8c5797c138c5211bb8a0db426663c34042f14ff91519c4ba06.*
#    actual: {"status":"pulling","stream":"Trying to pull localhost:5328/chunked-test:latest...
"}
{"status":"pulling","stream":"Getting image source signatures
"}
{"status":"pulling","stream":"Copying blob sha256:d684db2c15374e8c5797c138c5211bb8a0db426663c34042f14ff91519c4ba06
"}
{"status":"pulling","stream":"Copying config sha256:a72eb130ce0f10876fdd2f367c24516ed3fd583f360a8da860b390232c3491b8
"}
{"status":"pulling","stream":"Starting to pull artifact","pullProgress":{"status":"pulling","total":542,"progressComponentID":"sha256:a72eb130ce0f10876fdd2f367c24516ed3fd583f360a8da860b390232c3491b8"}}
{"status":"pulling","stream":"Artifact pulled successfully","pullProgress":{"status":"success","current":542,"total":542,"progressComponentID":"sha256:a72eb130ce0f10876fdd2f367c24516ed3fd583f360a8da860b390232c3491b8"}}
{"status":"pulling","stream":"Writing manifest to image destination
"}
{"status":"success","images":["a72eb130ce0f10876fdd2f367c24516ed3fd583f360a8da860b390232c3491b8"],"id":"a72eb130ce0f10876fdd2f367c24516ed3fd583f360a8da860b390232c3491b8"}
```
## Test with changes applied:
```
ok 334 [10-images] POST libpod/images/pull?reference=localhost:5000/idonotexist:latest&pullProgress=true [-d {}] : .response=500
ok 335 [10-images] POST libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true [-d {}] : status=200
ok 336 [10-images] POST libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true [-d {}] : .status ('pulling') ~ .*success.*
ok 337 [10-images] POST libpod/images/pull?reference=quay.io/libpod/alpine:latest&pullProgress=true [-d {}] : .stream ('Trying to pull quay.io/libpod/alpine:latest...') ~ .*Artifact pulled successfully.*
ok 338 [10-images] pullProgress shows layer ID 161a397ac5ee9e631cd79cdfb5f0b36a861071d42e67afe98ed3cb69155ea5ff ('{"status":"pulling","stream":"Trying to pull quay.io/libpod/alpine:latest...
"}') ~ .*161a397ac5ee9e631cd79cdfb5f0b36a861071d42e67afe98ed3cb69155ea5ff.*
....+.....+...+.+..+...+.+.........+.........+..+...+.+.....+......+.+............+...+++++++++++++++++++++++++++++++++++++++++++++*.+...+....+...+..+..........+........+...+....+...+...+...........+...+.+.....+.+++++++++++++++++++++++++++++++++++++++++++++*.+...+...+.+......+........+...............+.+...........+...+.+........+...+...+......+.........+.........+++++
.....+......+.....+...+.......+.....+.+.................+...............+.+..+..................+..........+.....+.......+...+...........+.........+..........+..+++++++++++++++++++++++++++++++++++++++++++++*............+...+..+....+...+..+.........+...............+......+.........+.+.....+.+..+...+.......+...........+....+...........+....+...+.....+............+.+..+..................+.+.........+...........+.+...........................+......+..+++++++++++++++++++++++++++++++++++++++++++++*.+.....+..........+++++
-----
# started registry (auth=none) on port 8081
ok 339 [10-images] POST libpod/images/pull?reference=localhost:5383/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : status=200
ok 340 [10-images] POST libpod/images/pull?reference=localhost:5383/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : .status ('pulling') ~ .*success.*
ok 341 [10-images] POST libpod/images/pull?reference=localhost:5383/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : .stream ('Trying to pull localhost:5383/chunked-test:latest...') ~ .*Starting to pull artifact.*
ok 342 [10-images] POST libpod/images/pull?reference=localhost:5383/chunked-test:latest&pullProgress=true&tlsVerify=false [-d {}] : .stream ('Trying to pull localhost:5383/chunked-test:latest...') ~ .*Artifact pulled successfully.*
ok 343 [10-images] pullProgress reports sha256:63ff4cd0ff8a821b4b8cfb03f5c6a2579d8000cc074fbb498226a7bbfcd0b5d1 as progressComponentID ('{"status":"pulling","stream":"Trying to pull localhost:5383/chunked-test:latest...
"}') ~ .*progressComponentID.*sha256:63ff4cd0ff8a821b4b8cfb03f5c6a2579d8000cc074fbb498226a7bbfcd0b5d1.*
```


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?
None.

