### PR TITLE
ci: enable fsverify for composefs

### DIFF
--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -31,10 +31,6 @@ fedora-rawhide)
     CI_DESIRED_COMPOSEFS="composefs"
     # Enable sequoia testing
     TEST_BUILD_TAGS="containers_image_sequoia"
-
-    # mount a tmpfs for the container storage. This is a work around for the staging pull composefs flake.
-    # FIXME: https://github.com/containers/podman/issues/28813
-    sudo mount -t tmpfs -o size=75%,mode=0700 none /var/lib/containers
     ;;
 debian-sid)
     ;;


### PR DESCRIPTION
Remove workaround and see if it still flakes, see #28813

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
