### PR TITLE
test: add apiv2 coverage for the manifest-create images query param

### DIFF
--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -120,7 +120,6 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	// - in: query
 	//   name: images
 	//   type: string
-	//   required: true
 	//   description: |
 	//     One or more names of an image or a manifest list. Repeat parameter as needed.
 	//

--- a/test/apiv2/15-manifest.at
+++ b/test/apiv2/15-manifest.at
@@ -29,6 +29,40 @@ RUN >file2
 EOF
 )
 
+# Create manifest lists and populate them at creation time via the `images`
+# query parameter. This path was previously untested (#22258). `images` may be
+# repeated to add more than one image.
+t POST "/v4.0.0/libpod/manifests/withimage?images=containers-storage:$id_abc_image" 201 \
+    .Id~[0-9a-f]\\{64\\}
+id_withimage=$(jq -r '.Id' <<<"$output")
+t GET /v4.0.0/libpod/manifests/$id_withimage/json 200 \
+    .manifests[0].digest~sha256:[0-9a-f]\\{64\\} \
+    '.manifests | length'=1
+
+# The same parameter is honored by the < 4.0.0 create endpoint, where the
+# success status is 200 instead of 201.
+t POST "/v3.4.0/libpod/manifests/create?name=withimage3&images=containers-storage:$id_xyz_image" 200 \
+    .Id~[0-9a-f]\\{64\\}
+id_withimage3=$(jq -r '.Id' <<<"$output")
+t GET /v4.0.0/libpod/manifests/$id_withimage3/json 200 \
+    .manifests[0].digest~sha256:[0-9a-f]\\{64\\} \
+    '.manifests | length'=1
+
+# Repeating the `images` parameter adds multiple images to the list in a single
+# create call.
+t POST "/v4.0.0/libpod/manifests/withimages?images=containers-storage:$id_abc_image&images=containers-storage:$id_xyz_image" 201 \
+    .Id~[0-9a-f]\\{64\\}
+id_withimages=$(jq -r '.Id' <<<"$output")
+t GET /v4.0.0/libpod/manifests/$id_withimages/json 200 \
+    .manifests[0].digest~sha256:[0-9a-f]\\{64\\} \
+    '.manifests | length'=2
+
+# `images` is optional: the create calls at the top of this file omit it and
+# still succeed, even though the API used to document it as required (#22258).
+t DELETE /v4.0.0/libpod/manifests/$id_withimage 200
+t DELETE /v4.0.0/libpod/manifests/$id_withimages 200
+t DELETE /v4.0.0/libpod/manifests/$id_withimage3 200
+
 # manifest add --annotation tests
 t POST /v3.4.0/libpod/manifests/$id_abc/add images="[\"containers-storage:$id_abc_image\"]" 200
 t PUT /v4.0.0/libpod/manifests/$id_xyz operation='update' images="[\"containers-storage:$id_xyz_image\"]" annotations="{\"foo\":\"bar\"}" annotation="[\"hoge=fuga\"]" 400 \


### PR DESCRIPTION
The libpod manifest-create `images` query parameter was never covered by the apiv2 tests. This adds cases for it on the v3 and v4 endpoints, and drops the stale `required: true` from that parameter in the swagger docs (the handler treats it as optional).

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`).
- [x] Referenced issues using `Fixes: #22258` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```
