### PR TITLE
test/system: fix random_rfc1918_subnet operator precedence

### DIFF
--- a/test/system/helpers.network.bash
+++ b/test/system/helpers.network.bash
@@ -60,7 +60,7 @@ function random_rfc1918_subnet() {
     while [ "$retries" -gt 0 ];do
         # 172.16.0.0 -> 172.31.255.255
         local n1=172
-        local n2=$(( 16 + $RANDOM & 15 ))
+        local n2=$(( 16 + ($RANDOM & 15) ))
         local n3=$(( $RANDOM & 255 ))
 
         if ! subnet_in_use $n1 $n2 $n3; then

--- a/test/system/helpers.t
+++ b/test/system/helpers.t
@@ -425,5 +425,23 @@ check_assert "0123456789abcdeff"  =~ "^[0-9a-f]{16}\$" "
 
 # END   check_assert
 ###############################################################################
+# BEGIN random_rfc1918_subnet
+
+# The whole point of the helper is to stay inside 172.16/12, so the middle
+# octet must land in 16..31. Operator precedence got this wrong once already:
+# in bash, + binds tighter than &, so "16 + $RANDOM & 15" is (16+RANDOM)&15,
+# which is 0..15 and not in the range at all.
+lo=255
+hi=0
+for i in $(seq 1 20); do
+    n2=$(random_rfc1918_subnet | cut -d. -f2)
+    if [[ $n2 -lt $lo ]]; then lo=$n2; fi
+    if [[ $n2 -gt $hi ]]; then hi=$n2; fi
+done
+check_result "$(( lo >= 16 && hi <= 31 ))" "1" \
+             "random_rfc1918_subnet second octet in 16..31 (saw $lo..$hi)"
+
+# END   random_rfc1918_subnet
+###############################################################################
 
 exit $rc


### PR DESCRIPTION
I was poking at the network system tests and noticed random_rfc1918_subnet does not actually return an rfc1918 address.

In bash arithmetic + binds tighter than &, so 16 + $RANDOM & 15 is really (16 + RANDOM) & 15, which gives 0..15 rather than 16..31. So the helper has been returning 172.0.x through 172.15.x, none of which is inside 172.16/12. Looks like it came in with 9e3363c5e when % 16 became & 15.

Nothing caught it because subnet_in_use only checks whether the subnet clashes with a host route, not whether it is private, so the tests carry on passing either way.

I added a regression test to helpers.t. I ran it both ways in a container - it reports "saw 0..15" and fails on the old expression, "saw 16..31" and passes on the new one. I could not run the actual system tests here though, so that part is down to CI.