### PR TITLE
Fix duplicated command in inspect Args when container has single-elenent command

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -77,8 +77,6 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 	var path string
 	if len(args) > 0 {
 		path = args[0]
-	}
-	if len(args) > 1 {
 		args = args[1:]
 	}
 

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -500,7 +500,7 @@ var _ = Describe("Podman pod create", func() {
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})
 		check2.WaitWithDefaultTimeout()
 		Expect(check2).Should(ExitCleanly())
-		Expect(check2.OutputToString()).To(Equal("/pause1:[/pause1]"))
+		Expect(check2.OutputToString()).To(Equal("/pause1:[]"))
 	})
 
 	It("podman create pod with --infra-image", func() {
@@ -527,7 +527,7 @@ entrypoint ["/fromimage"]
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})
 		check2.WaitWithDefaultTimeout()
 		Expect(check2).Should(ExitCleanly())
-		Expect(check2.OutputToString()).To(Equal("/fromimage:[/fromimage]"))
+		Expect(check2.OutputToString()).To(Equal("/fromimage:[]"))
 	})
 
 	It("podman create pod with --infra-command --infra-image", func() {
@@ -554,7 +554,7 @@ entrypoint ["/fromimage"]
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})
 		check2.WaitWithDefaultTimeout()
 		Expect(check2).Should(ExitCleanly())
-		Expect(check2.OutputToString()).To(Equal("/fromcommand:[/fromcommand]"))
+		Expect(check2.OutputToString()).To(Equal("/fromcommand:[]"))
 	})
 
 	It("podman pod status test", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -1961,4 +1961,23 @@ spec:
     run_podman rmi $image
 }
 
+# bats test_tags=ci:parallel
+@test "podman inspect - Args does not duplicate Path for single command" {
+    cname=c_$(safename)
+
+    run_podman run --name $cname -d $IMAGE top -b
+    run_podman inspect $cname --format '{{.Path}}'
+    is "$output" "top" ".Path is the command"
+    run_podman inspect $cname --format '{{join .Args " "}}'
+    is "$output" "-b" ".Args holds only the arguments after the command"
+    run_podman rm -f $cname
+
+    run_podman run --name $cname -d $IMAGE top
+    run_podman inspect $cname --format '{{.Path}}'
+    is "$output" "top" ".Path is the command"
+    run_podman inspect $cname --format '{{len .Args}}'
+    is "$output" "0" ".Args should be empty when command has no arguments"
+    run_podman rm -f $cname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION

Fixes: https://github.com/podman-container-tools/podman/issues/29155

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
