### PR TITLE
Makefile: allow `make validatepr` to be run from git worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,9 +336,14 @@ validate: validate-source validate-binaries ## Run all validation checks (lint, 
 # not automated right now.  The hope is that eventually the quay.io/libpod/fedora_podman is multiarch and can replace this
 # image in the future.
 .PHONY: validatepr
+# When run from a git worktree, $(CURDIR)/.git is a file pointing to the parent
+# git dir outside the bind mount; also mount that dir at its own path so git
+# inside the container can resolve and not throw ownership errors.
+validatepr: GIT_COMMON_DIR = $(shell git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
 validatepr: ## Run full PR validation in a container (lint, format, checks)
 	$(PODMANCMD) run --rm --init --tmpfs /tmp \
 		-v $(CURDIR):/go/src/github.com/containers/podman \
+		$(if $(GIT_COMMON_DIR),-v $(GIT_COMMON_DIR):$(GIT_COMMON_DIR)) \
 		-v validatepr-gocache:/root/.cache/go-build \
 		-v validatepr-gomodcache:/root/go/pkg/mod \
 		-v validatepr-lintcache:/root/.cache/golangci-lint \


### PR DESCRIPTION
When running `make validatepr` from a git worktree, $(CURDIR)/.git is a file pointing to the parent git dir outside the bind mount. Mount that dir at its own path so git inside the container can resolve and not throw ownership errors.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)