### PR TITLE
Windows installer tests: download v5.8.3 of the setup bundle

### DIFF
--- a/contrib/win-installer/utils.ps1
+++ b/contrib/win-installer/utils.ps1
@@ -4,7 +4,8 @@ function Get-Latest-Podman-Setup-From-GitHub {
         [ValidateSet("amd64", "arm64")]
         [string] $arch = "amd64"
     )
-    return Get-Podman-Setup-From-GitHub "latest" $arch
+    # Starting from v6.0 we stopped publishing the setup
+    return Get-Podman-Setup-From-GitHub "v5.8.3" $arch
 }
 
 function Get-Podman-Setup-From-GitHub {
@@ -16,7 +17,7 @@ function Get-Podman-Setup-From-GitHub {
     )
 
     Write-Host "Downloading the $arch $version Podman windows setup from GitHub..."
-    $apiUrl = "https://api.github.com/repos/podman-container-tools/podman/releases/$version"
+    $apiUrl = "https://api.github.com/repos/podman-container-tools/podman/releases/tags/$version"
     $headers = @{"User-Agent"="PowerShell"}
     if ($env:GITHUB_TOKEN) {
         $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

This fixes errors in the CI after the v6.0 release ([this](https://github.com/podman-container-tools/podman/actions/runs/28151939087/job/83371440747?pr=29033#step:11:22)) and is similar to what [we did in the past](https://github.com/podman-container-tools/podman/pull/25553/changes/91072dc9402e8228b87ae3523d5eb04166f34a49) but got lost during the cirrus to gh transition.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
