### PR TITLE
golangci-lint: enable more govet checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,11 @@ linters:
     - wastedassign
     - whitespace
   settings:
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
     forbidigo:
       forbid:
         # os.Is* error checking functions predate errors.Is. Therefore, they


### PR DESCRIPTION
There are more useful checks such as nilness that are not enabled by default. However fieldalignment and shadow produce a lot of warnings that are not real issues, i.e. we shadow "err" as variable all the time, so they get disabled.

see https://golangci-lint.run/docs/linters/configuration/#govet

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
