### PR TITLE
Extend support for the v5.8 series of releases upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Podman is based on libpod, a library for container lifecycle management that is 
 
 Podman releases a new major or minor release 4 times a year, during the second week of February, May, August, and November. Patch releases are more frequent and may occur at any time to get bugfixes out to users. All releases are PGP signed. Public keys of members of the team approved to make releases are located [here](https://github.com/containers/release-keys/tree/main/podman).
 
+Only the most recent release receives upstream support. Exceptions are sometimes made after a major Podman release, in recognition of the fact that not all users and distributions will be able to quickly migrate to a breaking change release. After the release of Podman 6.0, the Podman maintainers have decided to extend upstream support of the v5.8 series of releases until the 2nd week of June in 2027, one year after the release of Podman 6.0. This support will only include CVE fixes and critical bugfixes.
+
 * Continuous Integration:
   * [![Build Status](https://github.com/containers/podman/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/containers/podman/actions/workflows/ci.yml?query=branch%3Amain)
   * [GoDoc: ![GoDoc](https://godoc.org/github.com/containers/podman/libpod?status.svg)](https://godoc.org/github.com/containers/podman/libpod)


### PR DESCRIPTION
@podman-container-tools/podman-maintainers PTAL. This isn't a governance-marked PR but I would still like to get broad support for this from our maintainers before merging. We've usually done this on an unofficial basis to help folks transition, but providing a guarantee of support should help that.

The 1 year figure is potentially controversial, and I could easily be talked down here, but I don't feel that it's unreasonable if we restrict ourselves to just CVEs and critical bugfixes (and there won't be that many of the latter in a well-proven release like 5.8). Maybe we should restrict it further to moderate and above CVEs, though?
#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
NONE
```
