### PR TITLE
Honor label filters for volume prune when all is set

### DIFF
--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -21,6 +21,8 @@ removal unless **--force** is used.
 
 Remove all unused volumes (anonymous and named). Without this option, only anonymous unused volumes are removed.
 
+**--all** can be combined with **--filter**: **--all** widens the set of candidate volumes to all unused ones, and the filters then restrict which of those are removed. For example, **--all --filter label!=keep** removes every unused volume that does not have the *keep* label.
+
 #### **--dry-run**
 
 Show which volumes would be pruned without removing them.
@@ -75,6 +77,11 @@ $ podman volume prune --force
 Prune all unused volumes (anonymous and named).
 ```
 $ podman volume prune --all --force
+```
+
+Prune all unused volumes except those with a specific label (combine **--all** with a filter).
+```
+$ podman volume prune --all --force --filter label!=keep
 ```
 
 Prune all unused volumes using the filter (equivalent to **--all**).

--- a/pkg/util/filters.go
+++ b/pkg/util/filters.go
@@ -66,9 +66,12 @@ func NormalizeVolumePruneFilters(f url.Values) url.Values {
 	}
 	allValue := f.Get("all")
 	if strings.EqualFold(allValue, "true") || allValue == "1" {
-		for key := range f {
-			f.Del(key)
-		}
+		// "all" only widens the scope from anonymous-only to every unused
+		// volume; it is orthogonal to the other filters. Drop just the "all"
+		// key and keep the rest (e.g. label/label!, until) so they continue to
+		// constrain which volumes are pruned, matching Docker, which ANDs the
+		// "all" scope together with the label filters.
+		f.Del("all")
 		return f
 	}
 	f.Del("all")

--- a/pkg/util/filters_test.go
+++ b/pkg/util/filters_test.go
@@ -96,6 +96,19 @@ func TestNormalizeVolumePruneFilters(t *testing.T) {
 			t.Fatalf("got %#v, want no all/anonymous keys", got)
 		}
 	})
+	t.Run("all true keeps label filters", func(t *testing.T) {
+		t.Parallel()
+		got := NormalizeVolumePruneFilters(url.Values{"all": {"true"}, "label": {"k=v"}, "label!": {"x"}})
+		if got.Has("all") || got.Has("anonymous") {
+			t.Fatalf("got %#v, want no all/anonymous keys", got)
+		}
+		if got.Get("label") != "k=v" {
+			t.Fatalf("label dropped alongside all: got %#v", got)
+		}
+		if got.Get("label!") != "x" {
+			t.Fatalf("label! dropped alongside all: got %#v", got)
+		}
+	})
 	t.Run("label without anonymous key does not inject anonymous", func(t *testing.T) {
 		t.Parallel()
 		in := url.Values{"label": {"k=v"}}

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -110,6 +110,24 @@ var _ = Describe("Podman volume prune", func() {
 		podmanTest.PodmanExitCleanly("volume", "prune", "--force", "--filter", "label!=testlabel")
 	})
 
+	It("podman volume prune --all keeps the label filter", func() {
+		// Regression: the "all" flag must not discard a label/label! filter.
+		// With "--all --filter label!=keep" only unlabeled unused volumes are
+		// pruned; the labeled one survives. Before the fix, "all" cleared the
+		// filter and both volumes were removed.
+		podmanTest.PodmanExitCleanly("volume", "create", "--label", "keep=yes", "keepvol")
+		podmanTest.PodmanExitCleanly("volume", "create", "dropvol")
+
+		session := podmanTest.PodmanExitCleanly("volume", "ls", "-q")
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+
+		podmanTest.PodmanExitCleanly("volume", "prune", "--all", "--force", "--filter", "label!=keep")
+
+		session = podmanTest.PodmanExitCleanly("volume", "ls", "-q")
+		Expect(session.OutputToStringArray()).To(HaveLen(1))
+		Expect(session.OutputToString()).To(Equal("keepvol"))
+	})
+
 	It("podman system prune --volume", func() {
 		useCustomNetworkDir(podmanTest, tempdir)
 		podmanTest.PodmanExitCleanly("volume", "create")


### PR DESCRIPTION
#### What this PR does / why we need it:
 
`NormalizeVolumePruneFilters` discarded **every** filter when the `all` flag was set, deleting `label`/`label!`/`until` before they reached the filter generator. So `podman volume prune --all --filter label=foo` ignored the label and pruned every unused volume. `all` only widens the scope from anonymous-only to all unused volumes; it is orthogonal to the label filters, which must still select which volumes are pruned. The fix drops only the `all` key and keeps the rest.
 
#### How to verify it
 
`go test ./pkg/util/ -run TestNormalizeVolumePruneFilters`
 
#### Which issue(s) this PR fixes:
 
None
 
#### Special notes for your reviewer:
 
The existing `all true drops all and no anonymous` test is unchanged; the fix
only affects requests that combine `all` with other filters.


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed volume prune so `label`/`label!` filters are honored together with `--all` (e.g. `podman volume prune --all --filter label=...`).
```
