### PR TITLE
swagger: rename artifact annotation field"

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -680,14 +680,14 @@ func ManifestModify(w http.ResponseWriter, r *http.Request) {
 			// We waited until after the extraction goroutine finished to ensure
 			// that we'd pick up its changes to the ArtifactFiles list.
 			manifestAddArtifactOptions := entities.ManifestAddArtifactOptions{
-				Type:          body.ArtifactType,
-				LayerType:     body.ArtifactLayerType,
-				ConfigType:    body.ArtifactConfigType,
-				Config:        body.ArtifactConfig,
-				ExcludeTitles: body.ArtifactExcludeTitles,
-				Annotations:   body.ArtifactAnnotations,
-				Subject:       body.ArtifactSubject,
-				Files:         body.ArtifactFiles,
+				Type:                body.ArtifactType,
+				LayerType:           body.ArtifactLayerType,
+				ConfigType:          body.ArtifactConfigType,
+				Config:              body.ArtifactConfig,
+				ExcludeTitles:       body.ArtifactExcludeTitles,
+				ArtifactAnnotations: body.ArtifactAnnotations,
+				Subject:             body.ArtifactSubject,
+				Files:               body.ArtifactFiles,
 			}
 			id, err := imageEngine.ManifestAddArtifact(r.Context(), name, body.ArtifactFiles, manifestAddArtifactOptions)
 			if err != nil {

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -53,14 +53,14 @@ type ManifestAddOptions struct {
 type ManifestAddArtifactOptions struct {
 	ManifestAnnotateOptions
 	// Note to future maintainers: keep these fields synchronized with ManifestModifyOptions!
-	Type          *string           `json:"artifact_type" schema:"artifact_type"`
-	LayerType     string            `json:"artifact_layer_type" schema:"artifact_layer_type"`
-	ConfigType    string            `json:"artifact_config_type" schema:"artifact_config_type"`
-	Config        string            `json:"artifact_config" schema:"artifact_config"`
-	ExcludeTitles bool              `json:"artifact_exclude_titles" schema:"artifact_exclude_titles"`
-	Annotations   map[string]string `json:"artifact_annotations" schema:"artifact_annotations"`
-	Subject       string            `json:"artifact_subject" schema:"artifact_subject"`
-	Files         []string          `json:"artifact_files" schema:"-"`
+	Type                *string           `json:"artifact_type" schema:"artifact_type"`
+	LayerType           string            `json:"artifact_layer_type" schema:"artifact_layer_type"`
+	ConfigType          string            `json:"artifact_config_type" schema:"artifact_config_type"`
+	Config              string            `json:"artifact_config" schema:"artifact_config"`
+	ExcludeTitles       bool              `json:"artifact_exclude_titles" schema:"artifact_exclude_titles"`
+	ArtifactAnnotations map[string]string `json:"artifact_annotations" schema:"artifact_annotations"`
+	Subject             string            `json:"artifact_subject" schema:"artifact_subject"`
+	Files               []string          `json:"artifact_files" schema:"-"`
 }
 
 // ManifestAnnotateOptions provides model for annotating manifest list

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -362,7 +362,7 @@ func (ir *ImageEngine) ManifestAddArtifact(ctx context.Context, name string, fil
 		Config:        opts.Config,
 		LayerType:     opts.LayerType,
 		ExcludeTitles: opts.ExcludeTitles,
-		Annotations:   opts.Annotations,
+		Annotations:   opts.ArtifactAnnotations,
 		Subject:       opts.Subject,
 	}
 

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -117,7 +117,7 @@ func (ir *ImageEngine) ManifestAddArtifact(_ context.Context, name string, files
 	options.WithType(opts.Type).WithConfigType(opts.ConfigType).WithLayerType(opts.LayerType)
 	options.WithConfig(opts.Config)
 	options.WithExcludeTitles(opts.ExcludeTitles).WithSubject(opts.Subject)
-	options.WithAnnotations(opts.Annotations)
+	options.WithAnnotations(opts.ArtifactAnnotations)
 	options.WithFiles(files)
 	id, err := manifests.AddArtifact(ir.ClientCtx, name, options)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Resolution of the Swagger/schema x-go-name collision.
- Renaming of the Go field.
- Updates to the ABI, tunnel, and API handler wiring.
- Swagger/client generation succeeds after the change.
-  Referenced issues using: #22966.
<!--
For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->
```release-note
None
```

```
