### PR TITLE
kube: alias OCI runtime annotations without underscores

### DIFF
--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -7,6 +7,12 @@ const (
 	// RunOCIKeepOriginalGroups tells the OCI runtime to leak the users
 	// current groups into the container
 	RunOCIKeepOriginalGroups = "run.oci.keep_original_groups"
+	// KubeMountContextTypeAnnotation is the Kubernetes-safe annotation used to
+	// round-trip RunOCIMountContextType through kube generate/play.
+	KubeMountContextTypeAnnotation = "io.podman.annotations.mount-context-type"
+	// KubeKeepOriginalGroupsAnnotation is the Kubernetes-safe annotation used to
+	// round-trip RunOCIKeepOriginalGroups through kube generate/play.
+	KubeKeepOriginalGroupsAnnotation = "io.podman.annotations.keep-original-groups"
 	// InspectAnnotationCIDFile is used by Inspect to determine if a
 	// container ID file was created for the container.
 	// If an annotation with this key is found in the OCI spec, it will be
@@ -186,10 +192,26 @@ const (
 // already reserved annotation that Podman sets during container creation.
 func IsReservedAnnotation(value string) bool {
 	switch value {
-	case InspectAnnotationCIDFile, InspectAnnotationAutoremove, InspectAnnotationPrivileged, InspectAnnotationPublishAll, InspectAnnotationInit, InspectAnnotationLabel, InspectAnnotationSeccomp, InspectAnnotationApparmor, InspectResponseTrue, InspectResponseFalse, VolumesFromAnnotation:
+	case InspectAnnotationCIDFile, InspectAnnotationAutoremove, InspectAnnotationPrivileged, InspectAnnotationPublishAll, InspectAnnotationInit, InspectAnnotationLabel, InspectAnnotationSeccomp, InspectAnnotationApparmor, InspectResponseTrue, InspectResponseFalse, VolumesFromAnnotation, KubeMountContextTypeAnnotation, KubeKeepOriginalGroupsAnnotation:
 		return true
 
 	default:
 		return false
 	}
+}
+
+type AnnotationAlias struct {
+	Runtime string
+	Kube    string
+}
+
+var OCIRuntimeAnnotationAliases = []AnnotationAlias{
+	{
+		Runtime: RunOCIKeepOriginalGroups,
+		Kube:    KubeKeepOriginalGroupsAnnotation,
+	},
+	{
+		Runtime: RunOCIMountContextType,
+		Kube:    KubeMountContextTypeAnnotation,
+	},
 }

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -618,7 +618,7 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 				if !podmanOnly && (define.IsReservedAnnotation(k)) {
 					continue
 				}
-				podAnnotations[fmt.Sprintf("%s/%s", k, removeUnderscores(ctr.Name()))] = v
+				podAnnotations[fmt.Sprintf("%s/%s", kubeAnnotationAlias(k), removeUnderscores(ctr.Name()))] = v
 			}
 			// Convert auto-update labels into kube annotations
 			maps.Copy(podAnnotations, getAutoUpdateAnnotations(ctr.Name(), ctr.Labels()))
@@ -764,7 +764,7 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container, getServic
 			if !podmanOnly && define.IsReservedAnnotation(k) {
 				continue
 			}
-			kubeAnnotations[fmt.Sprintf("%s/%s", k, removeUnderscores(ctr.Name()))] = v
+			kubeAnnotations[fmt.Sprintf("%s/%s", kubeAnnotationAlias(k), removeUnderscores(ctr.Name()))] = v
 		}
 
 		// Convert auto-update labels into kube annotations
@@ -1447,6 +1447,15 @@ func generateKubeVolumeDeviceFromLinuxDevice(devices []specs.LinuxDevice) []v1.V
 		volumeDevices = append(volumeDevices, vd)
 	}
 	return volumeDevices
+}
+
+func kubeAnnotationAlias(annotationKey string) string {
+	for _, alias := range define.OCIRuntimeAnnotationAliases {
+		if alias.Runtime == annotationKey {
+			return alias.Kube
+		}
+	}
+	return annotationKey
 }
 
 func removeUnderscores(s string) string {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -42,6 +42,14 @@ import (
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 )
 
+func restoreKubeAnnotationAliases(annotations map[string]string, containerName string) {
+	for _, alias := range define.OCIRuntimeAnnotationAliases {
+		if value, ok := annotations[alias.Kube+"/"+containerName]; ok {
+			annotations[alias.Runtime] = value
+		}
+	}
+}
+
 func ToPodOpt(_ context.Context, podName string, p entities.PodCreateOptions, publishAllPorts bool, podYAML *v1.PodTemplateSpec) (entities.PodCreateOptions, error) {
 	p.Net = &entities.NetOptions{NoHosts: p.Net.NoHosts, NoHostname: p.Net.NoHostname}
 
@@ -377,6 +385,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		annotations[ann.SandboxID] = opts.PodInfraID
 	}
 	s.Annotations = annotations
+	restoreKubeAnnotationAliases(s.Annotations, opts.Container.Name)
 
 	if containerCIDFile, ok := opts.Annotations[define.InspectAnnotationCIDFile+"/"+opts.Container.Name]; ok {
 		s.Annotations[define.InspectAnnotationCIDFile] = containerCIDFile

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -6092,6 +6092,46 @@ spec:
 		Expect(kube).Should(ExitWithError(125, "annotation "+define.VolumesFromAnnotation+" without target volume is reserved for internal use"))
 	})
 
+	It("test with keep-groups OCI annotation round trip", func() {
+		SkipIfRemote("the --group-add keep-groups option is not supported in remote mode")
+
+		ctr := "ctr-keep-groups"
+		ctrNameInKubePod := ctr + "-pod-" + ctr
+		outputFile := filepath.Join(podmanTest.TempDir, "pod.yaml")
+		kubeAnnotation := define.KubeKeepOriginalGroupsAnnotation + "/" + ctr
+
+		podmanTest.PodmanExitCleanly("create", "--name", ctr, "--group-add", "keep-groups", CITEST_IMAGE, "top")
+		podmanTest.PodmanExitCleanly("kube", "generate", "-f", outputFile, ctr)
+
+		kubeYaml, err := os.ReadFile(outputFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kubeYaml).ToNot(ContainSubstring(define.RunOCIKeepOriginalGroups + "/" + ctr))
+		Expect(kubeYaml).To(ContainSubstring(kubeAnnotation + `: "1"`))
+
+		podmanTest.PodmanExitCleanly("kube", "play", "--start=false", outputFile)
+		inspect := podmanTest.PodmanExitCleanly("inspect", "-f", "{{ index .Config.Annotations \""+define.RunOCIKeepOriginalGroups+"\" }}", ctrNameInKubePod)
+		Expect(inspect.OutputToString()).To(Equal("1"))
+	})
+
+	It("test with mount-context-type OCI annotation round trip", func() {
+		ctr := "ctr-mount-context"
+		ctrNameInKubePod := ctr + "-pod-" + ctr
+		outputFile := filepath.Join(podmanTest.TempDir, "pod.yaml")
+		kubeAnnotation := define.KubeMountContextTypeAnnotation + "/" + ctr
+
+		podmanTest.PodmanExitCleanly("create", "--name", ctr, "--annotation", define.RunOCIMountContextType+"=rootcontext", CITEST_IMAGE, "top")
+		podmanTest.PodmanExitCleanly("kube", "generate", "-f", outputFile, ctr)
+
+		kubeYaml, err := os.ReadFile(outputFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kubeYaml).ToNot(ContainSubstring(define.RunOCIMountContextType + "/" + ctr))
+		Expect(kubeYaml).To(ContainSubstring(kubeAnnotation + `: rootcontext`))
+
+		podmanTest.PodmanExitCleanly("kube", "play", "--start=false", outputFile)
+		inspect := podmanTest.PodmanExitCleanly("inspect", "-f", "{{ index .Config.Annotations \""+define.RunOCIMountContextType+"\" }}", ctrNameInKubePod)
+		Expect(inspect.OutputToString()).To(Equal("rootcontext"))
+	})
+
 	It("test with reserved autoremove annotation in yaml", func() {
 		ctr := "ctr"
 		ctrNameInKubePod := ctr + "-pod-" + ctr


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed `podman kube generate` output for OCI runtime annotations with underscores so the generated YAML can be used with `podman kube play`.
```


#### Description

Fixes: #26871

`podman kube generate` could emit OCI runtime annotations such as `run.oci.keep_original_groups` and `run.oci.mount_context_type` directly into Pod YAML. Since these keys contain underscores, the generated YAML failed Kubernetes annotation validation when reused with `podman kube play`.

Use Kubernetes-valid Podman aliases in generated YAML and restore the original OCI runtime annotations during `podman kube play`, preserving the runtime-facing `run.oci.*` keys. Hope this makes sense.




