### PR TITLE
Fix remote podman start silently ignoring missing containers with --f…

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -790,7 +790,7 @@ func logIfRmError(id string, err error, reports []*reports.RmReport) {
 func (ic *ContainerEngine) ContainerStart(_ context.Context, namesOrIds []string, options entities.ContainerStartOptions) ([]*entities.ContainerStartReport, error) {
 	reports := []*entities.ContainerStartReport{}
 	exitCode := define.ExecErrorCodeGeneric
-	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, options.All, len(options.Filters) > 0, namesOrIds, options.Filters)
+	ctrs, rawInputs, err := getContainersAndInputByContext(ic.ClientCtx, options.All, false, namesOrIds, options.Filters)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/tunnel/helpers.go
+++ b/pkg/domain/infra/tunnel/helpers.go
@@ -81,8 +81,8 @@ func getContainersAndInputByContext(contextWithConnection context.Context, all, 
 			}
 		}
 
-		if !found && !ignore {
-			return nil, nil, fmt.Errorf("unable to find container %q: %w", nameOrID, define.ErrNoSuchCtr)
+		if !found {
+			continue
 		}
 	}
 	return filtered, rawInputs, nil

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -240,6 +240,16 @@ var _ = Describe("Podman start", func() {
 		Expect(session1.OutputToString()).To(BeEquivalentTo(cid2))
 	})
 
+	It("podman start --filter with nonexistent container name", func() {
+		session := podmanTest.Podman([]string{"container", "create", "--name", "startfiltertest", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+
+		session = podmanTest.Podman([]string{"start", "--filter", "name=startfiltertest", "nonexistent-start-filter-bogus"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, `no container with name or ID "nonexistent-start-filter-bogus" found: no such container`))
+	})
+
 	It("podman start container does not set HOME to home of caller", func() {
 		home, err := os.UserHomeDir()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -72,6 +72,15 @@ load helpers
     run_podman rm -f $c1 $c2 $c3
 }
 
+@test "podman start --filter with nonexistent container name" {
+    bogus="nonexistent-start-filter-$(random_string 15)"
+    run_podman create --name=startfiltertest $IMAGE sleep 3600
+    run_podman 125 start --filter name=startfiltertest "$bogus"
+    is "$output" 'Error: no container with name or ID "'"$bogus"'" found: no such container' \
+       "nonexistent name with --filter must fail"
+    run_podman rm -f startfiltertest
+}
+
 @test "podman start --filter invalid-restart-policy - return error" {
     run_podman run -d $IMAGE /bin/true
     cid="$output"


### PR DESCRIPTION
Fix remote podman start silently ignoring missing containers with filter

ContainerStart incorrectly passed len(options.Filters) > 0 as the ignore flag to getContainersAndInputByContext. Nonexistent container names were skipped instead of returning an error on remote clients.

## Summary

Remote podman start treated any use of `--filter` as ignore mode when resolving explicit container names. A typo or missing name exited 0 with no message on Windows, macOS, and podman remote. Local podman returned exit 125 with a no such container error.

This PR passes false for ignore in ContainerStart, matching ContainerRestart and local behavior.

## Test plan

Added e2e test podman start --filter with nonexistent container name in test/e2e/start_test.go

Manual check on Windows Podman 5.8.5

```
podman create --name testctr-filterbug alpine sleep 3600
podman start --filter name=testctr-filterbug nonexistent-container-xyz123
```

Before the fix exit 0 and no output. After the fix exit 125 and no such container error.

Replace ISSUE_NUMBER with your GitHub issue number before opening the PR.

Fixes containers/podman#29266

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits
- [ ] Referenced issues using Fixes in commit message
- [x] Tests have been added or updated
- [x] Documentation updated or not needed
- [ ] All commits pass make validatepr
- [x] Release note entered below

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where podman start --filter on remote clients silently succeeded when a specified container name did not exist.
```
