### PR TITLE
volumes: propagate error from MountCount in VolumeMounted

### DIFF
--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -209,8 +209,7 @@ func (ic *ContainerEngine) VolumeMounted(_ context.Context, nameOrID string) (*e
 	}
 	mountCount, err := vol.MountCount()
 	if err != nil {
-		// FIXME: this error should probably be returned
-		return &entities.BoolReport{Value: false}, nil //nolint: nilerr
+		return nil, err
 	}
 	if mountCount > 0 {
 		return &entities.BoolReport{Value: true}, nil


### PR DESCRIPTION
When checking if a volume is mounted, errors during mount count lookup were previously ignored and treated as `false` (unmounted). This could hide underlying storage driver or volume plugin failures.

What changed:
- Returned the error from mount count lookup directly instead of swallowing it.
- Removed the old FIXME comment and linter suppression directive.
