### PR TITLE
pkg/specgenutilexternal: add tests for FindMountType

### DIFF
--- a/pkg/specgenutilexternal/parse_test.go
+++ b/pkg/specgenutilexternal/parse_test.go
@@ -1,0 +1,97 @@
+package specgenutilexternal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindMountType(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		mountType string
+		tokens    []string
+	}{
+		{
+			name:      "bind with options",
+			input:     "type=bind,src=/foo,target=/bar",
+			mountType: "bind",
+			tokens:    []string{"src=/foo", "target=/bar"},
+		},
+		{
+			name:      "tmpfs",
+			input:     "type=tmpfs,target=/tmp",
+			mountType: "tmpfs",
+			tokens:    []string{"target=/tmp"},
+		},
+		{
+			name:      "no type defaults to volume",
+			input:     "src=/foo,target=/bar",
+			mountType: "volume",
+			tokens:    []string{"src=/foo", "target=/bar"},
+		},
+		{
+			name:      "type does not need to be first",
+			input:     "src=/foo,type=bind,target=/bar",
+			mountType: "bind",
+			tokens:    []string{"src=/foo", "target=/bar"},
+		},
+		{
+			name:      "only the first type is used",
+			input:     "type=bind,type=tmpfs",
+			mountType: "bind",
+			tokens:    []string{"type=tmpfs"},
+		},
+		{
+			name:      "token with multiple equals is preserved",
+			input:     "type=bind,opt=a=b",
+			mountType: "bind",
+			tokens:    []string{"opt=a=b"},
+		},
+		{
+			name:      "empty type value",
+			input:     "type=,target=/bar",
+			mountType: "",
+			tokens:    []string{"target=/bar"},
+		},
+		{
+			name:      "whitespace around type is not recognized",
+			input:     "type = a,target=/bar",
+			mountType: "volume",
+			tokens:    []string{"type = a", "target=/bar"},
+		},
+		{
+			name:      "literal backslash-n is not a newline",
+			input:     "type=bind\\nfoo=bar",
+			mountType: "volume",
+			tokens:    []string{"type=bind\\nfoo=bar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mountType, tokens, err := FindMountType(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.mountType, mountType)
+			assert.Equal(t, tt.tokens, tokens)
+		})
+	}
+}
+
+func TestFindMountTypeErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty input", input: ""},
+		{name: "newline creates multiple records", input: "type=bind\nfoo=bar"},
+		{name: "bare quote in value", input: `type=bind,src="/path,with,commas",target=/bar`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := FindMountType(tt.input)
+			assert.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### What
added tests for FindMountType parses --mount strings with a table driven coverage for that 


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
none
```
