### PR TITLE
fix: quadlet generator emits diagnostics to stderr under systemd-analyze verify

### DIFF
--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -70,10 +70,10 @@ func Logf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	line := fmt.Sprintf("quadlet-generator[%d]: %s", os.Getpid(), s)
 
-	if !logToKmsg(line) || dryRunFlag {
-		fmt.Fprintf(os.Stderr, "%s\n", line)
-		os.Stderr.Sync()
-	}
+	logToKmsg(line)
+
+	fmt.Fprintf(os.Stderr, "%s\n", line)
+	os.Stderr.Sync()
 }
 
 var debugEnabled = false

--- a/cmd/quadlet/main.go
+++ b/cmd/quadlet/main.go
@@ -70,7 +70,7 @@ func Logf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	line := fmt.Sprintf("quadlet-generator[%d]: %s", os.Getpid(), s)
 
-	logToKmsg(line)
+	_ = logToKmsg(line)
 
 	fmt.Fprintf(os.Stderr, "%s\n", line)
 	os.Stderr.Sync()

--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -3,10 +3,125 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestLogfWritesToStderrWhenKmsgUnavailable(t *testing.T) {
+	restoreLogGlobals(t)
+	noKmsg = true
+	kmsgFile = nil
+	dryRunFlag = false
+
+	stderr := captureStderr(t, func() {
+		Logf("kmsg unavailable")
+	})
+
+	assert.Equal(t, expectedLogLine("kmsg unavailable")+"\n", stderr)
+}
+
+func TestLogfWritesToStderrWhenKmsgSucceeds(t *testing.T) {
+	restoreLogGlobals(t)
+	noKmsg = false
+	dryRunFlag = false
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "kmsg")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		tmpFile.Close()
+	})
+	kmsgFile = tmpFile
+
+	stderr := captureStderr(t, func() {
+		Logf("kmsg succeeds")
+	})
+
+	line := expectedLogLine("kmsg succeeds")
+	assert.Equal(t, line+"\n", stderr)
+
+	_, err = tmpFile.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	kmsg, err := io.ReadAll(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, line, string(kmsg))
+}
+
+func TestLogfWritesToStderrInDryRun(t *testing.T) {
+	restoreLogGlobals(t)
+	noKmsg = true
+	kmsgFile = nil
+	dryRunFlag = true
+
+	stderr := captureStderr(t, func() {
+		Logf("dry run")
+	})
+
+	assert.Equal(t, expectedLogLine("dry run")+"\n", stderr)
+}
+
+func TestLogfWritesToStderrWhenKmsgWriteFails(t *testing.T) {
+	restoreLogGlobals(t)
+	noKmsg = false
+	dryRunFlag = false
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "kmsg")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	kmsgFile = tmpFile
+
+	stderr := captureStderr(t, func() {
+		Logf("kmsg write failure")
+	})
+
+	assert.Equal(t, expectedLogLine("kmsg write failure")+"\n", stderr)
+	assert.Nil(t, kmsgFile)
+}
+
+func restoreLogGlobals(t *testing.T) {
+	t.Helper()
+
+	oldNoKmsg := noKmsg
+	oldKmsgFile := kmsgFile
+	oldDryRunFlag := dryRunFlag
+
+	t.Cleanup(func() {
+		noKmsg = oldNoKmsg
+		kmsgFile = oldKmsgFile
+		dryRunFlag = oldDryRunFlag
+	})
+}
+
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	f()
+	require.NoError(t, writer.Close())
+	os.Stderr = oldStderr
+
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	return string(output)
+}
+
+func expectedLogLine(message string) string {
+	return fmt.Sprintf("quadlet-generator[%d]: %s", os.Getpid(), message)
+}
 
 func TestIsUnambiguousName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Running `sudo systemd-analyze --generators verify <unit>` against a broken quadlet printed no generator diagnostics, even though the same command without `sudo` (and `podman-system-generator -dryrun`) did. The cause is in `cmd/quadlet/main.go`: `Logf` wrote each line to `/dev/kmsg` and only fell back to stderr when that write failed or `-dryrun` was set. As root the kmsg write succeeds, so nothing was written to stderr, and `systemd-analyze verify` captures stderr rather than kmsg.

`Logf` now writes to `/dev/kmsg` best-effort (preserving the early-boot and journal logging that root services rely on at `daemon-reload`) and additionally always copies the same `quadlet-generator[pid]: ...` line to stderr, so `systemd-analyze verify` and interactive `sudo` runs surface the diagnostics. Rootless behavior, where kmsg is unavailable, is unchanged.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
The quadlet generator now writes its diagnostics to stderr in addition to /dev/kmsg, so errors are visible under `systemd-analyze --generators verify` and other tooling that captures the generator's stderr, including when run as root.
```

Fixes #28888
