### PR TITLE
pkg/machine: remove unused InstalledProviders function

### DIFF
--- a/pkg/machine/provider/platform.go
+++ b/pkg/machine/provider/platform.go
@@ -1,25 +1,9 @@
 package provider
 
 import (
-	"go.podman.io/podman/v6/pkg/machine/define"
 	"go.podman.io/podman/v6/pkg/machine/env"
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
 )
-
-func InstalledProviders() ([]define.VMType, error) {
-	installedTypes := []define.VMType{}
-	providers := GetAll()
-	for _, p := range providers {
-		installed, err := IsInstalled(p.VMType())
-		if err != nil {
-			return nil, err
-		}
-		if installed {
-			installedTypes = append(installedTypes, p.VMType())
-		}
-	}
-	return installedTypes, nil
-}
 
 // GetAllMachinesAndRootfulness collects all podman machine configs and returns
 // a map in the format: { machineName: isRootful }

--- a/pkg/machine/provider/platform_darwin.go
+++ b/pkg/machine/provider/platform_darwin.go
@@ -51,11 +51,6 @@ func GetAll() []vmconfigs.VMProvider {
 	return []vmconfigs.VMProvider{new(libkrun.LibKrunStubber), new(applehv.AppleHVStubber)}
 }
 
-// SupportedProviders returns the providers that are supported on the host operating system
-func SupportedProviders() []define.VMType {
-	return []define.VMType{define.AppleHvVirt, define.LibKrun}
-}
-
 func IsInstalled(provider define.VMType) (bool, error) {
 	switch provider {
 	case define.AppleHvVirt:

--- a/pkg/machine/provider/platform_test.go
+++ b/pkg/machine/provider/platform_test.go
@@ -8,32 +8,6 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/define"
 )
 
-func TestSupportedProviders(t *testing.T) {
-	switch runtime.GOOS {
-	case "darwin":
-		assert.Equal(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
-	case "windows":
-		assert.ElementsMatch(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
-	case "linux":
-		assert.Equal(t, []define.VMType{define.QemuVirt}, SupportedProviders())
-	}
-}
-
-func TestInstalledProviders(t *testing.T) {
-	installed, err := InstalledProviders()
-	assert.NoError(t, err)
-	switch runtime.GOOS {
-	case "darwin":
-		assert.Equal(t, []define.VMType{define.LibKrun, define.AppleHvVirt}, installed)
-	case "windows":
-		provider, err := Get()
-		assert.NoError(t, err)
-		assert.Contains(t, installed, provider.VMType())
-	case "linux":
-		assert.Equal(t, []define.VMType{define.QemuVirt}, installed)
-	}
-}
-
 func TestHasPermsForProvider(t *testing.T) {
 	provider, err := Get()
 	assert.NoError(t, err)
@@ -48,33 +22,5 @@ func TestHasBadPerms(t *testing.T) {
 		assert.False(t, HasPermsForProvider(define.QemuVirt))
 	case "linux":
 		assert.False(t, HasPermsForProvider(define.AppleHvVirt))
-	}
-}
-
-func TestBadSupportedProviders(t *testing.T) {
-	switch runtime.GOOS {
-	case "darwin":
-		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
-		assert.NotEqual(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
-		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
-	case "windows":
-		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
-	case "linux":
-		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
-	}
-}
-
-func TestBadInstalledProviders(t *testing.T) {
-	installed, err := InstalledProviders()
-	assert.NoError(t, err)
-	switch runtime.GOOS {
-	case "darwin":
-		assert.NotEqual(t, []define.VMType{define.QemuVirt}, installed)
-		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, installed)
-		assert.NotEqual(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, installed)
-	case "windows":
-		assert.NotContains(t, installed, define.QemuVirt)
-	case "linux":
-		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, installed)
 	}
 }

--- a/pkg/machine/provider/platform_unix.go
+++ b/pkg/machine/provider/platform_unix.go
@@ -48,11 +48,6 @@ func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
 	return nil, fmt.Errorf("unsupported virtualization provider: `%s`", resolvedVMType.String())
 }
 
-// SupportedProviders returns the providers that are supported on the host operating system
-func SupportedProviders() []define.VMType {
-	return []define.VMType{define.QemuVirt}
-}
-
 func IsInstalled(provider define.VMType) (bool, error) {
 	switch provider {
 	case define.QemuVirt:

--- a/pkg/machine/provider/platform_windows.go
+++ b/pkg/machine/provider/platform_windows.go
@@ -54,11 +54,6 @@ func GetAll() []vmconfigs.VMProvider {
 	}
 }
 
-// SupportedProviders returns the providers that are supported on the host operating system
-func SupportedProviders() []define.VMType {
-	return []define.VMType{define.HyperVVirt, define.WSLVirt}
-}
-
 func IsInstalled(provider define.VMType) (bool, error) {
 	switch provider {
 	case define.WSLVirt:


### PR DESCRIPTION
#### Checklist
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] Tests have been added/updated (or no tests are needed)
- [ ] Documentation has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] Release note entered in the section below
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)

#### What this PR does / why we need it:
The `InstalledProviders` function in `pkg/machine/provider/platform.go` is unused everywhere in the codebase except within its own test cases. This PR removes the dead code entirely to clean up the API surface.

#### Does this PR introduce a user-facing change?
```release-note
None
```