### PR TITLE
test: fix cgroups=split flake by adding Delegate=yes to scope

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1707,7 +1707,7 @@ VOLUME %s`, ALPINE, volPath, volPath)
 		}
 
 		scopeOptions := PodmanExecOptions{
-			Wrapper: []string{"systemd-run", "--scope"},
+			Wrapper: []string{"systemd-run", "--scope", "--property=Delegate=yes"},
 		}
 		if isRootless() {
 			scopeOptions.Wrapper = append(scopeOptions.Wrapper, "--user")


### PR DESCRIPTION
The `cgroups=split` e2e test wraps podman in `systemd-run --scope` but doesn't pass `Delegate=yes`. w/o explicit delegation, systemd cant guarantee that cgroup controllers like `pids` are written to `cgroup.subtree_control` for child cgroups so, whether they show up depends on the systemd session state at that moment, so the test flakes instead of failing consistently. when `--cgroups=split` runs, crun creates the container payload cgroup directly under the scope and expects all controllers to be available there; without delegation they sometimes aren't.

This adds `--property=Delegate=yes` to the `systemd-run` wrapper, matching what Quadlet already does (`Delegate=yes` in the `[Service]` section) whenever it generates a unit for `--cgroups=split`.

- Fixes: #28944

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] no documentation changes are needed
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```