### PR TITLE
rootless: fix heap-buffer-overflow in preexec hooks

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -447,7 +447,6 @@ do_preexec_hooks_dir (const char *dir, char **argv, int argc)
 
       strncpy (buffer + nfiles * (NAME_MAX + 1), de->d_name, NAME_MAX + 1);
       nfiles++;
-      buffer[nfiles * (NAME_MAX + 1)] = '\0';
     }
 
   qsort (buffer, nfiles, NAME_MAX + 1, (int (*)(const void *, const void *)) strcmp);


### PR DESCRIPTION
Remove an unnecessary null byte write after copying preexec hook names. The write was performed one byte past the allocated buffer because the filename copy already included the string terminator.

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/containers/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/containers/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```

Fixes #29326