### PR TITLE
libpod: propagate request context in HTTPAttach to prevent leak

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -5,7 +5,6 @@ package libpod
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -596,7 +595,7 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 			}
 			errChan <- err
 		}()
-		if err := ctr.ReadLog(context.Background(), logOpts, logChan, 0); err != nil {
+		if err := ctr.ReadLog(req.Context(), logOpts, logChan, 0); err != nil {
 			return err
 		}
 		go func() {


### PR DESCRIPTION
This PR fixes a goroutine and file descriptor leak in `libpod/oci_conmon_common.go`.

When streaming logs via the REST API, `HTTPAttach` was passing `context.Background()` into `ctr.ReadLog`. If the client dropped the connection, the tail loop would never receive a cancellation signal and would leak indefinitely. This PR swaps `context.Background()` for the active `req.Context()`. The issue was raised in issue #29323.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #29323` in commit message (if applicable)
- [x] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Fixed a resource leak in the REST API where dropping an attach session would cause the log-reading goroutine to persist in the background.