### PR TITLE
podman log-level debug must produce the same oci runtime errors

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1009,7 +1009,7 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 	defer errorhandling.CloseQuiet(parentStartPipe)
 
 	var ociLog string
-	if logrus.GetLevel() != logrus.DebugLevel && r.supportsJSON {
+	if r.supportsJSON {
 		ociLog = filepath.Join(ctr.state.RunDir, "oci-log")
 	}
 

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -47,10 +47,7 @@ func (r *ConmonOCIRuntime) ExecContainer(c *Container, sessionID string, options
 		attachStdin = streams.AttachInput
 	}
 
-	var ociLog string
-	if logrus.GetLevel() != logrus.DebugLevel && r.supportsJSON {
-		ociLog = c.execOCILog(sessionID)
-	}
+	ociLog := c.execOCILog(sessionID)
 
 	execCmd, pipes, err := r.startExec(c, sessionID, options, attachStdin, ociLog)
 	if err != nil {
@@ -115,10 +112,7 @@ func (r *ConmonOCIRuntime) ExecContainerHTTP(ctr *Container, sessionID string, o
 		attachStdin = streams.Stdin
 	}
 
-	var ociLog string
-	if logrus.GetLevel() != logrus.DebugLevel && r.supportsJSON {
-		ociLog = ctr.execOCILog(sessionID)
-	}
+	ociLog := ctr.execOCILog(sessionID)
 
 	execCmd, pipes, err := r.startExec(ctr, sessionID, options, attachStdin, ociLog)
 	if err != nil {
@@ -163,10 +157,7 @@ func (r *ConmonOCIRuntime) ExecContainerDetached(ctr *Container, sessionID strin
 		return -1, fmt.Errorf("must provide exec options to ExecContainerHTTP: %w", define.ErrInvalidArg)
 	}
 
-	var ociLog string
-	if logrus.GetLevel() != logrus.DebugLevel && r.supportsJSON {
-		ociLog = ctr.execOCILog(sessionID)
-	}
+	ociLog := ctr.execOCILog(sessionID)
 
 	execCmd, pipes, err := r.startExec(ctr, sessionID, options, stdin, ociLog)
 	if err != nil {

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -671,4 +671,19 @@ RUN useradd -u 1000 auser`, FEDORA_MINIMAL)
 		execSession.WaitWithDefaultTimeout()
 		Expect(execSession).Should(ExitWithError(137, ""))
 	})
+
+	It("podman exec command not in $PATH error", func() {
+		session := podmanTest.RunTopContainer("testctr")
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		execResult := podmanTest.Podman([]string{"exec", "testctr", "kjhasdf"})
+		execResult.WaitWithDefaultTimeout()
+		Expect(execResult).Should(ExitWithError(127, "not found in $PATH"))
+
+		// Test again with log level debug, this must produce the same error
+		execResult = podmanTest.Podman([]string{"--log-level=debug", "exec", "testctr", "kjhasdf"})
+		execResult.WaitWithDefaultTimeout()
+		Expect(execResult).Should(ExitWithError(127, "not found in $PATH"))
+	})
 })


### PR DESCRIPTION
I do not understand this condition in the code, not passing the log file to the runtime when run with log level debug makes no sense. It means we do not get the proper error message from the runtime so debug logging shows a much worse error:
"container create failed (no logs from conmon)..."

When the actual error is the command is not in $PATH for example. So to fix this just remove the log level check. Also not the support json flag condition is done inside execOCILog().



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Properly display oci runtime errors when running with `--log-level debug` 
```
