### PR TITLE
Fix inspect template `.HostIp` for Docker compatibility

### DIFF
--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -265,6 +265,12 @@ type InspectHostPort struct {
 	HostPort string `json:"HostPort"`
 }
 
+// HostIp allows Docker-compatible {{.HostIp}} access in Go templates.
+// See https://github.com/containers/podman/issues/29164
+func (hp InspectHostPort) HostIp() string {
+	return hp.HostIP
+}
+
 // InspectMount provides a record of a single mount in a container. It contains
 // fields for both named and normal volumes. Only user-specified volumes will be
 // included, and tmpfs volumes are not included even if the user specified them.

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -107,6 +107,19 @@ var _ = Describe("Podman container inspect", func() {
 		Expect(data[0].Config.Annotations[define.VolumesFromAnnotation]).To(Equal(volsctr))
 	})
 
+	// https://github.com/containers/podman/issues/29164
+	It("podman inspect supports docker-compatible HostIp in format template", func() {
+		ctrName := "hostip-compat"
+		session := podmanTest.Podman([]string{"create", "--name", ctrName, "-p", "127.0.0.1::8080/tcp", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		inspect := podmanTest.Podman([]string{"inspect", "--format", `{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostIp }}`, ctrName})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(ExitCleanly())
+		Expect(inspect.OutputToString()).To(Equal("127.0.0.1"))
+	})
+
 	It("podman inspect hides secrets mounted to env", func() {
 		secretName := "mysecret"
 


### PR DESCRIPTION
Docker-compatible inspect templates using `{{.HostIp}}` fail in Podman because Go templates resolve by struct field name (`HostIP`), not JSON tag (`HostIp`). Add a `HostIp()` method so both notations work.

Note: this does not address the struct-vs-map difference that prevents `range` over individual port bindings (would require an API break).

Relates: https://github.com/podman-container-tools/podman/issues/29164

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed `inspect --format` to support Docker-compatible `{{.HostIp}}` in `NetworkSettings.Ports` templates (https://github.com/podman-container-tools/podman/issues/29164).
```
