### PR TITLE
docs: clarify --transient-store behavior with volumes

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -206,6 +206,10 @@ Enables a global transient storage mode where all container metadata is stored o
 This mode allows starting containers faster, as well as guaranteeing a fresh state on boot in case of unclean shutdowns or other problems. However
 it is not compatible with a traditional model where containers persist across reboots.
 
+Only the Podman database (container and volume metadata) is stored transiently. Volume data on disk is not affected and persists across reboots. After a reboot, previously created volumes will not appear in **podman volume ls** because their database entries were lost, but the underlying data remains in the volume storage directory. If a container later creates a volume with the same name, it will reuse the existing data. To clean up leftover volume data that is no longer tracked by the database, use **podman system prune --external**.
+
+It should be used consistently across all Podman commands and not mixed with regular (non-transient) usage within the same environment.
+
 Default value for this is configured in `containers-storage.conf(5)`.
 
 #### **--url**=*value*


### PR DESCRIPTION
The `--transient-store` documentation didn't explain what happens to volumes, leading users to expect that volume data would also be transient. In practice only the Podman database (container and volume metadata) is stored on non-persistent media, volume data on disk persists across reboots. After a reboot the volumes disappear from `podman volume ls` because their database entries are gone, but the data stays on disk and gets silently reused if a volume with the same name is created again.

This updates the `--transient-store` section in `podman.1.md` to document this behavior, point users to `podman system prune --external` for cleaning up orphaned volume data, and note that the option is designed for Quadlet use and should not be mixed with regular non-transient commands.

- Fixes: #25295

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
None
```