### PR TITLE
Bump bundled krunkit from 1.3.1 to 1.3.2

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -9,7 +9,7 @@ else
 endif
 GVPROXY_VERSION=$(shell $(GO) list -m -f '{{.Version}}' github.com/containers/gvisor-tap-vsock)
 VFKIT_VERSION ?= 0.6.1
-KRUNKIT_VERSION ?= 1.3.1
+KRUNKIT_VERSION ?= 1.3.2
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/$(GVPROXY_VERSION)/gvproxy-darwin
 VFKIT_RELEASE_URL ?= https://github.com/crc-org/vfkit/releases/download/v$(VFKIT_VERSION)/vfkit-unsigned
 KRUNKIT_RELEASE_URL ?= https://github.com/containers/krunkit/releases/download/v$(KRUNKIT_VERSION)/krunkit-podman-unsigned-$(KRUNKIT_VERSION).tgz


### PR DESCRIPTION
Bump bundled krunkit to 1.3.2, which comes with libkrun 1.19.4.

This version of libkrun includes a fix in virtio-fs on macOS for libkrun/libkrun#769 that potentially impacts podman users.