### PR TITLE
Add a machine e2e test to test connection to `host.containers.internal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,17 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$env:AppData\containers" | Out-Null
           Copy-Item -Path pkg\machine\ocipull\policy.json -Destination "$env:AppData\containers"
 
+      # The test "Podman ops with port forwarding and gvproxy" starts a local HTTP server
+      # to verify that a client inside a container can send a request to the host. A connection
+      # from WSL appears like a remote connection and we need a NetFirewallRule to allow it.
+      - name: Firewall Rule
+        if: matrix.provider == 'wsl'
+        env:
+          TARGET_PORT: '62545' # Must match the value in "Podman ops with port forwarding and gvproxy".
+        shell: pwsh
+        run: |
+          New-NetFirewallRule -DisplayName "Allow connections from WSL to local HTTP Server (port $env:TARGET_PORT)" -Direction Inbound -Protocol TCP -LocalPort "$env:TARGET_PORT" -RemoteAddress LocalSubnet -Action Allow
+
       - name: Run machine e2e
         shell: pwsh
         run: .\winmake.ps1 localmachine

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -198,7 +198,7 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exec).To(Exit(0))
 
-		out, err := pgrep("gvproxy")
+		out, err := pgrep(gvproxy)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).ToNot(BeEmpty())
 
@@ -213,8 +213,8 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(stopSession).To(Exit(0))
 
 		// gxproxy should exit after machine is stopped
-		out, _ = pgrep("gvproxy")
-		Expect(out).ToNot(ContainSubstring("gvproxy"))
+		out, _ = pgrep(gvproxy)
+		Expect(out).ToNot(ContainSubstring(gvproxy))
 	})
 
 	It("podman volume on non-standard path", func() {

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -202,6 +202,23 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).ToNot(BeEmpty())
 
+		// Start a server on the host and send a request from a container
+		// using host.containers.internal and host.docker.internal
+		port := "62545"
+		msg := "message from the host"
+		url1 := "http://host.containers.internal:" + port
+		url2 := "http://host.docker.internal:" + port
+		s := startLocalHTTPServer(port, msg)
+		defer s.Close()
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", ctrName, "wget", "-q", "-O-", url1})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(msg))
+		exec, err = mb.setCmd(bm.withPodmanCommand([]string{"exec", ctrName, "wget", "-q", "-O-", url2})).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec).To(Exit(0))
+		Expect(exec.outputToString()).To(Equal(msg))
+
 		rmCon, err := mb.setCmd(bm.withPodmanCommand([]string{"rm", "-af"})).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rmCon).To(Exit(0))
@@ -346,6 +363,21 @@ func testHTTPServer(port string, shouldErr bool, expectedResponse string) {
 	body, err := io.ReadAll(resp.Body)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(string(body)).Should(Equal(expectedResponse))
+}
+
+func startLocalHTTPServer(port string, response string) *http.Server {
+	l, err := net.Listen("tcp", ":"+port)
+	Expect(err).ToNot(HaveOccurred())
+	s := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, response)
+		}),
+	}
+	go func() {
+		_ = s.Serve(l)
+		l.Close()
+	}()
+	return s
 }
 
 type TLSConfig struct {

--- a/pkg/machine/e2e/config_unix_test.go
+++ b/pkg/machine/e2e/config_unix_test.go
@@ -7,10 +7,13 @@ import (
 	"os/exec"
 )
 
-var fakeImagePath string = os.DevNull
+var (
+	fakeImagePath = os.DevNull
+	gvproxy       = "gvproxy"
+)
 
-func pgrep(_ string) (string, error) {
-	out, err := exec.Command("pgrep", "gvproxy").Output()
+func pgrep(n string) (string, error) {
+	out, err := exec.Command("pgrep", n).Output()
 	return string(out), err
 }
 

--- a/pkg/machine/e2e/config_windows_test.go
+++ b/pkg/machine/e2e/config_windows_test.go
@@ -15,7 +15,10 @@ import (
 
 const podmanBinary = "../../../bin/windows/podman.exe"
 
-var fakeImagePath string = ""
+var (
+	fakeImagePath = ""
+	gvproxy       = "gvproxy.exe"
+)
 
 func initPlatform() {
 	switch testProvider.VMType().String() {
@@ -29,6 +32,7 @@ func initPlatform() {
 		fakeImagePath = fullFileName
 		fmt.Println("Created fake disk image: " + fakeImagePath)
 	case define.WSLVirt.String():
+		gvproxy = "win-sshproxy.exe"
 	default:
 		Fail(fmt.Sprintf("unknown Windows provider: %q", testProvider.VMType().String()))
 	}
@@ -50,7 +54,7 @@ func pgrep(n string) (string, error) {
 	}
 	strOut := string(out)
 	// in pgrep, if no running process is found, it exits 1 and the output is zilch
-	if strings.Contains(strOut, "INFO: No tasks are running which match the specified search") {
+	if strings.Contains(strOut, "INFO: No tasks") {
 		return "", fmt.Errorf("no task found")
 	}
 	return strOut, nil

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -402,7 +402,7 @@ var _ = Describe("podman machine start", func() {
 		Expect(inspectSession.outputToString()).To(Equal(define.Stopped))
 
 		// Verify no orphan gvproxy
-		_, err = pgrep("gvproxy")
+		_, err = pgrep(gvproxy)
 		Expect(err).To(HaveOccurred(), "gvproxy should not be running after SIGTERM cleanup")
 
 		// Restart without interrupting and confirm that completes without error


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

Related to https://github.com/podman-container-tools/container-libs/pull/959: keeping this PR as a draft until we have a WSL image with the fix

The original issue https://github.com/podman-container-tools/podman/issues/28477

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
