### PR TITLE
podman-remote: do not check for cgroupv2

### DIFF
--- a/cmd/podman/root_cgroups_linux.go
+++ b/cmd/podman/root_cgroups_linux.go
@@ -1,13 +1,18 @@
-//go:build linux
+//go:build linux && !remote
 
 package main
 
 import (
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/cgroups"
+	"go.podman.io/podman/v6/cmd/podman/registry"
 )
 
 func checkSupportedCgroups() {
+	if registry.IsRemote() {
+		// In remote mode we should not error for missing cgroups as just the server needs it.
+		return
+	}
 	unified, err := cgroups.IsCgroup2UnifiedMode()
 	if err != nil {
 		logrus.Fatalf("Error determining cgroups mode")

--- a/cmd/podman/root_cgroups_unsupported.go
+++ b/cmd/podman/root_cgroups_unsupported.go
@@ -1,7 +1,7 @@
-//go:build !linux
+//go:build !linux || remote
 
 package main
 
 func checkSupportedCgroups() {
-	// NOP on Non Linux
+	// NOP on Non Linux or Remote
 }


### PR DESCRIPTION
With the remote client on linux we should not check for cgroups and hard fail if it is not v2. Only the server side matters not the client.

The problem can be reproduced with:
unshare -rm sh -c "mount -t tmpfs none /sys/fs/cgroup  && ./bin/podman --remote ps"

I did not add a regression test as it does not seem to fit well into a test suite, over mounting cgroups seems like not a good idea.

Fixes: #29241



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixes a regression which caused podman-remote to error our when the system had no cgroup v2 mounted. (#29241)
```
