### PR TITLE
docs: clarify network create isolate option

### DIFF
--- a/docs/source/markdown/options/opt.md
+++ b/docs/source/markdown/options/opt.md
@@ -20,7 +20,10 @@ manually by creating a custom route using `--route`.
 Additionally the `bridge` driver supports the following options:
 
 - `vlan`: This option assigns a VLAN tag and enables vlan\_filtering. Defaults to none.
-- `isolate`: This option isolates networks by blocking traffic between those that have this option enabled.
+- `isolate`: This option isolates bridge networks from other bridge networks. Must be set as `isolate=<value>` (a value is required; bare `isolate` is invalid). Defaults to `strict`. Supported values:
+  - `strict`: Block traffic to and from all other bridge networks. This is the default when the option is omitted.
+  - `true`: Block traffic only between networks that also have isolation enabled (`true` or `strict`).
+  - `false`: Do not isolate the network; allow traffic to other bridge networks. Use this to restore the pre-Podman 6 / Netavark 2 behavior.
 - `com.docker.network.bridge.name`: This option assigns the given name to the created Linux Bridge
 - `com.docker.network.driver.mtu`: Sets the Maximum Transmission Unit (MTU) and takes an integer value.
 - `vrf`: This option assigns a Virtual Routing and Forwarding (VRF) routing table to the bridge interface. It accepts the VRF name and defaults to none. Can only be used with the Netavark network backend.

--- a/docs/source/markdown/podman-network-create.1.md.in
+++ b/docs/source/markdown/podman-network-create.1.md.in
@@ -105,6 +105,13 @@ route.
 $ podman network create --subnet 192.168.33.0/24 --route 10.1.0.0/24,192.168.33.10 --opt no_default_route=true newnet
 ```
 
+Create a bridge network without isolation from other bridge networks (isolation
+defaults to `strict`). The option must be given as `key=value`.
+```
+$ podman network create --opt isolate=false mynet
+mynet
+```
+
 Create a network with a route type blackhole. This means the traffic to the destination subnet will be dropped silently.
 ```
 $ podman network create --route 10.1.0.0/24,blackhole --opt no_default_route=true newnet


### PR DESCRIPTION
Fixes: https://github.com/podman-container-tools/podman/issues/29162

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Documented that the bridge `isolate` network option defaults to `strict`, requires `isolate=<value>`, and accepts `strict`, `true`, or `false`.
```
