### PR TITLE
fix podman machine os upgrade distro check

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -11,3 +11,7 @@ macos:
 remote:
   # we cannot use multiline regex so we check for serviceIsRemote in podman info
   - 'serviceIsRemote:\strue'
+
+machine:
+  # machine-os uses its own variant so use that to label issues with machine based on podman info
+  - 'variant:\spodman-machine-os'

--- a/cmd/podman/machine/os/manager.go
+++ b/cmd/podman/machine/os/manager.go
@@ -5,6 +5,7 @@ package os
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -54,10 +55,10 @@ func NewOSManager(opts ManagerOpts) (pkgOS.Manager, error) {
 func guestOSManager() (pkgOS.Manager, error) {
 	dist := GetDistribution()
 	switch {
-	case dist.Name == "fedora" && dist.Variant == "coreos":
+	case dist.Name == "fedora" && dist.Variant == "podman-machine-os":
 		return &pkgOS.OSTree{}, nil
 	default:
-		return nil, errors.New("unsupported OS")
+		return nil, fmt.Errorf("unsupported OS/Variant: %s/%s", dist.Name, dist.Variant)
 	}
 }
 

--- a/docs/source/markdown/podman-machine-os-upgrade.1.md
+++ b/docs/source/markdown/podman-machine-os-upgrade.1.md
@@ -18,6 +18,8 @@ then the OS changes will be applied to `podman-machine-default`.
 
 The machine must be started for this command to be run.
 
+Note: This command is not supported with the WSL machine provider.
+
 ### UPGRADE LOGIC
 
 The upgrade function compares the client version against the machine version using semantic versioning (major.minor


### PR DESCRIPTION
We renamed the variant in machine-os to podman-machine-os so it is not coreos:
https://github.com/podman-container-tools/podman-machine-os/commit/a5c8fbcfc6225fc0e1a7b2c8a49d10ad352ab480

Now the main issue with this is the code runs inside the VM, which means updates from 6.0.0 to the next one still will be broken and needs the os apply command until this can work again. Of course a new init will also work with the new image.


Fixes: #29085
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Make podman machine os upgrade work (Note this will require an update inside the image so only updates with the newer image can work) #29085
```
