### PR TITLE
Windows installer: remove unused IS_UPGRADE property

### DIFF
--- a/contrib/win-installer/wix/podman-main.wxs
+++ b/contrib/win-installer/wix/podman-main.wxs
@@ -66,14 +66,14 @@ and other data will be preserved." />
 				Action="SetCONFDIR_User"
 				Value="[AppDataFolder]containers\containers.conf.d"
 				Before="AppSearch"
-				Condition="MSIINSTALLPERUSER=1 AND NOT IS_UPGRADE"
+				Condition="MSIINSTALLPERUSER=1"
 				Sequence="first" />
 
 		<SetProperty Id="CONFDIR"
 				Action="SetCONFDIR_Machine"
 				Value="[CommonAppDataFolder]containers\containers.conf.d"
 				Before="AppSearch"
-				Condition="ALLUSERS=1 AND NOT MSIINSTALLPERUSER=1 AND NOT IS_UPGRADE"
+				Condition="ALLUSERS=1 AND NOT MSIINSTALLPERUSER=1"
 				Sequence="first" />
 
 		<!--
@@ -81,6 +81,7 @@ and other data will be preserved." />
 			The machine provider config file is created (or is not deleted if it already exist) if these conditions are met:
 				- The user hasn't set property `SKIP_CONFIG_FILE_CREATION` to 1
 				- The main executable file (<PFILESDIR>/Podman/podman.exe) doesn't exist or, if it exists, the machine provider config file exists
+			Note: if the podman.exe exists AND the config file exists we must set to 1 or the installer deletes the existing config file ¯\_(ツ)_/¯
 		-->
 		<SetProperty Id="CREATE_MACHINE_PROVIDER_CONFIG_FILE"
 			After="AppSearch"


### PR DESCRIPTION
This is a follow-up after @lstocchi comment:

https://github.com/podman-container-tools/podman/pull/29169#discussion_r3588942348

The property `IS_UPGRADE` isn't set and was a leftover of the legacy Windows installer.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
