### PR TITLE
test/system: remove debug instrumentation for closed issues

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -288,9 +288,6 @@ EOF
        "Conmon pid in pidfile matches what 'podman inspect' claims"
 
     # /proc/PID/exe should be a symlink to a conmon executable
-    # FIXME: 'echo' and 'ls' are to help debug #7580, a CI flake
-    echo "conmon pid = $conmon_pid_from_file"
-    ls -l /proc/$conmon_pid_from_file
     is "$(readlink /proc/$conmon_pid_from_file/exe)" ".*/conmon"  \
        "conmon pidfile (= PID $conmon_pid_from_file) points to conmon process"
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -571,15 +571,6 @@ function run_podman() {
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$(timestamp) $output"
-
-        # FIXME FIXME FIXME: instrumenting to track down #15488. Please
-        # remove once that's fixed. We include the args because, remember,
-        # bats only shows output on error; it's possible that the first
-        # instance of the metacopy warning happens in a test that doesn't
-        # check output, hence doesn't fail.
-        if [[ "$output" =~ Ignoring.global.metacopy.option ]]; then
-            echo "# YO! metacopy warning triggered by: podman $*" >&3
-        fi
     fi
     if [ "$status" -ne 0 ]; then
         echo -n "$(timestamp) [ rc=$status ";


### PR DESCRIPTION
I was going through FIXMEs that point at issues which are already closed, and found two bits of debugging left in the system tests.

The first one is in `run_podman`. The comment there says to remove it once #15488 is fixed, and that closed in December 2022. It runs on every podman call in the suite and writes to fd 3, so the output shows up even when the test passes. I grepped four recent system test job logs and the warning is not in any of them.

The second one is an echo and an ls added to debug #7580, which is closed  The readlink check just below is the real assertion and it already prints the pid when it fails.

I ran `test/system/helpers.t` on Linux with both changes and it passes 83/83.

I left the #11871 debugging in `500-networking.bats` alone. That one dumps resolv.conf and runs ps, and networking still flakes, so I think it might still be wanted.

#### Does this PR introduce a user-facing change?

```
None
```
