### PR TITLE
compat: skip AppArmor profile assignment when service runs inside a container

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -406,6 +406,27 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		parsedTmp = append(parsedTmp, finalString)
 	}
 
+
+
+	// If the podman service is running inside a container (e.g. Quadlet/systemd),
+	// and the Docker-compat client did not request a specific AppArmor profile,
+	// inject "apparmor=unconfined" to avoid crun failing to write
+	// /proc/thread-self/attr/apparmor/exec on kernel >= 6.17 where the outer
+	// container's AppArmor policy blocks change_profile.
+	// See: https://github.com/containers/podman/issues/28992
+	if _, statErr := os.Stat("/run/.containerenv"); statErr == nil {
+		hasApparmorOpt := false
+		for _, opt := range cc.HostConfig.SecurityOpt {
+			if strings.HasPrefix(opt, "apparmor=") {
+				hasApparmorOpt = true
+				break
+			}
+		}
+		if !hasApparmorOpt {
+			cc.HostConfig.SecurityOpt = append(cc.HostConfig.SecurityOpt, "apparmor=unconfined")
+		}
+	}
+
 	// Note: several options here are marked as "don't need". this is based
 	// on speculation by Matt and I. We think that these come into play later
 	// like with start. We believe this is just a difference in podman/compat


### PR DESCRIPTION
## Problem

On kernel 6.17, starting a container via the Docker-compat API
(`docker compose` / `docker` CLI pointed at the podman socket) from
inside a **systemd/Quadlet-launched** container fails with:

The container is created but stuck in `Created` state. Native
`podman run` on the host works fine. `podman --remote` also works.
Only the compat API path from inside a confined systemd/Quadlet
container fails.

**Root cause:** when no `apparmor=` SecurityOpt is sent by the Docker
client, the compat path falls through to the `containers-default-*`
profile from `containers.conf`. On kernel 6.17, crun's write to
`/proc/thread-self/attr/apparmor/exec` is blocked by the outer
container's AppArmor policy, which does not permit `change_profile`.

## Fix

When `/run/.containerenv` is present (podman sets this inside every
container) and the client sent no explicit `apparmor=` SecurityOpt,
inject `apparmor=unconfined` so crun skips the profile-assignment
write entirely.

Users who need a specific AppArmor profile can still pass
`--security-opt apparmor=<profile>` explicitly.

The proper upstream fix (adding `change_profile -> **,` to the
`containers-default` profile template) is in containers/common:
**containers/common#2548** 
**containers/common/pull/2548**
## References
- Fixes: #28992
- Downstream report: https://github.com/moghtech/komodo/issues/1488
- containers/common fix: containers/common#2548
https://github.com/containers/common/pull/2548
https://github.com/podman-container-tools/container-libs/pull/942