### PR TITLE
libpod: use %w instead of %v in fmt.Errorf calls

### DIFF
--- a/libpod/events.go
+++ b/libpod/events.go
@@ -80,7 +80,7 @@ func (c *Container) newContainerEventWithInspectData(status events.Status, healt
 			return nil
 		}()
 		if err != nil {
-			return fmt.Errorf("adding inspect data to container-create event: %v", err)
+			return fmt.Errorf("adding inspect data to container-create event: %w", err)
 		}
 	}
 

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -292,14 +292,14 @@ func (c *Container) recreateHealthCheckTimer(ctx context.Context, isStartup bool
 	}
 
 	if err := c.createTimer(interval, isStartup); err != nil {
-		return fmt.Errorf("recreating container %s (isStartup: %t) healthcheck: %v", c.ID(), isStartup, err)
+		return fmt.Errorf("recreating container %s (isStartup: %t) healthcheck: %w", c.ID(), isStartup, err)
 	}
 	if err := c.startTimer(isStartup); err != nil {
-		return fmt.Errorf("restarting container %s (isStartup: %t) healthcheck timer: %v", c.ID(), isStartup, err)
+		return fmt.Errorf("restarting container %s (isStartup: %t) healthcheck timer: %w", c.ID(), isStartup, err)
 	}
 
 	if err := c.removeTransientFiles(ctx, isStartupRemoved, oldUnit); err != nil {
-		return fmt.Errorf("removing container %s healthcheck: %v", c.ID(), err)
+		return fmt.Errorf("removing container %s healthcheck: %w", c.ID(), err)
 	}
 	return nil
 }
@@ -326,7 +326,7 @@ func (c *Container) incrementStartupHCFailureCounter(ctx context.Context) error 
 		logrus.Infof("Restarting container %s as startup healthcheck failed", c.ID())
 		// Restart the container
 		if err := c.restartWithTimeout(ctx, c.config.StopTimeout); err != nil {
-			return fmt.Errorf("restarting container %s after healthcheck failure: %v", c.ID(), err)
+			return fmt.Errorf("restarting container %s after healthcheck failure: %w", c.ID(), err)
 		}
 		return nil
 	}


### PR DESCRIPTION
This PR updates several `fmt.Errorf` calls in `libpod/healthcheck.go` and `libpod/events.go` from `%v` to `%w`.

Errors returned in the healthcheck timer path and events inspect data were formatted with `%v`, discarding the error chain. Replaced with `%w` so callers can use `errors.Is`/`errors.As` to inspect the underlying causes. 

As stated in the official Go standard library documentation for `fmt.Errorf`, "If the format specifier includes a %w verb with an error operand, the returned error will implement an Unwrap method returning the operand". Furthermore, error wrapping was introduced in Go 1.13 to allow developers to add context to errors while preserving the original error for inspection.

**Official Documentation Proof:**
*   [Go 1.13 Error Wrapping Release Blog](https://go.dev/blog/go1.13-errors)

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

```release-note
NONE