### PR TITLE
docs: fix --image-volume default and accepted values

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1151,9 +1151,9 @@ func AutocompleteCgroupMode(_ *cobra.Command, _ []string, _ string) ([]string, c
 }
 
 // AutocompleteImageVolume - Autocomplete image volume options.
-// -> "bind", "tmpfs", "ignore"
+// -> "anonymous", "tmpfs", "ignore"
 func AutocompleteImageVolume(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	imageVolumes := []string{"bind", "tmpfs", "ignore"}
+	imageVolumes := []string{"anonymous", "tmpfs", "ignore"}
 	return imageVolumes, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -174,7 +174,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		imageVolumeFlagName := "image-volume"
 		createFlags.String(
 			imageVolumeFlagName, cf.ImageVolume,
-			`Tells podman how to handle the builtin image volumes ("bind"|"tmpfs"|"ignore")`,
+			`Tells podman how to handle the builtin image volumes ("anonymous"|"tmpfs"|"ignore")`,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(imageVolumeFlagName, AutocompleteImageVolume)
 

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -243,6 +243,10 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 		logrus.Warnf("The --kernel-memory flag is no longer supported. This flag is a noop.")
 	}
 
+	if c.Flag("image-volume") != nil && c.Flag("image-volume").Changed && c.Flag("image-volume").Value.String() == "bind" {
+		logrus.Warnf("The --image-volume=bind value is deprecated, use --image-volume=anonymous instead")
+	}
+
 	if cliVals.LogDriver == define.PassthroughLogging {
 		if term.IsTerminal(0) || term.IsTerminal(1) || term.IsTerminal(2) {
 			return vals, errors.New("the '--log-driver passthrough' option cannot be used on a TTY.  If you really want it, use '--log-driver passthrough-tty'")

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -5,12 +5,14 @@
 << if is_quadlet >>
 ### `ImageVolume=mode`
 << else >>
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+#### **--image-volume**=**anonymous** | *tmpfs* | *ignore*
 << endif >>
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
+Tells Podman how to handle the builtin image volumes. Default is **anonymous**.
 
-- **bind**: An anonymous named volume is created and mounted into the container.
+- **anonymous**: An anonymous named volume is created and mounted into the container.
 - **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
 content that disappears when the container is stopped.
 - **ignore**: All volumes are just ignored and no action is taken.
+
+In the past, a **bind** option was accepted as well. This is deprecated, and currently aliased to **anonymous**.

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -724,7 +724,8 @@ Special Cases:
 
 ### `ImageVolume=`
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
+Tells Podman how to handle the builtin image volumes. Default is **anonymous**.
+In the past, a **bind** option was accepted as well. This is deprecated, and currently aliased to **anonymous**.
 Equivalent to the Podman `--image-volume` option.
 
 ### `IP=`


### PR DESCRIPTION
`--image-volume` is documented and auto-completed as `bind`, but the canonical values are `anonymous | tmpfs | ignore` (default `anonymous`); `bind` is only a deprecated alias. This shows `anonymous` in the docs, `--help` and completion, and notes that `bind` still works. No behavior change.

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [x] Referenced issues using `Fixes: #27674` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
