### PR TITLE
compat API: accept inline seccomp profiles

### DIFF
--- a/pkg/seccomp/seccomp.go
+++ b/pkg/seccomp/seccomp.go
@@ -3,6 +3,7 @@ package seccomp
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // ContainerImageLabel is the key of the image annotation embedding a seccomp
@@ -50,4 +51,9 @@ func LookupPolicy(s string) (Policy, error) {
 	sort.Strings(keys)
 
 	return -1, fmt.Errorf("invalid seccomp policy %q: valid policies are %+q", s, keys)
+}
+
+// IsProfileInline reports whether profile contains an inline JSON object.
+func IsProfileInline(profile string) bool {
+	return strings.HasPrefix(strings.TrimSpace(profile), "{")
 }

--- a/pkg/specgen/generate/config_linux_seccomp.go
+++ b/pkg/specgen/generate/config_linux_seccomp.go
@@ -45,13 +45,23 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libi
 	}
 
 	if s.SeccompProfilePath != "" {
-		logrus.Debugf("Loading seccomp profile from %q", s.SeccompProfilePath)
-		seccompProfile, err := os.ReadFile(s.SeccompProfilePath)
-		if err != nil {
-			return nil, fmt.Errorf("opening seccomp profile failed: %w", err)
+		seccompProfile := s.SeccompProfilePath
+		inlineProfile := seccomp.IsProfileInline(seccompProfile)
+		if inlineProfile {
+			logrus.Debug("Loading inline seccomp profile")
+		} else {
+			logrus.Debugf("Loading seccomp profile from %q", seccompProfile)
+			seccompProfileBytes, err := os.ReadFile(seccompProfile)
+			if err != nil {
+				return nil, fmt.Errorf("opening seccomp profile failed: %w", err)
+			}
+			seccompProfile = string(seccompProfileBytes)
 		}
-		seccompConfig, err = goSeccomp.LoadProfile(string(seccompProfile), configSpec)
+		seccompConfig, err = goSeccomp.LoadProfile(seccompProfile, configSpec)
 		if err != nil {
+			if inlineProfile {
+				return nil, fmt.Errorf("loading seccomp profile (inline) failed: %w", err)
+			}
 			return nil, fmt.Errorf("loading seccomp profile (%s) failed: %w", s.SeccompProfilePath, err)
 		}
 	} else {

--- a/pkg/specgen/generate/config_linux_seccomp_test.go
+++ b/pkg/specgen/generate/config_linux_seccomp_test.go
@@ -1,0 +1,60 @@
+//go:build linux && !remote && seccomp
+
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/podman/v6/pkg/specgen"
+)
+
+const testSeccompProfile = `{
+	"defaultAction": "SCMP_ACT_ALLOW",
+	"syscalls": [
+		{
+			"names": ["link", "linkat"],
+			"action": "SCMP_ACT_ERRNO"
+		}
+	]
+}`
+
+func TestGetSeccompConfigFromFileOrInline(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "seccomp.json")
+	require.NoError(t, os.WriteFile(profilePath, []byte(testSeccompProfile), 0o600))
+
+	tests := []struct {
+		name    string
+		profile string
+	}{
+		{name: "file", profile: profilePath},
+		{name: "inline", profile: testSeccompProfile},
+		{name: "inline with surrounding whitespace", profile: " \n\t" + testSeccompProfile + " \n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := specgen.NewSpecGenerator("", false)
+			s.SeccompProfilePath = test.profile
+
+			config, err := getSeccompConfig(s, &spec.Spec{}, nil)
+			require.NoError(t, err)
+			assert.Equal(t, spec.ActAllow, config.DefaultAction)
+			require.Len(t, config.Syscalls, 1)
+			assert.Equal(t, spec.ActErrno, config.Syscalls[0].Action)
+			assert.Equal(t, []string{"link", "linkat"}, config.Syscalls[0].Names)
+		})
+	}
+}
+
+func TestGetSeccompConfigRejectsInvalidInlineProfile(t *testing.T) {
+	s := specgen.NewSpecGenerator("", false)
+	s.SeccompProfilePath = " {invalid JSON"
+
+	_, err := getSeccompConfig(s, &spec.Spec{}, nil)
+	require.ErrorContains(t, err, "loading seccomp profile failed: decoding seccomp profile failed")
+}

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -412,7 +412,7 @@ type ContainerSecurityConfig struct {
 	// the container. valid values: empty,default,image
 	SeccompPolicy string `json:"seccomp_policy,omitempty"`
 	// SeccompProfilePath is the path to a JSON file containing the
-	// container's Seccomp profile.
+	// container's Seccomp profile, or the JSON profile itself.
 	// If not specified, no Seccomp profile will be used.
 	// Optional.
 	SeccompProfilePath string `json:"seccomp_profile_path,omitempty"`

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -19,6 +19,7 @@ import (
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	envLib "go.podman.io/podman/v6/pkg/env"
 	"go.podman.io/podman/v6/pkg/namespaces"
+	"go.podman.io/podman/v6/pkg/seccomp"
 	"go.podman.io/podman/v6/pkg/specgen"
 	systemdDefine "go.podman.io/podman/v6/pkg/systemd/define"
 	"go.podman.io/podman/v6/pkg/util"
@@ -739,7 +740,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 			convertedPath := val
 			// Do not try to convert special value "unconfined",
 			// https://github.com/containers/podman/issues/26855
-			if val != "unconfined" {
+			// or inline JSON seccomp profile,
+			// https://github.com/containers/podman/issues/27710
+			if val != "unconfined" && !seccomp.IsProfileInline(val) {
 				convertedPath, err = specgen.ConvertWinMountPath(val)
 				if err != nil {
 					// If the conversion fails, use the original path

--- a/pkg/specgenutil/specgenutil_windows_test.go
+++ b/pkg/specgenutil/specgenutil_windows_test.go
@@ -33,6 +33,8 @@ func TestSeccompProfilePath(t *testing.T) {
 		{`\\computer\loc`, `\\computer\loc`},
 		{`\\.\drive\loc`, "/mnt/wsl/drive/loc"},
 		{"unconfined", "unconfined"},
+		{`{"defaultAction":"SCMP_ACT_ALLOW"}`, `{"defaultAction":"SCMP_ACT_ALLOW"}`},
+		{" \n{\"defaultAction\":\"SCMP_ACT_ALLOW\"}", " \n{\"defaultAction\":\"SCMP_ACT_ALLOW\"}"},
 	}
 
 	f := func(secopt string) (*specgen.SpecGenerator, error) {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -339,6 +339,24 @@ t GET    libpod/containers/${cid}/json 200 \
 
 t DELETE containers/$cid 204
 
+# Regression test for #27710. Docker accepts the seccomp profile itself in
+# HostConfig.SecurityOpt. Include enough whitespace to exceed NAME_MAX.
+SECCOMP_TMPD=$(mktemp -d podman-apiv2-test.seccomp.XXXXXXXX)
+seccomp_profile=$(printf '\n  {"defaultAction":"SCMP_ACT_ALLOW","syscalls":[{"names":["link","linkat"],"action":"SCMP_ACT_ERRNO"}]}%300s' '')
+jq -cn --arg image "$IMAGE" --arg profile "$seccomp_profile" \
+  '{Image:$image,
+    Cmd:["sh","-c","echo test > /tmp/link-src && ln /tmp/link-src /tmp/link-not-allowed"],
+    HostConfig:{SecurityOpt:["seccomp=" + $profile]}}' \
+  >$SECCOMP_TMPD/create.json
+t POST containers/create $SECCOMP_TMPD/create.json 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t POST containers/$cid/start 204
+t POST containers/$cid/wait 200 \
+  .StatusCode=1
+t DELETE containers/$cid 204
+rm -rf $SECCOMP_TMPD
+
 # test only set the entrypoint, Cmd should be []
 t POST containers/create \
   Image=$IMAGE \


### PR DESCRIPTION
Docker-compatible clients may pass the seccomp profile JSON itself via HostConfig.SecurityOpt, as seccomp=..., instead of passing a path to a profile JSON.

Detect inline JSON profiles before Windows path conversion and profile loading, and pass it directly to the seccomp loader. When inline JSON is not detected, proceed with loading the profile from path.

Add unit tests for loading profile from path and inline seccomp profiles, cover Windows path-conversion behaviour for inline JSON, and add an API v2 regression test for containers/create with HostConfig.SecurityOpt.

Fixes: https://github.com/podman-container-tools/podman/issues/27710

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed Docker-compatible container creation to accept inline seccomp profile JSON
```
