### PR TITLE
inspect: reject docker transport image references

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -85,6 +85,11 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 			return errors.New("no names or ids specified")
 		}
 	}
+	for _, nameOrID := range namesOrIDs {
+		if strings.HasPrefix(nameOrID, "docker://") {
+			return fmt.Errorf("image %q is not in local storage; remove the docker:// prefix", nameOrID)
+		}
+	}
 
 	tmpType := i.options.Type
 	if i.options.Latest {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -12,6 +12,12 @@ import (
 )
 
 var _ = Describe("Podman inspect", func() {
+	It("podman inspect rejects docker transport", func() {
+		session := podmanTest.Podman([]string{"inspect", "docker://" + ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitWithError(125, "is not in local storage; remove the docker:// prefix"))
+	})
+
 	It("podman inspect alpine image", func() {
 		session := podmanTest.Podman([]string{"inspect", "--format=json", ALPINE})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
## Summary

Update `podman inspect` to reject `docker://` image references before inspect type resolution.

This provides a clearer error for transport-qualified image references instead of allowing them to fail later with a generic unsupported transport message.

The validation also applies to `podman image inspect`.

An e2e test has been added to verify the new behavior.

Referenced issue:
Non-actionable error message: "unsupported transport \"docker\" for looking up local images" #20775

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`)
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [x] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below

#### Does this PR introduce a user-facing change?

```release-note
When `podman inspect` or `podman image inspect` is invoked with `docker://{image}`, a clearer error is now returned instead of the generic unsupported transport error.
```