### PR TITLE
fix: update packit failure-notification team to new org

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -53,7 +53,7 @@ jobs:
     packages: [podman-fedora]
     notifications: &packit_generic_failure_notification
       failure_comment:
-        message: "[NON-BLOCKING] Packit jobs failed. @containers/packit-build please check. Everyone else, feel free to ignore."
+        message: "[NON-BLOCKING] Packit jobs failed. @podman-container-tools/packit-jobs please check. Everyone else, feel free to ignore."
     enable_net: true
     # CAUTION: The builds from these jobs are consumed by podman-machine-os
     # during the release process. Any change here should be mindful of it.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

The Packit failure-notification comment in `.packit.yaml` tagged `@containers/packit-build`, a team under the old `containers` org that no longer resolves now that the repo lives in `podman-container-tools`. As a result the mention is dead and maintainers are not pinged when Packit jobs fail.

This points the mention at `@podman-container-tools/packit-build`. The message is defined once on the `&packit_generic_failure_notification` YAML anchor (`.packit.yaml` line 56) and reused by reference on lines 71, 85, and 106, so the single edit covers every job that uses it. The individual `@`-handles on the Cockpit and tmt failure comments are untouched.

cc @lsm5 to confirm the exact team slug exists under the new org.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```

Fixes #28882
