### PR TITLE
Close the Progress Bar Container (Resource Leak)

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -109,6 +109,12 @@ func RemoveFilesExcept(path string, excludeFile string) error {
 	return nil
 }
 
+
+// ProgressBar initializes a progress bar container and an individual bar. 
+//
+// CRITICAL: The caller MUST call `p.Wait()` on the returned *mpb.Progress 
+// container (typically via `defer p.Wait()`) once processing is complete to 
+// prevent a goroutine leak.
 func ProgressBar(prefix string, size int64, onComplete string) (*mpb.Progress, *mpb.Bar) {
 	p := mpb.New(
 		mpb.WithWidth(80), // Do not go below 80, see bug #17718


### PR DESCRIPTION
In ProgressBar, initialization of an mpb.New(...) container, but it returns alongside the bar without waiting for it or closing it. The mpb package leaks a goroutine if p.Wait() is never called on the returned *mpb.Progress instance by the caller.

To ensure the caller knows they must wait for it, updating the comment documentation is highly recommended so they know to defer p.Wait().

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
