### PR TITLE
api: avoid sizing logs channel from tail

### DIFF
--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -94,7 +94,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 	var wg sync.WaitGroup
 	options.WaitGroup = &wg
 
-	logChannel := make(chan *logs.LogLine, tail+1)
+	logChannel := make(chan *logs.LogLine, 5)
 	if err := runtime.Log(r.Context(), []*libpod.Container{ctnr}, options, logChannel); err != nil {
 		utils.InternalServerError(w, fmt.Errorf("failed to obtain logs for Container '%s': %w", name, err))
 		return


### PR DESCRIPTION
This PR stops using the `tail` query parameter as the capacity for the compat logs handler's internal channel.

`tail` should only control how many log lines are returned.  Using it as a channel capacity ties memory allocation to a user-controlled API parameter: negative values can panic when used as a channel size, and very large values can allocate excessive memory before log streaming starts.

The log reader still receives the original `Tail` value, so the visible logs behavior is unchanged.  This only changes the buffering between the log reader and the HTTP response writer.

I used an unbuffered channel here because it keeps the fix small and avoids deriving allocation size from `tail`.  I am not opposed to other approaches, for example using a small fixed-size buffer or normalizing the capacity, if you prefer a different tradeoff.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
None
