### PR TITLE
[v6.0] Fix machine init when wsl isnt installed 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,9 +607,21 @@ jobs:
       - name: WSL info
         if: matrix.provider == 'wsl'
         shell: pwsh
+        env:
+          WSL_UTF8: '1'
         run: |
           wsl --update
           wsl --version
+          wsl --status
+
+      - name: Uninstall WSL
+        if: matrix.provider == 'hyperv'
+        env:
+          WSL_UTF8: '1'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          wsl --uninstall
           wsl --status
 
       - name: Configure container policy

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -91,6 +91,9 @@ func (w WSLStubber) PrepareIgnition(_ *vmconfigs.MachineConfig, _ *ignition.Igni
 }
 
 func (w WSLStubber) Exists(name string) (bool, error) {
+	if !wutil.IsWSLInstalled() {
+		return false, nil
+	}
 	return isWSLExist(env.WithPodmanPrefix(name))
 }
 

--- a/pkg/machine/wsl/wutil/wutil.go
+++ b/pkg/machine/wsl/wutil/wutil.go
@@ -4,6 +4,7 @@ package wutil
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -52,11 +53,7 @@ func SilentExecCmd(args ...string) *exec.Cmd {
 
 func parseWSLStatus() wslStatus {
 	onceStatus.Do(func() {
-		status = wslStatus{
-			installed:         false,
-			vmpFeatureEnabled: false,
-			wslFeatureEnabled: false,
-		}
+		status = wslStatus{}
 		cmd := SilentExecCmd("--status")
 		out, err := cmd.StdoutPipe()
 		cmd.Stderr = nil
@@ -66,14 +63,17 @@ func parseWSLStatus() wslStatus {
 		if err = cmd.Start(); err != nil {
 			return
 		}
-
 		status = matchOutputLine(out)
-
-		if err := cmd.Wait(); err != nil {
-			return
+		err = cmd.Wait()
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// If `wsl --status` returns an exit error
+			// we assume that WSL isn't installed and
+			// override whatever was returned by
+			// matchOutputLine()
+			status = wslStatus{}
 		}
 	})
-
 	return status
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

Cherry-picking 697f9116 and 80203302 (original [PR](https://github.com/podman-container-tools/podman/pull/29063))

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fix Hyper-V machine init on hosts where WSL isn't installed
```
