### PR TITLE
add logformatter back and provide better github log output 

### DIFF
--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -33,6 +33,10 @@ env:
   # ENV is managed by renovate, do not change the name without
   # updating the renovate config in the automation repo.
   AUTOMATION_RELEASE: 20260722t094115z
+  # Needed for logformatter
+  PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+  PR_TITLE: ${{ github.event.pull_request.title || ''  }}
+  GITHUB_RUN_ID: ${{ github.run_id }}
 
 jobs:
   lima:
@@ -70,6 +74,10 @@ jobs:
         run: | # zizmor: ignore[template-injection]
           ./hack/ci/ci.sh ${{ inputs.test }} ${{ inputs.mode }} ${{ inputs.priv }} ${{ inputs.distro }}
 
+      - name: Output failure log as GITHUB_STEP_SUMMARY
+        if: failure()
+        run: hack/ci/github_log_summary.py hack/ci/logs/*.html > $GITHUB_STEP_SUMMARY || true
+
       # TODO: figure out how to cache the binaries from the build job to the actual test tasks
       # - name: Upload binaries as artifact
       #   if: ${{ inputs.test == 'build' }}
@@ -83,6 +91,6 @@ jobs:
         if: always() # always collect the log
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          name: "journal-${{ inputs.test }}-${{ inputs.mode }}-${{ inputs.priv }}-${{ inputs.distro }}.log"
-          path: "./hack/ci/journal.log"
+          name: "${{ inputs.test }}-${{ inputs.mode }}-${{ inputs.priv }}-${{ inputs.distro }}.logs"
+          path: "./hack/ci/logs/*"
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverprofile
 /docs/*.[158].gz
 /docs/build/
 /docs/remote
+/hack/ci/logs/
 **.DS_Store
 .gopathok
 .idea*

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -20,6 +20,7 @@ IMAGE_URL="https://objectstorage.us-ashburn-1.oraclecloud.com/n/id0lmbbwgcdv/b/p
 
 trap "limactl delete --force $LIMA_VM_NAME" EXIT
 
+echo "::group::Starting VM"
 limactl --yes start --plain --name=$LIMA_VM_NAME --cpus $(nproc) --memory 8 --nested-virt \
     --set ".images=[{\"location\":\"$IMAGE_URL\", \"arch\": \"x86_64\"}]" \
     "$SCRIPT_DIR/template.lima.yml"
@@ -28,12 +29,16 @@ limactl shell $LIMA_VM_NAME mkdir -p /var/tmp/podman-container-tools
 
 limactl copy "$REPO_DIR" $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman
 
+echo "::endgroup::"
+
 set +e
 
 limactl shell --preserve-env --workdir /var/tmp/podman-container-tools/podman $LIMA_VM_NAME ./hack/ci/runner.sh "${@}"
 rc=$?
 
+echo "::group::Collecting logs"
 limactl copy $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman/hack/ci/logs/ $SCRIPT_DIR/logs
+echo "::endgroup::"
 
 # TODO: figure out how to cache the binaries from the build job to the actual test tasks
 # Copy the binaries out of the VM in gh actions so we can upload them as artifact

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -24,19 +24,21 @@ limactl --yes start --plain --name=$LIMA_VM_NAME --cpus $(nproc) --memory 8 --ne
     --set ".images=[{\"location\":\"$IMAGE_URL\", \"arch\": \"x86_64\"}]" \
     "$SCRIPT_DIR/template.lima.yml"
 
-limactl copy "$REPO_DIR" $LIMA_VM_NAME:/var/tmp/podman
+limactl shell $LIMA_VM_NAME mkdir -p /var/tmp/podman-container-tools
+
+limactl copy "$REPO_DIR" $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman
 
 set +e
 
-limactl shell --workdir /var/tmp/podman $LIMA_VM_NAME ./hack/ci/runner.sh "${@}"
+limactl shell --preserve-env --workdir /var/tmp/podman-container-tools/podman $LIMA_VM_NAME ./hack/ci/runner.sh "${@}"
 rc=$?
 
-limactl shell --workdir /var/tmp/podman $LIMA_VM_NAME sudo ./hack/ci/logcollector.sh journal &> "$SCRIPT_DIR/journal.log"
+limactl copy $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman/hack/ci/logs/ $SCRIPT_DIR/logs
 
 # TODO: figure out how to cache the binaries from the build job to the actual test tasks
 # Copy the binaries out of the VM in gh actions so we can upload them as artifact
 # if [[ -n "$GITHUB_ACTIONS" && "$TEST" == build ]]; then
-#    limactl copy $LIMA_VM_NAME:/var/tmp/podman/bin "$REPO_DIR/bin" || die "failed to copy binaries"
+#    limactl copy $LIMA_VM_NAME:/var/tmp/podman-container-tools/podman/bin "$REPO_DIR/bin" || die "failed to copy binaries"
 # fi
 
 exit $rc

--- a/hack/ci/github_log_summary.py
+++ b/hack/ci/github_log_summary.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+from html.parser import HTMLParser
+import html
+import sys
+
+class GinkgoLogFilterParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        # Stack to keep track of nested elements
+        self.stack = []
+        # Store the raw HTML strings of matching 'tt' elements
+        self.results = []
+
+    def _get_classes(self, attrs):
+        """Helper to extract classes from an attribute list."""
+        for attr, value in attrs:
+            if attr == 'class' and value:
+                return value.split()
+        return []
+
+    def handle_starttag(self, tag, attrs):
+        classes = self._get_classes(attrs)
+        is_tt = 'tt' in classes
+        is_failed = 'log-failed' in classes
+
+        # If we see a 'log-failed' class, flag all 'tt' ancestors in the stack
+        if is_failed:
+            for node in self.stack:
+                if node['is_tt']:
+                    node['keep'] = True
+
+        # Push the new element to the stack
+        self.stack.append({
+            'tag': tag,
+            'text_chunks': [],
+            'is_tt': is_tt,
+            'keep': False
+        })
+
+    def handle_startendtag(self, tag, attrs):
+        # Handle self-closing tags just to check for the failure class
+        classes = self._get_classes(attrs)
+        if 'log-failed' in classes:
+            for node in self.stack:
+                if node['is_tt']:
+                    node['keep'] = True
+
+    def handle_data(self, data):
+        # Capture raw text data
+        if self.stack:
+            self.stack[-1]['text_chunks'].append(data)
+
+    def handle_endtag(self, tag):
+        # Find the matching start tag in the stack
+        for i in reversed(range(len(self.stack))):
+            if self.stack[i]['tag'] == tag:
+                # Pop the matching tag and any unclosed children
+                while len(self.stack) > i:
+                    node = self.stack.pop()
+
+                    # Join all the collected text for this node
+                    node_text = "".join(node['text_chunks'])
+                    # Trim down the spaces for the ginkgo long indentation.
+                    node_text = node_text.removeprefix(' ' * 9)
+
+                    # If this is a 'tt' element and it contains a 'log-failed' child, save the text
+                    if node['is_tt'] and node['keep']:
+                        self.results.append(node_text)
+
+                    # Pass the text of this node up to its parent so we don't lose inner text
+                    if self.stack:
+                        self.stack[-1]['text_chunks'].append(node_text)
+                break
+
+class BatsLogFilterParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        # Current Tag which text should be stored
+        self.record = None
+        self.data = ""
+
+    def _get_classes(self, attrs):
+        """Helper to extract classes from an attribute list."""
+        for attr, value in attrs:
+            if attr == 'class' and value:
+                return value.split()
+        return []
+
+    def handle_starttag(self, tag, attrs):
+        classes = self._get_classes(attrs)
+
+        if 'bats-failed' in classes or 'bats-log-failblock' in classes or 'bats-log' in classes:
+            self.record = tag
+
+    def handle_data(self, data):
+        if self.record:
+            self.data += data
+
+    def handle_endtag(self, tag):
+        if self.record == tag:
+            self.data += "\n"
+            self.record = None
+
+
+
+def filter_html_file(file_path):
+    # Read the HTML content
+    with open(file_path, 'r', encoding='utf-8') as f:
+        html_content = f.read()
+
+    if 'int-' in file_path:
+        parser = GinkgoLogFilterParser()
+        parser.feed(html_content)
+        return parser.results
+
+    parser = BatsLogFilterParser()
+    parser.feed(html_content)
+    return [parser.data]
+
+
+# Running the filter
+matching_elements = filter_html_file(sys.argv[1])
+
+for element in matching_elements:
+    print(f"```")
+    print(element)
+    print("```")

--- a/hack/ci/lib.sh
+++ b/hack/ci/lib.sh
@@ -10,6 +10,11 @@ OS_RELEASE_ID="$(
 )"
 OS_REL_VER="$OS_RELEASE_ID-$OS_RELEASE_VER"
 
+TEST_NAME=$(
+    IFS=-
+    echo "${*}"
+)
+
 function die() {
     echo "$1" >&2
     exit 1

--- a/hack/ci/logformatter
+++ b/hack/ci/logformatter
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# logformatter - highlight a Cirrus test log (ginkgo or bats)
+# logformatter - highlight a ci test log (ginkgo or bats)
 #
 # Adapted from https://raw.githubusercontent.com/edsantiago/greasemonkey/podman-ginkgo-highlight
 #
@@ -19,7 +19,7 @@ use warnings;
 
 (our $ME = $0) =~ s|.*/||;
 
-our $VERSION = '0.3';
+our $VERSION = '0.4';
 
 # Autoflush stdout
 $| = 1;
@@ -112,7 +112,7 @@ Usage: $ME [OPTIONS] TEST_NAME
 $ME is a filter; it HTMLifies an input stream (presumably
 Ginkgo or BATS log results), writing HTML results to an output file
 but passing stdin unmodified to stdout. It is intended to run in
-the Cirrus CI environment.
+the github CI environment.
 
 Parameters:
 
@@ -212,26 +212,9 @@ END_HTML
     print { $out_fh } "<h2>Synopsis</h2>\n<hr/>\n",
         job_synopsis($test_name), "<hr/>\n";
 
-    # FOR DEBUGGING: dump environment, but in HTML comments to not clutter
-    # This is safe. There is a TOKEN envariable, but it's not sensitive.
-    # There are no sensitive/secret values in our execution environment,
-    # but we're careful anyway. $SECRET_ENV_RE is set in lib.sh
-    my $filter_re = $ENV{SECRET_ENV_RE} || 'ACCOUNT|GC[EP]|PASSW|SECRET|TOKEN';
-    $filter_re .= '|BASH_FUNC';   # These are long and un-useful
-
-    print { $out_fh } "<!-- Environment: -->\n";
-    for my $e (sort keys %ENV) {
-        next if $e =~ /$filter_re/;
-
-        my $val = escapeHTML($ENV{$e});
-        $val =~ s/--/-&#x002D;/g;       # double dash not valid in comments
-        printf { $out_fh } "<!--  %-20s %s -->\n", $e, $val;
-    }
-
     # State variables
     my $previous_timestamp = '';  # timestamp of previous line
     my $previous_timestamp_fine;  # fine-grain timestamp (BATS only)
-    my $cirrus_task;              # Cirrus task number, used for linking
     my $git_commit;               # git SHA, used for linking to source files
     my $subtest_status;           # pass, fail, skip, flake - for each subtest
     my $subtest_name;             # assembled from two or more Describe()/It()s
@@ -243,8 +226,8 @@ END_HTML
     my $looks_like_python;        #   " "   "  : for colorizing python tests
     my %bats_count;               # For summary line: count of pass/fail/skip
 
-    # When running in cirrus, we have the commit SHA
-    $git_commit = $ENV{CIRRUS_CHANGE_IN_REPO};
+    # When running in github, we have the commit SHA
+    $git_commit = $ENV{GITHUB_SHA};
 
     print { $out_fh } "<div class='tt'> <!-- begin processed output -->\n";
 
@@ -314,29 +297,14 @@ END_HTML
         }
         # ...so we can link to specific lines in source files
         if ($git_commit) {
-            #           1  12  3                 34     4 5   526  6
-            $line =~ s{^(.*)(\/(containers\/[^/]+)(\/\S+):(\d+))(.*)$}
+            #           1  12  3                             34     4 5   526  6
+            $line =~ s{^(.*)(\/(podman-container-tools\/[^/]+)(\/\S+):(\d+))(.*)$}
                       {$1<a class="codelink" href='https://github.com/$3/blob/$git_commit$4#L$5'>$2</a>$6};
 
             # Same, for python errors
-            #           1  12  3                 34         4             5   526
-            $line =~ s{^(.*)(\/(containers\/[^/]+)(\/\S+\.py).*,\s+line\s+(\d+))(,\s+in.*)$}
+            #           1  12  3                             34         4             5   526
+            $line =~ s{^(.*)(\/(podman-container-tools\/[^/]+)(\/\S+\.py).*,\s+line\s+(\d+))(,\s+in.*)$}
                       {$1<a class="codelink" href='https://github.com/$3/blob/$git_commit$4#L$5'>$2</a>$6};
-
-            # And, sigh, Macintosh always has to be different
-            #           1              123    3 4   425  5
-            $line =~ s{^(.*/ci/task-\d+)((/\S+):(\d+))(.*)$}
-                      {$1<a class="codelink" href="https://github.com/containers/podman/blob/$git_commit$3#L$4">$2</a>$5};
-
-            # ...as does Windows
-            #           1                             123    3 4   435  5
-            $line =~ s{^(.*/Local/cirrus-ci-build/repo)((/\S+):(\d+))(.*)$}
-                      {$1<a class="codelink" href="https://github.com/containers/podman/blob/$git_commit$3#L$4">$2</a>$5}
-        }
-
-        # Try to identify the cirrus task
-        if ($line =~ /cirrus-task-(\d+)/) {
-            $cirrus_task = $1;
         }
 
         # logrus messages, always highlighted
@@ -440,7 +408,7 @@ END_HTML
             # and 'test/system' because there's no way to get them from log.
             #
             #          1  2      2               13     4         43           5
-            $line =~ s{(in(\stest)?\s+file\s+\S+/)(\S+\.(bats|bash)),\s+line\s+(\d+)}{$1<a class="codelink" href="https://github.com/containers/podman/blob/$git_commit/test/system/$3#L$5">$3, line $5</a>};
+            $line =~ s{(in(\stest)?\s+file\s+\S+/)(\S+\.(bats|bash)),\s+line\s+(\d+)}{$1<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/$git_commit/test/system/$3#L$5">$3, line $5</a>};
 
             if ($css) {
                 # Make it linkable, e.g. foo.html#t--00001
@@ -746,14 +714,6 @@ END_HTML
 
         print { $out_fh } "</div>  <!-- end processed output -->\n";
 
-        # Did we find a cirrus task? Link back.
-        if ($cirrus_task) {
-            print { $out_fh } <<"END_HTML";
-<hr />
-<h3>Cirrus <a href="https://cirrus-ci.com/task/$cirrus_task">task $cirrus_task</a></h3>
-END_HTML
-        }
-
         # FIXME: need a safe way to get TZ
         printf { $out_fh } <<"END_HTML", scalar(CORE::localtime);
 <hr />
@@ -782,27 +742,6 @@ END_HTML
         print  "\n";
         printf "Failed tests (%d):\n", scalar(@$fails);
         printf " - %d %s\n", @$_ for @$fails;
-    }
-
-    # If Cirrus magic envariables are available, write a link to results.
-    # FIXME: it'd be so nice to make this a clickable live link.
-    #
-    # As of June 2022 we use the Cirrus API[1] as the source of our logs,
-    # instead of linking directly to googleapis.com. This will allow us
-    # to abstract cloud-specific details, so we can one day use Amazon cloud.
-    # See #14569 for more info.
-    #
-    #   [1] https://cirrus-ci.org/guide/writing-tasks/#latest-build-artifacts
-    if ($have_formatted_log && $ENV{CIRRUS_TASK_ID}) {
-        my $URL_BASE = "https://api.cirrus-ci.com";
-        my $task_id  = $ENV{CIRRUS_TASK_ID};
-
-        # Link by *taskID*, not buildID + taskname. First, this is shorter
-        # and less duplicaty. Second, and more important, buildID + taskname
-        # is non-unique, and a link to a flake log will be clobbered.
-        my $URL = "${URL_BASE}/v1/artifact/task/$task_id/html/${outfile}";
-
-        print "\n\nAnnotated results:\n  $URL\n";
     }
 }
 
@@ -846,61 +785,23 @@ sub job_synopsis {
 <table class="synopsis">
 END_SYNOPSIS
 
-    # PR 1234 - title of the pr
-    my $pr_title = escapeHTML(_env_replace("{CIRRUS_CHANGE_TITLE}"));
+    # PR 1234 - title of the pr, envs are set in lima.yml
+    my $pr_title = escapeHTML(_env_replace("{PR_TITLE}"));
     $s .= _tr("GitHub PR", sprintf("%s - %s",
-                                   _a("{CIRRUS_PR}", "https://{CIRRUS_REPO_CLONE_HOST}/{CIRRUS_REPO_FULL_NAME}/pull/{CIRRUS_PR}"),
+                                   _a("{PR_NUMBER}", "{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}/pull/{PR_NUMBER}"),
                                    $pr_title));
 
     # PR author, if signed-off-by
-    if (my $msg = _env_replace("{CIRRUS_COMMIT_MESSAGE}")) {
-        while ($msg =~ /^Signed-off-by:\s+(\S.*\S)$/gmi) {
-            $s .= _tr("Author", escapeHTML($1));
-        }
+    if (my $actor = _env_replace("{GITHUB_ACTOR}")) {
+        $s .= _tr("Author", escapeHTML($actor));
     }
 
-    # eg "test fedora", "special_testing_rootless"
-    # WARNING: As of 2020-10-05, $CIRRUS_TASK_NAME reflects the same
-    # descriptive content as our $subtest_name argument (confirm via
-    # cross-checking runner.sh:logformatter() vs cirrus.yml:&std_name_fmt).
-    # If this ever becomes untrue, just add _tr("Subtest", $subtest_name).
-    my $test_name = _env_replace("{CIRRUS_TASK_NAME}");
-    # (Special-case cleanup: Cirrus\ quotes\ spaces; remove for readability).
-    $test_name =~ s/\\\s+/ /g;
-    $s .= _tr("Test name", $test_name);
+    $s .= _tr("Test name", $subtest_name);
 
-    # Macs always have to be different
-    my $is_mac = ($test_name =~ /darwin/);
-
-    # Link to further Cirrus results, e.g. other runs.
-    # Build is mostly boring, it's usually TASK that we want to see.
-    $s .= _tr("Cirrus", sprintf("<small>Build %s</small> / <b>Task %s</b>",
-                                _a("{CIRRUS_BUILD_ID}", "https://cirrus-ci.com/build/{CIRRUS_BUILD_ID}"),
-                                _a("{CIRRUS_TASK_ID}", "https://cirrus-ci.com/task/{CIRRUS_TASK_ID}")));
-
-    # Logs: link to original (unformatted) log; journal; cleanup tracer; and, if remote, server
-    my @logs;
-    push @logs, _a("main", sprintf("https://api.cirrus-ci.com/v1/task/{CIRRUS_TASK_ID}/logs/%s.log",
-                                   ($is_mac ? 'test' : 'main')));
-    push @logs, _a("journal", "https://api.cirrus-ci.com/v1/task/{CIRRUS_TASK_ID}/logs/journal.log")
-        unless $is_mac;
-
-    push @logs, _a("cleanup tracer", "https://api.cirrus-ci.com/v1/artifact/task/{CIRRUS_TASK_ID}/cleanup_tracer/podman-cleanup-tracer.log")
-        unless $is_mac;
-
-    # System tests are single-threaded, and have a server log available
-    if ($test_name =~ /sys\s+remote\s/) {
-        push @logs, _a("remote server", "https://api.cirrus-ci.com/v1/artifact/task/{CIRRUS_TASK_ID}/server_log/podman-server.log");
-    }
-    $s .= _tr("Logs", join(" / ", @logs));
-
-    # PR_BASE_SHA (set in lib.sh) can tell us if our parent includes--or
-    # doesn't--a purported fix for a flake. Note about the URL: "commits", plural,
-    # links to a git history listing; if we used "commit", singular, that would
-    # be less useful.
-    if (my $base = $ENV{PR_BASE_SHA}) {
-        $s .= _tr("Base commit", _a($base, "https://{CIRRUS_REPO_CLONE_HOST}/{CIRRUS_REPO_FULL_NAME}/commits/$base"));
-    }
+    # Link to github action results.
+    # We cannot direct link to the job result, only to the overall run as the job is does not seem to be exposed anywhere by default.
+    $s .= _tr("GitHub Actions RUN", sprintf("<b>%s</b>",
+                        _a("{GITHUB_RUN_ID}", "{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}/actions/runs/{GITHUB_RUN_ID}")));
 
     $s .= "</table>\n";
     return $s;

--- a/hack/ci/logformatter.t
+++ b/hack/ci/logformatter.t
@@ -13,7 +13,7 @@ use File::Temp          qw(tempdir);
 use Test::More;
 
 # To test links to source files
-$ENV{CIRRUS_CHANGE_IN_REPO} = 'ceci-nest-pas-une-sha';
+$ENV{GITHUB_SHA} = 'ceci-nest-pas-une-sha';
 
 #
 # Read the test cases (see __END__ section below)
@@ -67,7 +67,7 @@ for my $t (@tests) {
     }
     close $fh_in;
 
-    # Strip off leading and trailing "<pre>"
+    # Strip off leading and trailing "<div>"
     shift @actual; pop @actual;
 
     # For debugging: preserve expected results
@@ -106,9 +106,9 @@ ok 4 blah
 <span class='bats-passed'><a name='t--00001'>ok 1 hi</a></span>
 <span class='bats-skipped'><a name='t--00002'>ok 2 bye # skip no reason</a></span>
 <span class='bats-failed'><a name='t--00003'>not ok 3 fail</a></span>
-<span class='bats-log'># (from function `assert&#39; in file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L343">helpers.bash, line 343</a>,</span>
-<span class='bats-log'>#  from function `expect_output&#39; in file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L370">helpers.bash, line 370</a>,</span>
-<span class='bats-log'>#  in test file ./<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/run.bats#L786">run.bats, line 786</a>)</span>
+<span class='bats-log'># (from function `assert&#39; in file ./<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L343">helpers.bash, line 343</a>,</span>
+<span class='bats-log'>#  from function `expect_output&#39; in file ./<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L370">helpers.bash, line 370</a>,</span>
+<span class='bats-log'>#  in test file ./<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/system/run.bats#L786">run.bats, line 786</a>)</span>
 <span class='bats-log'># $ <b><span title="/path/to/podman">podman</span> foo -bar</b></span>
 <span class='bats-log'># time=<span class='log-debug'>&quot;2023-01-05T15:15:20Z&quot;</span> level=<span class='log-debug'>debug</span> msg=<span class='log-debug'>&quot;this is debug&quot;</span></span>
 <span class='bats-log'># time=<span class='log-warning'>&quot;2023-01-05T15:15:20Z&quot;</span> level=<span class='log-warning'>warning</span> msg=<span class='log-warning'>&quot;this is warning&quot;</span></span>
@@ -151,9 +151,9 @@ ok 4 blah
 <span class="timestamp">[+0000s] </span>1..2
 <span class="timestamp">         </span><span class='bats-passed'><a name='t--00001'>ok 1 this passes</a></span>
 <span class="timestamp">[+0018s] </span><span class='bats-failed'><a name='t--00002'>not ok 2 this fails, and includes command timestamps</a></span>
-<span class="timestamp">         </span><span class='bats-log'># (from function `die&#39; in file test/system/<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L564">helpers.bash, line 564</a>,</span>
-<span class="timestamp">         </span><span class='bats-log'>#  from function `run_podman&#39; in file test/system/<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L245">helpers.bash, line 245</a>,</span>
-<span class="timestamp">         </span><span class='bats-log'>#  in test file test/system/<a class="codelink" href="https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/system/888-foo.bats#L15">888-foo.bats, line 15</a>)</span>
+<span class="timestamp">         </span><span class='bats-log'># (from function `die&#39; in file test/system/<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L564">helpers.bash, line 564</a>,</span>
+<span class="timestamp">         </span><span class='bats-log'>#  from function `run_podman&#39; in file test/system/<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/system/helpers.bash#L245">helpers.bash, line 245</a>,</span>
+<span class="timestamp">         </span><span class='bats-log'>#  in test file test/system/<a class="codelink" href="https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/system/888-foo.bats#L15">888-foo.bats, line 15</a>)</span>
 <span class="timestamp">         </span><span class='bats-log'>#   `run_podman image exists sdfsdfsdf&#39; failed</span>
 <span class="timestamp"><span title="07:46:52.641456481">&lt;+     &gt;</span> </span><span class='bats-log'># $ <b><span title="/home/esm/src/atomic/2018-02.podman/libpod/bin/podman">podman</span> rm -t 0 --all --force --ignore</b></span>
 <span class="timestamp"><span title="07:46:52.688219032">&lt;+046ms&gt;</span> </span><span class='bats-log'># $ <b><span title="/home/esm/src/atomic/2018-02.podman/libpod/bin/podman">podman</span> ps --all --external --format {{.ID}} {{.Names}}</b></span>
@@ -188,36 +188,36 @@ ok 4 blah
 [+0270s] ------------------------------
 [+0271s] • [3.327 seconds]
 [+0271s] Podman restart
-[+0271s] /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:14
+[+0271s] /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:14
 [+0271s]   podman restart non-stop container with short timeout
-[+0271s]   /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:148
+[+0271s]   /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:148
 [+0271s]&TRAILINGSPACE;
 [+0271s]   Timeline >>
-[+0271s]   > Enter [BeforeEach] Podman restart - /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:21 @ 04/17/23 10:00:28.653
-[+0271s]   < Exit [BeforeEach] Podman restart - /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:21 @ 04/17/23 10:00:28.653 (0s)
-[+0271s]   > Enter [It] podman restart non-stop container with short timeout - /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:148 @ 04/17/23 10:00:28.653
-[+0271s]   Running: /var/tmp/go/src/github.com/containers/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs run -d --name test1 --env STOPSIGNAL=SIGKILL quay.io/libpod/alpine:latest sleep 999
+[+0271s]   > Enter [BeforeEach] Podman restart - /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:21 @ 04/17/23 10:00:28.653
+[+0271s]   < Exit [BeforeEach] Podman restart - /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:21 @ 04/17/23 10:00:28.653 (0s)
+[+0271s]   > Enter [It] podman restart non-stop container with short timeout - /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:148 @ 04/17/23 10:00:28.653
+[+0271s]   Running: /var/tmp/podman-container-tools/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs run -d --name test1 --env STOPSIGNAL=SIGKILL quay.io/libpod/alpine:latest sleep 999
 [+0271s]   7f5f8fb3d043984cdff65994d14c4fd157479d20e0a0fcf769c35b50e8975edc
-[+0271s]   Running: /var/tmp/go/src/github.com/containers/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs restart -t 2 test1
+[+0271s]   Running: /var/tmp/podman-container-tools/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs restart -t 2 test1
 [+0271s]   time="2023-04-17T10:00:31-05:00" level=warning msg="StopSignal SIGTERM failed to stop container test1 in 2 seconds, resorting to SIGKILL"
 [+0271s]   test1
-[+0271s]   < Exit [It] podman restart non-stop container with short timeout - /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:148 @ 04/17/23 10:00:31.334 (2.681s)
-[+0271s]   > Enter [AfterEach] Podman restart - /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:30 @ 04/17/23 10:00:31.334
-[+0271s]   Running: /var/tmp/go/src/github.com/containers/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs stop --all -t 0
+[+0271s]   < Exit [It] podman restart non-stop container with short timeout - /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:148 @ 04/17/23 10:00:31.334 (2.681s)
+[+0271s]   > Enter [AfterEach] Podman restart - /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:30 @ 04/17/23 10:00:31.334
+[+0271s]   Running: /var/tmp/podman-container-tools/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs stop --all -t 0
 [+0271s]   7f5f8fb3d043984cdff65994d14c4fd157479d20e0a0fcf769c35b50e8975edc
-[+0271s]   Running: /var/tmp/go/src/github.com/containers/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs pod rm -fa -t 0
-[+0271s]   Running: /var/tmp/go/src/github.com/containers/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs rm -fa -t 0
+[+0271s]   Running: /var/tmp/podman-container-tools/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs pod rm -fa -t 0
+[+0271s]   Running: /var/tmp/podman-container-tools/podman/bin/podman --storage-opt vfs.imagestore=/tmp/imagecachedir --root /tmp/podman_test2968516396/root --runroot /tmp/podman_test2968516396/runroot --runtime crun --conmon /usr/bin/conmon --network-config-dir /tmp/podman_test2968516396/root/etc/networks --network-backend netavark --cgroup-manager systemd --tmpdir /tmp/podman_test2968516396 --events-backend file --db-backend sqlite --storage-driver vfs rm -fa -t 0
 [+0271s]   7f5f8fb3d043984cdff65994d14c4fd157479d20e0a0fcf769c35b50e8975edc
-[+0271s]   < Exit [AfterEach] Podman restart - /var/tmp/go/src/github.com/containers/podman/test/e2e/restart_test.go:30 @ 04/17/23 10:00:31.979 (645ms)
+[+0271s]   < Exit [AfterEach] Podman restart - /var/tmp/podman-container-tools/podman/test/e2e/restart_test.go:30 @ 04/17/23 10:00:31.979 (645ms)
 [+0271s]   << Timeline
 [+0296s] ------------------------------
 [+0298s] • [FAILED] [6.071 seconds]
 [+0298s] TOP-LEVEL [AfterEach]
-[+0298s] /var/tmp/go/src/github.com/containers/podman/test/e2e/common_test.go:117
+[+0298s] /var/tmp/podman-container-tools/podman/test/e2e/common_test.go:117
 [+0298s]   Podman pod create
-[+0298s]   /var/tmp/go/src/github.com/containers/podman/test/e2e/pod_infra_container_test.go:12
+[+0298s]   /var/tmp/podman-container-tools/podman/test/e2e/pod_infra_container_test.go:12
 [+0298s]     podman pod correctly sets up PIDNS
-[+0298s]     /var/tmp/go/src/github.com/containers/podman/test/e2e/pod_infra_container_test.go:154
+[+0298s]     /var/tmp/podman-container-tools/podman/test/e2e/pod_infra_container_test.go:154
 [+0298s]&TRAILINGSPACE;&TRAILINGSPACE;&TRAILINGSPACE;
 [+0298s]   Timeline >>
 [+0298s]   << Timeline
@@ -225,7 +225,7 @@ ok 4 blah
 [+1741s]&TRAILINGSPACE;
 [+1741s] Summarizing 1 Failure:
 [+1741s]   [FAIL] TOP-LEVEL [AfterEach] Podman pod create podman pod correctly sets up PIDNS
-[+1741s]   /var/tmp/go/src/github.com/containers/podman/test/e2e/common_test.go:657
+[+1741s]   /var/tmp/podman-container-tools/podman/test/e2e/common_test.go:657
 [+1741s]&TRAILINGSPACE;
 [+1741s] Ran 1889 of 2014 Specs in 1607.919 seconds
 [+1741s] FAIL! -- 1881 Passed | 1 Failed | 0 Pending | 125 Skipped
@@ -234,20 +234,20 @@ ok 4 blah
 <span class="timestamp">[+0004s] </span>CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build  -ldflags &#39;-X github.com/containers/podman/v4/libpod/define.gitCommit=074143b0fac7af72cd92048d27931a92fe745084 -X github.com/containers/podman/v4/libpod/define.buildInfo=1681728432 -X github.com/containers/podman/v4/libpod/config._installPrefix=/usr/local -X github.com/containers/podman/v4/libpod/config._etcDir=/usr/local/etc -X github.com/containers/podman/v4/pkg/systemd/quadlet._binDir=/usr/local/bin -X github.com/containers/common/pkg/config.additionalHelperBinariesDir= &#39; -tags &quot;   selinux systemd seccomp&quot; -o test/checkseccomp/checkseccomp ./test/checkseccomp
 <span class="timestamp">[+0006s] </span>CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build  -ldflags &#39;-X github.com/containers/podman/v4/libpod/define.gitCommit=074143b0fac7af72cd92048d27931a92fe745084 -X github.com/containers/podman/v4/libpod/define.buildInfo=1681728434 -X github.com/containers/podman/v4/libpod/config._installPrefix=/usr/local -X github.com/containers/podman/v4/libpod/config._etcDir=/usr/local/etc -X github.com/containers/podman/v4/pkg/systemd/quadlet._binDir=/usr/local/bin -X github.com/containers/common/pkg/config.additionalHelperBinariesDir= &#39; -o test/goecho/goecho ./test/goecho
 <span class="timestamp">         </span>./hack/install_catatonit.sh
-</pre>
+</div>
 <hr />
-<pre>
+<div class='tt'>
 <span class="timestamp">[+0271s] </span>• <b>[3.327 seconds]</b>
-<span class="timestamp">         </span><a name='t--Podman-restart--1'><h2 class="log-passed">Podman restart</h2></a>
-<span class="timestamp">         </span>/var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L14'>/containers/podman/test/e2e/restart_test.go:14</a>
-<span class="timestamp">         </span><a name='t--Podman-restart-podman-restart-non-stop-container-with-short-timeout--1'><h2 class="log-passed">  podman restart non-stop container with short timeout</h2></a>
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L148'>/containers/podman/test/e2e/restart_test.go:148</a>
+<span class="timestamp">         </span><a name='t--Podman-restart--1' /><h2 class="log-passed">Podman restart</h2>
+<span class="timestamp">         </span>/var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L14'>/podman-container-tools/podman/test/e2e/restart_test.go:14</a>
+<span class="timestamp">         </span><a name='t--Podman-restart-podman-restart-non-stop-container-with-short-timeout--1' /><h2 class="log-passed">  podman restart non-stop container with short timeout</h2>
+<span class="timestamp">         </span>  /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L148'>/podman-container-tools/podman/test/e2e/restart_test.go:148</a>
 <span class="timestamp">         </span>
 <span class="timestamp">         </span>  Timeline &gt;&gt;
-<div class="ginkgo-timeline ginkgo-beforeeach"><span class="timestamp">         </span>  &rarr; Enter [<b>BeforeEach</b>] Podman restart - /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L21'>/containers/podman/test/e2e/restart_test.go:21</a> @ 04/17/23 10:00:28.653
-<span class="timestamp">         </span>  &larr; Exit  [BeforeEach] Podman restart - /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L21'>/containers/podman/test/e2e/restart_test.go:21</a> @ 04/17/23 10:00:28.653 (0s)
-</div><div class="ginkgo-timeline ginkgo-it"><span class="timestamp">         </span>  &rarr; Enter [<b>It</b>] podman restart non-stop container with short timeout - /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L148'>/containers/podman/test/e2e/restart_test.go:148</a> @ 04/17/23 10:00:28.653
-<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
+<div class="ginkgo-timeline ginkgo-beforeeach"><span class="timestamp">         </span>  &rarr; Enter [<b>BeforeEach</b>] Podman restart - /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L21'>/podman-container-tools/podman/test/e2e/restart_test.go:21</a> @ 04/17/23 10:00:28.653
+<span class="timestamp">         </span>  &larr; Exit  [BeforeEach] Podman restart - /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L21'>/podman-container-tools/podman/test/e2e/restart_test.go:21</a> @ 04/17/23 10:00:28.653 (0s)
+</div><div class="ginkgo-timeline ginkgo-it"><span class="timestamp">         </span>  &rarr; Enter [<b>It</b>] podman restart non-stop container with short timeout - /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L148'>/podman-container-tools/podman/test/e2e/restart_test.go:148</a> @ 04/17/23 10:00:28.653
+<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/podman-container-tools/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
 --root /tmp/podman_test2968516396/root
 --runroot /tmp/podman_test2968516396/runroot
 --runtime crun
@@ -260,7 +260,7 @@ ok 4 blah
 --db-backend sqlite
 --storage-driver vfs">[options]</span><b> run -d --name test1 --env STOPSIGNAL=SIGKILL quay.io/libpod/alpine:latest sleep 999</b>
 <span class="timestamp">         </span>  7f5f8fb3d043984cdff65994d14c4fd157479d20e0a0fcf769c35b50e8975edc
-<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
+<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/podman-container-tools/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
 --root /tmp/podman_test2968516396/root
 --runroot /tmp/podman_test2968516396/runroot
 --runtime crun
@@ -274,9 +274,9 @@ ok 4 blah
 --storage-driver vfs">[options]</span><b> restart -t 2 test1</b>
 <span class="timestamp">         </span>  time=<span class='log-warning'>&quot;2023-04-17T10:00:31-05:00&quot;</span> level=<span class='log-warning'>warning</span> msg=<span class='log-warning'>&quot;StopSignal SIGTERM failed to stop container test1 in 2 seconds, resorting to SIGKILL&quot;</span>
 <span class="timestamp">         </span>  test1
-<span class="timestamp">         </span>  &larr; Exit  [It] podman restart non-stop container with short timeout - /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L148'>/containers/podman/test/e2e/restart_test.go:148</a> @ 04/17/23 10:00:31.334 (2.681s)
-</div><div class="ginkgo-timeline ginkgo-aftereach"><span class="timestamp">         </span>  &rarr; Enter [<b>AfterEach</b>] Podman restart - /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L30'>/containers/podman/test/e2e/restart_test.go:30</a> @ 04/17/23 10:00:31.334
-<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
+<span class="timestamp">         </span>  &larr; Exit  [It] podman restart non-stop container with short timeout - /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L148'>/podman-container-tools/podman/test/e2e/restart_test.go:148</a> @ 04/17/23 10:00:31.334 (2.681s)
+</div><div class="ginkgo-timeline ginkgo-aftereach"><span class="timestamp">         </span>  &rarr; Enter [<b>AfterEach</b>] Podman restart - /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L30'>/podman-container-tools/podman/test/e2e/restart_test.go:30</a> @ 04/17/23 10:00:31.334
+<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/podman-container-tools/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
 --root /tmp/podman_test2968516396/root
 --runroot /tmp/podman_test2968516396/runroot
 --runtime crun
@@ -289,7 +289,7 @@ ok 4 blah
 --db-backend sqlite
 --storage-driver vfs">[options]</span><b> stop --all -t 0</b>
 <span class="timestamp">         </span>  7f5f8fb3d043984cdff65994d14c4fd157479d20e0a0fcf769c35b50e8975edc
-<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
+<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/podman-container-tools/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
 --root /tmp/podman_test2968516396/root
 --runroot /tmp/podman_test2968516396/runroot
 --runtime crun
@@ -301,7 +301,7 @@ ok 4 blah
 --events-backend file
 --db-backend sqlite
 --storage-driver vfs">[options]</span><b> pod rm -fa -t 0</b>
-<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
+<span class="timestamp">         </span><span class="boring">  #</span> <span title="/var/tmp/podman-container-tools/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/imagecachedir
 --root /tmp/podman_test2968516396/root
 --runroot /tmp/podman_test2968516396/runroot
 --runtime crun
@@ -314,28 +314,28 @@ ok 4 blah
 --db-backend sqlite
 --storage-driver vfs">[options]</span><b> rm -fa -t 0</b>
 <span class="timestamp">         </span>  7f5f8fb3d043984cdff65994d14c4fd157479d20e0a0fcf769c35b50e8975edc
-<span class="timestamp">         </span>  &larr; Exit  [AfterEach] Podman restart - /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L30'>/containers/podman/test/e2e/restart_test.go:30</a> @ 04/17/23 10:00:31.979 (645ms)
+<span class="timestamp">         </span>  &larr; Exit  [AfterEach] Podman restart - /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/restart_test.go#L30'>/podman-container-tools/podman/test/e2e/restart_test.go:30</a> @ 04/17/23 10:00:31.979 (645ms)
 </div><span class="timestamp">         </span>  &lt;&lt; Timeline
-</pre>
+</div>
 <hr />
-<pre>
+<div class='tt'>
 <span class="timestamp">[+0298s] </span><span class="log-failed">• [FAILED] <b><span class='log-slow'>[6.071 seconds]</span></b></span>
-<span class="timestamp">         </span><a name='t--TOP-LEVEL--AfterEach---1'><h2 class="log-failed">TOP-LEVEL [AfterEach]</h2></a>
-<span class="timestamp">         </span>/var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/common_test.go#L117'>/containers/podman/test/e2e/common_test.go:117</a>
-<span class="timestamp">         </span><a name='t--Podman-pod-create--1'><h2 class="log-failed">  Podman pod create</h2></a>
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/pod_infra_container_test.go#L12'>/containers/podman/test/e2e/pod_infra_container_test.go:12</a>
-<span class="timestamp">         </span><a name='t--Podman-pod-create-podman-pod-correctly-sets-up-PIDNS--1'><h2 class="log-failed">    podman pod correctly sets up PIDNS</h2></a>
-<span class="timestamp">         </span>    /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/pod_infra_container_test.go#L154'>/containers/podman/test/e2e/pod_infra_container_test.go:154</a>
+<span class="timestamp">         </span><a name='t--TOP-LEVEL--AfterEach---1' /><h2 class="log-failed">TOP-LEVEL [AfterEach]</h2>
+<span class="timestamp">         </span>/var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/common_test.go#L117'>/podman-container-tools/podman/test/e2e/common_test.go:117</a>
+<span class="timestamp">         </span><a name='t--Podman-pod-create--1' /><h2 class="log-failed">  Podman pod create</h2>
+<span class="timestamp">         </span>  /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/pod_infra_container_test.go#L12'>/podman-container-tools/podman/test/e2e/pod_infra_container_test.go:12</a>
+<span class="timestamp">         </span><a name='t--Podman-pod-create-podman-pod-correctly-sets-up-PIDNS--1' /><h2 class="log-failed">    podman pod correctly sets up PIDNS</h2>
+<span class="timestamp">         </span>    /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/pod_infra_container_test.go#L154'>/podman-container-tools/podman/test/e2e/pod_infra_container_test.go:154</a>
 <span class="timestamp">         </span>&TRAILINGSPACE;&TRAILINGSPACE;
 <span class="timestamp">         </span>  Timeline &gt;&gt;
 <span class="timestamp">         </span>  &lt;&lt; Timeline
-</pre>
+</div>
 <hr />
-<pre>
+<div class='tt'>
 <span class="timestamp">[+1741s] </span>
 <span class="timestamp">         </span>Summarizing 1 Failure:
 <span class="timestamp">         </span><span class="log-error">  [FAIL] TOP-LEVEL [AfterEach] <a href='#t--Podman-pod-create-podman-pod-correctly-sets-up-PIDNS--1'>Podman pod create podman pod correctly sets up PIDNS</a></span>
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/common_test.go#L657'>/containers/podman/test/e2e/common_test.go:657</a>
+<span class="timestamp">         </span>  /var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/074143b0fac7af72cd92048d27931a92fe745084/test/e2e/common_test.go#L657'>/podman-container-tools/podman/test/e2e/common_test.go:657</a>
 <span class="timestamp">         </span>
 <span class="timestamp">         </span>Ran 1889 of 2014 Specs in 1607.919 seconds
 <span class="timestamp">         </span><span class="ginkgo-final-fail">FAIL!</span> -- <span class="bats-passed"><b>1881</b> Passed</span> | <span class="bats-failed"><b>1</b> Failed</span> | 0 Pending | <span class="bats-skipped"><b>125</b> Skipped</span>
@@ -343,7 +343,7 @@ ok 4 blah
 == simple python
 
 <<<
-[+0234s] env CONTAINERS_CONF=/var/tmp/go/src/github.com/containers/podman/test/apiv2/containers.conf PODMAN=./bin/podman /usr/bin/python3 -m unittest discover -v ./test/python/docker
+[+0234s] env CONTAINERS_CONF=/var/tmp/podman-container-tools/podman/test/apiv2/containers.conf PODMAN=./bin/podman /usr/bin/python3 -m unittest discover -v ./test/python/docker
 [+0238s] test_copy_to_container (compat.test_containers.TestContainers) ... /usr/lib/python3.10/site-packages/docker/utils/utils.py:269: DeprecationWarning: urllib.parse.splitnport() is deprecated as of 3.8, use urllib.parse.urlparse() instead
 [+0238s]   host, port = splitnport(parsed_url.netloc)
 [+0241s] ok
@@ -404,7 +404,7 @@ ok 4 blah
 [+0299s] Search for image
 [+0299s] ----------------------------------------------------------------------
 [+0299s] Traceback (most recent call last):
-[+0299s]   File "/var/tmp/go/src/github.com/containers/podman/test/python/docker/compat/test_images.py", line 90, in test_search_image
+[+0299s]   File "/var/tmp/podman-container-tools/podman/test/python/docker/compat/test_images.py", line 90, in test_search_image
 [+0299s]     self.assertIn("alpine", r["Name"])
 [+0299s] AssertionError: 'alpine' not found in 'docker.io/docker/desktop-kubernetes'
 [+0299s] ----------------------------------------------------------------------
@@ -412,7 +412,7 @@ ok 4 blah
 [+0299s] FAILED (failures=1, skipped=1)
 [+0299s] make: *** [Makefile:616: localapiv2] Error 1
 >>>
-<span class="timestamp">[+0234s] </span>env CONTAINERS_CONF=/var/tmp/go/src/github.com/containers/podman/test/apiv2/containers.conf PODMAN=./bin/podman /usr/bin/python3 -m unittest discover -v ./test/python/docker
+<span class="timestamp">[+0234s] </span>env CONTAINERS_CONF=/var/tmp/podman-container-tools/podman/test/apiv2/containers.conf PODMAN=./bin/podman /usr/bin/python3 -m unittest discover -v ./test/python/docker
 <span class="timestamp">[+0238s] </span>test_copy_to_container (compat.test_containers.TestContainers) ... /usr/lib/python3.10/site-packages/docker/utils/utils.py:269: DeprecationWarning: urllib.parse.splitnport() is deprecated as of 3.8, use urllib.parse.urlparse() instead
 <span class="timestamp">         </span>  host, port = splitnport(parsed_url.netloc)
 <span class="timestamp">[+0241s] </span>ok
@@ -474,7 +474,7 @@ ok 4 blah
 <span class="timestamp">         </span>Search for image
 <span class="timestamp">         </span>----------------------------------------------------------------------
 <span class="timestamp">         </span>Traceback (most recent call last):
-<span class="timestamp">         </span>  File &quot;/var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/ceci-nest-pas-une-sha/test/python/docker/compat/test_images.py#L90'>/containers/podman/test/python/docker/compat/test_images.py&quot;, line 90</a>, in test_search_image
+<span class="timestamp">         </span>  File &quot;/var/tmp<a class="codelink" href='https://github.com/podman-container-tools/podman/blob/ceci-nest-pas-une-sha/test/python/docker/compat/test_images.py#L90'>/podman-container-tools/podman/test/python/docker/compat/test_images.py&quot;, line 90</a>, in test_search_image
 <span class="timestamp">         </span>    self.assertIn(&quot;alpine&quot;, r[&quot;Name&quot;])
 <span class="timestamp">         </span>AssertionError: &#39;alpine&#39; not found in &#39;docker.io/docker/desktop-kubernetes&#39;
 <span class="timestamp">         </span>----------------------------------------------------------------------

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -137,7 +137,20 @@ echo "#################"
 "$SCRIPT_DIR/logcollector.sh" packages
 "$SCRIPT_DIR/logcollector.sh" ip
 
+mkdir -p "$SCRIPT_DIR/logs"
+# Log the journal at the end.
+trap "sudo \"$SCRIPT_DIR/logcollector.sh\" journal &> \"$SCRIPT_DIR/logs/journal-$TEST_NAME.log\"" EXIT
+
 ### TEST functions
+
+function logformatter() {
+    # Requires stdin and stderr combined!
+    awk --file "${SCRIPT_DIR}/timestamp.awk" |&
+        (
+            cd "${SCRIPT_DIR}/logs"
+            "${SCRIPT_DIR}/logformatter" "$TEST_NAME"
+        )
+}
 
 function run_build() {
     # Ensure always start from clean-slate with all vendor modules downloaded
@@ -161,24 +174,27 @@ function run_apiv2() {
     source .venv/requests/bin/activate
     pip install --upgrade pip
     pip install --requirement ./test/apiv2/python/requirements.txt
-    $SUDO make localapiv2-bash
-    $SUDO sh -c "source .venv/requests/bin/activate && make localapiv2-python"
+    $SUDO sh -c "(
+        make localapiv2-bash
+        source .venv/requests/bin/activate
+        make localapiv2-python
+    )" |& logformatter
 }
 
 function run_bindings() {
     make .install.ginkgo
-    $SUDO make testbindings
+    $SUDO make testbindings |& logformatter
 }
 
 function run_bud() {
-    $SUDO ./test/buildah-bud/run-buildah-bud-tests
+    $SUDO ./test/buildah-bud/run-buildah-bud-tests |& logformatter
 }
 
 function run_compose_v2() {
     # FIXME do not hard code the version here, and likely it would be best to embed this in the VM image to begin with.
     sudo curl --fail -SL https://github.com/docker/compose/releases/download/v2.32.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
-    $SUDO ./test/compose/test-compose
+    $SUDO ./test/compose/test-compose |& logformatter
 }
 
 function run_docker_py() {
@@ -186,7 +202,7 @@ function run_docker_py() {
     source .venv/docker-py/bin/activate
     pip install --upgrade pip
     pip install --requirement ./test/python/requirements.txt
-    $SUDO sh -c "source .venv/docker-py/bin/activate && make run-docker-py-tests"
+    $SUDO sh -c "source .venv/docker-py/bin/activate && make run-docker-py-tests" |& logformatter
 }
 
 function run_unit() {
@@ -197,15 +213,15 @@ function run_unit() {
 function run_upgrade() {
     export SUPPRESS_BOLTDB_WARNING=true
     export PODMAN_UPGRADE_FROM=${MODE}
-    $SUDO bats test/upgrade
+    $SUDO bats test/upgrade |& logformatter
 }
 
 function run_int() {
-    $SUDO make ${MODE}integration
+    $SUDO make ${MODE}integration |& logformatter
 }
 
 function run_sys() {
-    $SUDO make ${MODE}system
+    $SUDO make ${MODE}system |& logformatter
 }
 
 function run_machine() {

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -9,6 +9,8 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 
 source "$SCRIPT_DIR/lib.sh"
 
+echo "::group::Test Setup"
+
 parse_args "$@"
 
 PRESERVE_ENVS="CI_USE_REGISTRY_CACHE,CI_DESIRED_COMPOSEFS,OCI_RUNTIME,CGROUP_MANAGER,STORAGE_FS,STORAGE_OPTIONS_OVERLAY,STORAGE_OPTIONS_VFS,PODMAN_UPGRADE_FROM"
@@ -127,15 +129,14 @@ fi
 $SUDO git config --global user.name "Podman CI"
 $SUDO git config --global user.email "no-reply@podman.io"
 
+echo "::endgroup::" # Test Setup
+
 ### LOG various relevant things
 
-echo
-echo "#################"
-echo "Setup complete, logging versions"
-echo "#################"
-
+echo "::group::Logging system info"
 "$SCRIPT_DIR/logcollector.sh" packages
 "$SCRIPT_DIR/logcollector.sh" ip
+echo "::endgroup::" # Logging system info
 
 mkdir -p "$SCRIPT_DIR/logs"
 # Log the journal at the end.
@@ -228,9 +229,6 @@ function run_machine() {
     $SUDO make ${MODE}machine
 }
 
-echo
-echo "#################"
 echo "Starting Test"
-echo "#################"
 
 run_$TEST

--- a/hack/ci/timestamp.awk
+++ b/hack/ci/timestamp.awk
@@ -1,0 +1,20 @@
+
+
+# This script is intended to be piped into by automation, in order to
+# mark output lines with timing information.  For example:
+#      /path/to/command |& awk --file timestamp.awk
+
+BEGIN {
+    STARTTIME=systime()
+    printf "[%s] START", strftime("%T")
+    printf " - All [+xxxx] lines that follow are relative to %s.\n", strftime("%FT%TZ", systime(), 1)
+}
+
+{
+    printf "[%+05ds] %s\n", systime()-STARTTIME, $0
+}
+
+END {
+    printf "[%s] END", strftime("%T")
+    printf " - [%+05ds] total duration since %s\n", systime()-STARTTIME, strftime("%FT%TZ", systime(), 1)
+}


### PR DESCRIPTION
Adapt the logformatter script to run again to produce nicely formatted
html logs. Because github cannot upload and show raw html files we can
only add it to the log archive which must be downloaded and viewed
locally.

To improve the online experience however github does have the
GITHUB_STEP_SUMMARY logic which allows us to produce markdown which will
be shown on the summary page for a given test run.

The problem is even though github markdown supports some html is does
not support CSS and out custom style of the logformatter, in addition
the output size is limited so I wrote another script parsing the html
output again and turning it into plain test for only the failed tests
and then show this as plain text inside codeblocks in the markdown.

With this we have a short failure summary which should display all
failures at once in the run page so maintainers can see if the failed
log was just some flake or an actual problem with the PR.

Fixes: #28828

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
