### PR TITLE
Always unprovision if the WSL machine init fail

### DIFF
--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -288,9 +288,19 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 	if err != nil {
 		return err
 	}
+	rmVM := func() error {
+		if err == nil {
+			return nil
+		}
+		if _, rm, _ := mp.Remove(mc); rm != nil {
+			return rm()
+		}
+		return nil
+	}
+	callbackFuncs.Add(rmVM)
 
 	// TODO AddSSHConnectionToPodmanSocket could take an machineconfig instead
-	if err := connection.AddSSHConnectionsToPodmanSocket(mc.HostUser.UID, mc.SSH.Port, mc.SSH.IdentityPath, mc.Name, mc.SSH.RemoteUsername, opts); err != nil {
+	if err = connection.AddSSHConnectionsToPodmanSocket(mc.HostUser.UID, mc.SSH.Port, mc.SSH.IdentityPath, mc.Name, mc.SSH.RemoteUsername, opts); err != nil {
 		return err
 	}
 

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -36,7 +36,11 @@ var (
 // TODO like provisionWSL, i think this needs to be pushed to use common
 // paths and types where possible
 func unprovisionWSL(mc *vmconfigs.MachineConfig) error {
-	dist := env.WithPodmanPrefix(mc.Name)
+	return unprovisionWSLByName(mc.Name)
+}
+
+func unprovisionWSLByName(name string) error {
+	dist := env.WithPodmanPrefix(name)
 	if err := terminateDist(dist); err != nil {
 		logrus.Error(err)
 	}
@@ -49,7 +53,7 @@ func unprovisionWSL(mc *vmconfigs.MachineConfig) error {
 		return err
 	}
 	distDir := filepath.Join(vmDataDir, "wsldist")
-	distTarget := filepath.Join(distDir, mc.Name)
+	distTarget := filepath.Join(distDir, name)
 	return utils.GuardedRemoveAll(distTarget)
 }
 
@@ -88,6 +92,15 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("the WSL import of guest OS failed: %w", err)
 	}
+
+	// From now on, unregister the WSL distribution in case of error.
+	defer func() {
+		if err != nil {
+			if e := unprovisionWSLByName(name); e != nil {
+				logrus.Error(e)
+			}
+		}
+	}()
 
 	// Fixes newuidmap
 	if err = wslInvoke(dist, "rpm", "--restore", "shadow-utils"); err != nil {


### PR DESCRIPTION
Remove the just provisioned WSL distribution if one of the post install scripts fail.

Fixes #27036

Before:

<img width="943" height="466" alt="Image" src="https://github.com/user-attachments/assets/11b49ccb-fbf0-412a-9a06-67c952e2b76a" />

After:

<img width="956" height="530" alt="Image" src="https://github.com/user-attachments/assets/3420ae42-67f1-4705-880b-a84a3c5d99ae" />

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
