### PR TITLE
ci: update VM image to 2026-07-22

### DIFF
--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -32,7 +32,7 @@ env:
   # CI automation repo release for the VM image downloads in ci.sh.
   # ENV is managed by renovate, do not change the name without
   # updating the renovate config in the automation repo.
-  AUTOMATION_RELEASE: 20260616t073924z
+  AUTOMATION_RELEASE: 20260722t094115z
 
 jobs:
   lima:

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1830,3 +1830,29 @@ func SkipIfNotAMD64() {
 		Skip("test only valid on amd64")
 	}
 }
+
+const policyContent = `{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports":
+        {
+            "docker-daemon":
+                {
+                    "": [{"type":"insecureAcceptAnything"}]
+                }
+        }
+}
+`
+
+// createPolicyJSONFile creates a policy.json file in podmanTest.TempDir with an
+// insecureAcceptAnything policy and returns the path to that file.
+func createPolicyJSONFile() string {
+	GinkgoHelper()
+	path := filepath.Join(podmanTest.TempDir, "policy.json")
+	err := os.WriteFile(path, []byte(policyContent), 0o600)
+	Expect(err).ToNot(HaveOccurred())
+	return path
+}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Podman create", func() {
 			Expect(session).To(ExitWithError(125, "open /no/such/file: no such file or directory"))
 		}
 
-		session = podmanTest.Podman([]string{"create", "-q", "--pull=always", "--signature-policy", "/etc/containers/policy.json", ALPINE})
+		session = podmanTest.Podman([]string{"create", "-q", "--pull=always", "--signature-policy", createPolicyJSONFile(), ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Podman import", func() {
 		importImage.WaitWithDefaultTimeout()
 		Expect(importImage).To(ExitWithError(125, "open /no/such/file: no such file or directory"))
 
-		result := podmanTest.Podman([]string{"import", "-q", "--signature-policy", "/etc/containers/policy.json", outfile})
+		result := podmanTest.Podman([]string{"import", "-q", "--signature-policy", createPolicyJSONFile(), outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
 	})

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Podman load", func() {
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi).Should(ExitCleanly())
 
-		result := podmanTest.Podman([]string{"load", "-q", "--signature-policy", "/etc/containers/policy.json", "-i", outfile})
+		result := podmanTest.Podman([]string{"load", "-q", "--signature-policy", createPolicyJSONFile(), "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		if IsRemote() {
 			Expect(result).To(ExitWithError(125, "unknown flag: --signature-policy"))

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Podman run", func() {
 		}
 		Expect(session).To(ExitWithError(125, "open /no/such/file: no such file or directory"))
 
-		session = podmanTest.Podman([]string{"run", "--pull=always", "--signature-policy", "/etc/containers/policy.json", ALPINE})
+		session = podmanTest.Podman([]string{"run", "--pull=always", "--signature-policy", createPolicyJSONFile(), ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Getting image source signatures"))

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Podman save", func() {
 		SkipIfRemote("--signature-policy N/A for remote")
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-q", "--signature-policy", "/etc/containers/policy.json", "-o", outfile, ALPINE})
+		save := podmanTest.Podman([]string{"save", "-q", "--signature-policy", createPolicyJSONFile(), "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save).Should(ExitCleanly())
 	})


### PR DESCRIPTION
test/e2e: do not assume /etc/containers/policy.json

With the new config work we expect policy.json to be shipped under
/usr/share/containers/policy.json. However the CI VMs and local users
might still have it in /etc so instead of assuming any host path lets
just create our own files for the --signature-policy tests.


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
