### PR TITLE
docs: document hack/ci/ci.sh lima workflow in test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -232,3 +232,45 @@ For usage run:
 ```
 hack/bats --help
 ```
+
+## Reproducing CI failures locally with Lima
+
+CI jobs whose names end in `/ lima` run inside a Lima VM. To reproduce one,
+copy the job name before `/ lima` and pass it to `hack/ci/ci.sh`:
+
+```bash
+hack/ci/ci.sh TEST MODE PRIV DISTRO
+```
+
+For example, `sys remote rootless fedora-current / lima` becomes:
+
+```bash
+hack/ci/ci.sh sys remote rootless fedora-current
+```
+
+Jobs without the `/ lima` suffix cannot be reproduced this way, including
+machine tests and Windows and macOS jobs.
+
+`TEST` is the suite, one of:
+
+- `build` builds Podman and its documentation
+- `apiv2` runs API v2 tests
+- `bindings` runs bindings tests
+- `bud` runs Buildah bud tests
+- `compose_v2` runs Docker Compose v2 tests
+- `docker_py` runs Docker SDK for Python tests
+- `unit` runs unit tests
+- `upgrade` runs upgrade tests
+- `int` runs integration tests
+- `sys` runs system tests
+
+`MODE` is `local` or `remote` and defaults to `local`. `PRIV` is `root` or
+`rootless` and defaults to `rootless`. `DISTRO` is `fedora-current`,
+`fedora-prior`, `fedora-rawhide`, or `debian-sid`.
+
+For the `upgrade` suite, `MODE` is the version to upgrade from (for example,
+`v5.3.1`) instead of `local` or `remote`.
+
+The script requires [Lima](https://lima-vm.io/docs/installation/). It starts a
+nested-virtualization VM with 8 GB of memory, copies this repository into it,
+and runs `hack/ci/runner.sh`, so the host distribution does not matter.


### PR DESCRIPTION
## Summary

Adds a short "Reproducing CI failures locally with lima" section to `test/README.md` documenting `hack/ci/ci.sh`. It covers the lima prerequisite, the 2-to-4 positional argument forms (`TEST [MODE] [PRIV] DISTRO`), the accepted values for each argument, the `sys remote rootless fedora-current` example, and the caveat that some test parts cannot run inside the VM. I read `hack/ci/ci.sh`, `hack/ci/lib.sh`, and `hack/ci/runner.sh` to make sure the documented argument order and accepted values match the actual scripts, including the detail that the `upgrade` suite reuses the `MODE` slot to pass the version to upgrade from.

`hack/ci/ci.sh` runs the suites in the same lima VM image that CI uses, so it is the supported way to reproduce a CI failure locally regardless of host distro. Until now `test/README.md` only documented the `make` targets and never mentioned this script or the lima workflow.

Fixes #28947

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```

AI was used for assistance.
