### PR TITLE
close rootfs tar stream after use

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -1238,6 +1238,7 @@ func (c *Container) exportCheckpoint(options ContainerCheckpointOptions) error {
 	if err != nil {
 		return fmt.Errorf("reading checkpoint directory %q: %w", c.ID(), err)
 	}
+	defer input.Close()
 
 	outFile, err := os.Create(options.TargetFile)
 	if err != nil {

--- a/pkg/checkpoint/crutils/checkpoint_restore_utils.go
+++ b/pkg/checkpoint/crutils/checkpoint_restore_utils.go
@@ -166,6 +166,7 @@ func CRCreateRootFsDiffTar(changes *[]archive.Change, mountPoint, destination st
 		if err != nil {
 			return includeFiles, fmt.Errorf("exporting root file-system diff to %q: %w", rootfsDiffPath, err)
 		}
+		defer rootfsTar.Close()
 		rootfsDiffFile, err := os.Create(rootfsDiffPath)
 		if err != nil {
 			return includeFiles, fmt.Errorf("creating root file-system diff file %q: %w", rootfsDiffPath, err)


### PR DESCRIPTION
`chrootarchive.Tar` returns an `io.ReadCloser` backed by a pipe to the tar-producing process.  `CRCreateRootFsDiffTar` copies from the stream but never closes it.

On the successful path the stream is read to EOF, so the producer normally exits.  On early errors, such as failing to create the destination file or failing while copying to it, the producer can be left without a consumer. Same behavior in `(*Container).exportCheckpoint`.

Close the tar stream after it is created so error paths release the pipe and allow the producer to exit.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
None