### PR TITLE
machine/wsl: fix config mount logic

### DIFF
--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -480,6 +480,15 @@ var _ = Describe("podman machine init", func() {
 		Expect(sshSession2).To(Exit(0))
 		output := strings.TrimSpace(sshSession2.outputToString())
 		Expect(output).To(Equal("/run/podman/podman.sock"))
+
+		// Ensure we can at least connect to the rootful podman socket and that it is actually a rootful one by checking the paths
+		bm := basicMachine{}
+		info, err := mb.setCmd(bm.withPodmanCommand([]string{"info"})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info).To(Exit(0))
+		Expect(info.outputToString()).To(ContainSubstring("/run/podman/podman.sock"))
+		Expect(info.outputToString()).To(ContainSubstring("serviceIsRemote: true"))
+		Expect(info.outputToString()).To(ContainSubstring("/var/lib/containers"))
 	})
 
 	It("init should cleanup on failure", func() {

--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -98,7 +98,8 @@ LoadCredential=
 const bindMountConfigDirSystemService = `
 [Unit]
 Description=Bind mount for config directory
-Before=podman.socket
+Before=multi-user.target
+After=local-fs.target
 
 [Service]
 RemainAfterExit=true
@@ -157,12 +158,13 @@ const (
 	podmanSocketDropin     = "podman.socket.d"
 	podmanSocketDropinPath = sysSystemdPath + "/" + podmanSocketDropin
 
-	configBindSysUnitName = "podman-mnt-config.service"
-	configBindSysUnitPath = sysSystemdPath + "/" + configBindSysUnitName
-	configBindSysUnitWant = sysSystemdWants + "/" + configBindSysUnitName
+	configBindSysUnitName           = "podman-mnt-config.service"
+	configBindSysUnitPath           = sysSystemdPath + "/" + configBindSysUnitName
+	configBindSysUnitWantsDirectory = sysSystemdPath + "/local-fs.target.wants"
+	configBindSysUnitWant           = configBindSysUnitWantsDirectory + "/" + configBindSysUnitName
 )
 
-const configBindServices = "mkdir -p " + userSystemdWants + " " + sysSystemdWants + " " + podmanSocketDropinPath + "\n" +
+const configBindServices = "mkdir -p " + userSystemdWants + " " + sysSystemdWants + " " + podmanSocketDropinPath + " " + configBindSysUnitWantsDirectory + "\n" +
 	"ln -fs " + bindUserUnitPath + " " + bindUserUnitWant + "\n" +
 	"ln -fs " + bindSysUnitPath + " " + bindSysUnitWant + "\n" +
 	"ln -fs " + configBindSysUnitPath + " " + configBindSysUnitWant + "\n"


### PR DESCRIPTION
The current systemd service to mount /etc/containers is not working right. The Before=podman.socket causes a ordering conflict which causes the socket to be disabled and thus all podman remote connections fail.

The problem is the unit is wanted by the default.target while the socket is wanted by sockets.target which can be before the default.target is triggered. That means that the Before= line cannot be fulfilled and sometimes systemd thus seems to not start the socket. It is unclear to me why this is racy as it is sometimes also works.

This was reported by Vladimir Lazar from the PD team, our CI did not caught this as we use rootless machines by default and the problem only happens for the rootful socket so we do not see connection failures. To fix this add at least one rootful socket check.

We do however have a different CI flake that was also caused by the incorrect mount dependencies. The mount could happen after sshd or other programs run. So to fix this we must hook the podman-mnt-config.service into the local-fs.target which runs much earlier and is used for all the mounts.

Fixes: #29003

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed an issue with podman machine on WSL where the rootful socket would not be created
```
