### PR TITLE
ci: make the automation release renovate managed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,8 +19,8 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
 
   // Reuse predefined sets of configuration options to DRY
   "extends": [
-    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
-    "github>containers/automation//renovate/defaults.json5"
+    // https://github.com/podman-container-tools/automation/blob/main/renovate/defaults.json5
+    "github>podman-container-tools/automation//renovate/defaults.json5"
   ],
 
   /*************************************************

--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -28,6 +28,12 @@ on:
 
 permissions: {}
 
+env:
+  # CI automation repo release for the VM image downloads in ci.sh.
+  # ENV is managed by renovate, do not change the name without
+  # updating the renovate config in the automation repo.
+  AUTOMATION_RELEASE: 20260616t073924z
+
 jobs:
   lima:
     if: ${{ inputs.if }}

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 
 source "$SCRIPT_DIR/lib.sh"
 
-AUTOMATION_RELEASE="20260616t073924z" # TODO should be renovate managed
+AUTOMATION_RELEASE="${AUTOMATION_RELEASE:-$(get_automation_release)}"
 LIMA_VM_NAME=podman-ci
 
 REPO_DIR="$SCRIPT_DIR/../.."

--- a/hack/ci/lib.sh
+++ b/hack/ci/lib.sh
@@ -111,3 +111,9 @@ function remove_packaged_podman_files() {
         sudo rm -f "$fullpath"
     done
 }
+
+# Reads and prints the AUTOMATION_RELEASE value from the workflow file.
+# Used for local runs where ci.sh is not triggered by gh actions.
+function get_automation_release() {
+    sed -En 's/.*AUTOMATION_RELEASE:\s(.*)/\1/p' .github/workflows/lima.yml
+}


### PR DESCRIPTION
Put the variable in the workflow file like the renovate config expects,
see https://github.com/podman-container-tools/automation/pull/29

To ensure the local runs keep working we need a fall back to parse the
file manually.



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
