### PR TITLE
docs: fix network create

### DIFF
--- a/docs/source/markdown/options/opt.md
+++ b/docs/source/markdown/options/opt.md
@@ -14,7 +14,7 @@ All drivers accept the `mtu`, `metric`, `no_default_route` and options.
 
 - `mtu`: Sets the Maximum Transmission Unit (MTU) and takes an integer value.
 - `metric` Sets the Route Metric for the default route created in every container joined to this network. Accepts a positive integer value. Can only be used with the Netavark network backend.
-- `no_default_route`: If set to 1, Podman will not automatically add a default route to subnets. Routes can still be added
+- `no_default_route`: If set to `true`, Podman will not automatically add a default route to subnets. Routes can still be added
 manually by creating a custom route using `--route`.
 
 Additionally the `bridge` driver supports the following options:

--- a/docs/source/markdown/podman-network-create.1.md.in
+++ b/docs/source/markdown/podman-network-create.1.md.in
@@ -46,7 +46,13 @@ Ignore the create request if a network with the same name already exists instead
 
 #### **--route**=*route*
 
-A static route in the format `<destination in CIDR notation>,<gateway>,<route metric (optional)>`. This route will be added to every container in this network. Only available with the netavark backend. It can be specified multiple times if more than one static route is desired.
+A static route in the format `<destination in CIDR notation>,<gateway|type>,<route metric (optional)>`.
+The gateway must be a valid ip address or alternatively a type can be set instead which must be either
+of `blackhole`, `unreachable` or `prohibit` and means the subnet will not be routed anywhere.
+This route will be added to every container in this network. It can be specified multiple times if more than one static route is desired.
+
+Note, routes are added into the container namespace, if a container is given the CAP_NET_ADMIN capability it is able to alter
+the routes so this cannot be used for security relevant things in that case.
 
 @@option subnet
 
@@ -97,6 +103,11 @@ Create a network with a static subnet and a static route without a default
 route.
 ```
 $ podman network create --subnet 192.168.33.0/24 --route 10.1.0.0/24,192.168.33.10 --opt no_default_route=true newnet
+```
+
+Create a network with a route type blackhole. This means the traffic to the destination subnet will be dropped silently.
+```
+$ podman network create --route 10.1.0.0/24,blackhole --opt no_default_route=true newnet
 ```
 
 Create a Macvlan based network using the host interface eth0. Macvlan networks can only be used as root.

--- a/docs/source/markdown/podman-network-create.1.md.in
+++ b/docs/source/markdown/podman-network-create.1.md.in
@@ -96,7 +96,7 @@ $ podman network create --subnet 192.168.33.0/24 --route 10.1.0.0/24,192.168.33.
 Create a network with a static subnet and a static route without a default
 route.
 ```
-$ podman network create --subnet 192.168.33.0/24 --route 10.1.0.0/24,192.168.33.10 --opt no_default_route=1 newnet
+$ podman network create --subnet 192.168.33.0/24 --route 10.1.0.0/24,192.168.33.10 --opt no_default_route=true newnet
 ```
 
 Create a Macvlan based network using the host interface eth0. Macvlan networks can only be used as root.


### PR DESCRIPTION
docs: fix network create no_default_route doc

With netavark v2 we require true not 1.

This was correctly changed in commit https://github.com/podman-container-tools/podman/commit/bb02e490809e1a5587665ac38af3fbbca81410df but then reverted in
commit https://github.com/podman-container-tools/podman/commit/7612af4c0e47c56bead3330690df291078b57273 again as it did not properly rebase and solve the
conflicts.

docs: update network create --route description

The netavark mention is not needed as we only support it now. Then
update it for the new route type syntax which was not documented in
commit https://github.com/podman-container-tools/podman/commit/daaf8b62ba9eeff5af3c9deed450f0475e10c5c5.

Also add an example and a note that containers with CAP_NET_ADMIN can
alter routes still.


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
