### PR TITLE
ci: bump validate runner and machine timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
   validate-source:
     name: Validate source code changes
-    runs-on: cncf-ubuntu-8-32-x86
+    runs-on: cncf-ubuntu-16-64-x86
     if: github.repository == 'podman-container-tools/podman'
     # While in most cases it should faster than 10m, if there are many commits in the PR "Build each commit" takes a bit longer
     timeout-minutes: 20
@@ -437,7 +437,7 @@ jobs:
       needs.path-filter.outputs.machine == 'true'
     name: machine linux ${{ matrix.os.arch }}
     runs-on: ${{ matrix.os.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:

--- a/hack/ci/ci_yaml_test.py
+++ b/hack/ci/ci_yaml_test.py
@@ -50,7 +50,7 @@ class TestCase(unittest.TestCase):
             if item.get('runs-on') is not None:
                 timeout = item.get('timeout-minutes')
                 self.assertIsNotNone(timeout, msg=f"job '{job}' has no timeout-minutes set")
-                self.assertLessEqual(timeout, 60, msg=f"job '{job}' should never take longer than 1 hour")
+                self.assertLessEqual(timeout, 70, msg=f"job '{job}' should never take longer than 70 minutes")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
With the CNCF downgrade machine tests take an hour, a larger runner
also does not really speed this up so just bump the timeout there.

Also upgrade the validate task as golangci-lint is quite slow otherwise
and this blocks until the real tests start so we like to have this down
quicker.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->


#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
