### PR TITLE
docs: align --image-volume modes with anonymous/tmpfs/ignore

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1151,9 +1151,9 @@ func AutocompleteCgroupMode(_ *cobra.Command, _ []string, _ string) ([]string, c
 }
 
 // AutocompleteImageVolume - Autocomplete image volume options.
-// -> "bind", "tmpfs", "ignore"
+// -> "anonymous", "tmpfs", "ignore"
 func AutocompleteImageVolume(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	imageVolumes := []string{"bind", "tmpfs", "ignore"}
+	imageVolumes := []string{"anonymous", "tmpfs", "ignore"}
 	return imageVolumes, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -174,7 +174,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		imageVolumeFlagName := "image-volume"
 		createFlags.String(
 			imageVolumeFlagName, cf.ImageVolume,
-			`Tells podman how to handle the builtin image volumes ("bind"|"tmpfs"|"ignore")`,
+			`Tells podman how to handle the builtin image volumes ("anonymous"|"tmpfs"|"ignore")`,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(imageVolumeFlagName, AutocompleteImageVolume)
 

--- a/docs/source/locale/ja/LC_MESSAGES/markdown.po
+++ b/docs/source/locale/ja/LC_MESSAGES/markdown.po
@@ -9067,18 +9067,18 @@ msgstr ""
 
 #: ../../source/markdown/podman-create.1.md:810
 #: ../../source/markdown/podman-run.1.md:852
-msgid "**--image-volume**=**bind** | *tmpfs* | *ignore*"
+msgid "**--image-volume**=**anonymous** | *tmpfs* | *ignore*"
 msgstr ""
 
 #: ../../source/markdown/podman-create.1.md:812
 #: ../../source/markdown/podman-run.1.md:854
-msgid "Tells Podman how to handle the builtin image volumes. Default is **bind**."
+msgid "Tells Podman how to handle the builtin image volumes. Default is **anonymous**."
 msgstr ""
 
 #: ../../source/markdown/podman-create.1.md:814
 #: ../../source/markdown/podman-run.1.md:856
 msgid ""
-"**bind**: An anonymous named volume is created and mounted into the "
+"**anonymous**: An anonymous named volume is created and mounted into the "
 "container."
 msgstr ""
 

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -5,12 +5,12 @@
 << if is_quadlet >>
 ### `ImageVolume=mode`
 << else >>
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+#### **--image-volume**=**anonymous** | *tmpfs* | *ignore*
 << endif >>
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
+Tells Podman how to handle the builtin image volumes. Default is **anonymous**.
 
-- **bind**: An anonymous named volume is created and mounted into the container.
+- **anonymous**: An anonymous named volume is created and mounted into the container.
 - **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
 content that disappears when the container is stopped.
 - **ignore**: All volumes are just ignored and no action is taken.

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -724,7 +724,7 @@ Special Cases:
 
 ### `ImageVolume=`
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
+Tells Podman how to handle the builtin image volumes. Default is **anonymous**.
 Equivalent to the Podman `--image-volume` option.
 
 ### `IP=`


### PR DESCRIPTION
#### Summary

`--image-volume` docs and CLI help still listed `bind` as a valid mode, but validation only accepts `anonymous`, `tmpfs`, and `ignore` (and the error message already says that). This updates the man page option text, the systemd/quadlet note, flag help, and shell completion to match.

Fixes #27674

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). The author email must match the sign-off email address.
- [x] Referenced issues using `Fixes: #27674` in commit message
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below

#### Does this PR introduce a user-facing change?

```release-note
Fix `--image-volume` documentation and help text to list `anonymous` instead of the outdated `bind` mode.
```
