### PR TITLE
issue_pr_lock.yml: use client id

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -57,8 +57,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          # N/B: These are both defined at the containers-org level
-          app-id: ${{ vars.STALE_LOCKING_APP_ID }}
+          # N/B: These are both defined at the podman-container-tools org level
+          client-id: ${{ vars.STALE_LOCKING_CLIENT_ID }}
           private-key: ${{ secrets.STALE_LOCKING_APP_PRIVATE_KEY }}
 
       # Ref: https://github.com/dessant/lock-threads#usage

--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -62,7 +62,7 @@ jobs:
           private-key: ${{ secrets.STALE_LOCKING_APP_PRIVATE_KEY }}
 
       # Ref: https://github.com/dessant/lock-threads#usage
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: '${{ steps.generate-token.outputs.token }}'
           process-only: 'issues, prs'


### PR DESCRIPTION
Using the app id is deprecated, also so far since the repo move this
workflow failed all the time as the github app was not in the new org.
I created a new app for this and set the right vars.

Also update dessant/lock-threads to v6.0.2
We need this so the action accepts the new github token format.


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
