### PR TITLE
quadlet: only log to kmsg when running under systemd

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -66,11 +66,33 @@ func logToKmsg(s string) bool {
 	return true
 }
 
+func shouldLogToStderr(kmsgOK bool, dryRun bool, stderrIsTerminal bool) bool {
+	return !kmsgOK || dryRun || stderrIsTerminal
+}
+
+// stderrIsTerminal reports whether stderr is a character device (e.g. a tty).
+// Used as a lightweight isatty so quadlet logs to stderr when run interactively
+// and to kmsg when run non-interactively (e.g. under systemd), without pulling
+// golang.org/x/term (and its golang.org/x/sys dependency) into the generator
+// binary.
+func stderrIsTerminal() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
 func Logf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	line := fmt.Sprintf("quadlet-generator[%d]: %s", os.Getpid(), s)
 
-	if !logToKmsg(line) || dryRunFlag {
+	isTerminal := stderrIsTerminal()
+	kmsgOK := false
+	if !isTerminal {
+		kmsgOK = logToKmsg(line)
+	}
+	if shouldLogToStderr(kmsgOK, dryRunFlag, isTerminal) {
 		fmt.Fprintf(os.Stderr, "%s\n", line)
 		os.Stderr.Sync()
 	}

--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -66,33 +66,19 @@ func logToKmsg(s string) bool {
 	return true
 }
 
-func shouldLogToStderr(kmsgOK bool, dryRun bool, stderrIsTerminal bool) bool {
-	return !kmsgOK || dryRun || stderrIsTerminal
-}
-
-// stderrIsTerminal reports whether stderr is a character device (e.g. a tty).
-// Used as a lightweight isatty so quadlet logs to stderr when run interactively
-// and to kmsg when run non-interactively (e.g. under systemd), without pulling
-// golang.org/x/term (and its golang.org/x/sys dependency) into the generator
-// binary.
-func stderrIsTerminal() bool {
-	fi, err := os.Stderr.Stat()
-	if err != nil {
-		return false
-	}
-	return fi.Mode()&os.ModeCharDevice != 0
+func shouldLogToStderr(kmsgOK bool, dryRun bool) bool {
+	return !kmsgOK || dryRun
 }
 
 func Logf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	line := fmt.Sprintf("quadlet-generator[%d]: %s", os.Getpid(), s)
 
-	isTerminal := stderrIsTerminal()
 	kmsgOK := false
-	if !isTerminal {
+	if os.Geteuid() == 0 {
 		kmsgOK = logToKmsg(line)
 	}
-	if shouldLogToStderr(kmsgOK, dryRunFlag, isTerminal) {
+	if shouldLogToStderr(kmsgOK, dryRunFlag) {
 		fmt.Fprintf(os.Stderr, "%s\n", line)
 		os.Stderr.Sync()
 	}

--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -42,3 +42,49 @@ func TestIsUnambiguousName(t *testing.T) {
 		assert.Equal(t, res, test.res, "%q", test.input)
 	}
 }
+
+func TestShouldLogToStderr(t *testing.T) {
+	tests := []struct {
+		name             string
+		kmsgOK           bool
+		dryRun           bool
+		stderrIsTerminal bool
+		want             bool
+	}{
+		{
+			name:             "kmsg failed",
+			kmsgOK:           false,
+			dryRun:           false,
+			stderrIsTerminal: false,
+			want:             true,
+		},
+		{
+			name:             "dry run",
+			kmsgOK:           true,
+			dryRun:           true,
+			stderrIsTerminal: false,
+			want:             true,
+		},
+		{
+			name:             "terminal stderr",
+			kmsgOK:           true,
+			dryRun:           false,
+			stderrIsTerminal: true,
+			want:             true,
+		},
+		{
+			name:             "kmsg succeeded and non-terminal stderr",
+			kmsgOK:           true,
+			dryRun:           false,
+			stderrIsTerminal: false,
+			want:             false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := shouldLogToStderr(test.kmsgOK, test.dryRun, test.stderrIsTerminal)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -45,45 +45,40 @@ func TestIsUnambiguousName(t *testing.T) {
 
 func TestShouldLogToStderr(t *testing.T) {
 	tests := []struct {
-		name             string
-		kmsgOK           bool
-		dryRun           bool
-		stderrIsTerminal bool
-		want             bool
+		name   string
+		kmsgOK bool
+		dryRun bool
+		want   bool
 	}{
 		{
-			name:             "kmsg failed",
-			kmsgOK:           false,
-			dryRun:           false,
-			stderrIsTerminal: false,
-			want:             true,
+			name:   "kmsg succeeded",
+			kmsgOK: true,
+			dryRun: false,
+			want:   false,
 		},
 		{
-			name:             "dry run",
-			kmsgOK:           true,
-			dryRun:           true,
-			stderrIsTerminal: false,
-			want:             true,
+			name:   "kmsg failed",
+			kmsgOK: false,
+			dryRun: false,
+			want:   true,
 		},
 		{
-			name:             "terminal stderr",
-			kmsgOK:           true,
-			dryRun:           false,
-			stderrIsTerminal: true,
-			want:             true,
+			name:   "dry run with successful kmsg",
+			kmsgOK: true,
+			dryRun: true,
+			want:   true,
 		},
 		{
-			name:             "kmsg succeeded and non-terminal stderr",
-			kmsgOK:           true,
-			dryRun:           false,
-			stderrIsTerminal: false,
-			want:             false,
+			name:   "dry run with failed kmsg",
+			kmsgOK: false,
+			dryRun: true,
+			want:   true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := shouldLogToStderr(test.kmsgOK, test.dryRun, test.stderrIsTerminal)
+			got := shouldLogToStderr(test.kmsgOK, test.dryRun)
 			assert.Equal(t, test.want, got)
 		})
 	}


### PR DESCRIPTION
#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `gofmt` and `go vet` (`make validatepr` needs a containerized environment not available locally; CI runs the full validation)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
The quadlet generator no longer writes warnings to /dev/kmsg when run manually from a terminal; kmsg logging is kept for systemd invocations.
```

Fixes #28888
