### PR TITLE
pkg/kube/quadlet: add podman kube quadlet subcommand

### DIFF
--- a/cmd/podman/kube/quadlet.go
+++ b/cmd/podman/kube/quadlet.go
@@ -1,0 +1,270 @@
+package kube
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.podman.io/common/pkg/completion"
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/kube/quadlet"
+	"sigs.k8s.io/yaml"
+
+	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/validate"
+)
+
+// quadletJSON is the element type for --format json output.
+type quadletJSON struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+}
+
+var (
+	quadletOptions = struct {
+		OutputDir  string
+		Format     string
+		NamePrefix string
+		Network    string
+		ConfigMaps []string
+		Secrets    []string
+	}{}
+
+	kubeQuadletCmd = &cobra.Command{
+		Use:   "quadlet [options] POD_YAML",
+		Short: "Convert a Kubernetes Pod YAML into Quadlet unit files",
+		Long: `Reads a Kubernetes Pod YAML file and generates the corresponding Quadlet
+unit files (.pod, .container, .volume, .env, .sh) without connecting to a Podman daemon.
+
+A .pod unit is always generated so that all containers share a proper infra
+container (like a Kubernetes pause container) rather than one container acting
+as an anchor for the others.
+
+The output files can be written to a directory or printed to stdout.  Use
+--format json for programmatic consumption.`,
+		RunE:              runKubeQuadlet,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.AutocompleteDefault,
+		// Override the root PersistentPreRunE so no daemon/storage setup is needed.
+		PersistentPreRunE: validate.NoOp,
+		Example: `podman kube quadlet pod.yaml
+podman kube quadlet --output-dir /etc/containers/systemd pod.yaml
+podman kube quadlet --format json pod.yaml | jq .[].name`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: kubeQuadletCmd,
+		Parent:  kubeCmd,
+	})
+
+	flags := kubeQuadletCmd.Flags()
+
+	outputDirFlagName := "output-dir"
+	flags.StringVarP(&quadletOptions.OutputDir, outputDirFlagName, "o", "", "Write generated files to this directory (default: print to stdout)")
+	_ = kubeQuadletCmd.RegisterFlagCompletionFunc(outputDirFlagName, completion.AutocompleteDefault)
+
+	formatFlagName := "format"
+	flags.StringVar(&quadletOptions.Format, formatFlagName, "text", `Output format: "text" or "json"`)
+	_ = kubeQuadletCmd.RegisterFlagCompletionFunc(formatFlagName, completion.AutocompleteNone)
+
+	namePrefixFlagName := "name-prefix"
+	flags.StringVar(&quadletOptions.NamePrefix, namePrefixFlagName, "", "Override the name prefix for generated files (default: pod.metadata.name)")
+	_ = kubeQuadletCmd.RegisterFlagCompletionFunc(namePrefixFlagName, completion.AutocompleteNone)
+
+	networkFlagName := "network"
+	flags.StringVar(&quadletOptions.Network, networkFlagName, "", "Network= value for the pod unit (e.g. podman, host)")
+	_ = kubeQuadletCmd.RegisterFlagCompletionFunc(networkFlagName, completion.AutocompleteNone)
+
+	configmapFlagName := "configmap"
+	flags.StringArrayVar(&quadletOptions.ConfigMaps, configmapFlagName, nil, "Path to a ConfigMap YAML file (repeatable)")
+	_ = kubeQuadletCmd.RegisterFlagCompletionFunc(configmapFlagName, completion.AutocompleteDefault)
+
+	secretFlagName := "secret"
+	flags.StringArrayVar(&quadletOptions.Secrets, secretFlagName, nil, "Path to a Secret YAML file (repeatable)")
+	_ = kubeQuadletCmd.RegisterFlagCompletionFunc(secretFlagName, completion.AutocompleteDefault)
+}
+
+func runKubeQuadlet(_ *cobra.Command, args []string) error {
+	if quadletOptions.Format != "text" && quadletOptions.Format != "json" {
+		return fmt.Errorf("--format must be \"text\" or \"json\", got %q", quadletOptions.Format)
+	}
+
+	pod, err := podFromFile(args[0])
+	if err != nil {
+		return err
+	}
+
+	opts, err := buildQuadletOptions()
+	if err != nil {
+		return err
+	}
+
+	files, err := quadlet.Convert(pod, opts)
+	if err != nil {
+		return fmt.Errorf("converting pod to Quadlet: %w", err)
+	}
+
+	if quadletOptions.OutputDir != "" {
+		return writeFiles(files, quadletOptions.OutputDir)
+	}
+
+	switch quadletOptions.Format {
+	case "json":
+		return printJSON(files)
+	default:
+		return printText(files)
+	}
+}
+
+// podFromFile reads and unmarshals a Kubernetes Pod from a YAML file.
+func podFromFile(path string) (*v1.Pod, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %w", path, err)
+	}
+
+	// Detect kind before committing to Pod decode.
+	var meta struct {
+		Kind string `json:"kind"`
+	}
+	if err := yaml.Unmarshal(raw, &meta); err != nil {
+		return nil, fmt.Errorf("parsing YAML from %q: %w", path, err)
+	}
+	if meta.Kind != "Pod" {
+		return nil, fmt.Errorf("%q has kind %q; only \"Pod\" is supported", path, meta.Kind)
+	}
+
+	var pod v1.Pod
+	if err := yaml.Unmarshal(raw, &pod); err != nil {
+		return nil, fmt.Errorf("parsing Pod from %q: %w", path, err)
+	}
+	return &pod, nil
+}
+
+// buildQuadletOptions constructs Options from CLI flags and any provided
+// ConfigMap/Secret YAML files.
+func buildQuadletOptions() (quadlet.Options, error) {
+	opts := quadlet.Options{
+		NamePrefix: quadletOptions.NamePrefix,
+		Network:    quadletOptions.Network,
+	}
+
+	if len(quadletOptions.ConfigMaps) > 0 {
+		opts.ConfigMaps = make(map[string]v1.ConfigMap)
+		for _, cmPath := range quadletOptions.ConfigMaps {
+			cm, err := loadConfigMap(cmPath)
+			if err != nil {
+				return opts, err
+			}
+			opts.ConfigMaps[cm.Name] = cm
+		}
+	}
+
+	if len(quadletOptions.Secrets) > 0 {
+		opts.Secrets = make(map[string]v1.Secret)
+		for _, secPath := range quadletOptions.Secrets {
+			sec, err := loadSecret(secPath)
+			if err != nil {
+				return opts, err
+			}
+			opts.Secrets[sec.Name] = sec
+		}
+	}
+
+	return opts, nil
+}
+
+func loadConfigMap(path string) (v1.ConfigMap, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return v1.ConfigMap{}, fmt.Errorf("reading ConfigMap %q: %w", path, err)
+	}
+	var cm v1.ConfigMap
+	if err := yaml.Unmarshal(raw, &cm); err != nil {
+		return v1.ConfigMap{}, fmt.Errorf("parsing ConfigMap %q: %w", path, err)
+	}
+	return cm, nil
+}
+
+func loadSecret(path string) (v1.Secret, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return v1.Secret{}, fmt.Errorf("reading Secret %q: %w", path, err)
+	}
+	var sec v1.Secret
+	if err := yaml.Unmarshal(raw, &sec); err != nil {
+		return v1.Secret{}, fmt.Errorf("parsing Secret %q: %w", path, err)
+	}
+	return sec, nil
+}
+
+// writeFiles writes each GeneratedFile to outputDir.
+func writeFiles(files []*quadlet.GeneratedFile, outputDir string) error {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory %q: %w", outputDir, err)
+	}
+	for _, f := range files {
+		dest := filepath.Join(outputDir, f.Name)
+		var content []byte
+		if f.Unit != nil {
+			var buf bytes.Buffer
+			if err := f.Unit.Write(&buf); err != nil {
+				return fmt.Errorf("serializing %q: %w", f.Name, err)
+			}
+			content = buf.Bytes()
+		} else {
+			content = []byte(f.Content)
+		}
+		if err := os.WriteFile(dest, content, 0o644); err != nil {
+			return fmt.Errorf("writing %q: %w", dest, err)
+		}
+		fmt.Println(dest)
+	}
+	return nil
+}
+
+// printText prints each file separated by a header line.
+func printText(files []*quadlet.GeneratedFile) error {
+	for i, f := range files {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("=== %s ===\n", f.Name)
+		if f.Unit != nil {
+			var buf bytes.Buffer
+			if err := f.Unit.Write(&buf); err != nil {
+				return fmt.Errorf("serializing %q: %w", f.Name, err)
+			}
+			fmt.Print(buf.String())
+		} else {
+			fmt.Print(f.Content)
+		}
+	}
+	return nil
+}
+
+// printJSON emits a JSON array of {name, content} objects.
+func printJSON(files []*quadlet.GeneratedFile) error {
+	out := make([]quadletJSON, 0, len(files))
+	for _, f := range files {
+		var content string
+		if f.Unit != nil {
+			var buf bytes.Buffer
+			if err := f.Unit.Write(&buf); err != nil {
+				return fmt.Errorf("serializing %q: %w", f.Name, err)
+			}
+			content = buf.String()
+		} else {
+			content = f.Content
+		}
+		out = append(out, quadletJSON{Name: f.Name, Content: content})
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/docs/source/markdown/podman-kube-quadlet.1.md
+++ b/docs/source/markdown/podman-kube-quadlet.1.md
@@ -1,0 +1,80 @@
+% podman-kube-quadlet 1
+
+## NAME
+podman\-kube\-quadlet - Convert a Kubernetes Pod YAML into Quadlet unit files
+
+## SYNOPSIS
+**podman kube quadlet** [*options*] *pod-yaml*
+
+## DESCRIPTION
+**podman kube quadlet** reads a Kubernetes Pod YAML file and generates the
+corresponding Quadlet unit files (`.pod`, `.container`, `.volume`, `.env`,
+`.sh`) without connecting to a Podman daemon. The generated files can be placed
+in a systemd user unit directory (e.g. `~/.config/containers/systemd/`) so that
+**podman-systemd-generator(8)** starts and manages the pod as a systemd service.
+
+Each container in the Pod becomes a `.container` unit that joins the `.pod` unit
+via `Pod=`. Init containers are emitted before regular containers and are given
+`Restart=no`. Volume sources are mapped as follows:
+
+- `PersistentVolumeClaim` → `Volume=` (or `Mount=type=volume,subpath=...` when SubPath is set)
+- `EmptyDir` → a named tmpfs volume shared across all containers in the pod
+- `HostPath` → `Volume=` with `:z` SELinux relabeling
+- `Image` → `Mount=type=image`
+
+## OPTIONS
+
+#### **--configmap**=*path*
+
+Path to a Kubernetes ConfigMap YAML file. May be specified multiple times.
+ConfigMap volumes in the Pod spec are written as read-only bind-mount directories
+containing the key/value pairs.
+
+#### **--format**=**text** | **json**
+
+Output format. **text** (default) writes unit files to the directory given by
+**--output-dir** or, if omitted, prints them to standard output. **json** emits
+a JSON array where each element has `name` (filename) and `content` (unit file
+text) fields; useful for programmatic consumption.
+
+#### **--name-prefix**=*prefix*
+
+Override the name prefix used for all generated unit files. Defaults to the Pod
+metadata name.
+
+#### **--network**=*network*
+
+Network to attach the pod to (passed as `Network=` in the `.pod` unit).
+
+#### **--output-dir**, **-o**=*dir*
+
+Directory to write the generated unit files into. If omitted, files are printed
+to standard output (one after another, each preceded by a `# filename` comment).
+
+#### **--script-dir**=*dir*
+
+Directory in which companion `.sh` scripts are written when a container's
+command is a shell one-liner (`/bin/sh -c <script>`). Defaults to the same
+directory as **--output-dir**.
+
+#### **--secret**=*path*
+
+Path to a Kubernetes Secret YAML file. May be specified multiple times.
+
+## EXAMPLES
+
+Convert a pod YAML and write unit files to a systemd user directory.
+```
+$ podman kube quadlet --output-dir ~/.config/containers/systemd/myapp pod.yaml
+```
+
+Convert and emit JSON for programmatic consumption.
+```
+$ podman kube quadlet --format json pod.yaml | jq '.[].name'
+```
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **[podman-systemd.unit(5)](podman-systemd.unit.5.md)**
+
+## HISTORY
+June 2026, Originally compiled by Asaf Ben Natan (asafbennatan at gmail dot com)

--- a/docs/source/markdown/podman-kube.1.md
+++ b/docs/source/markdown/podman-kube.1.md
@@ -22,9 +22,10 @@ are deployed to a Kubernetes cluster from podman, please use `kubectl` to manage
 | down     | [podman-kube-down(1)](podman-kube-down.1.md)         | Remove containers and pods based on Kubernetes YAML.                          |
 | generate | [podman-kube-generate(1)](podman-kube-generate.1.md) | Generate Kubernetes YAML based on containers, pods or volumes.                |
 | play     | [podman-kube-play(1)](podman-kube-play.1.md)         | Create containers, pods and volumes based on Kubernetes YAML.                 |
+| quadlet  | [podman-kube-quadlet(1)](podman-kube-quadlet.1.md)   | Convert a Kubernetes Pod YAML into Quadlet unit files.                        |
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-container(1)](podman-container.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **[podman-kube-down(1)](podman-kube-down.1.md)**, **[podman-kube-generate(1)](podman-kube-generate.1.md)**, **[podman-kube-apply(1)](podman-kube-apply.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-container(1)](podman-container.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **[podman-kube-down(1)](podman-kube-down.1.md)**, **[podman-kube-generate(1)](podman-kube-generate.1.md)**, **[podman-kube-apply(1)](podman-kube-apply.1.md)**, **[podman-kube-quadlet(1)](podman-kube-quadlet.1.md)**
 
 ## HISTORY
 December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -91,6 +91,7 @@ my %Format_Option_Is_Special = map { $_ => 1 } (
     'commit', 'container commit',               #  "  "  " "
     'diff',   'container diff', 'image diff',   # only supports "json"
     'generate systemd',                         #  "    "  "      "
+    'kube quadlet',                             #  "    "  "      "
     'mount',  'container mount', 'image mount', #  "    "  "      "
     'machine os upgrade',                       #  "    "  "      "
     'push',   'image push', 'manifest push',    # oci | v2s*

--- a/pkg/kube/quadlet/container.go
+++ b/pkg/kube/quadlet/container.go
@@ -1,0 +1,361 @@
+package quadlet
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/api/resource"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+// buildContainerUnit assembles a Quadlet .container unit for c.
+// It returns the primary unit plus any companion files (a .sh script or .env file).
+// pod-level directives (Network=, Sysctl=, After=, etc.) are applied by Convert().
+func buildContainerUnit(c v1.Container, pod *v1.Pod, opts Options) ([]*GeneratedFile, error) {
+	unit := parser.NewUnitFile()
+	unit.Filename = fmt.Sprintf("%s-%s.container", opts.NamePrefix, c.Name)
+
+	unit.Set(quadlet.UnitGroup, "Description",
+		fmt.Sprintf("Container %s for pod %s", c.Name, pod.Name))
+
+	// ?6.1 Identity
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyImage, c.Image)
+
+	if c.ImagePullPolicy != "" {
+		if pull := pullValue(c.ImagePullPolicy); pull != "" {
+			unit.Set(quadlet.ContainerGroup, quadlet.KeyPull, pull)
+		}
+	}
+	if c.WorkingDir != "" {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeyWorkingDir, c.WorkingDir)
+	}
+
+	// ?6.2 Command & args
+	scriptFile := applyExec(unit, c.Command, c.Args, opts.NamePrefix, c.Name)
+
+	// ?6.3 Environment (large values collected for env file)
+	envLines, err := applyEnv(unit, c.Env, c.EnvFrom, pod, &c, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// ?6.4 Security context
+	applySecurityContext(unit, c.SecurityContext, pod.Spec.SecurityContext)
+	// Pod-level supplemental groups are applied to every container.
+	applySupplementalGroups(unit, pod.Spec.SecurityContext)
+
+	// ?6.5 Resources
+	applyResources(unit, c.Resources)
+
+	// ?6.6 Volumes (ConfigMap/Secret handled via applyConfigMapVolume/applySecretVolume below)
+	if err := applyVolumeMountsWithConfigSecrets(unit, c.VolumeMounts, pod.Spec.Volumes, opts); err != nil {
+		return nil, err
+	}
+
+	// ?6.7 Health probes
+	applyProbes(unit, c.LivenessProbe, c.ReadinessProbe, c.StartupProbe, pod.Spec.RestartPolicy)
+
+	// ?6.9 Ports ? not published, just a comment
+	if len(c.Ports) > 0 {
+		unit.AddComment(quadlet.ContainerGroup, "Ports declared in pod spec (not published by default):")
+		for _, p := range c.Ports {
+			proto := p.Protocol
+			if proto == "" {
+				proto = v1.ProtocolTCP
+			}
+			unit.AddComment(quadlet.ContainerGroup,
+				fmt.Sprintf("  - %d/%s", p.ContainerPort, proto))
+		}
+		unit.AddComment(quadlet.ContainerGroup, "To publish, add a drop-in: [Container]")
+		unit.AddComment(quadlet.ContainerGroup, "PublishPort=<hostPort>:<containerPort>")
+	}
+
+	// ?6.1 tty / stdin
+	if c.TTY {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs, "--tty")
+	}
+	if c.Stdin {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs, "--interactive")
+	}
+
+	// ?6.8 Lifecycle
+	if c.Lifecycle != nil && c.Lifecycle.StopSignal != nil {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeyStopSignal, *c.Lifecycle.StopSignal)
+	}
+
+	result := []*GeneratedFile{{Name: unit.Filename, Unit: unit}}
+	if scriptFile != nil {
+		result = append(result, scriptFile)
+	}
+
+	// ?6.3 Env file
+	if len(envLines) > 0 {
+		envFileName := fmt.Sprintf("%s-%s.env", opts.NamePrefix, c.Name)
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyEnvironmentFile, envFileName)
+		result = append(result, &GeneratedFile{
+			Name:    envFileName,
+			Content: strings.Join(envLines, "\n") + "\n",
+		})
+	}
+
+	return result, nil
+}
+
+// applyVolumeMountsWithConfigSecrets extends applyVolumeMounts with ConfigMap/Secret volumes.
+func applyVolumeMountsWithConfigSecrets(unit *parser.UnitFile, mounts []v1.VolumeMount, volumes []v1.Volume, opts Options) error {
+	volByName := make(map[string]v1.VolumeSource, len(volumes))
+	for _, v := range volumes {
+		volByName[v.Name] = v.VolumeSource
+	}
+
+	for _, m := range mounts {
+		src, ok := volByName[m.Name]
+		if !ok {
+			return fmt.Errorf("volumeMount %q references unknown volume %q", m.Name, m.Name)
+		}
+		switch {
+		case src.ConfigMap != nil:
+			if err := applyConfigMapVolume(unit, m, src.ConfigMap, opts); err != nil {
+				return err
+			}
+		case src.Secret != nil:
+			if err := applySecretVolume(unit, m, src.Secret, opts); err != nil {
+				return err
+			}
+		default:
+			if err := applyMount(unit, m, src, opts.NamePrefix); err != nil {
+				return fmt.Errorf("volume %q: %w", m.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// pullValue maps an ImagePullPolicy to the Quadlet Pull= directive value.
+func pullValue(p v1.PullPolicy) string {
+	switch p {
+	case v1.PullAlways:
+		return "always"
+	case v1.PullNever:
+		return "never"
+	case v1.PullIfNotPresent:
+		return "missing"
+	}
+	return ""
+}
+
+// largeEnvThreshold is the byte size above which an env value is moved to an env file.
+const largeEnvThreshold = 1024
+
+// applyEnv maps env[] and envFrom[] sources onto unit.
+// Large or complex values are collected into envFileLines and written by the caller
+// as a companion .env GeneratedFile.
+// Returns companion env file lines (nil when none).
+func applyEnv(
+	unit *parser.UnitFile,
+	envVars []v1.EnvVar,
+	envFrom []v1.EnvFromSource,
+	pod *v1.Pod,
+	container *v1.Container,
+	opts Options,
+) (envFileLines []string, err error) {
+	for _, e := range envVars {
+		val, skip, envErr := resolveEnvVar(e, pod, container, opts)
+		if envErr != nil {
+			return nil, envErr
+		}
+		if skip {
+			continue
+		}
+		kv := e.Name + "=" + val
+		if isLargeEnvValue(val) {
+			envFileLines = append(envFileLines, kv)
+		} else {
+			unit.AddEscaped(quadlet.ContainerGroup, quadlet.KeyEnvironment, kv)
+		}
+	}
+
+	for _, ef := range envFrom {
+		lines, envErr := resolveEnvFrom(ef, opts)
+		if envErr != nil {
+			return nil, envErr
+		}
+		for _, kv := range lines {
+			unit.AddEscaped(quadlet.ContainerGroup, quadlet.KeyEnvironment, kv)
+		}
+	}
+
+	return envFileLines, nil
+}
+
+// resolveEnvVar resolves a single EnvVar to its string value.
+// Returns (value, skip, error). skip=true means the var is optional and missing.
+func resolveEnvVar(e v1.EnvVar, pod *v1.Pod, container *v1.Container, opts Options) (string, bool, error) {
+	if e.ValueFrom == nil {
+		return e.Value, false, nil
+	}
+	vf := e.ValueFrom
+
+	switch {
+	case vf.ConfigMapKeyRef != nil:
+		return resolveConfigMapKeyRef(vf.ConfigMapKeyRef, opts)
+	case vf.SecretKeyRef != nil:
+		return resolveSecretKeyRef(vf.SecretKeyRef, opts)
+	case vf.FieldRef != nil:
+		return resolveFieldRef(vf.FieldRef, pod, e.Name)
+	case vf.ResourceFieldRef != nil:
+		return resolveResourceFieldRef(vf.ResourceFieldRef, container)
+	}
+	return "", false, nil
+}
+
+func resolveConfigMapKeyRef(ref *v1.ConfigMapKeySelector, opts Options) (string, bool, error) {
+	optional := ref.Optional != nil && *ref.Optional
+	cm, ok := opts.ConfigMaps[ref.Name]
+	if !ok {
+		if optional {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("configMap %q not found in opts.ConfigMaps", ref.Name)
+	}
+	val, ok := cm.Data[ref.Key]
+	if !ok {
+		if optional {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("configMap %q has no key %q", ref.Name, ref.Key)
+	}
+	return val, false, nil
+}
+
+func resolveSecretKeyRef(ref *v1.SecretKeySelector, opts Options) (string, bool, error) {
+	optional := ref.Optional != nil && *ref.Optional
+	sec, ok := opts.Secrets[ref.Name]
+	if !ok {
+		if optional {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("secret %q not found in opts.Secrets", ref.Name)
+	}
+	val, ok := sec.Data[ref.Key]
+	if !ok {
+		if optional {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("secret %q has no key %q", ref.Name, ref.Key)
+	}
+	return string(val), false, nil
+}
+
+func resolveFieldRef(ref *v1.ObjectFieldSelector, pod *v1.Pod, envName string) (string, bool, error) {
+	switch ref.FieldPath {
+	case "metadata.name":
+		return pod.Name, false, nil
+	case "metadata.namespace":
+		return pod.Namespace, false, nil
+	case "metadata.uid":
+		return string(pod.UID), false, nil
+	}
+
+	// metadata.labels["key"] and metadata.annotations["key"]
+	if after, ok := strings.CutPrefix(ref.FieldPath, "metadata.labels[\""); ok {
+		key := strings.TrimSuffix(after, "\"]")
+		return pod.Labels[key], false, nil
+	}
+	if after, ok := strings.CutPrefix(ref.FieldPath, "metadata.annotations[\""); ok {
+		key := strings.TrimSuffix(after, "\"]")
+		return pod.Annotations[key], false, nil
+	}
+
+	// status.* fields are not knowable at generation time.
+	return "", false, fmt.Errorf("fieldRef path %q for env %q is not supported at generation time", ref.FieldPath, envName)
+}
+
+func resolveResourceFieldRef(ref *v1.ResourceFieldSelector, container *v1.Container) (string, bool, error) {
+	if container == nil {
+		return "0", false, nil
+	}
+	divisor := ref.Divisor
+	if divisor.IsZero() {
+		// Default divisor is 1.
+		divisor = *resource.NewMilliQuantity(1000, resource.DecimalSI)
+	}
+
+	switch ref.Resource {
+	case "limits.cpu":
+		if container.Resources.Limits != nil {
+			if q, ok := container.Resources.Limits[v1.ResourceCPU]; ok {
+				return fmt.Sprintf("%d", q.MilliValue()/divisor.MilliValue()), false, nil
+			}
+		}
+	case "limits.memory":
+		if container.Resources.Limits != nil {
+			if q, ok := container.Resources.Limits[v1.ResourceMemory]; ok {
+				return fmt.Sprintf("%d", q.Value()/divisor.Value()), false, nil
+			}
+		}
+	case "requests.cpu":
+		if container.Resources.Requests != nil {
+			if q, ok := container.Resources.Requests[v1.ResourceCPU]; ok {
+				return fmt.Sprintf("%d", q.MilliValue()/divisor.MilliValue()), false, nil
+			}
+		}
+	case "requests.memory":
+		if container.Resources.Requests != nil {
+			if q, ok := container.Resources.Requests[v1.ResourceMemory]; ok {
+				return fmt.Sprintf("%d", q.Value()/divisor.Value()), false, nil
+			}
+		}
+	}
+	return "0", false, nil
+}
+
+func resolveEnvFrom(ef v1.EnvFromSource, opts Options) ([]string, error) {
+	switch {
+	case ef.ConfigMapRef != nil:
+		return resolveEnvFromConfigMap(ef.ConfigMapRef, opts)
+	case ef.SecretRef != nil:
+		return resolveEnvFromSecret(ef.SecretRef, opts)
+	}
+	return nil, nil
+}
+
+func resolveEnvFromConfigMap(ref *v1.ConfigMapEnvSource, opts Options) ([]string, error) {
+	optional := ref.Optional != nil && *ref.Optional
+	cm, ok := opts.ConfigMaps[ref.Name]
+	if !ok {
+		if optional {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("configMap %q not found in opts.ConfigMaps", ref.Name)
+	}
+	lines := make([]string, 0, len(cm.Data))
+	for k, v := range cm.Data {
+		lines = append(lines, k+"="+v)
+	}
+	return lines, nil
+}
+
+func resolveEnvFromSecret(ref *v1.SecretEnvSource, opts Options) ([]string, error) {
+	optional := ref.Optional != nil && *ref.Optional
+	sec, ok := opts.Secrets[ref.Name]
+	if !ok {
+		if optional {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("secret %q not found in opts.Secrets", ref.Name)
+	}
+	lines := make([]string, 0, len(sec.Data))
+	for k, v := range sec.Data {
+		lines = append(lines, k+"="+string(v))
+	}
+	return lines, nil
+}
+
+// isLargeEnvValue reports whether a value should be moved to an env file.
+func isLargeEnvValue(val string) bool {
+	return len(val) > largeEnvThreshold ||
+		strings.ContainsAny(val, "\n=\"")
+}

--- a/pkg/kube/quadlet/convert.go
+++ b/pkg/kube/quadlet/convert.go
@@ -1,0 +1,282 @@
+package quadlet
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+// Convert translates a Kubernetes Pod spec into a set of Quadlet unit files.
+//
+// Output ordering: .volume files first, then the .pod unit, then init
+// .container files in pod order (with companion .sh files immediately
+// following each), then regular .container files, then .env files.
+func Convert(pod *v1.Pod, opts Options) ([]*GeneratedFile, error) {
+	if opts.NamePrefix == "" {
+		opts.NamePrefix = pod.Name
+	}
+
+	prefix := opts.NamePrefix
+
+	// podSvcName is the systemd service name Quadlet derives from the .pod unit:
+	// "<prefix>.pod" → "<prefix>-pod.service".
+	podSvcName := fmt.Sprintf("%s-pod.service", prefix)
+
+	// firstContainerSvcName is used as WantedBy= target for init containers so
+	// that enabling the pod also activates them in the right order.
+	var firstContainerSvcName string
+	if len(pod.Spec.Containers) > 0 {
+		firstContainerSvcName = fmt.Sprintf("%s-%s.service", prefix, pod.Spec.Containers[0].Name)
+	}
+
+	var output []*GeneratedFile
+	var envFiles []*GeneratedFile
+
+	// emptyDirVolNames collects the generated volume names for all emptyDir
+	// volumes so the pod unit can mount them on the infra container (Step 2).
+	var emptyDirVolNames []string
+
+	// Step 1 — .volume units for PVC volumes and emptyDir volumes.
+	for _, v := range pod.Spec.Volumes {
+		switch {
+		case v.PersistentVolumeClaim != nil:
+			volUnit := parser.NewUnitFile()
+			volUnit.Filename = fmt.Sprintf("%s-%s.volume", prefix, v.Name)
+			volUnit.Set(quadlet.UnitGroup, "Description",
+				fmt.Sprintf("Volume %s for pod %s", v.Name, pod.Name))
+			volUnit.AddComment(quadlet.VolumeGroup, "Local named volume, no driver required.")
+			output = append(output, &GeneratedFile{Name: volUnit.Filename, Unit: volUnit})
+
+		case v.EmptyDir != nil:
+			// All emptyDir volumes (regardless of medium) map to a tmpfs-backed
+			// named volume. In Kubernetes, emptyDir is always ephemeral — data is
+			// cleared on every pod restart. Using a named volume (rather than a
+			// per-container Mount=type=tmpfs) ensures all containers in the pod
+			// share the same tmpfs instance, matching Kubernetes pod-scoped semantics.
+			// A tmpfs-backed named volume is naturally volatile: data lives only
+			// as long as the volume is mounted, so each pod start gets clean state.
+			volName := fmt.Sprintf("%s-%s-empty", prefix, v.Name)
+			volUnit := parser.NewUnitFile()
+			volUnit.Filename = volName + ".volume"
+			volUnit.Set(quadlet.UnitGroup, "Description",
+				fmt.Sprintf("Shared tmpfs volume %s for pod %s", v.Name, pod.Name))
+			volUnit.Set(quadlet.VolumeGroup, "Driver", "local")
+			volUnit.Set(quadlet.VolumeGroup, "Device", "tmpfs")
+			volUnit.Set(quadlet.VolumeGroup, "Type", "tmpfs")
+			volUnit.Set(quadlet.VolumeGroup, "Options", "nodev,mode=0777")
+			output = append(output, &GeneratedFile{Name: volUnit.Filename, Unit: volUnit})
+			emptyDirVolNames = append(emptyDirVolNames, volName)
+		}
+	}
+
+	// Step 2 — .pod unit.
+	podUnit := buildPodUnit(pod, opts, emptyDirVolNames)
+	output = append(output, &GeneratedFile{Name: podUnit.Filename, Unit: podUnit})
+
+	// Step 3 — init container units.
+	var initServiceNames []string
+	for _, c := range pod.Spec.InitContainers {
+		files, err := buildContainerUnit(c, pod, opts)
+		if err != nil {
+			return nil, fmt.Errorf("init container %q: %w", c.Name, err)
+		}
+		unitFile := files[0].Unit
+
+		// Join the pod.
+		unitFile.Set(quadlet.ContainerGroup, quadlet.KeyPod,
+			fmt.Sprintf("%s.pod", prefix))
+
+		// After= all prior init services (pod dependency is implicit via Pod=).
+		for _, svc := range initServiceNames {
+			unitFile.Add(quadlet.UnitGroup, "After", svc)
+			unitFile.Add(quadlet.UnitGroup, "Requires", svc)
+		}
+
+		// Oneshot — runs to completion.
+		unitFile.Set(quadlet.ServiceGroup, "Type", "oneshot")
+		unitFile.Set(quadlet.ServiceGroup, "RemainAfterExit", "yes")
+
+		// WantedBy= the first regular container: activating the pod service
+		// activates the first container service, which pulls in these init services.
+		if firstContainerSvcName != "" {
+			unitFile.Add(quadlet.InstallGroup, "WantedBy", firstContainerSvcName)
+		}
+
+		svcName := fmt.Sprintf("%s-%s.service", prefix, c.Name)
+		initServiceNames = append(initServiceNames, svcName)
+
+		collectFiles(files, &output, &envFiles)
+	}
+
+	// Step 4 — regular container units.
+	for i, c := range pod.Spec.Containers {
+		files, err := buildContainerUnit(c, pod, opts)
+		if err != nil {
+			return nil, fmt.Errorf("container %q: %w", c.Name, err)
+		}
+		unitFile := files[0].Unit
+
+		// Join the pod.
+		unitFile.Set(quadlet.ContainerGroup, quadlet.KeyPod,
+			fmt.Sprintf("%s.pod", prefix))
+
+		// First container waits for all init containers.
+		if i == 0 {
+			for _, svc := range initServiceNames {
+				unitFile.Add(quadlet.UnitGroup, "After", svc)
+				unitFile.Add(quadlet.UnitGroup, "Requires", svc)
+			}
+		}
+
+		// [Service] restart policy.
+		applyRestartPolicy(unitFile, pod.Spec.RestartPolicy)
+
+		// [Install] — activated when the pod service starts.
+		unitFile.Add(quadlet.InstallGroup, "WantedBy", podSvcName)
+
+		collectFiles(files, &output, &envFiles)
+	}
+
+	// Env files go last.
+	output = append(output, envFiles...)
+	return output, nil
+}
+
+// buildPodUnit constructs the .pod Quadlet unit for the pod.
+// Pod-level networking, DNS, hostname, and namespace fields live here so that
+// all containers share them through the Podman infra container — the same way
+// Kubernetes uses a pause container to hold shared namespaces.
+//
+// emptyDirVolNames lists the generated volume names for all emptyDir volumes.
+// Each is mounted on the infra container at /.emptydir/<name> to keep the
+// underlying tmpfs alive as long as the pod runs. This matches Kubernetes
+// emptyDir semantics: data survives individual container crashes (infra is
+// still running) but is cleared when the pod itself is terminated.
+func buildPodUnit(pod *v1.Pod, opts Options, emptyDirVolNames []string) *parser.UnitFile {
+	prefix := opts.NamePrefix
+	u := parser.NewUnitFile()
+	u.Filename = fmt.Sprintf("%s.pod", prefix)
+	u.Set(quadlet.UnitGroup, "Description",
+		fmt.Sprintf("Pod %s", pod.Name))
+
+	// Explicit pod name so all containers join the right pod.
+	u.Set(quadlet.PodGroup, quadlet.KeyPodName, prefix)
+
+	// Keep the infra container alive regardless of workload container state.
+	// This matches Kubernetes pause-container semantics: the pod's network
+	// namespace is owned by the infra container and must outlive any individual
+	// workload, including init containers that complete and are removed.
+	// Without this, Podman's default "stop" exit policy tears down the infra
+	// when the last non-infra container exits — creating a race where init
+	// containers complete before main containers start, leaving the pod empty.
+	u.Set(quadlet.PodGroup, quadlet.KeyExitPolicy, "continue")
+
+	// Network.
+	if pod.Spec.HostNetwork {
+		u.Set(quadlet.PodGroup, quadlet.KeyNetwork, "host")
+	} else if opts.Network != "" {
+		u.Set(quadlet.PodGroup, quadlet.KeyNetwork, opts.Network)
+	}
+
+	// Hostname.
+	if pod.Spec.Hostname != "" {
+		u.Set(quadlet.PodGroup, quadlet.KeyHostName, pod.Spec.Hostname)
+	}
+
+	// Host aliases.
+	for _, ha := range pod.Spec.HostAliases {
+		for _, h := range ha.Hostnames {
+			u.Add(quadlet.PodGroup, quadlet.KeyAddHost,
+				fmt.Sprintf("%s:%s", h, ha.IP))
+		}
+	}
+
+	// DNS config.
+	if pod.Spec.DNSConfig != nil {
+		for _, ns := range pod.Spec.DNSConfig.Nameservers {
+			u.Add(quadlet.PodGroup, quadlet.KeyDNS, ns)
+		}
+		for _, s := range pod.Spec.DNSConfig.Searches {
+			u.Add(quadlet.PodGroup, quadlet.KeyDNSSearch, s)
+		}
+		for _, o := range pod.Spec.DNSConfig.Options {
+			opt := o.Name
+			if o.Value != nil {
+				opt += "=" + *o.Value
+			}
+			u.Add(quadlet.PodGroup, quadlet.KeyDNSOption, opt)
+		}
+	}
+
+	// Host namespaces.
+	if pod.Spec.HostPID {
+		u.Add(quadlet.PodGroup, quadlet.KeyPodmanArgs, "--pid=host")
+	}
+	if pod.Spec.HostIPC {
+		u.Add(quadlet.PodGroup, quadlet.KeyPodmanArgs, "--ipc=host")
+	}
+
+	// Process namespace sharing between containers.
+	if pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
+		u.Add(quadlet.PodGroup, quadlet.KeyPodmanArgs, "--share pid")
+	}
+
+	// Pod-level sysctls.
+	if pod.Spec.SecurityContext != nil {
+		for _, s := range pod.Spec.SecurityContext.Sysctls {
+			u.Add(quadlet.PodGroup, quadlet.KeyPodmanArgs,
+				fmt.Sprintf("--sysctl %s=%s", s.Name, s.Value))
+		}
+	}
+
+	// Termination grace period.
+	if pod.Spec.TerminationGracePeriodSeconds != nil {
+		u.Set(quadlet.PodGroup, quadlet.KeyStopTimeout,
+			fmt.Sprintf("%d", *pod.Spec.TerminationGracePeriodSeconds))
+	}
+
+	// Mount each emptyDir volume on the infra container.
+	// The infra container keeps the tmpfs live for the full pod lifetime, so
+	// individual container crashes do not lose emptyDir data — matching the
+	// Kubernetes guarantee that emptyDir survives container restarts but not
+	// pod termination. Containers mount the same named volume via their own
+	// Volume= lines; this entry merely anchors the tmpfs to the pod lifecycle.
+	// The ".volume" suffix ensures Quadlet uses the managed tmpfs-backed volume.
+	for _, volName := range emptyDirVolNames {
+		u.Add(quadlet.PodGroup, quadlet.KeyVolume,
+			fmt.Sprintf("%s.volume:/.emptydir/%s", volName, volName))
+	}
+
+	// [Install] — the pod service is the root systemd unit.
+	u.Add(quadlet.InstallGroup, "WantedBy", "default.target")
+
+	return u
+}
+
+// collectFiles splits files from buildContainerUnit into unit files (output)
+// and env files (envFiles). Script (.sh) files follow their container unit
+// immediately; .env files are deferred to the end.
+func collectFiles(files []*GeneratedFile, output, envFiles *[]*GeneratedFile) {
+	*output = append(*output, files[0])
+	for _, f := range files[1:] {
+		if strings.HasSuffix(f.Name, ".env") {
+			*envFiles = append(*envFiles, f)
+		} else {
+			*output = append(*output, f)
+		}
+	}
+}
+
+// applyRestartPolicy emits Restart= in [Service].
+func applyRestartPolicy(unit *parser.UnitFile, policy v1.RestartPolicy) {
+	switch policy {
+	case v1.RestartPolicyAlways:
+		unit.Set(quadlet.ServiceGroup, "Restart", "always")
+	case v1.RestartPolicyOnFailure:
+		unit.Set(quadlet.ServiceGroup, "Restart", "on-failure")
+		// Never: omit Restart=
+	}
+}

--- a/pkg/kube/quadlet/convert_test.go
+++ b/pkg/kube/quadlet/convert_test.go
@@ -1,0 +1,1088 @@
+package quadlet
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/api/resource"
+	metav1 "go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/apis/meta/v1"
+	"go.podman.io/podman/v6/pkg/k8s.io/apimachinery/pkg/util/intstr"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+// helpers
+
+func minimalPod(name, image string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "app", Image: image},
+			},
+		},
+	}
+}
+
+func findFile(files []*GeneratedFile, suffix string) *GeneratedFile {
+	for _, f := range files {
+		if strings.HasSuffix(f.Name, suffix) {
+			return f
+		}
+	}
+	return nil
+}
+
+// podUnit returns the .pod GeneratedFile from the output slice.
+func podUnit(files []*GeneratedFile) *GeneratedFile {
+	for _, f := range files {
+		if strings.HasSuffix(f.Name, ".pod") {
+			return f
+		}
+	}
+	return nil
+}
+
+// containerUnit returns the .container GeneratedFile for the given container name.
+func containerUnit(files []*GeneratedFile, prefix, name string) *GeneratedFile {
+	return findFile(files, fmt.Sprintf("%s-%s.container", prefix, name))
+}
+
+func indexOf(slice []string, s string) int {
+	for i, v := range slice {
+		if v == s {
+			return i
+		}
+	}
+	return -1
+}
+
+func intOrString(i int) intstr.IntOrString {
+	return intstr.FromInt(i)
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+func TestConvert_AlwaysEmitsPodUnit(t *testing.T) {
+	pod := minimalPod("myapp", "nginx:latest")
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	pu := podUnit(files)
+	require.NotNil(t, pu, "expected .pod unit in output")
+	assert.Equal(t, "myapp.pod", pu.Name)
+
+	// PodName= must be set
+	name, ok := pu.Unit.Lookup(quadlet.PodGroup, quadlet.KeyPodName)
+	assert.True(t, ok)
+	assert.Equal(t, "myapp", name)
+
+	// ExitPolicy=continue must be set so the infra container (pause) outlives
+	// individual workload containers — including init containers that complete
+	// before main containers start. Without this, Podman's default "stop" policy
+	// tears down the infra on the first container exit, killing the pod.
+	ep, ok := pu.Unit.Lookup(quadlet.PodGroup, quadlet.KeyExitPolicy)
+	assert.True(t, ok, "ExitPolicy must be set on pod unit")
+	assert.Equal(t, "continue", ep)
+
+	// Pod unit is WantedBy default.target
+	wb := pu.Unit.LookupAll(quadlet.InstallGroup, "WantedBy")
+	assert.Contains(t, wb, "default.target")
+}
+
+func TestConvert_ContainerJoinsPod(t *testing.T) {
+	pod := minimalPod("myapp", "nginx:latest")
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	cu := containerUnit(files, "myapp", "app")
+	require.NotNil(t, cu)
+
+	pod_, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyPod)
+	assert.True(t, ok)
+	assert.Equal(t, "myapp.pod", pod_)
+
+	// Container WantedBy pod service
+	wb := cu.Unit.LookupAll(quadlet.InstallGroup, "WantedBy")
+	assert.Contains(t, wb, "myapp-pod.service")
+}
+
+func TestConvert_NamePrefix(t *testing.T) {
+	pod := minimalPod("myapp", "nginx:latest")
+	files, err := Convert(pod, Options{NamePrefix: "custom"})
+	require.NoError(t, err)
+
+	assert.NotNil(t, findFile(files, "custom.pod"))
+	assert.NotNil(t, findFile(files, "custom-app.container"))
+}
+
+func TestConvert_InitContainerOrdering(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: "init-a", Image: "busybox"},
+				{Name: "init-b", Image: "busybox"},
+			},
+			Containers: []v1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	initA := containerUnit(files, "p", "init-a")
+	require.NotNil(t, initA)
+	// init-a has no After= (no prior init services)
+	assert.False(t, initA.Unit.HasKey(quadlet.UnitGroup, "After"))
+	// init-a is oneshot
+	svcType, _ := initA.Unit.Lookup(quadlet.ServiceGroup, "Type")
+	assert.Equal(t, "oneshot", svcType)
+	// init-a WantedBy first regular container
+	wb := initA.Unit.LookupAll(quadlet.InstallGroup, "WantedBy")
+	assert.Contains(t, wb, "p-app.service")
+
+	initB := containerUnit(files, "p", "init-b")
+	require.NotNil(t, initB)
+	// init-b After= init-a
+	afters := initB.Unit.LookupAll(quadlet.UnitGroup, "After")
+	assert.Contains(t, afters, "p-init-a.service")
+
+	// Both init containers join the pod
+	for _, iu := range []*GeneratedFile{initA, initB} {
+		pod_, ok := iu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyPod)
+		assert.True(t, ok)
+		assert.Equal(t, "p.pod", pod_)
+	}
+
+	// app container After= both init services
+	appCU := containerUnit(files, "p", "app")
+	require.NotNil(t, appCU)
+	appAfters := appCU.Unit.LookupAll(quadlet.UnitGroup, "After")
+	assert.Contains(t, appAfters, "p-init-a.service")
+	assert.Contains(t, appAfters, "p-init-b.service")
+}
+
+func TestConvert_MultipleContainersAllJoinPod(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "web", Image: "nginx"},
+				{Name: "proxy", Image: "envoy"},
+			},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	for _, name := range []string{"web", "proxy"} {
+		cu := containerUnit(files, "p", name)
+		require.NotNil(t, cu, "missing container unit for %s", name)
+		pod_, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyPod)
+		assert.True(t, ok)
+		assert.Equal(t, "p.pod", pod_)
+		// No explicit Network= in container unit — networking is handled by pod
+		assert.False(t, cu.Unit.HasKey(quadlet.ContainerGroup, quadlet.KeyNetwork),
+			"container %s must not have Network= (pod handles it)", name)
+	}
+}
+
+func TestConvert_NoAnchorPattern(t *testing.T) {
+	// Regression: sidecars must not use Network=container: or --volumes-from.
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "web", Image: "nginx"},
+				{Name: "proxy", Image: "envoy"},
+			},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	for _, f := range files {
+		if f.Unit == nil {
+			continue
+		}
+		content, err := f.Unit.ToString()
+		require.NoError(t, err)
+		assert.NotContains(t, content, "Network=container:", "anchor pattern found in %s", f.Name)
+		assert.NotContains(t, content, "--volumes-from", "anchor pattern found in %s", f.Name)
+	}
+}
+
+func TestConvert_RestartPolicy(t *testing.T) {
+	tests := []struct {
+		policy v1.RestartPolicy
+		want   string
+	}{
+		{v1.RestartPolicyAlways, "always"},
+		{v1.RestartPolicyOnFailure, "on-failure"},
+		{v1.RestartPolicyNever, ""},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.policy), func(t *testing.T) {
+			pod := minimalPod("p", "nginx")
+			pod.Spec.RestartPolicy = tt.policy
+			files, err := Convert(pod, Options{})
+			require.NoError(t, err)
+			cu := containerUnit(files, "p", "app")
+			require.NotNil(t, cu)
+			val, ok := cu.Unit.Lookup(quadlet.ServiceGroup, "Restart")
+			if tt.want == "" {
+				assert.False(t, ok)
+			} else {
+				assert.True(t, ok)
+				assert.Equal(t, tt.want, val)
+			}
+		})
+	}
+}
+
+func TestConvert_TerminationGracePeriod_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	grace := int64(30)
+	pod.Spec.TerminationGracePeriodSeconds = &grace
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	val, ok := pu.Unit.Lookup(quadlet.PodGroup, quadlet.KeyStopTimeout)
+	assert.True(t, ok)
+	assert.Equal(t, "30", val)
+
+	// Must NOT be on the container unit
+	cu := containerUnit(files, "p", "app")
+	require.NotNil(t, cu)
+	assert.False(t, cu.Unit.HasKey(quadlet.ContainerGroup, quadlet.KeyStopTimeout))
+}
+
+func TestConvert_ImagePullPolicy(t *testing.T) {
+	tests := []struct {
+		policy v1.PullPolicy
+		want   string
+	}{
+		{v1.PullAlways, "always"},
+		{v1.PullNever, "never"},
+		{v1.PullIfNotPresent, "missing"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.policy), func(t *testing.T) {
+			pod := minimalPod("p", "nginx")
+			pod.Spec.Containers[0].ImagePullPolicy = tt.policy
+			files, err := Convert(pod, Options{})
+			require.NoError(t, err)
+			cu := containerUnit(files, "p", "app")
+			require.NotNil(t, cu)
+			val, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyPull)
+			if tt.want == "" {
+				assert.False(t, ok)
+			} else {
+				assert.Equal(t, tt.want, val)
+			}
+		})
+	}
+}
+
+func TestConvert_Network_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	files, err := Convert(pod, Options{Network: "podman"})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	net, ok := pu.Unit.Lookup(quadlet.PodGroup, quadlet.KeyNetwork)
+	assert.True(t, ok)
+	assert.Equal(t, "podman", net)
+}
+
+func TestConvert_HostNetwork_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.HostNetwork = true
+	files, err := Convert(pod, Options{Network: "podman"})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	// hostNetwork overrides opts.Network
+	net, ok := pu.Unit.Lookup(quadlet.PodGroup, quadlet.KeyNetwork)
+	assert.True(t, ok)
+	assert.Equal(t, "host", net)
+}
+
+func TestConvert_HostPID_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.HostPID = true
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	args := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyPodmanArgs)
+	assert.Contains(t, args, "--pid=host")
+}
+
+func TestConvert_HostIPC_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.HostIPC = true
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	args := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyPodmanArgs)
+	assert.Contains(t, args, "--ipc=host")
+}
+
+func TestConvert_Hostname_HostAliases_DNS_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Hostname = "myhost"
+	pod.Spec.HostAliases = []v1.HostAlias{
+		{IP: "1.2.3.4", Hostnames: []string{"foo.local", "bar.local"}},
+	}
+	pod.Spec.DNSConfig = &v1.PodDNSConfig{
+		Nameservers: []string{"8.8.8.8"},
+		Searches:    []string{"example.com"},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+
+	hn, _ := pu.Unit.Lookup(quadlet.PodGroup, quadlet.KeyHostName)
+	assert.Equal(t, "myhost", hn)
+
+	hosts := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyAddHost)
+	assert.Contains(t, hosts, "foo.local:1.2.3.4")
+	assert.Contains(t, hosts, "bar.local:1.2.3.4")
+
+	dns := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyDNS)
+	assert.Contains(t, dns, "8.8.8.8")
+
+	search := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyDNSSearch)
+	assert.Contains(t, search, "example.com")
+}
+
+func TestConvert_ShareProcessNamespace_OnPodUnit(t *testing.T) {
+	yes := true
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			ShareProcessNamespace: &yes,
+			Containers: []v1.Container{
+				{Name: "a", Image: "nginx"},
+				{Name: "b", Image: "busybox"},
+			},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	args := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyPodmanArgs)
+	assert.Contains(t, args, "--share pid")
+}
+
+func TestConvert_PodLevelSysctls_OnPodUnit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.SecurityContext = &v1.PodSecurityContext{
+		Sysctls: []v1.Sysctl{
+			{Name: "net.ipv4.ip_forward", Value: "1"},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	pu := podUnit(files)
+	require.NotNil(t, pu)
+	args := pu.Unit.LookupAll(quadlet.PodGroup, quadlet.KeyPodmanArgs)
+	assert.True(t, func() bool {
+		for _, a := range args {
+			if strings.Contains(a, "--sysctl") && strings.Contains(a, "net.ipv4.ip_forward=1") {
+				return true
+			}
+		}
+		return false
+	}(), "expected --sysctl net.ipv4.ip_forward=1 in pod PodmanArgs")
+}
+
+func TestConvert_PodLevelSupplementalGroups_OnContainers(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.SecurityContext = &v1.PodSecurityContext{
+		SupplementalGroups: []int64{1001, 1002},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	require.NotNil(t, cu)
+	groups := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyGroupAdd)
+	assert.Contains(t, groups, "1001")
+	assert.Contains(t, groups, "1002")
+}
+
+func TestConvert_SecurityContext_Capabilities(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Add:  []v1.Capability{"NET_ADMIN", "SYS_TIME"},
+			Drop: []v1.Capability{"ALL"},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	require.NotNil(t, cu)
+
+	adds := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyAddCapability)
+	assert.Contains(t, adds, "NET_ADMIN")
+	assert.Contains(t, adds, "SYS_TIME")
+
+	drops := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyDropCapability)
+	assert.Contains(t, drops, "ALL")
+}
+
+func TestConvert_SecurityContext_ReadOnly(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	yes := true
+	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{ReadOnlyRootFilesystem: &yes}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	val, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyReadOnly)
+	assert.True(t, ok)
+	assert.Equal(t, "true", val)
+}
+
+func TestConvert_SecurityContext_NoNewPrivileges(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	no := false
+	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{AllowPrivilegeEscalation: &no}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	val, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyNoNewPrivileges)
+	assert.True(t, ok)
+	assert.Equal(t, "true", val)
+}
+
+func TestConvert_SecurityContext_UserGroup(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	uid, gid := int64(1000), int64(2000)
+	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
+		RunAsUser:  &uid,
+		RunAsGroup: &gid,
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	val, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyUser)
+	assert.True(t, ok)
+	assert.Equal(t, "1000:2000", val)
+}
+
+func TestConvert_SecurityContext_SELinux(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
+		SELinuxOptions: &v1.SELinuxOptions{
+			User:  "u",
+			Role:  "r",
+			Type:  "container_t",
+			Level: "s0",
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+
+	args := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyPodmanArgs)
+	assert.Contains(t, args, "--security-opt label=user:u")
+	assert.Contains(t, args, "--security-opt label=role:r")
+
+	typ, _ := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeySecurityLabelType)
+	assert.Equal(t, "container_t", typ)
+	lvl, _ := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeySecurityLabelLevel)
+	assert.Equal(t, "s0", lvl)
+}
+
+func TestConvert_SecurityContext_Seccomp(t *testing.T) {
+	localhostPath := "profiles/myprofile.json"
+	tests := []struct {
+		name    string
+		profile v1.SeccompProfile
+		want    string
+	}{
+		{"localhost", v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: &localhostPath}, localhostPath},
+		{"runtime-default", v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}, ""},
+		{"unconfined", v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}, "unconfined"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := minimalPod("p", "nginx")
+			profile := tt.profile
+			pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &profile}
+			files, err := Convert(pod, Options{})
+			require.NoError(t, err)
+			cu := containerUnit(files, "p", "app")
+			val, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeySeccompProfile)
+			assert.True(t, ok)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func TestConvert_ResourceLimits(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+			v1.ResourceCPU:    resource.MustParse("500m"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	require.NotNil(t, cu)
+
+	mem, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyMemory)
+	assert.True(t, ok)
+	assert.Equal(t, fmt.Sprintf("%d", int64(512*1024*1024)), mem, "memory must be raw bytes")
+
+	args := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyPodmanArgs)
+	hasCPUQuota := false
+	hasMemReservation := false
+	for _, a := range args {
+		if strings.HasPrefix(a, "--cpu-quota=") {
+			hasCPUQuota = true
+		}
+		if strings.HasPrefix(a, "--memory-reservation=") {
+			hasMemReservation = true
+		}
+	}
+	assert.True(t, hasCPUQuota, "cpu-quota PodmanArgs expected")
+	assert.True(t, hasMemReservation, "memory-reservation PodmanArgs expected")
+}
+
+func TestConvert_MemoryDirectiveIsMemory_NotMemoryLimit(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Limits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("1Gi")},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	content, err := cu.Unit.ToString()
+	require.NoError(t, err)
+	assert.Contains(t, content, "Memory=")
+	assert.NotContains(t, content, "MemoryLimit=")
+}
+
+func TestConvert_VolumeMount_PVC(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Volumes = []v1.Volume{
+		{Name: "data", VolumeSource: v1.VolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"},
+		}},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+		{Name: "data", MountPath: "/data"},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	volFile := findFile(files, "p-data.volume")
+	require.NotNil(t, volFile, "expected p-data.volume in output")
+
+	cu := containerUnit(files, "p", "app")
+	vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+	assert.True(t, func() bool {
+		for _, v := range vols {
+			if strings.HasPrefix(v, "p-data.volume:/data") {
+				return true
+			}
+		}
+		return false
+	}(), "expected p-data.volume:/data in container Volume=")
+}
+
+func TestConvert_VolumeMount_PVC_SubPath(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Volumes = []v1.Volume{
+		{Name: "state", VolumeSource: v1.VolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "vm-state"},
+		}},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+		{Name: "state", MountPath: "/data/nvram", SubPath: "nvram"},
+		{Name: "state", MountPath: "/data/swtpm", SubPath: "swtpm"},
+		{Name: "state", MountPath: "/data/swtpm-localca", SubPath: "swtpm-localca", ReadOnly: true},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	cu := containerUnit(files, "p", "app")
+
+	// SubPath mounts must use Mount= (--mount type=volume,subpath=...) because
+	// Podman's -v syntax does not support the subpath= option.
+	mounts := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyMount)
+	assert.Contains(t, mounts, "type=volume,source=p-state.volume,destination=/data/nvram,subpath=nvram")
+	assert.Contains(t, mounts, "type=volume,source=p-state.volume,destination=/data/swtpm,subpath=swtpm")
+	assert.Contains(t, mounts, "type=volume,source=p-state.volume,destination=/data/swtpm-localca,subpath=swtpm-localca,ro")
+
+	// None of the SubPath mounts should appear in Volume= lines.
+	vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+	for _, v := range vols {
+		assert.NotContains(t, v, "subpath", "SubPath mount must not appear in Volume= line")
+	}
+
+	// The companion .volume unit must still be generated.
+	volFile := findFile(files, "p-state.volume")
+	require.NotNil(t, volFile, "expected p-state.volume in output")
+}
+
+func TestConvert_VolumeMount_HostPath(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Volumes = []v1.Volume{
+		{Name: "d", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/host/data"}}},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{{Name: "d", MountPath: "/data"}}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+	assert.True(t, func() bool {
+		for _, v := range vols {
+			if strings.HasPrefix(v, "/host/data:/data:z") {
+				return true
+			}
+		}
+		return false
+	}(), "expected /host/data:/data:z in Volume=")
+}
+
+func TestConvert_VolumeMount_HostPath_SysFs(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Volumes = []v1.Volume{
+		{Name: "sys", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/sys/fs/cgroup"}}},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{{Name: "sys", MountPath: "/sys/fs/cgroup"}}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	content, err := cu.Unit.ToString()
+	require.NoError(t, err)
+	assert.NotContains(t, content, ":z")
+}
+
+func TestConvert_VolumeMount_EmptyDir_DefaultIsNamedVolume(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Volumes = []v1.Volume{
+		{Name: "tmp", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp/data"}}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	content, err := cu.Unit.ToString()
+	require.NoError(t, err)
+	assert.NotContains(t, content, "tmpfs", "emptyDir default medium must not use tmpfs")
+	vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+	assert.True(t, func() bool {
+		for _, v := range vols {
+			if strings.Contains(v, "p-tmp-empty") {
+				return true
+			}
+		}
+		return false
+	}(), "emptyDir should produce named anonymous volume p-tmp-empty")
+}
+
+func TestConvert_VolumeMount_EmptyDir_Memory(t *testing.T) {
+	// Memory-medium emptyDir must generate a SHARED named volume backed by
+	// tmpfs, not a per-container Mount=type=tmpfs.  Using a named volume
+	// ensures all containers in the pod mount the same tmpfs instance,
+	// matching Kubernetes emptyDir pod-scoped sharing semantics.
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Volumes = []v1.Volume{
+		{Name: "mem", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{Medium: v1.StorageMediumMemory}}},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{{Name: "mem", MountPath: "/mem"}}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	// A companion .volume unit with tmpfs options must be generated.
+	volFile := findFile(files, "p-mem-empty.volume")
+	require.NotNil(t, volFile, "expected p-mem-empty.volume for Memory-medium emptyDir")
+	volContent, err := volFile.Unit.ToString()
+	require.NoError(t, err)
+	assert.Contains(t, volContent, "Type=tmpfs", "volume unit must declare tmpfs type")
+
+	// The container must use Volume= referencing the named .volume unit, not Mount=type=tmpfs.
+	cu := containerUnit(files, "p", "app")
+	vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+	hasNamedVol := false
+	for _, v := range vols {
+		if strings.HasPrefix(v, "p-mem-empty.volume:/mem") {
+			hasNamedVol = true
+			break
+		}
+	}
+	assert.True(t, hasNamedVol, "container must mount p-mem-empty.volume named volume at /mem")
+
+	// No per-container Mount=type=tmpfs directive.
+	mounts := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyMount)
+	for _, m := range mounts {
+		assert.NotContains(t, m, "type=tmpfs", "per-container tmpfs mount must not be emitted; use named volume instead")
+	}
+}
+
+func TestConvert_EmptyDir_Memory_SharedAcrossContainers(t *testing.T) {
+	// Two containers that both mount the same Memory-medium emptyDir volume
+	// must reference the same named volume so they see each other's writes —
+	// matching Kubernetes pod-scoped emptyDir sharing semantics.
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{Name: "shared", VolumeSource: v1.VolumeSource{
+					EmptyDir: &v1.EmptyDirVolumeSource{Medium: v1.StorageMediumMemory},
+				}},
+			},
+			Containers: []v1.Container{
+				{
+					Name:         "main",
+					Image:        "nginx",
+					VolumeMounts: []v1.VolumeMount{{Name: "shared", MountPath: "/run/shared"}},
+				},
+				{
+					Name:         "sidecar",
+					Image:        "busybox",
+					VolumeMounts: []v1.VolumeMount{{Name: "shared", MountPath: "/run/shared"}},
+				},
+			},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	// Exactly one .volume unit for the shared emptyDir.
+	var volFiles []*GeneratedFile
+	for _, f := range files {
+		if strings.HasSuffix(f.Name, "-shared-empty.volume") {
+			volFiles = append(volFiles, f)
+		}
+	}
+	assert.Len(t, volFiles, 1, "exactly one .volume unit for the shared emptyDir")
+
+	volName := "p-shared-empty"
+
+	// Both containers reference the same named .volume unit at the same mount path.
+	for _, ctrName := range []string{"main", "sidecar"} {
+		cu := containerUnit(files, "p", ctrName)
+		require.NotNil(t, cu, "missing container unit for %s", ctrName)
+		vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+		hasVol := false
+		for _, v := range vols {
+			if strings.HasPrefix(v, volName+".volume:") {
+				hasVol = true
+				break
+			}
+		}
+		assert.True(t, hasVol, "container %s must mount named volume %s", ctrName, volName+".volume")
+	}
+}
+
+func TestConvert_VolumeMount_MountPropagation(t *testing.T) {
+	hostToContainer := v1.MountPropagationHostToContainer
+	bidirectional := v1.MountPropagationBidirectional
+	tests := []struct {
+		name     string
+		prop     *v1.MountPropagationMode
+		wantOpts string
+	}{
+		{"HostToContainer", &hostToContainer, "rslave"},
+		{"Bidirectional", &bidirectional, "rshared"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := minimalPod("p", "nginx")
+			pod.Spec.Volumes = []v1.Volume{
+				{Name: "d", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/host"}}},
+			}
+			pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+				{Name: "d", MountPath: "/mnt", MountPropagation: tt.prop},
+			}
+			files, err := Convert(pod, Options{})
+			require.NoError(t, err)
+			cu := containerUnit(files, "p", "app")
+			vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+			assert.True(t, func() bool {
+				for _, v := range vols {
+					if strings.Contains(v, tt.wantOpts) {
+						return true
+					}
+				}
+				return false
+			}(), "expected %s in volume options", tt.wantOpts)
+		})
+	}
+}
+
+func TestConvert_LivenessProbe_Exec(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].LivenessProbe = &v1.Probe{
+		Handler:          v1.Handler{Exec: &v1.ExecAction{Command: []string{"cat", "/tmp/healthy"}}},
+		PeriodSeconds:    5,
+		TimeoutSeconds:   2,
+		FailureThreshold: 3,
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	cmd, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyHealthCmd)
+	assert.True(t, ok)
+	assert.Contains(t, cmd, "cat")
+	interval, _ := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyHealthInterval)
+	assert.Equal(t, "5s", interval)
+}
+
+func TestConvert_LivenessProbe_HTTPGet(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].LivenessProbe = &v1.Probe{
+		Handler: v1.Handler{HTTPGet: &v1.HTTPGetAction{Port: intOrString(8080), Path: "/healthz"}},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	cmd, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyHealthCmd)
+	assert.True(t, ok)
+	assert.Contains(t, cmd, "curl")
+	assert.Contains(t, cmd, "8080")
+}
+
+func TestConvert_LivenessProbe_TCPSocket(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].LivenessProbe = &v1.Probe{
+		Handler: v1.Handler{TCPSocket: &v1.TCPSocketAction{Port: intOrString(3306)}},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	cmd, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyHealthCmd)
+	assert.True(t, ok)
+	assert.Contains(t, cmd, "/dev/tcp/localhost/3306")
+}
+
+func TestConvert_StartupProbe(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].StartupProbe = &v1.Probe{
+		Handler:          v1.Handler{Exec: &v1.ExecAction{Command: []string{"test", "-f", "/ready"}}},
+		FailureThreshold: 30,
+		PeriodSeconds:    10,
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	cmd, ok := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyHealthStartupCmd)
+	assert.True(t, ok)
+	assert.Contains(t, cmd, "/ready")
+	retries, _ := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyHealthStartupRetries)
+	assert.Equal(t, "30", retries)
+}
+
+func TestConvert_ExecCommand_ShellScript(t *testing.T) {
+	pod := minimalPod("p", "busybox")
+	pod.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
+	pod.Spec.Containers[0].Args = []string{"echo hello && sleep 1"}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	scriptFile := findFile(files, "p-app.sh")
+	require.NotNil(t, scriptFile)
+	assert.Equal(t, "echo hello && sleep 1", scriptFile.Content)
+
+	cu := containerUnit(files, "p", "app")
+	entrypoint, _ := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyEntrypoint)
+	assert.Equal(t, "/bin/sh", entrypoint)
+	exec, _ := cu.Unit.Lookup(quadlet.ContainerGroup, quadlet.KeyExec)
+	assert.Equal(t, "/init.sh", exec)
+
+	vols := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyVolume)
+	assert.Contains(t, vols, "./p-app.sh:/init.sh:ro,z",
+		"script must be bind-mounted via relative path so units are self-contained")
+}
+
+func TestConvert_EnvPlain(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].Env = []v1.EnvVar{{Name: "FOO", Value: "bar"}}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	envs := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyEnvironment)
+	assert.True(t, func() bool {
+		for _, e := range envs {
+			if strings.Contains(e, "FOO") {
+				return true
+			}
+		}
+		return false
+	}())
+}
+
+func TestConvert_EnvConfigMapKeyRef(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].Env = []v1.EnvVar{
+		{Name: "DB_HOST", ValueFrom: &v1.EnvVarSource{
+			ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{Name: "mycm"},
+				Key:                  "host",
+			},
+		}},
+	}
+	opts := Options{ConfigMaps: map[string]v1.ConfigMap{
+		"mycm": {Data: map[string]string{"host": "postgres"}},
+	}}
+	files, err := Convert(pod, opts)
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	envs := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyEnvironment)
+	assert.True(t, func() bool {
+		for _, e := range envs {
+			if strings.Contains(e, "DB_HOST") && strings.Contains(e, "postgres") {
+				return true
+			}
+		}
+		return false
+	}())
+}
+
+func TestConvert_EnvConfigMapKeyRef_Missing_Required(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].Env = []v1.EnvVar{
+		{Name: "KEY", ValueFrom: &v1.EnvVarSource{
+			ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{Name: "missing"},
+				Key:                  "key",
+			},
+		}},
+	}
+	_, err := Convert(pod, Options{})
+	assert.Error(t, err)
+}
+
+func TestConvert_EnvFieldRef(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Namespace = "mynamespace"
+	pod.Spec.Containers[0].Env = []v1.EnvVar{
+		{Name: "POD_NS", ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+		}},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	envs := cu.Unit.LookupAll(quadlet.ContainerGroup, quadlet.KeyEnvironment)
+	assert.True(t, func() bool {
+		for _, e := range envs {
+			if strings.Contains(e, "POD_NS") && strings.Contains(e, "mynamespace") {
+				return true
+			}
+		}
+		return false
+	}())
+}
+
+func TestConvert_PortsComment(t *testing.T) {
+	pod := minimalPod("p", "nginx")
+	pod.Spec.Containers[0].Ports = []v1.ContainerPort{
+		{ContainerPort: 8080, Protocol: v1.ProtocolTCP},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+	cu := containerUnit(files, "p", "app")
+	content, err := cu.Unit.ToString()
+	require.NoError(t, err)
+	assert.Contains(t, content, "8080")
+	assert.NotContains(t, content, "PublishPort=8080")
+}
+
+func TestConvert_OutputOrdering(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: "init", Image: "busybox"},
+			},
+			Containers: []v1.Container{
+				{Name: "app", Image: "nginx"},
+				{Name: "sidecar", Image: "envoy"},
+			},
+			Volumes: []v1.Volume{
+				{Name: "data", VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
+				}},
+			},
+		},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{{Name: "data", MountPath: "/data"}}
+
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	names := make([]string, len(files))
+	for i, f := range files {
+		names[i] = f.Name
+	}
+
+	volIdx := indexOf(names, "p-data.volume")
+	podIdx := indexOf(names, "p.pod")
+	initIdx := indexOf(names, "p-init.container")
+	appIdx := indexOf(names, "p-app.container")
+	sideIdx := indexOf(names, "p-sidecar.container")
+
+	assert.Less(t, volIdx, podIdx, ".volume must come before .pod")
+	assert.Less(t, podIdx, initIdx, ".pod must come before init container")
+	assert.Less(t, initIdx, appIdx, "init container must come before first regular container")
+	assert.Less(t, appIdx, sideIdx, "first container before second container")
+}
+
+func TestConvert_OutputOrdering_EmptyDirVolumeBeforePod(t *testing.T) {
+	// Memory-medium emptyDir generates a .volume unit.  It must be ordered
+	// before the .pod unit so that Quadlet can resolve the volume reference
+	// when it processes the pod and container units.
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{Name: "runtime", VolumeSource: v1.VolumeSource{
+					EmptyDir: &v1.EmptyDirVolumeSource{Medium: v1.StorageMediumMemory},
+				}},
+			},
+			Containers: []v1.Container{
+				{
+					Name:         "app",
+					Image:        "nginx",
+					VolumeMounts: []v1.VolumeMount{{Name: "runtime", MountPath: "/run"}},
+				},
+			},
+		},
+	}
+	files, err := Convert(pod, Options{})
+	require.NoError(t, err)
+
+	names := make([]string, len(files))
+	for i, f := range files {
+		names[i] = f.Name
+	}
+
+	volIdx := indexOf(names, "p-runtime-empty.volume")
+	podIdx := indexOf(names, "p.pod")
+
+	assert.GreaterOrEqual(t, volIdx, 0, "p-runtime-empty.volume must be present")
+	assert.Less(t, volIdx, podIdx, "emptyDir .volume unit must come before .pod unit")
+}

--- a/pkg/kube/quadlet/exec.go
+++ b/pkg/kube/quadlet/exec.go
@@ -1,0 +1,73 @@
+package quadlet
+
+import (
+	"fmt"
+
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+// scriptShells is the set of shell executables that trigger .sh script extraction.
+var scriptShells = map[string]bool{
+	"/bin/sh":     true,
+	"sh":          true,
+	"/usr/bin/sh": true,
+}
+
+// applyExec maps a container's command and args onto unit.
+//
+// When the combined sequence is exactly [shell, "-c", script], the script body
+// is extracted into a companion GeneratedFile (.sh). The unit receives an
+// Entrypoint=/bin/sh + Exec=/init.sh + Volume= bind-mount for the script.
+//
+// Returns the companion script file, or nil when no extraction occurred.
+func applyExec(unit *parser.UnitFile, command, args []string, prefix, name string) *GeneratedFile {
+	combined := append(command, args...) //nolint:gocritic // intentional: command is never reused after this call
+	if len(combined) == 0 {
+		return nil
+	}
+
+	if script, ok := isShellScript(combined); ok {
+		return applyShellScript(unit, script, prefix, name)
+	}
+
+	if len(command) > 0 {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeyEntrypoint, command[0])
+		execArgs := append(append([]string(nil), command[1:]...), args...)
+		if len(execArgs) > 0 {
+			unit.AddCmdline(quadlet.ContainerGroup, quadlet.KeyExec, execArgs)
+		}
+	} else if len(args) > 0 {
+		unit.AddCmdline(quadlet.ContainerGroup, quadlet.KeyExec, args)
+	}
+	return nil
+}
+
+// isShellScript reports whether combined matches [shell, "-c", script].
+func isShellScript(combined []string) (script string, ok bool) {
+	if len(combined) != 3 {
+		return "", false
+	}
+	if !scriptShells[combined[0]] || combined[1] != "-c" {
+		return "", false
+	}
+	return combined[2], true
+}
+
+// applyShellScript handles the shell-script extraction path.
+//
+// The bind-mount source uses a relative path (./<name>.sh) so the generated
+// unit files are self-contained: they work regardless of the directory they
+// are placed in, relying on Quadlet's getAbsolutePath resolution.
+func applyShellScript(unit *parser.UnitFile, script, prefix, name string) *GeneratedFile {
+	scriptName := fmt.Sprintf("%s-%s.sh", prefix, name)
+
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyEntrypoint, "/bin/sh")
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyExec, "/init.sh")
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume, fmt.Sprintf("./%s:/init.sh:ro,z", scriptName))
+
+	return &GeneratedFile{
+		Name:    scriptName,
+		Content: script,
+	}
+}

--- a/pkg/kube/quadlet/probe.go
+++ b/pkg/kube/quadlet/probe.go
@@ -1,0 +1,135 @@
+package quadlet
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+const (
+	defaultPeriodSeconds   = 10
+	defaultTimeoutSeconds  = 1
+	defaultFailureThresh   = 3
+	defaultSuccessThresh   = 1
+	defaultInitialDelaySec = 0
+)
+
+// applyProbes maps liveness, readiness, and startup probes onto unit.
+//
+// Quadlet exposes a single HealthCmd slot (plus a separate HealthStartupCmd).
+// There is no independent readiness health check key, so liveness and readiness
+// probes compete for the same slot. The priority is:
+//
+//	liveness  > readiness  (liveness is strictly stronger: same check + restart)
+//
+// When both are present, the readiness probe is silently dropped — the
+// liveness probe already subsumes it. When only a readiness probe is present,
+// it is mapped to HealthCmd without HealthOnFailure=restart because a failing
+// readiness check does not imply the container should be restarted.
+func applyProbes(unit *parser.UnitFile, liveness, readiness, startup *v1.Probe, restartPolicy v1.RestartPolicy) {
+	switch {
+	case liveness != nil:
+		applyLivenessProbe(unit, liveness, restartPolicy)
+	case readiness != nil:
+		applyReadinessProbe(unit, readiness)
+	}
+	if startup != nil {
+		applyStartupProbe(unit, startup)
+	}
+}
+
+func applyLivenessProbe(unit *parser.UnitFile, p *v1.Probe, restartPolicy v1.RestartPolicy) {
+	cmd := probeCommand(p.Handler)
+	if cmd == "" {
+		return
+	}
+	period := probeInt(p.PeriodSeconds, defaultPeriodSeconds)
+	timeout := probeInt(p.TimeoutSeconds, defaultTimeoutSeconds)
+	failure := probeInt(p.FailureThreshold, defaultFailureThresh)
+	initial := probeInt(p.InitialDelaySeconds, defaultInitialDelaySec)
+
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthCmd, cmd)
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthInterval, fmt.Sprintf("%ds", period))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthRetries, fmt.Sprintf("%d", failure))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthTimeout, fmt.Sprintf("%ds", timeout))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartPeriod, fmt.Sprintf("%ds", initial))
+
+	if restartPolicy == v1.RestartPolicyAlways || restartPolicy == v1.RestartPolicyOnFailure {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthOnFailure, "restart")
+	}
+}
+
+func applyReadinessProbe(unit *parser.UnitFile, p *v1.Probe) {
+	cmd := probeCommand(p.Handler)
+	if cmd == "" {
+		return
+	}
+	period := probeInt(p.PeriodSeconds, defaultPeriodSeconds)
+	timeout := probeInt(p.TimeoutSeconds, defaultTimeoutSeconds)
+	failure := probeInt(p.FailureThreshold, defaultFailureThresh)
+	initial := probeInt(p.InitialDelaySeconds, defaultInitialDelaySec)
+
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthCmd, cmd)
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthInterval, fmt.Sprintf("%ds", period))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthRetries, fmt.Sprintf("%d", failure))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthTimeout, fmt.Sprintf("%ds", timeout))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartPeriod, fmt.Sprintf("%ds", initial))
+}
+
+func applyStartupProbe(unit *parser.UnitFile, p *v1.Probe) {
+	cmd := probeCommand(p.Handler)
+	if cmd == "" {
+		return
+	}
+	period := probeInt(p.PeriodSeconds, defaultPeriodSeconds)
+	timeout := probeInt(p.TimeoutSeconds, defaultTimeoutSeconds)
+	failure := probeInt(p.FailureThreshold, defaultFailureThresh)
+	success := probeInt(p.SuccessThreshold, defaultSuccessThresh)
+
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartupCmd, cmd)
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartupInterval, fmt.Sprintf("%ds", period))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartupRetries, fmt.Sprintf("%d", failure))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartupSuccess, fmt.Sprintf("%d", success))
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyHealthStartupTimeout, fmt.Sprintf("%ds", timeout))
+}
+
+// probeCommand converts a probe's Handler into the string Quadlet expects for HealthCmd.
+func probeCommand(h v1.Handler) string {
+	switch {
+	case h.Exec != nil:
+		data, err := json.Marshal(h.Exec.Command)
+		if err != nil {
+			return ""
+		}
+		return string(data)
+
+	case h.HTTPGet != nil:
+		hg := h.HTTPGet
+		url := fmt.Sprintf("http://localhost:%s%s", hg.Port.String(), hg.Path)
+		var headers []string
+		for _, hdr := range hg.HTTPHeaders {
+			headers = append(headers, fmt.Sprintf("-H %q", hdr.Name+": "+hdr.Value))
+		}
+		cmd := "curl -f -s"
+		if len(headers) > 0 {
+			cmd += " " + strings.Join(headers, " ")
+		}
+		return cmd + " " + url
+
+	case h.TCPSocket != nil:
+		return fmt.Sprintf("sh -c \"echo > /dev/tcp/localhost/%s\"", h.TCPSocket.Port.String())
+	}
+	return ""
+}
+
+// probeInt returns val when non-zero, otherwise the supplied default.
+func probeInt(val int32, def int32) int32 {
+	if val == 0 {
+		return def
+	}
+	return val
+}

--- a/pkg/kube/quadlet/resources.go
+++ b/pkg/kube/quadlet/resources.go
@@ -1,0 +1,57 @@
+package quadlet
+
+import (
+	"fmt"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+	"go.podman.io/podman/v6/pkg/util"
+)
+
+// applyResources maps CPU and memory resource limits/requests onto unit.
+func applyResources(unit *parser.UnitFile, resources v1.ResourceRequirements) {
+	applyMemoryLimit(unit, resources)
+	applyMemoryRequest(unit, resources)
+	applyCPULimit(unit, resources)
+}
+
+func applyMemoryLimit(unit *parser.UnitFile, resources v1.ResourceRequirements) {
+	if resources.Limits == nil {
+		return
+	}
+	mem, ok := resources.Limits[v1.ResourceMemory]
+	if !ok || mem.IsZero() {
+		return
+	}
+	// Emit raw bytes — unambiguous, no suffix needed.
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyMemory, fmt.Sprintf("%d", mem.Value()))
+}
+
+func applyMemoryRequest(unit *parser.UnitFile, resources v1.ResourceRequirements) {
+	if resources.Requests == nil {
+		return
+	}
+	mem, ok := resources.Requests[v1.ResourceMemory]
+	if !ok || mem.IsZero() {
+		return
+	}
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs,
+		fmt.Sprintf("--memory-reservation=%d", mem.Value()))
+}
+
+func applyCPULimit(unit *parser.UnitFile, resources v1.ResourceRequirements) {
+	if resources.Limits == nil {
+		return
+	}
+	cpu, ok := resources.Limits[v1.ResourceCPU]
+	if !ok || cpu.IsZero() {
+		return
+	}
+	milliCPU := cpu.MilliValue()
+	period, quota := util.CoresToPeriodAndQuota(float64(milliCPU) / 1000)
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs,
+		fmt.Sprintf("--cpu-quota=%d", quota))
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs,
+		fmt.Sprintf("--cpu-period=%d", period))
+}

--- a/pkg/kube/quadlet/security.go
+++ b/pkg/kube/quadlet/security.go
@@ -1,0 +1,166 @@
+package quadlet
+
+import (
+	"fmt"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+// applySecurityContext maps security context fields onto unit.
+// Container-level fields take precedence over pod-level fields (K8s semantics).
+// supplementalGroups and sysctls are applied by the caller (Convert) at the
+// pod level since they affect multiple units.
+func applySecurityContext(unit *parser.UnitFile, csc *v1.SecurityContext, psc *v1.PodSecurityContext) {
+	applyCapabilities(unit, csc)
+	applyPrivileged(unit, csc)
+	applyReadOnly(unit, csc)
+	applyNoNewPrivileges(unit, csc)
+	applyUserGroup(unit, csc, psc)
+	applySeLinux(unit, csc, psc)
+	applySeccomp(unit, csc, psc)
+	applyProcMount(unit, csc)
+}
+
+func applyCapabilities(unit *parser.UnitFile, csc *v1.SecurityContext) {
+	if csc == nil || csc.Capabilities == nil {
+		return
+	}
+	for _, cap := range csc.Capabilities.Add {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyAddCapability, string(cap))
+	}
+	for _, cap := range csc.Capabilities.Drop {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyDropCapability, string(cap))
+	}
+}
+
+func applyPrivileged(unit *parser.UnitFile, csc *v1.SecurityContext) {
+	if csc == nil || csc.Privileged == nil || !*csc.Privileged {
+		return
+	}
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs, "--privileged")
+}
+
+func applyReadOnly(unit *parser.UnitFile, csc *v1.SecurityContext) {
+	if csc == nil || csc.ReadOnlyRootFilesystem == nil || !*csc.ReadOnlyRootFilesystem {
+		return
+	}
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyReadOnly, "true")
+}
+
+func applyNoNewPrivileges(unit *parser.UnitFile, csc *v1.SecurityContext) {
+	if csc == nil || csc.AllowPrivilegeEscalation == nil {
+		return
+	}
+	if !*csc.AllowPrivilegeEscalation {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeyNoNewPrivileges, "true")
+	}
+}
+
+// applyUserGroup resolves User= from container-level runAsUser/runAsGroup,
+// falling back to pod-level when the container does not set its own.
+func applyUserGroup(unit *parser.UnitFile, csc *v1.SecurityContext, psc *v1.PodSecurityContext) {
+	var uid, gid *int64
+
+	if csc != nil {
+		uid = csc.RunAsUser
+		gid = csc.RunAsGroup
+	}
+	if uid == nil && psc != nil {
+		uid = psc.RunAsUser
+	}
+	if gid == nil && psc != nil {
+		gid = psc.RunAsGroup
+	}
+
+	if uid == nil && gid == nil {
+		return
+	}
+
+	var userStr string
+	if uid != nil {
+		userStr = fmt.Sprintf("%d", *uid)
+	}
+	if gid != nil {
+		userStr = fmt.Sprintf("%s:%d", userStr, *gid)
+	}
+	unit.Set(quadlet.ContainerGroup, quadlet.KeyUser, userStr)
+}
+
+// applySeLinux maps SELinux options, resolving container-level over pod-level.
+// SecurityLabelUser and SecurityLabelRole have no native Quadlet key; they go
+// via PodmanArgs --security-opt.
+func applySeLinux(unit *parser.UnitFile, csc *v1.SecurityContext, psc *v1.PodSecurityContext) {
+	var sel *v1.SELinuxOptions
+	if csc != nil && csc.SELinuxOptions != nil {
+		sel = csc.SELinuxOptions
+	} else if psc != nil && psc.SELinuxOptions != nil {
+		sel = psc.SELinuxOptions
+	}
+	if sel == nil {
+		return
+	}
+
+	if sel.User != "" {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs,
+			fmt.Sprintf("--security-opt label=user:%s", sel.User))
+	}
+	if sel.Role != "" {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyPodmanArgs,
+			fmt.Sprintf("--security-opt label=role:%s", sel.Role))
+	}
+	if sel.Type != "" {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeySecurityLabelType, sel.Type)
+	}
+	if sel.Level != "" {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeySecurityLabelLevel, sel.Level)
+	}
+	if sel.FileType != "" {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeySecurityLabelFileType, sel.FileType)
+	}
+}
+
+// applySeccomp maps seccompProfile, resolving container-level over pod-level.
+func applySeccomp(unit *parser.UnitFile, csc *v1.SecurityContext, psc *v1.PodSecurityContext) {
+	var profile *v1.SeccompProfile
+	if csc != nil && csc.SeccompProfile != nil {
+		profile = csc.SeccompProfile
+	} else if psc != nil && psc.SeccompProfile != nil {
+		profile = psc.SeccompProfile
+	}
+	if profile == nil {
+		return
+	}
+
+	switch profile.Type {
+	case v1.SeccompProfileTypeLocalhost:
+		if profile.LocalhostProfile != nil {
+			unit.Set(quadlet.ContainerGroup, quadlet.KeySeccompProfile, *profile.LocalhostProfile)
+		}
+	case v1.SeccompProfileTypeRuntimeDefault:
+		unit.Set(quadlet.ContainerGroup, quadlet.KeySeccompProfile, "")
+	case v1.SeccompProfileTypeUnconfined:
+		unit.Set(quadlet.ContainerGroup, quadlet.KeySeccompProfile, "unconfined")
+	}
+}
+
+func applyProcMount(unit *parser.UnitFile, csc *v1.SecurityContext) {
+	if csc == nil || csc.ProcMount == nil {
+		return
+	}
+	if *csc.ProcMount == v1.UnmaskedProcMount {
+		unit.Set(quadlet.ContainerGroup, quadlet.KeyUnmask, "ALL")
+	}
+}
+
+// applySupplementalGroups emits GroupAdd= for each pod-level supplemental group.
+// Called for every regular container unit.
+func applySupplementalGroups(unit *parser.UnitFile, psc *v1.PodSecurityContext) {
+	if psc == nil {
+		return
+	}
+	for _, gid := range psc.SupplementalGroups {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyGroupAdd, fmt.Sprintf("%d", gid))
+	}
+}

--- a/pkg/kube/quadlet/types.go
+++ b/pkg/kube/quadlet/types.go
@@ -1,0 +1,55 @@
+package quadlet
+
+import (
+	"io"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+)
+
+// Options controls how a Kubernetes Pod spec is translated into Quadlet unit files.
+type Options struct {
+	// NamePrefix is prepended to every generated filename.
+	// Defaults to pod.Name.
+	NamePrefix string
+
+	// Network is the Quadlet Network= value for the pod unit.
+	// Empty string omits the directive (Podman default: pasta for rootless, bridge for root).
+	Network string
+
+	// ConfigMaps provides ConfigMap data to resolve configMapKeyRef and configMap volume sources.
+	// Key: ConfigMap name.
+	ConfigMaps map[string]v1.ConfigMap
+
+	// Secrets provides Secret data to resolve secretKeyRef and secret volume sources.
+	// Key: Secret name.
+	Secrets map[string]v1.Secret
+
+	// ConfigMapDir is the host directory where ConfigMap volume files will be written.
+	// Required when ConfigMaps is non-empty and volume-type configMap sources are present.
+	ConfigMapDir string
+}
+
+// GeneratedFile is a single file produced by Convert.
+//
+// Exactly one of Unit or Content is set:
+//   - Unit is set for structured Quadlet unit files (.pod, .container, .volume). Use
+//     Unit.Write or Unit.ToString to serialize.
+//   - Content is set for raw text files (.sh init scripts, .env files).
+type GeneratedFile struct {
+	// Name is the output filename (e.g. "myapp.pod", "myapp-web.container", "myapp-init.sh").
+	Name string
+	// Unit is non-nil for .pod, .container and .volume Quadlet unit files.
+	Unit *parser.UnitFile
+	// Content is non-empty for .sh and .env plain-text files.
+	Content string
+}
+
+// Write serializes the file to w.
+func (f *GeneratedFile) Write(w io.Writer) error {
+	if f.Unit != nil {
+		return f.Unit.Write(w)
+	}
+	_, err := io.WriteString(w, f.Content)
+	return err
+}

--- a/pkg/kube/quadlet/volume.go
+++ b/pkg/kube/quadlet/volume.go
@@ -1,0 +1,189 @@
+package quadlet
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "go.podman.io/podman/v6/pkg/k8s.io/api/core/v1"
+	"go.podman.io/podman/v6/pkg/systemd/parser"
+	"go.podman.io/podman/v6/pkg/systemd/quadlet"
+)
+
+func applyMount(unit *parser.UnitFile, m v1.VolumeMount, src v1.VolumeSource, prefix string) error {
+	switch {
+	case src.HostPath != nil:
+		return applyHostPathMount(unit, m, src.HostPath)
+	case src.PersistentVolumeClaim != nil:
+		return applyPVCMount(unit, m, prefix)
+	case src.EmptyDir != nil:
+		return applyEmptyDirMount(unit, m, m.Name, prefix)
+	case src.Image != nil:
+		return applyImageMount(unit, m, src.Image)
+	case src.ConfigMap != nil, src.Secret != nil:
+		// ConfigMap/Secret volumes are handled by applyVolumeMountsWithConfigSecrets.
+		return nil
+	default:
+		// Unsupported volume source — silently skip (consistent with kube play).
+		return nil
+	}
+}
+
+// mountOptions builds the -v options string from a VolumeMount.
+// SubPath is intentionally excluded: PVC mounts with SubPath use Mount=
+// (--mount type=volume,subpath=...) instead of Volume= (-v), because
+// Podman's -v syntax does not support the subpath= option.
+func mountOptions(m v1.VolumeMount) string {
+	var opts []string
+	if m.ReadOnly {
+		opts = append(opts, "ro")
+	}
+	if m.MountPropagation != nil {
+		switch *m.MountPropagation {
+		case v1.MountPropagationHostToContainer:
+			opts = append(opts, "rslave")
+		case v1.MountPropagationBidirectional:
+			opts = append(opts, "rshared")
+		case v1.MountPropagationNone:
+			opts = append(opts, "private")
+		}
+	}
+	return strings.Join(opts, ",")
+}
+
+func applyHostPathMount(unit *parser.UnitFile, m v1.VolumeMount, hp *v1.HostPathVolumeSource) error {
+	path := hp.Path
+	opts := mountOptions(m)
+
+	// Device types use AddDevice=, not Volume=.
+	// Podman's --device only accepts r/w/m permission chars; b/c are Linux
+	// device-type indicators that --device does not understand.
+	if hp.Type != nil {
+		switch *hp.Type {
+		case v1.HostPathBlockDev, v1.HostPathCharDev:
+			unit.Add(quadlet.ContainerGroup, quadlet.KeyAddDevice,
+				fmt.Sprintf("%s:%s", path, m.MountPath))
+			return nil
+		}
+	}
+
+	// Paths directly under /dev/ use AddDevice=.
+	if strings.HasPrefix(path, "/dev/") {
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyAddDevice, path)
+		return nil
+	}
+
+	// Kernel virtual filesystems must not be relabeled.
+	if strings.HasPrefix(path, "/sys/") || strings.HasPrefix(path, "/proc/") {
+		vol := path + ":" + m.MountPath
+		if m.ReadOnly {
+			vol += ":ro"
+		}
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume, vol)
+		return nil
+	}
+
+	// All other host paths get :z for SELinux relabeling.
+	vol := path + ":" + m.MountPath + ":z"
+	if opts != "" {
+		vol += "," + opts
+	}
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume, vol)
+	return nil
+}
+
+func applyPVCMount(unit *parser.UnitFile, m v1.VolumeMount, prefix string) error {
+	volName := fmt.Sprintf("%s-%s.volume", prefix, m.Name)
+
+	if m.SubPath != "" {
+		// Podman's -v short syntax does not support subpath=; use --mount
+		// type=volume instead. resolveContainerMountParams resolves the
+		// .volume unit reference and adds the correct Requires=/After=
+		// dependencies, identical to what Volume= would produce.
+		mountStr := fmt.Sprintf("type=volume,source=%s,destination=%s,subpath=%s",
+			volName, m.MountPath, m.SubPath)
+		if m.ReadOnly {
+			mountStr += ",ro"
+		}
+		unit.Add(quadlet.ContainerGroup, quadlet.KeyMount, mountStr)
+		return nil
+	}
+
+	vol := volName + ":" + m.MountPath
+	if opts := mountOptions(m); opts != "" {
+		vol += ":" + opts
+	}
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume, vol)
+	return nil
+}
+
+func applyEmptyDirMount(unit *parser.UnitFile, m v1.VolumeMount, volName, prefix string) error {
+	// Always use a named volume so all containers in the pod share the same
+	// underlying storage — matching Kubernetes emptyDir semantics where every
+	// container that mounts the volume sees the same data.
+	// A companion .volume unit with tmpfs options is generated in convert.go,
+	// making the volume volatile (data clears on each pod start).
+	// The ".volume" suffix on the reference tells Quadlet to use the managed
+	// volume (systemd-<name>) rather than creating a new plain named volume.
+	//
+	// :z triggers a shared SELinux relabel of the volume at mount time,
+	// changing the label from tmpfs_t to container_file_t. This allows
+	// container_t processes to create UNIX sockets and execute binaries
+	// inside these tmpfs volumes without disabling SELinux confinement.
+	// On non-SELinux systems the option is silently ignored.
+	anonVol := fmt.Sprintf("%s-%s-empty", prefix, volName)
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume,
+		fmt.Sprintf("%s.volume:%s:z", anonVol, m.MountPath))
+	return nil
+}
+
+func applyImageMount(unit *parser.UnitFile, m v1.VolumeMount, img *v1.ImageVolumeSource) error {
+	// OCI image volumes are read-only by default in Podman. Add ",rw" unless
+	// the mount is explicitly marked read-only (e.g. a read-only container disk).
+	mountStr := fmt.Sprintf("type=image,source=%s,dst=%s", img.Reference, m.MountPath)
+	if !m.ReadOnly {
+		mountStr += ",rw"
+	}
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyMount, mountStr)
+	return nil
+}
+
+// applyConfigMapVolume emits the Volume= bind-mount for a configMap volume source.
+// Caller is responsible for writing the actual files to ConfigMapDir.
+func applyConfigMapVolume(unit *parser.UnitFile, m v1.VolumeMount, cm *v1.ConfigMapVolumeSource, opts Options) error {
+	if opts.ConfigMaps == nil {
+		if cm.Optional != nil && *cm.Optional {
+			return nil
+		}
+		return fmt.Errorf("configMap %q not provided in opts.ConfigMaps", cm.Name)
+	}
+	if _, ok := opts.ConfigMaps[cm.Name]; !ok {
+		if cm.Optional != nil && *cm.Optional {
+			return nil
+		}
+		return fmt.Errorf("configMap %q not found in opts.ConfigMaps", cm.Name)
+	}
+	dir := opts.ConfigMapDir + "/" + m.Name
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume,
+		fmt.Sprintf("%s:%s:ro,z", dir, m.MountPath))
+	return nil
+}
+
+// applySecretVolume emits the Volume= bind-mount for a secret volume source.
+func applySecretVolume(unit *parser.UnitFile, m v1.VolumeMount, sec *v1.SecretVolumeSource, opts Options) error {
+	if opts.Secrets == nil {
+		if sec.Optional != nil && *sec.Optional {
+			return nil
+		}
+		return fmt.Errorf("secret %q not provided in opts.Secrets", sec.SecretName)
+	}
+	if _, ok := opts.Secrets[sec.SecretName]; !ok {
+		if sec.Optional != nil && *sec.Optional {
+			return nil
+		}
+		return fmt.Errorf("secret %q not found in opts.Secrets", sec.SecretName)
+	}
+	dir := opts.ConfigMapDir + "/" + m.Name
+	unit.Add(quadlet.ContainerGroup, quadlet.KeyVolume,
+		fmt.Sprintf("%s:%s:ro,z", dir, m.MountPath))
+	return nil
+}


### PR DESCRIPTION
this is useful for converting pod.yaml into first class systemd (quadlet) units .
the current kube play approach bypasses native qudlet constructs making it harder to manage.

the approach taken by podman kube play is understandable since it precedes quadlets .
i suspect that if this was done today - translating it to quadlets would have been the approach taken 