### PR TITLE
journald: support --log-opt labels (#28187)

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -674,6 +674,12 @@ func (c *Container) LogLabels() map[string]string {
 	return c.config.LogLabels
 }
 
+// LogPromotedLabels returns the container label keys that should be
+// promoted as structured journald fields.
+func (c *Container) LogPromotedLabels() []string {
+    return c.config.LogPromotedLabels
+}
+
 // RestartPolicy returns the container's restart policy.
 func (c *Container) RestartPolicy() string {
 	return c.config.RestartPolicy

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -377,6 +377,9 @@ type ContainerMiscConfig struct {
 	LogTag string `json:"logTag"`
 	// LogLabels is a set of key-value pairs used to label log messages
 	LogLabels map[string]string `json:"logLabels,omitempty"`
+	// LogPromotedLabels contains container label keys that should be
+	// promoted as structured journald fields.
+	LogPromotedLabels []string `json:"logPromotedLabels,omitempty"`
 	// LogSize is the maximum size of the container's log file
 	LogSize int64 `json:"logSize"`
 	// LogDriver driver for logs

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -8,20 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"slices"
-	"strconv"
-	"strings"
-	"sync"
-	"syscall"
-	"text/template"
-	"time"
-
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
@@ -39,6 +25,20 @@ import (
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/regexp"
 	"golang.org/x/sys/unix"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"text/template"
+	"time"
+	"unicode"
 )
 
 const (
@@ -915,8 +915,12 @@ func (r *ConmonOCIRuntime) getLogData(ctr *Container) (string, map[string]string
 	logTag := ctr.LogTag()
 	logLabels := ctr.LogLabels()
 
+	logPromotedLabels := ctr.LogPromotedLabels()
+
 	// inspectLocked is expensive, skip it if possible
-	if logTag == "" && len(logLabels) == 0 {
+	if logTag == "" &&
+		len(logLabels) == 0 &&
+		len(logPromotedLabels) == 0 {
 		return "", nil, nil
 	}
 
@@ -954,7 +958,14 @@ func (r *ConmonOCIRuntime) getLogData(ctr *Container) (string, map[string]string
 		}
 		parsedLogLabels[labelKey] = b.String()
 	}
-
+	for _, key := range logPromotedLabels {
+		if value, ok := data.Config.Labels[key]; ok {
+			journalKey := sanitizeJournaldFieldName(key)
+			if journalKey != "" {
+				parsedLogLabels[journalKey] = value
+			}
+		}
+	}
 	return parsedLogTag, parsedLogLabels, nil
 }
 
@@ -1293,6 +1304,27 @@ var journaldFieldNameRegexp = regexp.Delayed(`^[A-Z0-9_]+$`)
 
 func validJournaldFieldName(s string) bool {
 	return journaldFieldNameRegexp.MatchString(s)
+}
+
+// sanitizeJournaldFieldName converts a container label key into a valid
+// journald field name, matching Docker's behavior.
+func sanitizeJournaldFieldName(s string) string {
+	n := ""
+	for _, v := range s {
+		if 'a' <= v && v <= 'z' {
+			v = unicode.ToUpper(v)
+		} else if ('Z' < v || v < 'A') && ('9' < v || v < '0') {
+			v = '_'
+		}
+
+		// journald fields cannot begin with '_'
+		if n == "" && v == '_' {
+			continue
+		}
+
+		n += string(v)
+	}
+	return n
 }
 
 // sharedConmonArgs takes common arguments for exec and create/restore and formats them for the conmon CLI

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1065,6 +1065,17 @@ func WithLogLabels(logLabels map[string]string) CtrCreateOption {
 	}
 }
 
+func WithLogPromotedLabels(logPromotedLabels []string) CtrCreateOption {
+    return func(ctr *Container) error {
+        if ctr.valid {
+            return define.ErrCtrFinalized
+        }
+
+        ctr.config.LogPromotedLabels = logPromotedLabels
+        return nil
+    }
+}
+
 // WithCgroupsMode disables the creation of Cgroups for the conmon process.
 func WithCgroupsMode(mode string) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -568,6 +568,9 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		if len(s.LogConfiguration.Labels) > 0 {
 			options = append(options, libpod.WithLogLabels(s.LogConfiguration.Labels))
 		}
+		if len(s.LogConfiguration.LogPromotedLabels) > 0 {
+ 			options = append(options, libpod.WithLogPromotedLabels(s.LogConfiguration.LogPromotedLabels))
+		}
 		if len(s.LogConfiguration.Driver) > 0 {
 			options = append(options, libpod.WithLogDriver(s.LogConfiguration.Driver))
 		}

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -33,6 +33,9 @@ type LogConfig struct {
 	// A set of options to accompany the log driver.
 	// Optional.
 	Options map[string]string `json:"options,omitempty"`
+	// LogPromotedLabels contains container label keys that should be
+	// promoted to structured journald fields.
+	LogPromotedLabels []string `json:"logPromotedLabels,omitempty"`
 }
 
 // ContainerBasicConfig contains the basic parts of a container.

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -869,6 +869,11 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 				return fmt.Errorf("invalid log label %q", o)
 			}
 			logLabels[labelKey] = labelVal
+		case "labels":
+			if val == "" {
+				return fmt.Errorf("invalid log labels %q", o)
+			}
+			s.LogConfiguration.LogPromotedLabels = strings.Split(val, ",")
 		default:
 			logOpts[key] = val
 		}

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -619,6 +619,50 @@ var _ = Describe("Podman logs", func() {
 		}).Should(Succeed())
 	})
 
+	It("using promoted journald labels", func() {
+  	      SkipIfJournaldUnavailable()
+              SkipIfConmonVersionLessThan("2.2.0")
+
+              containerName := "inside-journal-promoted"
+
+              logc := podmanTest.Podman([]string{
+                "run",
+                "--log-driver", "journald",
+                "--label", "team=payments",
+                "--label", "env=prod",
+                "--log-opt", "labels=team,env",
+                "-d",
+                "--name", containerName,
+                ALPINE,
+                "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman",
+              })
+
+              logc.WaitWithDefaultTimeout()
+              Expect(logc).To(ExitCleanly())
+              cid := logc.OutputToString()
+
+              wait := podmanTest.Podman([]string{"wait", cid})
+              wait.WaitWithDefaultTimeout()
+              Expect(wait).To(ExitCleanly())
+
+              Eventually(func(g Gomega) {
+                cmd := exec.Command(
+                        "journalctl",
+                        "--no-pager",
+                        "-o", "json",
+                        "--output-fields=TEAM,ENV",
+                        fmt.Sprintf("CONTAINER_ID_FULL=%s", cid),
+                )
+
+                out, err := cmd.CombinedOutput()
+                g.Expect(err).ToNot(HaveOccurred())
+
+                output := string(out)
+                g.Expect(output).To(ContainSubstring("payments"))
+                g.Expect(output).To(ContainSubstring("prod"))
+        	}).Should(Succeed())
+	})
+
 	It("podman logs with log-driver=none errors", func() {
 		ctrName := "logsctr"
 		logc := podmanTest.Podman([]string{"run", "--name", ctrName, "-d", "--log-driver", "none", ALPINE, "top"})


### PR DESCRIPTION
## Summary

Implement support for Docker-compatible `--log-opt labels=` with the `journald` log driver.

This allows users to promote selected container labels into structured journald fields, matching Docker's behavior.

Example:

```console
podman run \
  --log-driver=journald \
  --label team=payments \
  --label env=prod \
  --log-opt labels=team,env \
  alpine echo hello
```

The selected container labels are promoted to structured journald fields (after sanitizing field names for journald compatibility).

## Changes

* Add parsing support for `--log-opt labels=`
* Store promoted label keys in the container configuration
* Promote selected container labels in `getLogData()`
* Sanitize journald field names before passing them to conmon
* Add an end-to-end test covering the new functionality

## Testing

Successfully completed:

* `make podman`
* `go test ./pkg/specgen/...`
* `go test ./libpod/...`

Local verification confirmed that Podman generates the expected conmon arguments:

```text
--log-label TEAM=payments
--log-label ENV=prod
```

I was not able to complete end-to-end runtime verification locally because the installed `conmon` version does not support the `--log-label` option, and the local integration test environment encountered unrelated `netavark.lock` permission issues before executing the test suite.

Fixes #28187
