### PR TITLE
Fix Windows installer machine scope PATH update

### DIFF
--- a/contrib/win-installer/test.ps1
+++ b/contrib/win-installer/test.ps1
@@ -389,6 +389,62 @@ function Test-Podman-Machine-Conf-Content {
     Write-Host "Verification was successful!`n"
 }
 
+function Test-Path-In-Environment-Reg-Key {
+    param (
+        [ValidateSet('machine-legacy', 'machine', 'user')]
+        [string]$scope = $script:scope,
+        [switch]$expectIsMissing = $false
+    )
+    if ($scope -eq 'machine') {
+        $PodmanFolderPath = $PodmanFolderPathPerMachine
+        $EnvironmentPathRegistryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+    }
+    elseif ($scope -eq 'machine-legacy') {
+        $PodmanFolderPath = $PodmanFolderPathPerMachineLegacy
+        $EnvironmentPathRegistryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+    }
+    else {
+        $PodmanFolderPath = $PodmanFolderPathPerUser
+        $EnvironmentPathRegistryKey = "HKCU:\Environment"
+    }
+    $EnvironmentPathRegistryKeyValue = "Path"
+    Write-Host "Verifying if Podman is in PATH...(scope=$scope, expectIsMissing=$expectIsMissing)"
+    if (! (Test-Path -Path $EnvironmentPathRegistryKey) ) {
+        throw "Expected $EnvironmentPathRegistryKey but doesn't exist"
+    }
+    try {
+        $rawPath = (Get-ItemProperty -Path $EnvironmentPathRegistryKey -Name $EnvironmentPathRegistryKeyValue -ErrorAction Stop).$EnvironmentPathRegistryKeyValue
+    }
+    catch {
+        throw "Could not read '$EnvironmentPathRegistryKeyValue' from '$EnvironmentPathRegistryKey': $_"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($rawPath)) {
+        throw "The '$EnvironmentPathRegistryKeyValue' value is empty."
+    }
+
+    $pathEntries = $rawPath -split ';' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -ne '' }
+
+    function Normalize-Path {
+        param([string]$Path)
+        return $Path.TrimEnd('\').ToLowerInvariant()
+    }
+
+    $normalizedTarget = Normalize-Path $PodmanFolderPath
+
+    $match = $pathEntries | Where-Object { (Normalize-Path $_) -eq $normalizedTarget }
+
+    if ( (-not $match) -and (-not $expectIsMissing) ) {
+        throw "Not found: '$PodmanFolderPath' is NOT present in '${EnvironmentPathRegistryKey}\${EnvironmentPathRegistryKeyValue}'."
+    }
+    if ( $match -and $expectIsMissing ) {
+        throw "Found: '$PodmanFolderPath' is present in '${EnvironmentPathRegistryKey}\${EnvironmentPathRegistryKeyValue}'."
+    }
+    Write-Host "Verification was successful!`n"
+}
+
 function Uninstall-Podman-Bundle {
     param (
         # [Parameter(Mandatory)]
@@ -558,6 +614,7 @@ function Test-Installation {
             Test-Podman-Machine-Conf-Content -scope $scope
         }
     }
+    Test-Path-In-Environment-Reg-Key -scope $scope
 }
 
 function Test-Installation-No-Config {
@@ -567,6 +624,7 @@ function Test-Installation-No-Config {
     )
     Test-Podman-Objects-Exist -scope $scope
     Test-Podman-Machine-Conf-Exist-Not -scope $scope
+    Test-Path-In-Environment-Reg-Key -scope $scope
 }
 
 function Test-Uninstallation {
@@ -576,6 +634,7 @@ function Test-Uninstallation {
     )
     Test-Podman-Objects-Exist-Not -scope $scope
     Test-Podman-Machine-Conf-Exist-Not -scope $scope
+    Test-Path-In-Environment-Reg-Key -scope $scope -expectIsMissing
 }
 
 # SCENARIOS

--- a/contrib/win-installer/wix/podman-main.wxs
+++ b/contrib/win-installer/wix/podman-main.wxs
@@ -107,6 +107,7 @@ and other data will be preserved." />
 		<Feature Id="Complete" Level="1">
 			<ComponentRef Id="INSTALLDIR_Component" />
 			<ComponentRef Id="EnvEntriesComponent" />
+			<ComponentRef Id="EnvEntriesComponentPerMachine" />
 			<ComponentRef Id="MainExecutable" />
 			<ComponentRef Id="WinSshProxyExecutable" />
 			<?if $(var.UseGVProxy) != Skip?>
@@ -171,9 +172,15 @@ and other data will be preserved." />
 			</Component>
 		</Directory>
 		<Directory Id="EnvEntries">
-			<Component Id="EnvEntriesComponent" Guid="b662ec43-0e0e-4018-8bf3-061904bb8f5b" Bitness="always64">
+			<Component Id="EnvEntriesComponent" Guid="b662ec43-0e0e-4018-8bf3-061904bb8f5b" Bitness="always64"
+				Condition="MSIINSTALLPERUSER=1" >
 				<CreateFolder />
-				<Environment Id="UpdatePath" Name="PATH" Action="set" Permanent="no" Part="last" Value="[INSTALLDIR]" />
+				<Environment Id="UpdatePath" Name="PATH" Action="set" Permanent="no" Part="last" Value="[INSTALLDIR]" System="false"/>
+			</Component>
+			<Component Id="EnvEntriesComponentPerMachine" Guid="b0fc674f-1b96-45d4-82a6-cf7d860afb72" Bitness="always64"
+				Condition="ALLUSERS=1 AND NOT MSIINSTALLPERUSER=1" >
+				<CreateFolder />
+				<Environment Id="UpdatePathPerMachine" Name="PATH" Action="set" Permanent="no" Part="last" Value="[INSTALLDIR]" System="true"/>
 			</Component>
 		</Directory>
   </Package>


### PR DESCRIPTION
Update Podman Windows installer to update the PATH for all users if executed in machine scope mode.

Added a new test that checks if Podman installation folder is in PATH.

Fixes #29160

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
