### PR TITLE
compat: Implement deprecations from Docker API v1.44

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -212,6 +212,12 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
+	if _, err := utils.SupportedVersion(r, ">=1.52.0"); err == nil || errors.Is(err, apiutil.ErrVersionNotGiven) {
+		if api.NetworkSettings != nil {
+			api.NetworkSettings.SecondaryIPAddresses = nil
+			api.NetworkSettings.SecondaryIPv6Addresses = nil
+		}
+	}
 	utils.WriteResponse(w, http.StatusOK, api)
 }
 

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -418,7 +418,7 @@ func imageDataToImageInspect(ctx context.Context, l *libimage.Image, r *http.Req
 	}
 
 	if _, err := apiutil.SupportedVersion(r, "<1.45.0"); err == nil {
-		imageInspect.ContainerConfig = cc
+		imageInspect.ContainerConfig = cc //nolint:staticcheck // Deprecated field
 	}
 
 	return &imageInspect, nil

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/moby/moby/api/types/registry"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/libpod"
 	"go.podman.io/podman/v6/pkg/api/handlers/utils"
@@ -77,7 +78,26 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 			utils.ImageNotFound(w, query.Term, storage.ErrImageUnknown)
 			return
 		}
+		compatResults := make([]registry.SearchResult, len(reports))
+		for i, r := range reports {
+			compatResults[i] = registry.SearchResult{
+				Name:        r.Name,
+				Description: r.Description,
+				StarCount:   r.Stars,
+				IsOfficial:  toBool(r.Official),
+				IsAutomated: toBool(r.Automated),
+			}
+		}
+		utils.WriteResponse(w, http.StatusOK, compatResults)
+		return
 	}
 
 	utils.WriteResponse(w, http.StatusOK, reports)
+}
+
+// toBool converts the string representation
+// of ImageSearchReport's Automated and Official fields
+// to bool that the Docker representation uses.
+func toBool(s string) bool {
+	return s == entities.ImageSearchTrue
 }

--- a/pkg/api/handlers/swagger/responses.go
+++ b/pkg/api/handlers/swagger/responses.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	dockerImage "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/volume"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/image/v5/manifest"
@@ -93,6 +94,13 @@ type imageDeleteResponse struct {
 // Registry Search
 // swagger:response
 type registrySearchResponse struct {
+	// in:body
+	Body []registry.SearchResult
+}
+
+// Registry Search
+// swagger:response
+type registrySearchResponseLibpod struct {
 	// in:body
 	Body []entities.ImageSearchReport
 }

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -25,7 +25,12 @@ type ImageInspect struct {
 	// If a field in the outer struct has the same name as a field in the embedded struct,
 	// the outer struct's field will shadow or override the embedded one allowing for a clean way to
 	// hide fields from the swagger spec that still exist in the libraries struct.
-	Container       string                  `json:"Container,omitempty"`
+	//
+	// Deprecated: since API v1.44, will no longer be included in API v1.45.
+	// https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes
+	Container string `json:"Container,omitempty"`
+	// Deprecated: since API v1.44, will no longer be included in API v1.45.
+	// https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes
 	ContainerConfig *dockerContainer.Config `json:"ContainerConfig,omitempty"`
 	VirtualSize     int64                   `json:"VirtualSize,omitempty"`
 	Parent          string                  `json:"Parent"`

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1287,7 +1287,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// - application/json
 	// responses:
 	//   200:
-	//      $ref: "#/responses/registrySearchResponse"
+	//      $ref: "#/responses/registrySearchResponseLibpod"
 	//   500:
 	//      $ref: '#/responses/internalError'
 	r.Handle(VersionedPath("/libpod/images/search"), s.APIHandler(compat.SearchImages)).Methods(http.MethodGet)

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -220,6 +220,10 @@ type ImageSearchOptions struct {
 	ListTags bool
 }
 
+// ImageSearchTrue is the string representation of true for
+// the Official and Automated fields in ImageSearchReport.
+const ImageSearchTrue = entitiesTypes.ImageSearchTrue
+
 // ImageSearchReport is the response from searching images.
 type ImageSearchReport = entitiesTypes.ImageSearchReport
 

--- a/pkg/domain/entities/types/images.go
+++ b/pkg/domain/entities/types/images.go
@@ -62,6 +62,10 @@ type ImageImportReport struct {
 	Id string
 }
 
+// ImageSearchTrue is the string representation of true for
+// the Official and Automated fields in ImageSearchReport.
+const ImageSearchTrue = "[OK]"
+
 // ImageSearchReport is the response from searching images.
 type ImageSearchReport struct {
 	// Index is the image index (e.g., "docker.io" or "quay.io")
@@ -73,8 +77,10 @@ type ImageSearchReport struct {
 	// Stars is the number of stars of the image.
 	Stars int
 	// Official indicates if it's an official image.
+	// ImageSearchTrue represents true and "" is false.
 	Official string
 	// Automated indicates if the image was created by an automated build.
+	// ImageSearchTrue represents true and "" is false.
 	Automated string
 	// Tag is the repository tag
 	Tag string

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -567,9 +567,16 @@ func (ir *ImageEngine) Search(ctx context.Context, term string, opts entities.Im
 		reports[i].Name = searchResults[i].Name
 		reports[i].Description = searchResults[i].Description
 		reports[i].Stars = searchResults[i].Stars
-		reports[i].Official = searchResults[i].Official
-		reports[i].Automated = searchResults[i].Automated
 		reports[i].Tag = searchResults[i].Tag
+
+		// Use the bool methods to make sure
+		// we have a stable string representation.
+		if searchResults[i].IsOfficial() {
+			reports[i].Official = entities.ImageSearchTrue
+		}
+		if searchResults[i].IsAutomated() {
+			reports[i].Automated = entities.ImageSearchTrue
+		}
 	}
 
 	return reports, nil

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -535,13 +535,22 @@ class ContainerCompatibleAPITestCase(APITestCase):
             r = requests.post(self.uri(self.resolve_container("/containers/{}/start")))
             self.assertIn(r.status_code, (204, 304), r.text)
 
-            r = requests.get(self.compat_uri(self.resolve_container("/containers/{}/json")))
+            container_uri = self.resolve_container("/containers/{}/json")
+
+            # SecondaryIPAddresses present for API < v1.52
+            r = requests.get(self.podman_url + "/v1.44/" + container_uri)
             self.assertEqual(r.status_code, 200, r.text)
             self.assertId(r.content)
             out = r.json()
-
             self.assertEqual("10.0.2.0", out["NetworkSettings"]["SecondaryIPAddresses"][0]["Addr"])
             self.assertEqual(24, out["NetworkSettings"]["SecondaryIPAddresses"][0]["PrefixLen"])
+
+            # SecondaryIPAddresses removed for API >= v1.52
+            r = requests.get(self.podman_url + "/v1.52/" + container_uri)
+            self.assertEqual(r.status_code, 200, r.text)
+            self.assertId(r.content)
+            out = r.json()
+            self.assertIsNone(out["NetworkSettings"].get("SecondaryIPAddresses"))
         finally:
             delete_named_network_ns(network_ns_name)
 

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -1,7 +1,5 @@
 import json
 import unittest
-import multiprocessing as mp
-
 import requests
 from dateutil.parser import parse
 from .fixtures import APITestCase
@@ -164,18 +162,33 @@ class ImageTestCase(APITestCase):
         self.assertEqual(r.status_code, 200, r.text)
 
     def test_search_compat(self):
-        url = self.podman_url + "/v1.40/images/search"
+        url = self.podman_url + "/v1.44/images/search"
 
         # Had issues with this test hanging when repositories not happy
         def do_search1():
+            required_keys = (
+                "description",
+                "is_automated",  # Deprecated: always false.
+                "is_official",
+                "name",
+                "star_count",
+            )
             payload = {"term": "alpine"}
-            r = requests.get(url, params=payload, timeout=5)
+            r = requests.get(url, params=payload, timeout=30)
             self.assertEqual(r.status_code, 200, f"#1: {r.text}")
-            self.assertIsInstance(r.json(), list)
+
+            results = r.json()
+            self.assertIsInstance(results, list)
+            for item in results:
+                for k in required_keys:
+                    self.assertIn(k, item)
 
         def do_search2():
-            payload = {"term": "alpine", "limit": 1}
-            r = requests.get(url, params=payload, timeout=5)
+            # The containers.conf uses:
+            #   compat_api_enforce_docker_hub=false
+            # and full name needs to be used here.
+            payload = {"term": "docker.io/library/alpine", "limit": 1}
+            r = requests.get(url, params=payload, timeout=30)
             self.assertEqual(r.status_code, 200, f"#2: {r.text}")
 
             results = r.json()
@@ -186,7 +199,7 @@ class ImageTestCase(APITestCase):
             # FIXME: Research if quay.io supports is-official and which image is "official"
             return
             payload = {"term": "thanos", "filters": '{"is-official":["true"]}'}
-            r = requests.get(url, params=payload, timeout=5)
+            r = requests.get(url, params=payload, timeout=30)
             self.assertEqual(r.status_code, 200, f"#3: {r.text}")
 
             results = r.json()
@@ -198,32 +211,18 @@ class ImageTestCase(APITestCase):
         def do_search4():
             headers = {"X-Registry-Auth": "null"}
             payload = {"term": "alpine"}
-            r = requests.get(url, params=payload, headers=headers, timeout=5)
+            r = requests.get(url, params=payload, headers=headers, timeout=30)
             self.assertEqual(r.status_code, 200, f"#4: {r.text}")
 
         def do_search5():
             headers = {"X-Registry-Auth": "invalid value"}
             payload = {"term": "alpine"}
-            r = requests.get(url, params=payload, headers=headers, timeout=5)
+            r = requests.get(url, params=payload, headers=headers, timeout=30)
             self.assertEqual(r.status_code, 400, f"#5: {r.text}")
 
-        i = 1
-        # Need to explicitly set start method
-        # # https://docs.python.org/dev/library/multiprocessing.html#contexts-and-start-methods
-        mp.set_start_method('fork')
-        for fn in [do_search1, do_search2, do_search3, do_search4, do_search5]:
+        for i, t in enumerate([do_search1, do_search2, do_search3, do_search4, do_search5], start=1):
             with self.subTest(i=i):
-                search = mp.Process(target=fn)
-                search.start()
-                search.join(timeout=10)
-                self.assertFalse(search.is_alive(), f"#{i} /images/search took too long")
-
-        # search_methods = [do_search1, do_search2, do_search3, do_search4, do_search5]
-        # for search_method in search_methods:
-        #     search = Process(target=search_method)
-        #     search.start()
-        #     search.join(timeout=10)
-        #     self.assertFalse(search.is_alive(), "/images/search took too long")
+                t()
 
     def test_history(self):
         r = requests.get(self.podman_url + "/v1.40/images/alpine/history")


### PR DESCRIPTION
This PR implements API deprecations to be compatible with [Docker API v1.44](https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes).

- api: Deprecate fields `Container` and `ContainerConfig` from GET `/images/{name}/json`
- api: Deprecate response fields `HairpinMode`, `LinkLocalIPv6Address`,
`LinkLocalIPv6PrefixLen`, `SecondaryIPAddresses`, `SecondaryIPv6Addresses` from GET `/containers/{id}/json`
- api: Deprecate `is-automated filter` for the GET `/images/search` endpoint

### Deprecations in Docker Engine API v1.44 API

> Deprecated: The is_automated field in the GET /images/search response has been deprecated and will always be set to false in the future because Docker Hub is deprecating the is_automated field in its search API. The deprecation is not versioned, and applies to all API versions.
> Deprecated: The is-automated filter for the GET /images/search endpoint. The is_automated field has been deprecated by Docker Hub's search API. Consequently, searching for is-automated=true will yield no results. The deprecation is not versioned, and applies to all API versions.

> The fields HairpinMode, LinkLocalIPv6Address, LinkLocalIPv6PrefixLen, SecondaryIPAddresses, SecondaryIPv6Addresses available in NetworkSettings when calling GET /containers/{id}/json are deprecated and will be removed in a future release. You should instead look for the default network in NetworkSettings.Networks.

> The Container and ContainerConfig fields in the GET /images/{name}/json response are deprecated and will no longer be included in API v1.45.

**Fixes**: https://redhat.atlassian.net/browse/RUN-3323

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
- api: is_automated field in the Compat GET /images/search response has been deprecated 
- api: is-automated filter for the Compat GET /images/search endpoint has been deprecated and will be ignored
- api: fields HairpinMode, LinkLocalIPv6Address, LinkLocalIPv6PrefixLen, SecondaryIPAddresses, SecondaryIPv6Addresses available in NetworkSettings when calling Compat GET /containers/{id}/json are deprecated
- api: Container and ContainerConfig fields in the Compat GET /images/{name}/json response are deprecated
```

### Questions and Notes
- The changes to `is_automated` are according to the Docker docs `not versioned, and apply to all API versions`. Hence, I'm not sure if my approach is correct.
- Should there be any warning log? I couldn't find any example of that in the existing code.
- The [PR](https://github.com/containers/podman/pull/27172) version gated the `ContainerConfig` field for `v1.45` so I kept the version. https://github.com/containers/podman/pull/27172
- The test mocked output in [search_mock_registry.go](https://github.com/containers/podman/blob/main/test/e2e/search_mock_registry.go) includes `is_automated` and I kept it there.