### PR TITLE
ci: update machine linux timeout to 60m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,7 +437,7 @@ jobs:
       needs.path-filter.outputs.machine == 'true'
     name: machine linux ${{ matrix.os.arch }}
     runs-on: ${{ matrix.os.runner }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It seems CNCF downgraded the runner performance and thus the task can no longer finish in under 40 minutes. Bump it to 60m and hope this is enough.

We cannot use a bigger runner (more cores) as the tests are largely single threaded by design.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->



#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
