### PR TITLE
systemd: fix negative number conversion

### DIFF
--- a/pkg/systemd/parser/unitfile.go
+++ b/pkg/systemd/parser/unitfile.go
@@ -661,7 +661,7 @@ func convertNumber(v string) (int64, error) {
 		v = v[1:]
 	} else if strings.HasPrefix(v, "-") {
 		v = v[1:]
-		mult = int64(-11)
+		mult = int64(-1)
 	}
 
 	switch {

--- a/pkg/systemd/parser/unitfile_test.go
+++ b/pkg/systemd/parser/unitfile_test.go
@@ -371,6 +371,32 @@ func TestLookupQuoteStripping(t *testing.T) {
 	}
 }
 
+func TestLookupIntParsesSignedNumbers(t *testing.T) {
+	unit := NewUnitFile()
+	unit.Add("Service", "Positive", "42")
+	unit.Add("Service", "ExplicitPositive", "+42")
+	unit.Add("Service", "Negative", "-42")
+	unit.Add("Service", "Hex", "0x2a")
+	unit.Add("Service", "Octal", "052")
+
+	tests := []struct {
+		key      string
+		expected int64
+	}{
+		{"Positive", 42},
+		{"ExplicitPositive", 42},
+		{"Negative", -42},
+		{"Hex", 42},
+		{"Octal", 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.expected, unit.LookupInt("Service", tt.key, 0))
+		})
+	}
+}
+
 func FuzzParser(f *testing.F) {
 	for _, sample := range samples {
 		f.Add([]byte(sample))


### PR DESCRIPTION
This PR fixes negative number parsing in the systemd unit parser.

`convertNumber()` removes a leading sign before parsing the value, then applies the sign back using a multiplier.  The negative path currently uses `-11`, which makes negative values incorrect and can also lead to surprising wraparound behavior for very large inputs.

The fix changes the multiplier to `-1`, matching the intended sign handling.
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
None
