### PR TITLE
.github/workflows/issue_pr_lock.yml: run for the full org

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -47,7 +47,7 @@ env:
 
 jobs:
   manage_locking:
-    if: github.repository == 'podman-container-tools/podman'
+    if: github.repository_owner == 'podman-container-tools'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
This workflow is used and called by buildah and skopeo, however due this new if it will just get skipped there as the context on a action reuse will still be set to the proper repo which calls the action.

The point of this new if from commit 32f987fc8c
("ci: restrict specific workflows to the upstream repository") was to avoid running our actions on forks where they will fail due to missing secrets, etc...

So by limiting the scope to our org here we can reuse it from buildah and skopeo and still prevent it running on forks from users.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
