### PR TITLE
test system: increase nproc ulimit value to avoid flake

### DIFF
--- a/test/system/280-update.bats
+++ b/test/system/280-update.bats
@@ -366,11 +366,17 @@ function nrand() {
     assert "$output" =~ "nofile: 1024" "nofile ulimit updated to 1024 in main process"
 
     # Update with multiple ulimits
-    run_podman update --ulimit nofile=2048:2048 --ulimit nproc=512:512 $ctrname
+    # nproc is set high (10000) on purpose, not just "safely above default".
+    # RLIMIT_NPROC is enforced per user *namespace*, not per container, so a
+    # low value here can flake: on remote, conmon processes for exec
+    # sessions are leaked and sleep for ~300s, adding to the process count
+    # in the shared rootless user namespace. Do not lower this without
+    # reading https://github.com/containers/podman/issues/28940
+    run_podman update --ulimit nofile=2048:2048 --ulimit nproc=10000:10000 $ctrname
     run_podman restart $ctrname
     run_podman logs $ctrname
     assert "$output" =~ "nofile: 2048" "nofile ulimit updated to 2048 in main process"
-    assert "$output" =~ "nproc: 512" "nproc ulimit updated to 512 in main process"
+    assert "$output" =~ "nproc: 10000" "nproc ulimit updated to 10000 in main process"
 
     # Capture host values by running a temporary container with --ulimit host option
     run_podman run --rm --ulimit host $IMAGE sh -c "echo 'nofile:' \$(ulimit -n); echo 'nproc:' \$(ulimit -u)"


### PR DESCRIPTION
RLIMIT_NPROC is enforced per user namespace, not per container. On remote with rootless, leaked conmon exec-session processes (which sleep ~300s) can push the process count in the shared user namespace high enough that a low nproc ulimit like 512 causes crun to fail with 'clone: Resource temporarily unavailable'. Bump the test value to 10000, with a comment explaining why, so it isn't quietly lowered again.

Verified locally with:
hack/bats --rootless 280:"podman update - set ulimits"

Fixes: #28940

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
