### PR TITLE
libpod: cleanup after failed container init

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -42,7 +42,7 @@ func (c *Container) Init(ctx context.Context, recursive bool) error {
 	return c.initUnlocked(ctx, recursive)
 }
 
-func (c *Container) initUnlocked(ctx context.Context, recursive bool) error {
+func (c *Container) initUnlocked(ctx context.Context, recursive bool) (retErr error) {
 	if !c.ensureState(define.ContainerStateConfigured, define.ContainerStateStopped, define.ContainerStateExited) {
 		return fmt.Errorf("container %s has already been created in runtime: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
@@ -57,10 +57,15 @@ func (c *Container) initUnlocked(ctx context.Context, recursive bool) error {
 		}
 	}
 
-	if err := c.prepare(); err != nil {
-		if err2 := c.cleanup(ctx); err2 != nil {
-			logrus.Errorf("Cleaning up container %s: %v", c.ID(), err2)
+	defer func() {
+		if retErr != nil {
+			if err := c.cleanup(ctx); err != nil {
+				logrus.Errorf("Cleaning up container %s: %v", c.ID(), err)
+			}
 		}
+	}()
+
+	if err := c.prepare(); err != nil {
 		return err
 	}
 

--- a/test/e2e/init_test.go
+++ b/test/e2e/init_test.go
@@ -4,6 +4,8 @@ package integration
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -117,5 +119,32 @@ var _ = Describe("Podman init", func() {
 		init := podmanTest.Podman([]string{"init", "init_test"})
 		init.WaitWithDefaultTimeout()
 		Expect(init).Should(ExitWithError(125, fmt.Sprintf("Error: container %s has already been created in runtime: container state improper", cid)))
+	})
+
+	It("podman init cleans up after initialization failure", func() {
+		SkipIfRemote("requires local containers.conf configuration")
+
+		confPath := filepath.Join(podmanTest.TempDir, "containers.conf")
+		err := os.WriteFile(confPath, []byte("[containers]\nhost_containers_internal_ip = \"none\"\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.Setenv("CONTAINERS_CONF_OVERRIDE", confPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		name := "init-failure-cleanup"
+
+		podmanTest.PodmanExitCleanly("create", "--name", name, "--add-host", "host.docker.internal:host-gateway", ALPINE, "top")
+
+		init := podmanTest.Podman([]string{"init", name})
+		init.WaitWithDefaultTimeout()
+		Expect(init).Should(ExitWithError(125, "host containers internal IP address is empty"))
+
+		inspect := podmanTest.PodmanExitCleanly("inspect", "--format", "{{.State.Status}}", name)
+		Expect(inspect.OutputToString()).To(Equal("created"))
+
+		// Verify that start retries initialization instead of starting a partially initialized container.
+		start := podmanTest.Podman([]string{"start", name})
+		start.WaitWithDefaultTimeout()
+		Expect(start).Should(ExitWithError(125, "host containers internal IP address is empty"))
 	})
 })


### PR DESCRIPTION
Fixes: #26143

This rolls back the container state when init fails, not just when prepare fails. So in #26143, the container no longer starts after init failure.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a bug where failed container initialization could leave the container in a partially initialized state.
```
