### PR TITLE
Fix --image-volume docs and completion to use 'anonymous'

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1151,9 +1151,9 @@ func AutocompleteCgroupMode(_ *cobra.Command, _ []string, _ string) ([]string, c
 }
 
 // AutocompleteImageVolume - Autocomplete image volume options.
-// -> "bind", "tmpfs", "ignore"
+// -> "anonymous", "tmpfs", "ignore"
 func AutocompleteImageVolume(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	imageVolumes := []string{"bind", "tmpfs", "ignore"}
+	imageVolumes := []string{"anonymous", "tmpfs", "ignore"}
 	return imageVolumes, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -5,12 +5,12 @@
 << if is_quadlet >>
 ### `ImageVolume=mode`
 << else >>
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+#### **--image-volume**=**anonymous** | *tmpfs* | *ignore*
 << endif >>
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
+Tells Podman how to handle the builtin image volumes. Default is **anonymous**.
 
-- **bind**: An anonymous named volume is created and mounted into the container.
+- **anonymous**: An anonymous named volume is created and mounted into the container.
 - **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
 content that disappears when the container is stopped.
 - **ignore**: All volumes are just ignored and no action is taken.


### PR DESCRIPTION
The man page for --image-volume lists "bind" as an option, and the shell completion offers "bind" too, but the runtime only accepts anonymous, tmpfs and ignore. "bind" is just a legacy alias that is rewritten to "anonymous" during argument parsing, so users who try it against the docs get a confusing mismatch with the error message.

This change:
- updates docs/source/markdown/options/image-volume.md to document "anonymous" as the canonical value (and as the default)
- updates the AutocompleteImageVolume completion in cmd/podman/common/completion.go to suggest the same values the parser actually accepts

Fixes: #27674
