### PR TITLE
compat: Add DNSNames to GET /containers/{name:.*}/json

### DIFF
--- a/docs/source/markdown/podman-ps.1.md.in
+++ b/docs/source/markdown/podman-ps.1.md.in
@@ -66,6 +66,7 @@ Valid placeholders for the Go template are listed below:
 | .Labels            | All the labels assigned to the container     |
 | .Mounts            | Volumes mounted in the container             |
 | .Names             | Name of container                            |
+| .DNSNames          | DNS names of the container by network        |
 | .Networks          | Show all networks connected to the container |
 | .Pid               | Process ID on host system                    |
 | .Pod               | Pod the container is associated with (SHA)   |

--- a/libpod/networking_common.go
+++ b/libpod/networking_common.go
@@ -701,6 +701,36 @@ func getExtraNetworkAliases(c *Container) []string {
 	return alias
 }
 
+// DNSNames returns a map of a network name to
+// a deduplicated list of all DNS names for the network.
+func (c *Container) DNSNames() (map[string][]string, error) {
+	networks, err := c.networks()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get networks: %w", err)
+	}
+
+	netPodName := getNetworkPodName(c)
+	result := make(map[string][]string, len(networks))
+	for _, net := range networks {
+		dedup := make(map[string]struct{})
+
+		// Common.
+		dnsNames := []string{netPodName}
+		// Per-network aliases.
+		// Note: aliases include short ID and hostname.
+		dnsNames = append(dnsNames, net.Aliases...)
+
+		// Add for each network deduplicated.
+		for _, dnsName := range dnsNames {
+			if _, seen := dedup[dnsName]; !seen {
+				dedup[dnsName] = struct{}{}
+				result[net.Name] = append(result[net.Name], dnsName)
+			}
+		}
+	}
+	return result, nil
+}
+
 // DisconnectContainerFromNetwork removes a container from its network
 func (r *Runtime) DisconnectContainerFromNetwork(nameOrID, netName string, force bool) error {
 	ctr, err := r.LookupContainer(nameOrID)

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -432,6 +432,14 @@ func LibpodToContainer(l *libpod.Container, sz bool, includeHealth bool) (*handl
 		return nil, err
 	}
 
+	dnsNames, err := l.DNSNames()
+	if err != nil {
+		return nil, err
+	}
+	for netName, ep := range networkSettings.Networks {
+		ep.DNSNames = dnsNames[netName]
+	}
+
 	m, err := json.Marshal(inspect.Mounts)
 	if err != nil {
 		return nil, err
@@ -718,6 +726,14 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*handlers.LegacyImageI
 	// do not report null instead use an empty map
 	if networkSettings.Networks == nil {
 		networkSettings.Networks = map[string]*network.EndpointSettings{}
+	}
+
+	dnsNames, err := l.DNSNames()
+	if err != nil {
+		return nil, err
+	}
+	for netName, ep := range networkSettings.Networks {
+		ep.DNSNames = dnsNames[netName]
 	}
 
 	cb.Mounts = mounts

--- a/pkg/domain/entities/types/container_ps.go
+++ b/pkg/domain/entities/types/container_ps.go
@@ -49,6 +49,8 @@ type ListContainer struct {
 	Namespaces ListContainerNamespaces
 	// The network names assigned to the container
 	Networks []string
+	// DNSNames maps the container's DNS names by a network name.
+	DNSNames map[string][]string
 	// The process id of the container
 	Pid int
 	// If the container is part of Pod, the Pod ID. Requires the pod

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -181,6 +181,7 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		cgroup, ipc, mnt, net, pidns, user, uts string
 		portMappings                            []libnetworkTypes.PortMapping
 		networks                                []string
+		dnsNames                                map[string][]string
 		healthStatus                            string
 		restartCount                            uint
 		podName                                 string
@@ -223,6 +224,11 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		}
 
 		networks, err = c.Networks()
+		if err != nil {
+			return err
+		}
+
+		dnsNames, err = c.DNSNames()
 		if err != nil {
 			return err
 		}
@@ -298,6 +304,7 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 		Mounts:       ctr.UserVolumes(),
 		Names:        []string{conConfig.Name},
 		Networks:     networks,
+		DNSNames:     dnsNames,
 		Pid:          pid,
 		Pod:          conConfig.Pod,
 		PodName:      podName,

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -75,9 +75,11 @@ t GET libpod/containers/json?all=true 200 \
 # Test compat API for Network Settings (.Network is N/A when rootless)
 network_expect="Networks.pasta.NetworkID=pasta"
 network_mode_expect="pasta"
+default_network="pasta"
 if root; then
     network_expect="Networks.podman.NetworkID=2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9"
     network_mode_expect="bridge"
+    default_network="podman"
 fi
 t GET /containers/json?all=true 200 \
   length=1 \
@@ -86,6 +88,7 @@ t GET /containers/json?all=true 200 \
   .[0].State="exited" \
   .[0].Mounts~.*/tmp \
   .[0].NetworkSettings.$network_expect \
+  .[0].NetworkSettings.Networks.$default_network.DNSNames[0]="foo" \
   .[0].HostConfig.NetworkMode=$network_mode_expect
 
 # compat API imageid with sha256: prefix
@@ -100,7 +103,8 @@ t GET libpod/containers/json?limit=1 200 \
   .[0].Command[0]="true" \
   .[0].State~\\\(exited\\\|stopped\\\) \
   .[0].ExitCode=0 \
-  .[0].IsInfra=false
+  .[0].IsInfra=false \
+  .[0].DNSNames.$default_network[0]=foo
 
 # Make sure `last` works, which is an alias for `limit`.
 # See https://github.com/containers/podman/issues/6413.
@@ -379,7 +383,8 @@ t GET containers/testcon/json 200 \
   .NetworkSettings.Networks.testnet.IPPrefixLen=24 \
   .NetworkSettings.Networks.testnet.IPv6Gateway="" \
   .NetworkSettings.Networks.testnet.GlobalIPv6Address~fd.* \
-  .NetworkSettings.Networks.testnet.GlobalIPv6PrefixLen=64
+  .NetworkSettings.Networks.testnet.GlobalIPv6PrefixLen=64 \
+  .NetworkSettings.Networks.testnet.DNSNames[0]=testcon
 
 podman rm -f -t0 testcon
 podman network rm testnet


### PR DESCRIPTION
Docker Engine API [v1.44 ](https://docs.docker.com/reference/api/engine/version-history/#v144-api-changes) introduces a new field named `DNSNames` containing all non-fully qualified DNS names a container takes on a specific network for the `GET /containers/{name:.*}/json` endpoint.

- Populate `DNSNames` for the compat endpoints `GET /containers/json` and `GET /containers/{name:.*}/json` (the Docker changelog mentions only `/containers/{name:.*}/json`, but it's the same [moby structure](https://pkg.go.dev/github.com/moby/moby/api/types/network#EndpointSettings)).
- Add the `DNSNames` field to GET /libpod/containers/json (added to entities.ListContainer) too based on **RUN-3314** description - works with `podman list/ps --format '{{.DNSNames}}'`

Fixes: https://redhat.atlassian.net/browse/RUN-3314

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
Add field DNSNames to the compat endpoints GET /containers/json and GET /containers/{name:.*}/json and to the libpod endpoint GET /libpod/containers/json.
```

#### Example output

```
➜ curl -s http://localhost:8080/v1.44/containers/dnstest/json | jq '.NetworkSettings'
{
  "SandboxID": "",
  "SandboxKey": "/run/netns/netns-a3fa06b8-40a8-b0e7-10ab-c2d73127538f",
  "Ports": {},
  "Networks": {
    "podman": {
      "IPAMConfig": null,
      "Links": null,
      "Aliases": [
        "844f6d6ce177"
      ],
      "DriverOpts": null,
      "GwPriority": 0,
      "NetworkID": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
      "EndpointID": "",
      "Gateway": "10.88.0.1",
      "IPAddress": "10.88.0.186",
      "MacAddress": "ee:76:15:30:c1:7d",
      "IPPrefixLen": 16,
      "IPv6Gateway": "",
      "GlobalIPv6Address": "",
      "GlobalIPv6PrefixLen": 0,
      "DNSNames": [
        "dnstest",
        "844f6d6ce177"
      ]
    }
  }
}
```

```
➜  podman git:(main) ✗ curl -s http://localhost:8080/v1.44/containers/json | jq '.[].NetworkSettings'
{
  "Networks": {
    "podman": {
      "IPAMConfig": null,
      "Links": null,
      "Aliases": [
        "844f6d6ce177"
      ],
      "DriverOpts": null,
      "GwPriority": 0,
      "NetworkID": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
      "EndpointID": "",
      "Gateway": "10.88.0.1",
      "IPAddress": "10.88.0.186",
      "MacAddress": "ee:76:15:30:c1:7d",
      "IPPrefixLen": 16,
      "IPv6Gateway": "",
      "GlobalIPv6Address": "",
      "GlobalIPv6PrefixLen": 0,
      "DNSNames": [
        "dnstest",
        "844f6d6ce177"
      ]
    }
  }
}
```

```
➜  curl -s http://localhost:8080/v6.0.0/libpod/containers/json | jq .
[
  {
    "AutoRemove": false,
    "Command": [
      "top"
    ],
    "Created": "2026-07-30T14:26:23.637667619+02:00",
    "CreatedAt": "",
    "CIDFile": "",
    "Exited": false,
    "ExitedAt": -62135596800,
    "ExitCode": 0,
    "ExposedPorts": null,
    "Id": "844f6d6ce177a4d5d89aba9849b246e9ca7fa26d6e2c468eee988ad56d2cca88",
    "Image": "docker.io/library/alpine:latest",
    "ImageID": "1991bd789d7184290c3cce84fd6af068b8b745e9bddf178661ce7f5ecf68135c",
    "IsInfra": false,
    "Labels": null,
    "Mounts": [],
    "Names": [
      "dnstest"
    ],
    "Namespaces": {},
    "Networks": [
      "podman"
    ],
    "DNSNames": {
      "podman": [
        "dnstest",
        "844f6d6ce177"
      ]
    },
    "Pid": 366232,
    "Pod": "",
    "PodName": "",
    "Ports": null,
    "Restarts": 0,
    "Size": null,
    "StartedAt": 1785414383,
    "State": "running",
    "Status": ""
  }
]
```
