### PR TITLE
[v6.0] Windows installer tests: download v5.8.3 of the setup bundle

### DIFF
--- a/contrib/win-installer/utils.ps1
+++ b/contrib/win-installer/utils.ps1
@@ -4,7 +4,8 @@ function Get-Latest-Podman-Setup-From-GitHub {
         [ValidateSet("amd64", "arm64")]
         [string] $arch = "amd64"
     )
-    return Get-Podman-Setup-From-GitHub "latest" $arch
+    # Starting from v6.0 we stopped publishing the setup
+    return Get-Podman-Setup-From-GitHub "v5.8.3" $arch
 }
 
 function Get-Podman-Setup-From-GitHub {
@@ -16,7 +17,7 @@ function Get-Podman-Setup-From-GitHub {
     )
 
     Write-Host "Downloading the $arch $version Podman windows setup from GitHub..."
-    $apiUrl = "https://api.github.com/repos/podman-container-tools/podman/releases/$version"
+    $apiUrl = "https://api.github.com/repos/podman-container-tools/podman/releases/tags/$version"
     $headers = @{"User-Agent"="PowerShell"}
     if ($env:GITHUB_TOKEN) {
         $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"


### PR DESCRIPTION
(cherry picked from commit 6ae463a9cd176983c94d75cded628af5ed46939d)


Needed to fix CI on the branch.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
