### PR TITLE
pkg/domain: include container name in kube play start errors

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -45,6 +45,7 @@ import (
 	"go.podman.io/podman/v6/pkg/util"
 	"go.podman.io/storage/pkg/chrootarchive"
 	"go.podman.io/storage/pkg/fileutils"
+	"go.podman.io/storage/pkg/stringid"
 	yamlv3 "gopkg.in/yaml.v3"
 	"sigs.k8s.io/yaml"
 )
@@ -1165,8 +1166,18 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			return nil, nil, err
 		}
-		for id, err := range podStartErrors {
-			playKubePod.ContainerErrors = append(playKubePod.ContainerErrors, fmt.Errorf("starting container %s: %w", id, err).Error())
+		if len(podStartErrors) > 0 {
+			ctrNames := make(map[string]string, len(containers))
+			for _, ctr := range containers {
+				ctrNames[ctr.ID()] = ctr.Name()
+			}
+			for id, err := range podStartErrors {
+				if name, ok := ctrNames[id]; ok {
+					playKubePod.ContainerErrors = append(playKubePod.ContainerErrors, fmt.Errorf("starting container %s (%s): %w", name, stringid.TruncateID(id), err).Error())
+				} else {
+					playKubePod.ContainerErrors = append(playKubePod.ContainerErrors, fmt.Errorf("starting container %s: %w", stringid.TruncateID(id), err).Error())
+				}
+			}
 		}
 
 		// Wait for each proxy to receive a READY message. Use a wait

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2660,6 +2660,17 @@ var _ = Describe("Podman kube play", func() {
 		Expect(kube).Should(ExitWithError(125, `container "podDoesntHaveAnImage" is missing the required 'image' field`))
 	})
 
+	It("container start error identifies the container by name", func() {
+		pod := getPod(withCtr(getCtr(withImage(ALPINE), withCmd([]string{"/no/such/command"}), withArg(nil))))
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).ToNot(HaveOccurred())
+
+		kube := podmanTest.Podman([]string{"kube", "play", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(ExitWithError(125, "failed to start 1 containers"))
+		Expect(kube.ErrorToString()).To(ContainSubstring(getCtrNameInPod(pod)))
+	})
+
 	It("support container liveness probe", func() {
 		err := writeYaml(livenessProbePodYaml, kubeYaml)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes: #27196

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### PR Regarding 
kube-play start errors showed only the container ID, so you couldn't tell which container failed 
I included the name alongside the ID through this pr

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #27196` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes) - 


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
podman kube play now includes the container name alongside the ID when a container fails to start.
```
