### PR TITLE
fix missing error checks for bufio.Scanner

### DIFF
--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -5,6 +5,7 @@ package os
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -52,7 +53,10 @@ func NewOSManager(opts ManagerOpts) (pkgOS.Manager, error) {
 
 // guestOSManager returns an OSmanager for inside-VM operations
 func guestOSManager() (pkgOS.Manager, error) {
-	dist := GetDistribution()
+	dist, err := GetDistribution()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read os-release file: %w", err)
+	}
 	switch {
 	case dist.Name == "fedora" && dist.Variant == "coreos":
 		return &pkgOS.OSTree{}, nil
@@ -67,14 +71,11 @@ type Distribution struct {
 }
 
 // GetDistribution checks the OS distribution
-func GetDistribution() Distribution {
-	dist := Distribution{
-		Name:    "unknown",
-		Variant: "unknown",
-	}
+func GetDistribution() (Distribution, error) {
+	dist := Distribution{}
 	f, err := os.Open("/etc/os-release")
 	if err != nil {
-		return dist
+		return dist, err
 	}
 	defer f.Close()
 
@@ -87,5 +88,8 @@ func GetDistribution() Distribution {
 			dist.Variant = strings.Trim(after, "\"")
 		}
 	}
-	return dist
+	if err := l.Err(); err != nil {
+		return dist, err
+	}
+	return dist, nil
 }

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -343,5 +343,9 @@ func (r *Runtime) GetHostDistributionInfo() define.DistributionInfo {
 			dist.Codename = strings.Trim(after, "\"")
 		}
 	}
+	if err := l.Err(); err != nil {
+		// Not much we can do here, log a warning, no need to full fail info over this anyway.
+		logrus.Warnf("Failed to read /etc/os-release: %v", err)
+	}
 	return dist
 }

--- a/libpod/info_linux.go
+++ b/libpod/info_linux.go
@@ -112,6 +112,9 @@ func getCPUUtilization() (*define.CPUUsage, error) {
 	for scanner.Scan() {
 		break
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 	// column 1 is user, column 3 is system, column 4 is idle
 	stats := strings.Fields(scanner.Text())
 	return statToPercent(stats)

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1203,6 +1203,10 @@ func graphRootMounted() bool {
 			return true
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		logrus.Errorf("Failed to read /run/.containerenv: %v", err)
+		return false
+	}
 	return false
 }
 

--- a/pkg/emulation/binfmtmisc_linux.go
+++ b/pkg/emulation/binfmtmisc_linux.go
@@ -156,6 +156,9 @@ func parseBinfmtMisc(path string, r io.Reader) (int, []byte, []byte, error) {
 		}
 		continue
 	}
+	if err := scanner.Err(); err != nil {
+		return -1, nil, nil, err
+	}
 	if magicString == "" || maskString == "" { // entry is missing some info we need here
 		return -1, nil, nil, nil
 	}

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -1,7 +1,6 @@
 package machine
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -61,6 +60,13 @@ func LocalhostSSHCopy(username, identityPath string, sshPort int, srcPath, destP
 	return cmd.Run()
 }
 
+type sshDebugLogger struct{}
+
+func (w *sshDebugLogger) Write(p []byte) (int, error) {
+	logrus.Debugf("ssh output: %s", string(p))
+	return len(p), nil
+}
+
 func localhostBuiltinSSH(username, identityPath, name string, sshPort int, inputArgs []string, passOutput bool, stdin io.Reader) error {
 	config, err := createLocalhostConfig(username, identityPath) // WARNING: This MUST NOT be generalized to allow communication over untrusted networks.
 	if err != nil {
@@ -86,38 +92,12 @@ func localhostBuiltinSSH(username, identityPath, name string, sshPort int, input
 		session.Stdout = os.Stdout
 		session.Stderr = os.Stderr
 	} else if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		return runSessionWithDebug(session, cmd)
+		logger := &sshDebugLogger{}
+		session.Stdout = logger
+		session.Stderr = logger
 	}
 
 	return session.Run(cmd)
-}
-
-func runSessionWithDebug(session *ssh.Session, cmd string) error {
-	outPipe, err := session.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	errPipe, err := session.StderrPipe()
-	if err != nil {
-		return err
-	}
-	logOuput := func(pipe io.Reader, done chan struct{}) {
-		scanner := bufio.NewScanner(pipe)
-		for scanner.Scan() {
-			logrus.Debugf("ssh output: %s", scanner.Text())
-		}
-		done <- struct{}{}
-	}
-	if err := session.Start(cmd); err != nil {
-		return err
-	}
-	completed := make(chan struct{}, 2)
-	go logOuput(outPipe, completed)
-	go logOuput(errPipe, completed)
-	<-completed
-	<-completed
-
-	return session.Wait()
 }
 
 // createLocalhostConfig returns a *ssh.ClientConfig for authenticating a user using a private key

--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -53,7 +55,6 @@ func SilentExecCmd(args ...string) *exec.Cmd {
 
 func parseWSLStatus() wslStatus {
 	onceStatus.Do(func() {
-		status = wslStatus{}
 		cmd := SilentExecCmd("--status")
 		out, err := cmd.StdoutPipe()
 		cmd.Stderr = nil
@@ -63,7 +64,8 @@ func parseWSLStatus() wslStatus {
 		if err = cmd.Start(); err != nil {
 			return
 		}
-		status = matchOutputLine(out)
+		var outputErr error
+		status, outputErr = matchOutputLine(out)
 		err = cmd.Wait()
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -71,6 +73,10 @@ func parseWSLStatus() wslStatus {
 			// we assume that WSL isn't installed and
 			// override whatever was returned by
 			// matchOutputLine()
+			status = wslStatus{}
+		}
+		if outputErr != nil {
+			logrus.Errorf("Failed to read wsl --status output: %v", outputErr)
 			status = wslStatus{}
 		}
 	})
@@ -93,7 +99,7 @@ func IsWSLStoreVersionInstalled() bool {
 	return true
 }
 
-func matchOutputLine(output io.ReadCloser) wslStatus {
+func matchOutputLine(output io.ReadCloser) (wslStatus, error) {
 	status := wslStatus{
 		installed:         true,
 		vmpFeatureEnabled: true,
@@ -118,5 +124,8 @@ func matchOutputLine(output io.ReadCloser) wslStatus {
 			}
 		}
 	}
-	return status
+	if err := scanner.Err(); err != nil {
+		return status, err
+	}
+	return status, nil
 }

--- a/pkg/machine/wsl/wutil/wutil_test.go
+++ b/pkg/machine/wsl/wutil/wutil_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -136,7 +137,9 @@ func TestMatchOutputLine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.winVariant, func(t *testing.T) {
 			reader := io.NopCloser(strings.NewReader(tt.statusOutput))
-			assert.Equal(t, tt.want, matchOutputLine(reader))
+			status, err := matchOutputLine(reader)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, status)
 		})
 	}
 }

--- a/pkg/specgen/generate/oci_linux.go
+++ b/pkg/specgen/generate/oci_linux.go
@@ -14,6 +14,7 @@ import (
 
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/podman/v6/libpod"
@@ -37,6 +38,9 @@ var isMqueueSupported = sync.OnceValue(func() bool {
 		if len(fields) > 0 && fields[len(fields)-1] == "mqueue" {
 			return true
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		logrus.Warnf("Failed to read /proc/filesystems: %v, assuming mqueue is not supported", err)
 	}
 	return false
 })

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -1049,7 +1050,7 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with --pre-checkpoint", func() {
-		if podmanTest.Host.Arch == "arm64" {
+		if runtime.GOARCH == "arm64" {
 			Skip("skip on arm64/aarch64, https://github.com/checkpoint-restore/criu/issues/2676")
 		}
 		SkipIfContainerized("FIXME: #24230 - no longer works in container testing")
@@ -1085,7 +1086,7 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with --pre-checkpoint and export (migration)", func() {
-		if podmanTest.Host.Arch == "arm64" {
+		if runtime.GOARCH == "arm64" {
 			Skip("skip on arm64/aarch64, https://github.com/checkpoint-restore/criu/issues/2676")
 		}
 		SkipIfContainerized("FIXME: #24230 - no longer works in container testing")

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -68,7 +69,6 @@ type PodmanTestIntegration struct {
 	StorageOptions      string
 	SignaturePolicyPath string
 	CgroupManager       string
-	Host                HostOS
 	CliTmpDir           string // value of podman --tmpdir
 }
 
@@ -296,7 +296,6 @@ const (
 
 // PodmanTestCreateUtil creates a PodmanTestIntegration instance for the tests
 func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *PodmanTestIntegration {
-	host := GetHostDistributionInfo()
 	cwd, _ := os.Getwd()
 
 	root := filepath.Join(tempDir, "root")
@@ -387,7 +386,6 @@ func PodmanTestCreateUtil(tempDir string, target PodmanTestCreateUtilTarget) *Po
 		StorageOptions:      storageOptions,
 		SignaturePolicyPath: filepath.Join(INTEGRATION_ROOT, "test/policy.json"),
 		CgroupManager:       cgroupManager,
-		Host:                host,
 	}
 
 	var pathPrefix string
@@ -1828,7 +1826,7 @@ func skipWithoutDevNullb0() {
 }
 
 func SkipIfNotAMD64() {
-	if podmanTest.Host.Arch != "amd64" {
+	if runtime.GOARCH != "amd64" {
 		Skip("test only valid on amd64")
 	}
 }

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create with --mount flag", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("skip failing test on ppc64le")
 		}
 

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -3,6 +3,8 @@
 package integration
 
 import (
+	"runtime"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "go.podman.io/podman/v6/test/utils"
@@ -66,7 +68,7 @@ var _ = Describe("Podman history", func() {
 		Expect(len(lines[1])).To(BeNumerically(">", 45))
 
 		// Size is different on other architectures
-		if podmanTest.Host.Arch == "amd64" {
+		if runtime.GOARCH == "amd64" {
 			session = podmanTest.Podman([]string{"history", "--no-trunc", "--format", "{{.Size}}", ALPINE})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -145,7 +146,7 @@ var _ = Describe("Podman load", func() {
 	})
 
 	It("podman load multiple tags", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("skip on ppc64le")
 		}
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -196,7 +197,7 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("push with --add-compression and --force-compression", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		if isRootless() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -666,7 +666,7 @@ var _ = Describe("Podman pull", func() {
 		It("From local registry", func() {
 			SkipIfRemote("Remote pull does not support decryption")
 
-			if podmanTest.Host.Arch == "ppc64le" {
+			if runtime.GOARCH == "ppc64le" {
 				Skip("No registry image for ppc64le")
 			}
 

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -95,7 +96,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("push test --force-compression", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		if isRootless() {
@@ -152,7 +153,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("push test --force-compression --format=v2s2", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		if isRootless() {
@@ -193,7 +194,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to local registry", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		if isRootless() {
@@ -358,7 +359,7 @@ var _ = Describe("Podman push", func() {
 
 	It("podman push to local registry with authorization", func() {
 		SkipIfRootless("/etc/containers/certs.d not writable")
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		authPath := filepath.Join(podmanTest.TempDir, "auth")

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -24,7 +25,7 @@ const (
 
 var _ = Describe("Podman run with --sig-proxy", func() {
 	Specify("signals are forwarded to container using sig-proxy", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("Doesn't work on ppc64le")
 		}
 		signal := syscall.SIGFPE

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -459,7 +460,7 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(Not(BeEmpty()))
 		Expect(session).Should(ExitCleanly())
-		if podmanTest.Host.Arch == "amd64" {
+		if runtime.GOARCH == "amd64" {
 			session = podmanTest.Podman([]string{"exec", "maskCtr2", "ls", "/proc/acpi"})
 			session.WaitWithDefaultTimeout()
 			Expect(session.OutputToString()).To(Not(BeEmpty()))
@@ -495,7 +496,7 @@ var _ = Describe("Podman run", func() {
 		Expect(session).Should(ExitCleanly())
 		Expect(session.OutputToStringArray()).Should(HaveLen(1))
 
-		if podmanTest.Host.Arch == "amd64" {
+		if runtime.GOARCH == "amd64" {
 			session = podmanTest.Podman([]string{"run", "--security-opt", "unmask=/proc/a*", ALPINE, "ls", "/proc/acpi"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(ExitCleanly())
@@ -2286,7 +2287,7 @@ WORKDIR /madethis`, BB)
 	It("podman run and decrypt from local registry", func() {
 		SkipIfRemote("Remote run does not support decryption")
 
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -68,7 +69,7 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with --mount flag", func() {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("skip failing test on ppc64le")
 		}
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -121,7 +122,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save remove signature", func() {
 		podmanTest.AddImageToRWStore(ALPINE)
 		SkipIfRootless("FIXME: Need get in rootless push sign")
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		tempGNUPGHOME := filepath.Join(podmanTest.TempDir, "tmpGPG")

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"text/template"
 
@@ -44,7 +45,7 @@ insecure = false
 	registryFileBadTmpl := template.Must(template.New("registryFileBad").Parse(badRegFileContents))
 
 	mockFakeRegistryServerAsContainer := func(name string) endpoint {
-		if podmanTest.Host.Arch == "ppc64le" {
+		if runtime.GOARCH == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
 		port := GetPort()

--- a/test/utils/common_function_test.go
+++ b/test/utils/common_function_test.go
@@ -33,27 +33,20 @@ var _ = Describe("Common functions test", func() {
 	})
 
 	DescribeTable("Test GetHostDistributionInfo",
-		func(path, id, ver string, empty bool) {
+		func(path, id, ver string) {
 			txt := fmt.Sprintf("ID=%s\nVERSION_ID=%s", id, ver)
-			if !empty {
-				f, _ := os.Create(path)
-				_, err := f.WriteString(txt)
-				Expect(err).ToNot(HaveOccurred(), "Failed to write data.")
-				f.Close()
-			}
+			f, _ := os.Create(path)
+			_, err := f.WriteString(txt)
+			Expect(err).ToNot(HaveOccurred(), "Failed to write data.")
+			f.Close()
 
 			OSReleasePath = path
 			host := GetHostDistributionInfo()
-			if empty {
-				Expect(host).To(Equal(HostOS{}), "HostOs should be empty.")
-			} else {
-				Expect(host.Distribution).To(Equal(strings.Trim(id, "\"")))
-				Expect(host.Version).To(Equal(strings.Trim(ver, "\"")))
-			}
+			Expect(host.Distribution).To(Equal(strings.Trim(id, "\"")))
+			Expect(host.Version).To(Equal(strings.Trim(ver, "\"")))
 		},
-		Entry("Configure file is not exist.", "/tmp/nonexistent", "", "", true),
-		Entry("Item value with and without \"", "/tmp/os-release.test", "fedora", "\"28\"", false),
-		Entry("Item empty with and without \"", "/tmp/os-release.test", "", "\"\"", false),
+		Entry("Item value with and without \"", "/tmp/os-release.test", "fedora", "\"28\""),
+		Entry("Item empty with and without \"", "/tmp/os-release.test", "", "\"\""),
 	)
 
 	DescribeTable("Test TestIsCommandAvailable",

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -78,7 +77,6 @@ type PodmanSession struct {
 type HostOS struct {
 	Distribution string
 	Version      string
-	Arch         string
 }
 
 // MakeOptions assembles all podman options
@@ -397,14 +395,11 @@ func tagOutputToMap(imagesOutput []string) map[string]map[string]bool {
 // GetHostDistributionInfo returns a struct with its distribution Name and version
 func GetHostDistributionInfo() HostOS {
 	f, err := os.Open(OSReleasePath)
-	if err != nil {
-		return HostOS{}
-	}
+	Expect(err).ToNot(HaveOccurred(), "open %s", OSReleasePath)
 	defer f.Close()
 
 	l := bufio.NewScanner(f)
 	host := HostOS{}
-	host.Arch = runtime.GOARCH
 	for l.Scan() {
 		if strings.HasPrefix(l.Text(), "ID=") {
 			host.Distribution = strings.ReplaceAll(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "")
@@ -413,6 +408,8 @@ func GetHostDistributionInfo() HostOS {
 			host.Version = strings.ReplaceAll(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "")
 		}
 	}
+	err = l.Err()
+	Expect(err).ToNot(HaveOccurred(), "read %s", OSReleasePath)
 	return host
 }
 


### PR DESCRIPTION
Found via scannererr, but I also reworked some parts to not use a scanner. Of course reporting an error when we used to ignore it may result in different behaviours now, though in many cases where it is not important to read the file we still ignore it.

I also did some larger rework of the e2e tests which read the os-release file in each test case for no reason.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
