### PR TITLE
.github/workflows: do not run cron jobs at midnight

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -10,7 +10,9 @@ name: "Lock closed issues and PRs"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    # Do not run at the top of the hour to avoid github action job limits that will drop jobs sometimes.
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+    - cron: '17 1 * * *'
   # Allow reuse of this workflow by other repositories
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   workflow_call:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,9 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+  # Do not run at the top of the hour to avoid github action job limits that will drop jobs sometimes.
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+  - cron: "27 1 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
As documented on github running jobs at the top of the hour and I guess especially at midnight has the chance to get dropped as to many jobs are started around that time for the github workers to handle.

I observed that happening today:
"No server is currently available to service your request." https://github.com/podman-container-tools/podman/actions/runs/29709422226

So to fix that just move our cron time to some under "random" time during the night.

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
