### PR TITLE
Bump bundled krunkit from 1.2.1 to 1.3.1

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -9,7 +9,7 @@ else
 endif
 GVPROXY_VERSION=$(shell $(GO) list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
 VFKIT_VERSION ?= 0.6.1
-KRUNKIT_VERSION ?= 1.2.1
+KRUNKIT_VERSION ?= 1.3.1
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
 KRUNKIT_RELEASE_URL ?= https://github.com/containers/krunkit/releases/download/v$(KRUNKIT_VERSION)/krunkit-podman-unsigned-$(KRUNKIT_VERSION).tgz


### PR DESCRIPTION
Bump bundled krunkit to 1.3.1, which comes with libkrun 1.19.3.

This version of krunkit makes HTTP parsing on the rest-uri more robust to ensure it only acts on the right request.

It also enables a new permission semantics mode in libkrun that's closer to the user expectations on macOS.

Fixes: #21402
Fixes: #29084
