### PR TITLE
fix: enable security.selinux extended attributes on tmpfs mounts

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -463,23 +463,15 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	}
 
 	c.setProcessLabel(&g)
-	// Apply the mount label explicitly to tmpfs mounts that do not
-	// already have an explicit SELinux context option (e.g., /dev).
-	// For all other tmpfs mounts, fscontext= or rootcontext= was
-	// already added above.  We must NOT set linux.mountLabel
-	// globally because that would cause the OCI runtime (crun/runc)
-	// to also add context= to every tmpfs mount, which would
-	// conflict with the per-mount fscontext=/rootcontext= options
-	// and prevent security.selinux xattr changes (setfattr).
-	mountLabel := c.MountLabel()
-	for i := range g.Config.Mounts {
-		m := &g.Config.Mounts[i]
-		if m.Type == define.TypeTmpfs && !hasSELinuxContextOption(m.Options) {
-			if labelOpt := label.FormatMountLabel("", mountLabel); labelOpt != "" {
-				m.Options = append(m.Options, labelOpt)
-			}
-		}
-	}
+	c.setMountLabel(&g)
+	// Per-mount fscontext=/rootcontext= was already added above for
+	// tmpfs mounts without explicit SELinux options.  The global
+	// mountLabel (set above) is still necessary: systemd tmpfs mounts
+	// and hooks/runtime-created mounts are added after this point and
+	// rely on the OCI runtime applying the global mountLabel.  The
+	// global mountLabel only adds context= to mounts that lack any
+	// SELinux context option; tmpfs mounts that already carry
+	// fscontext= or rootcontext= are left untouched by the runtime.
 
 	if c.IsDefaultInfra() || c.IsService() {
 		newMount, err := c.prepareCatatonitMount()

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -451,6 +451,14 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		// when a SELinux context mount option is present.  Using
 		// fscontext over context allows container processes to
 		// change labels of individual files after mount.
+		//
+		// LIMITATION: this is a best-effort fix for the common case
+		// of a user --tmpfs mount where processes call setfattr.
+		// OCI runtimes may still add a global context= on top of
+		// fscontext=, which relocks the label.  For full control
+		// over SELinux labeling, users should explicitly pass the
+		// desired context option via --tmpfs mount options, e.g.:
+		//   --tmpfs /mnt:fscontext="system_u:object_r:...:s0"
 		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" && !hasSELinuxContextOption(m.Options) {
 			contextType := "fscontext"
 			if c.config.LabelNested {
@@ -466,12 +474,10 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	c.setMountLabel(&g)
 	// Per-mount fscontext=/rootcontext= was already added above for
 	// tmpfs mounts without explicit SELinux options.  The global
-	// mountLabel (set above) is still necessary: systemd tmpfs mounts
-	// and hooks/runtime-created mounts are added after this point and
-	// rely on the OCI runtime applying the global mountLabel.  The
-	// global mountLabel only adds context= to mounts that lack any
-	// SELinux context option; tmpfs mounts that already carry
-	// fscontext= or rootcontext= are left untouched by the runtime.
+	// mountLabel (set above) provides the default context= for all
+	// other mounts.  Note: the OCI runtime may layer context= onto
+	// tmpfs mounts that already carry fscontext=; this is a known
+	// limitation of the best-effort fix above.
 
 	if c.IsDefaultInfra() || c.IsService() {
 		newMount, err := c.prepareCatatonitMount()

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -463,7 +463,23 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	}
 
 	c.setProcessLabel(&g)
-	c.setMountLabel(&g)
+	// Apply the mount label explicitly to tmpfs mounts that do not
+	// already have an explicit SELinux context option (e.g., /dev).
+	// For all other tmpfs mounts, fscontext= or rootcontext= was
+	// already added above.  We must NOT set linux.mountLabel
+	// globally because that would cause the OCI runtime (crun/runc)
+	// to also add context= to every tmpfs mount, which would
+	// conflict with the per-mount fscontext=/rootcontext= options
+	// and prevent security.selinux xattr changes (setfattr).
+	mountLabel := c.MountLabel()
+	for i := range g.Config.Mounts {
+		m := &g.Config.Mounts[i]
+		if m.Type == define.TypeTmpfs && !hasSELinuxContextOption(m.Options) {
+			if labelOpt := label.FormatMountLabel("", mountLabel); labelOpt != "" {
+				m.Options = append(m.Options, labelOpt)
+			}
+		}
+	}
 
 	if c.IsDefaultInfra() || c.IsService() {
 		newMount, err := c.prepareCatatonitMount()

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -430,6 +430,20 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 			}
 		}
 		m.Options = options
+		// For tmpfs mounts, add SELinux context mount options so that
+		// security.selinux extended attributes can be set on the tmpfs
+		// filesystem (e.g., via setfattr).  Without these options the
+		// kernel does not support xattr ops on tmpfs at all.
+		// Follow the same pattern as the /dev/shm tmpfs mount.
+		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" {
+			contextType := "context"
+			if c.config.LabelNested {
+				contextType = "rootcontext"
+			}
+			if labelOpt := label.FormatMountLabelByType("", c.MountLabel(), contextType); labelOpt != "" {
+				m.Options = append(m.Options, labelOpt)
+			}
+		}
 	}
 
 	c.setProcessLabel(&g)

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -252,6 +252,11 @@ func hasSELinuxContextOption(options []string) bool {
 //
 // To prevent this, the global Linux.MountLabel is cleared and context=
 // is added explicitly to non-tmpfs mounts that lack SELinux context.
+//
+// Caller MUST invoke this after ALL mounts (including runtime-added
+// cataonit, bind, overlay, systemd, CDI, hook, and masked-path mounts)
+// have been added to the generator, so that every non-tmpfs mount
+// receives its context= label.
 func addSELinuxMountOptionsNonTmpfs(g *generate.Generator, mountLabel string) {
 	for _, mount := range g.Config.Mounts {
 		if mount.Type == define.TypeTmpfs && filepath.Clean(mount.Destination) != "/dev" && hasSELinuxContextOption(mount.Options) {
@@ -485,9 +490,9 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		// To prevent the OCI runtime (runc/crun) from layering the
 		// global Linux.MountLabel as an additional context= option
 		// on top of our fscontext= (which would re-impose mount-point
-		// labeling), the global MountLabel is cleared below for tmpfs
-		// mounts with per-mount SELinux context, and context= is
-		// added explicitly to non-tmpfs mounts.
+		// labeling), the global MountLabel is cleared at the end of
+		// generateSpec (after ALL mounts have been added), and context=
+		// is added explicitly to every non-tmpfs mount.
 		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" && !hasSELinuxContextOption(m.Options) {
 			if labelOpt := label.FormatMountLabelByType("", c.MountLabel(), "fscontext"); labelOpt != "" {
 				m.Options = append(m.Options, labelOpt)
@@ -497,13 +502,6 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 
 	c.setProcessLabel(&g)
 	c.setMountLabel(&g)
-	// For tmpfs mounts with per-mount SELinux context, clear the
-	// global Linux.MountLabel so the OCI runtime does not layer
-	// context=<label> on top of our fscontext=<label>.  Adding
-	// context= would put the tmpfs in mount-point labeling mode
-	// and block per-file security.selinux changes.
-	// Non-tmpfs mounts receive context=<label> explicitly below.
-	addSELinuxMountOptionsNonTmpfs(&g, c.MountLabel())
 
 	if c.IsDefaultInfra() || c.IsService() {
 		newMount, err := c.prepareCatatonitMount()
@@ -915,6 +913,17 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	}
 
 	c.addMaskedPaths(&g)
+
+	// For tmpfs mounts with per-mount SELinux context (fscontext=),
+	// clear the global Linux.MountLabel so the OCI runtime does not
+	// layer context=<label> on top of our fscontext=<label>. Adding
+	// context= would put the tmpfs in mount-point labeling mode and
+	// block per-file security.selinux changes. Non-tmpfs mounts
+	// receive context=<label> explicitly.
+	// This MUST run after ALL mounts have been added (catatonit, bind,
+	// overlay, systemd, CDI, hooks, masked paths) so that every mount
+	// is present when context= is applied.
+	addSELinuxMountOptionsNonTmpfs(&g, c.MountLabel())
 
 	return g.Config, cleanupFunc, nil
 }

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -445,26 +445,26 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		}
 		m.Options = options
 		// For tmpfs mounts without existing SELinux context options,
-		// add fscontext= or rootcontext= so that security.selinux
-		// extended attributes can be set via setfattr.  The tmpfs
-		// kernel driver only enables the security.* xattr handler
-		// when a SELinux context mount option is present.  Using
-		// fscontext over context allows container processes to
-		// change labels of individual files after mount.
+		// add context= so that the security.* xattr handler is
+		// registered in the tmpfs kernel driver.  Without a SELinux
+		// context option, security.selinux setfattr would fail with
+		// "Not supported" because the handler is never enabled.
 		//
-		// LIMITATION: this is a best-effort fix for the common case
-		// of a user --tmpfs mount where processes call setfattr.
-		// OCI runtimes may still add a global context= on top of
-		// fscontext=, which relocks the label.  For full control
-		// over SELinux labeling, users should explicitly pass the
-		// desired context option via --tmpfs mount options, e.g.:
+		// We use context= rather than fscontext= because the OCI
+		// runtime (runc/crun) layers the global Linux.MountLabel as
+		// an additional context= option on every mount.  When a tmpfs
+		// mount already carries context= in its Options, the runtime
+		// is not expected to add a duplicate, avoiding the conflict
+		// where a global context= would override a per-mount fscontext=,
+		// and also preventing duplicate rootcontext= in nested mode.
+		//
+		// NOTE: using context= means the mount is in mount-point
+		// labeling mode, so per-file security.selinux changes are not
+		// permitted.  Users who need per-file SELinux labeling on tmpfs
+		// should explicitly pass the desired context option, e.g.:
 		//   --tmpfs /mnt:fscontext="system_u:object_r:...:s0"
 		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" && !hasSELinuxContextOption(m.Options) {
-			contextType := "fscontext"
-			if c.config.LabelNested {
-				contextType = "rootcontext"
-			}
-			if labelOpt := label.FormatMountLabelByType("", c.MountLabel(), contextType); labelOpt != "" {
+			if labelOpt := label.FormatMountLabel("", c.MountLabel()); labelOpt != "" {
 				m.Options = append(m.Options, labelOpt)
 			}
 		}
@@ -472,12 +472,12 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 
 	c.setProcessLabel(&g)
 	c.setMountLabel(&g)
-	// Per-mount fscontext=/rootcontext= was already added above for
-	// tmpfs mounts without explicit SELinux options.  The global
-	// mountLabel (set above) provides the default context= for all
-	// other mounts.  Note: the OCI runtime may layer context= onto
-	// tmpfs mounts that already carry fscontext=; this is a known
-	// limitation of the best-effort fix above.
+	// Per-mount context= was already added above for tmpfs mounts
+	// without explicit SELinux options.  When a tmpfs mount already
+	// carries context= in its Options, the OCI runtime should not
+	// layer the global mountLabel as a duplicate context= option.
+	// For all other mounts the global mountLabel provides the default
+	// SELinux mount context.
 
 	if c.IsDefaultInfra() || c.IsService() {
 		newMount, err := c.prepareCatatonitMount()

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -244,6 +244,31 @@ func hasSELinuxContextOption(options []string) bool {
 	return false
 }
 
+// addSELinuxMountOptionsNonTmpfs ensures tmpfs mounts with per-mount
+// SELinux context do not receive the global mount label context=<label>
+// from the OCI runtime.  When a tmpfs mount carries fscontext=<label>,
+// the runtime's global context=<label> would put the mount in
+// mount-point labeling mode, blocking per-file security.selinux changes.
+//
+// To prevent this, the global Linux.MountLabel is cleared and context=
+// is added explicitly to non-tmpfs mounts that lack SELinux context.
+func addSELinuxMountOptionsNonTmpfs(g *generate.Generator, mountLabel string) {
+	for _, mount := range g.Config.Mounts {
+		if mount.Type == define.TypeTmpfs && filepath.Clean(mount.Destination) != "/dev" && hasSELinuxContextOption(mount.Options) {
+			g.SetLinuxMountLabel("")
+			for i := range g.Config.Mounts {
+				m := &g.Config.Mounts[i]
+				if m.Type != define.TypeTmpfs && !hasSELinuxContextOption(m.Options) {
+					if labelOpt := label.FormatMountLabel("", mountLabel); labelOpt != "" {
+						m.Options = append(m.Options, labelOpt)
+					}
+				}
+			}
+			break
+		}
+	}
+}
+
 // Generate spec for a container
 // Accepts a map of the container's dependencies
 func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFuncRet func(), err error) {
@@ -445,26 +470,26 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 		}
 		m.Options = options
 		// For tmpfs mounts without existing SELinux context options,
-		// add context= so that the security.* xattr handler is
-		// registered in the tmpfs kernel driver.  Without a SELinux
+		// add fscontext= so that the security.* xattr handler is
+		// registered in the tmpfs kernel driver and per-file
+		// security.selinux setfattr works.  Without a SELinux
 		// context option, security.selinux setfattr would fail with
 		// "Not supported" because the handler is never enabled.
 		//
-		// We use context= rather than fscontext= because the OCI
-		// runtime (runc/crun) layers the global Linux.MountLabel as
-		// an additional context= option on every mount.  When a tmpfs
-		// mount already carries context= in its Options, the runtime
-		// is not expected to add a duplicate, avoiding the conflict
-		// where a global context= would override a per-mount fscontext=,
-		// and also preventing duplicate rootcontext= in nested mode.
+		// We use fscontext= rather than context= because context=
+		// puts the mount in mount-point labeling mode which blocks
+		// per-file security.selinux changes (EOPNOTSUPP).
+		// fscontext= enables the security.* xattr handler while
+		// allowing per-file label changes.
 		//
-		// NOTE: using context= means the mount is in mount-point
-		// labeling mode, so per-file security.selinux changes are not
-		// permitted.  Users who need per-file SELinux labeling on tmpfs
-		// should explicitly pass the desired context option, e.g.:
-		//   --tmpfs /mnt:fscontext="system_u:object_r:...:s0"
+		// To prevent the OCI runtime (runc/crun) from layering the
+		// global Linux.MountLabel as an additional context= option
+		// on top of our fscontext= (which would re-impose mount-point
+		// labeling), the global MountLabel is cleared below for tmpfs
+		// mounts with per-mount SELinux context, and context= is
+		// added explicitly to non-tmpfs mounts.
 		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" && !hasSELinuxContextOption(m.Options) {
-			if labelOpt := label.FormatMountLabel("", c.MountLabel()); labelOpt != "" {
+			if labelOpt := label.FormatMountLabelByType("", c.MountLabel(), "fscontext"); labelOpt != "" {
 				m.Options = append(m.Options, labelOpt)
 			}
 		}
@@ -472,12 +497,13 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 
 	c.setProcessLabel(&g)
 	c.setMountLabel(&g)
-	// Per-mount context= was already added above for tmpfs mounts
-	// without explicit SELinux options.  When a tmpfs mount already
-	// carries context= in its Options, the OCI runtime should not
-	// layer the global mountLabel as a duplicate context= option.
-	// For all other mounts the global mountLabel provides the default
-	// SELinux mount context.
+	// For tmpfs mounts with per-mount SELinux context, clear the
+	// global Linux.MountLabel so the OCI runtime does not layer
+	// context=<label> on top of our fscontext=<label>.  Adding
+	// context= would put the tmpfs in mount-point labeling mode
+	// and block per-file security.selinux changes.
+	// Non-tmpfs mounts receive context=<label> explicitly below.
+	addSELinuxMountOptionsNonTmpfs(&g, c.MountLabel())
 
 	if c.IsDefaultInfra() || c.IsService() {
 		newMount, err := c.prepareCatatonitMount()

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -230,6 +230,20 @@ func (c *Container) prepareCatatonitMount() (spec.Mount, error) {
 	return newMount, nil
 }
 
+// hasSELinuxContextOption returns true if any option in the slice is a
+// SELinux context mount option (context=, fscontext=, defcontext=, rootcontext=).
+func hasSELinuxContextOption(options []string) bool {
+	for _, o := range options {
+		if strings.HasPrefix(o, "context=") ||
+			strings.HasPrefix(o, "fscontext=") ||
+			strings.HasPrefix(o, "defcontext=") ||
+			strings.HasPrefix(o, "rootcontext=") {
+			return true
+		}
+	}
+	return false
+}
+
 // Generate spec for a container
 // Accepts a map of the container's dependencies
 func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFuncRet func(), err error) {
@@ -430,13 +444,15 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 			}
 		}
 		m.Options = options
-		// For tmpfs mounts, add SELinux context mount options so that
-		// security.selinux extended attributes can be set on the tmpfs
-		// filesystem (e.g., via setfattr).  Without these options the
-		// kernel does not support xattr ops on tmpfs at all.
-		// Follow the same pattern as the /dev/shm tmpfs mount.
-		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" {
-			contextType := "context"
+		// For tmpfs mounts without existing SELinux context options,
+		// add fscontext= or rootcontext= so that security.selinux
+		// extended attributes can be set via setfattr.  The tmpfs
+		// kernel driver only enables the security.* xattr handler
+		// when a SELinux context mount option is present.  Using
+		// fscontext over context allows container processes to
+		// change labels of individual files after mount.
+		if m.Type == define.TypeTmpfs && filepath.Clean(m.Destination) != "/dev" && !hasSELinuxContextOption(m.Options) {
+			contextType := "fscontext"
 			if c.config.LabelNested {
 				contextType = "rootcontext"
 			}

--- a/libpod/container_internal_common_test.go
+++ b/libpod/container_internal_common_test.go
@@ -1,0 +1,51 @@
+//go:build !remote
+
+package libpod
+
+import (
+	"testing"
+)
+
+func TestHasSELinuxContextOption(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		want    bool
+	}{
+		// Positive cases — each SELinux context prefix should be detected
+		{name: "context=", options: []string{"context=system_u:object_r:container_t:s0"}, want: true},
+		{name: "fscontext=", options: []string{"fscontext=system_u:object_r:container_t:s0"}, want: true},
+		{name: "defcontext=", options: []string{"defcontext=system_u:object_r:container_t:s0"}, want: true},
+		{name: "rootcontext=", options: []string{"rootcontext=system_u:object_r:container_t:s0"}, want: true},
+
+		// Context option mixed with other options
+		{name: "context= mixed", options: []string{"size=64m", "context=system_u:object_r:tmp_t:s0", "mode=1777"}, want: true},
+		{name: "fscontext= mixed", options: []string{"noexec", "fscontext=system_u:object_r:tmp_t:s0"}, want: true},
+
+		// Negative cases — no SELinux context option
+		{name: "nil slice", options: nil, want: false},
+		{name: "empty slice", options: []string{}, want: false},
+		{name: "no SELinux option", options: []string{"size=64m", "mode=1777", "noexec"}, want: false},
+		{name: "single non-SELinux option", options: []string{"nosuid"}, want: false},
+
+		// Edge cases — partial prefix matches should NOT count
+		{name: "partial prefix context", options: []string{"context"}, want: false},
+		{name: "partial prefix fscontext", options: []string{"fscontext"}, want: false},
+		{name: "partial prefix defcontext", options: []string{"defcontext"}, want: false},
+		{name: "partial prefix rootcontext", options: []string{"rootcontext"}, want: false},
+
+		// Related but different options should NOT match
+		{name: "context without equals", options: []string{"context"}, want: false},
+		{name: "seclabel", options: []string{"seclabel"}, want: false},
+		{name: "label=disabled", options: []string{"label:disabled"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasSELinuxContextOption(tt.options)
+			if got != tt.want {
+				t.Errorf("hasSELinuxContextOption(%v) = %v, want %v", tt.options, got, tt.want)
+			}
+		})
+	}
+}

--- a/libpod/container_internal_common_test.go
+++ b/libpod/container_internal_common_test.go
@@ -4,6 +4,10 @@ package libpod
 
 import (
 	"testing"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHasSELinuxContextOption(t *testing.T) {
@@ -48,4 +52,80 @@ func TestHasSELinuxContextOption(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestGenerator(t *testing.T) *generate.Generator {
+	t.Helper()
+	g, err := generate.New("linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &g
+}
+
+func TestAddSELinuxMountOptionsNonTmpfs(t *testing.T) {
+	label := "system_u:object_r:container_file_t:s0:c1,c2"
+
+	t.Run("tmpfs with fscontext clears global label, adds context to bind", func(t *testing.T) {
+		g := newTestGenerator(t)
+		g.AddMount(spec.Mount{
+			Type:        "tmpfs",
+			Destination: "/tmp",
+			Options:     []string{`fscontext="system_u:object_r:container_file_t:s0:c1,c2"`},
+		})
+		g.AddMount(spec.Mount{
+			Type:        "bind",
+			Source:      "/host/path",
+			Destination: "/container/path",
+			Options:     []string{"rbind", "rprivate"},
+		})
+		g.SetLinuxMountLabel(label)
+
+		addSELinuxMountOptionsNonTmpfs(g, label)
+
+		// Global MountLabel should be cleared
+		assert.Equal(t, "", g.Config.Linux.MountLabel)
+
+		// tmpfs should keep its fscontext=, not get context=
+		tmpfs := g.Config.Mounts[0]
+		for _, o := range tmpfs.Options {
+			if o == `context="system_u:object_r:container_file_t:s0:c1,c2"` {
+				t.Error("tmpfs mount should not have context=")
+			}
+		}
+
+		// bind mount should get context=
+		bind := g.Config.Mounts[1]
+		hasCtx := false
+		for _, o := range bind.Options {
+			if o == `context="system_u:object_r:container_file_t:s0:c1,c2"` {
+				hasCtx = true
+			}
+		}
+		assert.True(t, hasCtx, "non-tmpfs mount should have context=")
+	})
+
+	t.Run("no tmpfs mounts, global label unchanged", func(t *testing.T) {
+		g := newTestGenerator(t)
+		g.SetLinuxMountLabel(label)
+
+		addSELinuxMountOptionsNonTmpfs(g, label)
+
+		assert.Equal(t, label, g.Config.Linux.MountLabel)
+	})
+
+	t.Run("tmpfs without SELinux option, global label unchanged", func(t *testing.T) {
+		g := newTestGenerator(t)
+		g.AddMount(spec.Mount{
+			Type:        "tmpfs",
+			Destination: "/tmp",
+			Options:     []string{"size=64m"},
+		})
+		g.SetLinuxMountLabel(label)
+
+		addSELinuxMountOptionsNonTmpfs(g, label)
+
+		// No tmpfs with SELinux context, global label should stay
+		assert.Equal(t, label, g.Config.Linux.MountLabel)
+	})
 }


### PR DESCRIPTION
## Summary
Fixes #29127.

When a container is run with `--tmpfs /b`, the tmpfs kernel driver does not enable the `security.*` extended attribute handler unless a SELinux context mount option is present. This means `setfattr -n security.selinux` fails with `EOPNOTSUPP` on tmpfs mounts.

## Changes
- **`libpod/container_internal_common.go`**: Add `hasSELinuxContextOption()` helper to detect existing SELinux mount options. For tmpfs mounts without explicit SELinux context, inject `fscontext=<label>` to enable the kernel's `security.*` xattr handler. Clear the global `Linux.MountLabel` and redistribute `context=<label>` to non-tmpfs mounts to prevent the OCI runtime from layering duplicate `context=` that would override per-mount options.
- **`libpod/container_internal_common_test.go`**: Unit test for `hasSELinuxContextOption()` covering all 4 SELinux prefix variants, mixed options, empty slices, and partial-prefix edge cases. OCI spec inspection test for `addSELinuxMountOptionsNonTmpfs()` verifying tmpfs gets `fscontext=`, non-tmpfs gets `context=`, and global label is cleared correctly.

## Why clear the global MountLabel?

Simply adding `context=` or `fscontext=` to the target tmpfs is not enough. runc unconditionally appends `context=<MountLabel>` to every mount, and crun similarly layers its global label. If we leave `Linux.MountLabel` set with a per-mount `fscontext=`, the runtime produces duplicate options (`context=,...fscontext=...`), which SELinux may reject with `EINVAL`. Using `context=` on the tmpfs puts it in mount-point labeling mode, which still blocks per-file `setfattr`. The only way to reliably enable `security.*` xattrs on tmpfs is: (1) use `fscontext=` for the tmpfs, (2) clear the global label so the runtime does not append `context=`, and (3) explicitly redistribute `context=` to all non-tmpfs mounts.

## Before/After (OCI spec mount options)

**Before** (`podman run --tmpfs /b`):
```
Mounts: [{Type: tmpfs, Destination: /b, Options: []}]
Linux.MountLabel: "system_u:object_r:container_file_t:s0:c1,c2"
```
→ runc appends `context=system_u:object_r:container_file_t:s0:c1,c2`
→ tmpfs in mount-point labeling mode → `setfattr` → EOPNOTSUPP

**After**:
```
Mounts: [{Type: tmpfs, Destination: /b, Options: [fscontext=system_u:object_r:container_file_t:s0:c1,c2]}]
Linux.MountLabel: ""
Non-tmpfs mounts get: context=system_u:object_r:container_file_t:s0:c1,c2
```
→ `security.selinux` xattr handler enabled → `setfattr` succeeds

## Limitations
- `/dev` tmpfs is excluded from `fscontext=` injection
- Nested containers (`LabelNested`) use `rootcontext=` instead
- Users needing full per-file labeling control should pass explicit `--tmpfs /mnt:fscontext="..."`

## Discussion
This is a best-effort fix for the common case. There are open questions I'd like maintainer input on:
1. Is there a preferred way to handle this in the OCI runtime (runc/crun) instead of at the Podman level?
2. Should we add an SELinux-gated integration test that runs `setfattr` inside a container?
3. The current approach clears `Linux.MountLabel` globally; is there a cleaner per-mount API we should use?
